### PR TITLE
Fix high memory task killer to kill highest memory consuming query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dep.drift.version>1.36</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
-        <dep.joda.version>2.12.2</dep.joda.version>
+        <dep.joda.version>2.12.5</dep.joda.version>
         <dep.tempto.version>1.53</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>

--- a/presto-docs/src/main/sphinx/develop/presto-native.rst
+++ b/presto-docs/src/main/sphinx/develop/presto-native.rst
@@ -76,6 +76,16 @@ The following properties allow the configuration of remote function execution:
 
     If empty, the function is registered as ``schema.function_name``.
 
+``remote-function-server.serde``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``string``
+    * **Default value:** ``"presto_page"``
+
+    The serialization/deserialization method to use when communicating with
+    the remote function server. Supported values are ``presto_page`` or
+    ``spark_unsafe_row``.
+
 ``remote-function-server.thrift.address``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -102,7 +102,20 @@ String
 
     Variable length character data with an optional maximum length.
 
-    Example type definitions: ``varchar``, ``varchar(20)``
+    Example type definitions: ``varchar``, ``varchar(20)``.
+
+    SQL supports simple and Unicode string literals:
+     - Literal string : ``'Hello winter !'``
+     - Unicode string with default escape character: ``U&'Hello winter \2603 !'``
+     - Unicode string with custom escape character: ``U&'Hello winter #2603 !' UESCAPE '#'``
+
+    A Unicode string is prefixed with ``U&`` and requires an escape character
+    before any Unicode character usage with 4 digits. In these examples
+    ``\2603`` and ``#2603`` represent a snowman character. Long Unicode codes
+    with 6 digits require a plus symbol ``+`` before the code. For example,
+    use ``\+01F600`` for a grinning face emoji.
+
+    Single quotes in string literals can be escaped by using another single quote: ``'It''s a beautiful day!'``
 
 ``CHAR``
 ^^^^^^^^

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -660,7 +660,7 @@ public class TaskManagerConfig
         return highMemoryTaskKillerStrategy;
     }
 
-    @Config("experiemental.task.high-memory-task-killer-strategy")
+    @Config("experimental.task.high-memory-task-killer-strategy")
     public TaskManagerConfig setHighMemoryTaskKillerStrategy(HighMemoryTaskKillerStrategy highMemoryTaskKillerStrategy)
     {
         this.highMemoryTaskKillerStrategy = highMemoryTaskKillerStrategy;

--- a/presto-main/src/main/java/com/facebook/presto/memory/HighMemoryTaskKiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/HighMemoryTaskKiller.java
@@ -181,6 +181,7 @@ public class HighMemoryTaskKiller
                 triggerTaskKiller = true;
             }
         }
+        log.debug("Task Killer Trigger: " + triggerTaskKiller + ", Before Full GC Head Size: " + beforeGcDataSize.toBytes() + " After Full GC Heap Size: " + afterGcDataSize.toBytes());
 
         return triggerTaskKiller;
     }
@@ -202,14 +203,13 @@ public class HighMemoryTaskKiller
         Comparator<Map.Entry<QueryId, Long>> comparator = Comparator.comparingLong(Map.Entry::getValue);
 
         Optional<QueryId> maxMemoryConsumpingQueryId = queryIDToSqlTaskMap.asMap().entrySet().stream()
-                //Convert to Entry<QueryId, Long>, QueryId -> Total Memory Reservation
                 .map(entry ->
                         new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().stream()
                                 .map(SqlTask::getTaskInfo)
                                 .map(TaskInfo::getStats)
                                 .mapToLong(stats -> stats.getUserMemoryReservationInBytes() + stats.getSystemMemoryReservationInBytes() + stats.getRevocableMemoryReservationInBytes())
                                 .sum())
-                ).max(comparator.reversed()).map(Map.Entry::getKey);
+                ).max(comparator).map(Map.Entry::getKey);
 
         return maxMemoryConsumpingQueryId;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
@@ -85,7 +85,7 @@ public class ParametricAggregation
         // Build state factory and serializer
         Class<?> stateClass = concreteImplementation.getStateClass();
         AccumulatorStateSerializer<?> stateSerializer = getAccumulatorStateSerializer(concreteImplementation, variables, functionAndTypeManager, stateClass, classLoader);
-        AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(stateClass, classLoader);
+        AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(stateClass, variables.getTypeVariables(), classLoader);
 
         // Bind provided dependencies to aggregation method handlers
         MethodHandle inputHandle = bindDependencies(concreteImplementation.getInputFunction(), concreteImplementation.getInputDependencies(), variables, functionAndTypeManager);
