### PR TITLE
[native] Make PrestoServer own the common thread pools

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -199,6 +199,7 @@ void PrestoServer::run() {
   protocol::registerTpchConnector();
 
   initializeVeloxMemory();
+  initializeThreadPools();
 
   auto catalogNames = registerConnectors(fs::path(configDirectoryPath_));
 
@@ -254,7 +255,7 @@ void PrestoServer::run() {
   }
 
   httpServer_ = std::make_unique<http::HttpServer>(
-      std::move(httpConfig), std::move(httpsConfig), httpExecThreads);
+      httpSrvIOExecutor_, std::move(httpConfig), std::move(httpsConfig));
 
   httpServer_->registerPost(
       "/v1/memory",
@@ -326,7 +327,7 @@ void PrestoServer::run() {
             destination,
             queue,
             pool,
-            driverCPUExecutor(),
+            driverExecutor_.get(),
             exchangeHttpExecutor_.get());
       });
 
@@ -338,7 +339,8 @@ void PrestoServer::run() {
       operators::BroadcastExchangeSource::createExchangeSource);
 
   pool_ = velox::memory::addDefaultLeafMemoryPool();
-  taskManager_ = std::make_unique<TaskManager>();
+  taskManager_ = std::make_unique<TaskManager>(
+      driverExecutor_.get(), httpSrvCpuExecutor_.get(), spillerExecutor_.get());
 
   std::string taskUri;
   if (httpsPort.has_value()) {
@@ -358,7 +360,8 @@ void PrestoServer::run() {
         << "Spilling root directory: " << baseSpillDirectory;
   }
 
-  taskResource_ = std::make_unique<TaskResource>(*taskManager_, pool_.get());
+  taskResource_ = std::make_unique<TaskResource>(
+      *taskManager_, pool_.get(), httpSrvCpuExecutor_.get());
   taskResource_->registerUris(*httpServer_);
   if (systemConfig->enableSerializedPageChecksum()) {
     enableChecksum();
@@ -389,15 +392,15 @@ void PrestoServer::run() {
       });
 
   PRESTO_STARTUP_LOG(INFO) << "Driver CPU executor has "
-                           << driverCPUExecutor()->numThreads() << " threads.";
+                           << driverExecutor_->numThreads() << " threads.";
   if (httpServer_->getExecutor()) {
     PRESTO_STARTUP_LOG(INFO)
         << "HTTP Server executor has "
         << httpServer_->getExecutor()->numThreads() << " threads.";
   }
-  if (spillExecutorPtr()) {
+  if (spillerExecutor_ != nullptr) {
     PRESTO_STARTUP_LOG(INFO) << "Spill executor has "
-                             << spillExecutorPtr()->numThreads() << " threads.";
+                             << spillerExecutor_->numThreads() << " threads.";
   } else {
     PRESTO_STARTUP_LOG(INFO) << "Spill executor was not configured.";
   }
@@ -411,7 +414,7 @@ void PrestoServer::run() {
   auto memoryAllocator = velox::memory::MemoryAllocator::getInstance();
   auto asyncDataCache = cache::AsyncDataCache::getInstance();
   periodicTaskManager_ = std::make_unique<PeriodicTaskManager>(
-      driverCPUExecutor(),
+      driverExecutor_.get(),
       httpServer_->getExecutor(),
       taskManager_.get(),
       memoryAllocator,
@@ -449,13 +452,12 @@ void PrestoServer::run() {
 
   unregisterConnectors();
 
-  auto cpuExecutor = driverCPUExecutor();
   PRESTO_SHUTDOWN_LOG(INFO)
-      << "Joining driver CPU Executor '" << cpuExecutor->getName()
-      << "': threads: " << cpuExecutor->numActiveThreads() << "/"
-      << cpuExecutor->numThreads()
-      << ", task queue: " << cpuExecutor->getTaskQueueSize();
-  cpuExecutor->join();
+      << "Joining driver CPU Executor '" << driverExecutor_->getName()
+      << "': threads: " << driverExecutor_->numActiveThreads() << "/"
+      << driverExecutor_->numThreads()
+      << ", task queue: " << driverExecutor_->getTaskQueueSize();
+  driverExecutor_->join();
 
   if (connectorIoExecutor_) {
     PRESTO_SHUTDOWN_LOG(INFO)
@@ -504,13 +506,35 @@ void PrestoServer::yieldTasks() {
     return;
   }
   static std::atomic<int32_t> numYields = 0;
-  const auto numQueued = driverCPUExecutor()->getTaskQueueSize();
+  const auto numQueued = driverExecutor_->getTaskQueueSize();
   if (numQueued > 0) {
     numYields += taskManager_->yieldTasks(numQueued, timeslice);
   }
   if (numYields > 100'000) {
     LOG(INFO) << "Yielded " << numYields << " more threads.";
     numYields = 0;
+  }
+}
+
+void PrestoServer::initializeThreadPools() {
+  auto* systemConfig = SystemConfig::instance();
+  driverExecutor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
+      systemConfig->numQueryThreads(),
+      std::make_shared<folly::NamedThreadFactory>("Driver"));
+
+  httpSrvIOExecutor_ = std::make_shared<folly::IOThreadPoolExecutor>(
+      systemConfig->httpExecThreads(),
+      std::make_shared<folly::NamedThreadFactory>("HTTPSrvIO"));
+
+  httpSrvCpuExecutor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
+      systemConfig->numHttpCpuThreads(),
+      std::make_shared<folly::NamedThreadFactory>("HTTPSrvCpu"));
+
+  const int32_t numSpillThreads = systemConfig->numSpillThreads();
+  if (numSpillThreads > 0) {
+    spillerExecutor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
+        numSpillThreads,
+        std::make_shared<folly::NamedThreadFactory>("Spiller"));
   }
 }
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -63,6 +63,7 @@ class SignalHandler;
 class TaskManager;
 class TaskResource;
 class PeriodicTaskManager;
+class SystemConfig;
 
 class PrestoServer {
  public:
@@ -144,6 +145,8 @@ class PrestoServer {
 
   void initializeVeloxMemory();
 
+  void initializeThreadPools();
+
  protected:
   void addServerPeriodicTasks();
 
@@ -172,6 +175,18 @@ class PrestoServer {
 
   // Executor for exchange data over http.
   std::shared_ptr<folly::IOThreadPoolExecutor> exchangeHttpExecutor_;
+
+  // Executor for HTTP request dispatching
+  std::shared_ptr<folly::IOThreadPoolExecutor> httpSrvIOExecutor_;
+
+  // Executor for HTTP request processing after dispatching
+  std::shared_ptr<folly::CPUThreadPoolExecutor> httpSrvCpuExecutor_;
+
+  // Executor for query engine driver executions.
+  std::shared_ptr<folly::CPUThreadPoolExecutor> driverExecutor_;
+
+  // Executor for spilling.
+  std::shared_ptr<folly::CPUThreadPoolExecutor> spillerExecutor_;
 
   // Instance of MemoryAllocator used for all query memory allocations.
   std::shared_ptr<velox::memory::MemoryAllocator> allocator_;

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -24,44 +24,6 @@ using facebook::presto::protocol::TaskId;
 
 namespace facebook::presto {
 namespace {
-static std::shared_ptr<folly::CPUThreadPoolExecutor>& executor() {
-  static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
-      SystemConfig::instance()->numQueryThreads(),
-      std::make_shared<folly::NamedThreadFactory>("Driver"));
-  return executor;
-}
-
-std::shared_ptr<folly::CPUThreadPoolExecutor>& httpProcessingExecutor() {
-  static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
-      SystemConfig::instance()->numQueryThreads(),
-      std::make_shared<folly::NamedThreadFactory>("HttpProcessing"));
-  return executor;
-}
-
-std::shared_ptr<folly::CPUThreadPoolExecutor> spillExecutor() {
-  const int32_t numSpillThreads = SystemConfig::instance()->numSpillThreads();
-  if (numSpillThreads <= 0) {
-    return nullptr;
-  }
-  static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
-      numSpillThreads, std::make_shared<folly::NamedThreadFactory>("Spiller"));
-  return executor;
-}
-} // namespace
-
-folly::CPUThreadPoolExecutor* driverCPUExecutor() {
-  return executor().get();
-}
-
-folly::CPUThreadPoolExecutor* httpProcessingExecutorPtr() {
-  return httpProcessingExecutor().get();
-}
-
-folly::CPUThreadPoolExecutor* spillExecutorPtr() {
-  return spillExecutor().get();
-}
-
-namespace {
 std::string maybeRemoveNativePrefix(const std::string& name) {
   static const std::string kNativePrefix = "native_";
   const auto result =
@@ -105,6 +67,11 @@ toConnectorConfigs(const protocol::SessionRepresentation& session) {
   return connectorConfigs;
 }
 } // namespace
+
+QueryContextManager::QueryContextManager(
+    folly::Executor* driverExecutor,
+    folly::Executor* spillerExecutor)
+    : driverExecutor_(driverExecutor), spillerExecutor_(spillerExecutor) {}
 
 std::shared_ptr<velox::core::QueryCtx>
 QueryContextManager::findOrCreateQueryCtx(
@@ -156,12 +123,12 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
           : nullptr);
 
   auto queryCtx = std::make_shared<core::QueryCtx>(
-      executor().get(),
+      driverExecutor_,
       std::move(queryConfig),
       connectorConfigs,
       cache::AsyncDataCache::getInstance(),
       std::move(pool),
-      spillExecutor(),
+      spillerExecutor_,
       queryId);
 
   return lockedCache->insert(queryId, queryCtx);

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.h
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.h
@@ -23,11 +23,6 @@
 #include "velox/core/QueryCtx.h"
 
 namespace facebook::presto {
-
-folly::CPUThreadPoolExecutor* driverCPUExecutor();
-folly::CPUThreadPoolExecutor* httpProcessingExecutorPtr();
-folly::CPUThreadPoolExecutor* spillExecutorPtr();
-
 class QueryContextCache {
  public:
   using QueryCtxWeakPtr = std::weak_ptr<velox::core::QueryCtx>;
@@ -103,7 +98,9 @@ class QueryContextCache {
 
 class QueryContextManager {
  public:
-  QueryContextManager() = default;
+  QueryContextManager(
+      folly::Executor* driverExecutor,
+      folly::Executor* spillerExecutor);
 
   std::shared_ptr<velox::core::QueryCtx> findOrCreateQueryCtx(
       const protocol::TaskId& taskId,
@@ -122,6 +119,9 @@ class QueryContextManager {
           std::string,
           std::unordered_map<std::string, std::string>>&&
           connectorConfigStrings);
+
+  folly::Executor* const driverExecutor_{nullptr};
+  folly::Executor* const spillerExecutor_{nullptr};
 
   folly::Synchronized<QueryContextCache> queryContextCache_;
 };

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -30,7 +30,10 @@ struct DriverCountStats {
 
 class TaskManager {
  public:
-  TaskManager();
+  TaskManager(
+      folly::Executor* driverExecutor,
+      folly::Executor* httpSrvExecutor,
+      folly::Executor* spillerExecutor);
 
   /// Invoked by Presto server shutdown to wait for all the tasks to complete
   /// and cleanup the completed tasks.
@@ -122,7 +125,7 @@ class TaskManager {
   std::string toString() const;
 
   QueryContextManager* getQueryContextManager() {
-    return &queryContextManager_;
+    return queryContextManager_.get();
   }
 
   /// Make upto target task threads to yield. Task candidate must have been on
@@ -178,8 +181,8 @@ class TaskManager {
   int32_t oldTaskCleanUpMs_;
   std::shared_ptr<velox::exec::OutputBufferManager> bufferManager_;
   folly::Synchronized<TaskMap> taskMap_;
-  QueryContextManager queryContextManager_;
-  folly::Executor* httpProcessingExecutor_{httpProcessingExecutorPtr()};
+  std::unique_ptr<QueryContextManager> queryContextManager_;
+  folly::Executor* httpSrvCpuExecutor_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -142,7 +142,7 @@ proxygen::RequestHandler* TaskResource::abortResults(
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         folly::via(
-            httpProcessingExecutorPtr(),
+            httpSrvCpuExecutor_,
             [this, taskId, destination, handlerState]() {
               taskManager_.abortResults(taskId, destination);
               return true;
@@ -177,7 +177,7 @@ proxygen::RequestHandler* TaskResource::acknowledgeResults(
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         folly::via(
-            httpProcessingExecutorPtr(),
+            httpSrvCpuExecutor_,
             [this, taskId, bufferId, token]() {
               taskManager_.acknowledgeResults(taskId, bufferId, token);
               return true;
@@ -218,7 +218,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         folly::via(
-            httpProcessingExecutorPtr(),
+            httpSrvCpuExecutor_,
             [this, &body, taskId, createOrUpdateFunc]() {
               const auto startProcessCpuTime = PrestoTask::getProcessCpuTime();
 
@@ -371,7 +371,7 @@ proxygen::RequestHandler* TaskResource::deleteTask(
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         folly::via(
-            httpProcessingExecutorPtr(),
+            httpSrvCpuExecutor_,
             [this, taskId, abort, downstream]() {
               std::unique_ptr<protocol::TaskInfo> taskInfo;
               taskInfo = taskManager_.deleteTask(taskId, abort);
@@ -425,7 +425,7 @@ proxygen::RequestHandler* TaskResource::getResults(
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         auto evb = folly::EventBaseManager::get()->getEventBase();
         folly::via(
-            httpProcessingExecutorPtr(),
+            httpSrvCpuExecutor_,
             [this,
              evb,
              taskId,
@@ -505,7 +505,7 @@ proxygen::RequestHandler* TaskResource::getTaskStatus(
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         auto evb = folly::EventBaseManager::get()->getEventBase();
         folly::via(
-            httpProcessingExecutorPtr(),
+            httpSrvCpuExecutor_,
             [this,
              evb,
              useThrift,
@@ -570,7 +570,7 @@ proxygen::RequestHandler* TaskResource::getTaskInfo(
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         folly::via(
-            httpProcessingExecutorPtr(),
+            httpSrvCpuExecutor_,
             [this,
              evb = folly::EventBaseManager::get()->getEventBase(),
              taskId,
@@ -625,7 +625,7 @@ proxygen::RequestHandler* TaskResource::removeRemoteSource(
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         folly::via(
-            httpProcessingExecutorPtr(),
+            httpSrvCpuExecutor_,
             [this, taskId, remoteId, downstream]() {
               taskManager_.removeRemoteSource(taskId, remoteId);
             })

--- a/presto-native-execution/presto_cpp/main/TaskResource.h
+++ b/presto-native-execution/presto_cpp/main/TaskResource.h
@@ -23,8 +23,11 @@ class TaskResource {
  public:
   explicit TaskResource(
       TaskManager& taskManager,
-      velox::memory::MemoryPool* pool)
-      : taskManager_(taskManager), pool_{pool} {}
+      velox::memory::MemoryPool* pool,
+      folly::Executor* httpSrvCpuExecutor)
+      : httpSrvCpuExecutor_(httpSrvCpuExecutor),
+        pool_{pool},
+        taskManager_(taskManager) {}
 
   void registerUris(http::HttpServer& server);
 
@@ -91,8 +94,10 @@ class TaskResource {
       proxygen::HTTPMessage* message,
       const std::vector<std::string>& pathMatch);
 
+  folly::Executor* const httpSrvCpuExecutor_;
+  velox::memory::MemoryPool* const pool_;
+
   TaskManager& taskManager_;
-  velox::memory::MemoryPool* pool_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -138,6 +138,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kMaxDriversPerTask, 16),
           NUM_PROP(kConcurrentLifespansPerTask, 1),
           NUM_PROP(kHttpExecThreads, 8),
+          NUM_PROP(kNumHttpCpuThreads, std::thread::hardware_concurrency() * 2),
           NONE_PROP(kHttpServerHttpsPort),
           STR_PROP(kHttpServerHttpsEnabled, "false"),
           STR_PROP(
@@ -297,6 +298,10 @@ int32_t SystemConfig::concurrentLifespansPerTask() const {
 
 int32_t SystemConfig::httpExecThreads() const {
   return optionalProperty<int32_t>(kHttpExecThreads).value();
+}
+
+int32_t SystemConfig::numHttpCpuThreads() const {
+  return optionalProperty<int32_t>(kNumHttpCpuThreads).value();
 }
 
 int32_t SystemConfig::numIoThreads() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -165,6 +165,7 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kConcurrentLifespansPerTask{
       "task.concurrent-lifespans-per-task"};
   static constexpr std::string_view kHttpExecThreads{"http_exec_threads"};
+  static constexpr std::string_view kNumHttpCpuThreads{"num-http-cpu-threads"};
   static constexpr std::string_view kHttpServerHttpsPort{
       "http-server.https.port"};
   static constexpr std::string_view kHttpServerHttpsEnabled{
@@ -407,6 +408,8 @@ class SystemConfig : public ConfigBase {
   int32_t concurrentLifespansPerTask() const;
 
   int32_t httpExecThreads() const;
+
+  int32_t numHttpCpuThreads() const;
 
   /// Size of global IO executor.
   int32_t numIoThreads() const;

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -269,9 +269,9 @@ class HttpsConfig {
 class HttpServer {
  public:
   explicit HttpServer(
+      const std::shared_ptr<folly::IOThreadPoolExecutor>& httpIOExecutor,
       std::unique_ptr<HttpConfig> httpConfig,
-      std::unique_ptr<HttpsConfig> httpsConfig = nullptr,
-      int httpExecThreads = 8);
+      std::unique_ptr<HttpsConfig> httpsConfig = nullptr);
 
   void start(
       std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>> filters =
@@ -280,7 +280,7 @@ class HttpServer {
       std::function<void(std::exception_ptr)> onError = nullptr);
 
   folly::IOThreadPoolExecutor* getExecutor() {
-    return httpExecutor_.get();
+    return httpIOExecutor_.get();
   }
 
   void stop() {
@@ -360,10 +360,9 @@ class HttpServer {
  private:
   const std::unique_ptr<HttpConfig> httpConfig_;
   const std::unique_ptr<HttpsConfig> httpsConfig_;
-  int httpExecThreads_;
   std::unique_ptr<DispatchingRequestHandlerFactory> handlerFactory_;
   std::unique_ptr<proxygen::HTTPServer> server_;
-  std::shared_ptr<folly::IOThreadPoolExecutor> httpExecutor_;
+  std::shared_ptr<folly::IOThreadPoolExecutor> httpIOExecutor_;
 
   static EndpointRequestHandlerFactory endPointWrapper(
       const RequestHandlerCallback& callback) {

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
@@ -71,8 +71,9 @@ class HttpJwtTestSuite : public ::testing::TestWithParam<bool> {
     auto clientConfig = jwtSystemConfig(clientSystemConfigOverride);
     auto systemConfig = SystemConfig::instance();
     systemConfig->initialize(std::move(clientConfig));
-
-    auto server = getServer(useHttps);
+    auto ioPool = std::make_shared<folly::IOThreadPoolExecutor>(
+        8, std::make_shared<folly::NamedThreadFactory>("HTTPSrvIO"));
+    auto server = getHttpServer(useHttps, ioPool);
 
     auto request = std::make_shared<AsyncMsgRequestState>();
 

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTestBase.h
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTestBase.h
@@ -237,9 +237,9 @@ folly::SemiFuture<std::unique_ptr<http::HttpResponse>> sendGet(
       .send(client, body, sendDelay);
 }
 
-static std::unique_ptr<http::HttpServer> getServer(
+static std::unique_ptr<http::HttpServer> getHttpServer(
     bool useHttps,
-    uint32_t numThreads = 8) {
+    const std::shared_ptr<folly::IOThreadPoolExecutor>& httpIOExecutor) {
   if (useHttps) {
     std::string certPath = getCertsPath("test_cert1.pem");
     std::string keyPath = getCertsPath("test_key1.pem");
@@ -247,13 +247,13 @@ static std::unique_ptr<http::HttpServer> getServer(
     auto httpsConfig = std::make_unique<http::HttpsConfig>(
         folly::SocketAddress("127.0.0.1", 0), certPath, keyPath, ciphers);
     return std::make_unique<http::HttpServer>(
-        nullptr, std::move(httpsConfig), numThreads);
+        httpIOExecutor, nullptr, std::move(httpsConfig));
   } else {
     return std::make_unique<http::HttpServer>(
+        httpIOExecutor,
         std::make_unique<http::HttpConfig>(
             folly::SocketAddress("127.0.0.1", 0)),
-        nullptr,
-        numThreads);
+        nullptr);
   }
 }
 

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -55,16 +55,21 @@ struct PromiseHolder {
   folly::Promise<T> promise_;
 };
 
-static std::unique_ptr<http::HttpServer> createHttpServer(bool useHttps) {
+static std::unique_ptr<http::HttpServer> createHttpServer(
+    bool useHttps,
+    std::shared_ptr<folly::IOThreadPoolExecutor> ioPool =
+        std::make_shared<folly::IOThreadPoolExecutor>(8)) {
   if (useHttps) {
     std::string certPath = getCertsPath("test_cert1.pem");
     std::string keyPath = getCertsPath("test_key1.pem");
     std::string ciphers = "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384";
     auto httpsConfig = std::make_unique<http::HttpsConfig>(
         folly::SocketAddress("127.0.0.1", 0), certPath, keyPath, ciphers);
-    return std::make_unique<http::HttpServer>(nullptr, std::move(httpsConfig));
+    return std::make_unique<http::HttpServer>(
+        ioPool, nullptr, std::move(httpsConfig));
   } else {
     return std::make_unique<http::HttpServer>(
+        ioPool,
         std::make_unique<http::HttpConfig>(
             folly::SocketAddress("127.0.0.1", 0)));
   }

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -348,16 +348,21 @@ void waitForEndMarker(const std::shared_ptr<exec::ExchangeQueue>& queue) {
   }
 }
 
-static std::unique_ptr<http::HttpServer> createHttpServer(bool useHttps) {
+static std::unique_ptr<http::HttpServer> createHttpServer(
+    bool useHttps,
+    std::shared_ptr<folly::IOThreadPoolExecutor> ioPool =
+        std::make_shared<folly::IOThreadPoolExecutor>(8)) {
   if (useHttps) {
     std::string certPath = getCertsPath("test_cert1.pem");
     std::string keyPath = getCertsPath("test_key1.pem");
     std::string ciphers = "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384";
     auto httpsConfig = std::make_unique<http::HttpsConfig>(
         folly::SocketAddress("127.0.0.1", 0), certPath, keyPath, ciphers);
-    return std::make_unique<http::HttpServer>(nullptr, std::move(httpsConfig));
+    return std::make_unique<http::HttpServer>(
+        ioPool, nullptr, std::move(httpsConfig));
   } else {
     return std::make_unique<http::HttpServer>(
+        ioPool,
         std::make_unique<http::HttpConfig>(
             folly::SocketAddress("127.0.0.1", 0)));
   }

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -20,8 +20,20 @@ namespace facebook::presto {
 class QueryContextManagerTest : public testing::Test {
  protected:
   void SetUp() override {
-    taskManager_ = std::make_unique<TaskManager>();
+    driverExecutor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
+        4, std::make_shared<folly::NamedThreadFactory>("Driver"));
+    httpSrvCpuExecutor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
+        4, std::make_shared<folly::NamedThreadFactory>("HTTPSrvCpu"));
+    spillerExecutor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
+        4, std::make_shared<folly::NamedThreadFactory>("Spiller"));
+    taskManager_ = std::make_unique<TaskManager>(
+        driverExecutor_.get(),
+        httpSrvCpuExecutor_.get(),
+        spillerExecutor_.get());
   }
+  std::shared_ptr<folly::CPUThreadPoolExecutor> driverExecutor_;
+  std::shared_ptr<folly::CPUThreadPoolExecutor> httpSrvCpuExecutor_;
+  std::shared_ptr<folly::CPUThreadPoolExecutor> spillerExecutor_;
   std::unique_ptr<TaskManager> taskManager_;
 };
 


### PR DESCRIPTION
Move thread pools initialization and ownership to PrestoServer, like other pools already owned by it.
```
== NO RELEASE NOTE ==
```

