### PR TITLE
Allow Type in agg function metadata constructors

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
@@ -85,7 +85,7 @@ public class ParametricAggregation
         // Build state factory and serializer
         Class<?> stateClass = concreteImplementation.getStateClass();
         AccumulatorStateSerializer<?> stateSerializer = getAccumulatorStateSerializer(concreteImplementation, variables, functionAndTypeManager, stateClass, classLoader);
-        AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(stateClass, classLoader);
+        AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(stateClass, variables.getTypeVariables(), classLoader);
 
         // Bind provided dependencies to aggregation method handlers
         MethodHandle inputHandle = bindDependencies(concreteImplementation.getInputFunction(), concreteImplementation.getInputDependencies(), variables, functionAndTypeManager);
@@ -188,7 +188,7 @@ public class ParametricAggregation
             }
         }
         else {
-            stateSerializer = generateStateSerializer(stateClass, classLoader);
+            stateSerializer = generateStateSerializer(stateClass, variables.getTypeVariables(), classLoader);
         }
         return stateSerializer;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/aggregation/AggregationMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/aggregation/AggregationMetadata.java
@@ -202,7 +202,7 @@ public class AggregationMetadata
             return;
         }
         Class<?>[] parameterTypes = method.type().parameterArray();
-        checkArgument(parameterTypes.length == stateDescriptors.size() + 1, "Number of arguments for combine function must be exactly one plus than number of states.");
+        checkArgument(parameterTypes.length == stateDescriptors.size() + 1, "Number of arguments for output function must be exactly one plus than number of states.");
         for (int i = 0; i < stateDescriptors.size(); i++) {
             checkArgument(parameterTypes[i].equals(stateDescriptors.get(i).getStateInterface()), format("Type for Parameter index %d is unexpected", i));
         }


### PR DESCRIPTION
## Description

This change introduces the ability to allow the AccumulatorStateMetadata classes, AccumulatorStateSerializer and AccumulatorStateFactory, to add `Type` parameters to their constructor with proper @TypeParameter annotations. This should allow most new parametric aggregation functions to be implemented using annotations rather than manually extending SqlAggregationFunction

## Motivation and Context

One of the main downsides to the previous implementation is that parametric aggregations with defined type parameters couldn't be easily specialized as their serialization and deserialization functions usually relied upon knowing the type parameters. Thus, many of the parametric aggregation functions presto codebase  don't use the @AggregationFunction and associated  annotations which makes the code more complex and hard to maintain.

## Impact

N/A

## Test Plan

A few additional unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

