### PR TITLE
Add Iceberg table register and unregister procedures

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -711,6 +711,52 @@ Drop the schema ``iceberg.web``::
 
     DROP SCHEMA iceberg.web
 
+Register table
+^^^^^^^^^^^^
+
+Iceberg tables for which table data and metadata already exist in the
+file system can be registered with the catalog using the ``register_table``
+procedure on the catalog's ``system`` schema by supplying the target schema,
+desired table name, and the location of the table metadata::
+
+    CALL iceberg.system.register_table('schema_name', 'table_name', 'hdfs://localhost:9000/path/to/iceberg/table/metadata/dir')
+
+.. note::
+
+    If multiple metadata files of the same version exist at the specified
+    location, the most recently modified one will be used.
+
+A metadata file can optionally be included as an argument to ``register_table``
+in the case where a specific metadata file contains the targeted table state::
+
+    CALL iceberg.system.register_table('schema_name', 'table_name', 'hdfs://localhost:9000/path/to/iceberg/table/metadata/dir', '00000-35a08aed-f4b0-4010-95d2-9d73ef4be01c.metadata.json')
+
+.. note::
+
+    When registering a table with the Hive metastore, the user calling the
+    procedure will be set as the owner of the table and will have ``SELECT``,
+    ``INSERT``, ``UPDATE``, and ``DELETE`` privileges for that table. These
+    privileges can be altered using the ``GRANT`` and ``REVOKE`` commands.
+
+.. note::
+
+    When using the Hive catalog, attempts to read registered Iceberg tables
+    using the Hive connector will fail.
+
+Unregister table
+^^^^^^^^^^^^
+
+Iceberg tables can be unregistered from the catalog using the ``unregister_table``
+procedure on the catalog's ``system`` schema::
+
+    CALL iceberg.system.unregister_table('schema_name', 'table_name')
+
+.. note::
+
+    Table data and metadata will remain in the filesystem after a call to
+    ``unregister_table`` only when using the Hive catalog. This is similar to
+    the behavior listed above for the ``DROP TABLE`` command.
+
 Schema Evolution
 -----------------
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -571,6 +571,17 @@ public class CachingHiveMetastore
     }
 
     @Override
