### PR TITLE
Check consistency of param N for min_byN/max_byN

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/minmaxby/AbstractMinMaxByNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/minmaxby/AbstractMinMaxByNAggregationFunction.java
@@ -102,7 +102,9 @@ public abstract class AbstractMinMaxByNAggregationFunction
             heap = new TypedKeyValueHeap(comparator, keyType, valueType, toIntExact(n));
             state.setTypedKeyValueHeap(heap);
         }
-
+        else {
+            checkCondition(n == heap.getCapacity(), INVALID_FUNCTION_ARGUMENT, "Count argument is not constant: found multiple values [%s, %s]", n, heap.getCapacity());
+        }
         long startSize = heap.getEstimatedSize();
         if (!key.isNull(blockIndex)) {
             heap.add(key, value, blockIndex);
@@ -121,6 +123,9 @@ public abstract class AbstractMinMaxByNAggregationFunction
             state.setTypedKeyValueHeap(otherHeap);
             return;
         }
+
+        checkCondition(otherHeap.getCapacity() == heap.getCapacity(), INVALID_FUNCTION_ARGUMENT, "Count argument is not constant: found multiple values [%s, %s]: %s", otherHeap.getCapacity(), heap.getCapacity());
+
         long startSize = heap.getEstimatedSize();
         heap.addAll(otherHeap);
         state.addMemoryUsage(heap.getEstimatedSize() - startSize);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/minmaxby/TestMinMaxByNAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/minmaxby/TestMinMaxByNAggregation.java
@@ -293,6 +293,13 @@ public class TestMinMaxByNAggregation
         }
     }
 
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Count argument is not constant: found multiple values \\[3, 2]")
+    public void testInconsistentN()
+    {
+        JavaAggregationFunctionImplementation function = getMaxByAggregation(BIGINT, BIGINT, BIGINT);
+        groupedAggregation(function, new Page(createDoublesBlock(new Double[] {3.0, 2.0, 1.0}), createDoublesBlock(new Double[] {1.0, 2.0, 3.0}), createLongsBlock(new Long[] {2L, 2L, 3L})));
+    }
+
     private JavaAggregationFunctionImplementation getMaxByAggregation(Type... arguments)
     {
         return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(


### PR DESCRIPTION
## Description
Fixes issue #20920 to check for uniqueness/consistency of N for maxbyN/minbyN aggregate functions.

## Motivation and Context
Currently the uniqueness/consistency of param N of minbyN/maxbyN is not checked.

## Impact
The test case in issue #20920 now fails as expected:
```sql 
presto> SELECT max_by(c0, c1, c2)
     ->       FROM (
     ->         VALUES
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '0', BIGINT '10', BIGINT '2'),
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '1', BIGINT '9', BIGINT '3'),
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '2', BIGINT '8', BIGINT '2'),
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '3', BIGINT '7', BIGINT '2'),
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '4', BIGINT '6', BIGINT '2'),
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '5', BIGINT '5', BIGINT '2'),
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '6', BIGINT '4', BIGINT '2'),
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '7', BIGINT '3', BIGINT '2'),
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '8', BIGINT '2', BIGINT '2'),
     ->           (cast(NULL as BIGINT), cast(NULL as BIGINT), cast(NULL as BIGINT)),
     ->           (BIGINT '9', BIGINT '1', BIGINT '2')
     ->       ) AS tmp (c0, c1, c2);

Query 20231103_190942_00004_r6sfw, FAILED, 1 node
Splits: 1 total, 0 done (0.00%)
[Latency: client-side: 97ms, server-side: 68ms] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20231103_190942_00004_r6sfw failed: Count argument is not constant: found multiple values [3, 2]
```

## Test Plan
Added UT ```testInconsistentN()``` inside ```/presto-main/src/test/java/com/facebook/presto/operator/aggregation/minmaxby/TestMinMaxByNAggregation.java```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* minbyN/maxbyN's third argument (N) is now checked to be unique.
```

