### PR TITLE
SQL statements support simple literal, as well as Unicode usage

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -102,7 +102,20 @@ String
 
     Variable length character data with an optional maximum length.
 
-    Example type definitions: ``varchar``, ``varchar(20)``
+    Example type definitions: ``varchar``, ``varchar(20)``.
+
+    SQL supports simple and Unicode string literals:
+     - Literal string : ``'Hello winter !'``
+     - Unicode string with default escape character: ``U&'Hello winter \2603 !'``
+     - Unicode string with custom escape character: ``U&'Hello winter #2603 !' UESCAPE '#'``
+
+    A Unicode string is prefixed with ``U&`` and requires an escape character
+    before any Unicode character usage with 4 digits. In these examples
+    ``\2603`` and ``#2603`` represent a snowman character. Long Unicode codes
+    with 6 digits require a plus symbol ``+`` before the code. For example,
+    use ``\+01F600`` for a grinning face emoji.
+
+    Single quotes in string literals can be escaped by using another single quote: ``'It''s a beautiful day!'``
 
 ``CHAR``
 ^^^^^^^^


### PR DESCRIPTION
Description
This PR adds examples and documentation for using simple literal and Unicode strings in SQL statements, including how to escape single quotes in string literals.

Motivation and Context
The motivation behind this change is to provide clearer instructions and examples for users on how to use and escape different types of string literals in SQL statements.

Impact
This change will not affect the public API or any user-facing features. There will be no performance impact.

Test Plan
To test these changes, we can create SQL statements using both simple literal and Unicode strings, and check that they are processed correctly. We should also test the escaping of single quotes in string literals to ensure this works as expected.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
General Changes
* Added documentation and examples for using simple literal and Unicode strings in SQL statements, including how to escape single quotes in string literals.
```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

