### PR TITLE
[native] add a test case for text reader

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -192,7 +192,7 @@
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
-                    <excludedGroups>remote-function</excludedGroups>
+                    <excludedGroups>remote-function,textfile_reader</excludedGroups>
                     <systemPropertyVariables>
                         <PRESTO_SERVER>/root/project/build/debug/presto_cpp/main/presto_server</PRESTO_SERVER>
                         <DATA_DIR>/tmp/velox</DATA_DIR>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -992,13 +992,23 @@ public abstract class AbstractTestNativeGeneralQueries
         return tableName;
     }
 
-    @Test
-    public void testReadTableWithUnsupportedFormats()
+    @Test(groups = {"no_json_reader"})
+    public void testReadTableWithUnsupportedJsonFormat()
     {
         assertQueryFails("SELECT * FROM nation_json", ".*ReaderFactory is not registered for format json.*");
+    }
+
+    @Test(groups = {"no_textfile_reader"})
+    public void testReadTableWithUnsupportedTextfileFormat()
+    {
         assertQueryFails("SELECT * FROM nation_text", ".*ReaderFactory is not registered for format text.*");
     }
 
+    @Test(groups = {"textfile_reader"})
+    public void testReadTableWithTextfileFormat()
+    {
+        assertQuery("SELECT * FROM nation_text");
+    }
     private void dropTableIfExists(String tableName)
     {
         // An ugly workaround for the lack of getExpectedQueryRunner()


### PR DESCRIPTION
## Description
* add a test case for text reader and exclude it in all-non-parquet-tests profile
* add tests case for non-json/text reads to their own group
To make it easier to run the tests when text reader is enabled.

## Impact
N/A

## Test Plan
Make sure all CI runs are green

```
== NO RELEASE NOTE ==
```

