### PR TITLE
[native pos] Trigger coredump when native process becomes unresponsive

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -67,6 +67,7 @@ public class PrestoSparkConfig
     private boolean adaptiveQueryExecutionEnabled;
     private boolean adaptiveJoinSideSwitchingEnabled;
     private String nativeExecutionBroadcastBasePath;
+    private boolean nativeTriggerCoredumpWhenUnresponsiveEnabled;
 
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
@@ -489,6 +490,19 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setNativeExecutionBroadcastBasePath(String nativeExecutionBroadcastBasePath)
     {
         this.nativeExecutionBroadcastBasePath = nativeExecutionBroadcastBasePath;
+        return this;
+    }
+
+    public boolean isNativeTriggerCoredumpWhenUnresponsiveEnabled()
+    {
+        return nativeTriggerCoredumpWhenUnresponsiveEnabled;
+    }
+
+    @Config("native-trigger-coredump-when-unresponsive-enabled")
+    @ConfigDescription("Trigger coredump of the native execution process when it becomes unresponsive")
+    public PrestoSparkConfig setNativeTriggerCoredumpWhenUnresponsiveEnabled(boolean nativeTriggerCoredumpWhenUnresponsiveEnabled)
+    {
+        this.nativeTriggerCoredumpWhenUnresponsiveEnabled = nativeTriggerCoredumpWhenUnresponsiveEnabled;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -66,6 +66,7 @@ public class PrestoSparkSessionProperties
     public static final String SPARK_ADAPTIVE_QUERY_EXECUTION_ENABLED = "spark_adaptive_query_execution_enabled";
     public static final String ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED = "adaptive_join_side_switching_enabled";
     public static final String NATIVE_EXECUTION_BROADCAST_BASE_PATH = "native_execution_broadcast_base_path";
+    public static final String NATIVE_TRIGGER_COREDUMP_WHEN_UNRESPONSIVE_ENABLED = "native_trigger_coredump_when_unresponsive_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -235,6 +236,11 @@ public class PrestoSparkSessionProperties
                         NATIVE_EXECUTION_BROADCAST_BASE_PATH,
                         "Base path for temporary storage of broadcast data",
                         prestoSparkConfig.getNativeExecutionBroadcastBasePath(),
+                        false),
+                booleanProperty(
+                        NATIVE_TRIGGER_COREDUMP_WHEN_UNRESPONSIVE_ENABLED,
+                        "Trigger coredump of the native execution process when it becomes unresponsive",
+                        prestoSparkConfig.isNativeTriggerCoredumpWhenUnresponsiveEnabled(),
                         false));
     }
 
@@ -391,5 +397,10 @@ public class PrestoSparkSessionProperties
     public static String getNativeExecutionBroadcastBasePath(Session session)
     {
         return session.getSystemProperty(NATIVE_EXECUTION_BROADCAST_BASE_PATH, String.class);
+    }
+
+    public static boolean isNativeTriggerCoredumpWhenUnresponsiveEnabled(Session session)
+    {
+        return session.getSystemProperty(NATIVE_TRIGGER_COREDUMP_WHEN_UNRESPONSIVE_ENABLED, Boolean.class);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
@@ -190,7 +190,7 @@ public class PrestoSparkHttpTaskClient
         });
     }
 
