### PR TITLE
Support TimeType for Iceberg with parquet format

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
@@ -368,6 +369,10 @@ public class IcebergPageSink
         if (type instanceof TimestampType) {
             long timestamp = type.getLong(block, position);
             return ((TimestampType) type).getPrecision() == MILLISECONDS ? MILLISECONDS.toMicros(timestamp) : timestamp;
+        }
+        if (type instanceof TimeType) {
+            long time = type.getLong(block, position);
+            return MILLISECONDS.toMicros(time);
         }
         throw new UnsupportedOperationException("Type not supported as partition column: " + type.getDisplayName());
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSource.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.Utils;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.RunLengthEncodedBlock;
+import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.HivePartitionKey;
@@ -175,7 +176,7 @@ public class IcebergPageSource
 
     private Block nativeValueToBlock(Type type, Object prefilledValue)
     {
-        if (prefilledValue != null && type instanceof TimestampType && ((TimestampType) type).getPrecision() == MILLISECONDS) {
+        if (prefilledValue != null && (type instanceof TimestampType && ((TimestampType) type).getPrecision() == MILLISECONDS || type instanceof TimeType)) {
             return Utils.nativeValueToBlock(type, MICROSECONDS.toMillis((long) prefilledValue));
         }
         return Utils.nativeValueToBlock(type, prefilledValue);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -296,6 +296,9 @@ public class PartitionTable
                 return MICROSECONDS.toMillis((long) value);
             }
         }
+        if (type instanceof Types.TimeType) {
+            return MICROSECONDS.toMillis((long) value);
+        }
         return value;
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -87,6 +87,15 @@ public class IcebergDistributedSmokeTestBase
     }
 
     @Test
