### PR TITLE
Improve latency for HBO optimizer

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -56,4 +56,6 @@ public class RuntimeMetricName
     // Size of the data retrieved by read call to storage
     public static final String STORAGE_READ_DATA_BYTES = "storageReadDataBytes";
     public static final String WRITTEN_FILES_COUNT = "writtenFilesCount";
+    public static final String HISTORY_OPTIMIZER_QUERY_REGISTRATION_GET_PLAN_NODE_HASHES = "historyOptimizerQueryRegistrationGetPlanNodeHashes";
+    public static final String HISTORY_OPTIMIZER_QUERY_REGISTRATION_GET_STATISTICS = "historyOptimizerQueryRegistrationGetStatistics";
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanCanonicalInfoProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CachingPlanCanonicalInfoProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
 import com.facebook.presto.cost.HistoryBasedStatisticsCacheManager;
 import com.facebook.presto.metadata.Metadata;
@@ -36,6 +37,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.getHistoryBasedOptimizerTimeoutLimit;
+import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.historyBasedPlanCanonicalizationStrategyList;
 import static com.google.common.hash.Hashing.sha256;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -57,42 +59,68 @@ public class CachingPlanCanonicalInfoProvider
     }
 
     @Override
-    public Optional<String> hash(Session session, PlanNode planNode, PlanCanonicalizationStrategy strategy)
+    public Optional<String> hash(Session session, PlanNode planNode, PlanCanonicalizationStrategy strategy, boolean cacheOnly)
     {
         CacheKey key = new CacheKey(planNode, strategy);
-        return loadValue(session, key).map(PlanNodeCanonicalInfo::getHash);
+        return loadValue(session, key, cacheOnly).map(PlanNodeCanonicalInfo::getHash);
     }
 
     @Override
-    public Optional<List<PlanStatistics>> getInputTableStatistics(Session session, PlanNode planNode)
+    public Optional<List<PlanStatistics>> getInputTableStatistics(Session session, PlanNode planNode, boolean cacheOnly)
     {
         CacheKey key = new CacheKey(planNode, historyBasedPlanCanonicalizationStrategyList().get(0));
-        return loadValue(session, key).map(PlanNodeCanonicalInfo::getInputTableStatistics);
+        return loadValue(session, key, cacheOnly).map(PlanNodeCanonicalInfo::getInputTableStatistics);
     }
 