@@ -188,7 +188,7 @@ public class ParametricAggregation
             }
         }
         else {
-            stateSerializer = generateStateSerializer(stateClass, classLoader);
+            stateSerializer = generateStateSerializer(stateClass, variables.getTypeVariables(), classLoader);
         }
         return stateSerializer;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -121,7 +121,7 @@ public class TestTaskManagerConfig
                 .put("task.interrupt-runaway-splits-timeout", "599s")
                 .put("experimental.task.memory-based-slowdown-threshold", "0.9")
                 .put("experimental.task.high-memory-task-killer-enabled", "true")
-                .put("experiemental.task.high-memory-task-killer-strategy", "FREE_MEMORY_ON_FREQUENT_FULL_GC")
+                .put("experimental.task.high-memory-task-killer-strategy", "FREE_MEMORY_ON_FREQUENT_FULL_GC")
                 .put("experimental.task.high-memory-task-killer-reclaim-memory-threshold", "0.8")
                 .put("experimental.task.high-memory-task-killer-frequent-full-gc-duration-threshold", "2s")
                 .put("experimental.task.high-memory-task-killer-heap-memory-threshold", "0.8")

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestHighMemoryTaskKiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestHighMemoryTaskKiller.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.airlift.stats.CounterStat;
+import com.facebook.airlift.stats.TestingGcMonitor;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.execution.SqlTask;
+import com.facebook.presto.execution.SqlTaskExecutionFactory;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.execution.TaskManagerConfig;
+import com.facebook.presto.execution.TaskState;
+import com.facebook.presto.execution.TaskStateMachine;
+import com.facebook.presto.execution.TestSqlTaskManager;
+import com.facebook.presto.execution.buffer.SpoolingOutputBufferFactory;
+import com.facebook.presto.execution.executor.TaskExecutor;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.operator.PipelineContext;
+import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.memory.MemoryPoolId;
+import com.facebook.presto.spiller.SpillSpaceTracker;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.gen.OrderingCompiler;
+import com.facebook.presto.sql.planner.LocalExecutionPlanner;
+import com.google.common.base.Functions;
+import com.google.common.base.Ticker;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.execution.SqlTask.createSqlTask;
+import static com.facebook.presto.execution.TaskManagerConfig.TaskPriorityTracking.TASK_FAIR;
+import static com.facebook.presto.execution.TaskTestUtils.PLAN_FRAGMENT;
+import static com.facebook.presto.execution.TaskTestUtils.createTestSplitMonitor;
+import static com.facebook.presto.execution.TaskTestUtils.createTestingPlanner;
+import static com.facebook.presto.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
+import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.ImmutableListMultimap.toImmutableListMultimap;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestHighMemoryTaskKiller
+{
+    private final AtomicInteger nextTaskId = new AtomicInteger();
+
+    private final TaskExecutor taskExecutor;
+    private final ScheduledExecutorService taskNotificationExecutor;
+    private final ScheduledExecutorService driverYieldExecutor;
+
+    private final SqlTaskExecutionFactory sqlTaskExecutionFactory;
+
+    public TestHighMemoryTaskKiller()
+    {
+        taskExecutor = new TaskExecutor(8, 16, 3, 4, TASK_FAIR, Ticker.systemTicker());
+        taskExecutor.start();
+
+        taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));
+        driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%s"));
+
+        LocalExecutionPlanner planner = createTestingPlanner();
+
+        sqlTaskExecutionFactory = new SqlTaskExecutionFactory(
+                taskNotificationExecutor,
+                taskExecutor,
+                planner,
+                new BlockEncodingManager(),
+                new OrderingCompiler(),
+                createTestSplitMonitor(),
+                new TaskManagerConfig());
+    }
+
+    @Test
+    public void testMaxMemoryConsumingQuery()
+            throws Exception
+    {
+        QueryId highMemoryQueryId = new QueryId("query1");
+        SqlTask highMemoryTask = createInitialTask(highMemoryQueryId);
+        updateTaskMemory(highMemoryTask, 200);
+
+        QueryId lowMemoryQueryId = new QueryId("query2");
+        SqlTask lowMemoryTask = createInitialTask(lowMemoryQueryId);
+        updateTaskMemory(lowMemoryTask, 100);
+
+        List<SqlTask> activeTasks = ImmutableList.of(highMemoryTask, lowMemoryTask);
+
+        ListMultimap<QueryId, SqlTask> activeQueriesToTasksMap = activeTasks.stream()
+                .collect(toImmutableListMultimap(task -> task.getQueryContext().getQueryId(), Function.identity()));
+
+        Optional<QueryId> optionalQueryId = HighMemoryTaskKiller.getMaxMemoryConsumingQuery(activeQueriesToTasksMap);
+
+        assertTrue(optionalQueryId.isPresent());
+        assertEquals(optionalQueryId.get(), highMemoryQueryId);
+    }
+
+    public void updateTaskMemory(SqlTask sqlTask, long systemMemory)
+    {
+        TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
+                Optional.of(PLAN_FRAGMENT),
+                ImmutableList.of(),
+                createInitialEmptyOutputBuffers(PARTITIONED)
+                        .withNoMoreBufferIds(),
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+        assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
+
+        TaskContext taskContext = sqlTask.getTaskContext().get();
+        PipelineContext pipelineContext = taskContext.addPipelineContext(0, true, true, false);
+
+        pipelineContext.localSystemMemoryContext().setBytes(systemMemory);
+    }
+
+    public SqlTask createInitialTask(QueryId queryId)
+    {
+        TaskId taskId = new TaskId(queryId.getId(), 0, 0, nextTaskId.incrementAndGet(), 0);
+        URI location = URI.create("fake://task/" + taskId);
+
+        QueryContext queryContext = new QueryContext(queryId,
+                new DataSize(1, MEGABYTE),
+                new DataSize(2, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, GIGABYTE),
+                new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE)),
+                new TestingGcMonitor(),
+                taskNotificationExecutor,
+                driverYieldExecutor,
+                new DataSize(1, MEGABYTE),
+                new SpillSpaceTracker(new DataSize(1, GIGABYTE)),
+                listJsonCodec(TaskMemoryReservationSummary.class));
+
+
+        TaskContext taskContext = queryContext.addTaskContext(
+                                    new TaskStateMachine(taskId, taskNotificationExecutor),
+                                    testSessionBuilder().build(),
+                                    Optional.of(PLAN_FRAGMENT.getRoot()),
+                                    false,
+                                    false,
+                                    false,
+                                    false,
+                                    false);
+
+        return createSqlTask(
+                taskId,
+                location,
+                "fake",
+                queryContext,
+                sqlTaskExecutionFactory,
+                new TestSqlTaskManager.MockExchangeClientSupplier(),
+                taskNotificationExecutor,
+                Functions.identity(),
+                new DataSize(32, MEGABYTE),
+                new CounterStat(),
+                new SpoolingOutputBufferFactory(new FeaturesConfig()));
+    }
+}

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -813,9 +813,11 @@ void PrestoServer::registerRemoteFunctions() {
     PRESTO_STARTUP_LOG(INFO)
         << "Registering remote functions from path: " << *dirPath;
     if (auto remoteLocation = systemConfig->remoteFunctionServerLocation()) {
-      auto catalogName = systemConfig->remoteFunctionServerCatalogName();
+      const auto catalogName = systemConfig->remoteFunctionServerCatalogName();
+      const auto serdeName = systemConfig->remoteFunctionServerSerde();
       size_t registeredCount = presto::registerRemoteFunctions(
-          *dirPath, *remoteLocation, catalogName);
+          *dirPath, *remoteLocation, catalogName, serdeName);
+
       PRESTO_STARTUP_LOG(INFO)
           << registeredCount << " remote functions registered in the '"
           << catalogName << "' catalog.";

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -15,6 +15,7 @@
 #include "presto_cpp/main/QueryContextManager.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include "presto_cpp/main/common/Configs.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 using namespace facebook::velox;
@@ -24,14 +25,32 @@ using facebook::presto::protocol::TaskId;
 
 namespace facebook::presto {
 namespace {
-std::string maybeRemoveNativePrefix(const std::string& name) {
-  static const std::string kNativePrefix = "native_";
-  const auto result =
-      ::strncmp(name.c_str(), kNativePrefix.c_str(), kNativePrefix.size());
-  if (result == 0) {
-    return name.substr(kNativePrefix.length());
-  }
-  return name;
+// Utility function to translate a config name in Presto to its equivalent in
+// Velox. Returns 'name' as is if there is no mapping.
+std::string toVeloxConfig(const std::string& name) {
+  using velox::core::QueryConfig;
+  static const folly::F14FastMap<std::string, std::string>
+      kPrestoToVeloxMapping = {
+          {"native_aggregation_spill_memory_threshold",
+           QueryConfig::kAggregationSpillMemoryThreshold},
+          {"native_simplified_expression_evaluation_enabled",
+           QueryConfig::kExprEvalSimplified},
+          {"native_aggregation_spill_all", QueryConfig::kAggregationSpillAll},
+          {"native_join_spill_memory_threshold",
+           QueryConfig::kJoinSpillMemoryThreshold},
+          {"native_order_by_spill_memory_threshold",
+           QueryConfig::kOrderBySpillMemoryThreshold},
+          {"native_max_spill_level", QueryConfig::kMaxSpillLevel},
+          {"native_max_spill_file_size", QueryConfig::kMaxSpillFileSize},
+          {"native_spill_compression_codec",
+           QueryConfig::kSpillCompressionKind},
+          {"native_spill_write_buffer_size",
+           QueryConfig::kSpillWriteBufferSize},
+          {"native_join_spill_enabled", QueryConfig::kJoinSpillEnabled},
+          {"native_debug.validate_output_from_operators",
+           QueryConfig::kValidateOutputFromOperators}};
+  auto it = kPrestoToVeloxMapping.find(name);
+  return it == kPrestoToVeloxMapping.end() ? name : it->second;
 }
 
 std::unordered_map<std::string, std::string> toConfigs(
@@ -40,7 +59,7 @@ std::unordered_map<std::string, std::string> toConfigs(
   // properties on top of it.
   auto configs = BaseVeloxQueryConfig::instance()->values();
   for (const auto& it : session.systemProperties) {
-    configs[maybeRemoveNativePrefix(it.first)] = it.second;
+    configs[toVeloxConfig(it.first)] = it.second;
   }
 
   // If there's a timeZoneKey, convert to timezone name and add to the

--- a/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.h
+++ b/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.h
@@ -29,10 +29,15 @@ namespace facebook::presto {
 /// `prefix`, if not empty, it is added to the names of functions registered
 /// using '.' as a separator, e.g., 'prefix.functionName'.
 ///
+/// `serde` controls the serialization/deserialization format to be used when
+/// communicating with the remote server. "presto_page" and "spark_unsafe_row"
+/// are supported formats.
+///
 /// Returns the number of signatures registered.
 size_t registerRemoteFunctions(
     const std::string& inputPath,
     const folly::SocketAddress& location,
-    const std::string& prefix = "");
+    const std::string_view& prefix = "",
+    const std::string_view& serde = "presto_page");
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -170,6 +170,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kLocalShuffleMaxPartitionBytes, 268435456),
           STR_PROP(kShuffleName, ""),
           STR_PROP(kRemoteFunctionServerCatalogName, ""),
+          STR_PROP(kRemoteFunctionServerSerde, "presto_page"),
           STR_PROP(kHttpEnableAccessLog, "false"),
           STR_PROP(kHttpEnableStatsFilter, "false"),
           STR_PROP(kHttpEnableEndpointLatencyFilter, "false"),
@@ -286,6 +287,10 @@ SystemConfig::remoteFunctionServerSignatureFilesDirectoryPath() const {
 
 std::string SystemConfig::remoteFunctionServerCatalogName() const {
   return optionalProperty(kRemoteFunctionServerCatalogName).value();
+}
+
+std::string SystemConfig::remoteFunctionServerSerde() const {
+  return optionalProperty(kRemoteFunctionServerSerde).value();
 }
 
 int32_t SystemConfig::maxDriversPerTask() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -337,9 +337,15 @@ class SystemConfig : public ConfigBase {
           "remote-function-server.signature.files.directory.path"};
 
   /// Optional catalog name to be added as a prefix to the function names
-  /// registered. The patter registered is `catalog.schema.function_name`.
+  /// registered. The pattern registered is `catalog.schema.function_name`.
   static constexpr std::string_view kRemoteFunctionServerCatalogName{
       "remote-function-server.catalog-name"};
+
+  /// Optional string containing the serialization/deserialization format to be
+  /// used when communicating with the remote server. Supported types are
+  /// "spark_unsafe_row" or "presto_page" ("presto_page" by default).
+  static constexpr std::string_view kRemoteFunctionServerSerde{
+      "remote-function-server.serde"};
 
   /// Options to configure the internal (in-cluster) JWT authentication.
   static constexpr std::string_view kInternalCommunicationJwtEnabled{
@@ -402,6 +408,8 @@ class SystemConfig : public ConfigBase {
       const;
 
   std::string remoteFunctionServerCatalogName() const;
+
+  std::string remoteFunctionServerSerde() const;
 
   int32_t maxDriversPerTask() const;
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -184,6 +184,7 @@ public class PrestoNativeQueryRunnerUtils
                             configProperties = format("%s%n" +
                                     "remote-function-server.catalog-name=%s%n" +
                                     "remote-function-server.thrift.uds-path=%s%n" +
+                                    "remote-function-server.serde=presto_page%n" +
                                     "remote-function-server.signature.files.directory.path=%s%n", configProperties, REMOTE_FUNCTION_CATALOG_NAME, remoteFunctionServerUds.get(), jsonSignaturesPath);
                         }
                         Files.write(tempDirectoryPath.resolve("config.properties"), configProperties.getBytes());

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/ExecutionStrategyValidator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/ExecutionStrategyValidator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.spark.classloader_interface.ExecutionStrategy;
+import com.facebook.presto.spi.PrestoException;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static java.lang.String.format;
+
+public class ExecutionStrategyValidator
+        implements Consumer<String>
+{
+    private static final Set<String> validStrategies = Arrays.stream(ExecutionStrategy.values())
+            .map(strategy -> strategy.name())
+            .collect(Collectors.toSet());
+
+    @Override
+    public void accept(String strategy)
+    {
+        if (!validStrategies.contains(strategy)) {
+            throw new PrestoException(INVALID_SESSION_PROPERTY, format("Invalid value for execution strategy [%s]. Valid values: %s", strategy, String.join(",", validStrategies)));
+        }
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkExecutionSettings.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkExecutionSettings.java
@@ -17,12 +17,12 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-public class PrestoSparkRetryExecutionSettings
+public class PrestoSparkExecutionSettings
 {
     private final Map<String, String> sparkConfigProperties;
     private final Map<String, String> prestoSessionProperties;
 
-    public PrestoSparkRetryExecutionSettings(
+    public PrestoSparkExecutionSettings(
             Map<String, String> sparkConfigProperties,
             Map<String, String> prestoSessionProperties)
     {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkExecutionUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkExecutionUtils.java
@@ -15,9 +15,9 @@ package com.facebook.presto.spark.util;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
-import com.facebook.presto.spark.PrestoSparkRetryExecutionSettings;
+import com.facebook.presto.spark.PrestoSparkExecutionSettings;
 import com.facebook.presto.spark.PrestoSparkSessionContext;
-import com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy;
+import com.facebook.presto.spark.classloader_interface.ExecutionStrategy;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.google.common.collect.ImmutableMap;
@@ -32,21 +32,21 @@ import static com.facebook.presto.spark.PrestoSparkSessionProperties.getOutOfMem
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getOutOfMemoryRetrySparkConfigs;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_RETRY_EXECUTION_STRATEGY;
 
-public class PrestoSparkRetryExecutionUtils
+public class PrestoSparkExecutionUtils
 {
     private static final Logger log = Logger.get(PrestoSparkSessionContext.class);
 
-    private PrestoSparkRetryExecutionUtils() {}
+    private PrestoSparkExecutionUtils() {}
 
-    public static PrestoSparkRetryExecutionSettings getRetryExecutionSettings(
-            List<RetryExecutionStrategy> retryExecutionStrategies,
+    public static PrestoSparkExecutionSettings getExecutionSettings(
+            List<ExecutionStrategy> executionStrategies,
             Session session)
     {
         ImmutableMap.Builder<String, String> sparkConfigProperties = new ImmutableMap.Builder<>();
         ImmutableMap.Builder<String, String> prestoSessionProperties = new ImmutableMap.Builder<>();
 
-        for (RetryExecutionStrategy strategy : retryExecutionStrategies) {
-            log.info(String.format("Applying retry execution strategy: %s. Query Id: %s", strategy.name(), session.getQueryId().getId()));
+        for (ExecutionStrategy strategy : executionStrategies) {
+            log.info(String.format("Applying execution strategy: %s. Query Id: %s", strategy.name(), session.getQueryId().getId()));
             switch (strategy) {
                 case DISABLE_BROADCAST_JOIN:
                     prestoSessionProperties.put(JOIN_DISTRIBUTION_TYPE, FeaturesConfig.JoinDistributionType.PARTITIONED.name());
@@ -63,10 +63,10 @@ public class PrestoSparkRetryExecutionUtils
                     prestoSessionProperties.put(HASH_PARTITION_COUNT, Long.toString(updatedPartitionCount));
                     break;
                 default:
-                    throw new PrestoException(INVALID_RETRY_EXECUTION_STRATEGY, "Retry execution strategy not supported: " + retryExecutionStrategies);
+                    throw new PrestoException(INVALID_RETRY_EXECUTION_STRATEGY, "Execution strategy not supported: " + executionStrategies);
             }
         }
 
-        return new PrestoSparkRetryExecutionSettings(sparkConfigProperties.build(), prestoSessionProperties.build());
+        return new PrestoSparkExecutionSettings(sparkConfigProperties.build(), prestoSessionProperties.build());
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkFailureUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkFailureUtils.java
@@ -16,8 +16,8 @@ package com.facebook.presto.spark.util;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.ErrorCode;
 import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.spark.classloader_interface.ExecutionStrategy;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkFailure;
-import com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy;
 import com.facebook.presto.spi.ErrorCause;
 import com.google.common.collect.ImmutableList;
 
@@ -30,9 +30,9 @@ import static com.facebook.presto.spark.PrestoSparkSessionProperties.isRetryOnOu
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.isRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.isRetryOnOutOfMemoryWithIncreasedMemoryEnabled;
 import static com.facebook.presto.spark.SparkErrorCode.SPARK_EXECUTOR_OOM;
-import static com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy.DISABLE_BROADCAST_JOIN;
-import static com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy.INCREASE_CONTAINER_SIZE;
-import static com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy.INCREASE_HASH_PARTITION_COUNT;
+import static com.facebook.presto.spark.classloader_interface.ExecutionStrategy.DISABLE_BROADCAST_JOIN;
+import static com.facebook.presto.spark.classloader_interface.ExecutionStrategy.INCREASE_CONTAINER_SIZE;
+import static com.facebook.presto.spark.classloader_interface.ExecutionStrategy.INCREASE_HASH_PARTITION_COUNT;
 import static com.facebook.presto.spi.ErrorCause.LOW_PARTITION_COUNT;
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_LOCAL_BROADCAST_JOIN_MEMORY_LIMIT;
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
@@ -49,7 +49,7 @@ public class PrestoSparkFailureUtils
         PrestoSparkFailure prestoSparkFailure = toPrestoSparkFailure(executionFailureInfo);
         checkState(prestoSparkFailure != null);
 
-        List<RetryExecutionStrategy> retryExecutionStrategies = getRetryExecutionStrategies(session,
+        List<ExecutionStrategy> retryExecutionStrategies = getRetryExecutionStrategies(session,
                 executionFailureInfo.getErrorCode(),
                 executionFailureInfo.getMessage(),
                 executionFailureInfo.getErrorCause());
@@ -90,13 +90,13 @@ public class PrestoSparkFailureUtils
     /**
      * Returns a list of retry strategies based on the provided error.
      */
-    private static List<RetryExecutionStrategy> getRetryExecutionStrategies(Session session, ErrorCode errorCode, String message, ErrorCause errorCause)
+    private static List<ExecutionStrategy> getRetryExecutionStrategies(Session session, ErrorCode errorCode, String message, ErrorCause errorCause)
     {
         if (errorCode == null || message == null) {
             return ImmutableList.of();
         }
 
-        ImmutableList.Builder<RetryExecutionStrategy> strategies = new ImmutableList.Builder<>();
+        ImmutableList.Builder<ExecutionStrategy> strategies = new ImmutableList.Builder<>();
 
         if (isRetryOnOutOfMemoryBroadcastJoinEnabled(session) &&
                 errorCode.equals(EXCEEDED_LOCAL_BROADCAST_JOIN_MEMORY_LIMIT.toErrorCode())) {

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.spark.PrestoSparkSessionProperties.OUT_OF_MEMO
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.OUT_OF_MEMORY_RETRY_SPARK_CONFIGS;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_QUERY_EXECUTION_STRATEGIES;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_RETRY_ON_OUT_OF_MEMORY_BROADCAST_JOIN_ENABLED;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED;
@@ -926,14 +927,14 @@ public class TestPrestoSparkQueryRunner
         Session session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "BROADCAST")
                 .setSystemProperty(STORAGE_BASED_BROADCAST_JOIN_ENABLED, "true")
-                .setSystemProperty(SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE, "2MB")
+                .setSystemProperty(SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE, "1MB")
                 .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "100MB")
                 .build();
 
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                "Query exceeded per-node broadcast memory limit of 2MB \\[Broadcast size: 2.*MB\\]");
+                "Query exceeded per-node broadcast memory limit of 1MB \\[Broadcast size: .*MB\\]");
     }
 
     @Test
@@ -1338,6 +1339,105 @@ public class TestPrestoSparkQueryRunner
         // 2 new partitions added
         assertEquals(actual.getOnlyValue().toString(), "5");
         assertQuerySucceeds("DROP TABLE test_partition_table");
+    }
+
+    @Test
+    public void testDisableBroadcastJoinExecutionStrategy()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "BROADCAST")
+                .setSystemProperty(STORAGE_BASED_BROADCAST_JOIN_ENABLED, "true")
+                .setSystemProperty(SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE, "10B")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_BROADCAST_JOIN_ENABLED, "false")
+                .build();
+
+        // Query should fail with broadcast join OOM
+        assertQueryFails(
+                session,
+                "select * from lineitem l join orders o on l.orderkey = o.orderkey",
+                "Query exceeded per-node broadcast memory limit of 10B \\[Broadcast size: .*MB\\]");
+
+        session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "BROADCAST")
+                .setSystemProperty(STORAGE_BASED_BROADCAST_JOIN_ENABLED, "true")
+                .setSystemProperty(SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE, "10B")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_BROADCAST_JOIN_ENABLED, "false")
+                .setSystemProperty(SPARK_QUERY_EXECUTION_STRATEGIES, "DISABLE_BROADCAST_JOIN")
+                .build();
+
+        // Query should succeed since broadcast join will be disabled due to
+        // presence of DISABLE_BROADCAST_JOIN strategy in session property spark_query_execution_strategies
+        assertQuery(
+                session,
+                "select * from lineitem l join orders o on l.orderkey = o.orderkey");
+    }
+
+    @Test
+    public void testIncreaseContainerSizeExecutionStrategy()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "2MB")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "2MB")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED, "false")
+                .setSystemProperty(OUT_OF_MEMORY_RETRY_PRESTO_SESSION_PROPERTIES, "query_max_memory_per_node=100MB,query_max_total_memory_per_node=100MB")
+                .setSystemProperty(OUT_OF_MEMORY_RETRY_SPARK_CONFIGS, "spark.executor.memory=1G")
+                .build();
+
+        // Query should fail with OOM
+        assertQueryFails(
+                session,
+                "select * from lineitem l join orders o on l.orderkey = o.orderkey",
+                ".*Query exceeded per-node .* memory limit of 2MB.*");
+
+        session = Session.builder(getSession())
+                .setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "2MB")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "2MB")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED, "false")
+                .setSystemProperty(OUT_OF_MEMORY_RETRY_PRESTO_SESSION_PROPERTIES, "query_max_memory_per_node=100MB,query_max_total_memory_per_node=100MB")
+                .setSystemProperty(OUT_OF_MEMORY_RETRY_SPARK_CONFIGS, "spark.executor.memory=1G")
+                .setSystemProperty(SPARK_QUERY_EXECUTION_STRATEGIES, "INCREASE_CONTAINER_SIZE")
+                .build();
+
+        // Query should succeed since memory will be increased due to
+        // presence of INCREASE_CONTAINER_SIZE strategy in session property spark_query_execution_strategies
+        assertQuery(
+                session,
+                "select * from lineitem l join orders o on l.orderkey = o.orderkey");
+    }
+
+    @Test
+    public void testIncreaseHashPartitionCountExecutionStrategy()
+    {
+        String query = "with l as (" +
+                "select * from lineitem UNION ALL select * from lineitem UNION ALL select * from lineitem" +
+                "), " +
+                "o as (" +
+                "select * from orders UNION ALL select * from orders UNION ALL select * from orders" +
+                ") " +
+                "select * from l right outer join o on l.orderkey = o.orderkey";
+
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
+                .setSystemProperty(HASH_PARTITION_COUNT, "1")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "6.5MB")
+                .setSystemProperty(QUERY_MAX_MEMORY, "100MB")
+                .setSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, "true")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED, "false")
+                .build();
+        assertQueryFails(session,
+                query,
+                "Query exceeded per-node total memory limit of .*Top Consumers: \\{HashBuilderOperator.*");
+
+        session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
+                .setSystemProperty(HASH_PARTITION_COUNT, "1")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "6.5MB")
+                .setSystemProperty(QUERY_MAX_MEMORY, "100MB")
+                .setSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, "true")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED, "false")
+                .setSystemProperty(SPARK_QUERY_EXECUTION_STRATEGIES, "INCREASE_HASH_PARTITION_COUNT")
+                .build();
+        assertQuerySucceeds(session, query);
     }
 
     private void assertBucketedQuery(String sql)

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/ExecutionStrategy.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/ExecutionStrategy.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.spark.classloader_interface;
 
