### PR TITLE
[native]Change spiller executor to cpu executor

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -38,12 +38,12 @@ std::shared_ptr<folly::CPUThreadPoolExecutor>& httpProcessingExecutor() {
   return executor;
 }
 
-std::shared_ptr<folly::IOThreadPoolExecutor> spillExecutor() {
+std::shared_ptr<folly::CPUThreadPoolExecutor> spillExecutor() {
   const int32_t numSpillThreads = SystemConfig::instance()->numSpillThreads();
   if (numSpillThreads <= 0) {
     return nullptr;
   }
-  static auto executor = std::make_shared<folly::IOThreadPoolExecutor>(
+  static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
       numSpillThreads, std::make_shared<folly::NamedThreadFactory>("Spiller"));
   return executor;
 }
@@ -57,7 +57,7 @@ folly::CPUThreadPoolExecutor* httpProcessingExecutorPtr() {
   return httpProcessingExecutor().get();
 }
 
-folly::IOThreadPoolExecutor* spillExecutorPtr() {
+folly::CPUThreadPoolExecutor* spillExecutorPtr() {
   return spillExecutor().get();
 }
 

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.h
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.h
@@ -26,7 +26,7 @@ namespace facebook::presto {
 
 folly::CPUThreadPoolExecutor* driverCPUExecutor();
 folly::CPUThreadPoolExecutor* httpProcessingExecutorPtr();
-folly::IOThreadPoolExecutor* spillExecutorPtr();
+folly::CPUThreadPoolExecutor* spillExecutorPtr();
 
 class QueryContextCache {
  public:


### PR DESCRIPTION
Spilling is high priority operator so switch to use cpu executor instead of io.
```
== NO RELEASE NOTE ==
```