-    public ListenableFuture<BaseResponse<TaskInfo>> updateTask(
+    public BaseResponse<TaskInfo> updateTask(
             List<TaskSource> sources,
             PlanFragment planFragment,
             TableWriteInfo tableWriteInfo,
@@ -213,7 +213,7 @@ public class PrestoSparkHttpTaskClient
         URI batchTaskUri = uriBuilderFrom(taskUri)
                 .appendPath("batch")
                 .build();
-        return httpClient.executeAsync(
+        return httpClient.execute(
                 setContentTypeHeaders(false, preparePost())
                         .setUri(batchTaskUri)
                         .setBodyGenerator(createStaticBodyGenerator(taskUpdateRequestCodec.toBytes(batchTaskUpdateRequest)))

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -172,7 +172,7 @@ public class NativeExecutionProcess
                 process.waitFor(1, TimeUnit.SECONDS);
             }
             catch (InterruptedException e) {
-                e.printStackTrace();
+                Thread.currentThread().interrupt();
             }
             finally {
                 if (process.isAlive()) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -213,6 +213,8 @@ public class NativeExecutionProcess
     public void close()
     {
         if (process != null && process.isAlive()) {
+            long pid = getPid(process);
+            log.info("Destroying process: %s", pid);
             process.destroy();
             try {
                 // This 1 sec is arbitrary. Ideally, we do not need to be give any heads up
@@ -227,12 +229,15 @@ public class NativeExecutionProcess
             }
             finally {
                 if (process.isAlive()) {
-                    log.warn("Graceful shutdown of native execution process failed. Force killing it.");
+                    log.warn("Graceful shutdown of native execution process failed. Force killing it: %s", pid);
                     process.destroyForcibly();
                 }
             }
         }
-        process = null;
+        else if (process != null) {
+            log.info("Process is dead: %s", getPid(process));
+            process = null;
+        }
     }
 
     public boolean isAlive()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -81,7 +81,7 @@ public class NativeExecutionProcess
     private final HttpClient httpClient;
     private final WorkerProperty<?, ?, ?, ?> workerProperty;
 
-    private Process process;
+    private volatile Process process;
 
     public NativeExecutionProcess(
             Session session,
@@ -198,6 +198,7 @@ public class NativeExecutionProcess
     {
         return location;
     }
+
     private static URI getBaseUriWithPort(URI baseUri, int port)
     {
         return uriBuilderFrom(baseUri)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
@@ -22,26 +22,29 @@ import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.server.RequestErrorTracker;
 import com.facebook.presto.server.smile.BaseResponse;
 import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
 import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTaskInfoFetcher;
 import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTaskResultFetcher;
+import com.facebook.presto.spi.PrestoTransportException;
 import com.facebook.presto.spi.page.SerializedPage;
 import com.facebook.presto.spi.security.TokenAuthenticator;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.execution.TaskState.ABORTED;
 import static com.facebook.presto.execution.TaskState.CANCELED;
 import static com.facebook.presto.execution.TaskState.FAILED;
 import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
+import static com.facebook.presto.spi.StandardErrorCode.NATIVE_EXECUTION_TASK_ERROR;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -69,6 +72,9 @@ public class NativeExecutionTask
     private final Optional<String> broadcastBasePath;
     private final List<TaskSource> sources;
     private final Executor executor;
+
+    private final ScheduledExecutorService errorRetryScheduledExecutor;
+    private final Duration remoteTaskMaxErrorDuration;
     private final HttpNativeExecutionTaskInfoFetcher taskInfoFetcher;
     // Results will be fetched only if not written to shuffle.
     private final Optional<HttpNativeExecutionTaskResultFetcher> taskResultFetcher;
@@ -96,18 +102,20 @@ public class NativeExecutionTask
         this.broadcastBasePath = requireNonNull(broadcastBasePath, "broadcastBasePath is null");
         this.sources = requireNonNull(sources, "sources is null");
         this.executor = requireNonNull(executor, "executor is null");
+        this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
         this.workerClient = requireNonNull(workerClient, "workerClient is null");
         this.outputBuffers = createInitialEmptyOutputBuffers(planFragment.getPartitioningScheme().getPartitioning().getHandle()).withNoMoreBufferIds();
         requireNonNull(taskManagerConfig, "taskManagerConfig is null");
         requireNonNull(updateScheduledExecutor, "updateScheduledExecutor is null");
         requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
+        this.remoteTaskMaxErrorDuration = queryManagerConfig.getRemoteTaskMaxErrorDuration();
         this.taskInfoFetcher = new HttpNativeExecutionTaskInfoFetcher(
                 updateScheduledExecutor,
                 errorRetryScheduledExecutor,
                 this.workerClient,
                 this.executor,
                 taskManagerConfig.getInfoUpdateInterval(),
-                queryManagerConfig.getRemoteTaskMaxErrorDuration(),
+                remoteTaskMaxErrorDuration,
                 taskFinishedOrHasResult);
         if (!shuffleWriteInfo.isPresent()) {
             this.taskResultFetcher = Optional.of(new HttpNativeExecutionTaskResultFetcher(
@@ -115,7 +123,7 @@ public class NativeExecutionTask
                     errorRetryScheduledExecutor,
                     this.workerClient,
                     this.executor,
-                    queryManagerConfig.getRemoteTaskMaxErrorDuration(),
+                    remoteTaskMaxErrorDuration,
                     taskFinishedOrHasResult));
         }
         else {
@@ -196,28 +204,51 @@ public class NativeExecutionTask
 
     private TaskInfo sendUpdateRequest()
     {
-        try {
-            ListenableFuture<BaseResponse<TaskInfo>> future = workerClient.updateTask(
-                    sources,
-                    planFragment,
-                    tableWriteInfo,
-                    shuffleWriteInfo,
-                    broadcastBasePath,
-                    session,
-                    outputBuffers);
-            BaseResponse<TaskInfo> response = future.get();
-            if (response.hasValue()) {
-                return response.getValue();
+        RequestErrorTracker errorTracker = new RequestErrorTracker(
+                "NativeExecution",
+                workerClient.getLocation(),
+                NATIVE_EXECUTION_TASK_ERROR,
+                "sendUpdateRequest encountered too many errors talking to native process",
+                remoteTaskMaxErrorDuration,
+                errorRetryScheduledExecutor,
+                "sending update request to native process");
+
+        while (true) {
+            getFutureValue(errorTracker.acquireRequestPermit());
+            try {
+                errorTracker.startRequest();
+                BaseResponse<TaskInfo> response = doSendUpdateRequest();
+                errorTracker.requestSucceeded();
+                if (response.hasValue()) {
+                    return response.getValue();
+                }
+                else {
+                    String message = String.format("Create-or-update task request didn't return a result. %s: %s",
+                            HttpStatus.fromStatusCode(response.getStatusCode()),
+                            response.getStatusMessage());
+                    throw new IllegalStateException(message);
+                }
             }
-            else {
-                String message = String.format("Create-or-update task request didn't return a result. %s: %s",
-                        HttpStatus.fromStatusCode(response.getStatusCode()),
-                        response.getStatusMessage());
-                throw new IllegalStateException(message);
+            catch (RuntimeException e) {
+                errorTracker.requestFailed(e);
             }
         }
-        catch (InterruptedException | ExecutionException e) {
-            throw new RuntimeException(e);
-        }
+    }
+
+    private BaseResponse<TaskInfo> doSendUpdateRequest()
+    {
+        return workerClient.updateTask(
+                sources,
+                planFragment,
+                tableWriteInfo,
+                shuffleWriteInfo,
+                broadcastBasePath,
+                session,
+                outputBuffers);
+    }
+
+    public static boolean isNativeExecutionTaskError(RuntimeException ex)
+    {
+        return ex instanceof PrestoTransportException;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -94,7 +94,9 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.operator.ExchangeOperator.REMOTE_CONNECTOR_ID;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getNativeExecutionBroadcastBasePath;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.isNativeTriggerCoredumpWhenUnresponsiveEnabled;
 import static com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcessFactory.DEFAULT_URI;
+import static com.facebook.presto.spark.execution.task.NativeExecutionTask.isNativeExecutionTaskError;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.deserializeZstdCompressed;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.serializeZstdCompressed;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toPrestoSparkSerializedPage;
@@ -294,25 +296,43 @@ public class PrestoSparkNativeTaskExecutorFactory
         Optional<String> broadcastDirectory =
                 isFixedBroadcastDistribution ? Optional.of(getBroadcastDirectoryPath(session)) : Optional.empty();
 
-        // 3. Submit the task to cpp process for execution
-        log.info("Submitting native execution task ");
-        NativeExecutionTask task = nativeExecutionTaskFactory.createNativeExecutionTask(
-                session,
-                nativeExecutionProcess.getLocation(),
-                taskId,
-                fragment,
-                ImmutableList.copyOf(taskSources),
-                taskDescriptor.getTableWriteInfo(),
-                serializedShuffleWriteInfo,
-                broadcastDirectory);
+        boolean triggerCoredumpWhenUnresponsive = isNativeTriggerCoredumpWhenUnresponsiveEnabled(session);
+        try {
+            // 3. Submit the task to cpp process for execution
+            log.info("Submitting native execution task ");
+            NativeExecutionTask task = nativeExecutionTaskFactory.createNativeExecutionTask(
+                    session,
+                    nativeExecutionProcess.getLocation(),
+                    taskId,
+                    fragment,
+                    ImmutableList.copyOf(taskSources),
+                    taskDescriptor.getTableWriteInfo(),
+                    serializedShuffleWriteInfo,
+                    broadcastDirectory);
 
-        log.info("Creating task and will wait for remote task completion");
-        TaskInfo taskInfo = task.start();
+            log.info("Creating task and will wait for remote task completion");
+            TaskInfo taskInfo = task.start();
 
-        // task creation might have failed
-        processTaskInfoForErrorsOrCompletion(taskInfo);
-        // 4. return output to spark RDD layer
-        return new PrestoSparkNativeTaskOutputIterator<>(partitionId, task, outputType, taskInfoCollector, taskInfoCodec, executionExceptionFactory, cpuTracker);
+            // task creation might have failed
+            processTaskInfoForErrorsOrCompletion(taskInfo);
+            // 4. return output to spark RDD layer
+            return new PrestoSparkNativeTaskOutputIterator<>(
+                    partitionId,
+                    task,
+                    outputType,
+                    taskInfoCollector,
+                    taskInfoCodec,
+                    executionExceptionFactory,
+                    cpuTracker,
+                    nativeExecutionProcess,
+                    triggerCoredumpWhenUnresponsive);
+        }
+        catch (RuntimeException e) {
+            if (triggerCoredumpWhenUnresponsive && isNativeExecutionTaskError(e)) {
+                nativeExecutionProcess.sendCoreSignal();
+            }
+            throw e;
+        }
     }
 
     private String getBroadcastDirectoryPath(Session session)
@@ -494,7 +514,9 @@ public class PrestoSparkNativeTaskExecutorFactory
         private final Codec<TaskInfo> taskInfoCodec;
         private final Class<T> outputType;
         private final PrestoSparkExecutionExceptionFactory executionExceptionFactory;
-        private CpuTracker cpuTracker;
+        private final CpuTracker cpuTracker;
+        private final NativeExecutionProcess nativeExecutionProcess;
+        private final boolean triggerCoredumpWhenUnresponsive;
 
         public PrestoSparkNativeTaskOutputIterator(
                 int partitionId,
@@ -503,7 +525,9 @@ public class PrestoSparkNativeTaskExecutorFactory
                 CollectionAccumulator<SerializedTaskInfo> taskInfoCollectionAccumulator,
                 Codec<TaskInfo> taskInfoCodec,
                 PrestoSparkExecutionExceptionFactory executionExceptionFactory,
-                CpuTracker cpuTracker)
+                CpuTracker cpuTracker,
+                NativeExecutionProcess nativeExecutionProcess,
+                boolean triggerCoredumpWhenUnresponsive)
         {
             this.partitionId = partitionId;
             this.nativeExecutionTask = nativeExecutionTask;
@@ -512,6 +536,8 @@ public class PrestoSparkNativeTaskExecutorFactory
             this.outputType = outputType;
             this.executionExceptionFactory = executionExceptionFactory;
             this.cpuTracker = cpuTracker;
+            this.nativeExecutionProcess = requireNonNull(nativeExecutionProcess, "nativeExecutionProcess is null");
+            this.triggerCoredumpWhenUnresponsive = triggerCoredumpWhenUnresponsive;
         }
 
         /**
@@ -588,6 +614,9 @@ public class PrestoSparkNativeTaskExecutorFactory
                 processTaskInfoForErrorsOrCompletion(taskInfo.get());
             }
             catch (RuntimeException ex) {
+                if (triggerCoredumpWhenUnresponsive && isNativeExecutionTaskError(ex)) {
+                    nativeExecutionProcess.sendCoreSignal();
+                }
                 // For a failed task, if taskInfo is present we still want to log the metrics
                 completeTask(false, taskInfoCollectionAccumulator, nativeExecutionTask, taskInfoCodec, cpuTracker);
                 throw executionExceptionFactory.toPrestoSparkExecutionException(ex);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -593,7 +593,7 @@ public class PrestoSparkNativeTaskExecutorFactory
                 throw executionExceptionFactory.toPrestoSparkExecutionException(ex);
             }
             catch (InterruptedException e) {
-                log.error(e);
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -63,7 +63,8 @@ public class TestPrestoSparkConfig
                 .setAdaptiveJoinSideSwitchingEnabled(false)
                 .setExecutorAllocationStrategyEnabled(false)
                 .setHashPartitionCountAllocationStrategyEnabled(false)
-                .setNativeExecutionBroadcastBasePath(null));
+                .setNativeExecutionBroadcastBasePath(null)
+                .setNativeTriggerCoredumpWhenUnresponsiveEnabled(false));
     }
 
     @Test
@@ -102,6 +103,7 @@ public class TestPrestoSparkConfig
                 .put("spark.executor-allocation-strategy-enabled", "true")
                 .put("spark.hash-partition-count-allocation-strategy-enabled", "true")
                 .put("native-execution-broadcast-base-path", "/tmp/broadcast_path")
+                .put("native-trigger-coredump-when-unresponsive-enabled", "true")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -135,7 +137,8 @@ public class TestPrestoSparkConfig
                 .setAdaptiveJoinSideSwitchingEnabled(true)
                 .setHashPartitionCountAllocationStrategyEnabled(true)
                 .setExecutorAllocationStrategyEnabled(true)
-                .setNativeExecutionBroadcastBasePath("/tmp/broadcast_path");
+                .setNativeExecutionBroadcastBasePath("/tmp/broadcast_path")
+                .setNativeTriggerCoredumpWhenUnresponsiveEnabled(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -234,7 +234,7 @@ public class TestPrestoSparkHttpClient
         PrestoSparkHttpTaskClient workerClient = createWorkerClient(taskId);
 
         List<TaskSource> sources = new ArrayList<>();
-        ListenableFuture<BaseResponse<TaskInfo>> future = workerClient.updateTask(
+        BaseResponse<TaskInfo> response = workerClient.updateTask(
                 sources,
                 createPlanFragment(),
                 new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
@@ -244,7 +244,7 @@ public class TestPrestoSparkHttpClient
                 createInitialEmptyOutputBuffers(PARTITIONED));
 
         try {
-            TaskInfo taskInfo = future.get().getValue();
+            TaskInfo taskInfo = response.getValue();
             assertEquals(taskInfo.getTaskId().toString(), taskId.toString());
         }
         catch (Exception e) {


### PR DESCRIPTION
## Description

Capture native process state with coredump when the process becomes unresponsive

## Motivation and Context

Being able to inspect process state when diagnosing various "something stuck" issues simplifies the task

## Impact

The feature is disabled by default

## Test Plan

- Manually trigger failures in `TaskManager.cpp` to emulate tasks going unresponsive
- Observe core dump being generated

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [] CI passed.


```
== NO RELEASE NOTE ==
```

