### PR TITLE
Fix Typo in High Memory Task Manager Config

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -660,7 +660,7 @@ public class TaskManagerConfig
         return highMemoryTaskKillerStrategy;
     }
 
-    @Config("experiemental.task.high-memory-task-killer-strategy")
+    @Config("experimental.task.high-memory-task-killer-strategy")
     public TaskManagerConfig setHighMemoryTaskKillerStrategy(HighMemoryTaskKillerStrategy highMemoryTaskKillerStrategy)
     {
         this.highMemoryTaskKillerStrategy = highMemoryTaskKillerStrategy;

--- a/presto-main/src/main/java/com/facebook/presto/memory/HighMemoryTaskKiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/HighMemoryTaskKiller.java
@@ -181,6 +181,7 @@ public class HighMemoryTaskKiller
                 triggerTaskKiller = true;
             }
         }
+        log.debug("Task Killer Trigger: " + triggerTaskKiller + ", Before Full GC Head Size: " + beforeGcDataSize.toBytes() + " After Full GC Heap Size: " + afterGcDataSize.toBytes());
 
         return triggerTaskKiller;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -121,7 +121,7 @@ public class TestTaskManagerConfig
                 .put("task.interrupt-runaway-splits-timeout", "599s")
                 .put("experimental.task.memory-based-slowdown-threshold", "0.9")
                 .put("experimental.task.high-memory-task-killer-enabled", "true")
-                .put("experiemental.task.high-memory-task-killer-strategy", "FREE_MEMORY_ON_FREQUENT_FULL_GC")
+                .put("experimental.task.high-memory-task-killer-strategy", "FREE_MEMORY_ON_FREQUENT_FULL_GC")
                 .put("experimental.task.high-memory-task-killer-reclaim-memory-threshold", "0.8")
                 .put("experimental.task.high-memory-task-killer-frequent-full-gc-duration-threshold", "2s")
                 .put("experimental.task.high-memory-task-killer-heap-memory-threshold", "0.8")


### PR DESCRIPTION
## Description
Fixing typo in high memory task manager config.

## Motivation and Context
Fixing Typo

## Impact


## Test Plan
unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix typo in high memory task killer strategy config `experiemental.task.high-memory-task-killer-strategy` to `experimental.task.high-memory-task-killer-stragtegy`

