### PR TITLE
Partition Column transform support for Year, Month, Day & Hour

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -487,8 +487,13 @@ Available transforms in the Presto Iceberg connector include:
 
 * ``Bucket`` (partitions data into a specified number of buckets using a hash function)
 * ``Truncate`` (partitions the table based on the truncated value of the field and can specify the width of the truncated value)
+* ``Identity`` (partitions data using unmodified source value)
+* ``Year`` (partitions data using integer value by extracting a date or timestamp year, as years from 1970)
+* ``Month`` (partitions data using integer value by extracting a date or timestamp month, as months from 1970-01-01)
+* ``Day`` (partitions data using integer value by extracting a date or timestamp day, as days from 1970-01-01)
+* ``Hour`` (partitions data using integer value by extracting a timestamp hour, as hours from 1970-01-01 00:00:00)
 
-Create an Iceberg table partitioned into 8 buckets of equal sized ranges::
+Create an Iceberg table partitioned into 8 buckets of equal size ranges::
 
     CREATE TABLE players (
         id int,
@@ -500,7 +505,7 @@ Create an Iceberg table partitioned into 8 buckets of equal sized ranges::
         partitioning = ARRAY['bucket(team, 8)']
     );
 
-Create an Iceberg table partitioned by the first letter of the team field::
+Create an Iceberg table partitioned by the first letter of the ``team`` field::
 
     CREATE TABLE players (
         id int,
@@ -512,10 +517,31 @@ Create an Iceberg table partitioned by the first letter of the team field::
         partitioning = ARRAY['truncate(team, 1)']
     );
 
-.. note::
+Create an Iceberg table partitioned by ``ds``::
 
-    ``Day``, ``Month``, ``Year``, ``Hour`` partition column transform functions are not supported in Presto Iceberg
-    connector yet (:issue:`20570`).
+    CREATE TABLE players (
+        id int,
+        name varchar,
+        team varchar,
+        ds date
+    )
+    WITH (
+        format = 'ORC',
+        partitioning = ARRAY['year(ds)']
+    );
+
+Create an Iceberg table partitioned by ``ts``::
+
+    CREATE TABLE players (
+        id int,
+        name varchar,
+        team varchar,
+        ts timestamp
+    )
+    WITH (
+        format = 'ORC',
+        partitioning = ARRAY['hour(ts)']
+    );
 
 CREATE VIEW
 ^^^^^^^^^^^^

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -987,4 +987,138 @@ public class IcebergDistributedSmokeTestBase
                         "  (NULL, NULL, NULL, NULL, 2e0, NULL, NULL)");
         dropTable(session, tableName);
     }