+    public void dropTableFromMetastore(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        try {
+            delegate.dropTableFromMetastore(metastoreContext, databaseName, tableName);
+        }
+        finally {
+            invalidateTable(databaseName, tableName);
+        }
+    }
+
+    @Override
     public MetastoreOperationResult replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         try {

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -73,6 +73,15 @@ public interface ExtendedHiveMetastore
     void dropTable(MetastoreContext metastoreContext, String databaseName, String tableName, boolean deleteData);
 
     /**
+     * Drop table from the metastore, but preserve the data. If no override
+     * is available, default to dropTable with deleteData set to false.
+     */
+    default void dropTableFromMetastore(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        dropTable(metastoreContext, databaseName, tableName, false);
+    }
+
+    /**
      * This should only be used if the semantic here is drop and add. Trying to
      * alter one field of a table object previously acquired from getTable is
      * probably not what you want.

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -445,6 +445,20 @@ public class FileHiveMetastore
     }
 
     @Override
+    public synchronized void dropTableFromMetastore(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        requireNonNull(databaseName, "databaseName is null");
+        requireNonNull(tableName, "tableName is null");
+
+        Table table = getRequiredTable(metastoreContext, databaseName, tableName);
+
+        Path tableMetadataDirectory = getTableMetadataDirectory(databaseName, tableName);
+
+        deleteSchemaFile("table", tableMetadataDirectory);
+        deleteTablePrivileges(table);
+    }
+
+    @Override
     public synchronized MetastoreOperationResult replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         checkArgument(!newTable.getTableType().equals(TEMPORARY_TABLE), "temporary tables must never be stored in the metastore");

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -88,7 +88,7 @@ public class HiveTableOperations
     public static final String PREVIOUS_METADATA_LOCATION = "previous_metadata_location";
     private static final String METADATA_FOLDER_NAME = "metadata";
 
-    private static final StorageFormat STORAGE_FORMAT = StorageFormat.create(
+    public static final StorageFormat STORAGE_FORMAT = StorageFormat.create(
             LazySimpleSerDe.class.getName(),
             FileInputFormat.class.getName(),
             FileOutputFormat.class.getName());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -62,6 +62,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.airlift.slice.Slice;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFiles;
@@ -169,6 +170,10 @@ public abstract class IcebergAbstractMetadata
     protected abstract Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName);
 
     protected abstract boolean tableExists(ConnectorSession session, SchemaTableName schemaTableName);
+
+    protected abstract void registerTable(ConnectorSession clientSession, SchemaTableName schemaTableName, Path metadataLocation);
+
+    protected abstract void unregisterTable(ConnectorSession clientSession, SchemaTableName schemaTableName);
 
     /**
      * This class implements the default implementation for getTableLayouts which will be used in the case of a Java Worker

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -144,6 +144,8 @@ public class IcebergCommonModule
 
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(RollbackToSnapshotProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(RegisterTableProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(UnregisterTableProcedure.class).in(Scopes.SINGLETON);
 
         // for orc
         binder.bind(EncryptionLibrary.class).annotatedWith(HiveDwrfEncryptionProvider.ForCryptoService.class).to(UnsupportedEncryptionLibrary.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
@@ -219,5 +220,17 @@ public class IcebergNativeMetadata
         TableIdentifier from = toIcebergTableIdentifier(icebergTableHandle.getSchemaTableName());
         TableIdentifier to = toIcebergTableIdentifier(newTable);
         resourceFactory.getCatalog(session).renameTable(from, to);
+    }
+
+    @Override
+    public void registerTable(ConnectorSession clientSession, SchemaTableName schemaTableName, Path metadataLocation)
+    {
+        resourceFactory.getCatalog(clientSession).registerTable(toIcebergTableIdentifier(schemaTableName), metadataLocation.toString());
+    }
+
+    @Override
+    public void unregisterTable(ConnectorSession clientSession, SchemaTableName schemaTableName)
+    {
+        resourceFactory.getCatalog(clientSession).dropTable(toIcebergTableIdentifier(schemaTableName), false);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RegisterTableProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RegisterTableProcedure.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.SchemaNotFoundException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static com.facebook.presto.spi.StandardWarningCode.MULTIPLE_TABLE_METADATA;
+import static java.lang.Integer.parseInt;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.util.LocationUtil.stripTrailingSlash;
+
+public class RegisterTableProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle REGISTER_TABLE = methodHandle(
+            RegisterTableProcedure.class,
+            "registerTable",
+            ConnectorSession.class,
+            String.class,
+            String.class,
+            String.class,
+            String.class);
+    private final IcebergMetadataFactory metadataFactory;
+    private final HdfsEnvironment hdfsEnvironment;
+
+    public static final String METADATA_FOLDER_NAME = "metadata";
+    private static final String METADATA_FILE_EXTENSION = ".metadata.json";
+    private static final Pattern METADATA_VERSION_PATTERN = Pattern.compile("(?<version>\\d+)-(?<uuid>[-a-fA-F0-9]*)(?<compression>\\.[a-zA-Z0-9]+)?" + Pattern.quote(METADATA_FILE_EXTENSION) + "(?<compression2>\\.[a-zA-Z0-9]+)?");
+    private static final Pattern HADOOP_METADATA_VERSION_PATTERN = Pattern.compile("v(?<version>\\d+)(?<compression>\\.[a-zA-Z0-9]+)?" + Pattern.quote(METADATA_FILE_EXTENSION) + "(?<compression2>\\.[a-zA-Z0-9]+)?");
+
+    @Inject
+    public RegisterTableProcedure(
+            IcebergMetadataFactory metadataFactory,
+            HdfsEnvironment hdfsEnvironment)
+    {
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "register_table",
+                ImmutableList.of(
+                        new Procedure.Argument("schema", VARCHAR),
+                        new Procedure.Argument("table", VARCHAR),
+                        new Procedure.Argument("metadataLocation", VARCHAR),
+                        new Procedure.Argument("metadataFile", VARCHAR, false, null)),
+                REGISTER_TABLE.bindTo(this));
+    }
+
+    public void registerTable(ConnectorSession clientSession, String schema, String table, String metadataLocation, String metadataFile)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doRegisterTable(clientSession, schema, table, metadataLocation, Optional.ofNullable(metadataFile));
+        }
+    }
+
+    private void doRegisterTable(ConnectorSession clientSession, String schema, String table, String metadataLocation, Optional<String> metadataFile)
+    {
+        IcebergAbstractMetadata metadata = (IcebergAbstractMetadata) metadataFactory.create();
+        SchemaTableName schemaTableName = new SchemaTableName(schema, table);
+        if (!metadata.schemaExists(clientSession, schemaTableName.getSchemaName())) {
+            throw new SchemaNotFoundException(schemaTableName.getSchemaName());
+        }
+
+        metadataLocation = stripTrailingSlash(metadataLocation);
+        Path metadataDirectory = metadataLocation.endsWith(METADATA_FOLDER_NAME) ?
+                new Path(metadataLocation) : new Path(metadataLocation, METADATA_FOLDER_NAME);
+        Path metadataPath = metadataFile
+                .map(metadataFileName -> new Path(metadataDirectory, metadataFileName))
+                .orElseGet(() -> resolveLatestMetadataLocation(
+                        clientSession,
+                        getFileSystem(clientSession, hdfsEnvironment, schemaTableName, metadataDirectory),
+                        metadataDirectory));
+
+        metadata.registerTable(clientSession, schemaTableName, metadataPath);
+    }
+
+    public static FileSystem getFileSystem(ConnectorSession clientSession, HdfsEnvironment hdfsEnvironment, SchemaTableName schemaTableName, Path location)
+    {
+        HdfsContext hdfsContext = new HdfsContext(
+                clientSession,
+                schemaTableName.getSchemaName(),
+                schemaTableName.getTableName(),
+                location.getName(),
+                true);
+
+        try {
+            return hdfsEnvironment.getFileSystem(hdfsContext, location);
+        }
+        catch (Exception e) {
+            throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, format("Error getting file system at path %s", location), e);
+        }
+    }
+
+    public static Path resolveLatestMetadataLocation(ConnectorSession clientSession, FileSystem fileSystem, Path metadataPath)
+    {
+        int maxVersion = -1;
+        long lastModifiedTime = -1;
+        Path metadataFile = null;
+        boolean duplicateVersions = false;
+
+        try {
+            FileStatus[] files = fileSystem.listStatus(metadataPath, name -> name.getName().contains(METADATA_FILE_EXTENSION));
+            for (FileStatus file : files) {
+                int version = parseMetadataVersionFromFileName(file.getPath().getName());
+                if (version > maxVersion) {
+                    maxVersion = version;
+                    metadataFile = file.getPath();
+                    lastModifiedTime = file.getModificationTime();
+                    duplicateVersions = false;
+                }
+                else if (version == maxVersion) {
+                    duplicateVersions = true;
+
+                    long modifiedTime = file.getModificationTime();
+                    if (modifiedTime > lastModifiedTime) {
+                        lastModifiedTime = modifiedTime;
+                        metadataFile = file.getPath();
+                    }
+                }
+            }
+        }
+        catch (IOException io) {
+            throw new PrestoException(ICEBERG_FILESYSTEM_ERROR, format("Unable to find metadata at location %s", metadataPath), io);
+        }
+
+        if (duplicateVersions) {
+            clientSession.getWarningCollector().add(new PrestoWarning(MULTIPLE_TABLE_METADATA, format("Multiple metadata files of most recent version %d found at location %s. Using most recently modified version", maxVersion, metadataPath)));
+        }
+        if (metadataFile == null) {
+            throw new PrestoException(ICEBERG_INVALID_METADATA, format("No metadata found at location %s", metadataPath));
+        }
+
+        return metadataFile;
+    }
+
+    static int parseMetadataVersionFromFileName(String fileName)
+    {
+        Matcher matcher = METADATA_VERSION_PATTERN.matcher(fileName);
+        if (matcher.matches()) {
+            return parseInt(matcher.group("version"));
+        }
+        matcher = HADOOP_METADATA_VERSION_PATTERN.matcher(fileName);
+        if (matcher.matches()) {
+            return parseInt(matcher.group("version"));
+        }
+        return -1;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/UnregisterTableProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/UnregisterTableProcedure.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaNotFoundException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class UnregisterTableProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle UNREGISTER_TABLE = methodHandle(
+            UnregisterTableProcedure.class,
+            "unregisterTable",
+            ConnectorSession.class,
+            String.class,
+            String.class);
+
+    private final IcebergMetadataFactory metadataFactory;
+
+    @Inject
+    public UnregisterTableProcedure(IcebergMetadataFactory metadataFactory)
+    {
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "unregister_table",
+                ImmutableList.of(
+                        new Procedure.Argument("schema", VARCHAR),
+                        new Procedure.Argument("table", VARCHAR)),
+                UNREGISTER_TABLE.bindTo(this));
+    }
+
+    public void unregisterTable(ConnectorSession clientSession, String schema, String table)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doUnregisterTable(clientSession, schema, table);
+        }
+    }
+
+    private void doUnregisterTable(ConnectorSession clientSession, String schema, String table)
+    {
+        IcebergAbstractMetadata metadata = (IcebergAbstractMetadata) metadataFactory.create();
+        SchemaTableName schemaTableName = new SchemaTableName(schema, table);
+        if (!metadata.schemaExists(clientSession, schemaTableName.getSchemaName())) {
+            throw new SchemaNotFoundException(schemaTableName.getSchemaName());
+        }
+
+        metadata.unregisterTable(clientSession, schemaTableName);
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRegisterProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRegisterProcedure.java
@@ -1,0 +1,515 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.hive.HdfsConfiguration;
+import com.facebook.presto.hive.HdfsConfigurationInitializer;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveColumnConverterProvider;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.fs.FileSystem;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.hive.metastore.CachingHiveMetastore.memoizeMetastore;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.getMetastoreHeaders;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.isUserDefinedTypeEncodingEnabled;
+import static com.facebook.presto.iceberg.RegisterTableProcedure.METADATA_FOLDER_NAME;
+import static com.facebook.presto.iceberg.RegisterTableProcedure.getFileSystem;
+import static com.facebook.presto.iceberg.RegisterTableProcedure.parseMetadataVersionFromFileName;
+import static com.facebook.presto.iceberg.RegisterTableProcedure.resolveLatestMetadataLocation;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static org.apache.iceberg.util.LocationUtil.stripTrailingSlash;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestIcebergRegisterProcedure
+        extends AbstractTestQueryFramework
+{
+    private Session session;
+
+    public static final String ICEBERG_CATALOG = "iceberg";
+    public static final String TEST_DATA_DIRECTORY = "iceberg_data";
+    public static final String TEST_CATALOG_DIRECTORY = "catalog";
+    public static final String TEST_SCHEMA = "register";
+    public static final String TEST_TABLE_NAME = "iceberg_test";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        session = testSessionBuilder()
+            .setCatalog(ICEBERG_CATALOG)
+            .setSchema(TEST_SCHEMA)
+            .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        File metastoreDir = queryRunner.getCoordinator().getDataDirectory().resolve(TEST_DATA_DIRECTORY).resolve(TEST_CATALOG_DIRECTORY).toFile();
+        queryRunner.installPlugin(new IcebergPlugin());
+        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", metastoreDir.toURI().toString())
+                .build();
+
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
+        queryRunner.execute("CREATE SCHEMA " + TEST_SCHEMA);
+
+        return queryRunner;
+    }
+
+    public void dropTable(String tableName)
+    {
+        assertQuerySucceeds("DROP TABLE IF EXISTS iceberg." + TEST_SCHEMA + "." + tableName);
+    }
+
+    @Test
+    public void testRegisterWithMetadataLocation()
+    {
+        String tableName = "metadata_loc";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES(1, 1)", 1);
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        List<String> metadataLocations = Arrays.asList(
+                metadataLocation,  // without trailing slash
+                format("%s/", metadataLocation),  // with training slash
+                format("%s/metadata", metadataLocation),  // with metadata folder specified
+                format("%s/metadata/", metadataLocation));
+
+        for (String validLocation : metadataLocations) {
+            dropTableFromMetastore(TEST_SCHEMA, tableName);
+
+            assertUpdate("CALL system.register_table('" + TEST_SCHEMA + "', '" + tableName + "', '" + validLocation + "')");
+            assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1)");
+        }
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterWithMetadataLocationShowCreate()
+    {
+        String tableName = "show_create";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES(1, 1)", 1);
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        String showCreateTable = (String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue();
+
+        dropTableFromMetastore(TEST_SCHEMA, tableName);
+
+        assertUpdate("CALL system.register_table('" + TEST_SCHEMA + "', '" + tableName + "', '" + metadataLocation + "')");
+        String showCreateTableNew = (String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue();
+
+        assertThat(showCreateTable).isEqualTo(showCreateTableNew);
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterWithMetadataLocationMultipleVersions()
+    {
+        String tableName = "multiple_versions";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        // Create new snapshot
+        assertUpdate("INSERT INTO " + tableName + " VALUES(1, 1)", 1);
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+
+        dropTableFromMetastore(TEST_SCHEMA, tableName);
+
+        assertUpdate("CALL system.register_table('" + TEST_SCHEMA + "', '" + tableName + "', '" + metadataLocation + "')");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1)");
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterWithTableDataAndMetadataNotCoLocated()
+    {
+        String tableName = "original_table";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES(1, 1)", 1);
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        String metadataFileName = getMetadataFileLocation(session.toConnectorSession(), TEST_SCHEMA, tableName, metadataLocation);
+        String newTableName = "new_table";
+
+        assertUpdate("CALL system.register_table('" + TEST_SCHEMA + "', '" + newTableName + "', '" + metadataLocation + "', '" + metadataFileName + "')");
+        assertUpdate("INSERT INTO " + newTableName + " VALUES(2, 2)", 1);
+
+        assertQuery("SELECT * FROM " + newTableName, "VALUES (1, 1), (2, 2)");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1)");
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterWithMetadataLocationDuplicateVersions()
+    {
+        String tableName = "duplicate_versions";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        // Create new snapshots
+        assertUpdate("INSERT INTO " + tableName + " VALUES(1, 1)", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES(2, 2)", 1);
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        String metadataFileName = getMetadataFileLocation(session.toConnectorSession(), TEST_SCHEMA, tableName, metadataLocation);
+
+        // Rename file to spoof same version as previous file
+        File metadataFile = new File(format("%s/%s/%s", metadataLocation, METADATA_FOLDER_NAME, metadataFileName));
+        String newFileName = metadataFileName.replace("2", "1");
+        metadataFile.renameTo(new File(format("%s/%s/%s", metadataLocation, METADATA_FOLDER_NAME, newFileName)));
+
+        dropTableFromMetastore(TEST_SCHEMA, tableName);
+
+        // Ensure most recently modified version is chosen
+        assertUpdate("CALL system.register_table('" + TEST_SCHEMA + "', '" + tableName + "', '" + metadataLocation + "')");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1), (2, 2)");
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterWithMetadataFileName()
+    {
+        String tableName = "metadata_file";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        String metadataFileName = getMetadataFileLocation(session.toConnectorSession(), TEST_SCHEMA, tableName, metadataLocation);
+
+        dropTableFromMetastore(TEST_SCHEMA, tableName);
+
+        assertUpdate("CALL system.register_table('" + TEST_SCHEMA + "', '" + tableName + "', '" + metadataLocation + "', '" + metadataFileName + "')");
+        assertQueryReturnsEmptyResult("SELECT * FROM " + tableName);
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterWithMetadataFileNameMultipleVersions()
+    {
+        String tableName = "multiple_files";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        // Create new snapshot and get metadata filename for this snapshot
+        assertUpdate("INSERT INTO " + tableName + " VALUES(1, 1)", 1);
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        String metadataFileName = getMetadataFileLocation(session.toConnectorSession(), TEST_SCHEMA, tableName, metadataLocation);
+
+        // Create new snapshot
+        assertUpdate("INSERT INTO " + tableName + " VALUES(2, 2)", 1);
+
+        dropTableFromMetastore(TEST_SCHEMA, tableName);
+
+        // Register table using intermediate snapshot (not latest)
+        assertUpdate("CALL system.register_table('" + TEST_SCHEMA + "', '" + tableName + "', '" + metadataLocation + "', '" + metadataFileName + "')");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1)");
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterWithInvalidParameters()
+    {
+        @Language("RegExp") String errorMessage = "line 1:1: Required procedure argument 'schema' is missing";
+        assertQueryFails("CALL system.register_table()", errorMessage);
+
+        errorMessage = "line 1:1: Required procedure argument 'table' is missing";
+        assertQueryFails("CALL system.register_table('" + TEST_SCHEMA + "')", errorMessage);
+
+        errorMessage = "line 1:1: Required procedure argument 'metadataLocation' is missing";
+        assertQueryFails("CALL system.register_table('" + TEST_SCHEMA + "', '" + TEST_TABLE_NAME + "')", errorMessage);
+
+        errorMessage = "schemaName is empty";
+        assertQueryFails("CALL system.register_table('', '', '')", errorMessage);
+
+        errorMessage = "tableName is empty";
+        assertQueryFails("CALL system.register_table('" + TEST_SCHEMA + "', '', '')", errorMessage);
+
+        errorMessage = "path must not be null or empty";
+        assertQueryFails("CALL system.register_table('" + TEST_SCHEMA + "', '" + TEST_TABLE_NAME + "', '')", errorMessage);
+
+        errorMessage = "line 1:1: Too many arguments for procedure";
+        assertQueryFails("CALL system.register_table('" + TEST_SCHEMA + "', '" + TEST_TABLE_NAME + "', '/dummy/location', 'dummyfile.json', '')", errorMessage);
+    }
+
+    @Test
+    public void testRegisterWithInvalidSchema()
+    {
+        String invalidSchemaName = "invalid_schema";
+        @Language("RegExp") String errorMessage = format("Schema %s not found", invalidSchemaName);
+        assertQueryFails("CALL system.register_table('" + invalidSchemaName + "', '" + TEST_TABLE_NAME + "', '/dummy/metadata')", errorMessage);
+    }
+
+    @Test
+    public void testRegisterWithExistingTable()
+    {
+        String tableName = "existing_table";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+
+        @Language("RegExp") String errorMessage = format("Table already exists: '%s.%s'", TEST_SCHEMA, tableName);
+        assertQueryFails("CALL system.register_table('" + TEST_SCHEMA + "', '" + tableName + "', '" + metadataLocation + "')", errorMessage);
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterWithInvalidMetadataScheme()
+    {
+        String tableName = "invalid_scheme";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        String invalidMetadataLocation = format("invalidscheme://%s/%s", metadataLocation, METADATA_FOLDER_NAME);
+
+        @Language("RegExp") String errorMessage = format("Error getting file system at path invalidscheme:%s/%s", metadataLocation, METADATA_FOLDER_NAME);
+        assertQueryFails("CALL system.register_table ('" + TEST_SCHEMA + "', '" + tableName + "', '" + invalidMetadataLocation + "')", errorMessage);
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterWithMissingMetadata()
+    {
+        String tableName = "missing_md";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        String metadataFileName = getMetadataFileLocation(session.toConnectorSession(), TEST_SCHEMA, tableName, metadataLocation);
+
+        File metadataFile = new File(format("%s/%s/%s", metadataLocation, METADATA_FOLDER_NAME, metadataFileName));
+        metadataFile.delete();
+
+        @Language("RegExp") String errorMessage = format("No metadata found at location %s/%s", metadataLocation, METADATA_FOLDER_NAME);
+        assertQueryFails("CALL system.register_table ('" + TEST_SCHEMA + "', '" + tableName + "', '" + metadataLocation + "')", errorMessage);
+    }
+
+    @Test
+    public void testRegisterWithInvalidMetadataFilename()
+    {
+        String tableName = "invalid_loc";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        String metadataFileName = "00001-invalid-metadata-file.metadata.json";
+
+        dropTableFromMetastore(TEST_SCHEMA, tableName);
+
+        @Language("RegExp") String errorMessage = format("Unable to read metadata file %s/%s/%s", metadataLocation, METADATA_FOLDER_NAME, metadataFileName);
+        assertQueryFails("CALL system.register_table ('" + TEST_SCHEMA + "', '" + tableName + "', '" + metadataLocation + "', '" + metadataFileName + "')", errorMessage);
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testRegisterTableWithInvalidLocation()
+    {
+        String tableName = "invalid_loc_after_drop";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+        String newTableName = tableName + "_new";
+
+        // Drop table to remove underlying data and metadata
+        assertUpdate(format("DROP TABLE %s", tableName));
+
+        @Language("RegExp") String errorMessage = format("Unable to find metadata at location %s/%s", metadataLocation, METADATA_FOLDER_NAME);
+        assertQueryFails("CALL system.register_table ('" + TEST_SCHEMA + "', '" + newTableName + "', '" + metadataLocation + "')", errorMessage);
+
+        dropTable(tableName);
+    }
+
+    @Test
+    public void testUnregisterTable()
+    {
+        String tableName = "unregister";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+
+        // Unregister table with procedure
+        assertUpdate("CALL system.unregister_table('" + TEST_SCHEMA + "', '" + tableName + "')");
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
+    }
+
+    @Test
+    public void testRegisterAndUnregisterTable()
+    {
+        String tableName = "register_unregister";
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES(1, 1)", 1);
+
+        String metadataLocation = getMetadataLocation(TEST_SCHEMA, tableName);
+
+        // Unregister table with procedure
+        assertUpdate("CALL system.unregister_table('" + TEST_SCHEMA + "', '" + tableName + "')");
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
+
+        // Register table again
+        assertUpdate("CALL system.register_table('" + TEST_SCHEMA + "', '" + tableName + "', '" + metadataLocation + "')");
+        assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1)");
+
+        // Unregister table with procedure
+        assertUpdate("CALL system.unregister_table('" + TEST_SCHEMA + "', '" + tableName + "')");
+        assertFalse(getQueryRunner().tableExists(getSession(), tableName));
+
+        assertQueryFails(
+                "CALL system.unregister_table ('" + TEST_SCHEMA + "', '" + tableName + "')",
+                format("Table '%s.%s' not found", TEST_SCHEMA, tableName));
+    }
+
+    @Test
+    public void testUnregisterSchemaNonExistent()
+    {
+        String schemaName = "invalid_schema";
+        String tableName = "unregister_invalid_schema";
+
+        // Unregister table with procedure
+        @Language("RegExp") String errorMessage = format("Schema %s not found", schemaName);
+        assertQueryFails("CALL system.unregister_table ('" + schemaName + "', '" + tableName + "')", errorMessage);
+    }
+
+    @Test
+    public void testUnregisterTableNonExistent()
+    {
+        String tableName = "unregister_invalid_table";
+
+        // Unregister table with procedure
+        @Language("RegExp") String errorMessage = format("Table '%s.%s' not found", TEST_SCHEMA, tableName);
+        assertQueryFails("CALL system.unregister_table ('" + TEST_SCHEMA + "', '" + tableName + "')", errorMessage);
+    }
+
+    @Test
+    public void testUnregisterWithInvalidParameters()
+    {
+        @Language("RegExp") String errorMessage = "line 1:1: Required procedure argument 'schema' is missing";
+        assertQueryFails("CALL system.register_table()", errorMessage);
+
+        errorMessage = "line 1:1: Required procedure argument 'table' is missing";
+        assertQueryFails("CALL system.unregister_table('" + TEST_SCHEMA + "')", errorMessage);
+
+        errorMessage = "schemaName is empty";
+        assertQueryFails("CALL system.unregister_table('', '')", errorMessage);
+
+        errorMessage = "tableName is empty";
+        assertQueryFails("CALL system.unregister_table('" + TEST_SCHEMA + "', '')", errorMessage);
+
+        errorMessage = "line 1:1: Too many arguments for procedure";
+        assertQueryFails("CALL system.unregister_table('" + TEST_SCHEMA + "', '" + TEST_TABLE_NAME + "', '')", errorMessage);
+    }
+
+    @Test
+    public void testParseMetadataVersionFromFileName()
+    {
+        // Hive metadata file names and compressions
+        assertEquals(parseMetadataVersionFromFileName("00000-7a73c190-2c6e-4924-b1b7-d4e840cbcef2.metadata.json"), 0);
+        assertEquals(parseMetadataVersionFromFileName("00001-7a73c190-2c6e-4924-b1b7-d4e840cbcef2.metadata.json"), 1);
+        assertEquals(parseMetadataVersionFromFileName("00010-7a73c190-2c6e-4924-b1b7-d4e840cbcef2.metadata.json"), 10);
+        assertEquals(parseMetadataVersionFromFileName("00110-7a73c190-2c6e-4924-b1b7-d4e840cbcef2.metadata.json"), 110);
+        assertEquals(parseMetadataVersionFromFileName("99999-7a73c190-2c6e-4924-b1b7-d4e840cbcef2.metadata.json"), 99999);
+        assertEquals(parseMetadataVersionFromFileName("00000-7a73c190-2c6e-4924-b1b7-d4e840cbcef2.metadata.json.gz"), 0);
+        assertEquals(parseMetadataVersionFromFileName("00000-7a73c190-2c6e-4924-b1b7-d4e840cbcef2.gz.metadata.json"), 0);
+
+        // Hadoop metadata file names and compressions
+        assertEquals(parseMetadataVersionFromFileName("v0.metadata.json"), 0);
+        assertEquals(parseMetadataVersionFromFileName("v1.metadata.json"), 1);
+        assertEquals(parseMetadataVersionFromFileName("v10.metadata.json"), 10);
+        assertEquals(parseMetadataVersionFromFileName("v110.metadata.json"), 110);
+        assertEquals(parseMetadataVersionFromFileName("v99999.metadata.json"), 99999);
+        assertEquals(parseMetadataVersionFromFileName("v0.gz.metadata.json"), 0);
+        assertEquals(parseMetadataVersionFromFileName("v0.metadata.json.gz"), 0);
+
+        // Not a match
+        assertEquals(parseMetadataVersionFromFileName("00000-7a73c190-2c6e-4924-b1b7-d4e840cbcef2"), -1);
+        assertEquals(parseMetadataVersionFromFileName("9ed98089-c46a-48f3-b20f-a90344f8df48-m0.avro"), -1);
+        assertEquals(parseMetadataVersionFromFileName("00000_7a73c190-2c6e-4924-b1b7-d4e840cbcef2.metadata.json"), -1);
+        assertEquals(parseMetadataVersionFromFileName("v-0_metadata.json"), -1);
+        assertEquals(parseMetadataVersionFromFileName("v0_metadata.json"), -1);
+    }
+
+    protected Path getCatalogDirectory()
+    {
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory().resolve(TEST_DATA_DIRECTORY);
+        return dataDirectory.resolve(TEST_CATALOG_DIRECTORY);
+    }
+
+    private String getMetadataLocation(String schema, String table)
+    {
+        Path catalogDirectory = getCatalogDirectory();
+        return format("%s/%s/%s", stripTrailingSlash(catalogDirectory.toString()), schema, table);
+    }
+
+    public static String getMetadataFileLocation(ConnectorSession session, String schema, String table, String metadataLocation)
+    {
+        metadataLocation = stripTrailingSlash(metadataLocation);
+        org.apache.hadoop.fs.Path metadataDir = new org.apache.hadoop.fs.Path(metadataLocation, METADATA_FOLDER_NAME);
+        FileSystem fileSystem = getFileSystem(session, getHdfsEnvironment(), new SchemaTableName(schema, table), metadataDir);
+        return resolveLatestMetadataLocation(
+                session,
+                fileSystem,
+                metadataDir).getName();
+    }
+
+    protected static HdfsEnvironment getHdfsEnvironment()
+    {
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(
+                new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig),
+                ImmutableSet.of(),
+                hiveClientConfig);
+        return new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
+    }
+    protected ExtendedHiveMetastore getFileHiveMetastore()
+    {
+        FileHiveMetastore fileHiveMetastore = new FileHiveMetastore(getHdfsEnvironment(),
+                getCatalogDirectory().toFile().getPath(),
+                "test");
+        return memoizeMetastore(fileHiveMetastore, false, 1000, 0);
+    }
+
+    protected void dropTableFromMetastore(String schemaName, String tableName)
+    {
+        ExtendedHiveMetastore metastore = getFileHiveMetastore();
+        ConnectorSession connectorSession = session.toConnectorSession();
+        MetastoreContext metastoreContext = new MetastoreContext(connectorSession.getIdentity(), connectorSession.getQueryId(), connectorSession.getClientInfo(), connectorSession.getSource(), getMetastoreHeaders(connectorSession), isUserDefinedTypeEncodingEnabled(connectorSession), HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+
+        metastore.dropTableFromMetastore(metastoreContext, schemaName, tableName);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
@@ -25,6 +25,7 @@ public enum StandardWarningCode
     MULTIPLE_ORDER_BY(0x0000_0007),
     DEFAULT_SAMPLE_FUNCTION(0x0000_0008),
     SAMPLED_FIELDS(0x0000_0009),
+    MULTIPLE_TABLE_METADATA(0x0000_0010)
     /**/;
     private final WarningCode warningCode;
 


### PR DESCRIPTION
## Description
Adds two procedures for Iceberg tables: `register_table` and `unregister_table`, as well as documentation on how to invoke them.

`toHiveColumns` has been moved to `IcebergUtil` from `HiveTableOperations`. A function `dropTableFromMetastore` is also added that ensures that data/metadata isn't deleted in during 'unregister' for file-based metastores (mostly for testing purposes).

## Motivation and Context
Fixes #20421

## Impact
Two new procedures will be accessible to users

## Test Plan
Tested manually and added dedicated unit tests and smoke tests.

## Contributor checklist
- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Changes
* Add register and unregister procedures for Iceberg tables
```

