### PR TITLE
Ignore the newly added test in presto_on_spark native execution to unblock e2e tests

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -48,6 +48,7 @@ public class TestPrestoSparkNativeGeneralQueries
     public void testShowAndDescribe() {}
 
     @Override
+    @Ignore
     public void testSystemTables() {}
 
     // @TODO Refer https://github.com/prestodb/presto/issues/20294


### PR DESCRIPTION
Summary: As title

Reviewed By: mshang816

Differential Revision: D51001609