+
+    @Test
+    public void testDatePartitionedByYear()
+    {
+        Session session = getSession();
+        String tableName = "test_date_partitioned_by_year";
+
+        assertUpdate("CREATE TABLE " + tableName + " (c1 integer, c2 date) WITH(partitioning = ARRAY['year(c2)'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, date '2022-10-01')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (2, date '2023-11-02')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (3, date '1980-01-01'), (4, date '1990-02-02')", 2);
+
+        assertQuery("SELECT c2_year, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_year",
+                "VALUES (10, 1, 1), (20, 1, 1), (52, 1, 1), (53, 1, 1)");
+        assertQuery("SELECT * FROM " + tableName + " WHERE year(c2) = 2023", "VALUES (2, '2023-11-02')");
+
+        dropTable(session, tableName);
+    }
+
+    @Test
+    public void testDatePartitionedByMonth()
+    {
+        Session session = getSession();
+        String tableName = "test_date_partitioned_by_month";
+
+        assertUpdate("CREATE TABLE " + tableName + " (c1 integer, c2 date) WITH(partitioning = ARRAY['month(c2)'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, date '2022-01-01')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (2, date '2023-11-02')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (3, date '1970-02-02'), (4, date '1971-01-02')", 2);
+
+        assertQuery("SELECT c2_month, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_month",
+                "VALUES (1, 1, 1), (12, 1, 1), (624, 1, 1), (646, 1, 1)");
+        assertQuery("SELECT * FROM " + tableName + " WHERE month(c2) = 11", "VALUES (2, '2023-11-02')");
+
+        dropTable(session, tableName);
+    }
+
+    @Test
+    public void testDatePartitionedByDay()
+    {
+        Session session = getSession();
+        String tableName = "test_date_partitioned_by_day";
+
+        assertUpdate("CREATE TABLE " + tableName + " (c1 integer, c2 date) WITH(partitioning = ARRAY['day(c2)'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, date '2022-10-01')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (2, date '2023-11-02')", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (3, date '1970-10-01'), (4, date '1971-11-05')", 2);
+
+        assertQuery("SELECT c2_day, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_day",
+                "VALUES ('1970-10-01', 1, 1), ('1971-11-05', 1, 1), ('2022-10-01', 1, 1), ('2023-11-02', 1, 1)");
+        assertQuery("SELECT * FROM " + tableName + " WHERE day(c2) = 2", "VALUES (2, '2023-11-02')");
+
+        dropTable(session, tableName);
+    }
+
+    @Test
+    public void testTimestampPartitionedByYear()
+    {
+        Session session = Session.builder(getSession())
+                .setTimeZoneKey(UTC_KEY)
+                .build();
+        String tableName = "test_timestamp_partitioned_by_year";
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['year(c2)'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 00:00:00.000')", 1);
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1980-01-01 12:10:31.315'), (4, timestamp '1990-01-01 12:10:31.315')", 2);
+
+        assertQuery(session, "SELECT c2_year, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_year",
+                "VALUES (10, 1, 1), (20, 1, 1), (52, 1, 1), (53, 1, 1)");
+        assertQuery(session, "SELECT * FROM " + tableName + " WHERE year(c2) = 2023", "VALUES (2, '2023-11-02 12:10:31.315')");
+
+        dropTable(session, tableName);
+    }
+
+    @Test
+    public void testTimestampPartitionedByMonth()
+    {
+        Session session = Session.builder(getSession())
+                .setTimeZoneKey(UTC_KEY)
+                .build();
+        String tableName = "test_timestamp_partitioned_by_month";
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['month(c2)'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 00:00:00.000')", 1);
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1970-02-02 12:10:31.315'), (4, timestamp '1971-01-02 12:10:31.315')", 2);
+
+        assertQuery(session, "SELECT c2_month, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_month",
+                "VALUES (1, 1, 1), (12, 1, 1), (633, 1, 1), (646, 1, 1)");
+        assertQuery(session, "SELECT * FROM " + tableName + " WHERE month(c2) = 11", "VALUES (2, '2023-11-02 12:10:31.315')");
+
+        dropTable(session, tableName);
+    }
+
+    @Test
+    public void testTimestampPartitionedByDay()
+    {
+        Session session = Session.builder(getSession())
+                .setTimeZoneKey(UTC_KEY)
+                .build();
+        String tableName = "test_timestamp_partitioned_by_day";
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['day(c2)'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 00:00:00.000')", 1);
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1970-01-05 00:00:00.000'), (4, timestamp '1971-01-10 12:10:31.315')", 2);
+
+        assertQuery(session, "SELECT c2_day, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_day",
+                "VALUES ('1970-01-05', 1, 1), ('1971-01-10', 1, 1), ('2022-10-01', 1, 1), ('2023-11-02', 1, 1)");
+        assertQuery(session, "SELECT * FROM " + tableName + " WHERE day(c2) = 2", "VALUES (2, '2023-11-02 12:10:31.315')");
+
+        dropTable(session, tableName);
+    }
+
+    @Test
+    public void testTimestampPartitionedByHour()
+    {
+        Session session = Session.builder(getSession())
+                .setTimeZoneKey(UTC_KEY)
+                .build();
+        String tableName = "test_timestamp_partitioned_by_hour";
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['hour(c2)'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 10:00:00.000')", 1);
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
+        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1970-01-01 10:10:31.315'), (4, timestamp '1970-01-02 10:10:31.315')", 2);
+
+        assertQuery(session, "SELECT c2_hour, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_hour",
+                "VALUES (10, 1, 1), (34, 1, 1), (462394, 1, 1), (471924, 1, 1)");
+        assertQuery(session, "SELECT * FROM " + tableName + " WHERE hour(c2) = 12", "VALUES (2, '2023-11-02 12:10:31.315')");
+
+        dropTable(session, tableName);
+    }
 }


### PR DESCRIPTION


## Description
Presto issue https://github.com/prestodb/presto/issues/20570
- Fix getColumnTransform() for date and timestamp columns to support transform based on iceberg partition spec
- Add a new function transformBlock() to write partition column values using INTEGER type 


## Motivation and Context
Beyond selecting a particular column to partition by, you can select a “transform” and partition the table by the transformed value of the column.

Available in Iceberg include: https://iceberg.apache.org/spec/#partition-specs
Day, Month, Year, Hour, Bucket, Truncate

Presto Iceberg Connector currently already supports Bucket & Truncate transform with partition column in Iceberg Table. This feature request is to add transform support for Day, Month, Year, Hour

## Impact
- Presto Iceberg connector will support these partition transform functions.

## Test Plan
- Add new cases for Year, Month, Day, Hour in IcebergDistributedSmokeTestBase.java
- Manual testing 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==


Iceberg Changes
* Day, Month & Year partition column transform functions are supported for date type in Presto Iceberg connector.
* Day, Month, Year & Hour partition column transform functions are supported for timestamp type in Presto Iceberg connector.

```

