### PR TITLE
Update Joda-Time to 2.12.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dep.drift.version>1.36</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
-        <dep.joda.version>2.12.2</dep.joda.version>
+        <dep.joda.version>2.12.5</dep.joda.version>
         <dep.tempto.version>1.53</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Update Joda-Time from 2.12.2 to 2.12.5. The tzdata version is upgraded from  2022g to 2023c and the changes are:
- Lebanon delays the start of DST in 2023
- Egypt now uses DST again, from April through October
- In 2023, Morocco springs forward April 23, not April 30
- Palestine delays the start of DST in 2023
- Much of Greenland still uses DST from 2024 on
- America/Yellowknife now links to America/Edmonton

There is no new time zone, only new DST rules.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
fix: #21300

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
The update only introduces new DST rules but no new time zone.

## Test Plan
<!---Please fill in how you tested your change-->
Leverage the existing timezone test cases to make sure no regression

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Update Joda-Time to 2.12.5 to use 2023c tzdata.
  Note: a corresponding update to the Java runtime should also be made to ensure consistent timezone data.
  For example, Oracle JDK 8u381, tzdata-java-2023c rpm for OpenJDK, or use Timezone Updater Tool to apply
  2023c tzdata to existing JVM.