+    public void testTime()
+    {
+        assertUpdate("CREATE TABLE test_time (x time)");
+        assertUpdate("INSERT INTO test_time VALUES (time '10:12:34')", 1);
+        assertQuery("SELECT * FROM test_time", "SELECT CAST('10:12:34' AS TIME)");
+        dropTable(getSession(), "test_time");
+    }
+
+    @Test
     @Override
     public void testDescribeTable()
     {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ColumnReaderFactory.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ColumnReaderFactory.java
@@ -35,6 +35,7 @@ import com.facebook.presto.parquet.reader.FloatColumnReader;
 import com.facebook.presto.parquet.reader.IntColumnReader;
 import com.facebook.presto.parquet.reader.LongColumnReader;
 import com.facebook.presto.parquet.reader.LongDecimalColumnReader;
+import com.facebook.presto.parquet.reader.LongTimeMicrosColumnReader;
 import com.facebook.presto.parquet.reader.LongTimestampMicrosColumnReader;
 import com.facebook.presto.parquet.reader.ShortDecimalColumnReader;
 import com.facebook.presto.parquet.reader.TimestampColumnReader;
@@ -47,6 +48,7 @@ import static com.facebook.presto.parquet.ParquetTypeUtils.isTimeStampMicrosType
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static org.apache.parquet.schema.OriginalType.DECIMAL;
 import static org.apache.parquet.schema.OriginalType.TIMESTAMP_MICROS;
+import static org.apache.parquet.schema.OriginalType.TIME_MICROS;
 
 public class ColumnReaderFactory
 {
@@ -86,6 +88,9 @@ public class ColumnReaderFactory
             case INT64:
                 if (TIMESTAMP_MICROS.equals(descriptor.getPrimitiveType().getOriginalType())) {
                     return new LongTimestampMicrosColumnReader(descriptor);
+                }
+                if (TIME_MICROS.equals(descriptor.getPrimitiveType().getOriginalType())) {
+                    return new LongTimeMicrosColumnReader(descriptor);
                 }
                 return createDecimalColumnReader(descriptor).orElse(new LongColumnReader(descriptor));
             case INT96:

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
@@ -444,6 +444,8 @@ public final class MetadataReader
                 return OriginalType.DATE;
             case TIME_MILLIS:
                 return OriginalType.TIME_MILLIS;
+            case TIME_MICROS:
+                return OriginalType.TIME_MICROS;
             case TIMESTAMP_MICROS:
                 return OriginalType.TIMESTAMP_MICROS;
             case TIMESTAMP_MILLIS:

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LongTimeMicrosColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LongTimeMicrosColumnReader.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.TimeWithTimeZoneType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.parquet.RichColumnDescriptor;
+
+import static com.facebook.presto.common.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+public class LongTimeMicrosColumnReader
+        extends AbstractColumnReader
+{
+    public LongTimeMicrosColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            long utcMillis = MICROSECONDS.toMillis(valuesReader.readLong());
+            if (type instanceof TimeWithTimeZoneType) {
+                type.writeLong(blockBuilder, packDateTimeWithZone(utcMillis, UTC_KEY));
+            }
+            else {
+                type.writeLong(blockBuilder, utcMillis);
+            }
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readLong();
+        }
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/MessageTypeConverter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/MessageTypeConverter.java
@@ -147,6 +147,8 @@ class MessageTypeConverter
                 return ConvertedType.DATE;
             case TIME_MILLIS:
                 return ConvertedType.TIME_MILLIS;
+            case TIME_MICROS:
+                return ConvertedType.TIME_MICROS;
             case TIMESTAMP_MILLIS:
                 return ConvertedType.TIMESTAMP_MILLIS;
             case TIMESTAMP_MICROS:

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriters.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriters.java
@@ -27,6 +27,7 @@ import com.facebook.presto.parquet.writer.valuewriter.DoubleValueWriter;
 import com.facebook.presto.parquet.writer.valuewriter.IntegerValueWriter;
 import com.facebook.presto.parquet.writer.valuewriter.PrimitiveValueWriter;
 import com.facebook.presto.parquet.writer.valuewriter.RealValueWriter;
+import com.facebook.presto.parquet.writer.valuewriter.TimeValueWriter;
 import com.facebook.presto.parquet.writer.valuewriter.TimestampValueWriter;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
@@ -49,6 +50,7 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimeType.TIME;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -190,6 +192,9 @@ class ParquetWriters
         }
         if (TIMESTAMP.equals(type)) {
             return new TimestampValueWriter(valuesWriter, type, parquetType);
+        }
+        if (TIME.equals(type)) {
+            return new TimeValueWriter(valuesWriter, type, parquetType);
         }
         if (type instanceof VarcharType || type instanceof CharType || type instanceof VarbinaryType) {
             return new CharValueWriter(valuesWriter, type, parquetType);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/TimeValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/TimeValueWriter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.writer.valuewriter;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.Type;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class TimeValueWriter
+        extends PrimitiveValueWriter
+{
+    private final Type type;
+    private final boolean writeMicroseconds;
+
+    public TimeValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    {
+        super(parquetType, valuesWriter);
+        this.type = requireNonNull(type, "type is null");
+        this.writeMicroseconds = parquetType.isPrimitive() && parquetType.getOriginalType() == OriginalType.TIME_MICROS;
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (!block.isNull(i)) {
+                long value = type.getLong(block, i);
+                long scaledValue = writeMicroseconds ? MILLISECONDS.toMicros(value) : value;
+                getValueWriter().writeLong(scaledValue);
+                getStatistics().updateStats(scaledValue);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR support TimeType for Iceberg table with parquet format, both as a normal column type and as a partition column type.

To do this, we firstly should support reading and writing data of type TIME_MICROS in additional to TIME_MILLIS  in parquet, for Iceberg store and handle data of TimeType as long of microsecond.

Then we must resolve the difference that presto handle data of TimeType as long of milliseconds, but  Iceberg maintain data of TimeType as long of microseconds. 

## Motivation and Context

We can support reading and writing and partitioning by data of TimeType, because Iceberg spec, Parquet spec and presto engine itself are all support TimeType. 

## Test Plan

 - Newly added IcebergDistributedSmokeTestBase.testTime()
 - Newly added IcebergDistributedTestBase.testPartitionedByTimeType()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