-public enum RetryExecutionStrategy
+public enum ExecutionStrategy
 {
     DISABLE_BROADCAST_JOIN,
     INCREASE_CONTAINER_SIZE,

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkQueryExecutionFactory.java
@@ -33,6 +33,6 @@ public interface IPrestoSparkQueryExecutionFactory
             PrestoSparkTaskExecutorFactoryProvider executorFactoryProvider,
             Optional<String> queryStatusInfoOutputLocation,
             Optional<String> queryDataOutputLocation,
-            List<RetryExecutionStrategy> retryExecutionStrategies,
+            List<ExecutionStrategy> executionStrategies,
             Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector);
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkFailure.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkFailure.java
@@ -22,9 +22,9 @@ public class PrestoSparkFailure
 {
     private final String type;
     private final String errorCode;
-    private final List<RetryExecutionStrategy> retryExecutionStrategies;
+    private final List<ExecutionStrategy> retryExecutionStrategies;
 
-    public PrestoSparkFailure(String message, Throwable cause, String type, String errorCode, List<RetryExecutionStrategy> retryExecutionStrategies)
+    public PrestoSparkFailure(String message, Throwable cause, String type, String errorCode, List<ExecutionStrategy> retryExecutionStrategies)
     {
         super(message, cause);
         this.type = requireNonNull(type, "type is null");
@@ -42,7 +42,7 @@ public class PrestoSparkFailure
         return errorCode;
     }
 
-    public List<RetryExecutionStrategy> getRetryExecutionStrategies()
+    public List<ExecutionStrategy> getRetryExecutionStrategies()
     {
         return retryExecutionStrategies;
     }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunnerContext.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunnerContext.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.spark.launcher;
 
-import com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy;
+import com.facebook.presto.spark.classloader_interface.ExecutionStrategy;
 
 import java.security.Principal;
 import java.util.List;
@@ -44,7 +44,7 @@ public class PrestoSparkRunnerContext
     private final Optional<String> sparkQueueName;
     private final Optional<String> queryStatusInfoOutputLocation;
     private final Optional<String> queryDataOutputLocation;
-    private final List<RetryExecutionStrategy> retryExecutionStrategies;
+    private final List<ExecutionStrategy> executionStrategies;
 
     public PrestoSparkRunnerContext(
             String user,
@@ -66,7 +66,7 @@ public class PrestoSparkRunnerContext
             Optional<String> sparkQueueName,
             Optional<String> queryStatusInfoOutputLocation,
             Optional<String> queryDataOutputLocation,
-            List<RetryExecutionStrategy> retryExecutionStrategies)
+            List<ExecutionStrategy> executionStrategies)
     {
         this.user = user;
         this.principal = principal;
@@ -87,7 +87,7 @@ public class PrestoSparkRunnerContext
         this.sparkQueueName = sparkQueueName;
         this.queryStatusInfoOutputLocation = queryStatusInfoOutputLocation;
         this.queryDataOutputLocation = queryDataOutputLocation;
-        this.retryExecutionStrategies = retryExecutionStrategies;
+        this.executionStrategies = executionStrategies;
     }
 
     public String getUser()
