### PR TITLE
Add test case for deletion in Iceberg table with partition evolution

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -127,6 +127,37 @@ public class IcebergDistributedTestBase
     }
 
     @Test
+    public void testDeleteWithPartitionSpecEvolution()
+    {
+        // Create a partitioned table and insert some value
+        assertQuerySucceeds("create table test_delete(a int, b varchar) with (partitioning = ARRAY['a'])");
+        assertQuerySucceeds("insert into test_delete values(1, '1001'), (1, '1002'), (2, '1003')");
+        assertEquals(getQueryRunner().execute("SELECT count(*) FROM test_delete").getOnlyValue(), 3L);
+
+        // Rename partition column would not affect metadata deletion filtering by it's value
+        assertQuerySucceeds("alter table test_delete rename column a to c");
+        assertQuerySucceeds("insert into test_delete(c, b) values(2, '1004')");
+        assertUpdate("DELETE FROM test_delete WHERE c = 2", 2L);
+        assertEquals(getQueryRunner().execute("SELECT count(*) FROM test_delete").getOnlyValue(), 2L);
+
+        // Add a new partition column, and insert some value
+        assertQuerySucceeds("alter table test_delete add column d bigint with(partitioning = 'identity')");
+        assertQuerySucceeds("insert into test_delete values(1, '1001', 10001), (2, '1003', 10001), (3, '1004', 10003)");
+        assertEquals(getQueryRunner().execute("SELECT count(*) FROM test_delete").getOnlyValue(), 5L);
+
+        // Deletion fails, because column 'd' do not exists in older partition specs
+        String errorMessage = "This connector only supports delete where one or more partitions are deleted entirely";
+        assertQueryFails("delete from test_delete where d = 1001", errorMessage);
+        assertQueryFails("delete from test_delete where d = 1001 and c = 2", errorMessage);
+
+        // Deletion succeeds, because column 'c' exists in all partition specs
+        assertUpdate("DELETE FROM test_delete WHERE c = 1", 3);
+        assertEquals(getQueryRunner().execute("SELECT count(*) FROM test_delete").getOnlyValue(), 2L);
+
+        assertQuerySucceeds("DROP TABLE test_delete");
+    }
+
+    @Test
     public void testRenamePartitionColumn()
     {
         assertQuerySucceeds("create table test_partitioned_table(a int, b varchar) with (partitioning = ARRAY['a'])");


### PR DESCRIPTION
## Description

Add test case for metadata deletion in Iceberg table which have experienced partition evolution.

## Motivation and Context

Make sure metadata deletion would work well in case of various partition spec evolution.

## Test Plan

 - Confirm renaming partition column do not affect metadata deletion filtering by it's value
 - Confirm deletion will fail when some filter columns do not exist in all partition specs
 - Confirm deletion will succeed when all filter columns exist in all partition specs

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

