### PR TITLE
Extend pull lambda out for conditional expression

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullUpExpressionInLambdaRules.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullUpExpressionInLambdaRules.java
@@ -208,9 +208,7 @@ public class PullUpExpressionInLambdaRules
             implements RowExpressionVisitor<Boolean, Boolean>
     {
         // Bind expression will complicate the lambda expression, we apply this optimization before DesugarLambdaRule. And if there are bind expression, skip
-        // SWITCH, COALESCE, IF are conditional expressions, some of their expressions may not be executed, but will always be executed if pulled out
-        private static final List<SpecialFormExpression.Form> UNSUPPORTED_TYPES = ImmutableList.of(SpecialFormExpression.Form.SWITCH, SpecialFormExpression.Form.BIND,
-                SpecialFormExpression.Form.COALESCE, SpecialFormExpression.Form.WHEN, SpecialFormExpression.Form.IF);
+        private static final List<SpecialFormExpression.Form> UNSUPPORTED_TYPES = ImmutableList.of(SpecialFormExpression.Form.BIND);
         private final RowExpressionDeterminismEvaluator determinismEvaluator;
         private final FunctionResolution functionResolution;
         private final List<VariableReferenceExpression> inputVariables;
@@ -250,20 +248,48 @@ public class PullUpExpressionInLambdaRules
             return false;
         }
 
+        // For the conditional expressions, not all arguments will be evaluated, we only try to extract from the arguments which will always be executed
+        private static List<RowExpression> getValidArguments(SpecialFormExpression specialForm)
+        {
+            List<RowExpression> validArgument;
+            SpecialFormExpression.Form form = specialForm.getForm();
+            if (form.equals(SpecialFormExpression.Form.IF) || form.equals(SpecialFormExpression.Form.COALESCE) || form.equals(SpecialFormExpression.Form.WHEN)) {
+                validArgument = ImmutableList.of(specialForm.getArguments().get(0));
+            }
+            else if (form.equals(SpecialFormExpression.Form.SWITCH)) {
+                validArgument = ImmutableList.of(specialForm.getArguments().get(0), specialForm.getArguments().get(1));
+            }
+            else {
+                validArgument = specialForm.getArguments();
+            }
+            return validArgument;
+        }
+
+        // When expression cannot be pulled out, hence if we get a when expression, try to pull out its argument instead
+        private static RowExpression getArgumentOfWhen(RowExpression expression)
+        {
+            if (expression instanceof SpecialFormExpression && ((SpecialFormExpression) expression).getForm().equals(SpecialFormExpression.Form.WHEN)) {
+                return getArgumentOfWhen(((SpecialFormExpression) expression).getArguments().get(0));
+            }
+            return expression;
+        }
+
         @Override
         public Boolean visitSpecialForm(SpecialFormExpression specialForm, Boolean context)
         {
             if (UNSUPPORTED_TYPES.contains(specialForm.getForm())) {
                 return false;
             }
-            Map<RowExpression, Boolean> validRowExpressionMap = specialForm.getArguments().stream().distinct().collect(toImmutableMap(identity(), x -> x.accept(this, context)));
+            List<RowExpression> validArguments = getValidArguments(specialForm);
+            Map<RowExpression, Boolean> validRowExpressionMap = specialForm.getArguments().stream().distinct().collect(toImmutableMap(identity(), x -> validArguments.contains(x) ? x.accept(this, context) : false));
             if (context.equals(Boolean.TRUE)) {
                 boolean allArgumentsValid = validRowExpressionMap.values().stream().allMatch(x -> x.equals(Boolean.TRUE));
                 if (!allArgumentsValid) {
                     candidates.addAll(validRowExpressionMap.entrySet().stream()
                             .filter(x -> x.getValue().equals(Boolean.TRUE))
-                            .filter(x -> isSupportedExpression(x.getKey()))
                             .map(Map.Entry::getKey)
+                            .map(ValidExpressionExtractor::getArgumentOfWhen)
+                            .filter(ValidExpressionExtractor::isSupportedExpression)
                             .collect(toImmutableList()));
                 }
                 return allArgumentsValid && determinismEvaluator.isDeterministic(specialForm);
@@ -300,7 +326,7 @@ public class PullUpExpressionInLambdaRules
         }
 
         // WHEN expression should only exist within SWITCH expression, and will throw exception in RowExpressionInterpreter, also no byte code generator for standalone WHEN expression
-        private boolean isSupportedExpression(RowExpression expression)
+        private static boolean isSupportedExpression(RowExpression expression)
         {
             return expression instanceof CallExpression || (expression instanceof SpecialFormExpression && !((SpecialFormExpression) expression).getForm().equals(SpecialFormExpression.Form.WHEN));
         }


### PR DESCRIPTION
## Description
Try to extract independent expressions from the conditional expressions.

## Motivation and Context
In current code, when the expression is in a conditional expression, we will skip them. For example, for `transform(col1, x -> if(col3 > 2, col2[2], 0))`, we will skip and do not extract anything from the lambda expression. We chose this behavior because expressions in conditional expressions may not be executed.
However, some part of the conditional will always be evaluated, for example in the above expression `transform(col1, x -> if(col3 > 2, col2[2], 0))` we can extract `col3>2` out, as it's a condition and will always be evaluated. In this PR, I extend the optimizer to extract these expressions.

## Impact
Increase the coverage of this optimizer.

## Test Plan
Unit test and [verifier run test](https://www.internalfb.com/intern/presto/verifier/results/?test_id=146133)

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix lambda expression pull out optimizer so that it will be able to extract independent expressions from conditional expression.
```