@@ -185,9 +185,9 @@ public class PrestoSparkRunnerContext
         return queryDataOutputLocation;
     }
 
-    public List<RetryExecutionStrategy> getRetryExecutionStrategies()
+    public List<ExecutionStrategy> getExecutionStrategies()
     {
-        return retryExecutionStrategies;
+        return executionStrategies;
     }
 
     public static class Builder
@@ -211,7 +211,7 @@ public class PrestoSparkRunnerContext
         private Optional<String> sparkQueueName;
         private Optional<String> queryStatusInfoOutputLocation;
         private Optional<String> queryDataOutputLocation;
-        private List<RetryExecutionStrategy> retryExecutionStrategies;
+        private List<ExecutionStrategy> executionStrategies;
 
         public Builder(PrestoSparkRunnerContext prestoSparkRunnerContext)
         {
@@ -234,12 +234,12 @@ public class PrestoSparkRunnerContext
             this.sparkQueueName = prestoSparkRunnerContext.getSparkQueueName();
             this.queryStatusInfoOutputLocation = prestoSparkRunnerContext.getQueryStatusInfoOutputLocation();
             this.queryDataOutputLocation = prestoSparkRunnerContext.getQueryDataOutputLocation();
-            this.retryExecutionStrategies = prestoSparkRunnerContext.getRetryExecutionStrategies();
+            this.executionStrategies = prestoSparkRunnerContext.getExecutionStrategies();
         }
 
