### PR TITLE
Skip history optimizer query registration if previous registration timeout

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsCalculator.java
@@ -142,7 +142,7 @@ public class HistoryBasedPlanStatisticsCalculator
 
     private PlanNodeStatsEstimate getStatistics(PlanNode planNode, Session session, Lookup lookup, PlanNodeStatsEstimate delegateStats)
     {
-        if (!useHistoryBasedPlanStatisticsEnabled(session) || historyBasedStatisticsCacheManager.loadHistoryFailed(session.getQueryId())) {
+        if (!useHistoryBasedPlanStatisticsEnabled(session)) {
             return delegateStats;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedStatisticsCacheManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedStatisticsCacheManager.java
@@ -46,6 +46,9 @@ public class HistoryBasedStatisticsCacheManager
 
     private final Map<QueryId, Map<CachingPlanCanonicalInfoProvider.InputTableCacheKey, PlanStatistics>> inputTableStatistics = new ConcurrentHashMap<>();
 
+    // Stores query IDs which timeout during history optimizer registration
+    private final Set<QueryId> queryIdsRegistrationTimeOut = ConcurrentHashMap.newKeySet();
+
     public HistoryBasedStatisticsCacheManager() {}
 
     public LoadingCache<PlanNodeWithHash, HistoricalPlanStatistics> getStatisticsCache(QueryId queryId, Supplier<HistoryBasedPlanStatisticsProvider> historyBasedPlanStatisticsProvider, long timeoutInMilliSeconds)
@@ -87,11 +90,22 @@ public class HistoryBasedStatisticsCacheManager
         statisticsCache.remove(queryId);
         canonicalInfoCache.remove(queryId);
         inputTableStatistics.remove(queryId);
+        queryIdsRegistrationTimeOut.remove(queryId);
     }
 
     @VisibleForTesting
     public Map<QueryId, Map<CachingPlanCanonicalInfoProvider.CacheKey, PlanNodeCanonicalInfo>> getCanonicalInfoCache()
     {
         return canonicalInfoCache;
+    }
+
+    public boolean historyBasedQueryRegistrationTimeout(QueryId queryId)
+    {
+        return queryIdsRegistrationTimeOut.contains(queryId);
+    }
+
+    public void setHistoryBasedQueryRegistrationTimeout(QueryId queryId)
+    {
+        queryIdsRegistrationTimeOut.add(queryId);
     }
 }


### PR DESCRIPTION
## Description
Part of https://github.com/prestodb/presto/issues/20355

In current code, HBO optimizer runs twice. If in the first run, the query registration timeout, it's very likely that the second run will timeout too. Instead of run both and timeout twice, in this PR, I add code to record the timeout of the first run, so that the  second run will skip if the first run timeout.

## Motivation and Context
Reduce latency for HBO.

## Impact
HBO latency for queries which timeout during HBO query registration will be half as of now. For example, if timeout limit is 10 seconds, and the total latency caused by HBO optimizer which timeout will be 2*10 = 20 seconds. After this change, it will be 10 seconds.

## Test Plan
Test locally end to end, optimizer latency decreased from 25.44s to 10.2s

<br class="Apple-interchange-newline">

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve history optimizer latency for queries which timeout during query registration in history optimizer
```