-    private Optional<PlanNodeCanonicalInfo> loadValue(Session session, CacheKey key)
+    private Optional<PlanNodeCanonicalInfo> loadValue(Session session, CacheKey key, boolean cacheOnly)
     {
         long startTimeInNano = System.nanoTime();
+        long profileStartTime = 0;
         long timeoutInMilliseconds = getHistoryBasedOptimizerTimeoutLimit(session).toMillis();
+        boolean enableVerboseRuntimeStats = SystemSessionProperties.isVerboseRuntimeStatsEnabled(session);
         Map<CacheKey, PlanNodeCanonicalInfo> cache = historyBasedStatisticsCacheManager.getCanonicalInfoCache(session.getQueryId());
         PlanNodeCanonicalInfo result = cache.get(key);
-        if (result != null) {
-            return Optional.of(result);
+        if (result != null || cacheOnly) {
+            return Optional.ofNullable(result);
         }
         CanonicalPlanGenerator.Context context = new CanonicalPlanGenerator.Context();
+        if (enableVerboseRuntimeStats) {
+            profileStartTime = System.nanoTime();
+        }
         key.getNode().accept(new CanonicalPlanGenerator(key.getStrategy(), objectMapper, session), context);
+        if (enableVerboseRuntimeStats) {
+            profileTime("CanonicalPlanGenerator", profileStartTime, session);
+        }
+        if (loadValueTimeout(startTimeInNano, timeoutInMilliseconds)) {
+            return Optional.empty();
+        }
         for (Map.Entry<PlanNode, CanonicalPlan> entry : context.getCanonicalPlans().entrySet()) {
             CanonicalPlan canonicalPlan = entry.getValue();
             PlanNode plan = entry.getKey();
+            if (enableVerboseRuntimeStats) {
+                profileStartTime = System.nanoTime();
+            }
             String hashValue = hashCanonicalPlan(canonicalPlan, objectMapper);
+            if (enableVerboseRuntimeStats) {
+                profileTime("HashCanonicalPlan", profileStartTime, session);
+            }
+            if (loadValueTimeout(startTimeInNano, timeoutInMilliseconds)) {
+                return Optional.empty();
+            }
             // Compute input table statistics for the plan node. This is useful in history based optimizations,
             // where historical plan statistics are reused if input tables are similar in size across runs.
             ImmutableList.Builder<PlanStatistics> inputTableStatisticsBuilder = ImmutableList.builder();
+            if (enableVerboseRuntimeStats) {
+                profileStartTime = System.nanoTime();
+            }
             for (TableScanNode scanNode : context.getInputTables().get(plan)) {
                 if (loadValueTimeout(startTimeInNano, timeoutInMilliseconds)) {
-                    break;
+                    return Optional.empty();
                 }
-                inputTableStatisticsBuilder.add(getPlanStatisticsForTable(session, scanNode));
+                inputTableStatisticsBuilder.add(getPlanStatisticsForTable(session, scanNode, enableVerboseRuntimeStats));
+            }
+            if (enableVerboseRuntimeStats) {
+                profileTime("GetPlanStatisticsForTable", profileStartTime, session);
             }
             cache.put(new CacheKey(plan, key.getStrategy()), new PlanNodeCanonicalInfo(hashValue, inputTableStatisticsBuilder.build()));
         }
@@ -107,7 +135,12 @@ public class CachingPlanCanonicalInfoProvider
         return NANOSECONDS.toMillis(System.nanoTime() - startTimeInNano) > timeoutInMilliseconds;
     }
 
-    private PlanStatistics getPlanStatisticsForTable(Session session, TableScanNode table)
+    private void profileTime(String name, long startProfileTime, Session session)
+    {
+        session.getRuntimeStats().addMetricValue(String.format("CachingPlanCanonicalInfoProvider:%s", name), NANO, System.nanoTime() - startProfileTime);
+    }
+
+    private PlanStatistics getPlanStatisticsForTable(Session session, TableScanNode table, boolean profileRuntime)
     {
         InputTableCacheKey key = new InputTableCacheKey(new TableHandle(
                 table.getTable().getConnectorId(),
@@ -119,7 +152,14 @@ public class CachingPlanCanonicalInfoProvider
         if (planStatistics != null) {
             return planStatistics;
         }
+        long startProfileTime = 0;
+        if (profileRuntime) {
+            startProfileTime = System.nanoTime();
+        }
         TableStatistics tableStatistics = metadata.getTableStatistics(session, key.getTableHandle(), key.getColumnHandles(), key.getConstraint());
+        if (profileRuntime) {
+            profileTime("ReadFromMetaData", startProfileTime, session);
+        }
         planStatistics = new PlanStatistics(tableStatistics.getRowCount(), tableStatistics.getTotalSize(), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty());
         cache.put(key, planStatistics);
         return planStatistics;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanCanonicalInfoProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanCanonicalInfoProvider.java
@@ -32,16 +32,18 @@ public interface PlanCanonicalInfoProvider
      * @param session Session for query being run
      * @param planNode Plan node to hash
      * @param strategy Strategy to canonicalize the plan node
+     * @param cacheOnly Only fetch from cache, and return Optional.empty() if set to true and no entry found in cache
      * @return Hash of the plan node. Returns Optional.empty() if unable to hash.
      */
-    Optional<String> hash(Session session, PlanNode planNode, PlanCanonicalizationStrategy strategy);
+    Optional<String> hash(Session session, PlanNode planNode, PlanCanonicalizationStrategy strategy, boolean cacheOnly);
 
     /**
      * Canonicalize the plan, and return statistics of input tables. Output order is consistent with
      * plan canonicalization.
      * @param session Session for query being run
      * @param planNode Plan node to hash
+     * @param cacheOnly Only fetch from cache, and return Optional.empty() if set to true and no entry found in cache
      * @return Statistics of leaf input tables to plan node, ordered by a consistent canonicalization strategy.
      */
-    Optional<List<PlanStatistics>> getInputTableStatistics(Session session, PlanNode planNode);
+    Optional<List<PlanStatistics>> getInputTableStatistics(Session session, PlanNode planNode, boolean cacheOnly);
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanNodeCanonicalInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanNodeCanonicalInfo.java
@@ -84,8 +84,8 @@ public class PlanNodeCanonicalInfo
                     continue;
                 }
                 PlanNode statsEquivalentPlanNode = node.getStatsEquivalentPlanNode().get();
-                Optional<String> hash = planCanonicalInfoProvider.hash(session, statsEquivalentPlanNode, strategy);
-                Optional<List<PlanStatistics>> inputTableStatistics = planCanonicalInfoProvider.getInputTableStatistics(session, statsEquivalentPlanNode);
+                Optional<String> hash = planCanonicalInfoProvider.hash(session, statsEquivalentPlanNode, strategy, true);
+                Optional<List<PlanStatistics>> inputTableStatistics = planCanonicalInfoProvider.getInputTableStatistics(session, statsEquivalentPlanNode, true);
                 if (hash.isPresent() && inputTableStatistics.isPresent()) {
                     result.add(new CanonicalPlanWithInfo(new CanonicalPlan(statsEquivalentPlanNode, strategy), new PlanNodeCanonicalInfo(hash.get(), inputTableStatistics.get())));
                 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkStatsCalculator.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkStatsCalculator.java
@@ -116,7 +116,7 @@ public class TestPrestoSparkStatsCalculator
                 .registerVariable(planBuilder.variable("c1"))
                 .filter(planBuilder.rowExpression("c1 IS NOT NULL"),
                         planBuilder.values(planBuilder.variable("c1")));
-        Optional<String> hash = historyBasedPlanStatisticsCalculator.getPlanCanonicalInfoProvider().hash(session, statsEquivalentRemoteSource, REMOVE_SAFE_CONSTANTS);
+        Optional<String> hash = historyBasedPlanStatisticsCalculator.getPlanCanonicalInfoProvider().hash(session, statsEquivalentRemoteSource, REMOVE_SAFE_CONSTANTS, false);
 
         InMemoryHistoryBasedPlanStatisticsProvider historyBasedPlanStatisticsProvider = (InMemoryHistoryBasedPlanStatisticsProvider) historyBasedPlanStatisticsCalculator.getHistoryBasedPlanStatisticsProvider().get();
         historyBasedPlanStatisticsProvider.putStats(ImmutableMap.of(


### PR DESCRIPTION
## Description
Part of https://github.com/prestodb/presto/issues/20355

This PR optimizes the latency for HBO optimizer from the following aspects:

- Check timeout for plan canonicalization, plan hash and return empty when timeout
Previously it only checks timeout for meta data access, and do not return immediately when timeout. However, we found that plan canonicalization and hash can also be time consuming. And we need to check for these two, and also return immediately when timeout.
- Add a flag to specify whether to fetch HBO related data from cache only. It's false when register the query, and true when getting statistics
In the design of HBO, all HBO related stats are fetched and cached during query registration in `HistoricalStatisticsEquivalentPlanMarkingOptimizer` optimizer, and following fetch of stats will access from cache. This PR adds a new parameter `cacheOnly` to corresponding methods to enforce this behavior.
- Add verbose run time stats for plan hash, plan canonicalization and meta data read
This is only enabled when verbose runtime flag is set to true, and will help to debug HBO timeout.


## Motivation and Context
This is to reduce the latency of HBO optimizer.

## Impact
Tested with a few production queries, see significant drop of latency for HBO optimizer.

## Test Plan
Add unit tests. Also tested locally end to end to verify that HBO optimizer latency decreased. In tests, queries which takes minutes to have HBO optimizer timeout now timeouts within specified timeout limit, i.e. 20seconds.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve latency of history based optimizer
```