-        public Builder setRetryExecutionStrategies(List<RetryExecutionStrategy> retryExecutionStrategies)
+        public Builder setExecutionStrategies(List<ExecutionStrategy> executionStrategies)
         {
-            this.retryExecutionStrategies = requireNonNull(retryExecutionStrategies, "retryExecutionStrategies is null");
+            this.executionStrategies = requireNonNull(executionStrategies, "executionStrategies is null");
             return this;
         }
 
@@ -265,7 +265,7 @@ public class PrestoSparkRunnerContext
                     sparkQueueName,
                     queryStatusInfoOutputLocation,
                     queryDataOutputLocation,
-                    retryExecutionStrategies);
+                    executionStrategies);
         }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/aggregation/AggregationMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/aggregation/AggregationMetadata.java
@@ -202,7 +202,7 @@ public class AggregationMetadata
             return;
         }
         Class<?>[] parameterTypes = method.type().parameterArray();
-        checkArgument(parameterTypes.length == stateDescriptors.size() + 1, "Number of arguments for combine function must be exactly one plus than number of states.");
+        checkArgument(parameterTypes.length == stateDescriptors.size() + 1, "Number of arguments for output function must be exactly one plus than number of states.");
         for (int i = 0; i < stateDescriptors.size(); i++) {
             checkArgument(parameterTypes[i].equals(stateDescriptors.get(i).getStateInterface()), format("Type for Parameter index %d is unexpected", i));
         }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -23,7 +23,6 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static com.facebook.presto.Session.builder;
-import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
@@ -216,7 +215,7 @@ public abstract class AbstractTestAggregations
                         "  GROUP BY orderkey " +
                         "HAVING COUNT(DISTINCT partkey) != CARDINALITY(ARRAY_DISTINCT(ARRAY_AGG(partkey))))",
                 "VALUES 0");
-        assertQuery(builder(TEST_SESSION)
+        assertQuery(builder(getSession())
                         .setSystemProperty("use_mark_distinct", "false")
                         .build(),
                 " SELECT COUNT(*) FROM (SELECT orderkey, COUNT(DISTINCT partkey) FROM lineitem " +


### PR DESCRIPTION
## Description
High Memory task killer kills query with lowest memory. Fixing it and adding unit test for the same.

## Test Plan
Unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix High Memory Task killer to kill highest memory consuming query.

```

