### PR TITLE
[native] Add native-execution-enabled in NativeQueryRunnerUtils.getNativeWorkerSystemProperties

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -33,6 +33,7 @@ public class NativeQueryRunnerUtils
     public static Map<String, String> getNativeWorkerSystemProperties()
     {
         return ImmutableMap.<String, String>builder()
+                .put("native-execution-enabled", "true")
                 .put("optimizer.optimize-hash-generation", "false")
                 .put("parse-decimal-literals-as-double", "true")
                 .put("regex-library", "RE2J")

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -158,7 +158,6 @@ public class PrestoNativeQueryRunnerUtils
                 ImmutableMap.<String, String>builder()
                         .put("http-server.http.port", "8080")
                         .put("experimental.internal-communication.thrift-transport-enabled", String.valueOf(useThrift))
-                        .put("native-execution-enabled", "true")
                         .putAll(getNativeWorkerSystemProperties())
                         .build(),
                 ImmutableMap.of(),

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -81,7 +81,6 @@ public class PrestoSparkNativeQueryRunnerUtils
                 // Do not use default Prestissimo config files. Presto-Spark will generate the configs on-the-fly.
                 .put("catalog.config-dir", "/")
                 .put("task.info-update-interval", "100ms")
-                .put("native-execution-enabled", "true")
                 .put("spark.initial-partition-count", "1")
                 .put("register-test-functions", "true")
                 .put("native-execution-program-arguments", "--logtostderr=1 --minloglevel=3")


### PR DESCRIPTION
native-execution-enabled is being used at the co-ordinator for custom logic for native workers. While this was originally done for POS native, its impact has now extended to Prestissimo as well

[ref] (https://github.com/prestodb/presto/commit/18e047bd95409470963c0d82a49eeef55a93c8cd)

NativeQueryRunnerUtils.getNativeWorkerSystemProperties is an authoritative set of native worker system config that are used by several parties when setting up their clusters.

This property was set in the calling QueryRunner invocations instead leading to some confusion.

## Test Plan
This is a test infrastructure change. Covered by e2e tests


```
== NO RELEASE NOTE ==
```

