### PR TITLE
[native] Rename TestNativeProbabilityFunctionQueries to TestPresto...

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeProbabilityFunctionQueries.java
@@ -37,7 +37,7 @@ public abstract class AbstractTestNativeProbabilityFunctionQueries
     public void testBinomialCDF()
     {
         assertQuery("SELECT binomial_cdf(CAST (nationkey AS INTEGER), 0.1, 0 ) FROM nation WHERE nationkey > 0");
-        assertQuery("SELECT binomial_cdf(CAST (nationkey AS INTEGER), 0.1, CAST (regionkey AS INTEGER)) FROM nation WHERE nationkey > 0;");
+        assertQuery("SELECT binomial_cdf(CAST (nationkey AS INTEGER), 0.1, CAST (regionkey AS INTEGER)) FROM nation WHERE nationkey > 0");
     }
 
     @Test
@@ -105,9 +105,9 @@ public abstract class AbstractTestNativeProbabilityFunctionQueries
     @Test
     public void testLaplaceCDF()
     {
-        assertQuery("SELECT laplace_cdf(acctbal, 0.0, 1.0) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
+        assertQuery("SELECT laplace_cdf(acctbal, 0.1, 1.0) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
         assertQuery("SELECT laplace_cdf(1.0, acctbal, 1.5) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
-        assertQuery("SELECT laplace_cdf(11.0, -1.0, acctbal) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
+        assertQuery("SELECT laplace_cdf(11.0, 0.1, acctbal) FROM supplier WHERE acctbal > 0.0 AND acctbal < 999.0");
     }
 
     @Test

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeProbabilityFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeProbabilityFunctionQueries.java
@@ -15,7 +15,7 @@ package com.facebook.presto.nativeworker;
 
 import com.facebook.presto.testing.QueryRunner;
 
-public class TestNativeProbabilityFunctionQueries
+public class TestPrestoNativeProbabilityFunctionQueries
         extends AbstractTestNativeProbabilityFunctionQueries
 {
     @Override


### PR DESCRIPTION
## Description
For the test to be picked up by circle ci. 
CircleCI will only pick up TestPrestoNative*.java for testing so TestNativeProbabilityFunctionQueries never got run in CI before. 
Also fix a few failed test cases:
* removing ';' which will fail the query
* enlarge scale to 0.1 which must be greater than 0  

## Test Plan
Existing CI jobs

```
== NO RELEASE NOTE ==
```

