### PR TITLE
Infer domain filters during predicate pushdown

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -305,6 +305,7 @@ public final class SystemSessionProperties
     public static final String REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN = "remove_redundant_cast_to_varchar_in_join";
     public static final String HANDLE_COMPLEX_EQUI_JOINS = "handle_complex_equi_joins";
     public static final String SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT = "skip_hash_generation_for_join_with_table_scan_input";
+    public static final String GENERATE_DOMAIN_FILTERS = "generate_domain_filters";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -1847,6 +1848,11 @@ public final class SystemSessionProperties
                         SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT,
                         "Skip hash generation for join, when input is table scan node",
                         featuresConfig.isSkipHashGenerationForJoinWithTableScanInput(),
+                        false),
+                booleanProperty(
+                        GENERATE_DOMAIN_FILTERS,
+                        "Infer predicates from column domains during predicate pushdown",
+                        featuresConfig.getGenerateDomainFilters(),
                         false));
     }
 
@@ -3070,5 +3076,10 @@ public final class SystemSessionProperties
     public static boolean skipHashGenerationForJoinWithTableScanInput(Session session)
     {
         return session.getSystemProperty(SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT, Boolean.class);
+    }
+
+    public static boolean shouldGenerateDomainFilters(Session session)
+    {
+        return session.getSystemProperty(GENERATE_DOMAIN_FILTERS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -296,6 +296,7 @@ public class FeaturesConfig
     private boolean removeRedundantCastToVarcharInJoin = true;
     private boolean skipHashGenerationForJoinWithTableScanInput;
     private long kHyperLogLogAggregationGroupNumberLimit;
+    private boolean generateDomainFilters;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2969,6 +2970,19 @@ public class FeaturesConfig
     public FeaturesConfig setKHyperLogLogAggregationGroupNumberLimit(long kHyperLogLogAggregationGroupNumberLimit)
     {
         this.kHyperLogLogAggregationGroupNumberLimit = kHyperLogLogAggregationGroupNumberLimit;
+        return this;
+    }
+
+    public boolean getGenerateDomainFilters()
+    {
+        return generateDomainFilters;
+    }
+
+    @Config("optimizer.generate-domain-filters")
+    @ConfigDescription("Infer predicates from column domains during predicate pushdown")
+    public FeaturesConfig setGenerateDomainFilters(boolean generateDomainFilters)
+    {
+        this.generateDomainFilters = generateDomainFilters;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
@@ -132,7 +132,7 @@ public final class RowExpressionDomainTranslator
         return predicate.accept(new Visitor<>(metadata, session, columnExtractor), false);
     }
 
-    private RowExpression toPredicate(Domain domain, RowExpression reference)
+    public RowExpression toPredicate(Domain domain, RowExpression reference)
     {
         if (domain.getValues().isNone()) {
             return domain.isNullAllowed() ? isNull(reference) : FALSE_CONSTANT;

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -259,7 +259,8 @@ public class TestFeaturesConfig
                 .setHandleComplexEquiJoins(false)
                 .setSkipHashGenerationForJoinWithTableScanInput(false)
                 .setCteMaterializationStrategy(CteMaterializationStrategy.NONE)
-                .setKHyperLogLogAggregationGroupNumberLimit(0));
+                .setKHyperLogLogAggregationGroupNumberLimit(0)
+                .setGenerateDomainFilters(false));
     }
 
     @Test
@@ -465,6 +466,7 @@ public class TestFeaturesConfig
                 .put("optimizer.handle-complex-equi-joins", "true")
                 .put("optimizer.skip-hash-generation-for-join-with-table-scan-input", "true")
                 .put("khyperloglog-agg-group-limit", "1000")
+                .put("optimizer.generate-domain-filters", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -667,7 +669,8 @@ public class TestFeaturesConfig
                 .setHandleComplexEquiJoins(true)
                 .setSkipHashGenerationForJoinWithTableScanInput(true)
                 .setCteMaterializationStrategy(CteMaterializationStrategy.ALL)
-                .setKHyperLogLogAggregationGroupNumberLimit(1000);
+                .setKHyperLogLogAggregationGroupNumberLimit(1000)
+                .setGenerateDomainFilters(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.GENERATE_DOMAIN_FILTERS;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
@@ -50,6 +52,7 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REP
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
 import static com.facebook.presto.sql.relational.Expressions.constant;
+import static java.util.Collections.emptyList;
 
 public class TestPredicatePushdown
         extends BasePlanTest
@@ -166,6 +169,28 @@ public class TestPredicatePushdown
                                 anyTree(
                                         filter("ORDERS_ORDER_KEY = BIGINT '2'",
                                                 tableScan("orders", ImmutableMap.of("ORDERS_ORDER_KEY", "orderkey")))))));
+    }
+
+    @Test
+    public void testDomainPredicateFromFilterSidePropagatesToSourceSideOfSemiJoin()
+    {
+        assertPlan("SELECT quantity FROM (SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE (orderkey = 2 and comment = 'abc') " +
+                        "OR (orderkey = 3 and comment = 'def') OR (orderkey = 4 and comment = 'ghi')))",
+                anyTree(
+                        semiJoin("LINE_ORDER_KEY", "ORDERS_ORDER_KEY", "SEMI_JOIN_RESULT",
+                                anyTree(
+                                        filter("LINE_ORDER_KEY IN( BIGINT'2', BIGINT'3', BIGINT'4')",
+                                                tableScan("lineitem", ImmutableMap.of(
+                                                        "LINE_ORDER_KEY", "orderkey",
+                                                        "LINE_QUANTITY", "quantity")))),
+                                anyTree(
+                                        filter("ORDERS_ORDER_KEY IN (BIGINT '2',BIGINT '3',BIGINT '4') AND ORDERS_COMMENT IN ('abc','def','ghi') " +
+                                                        "AND (((((ORDERS_ORDER_KEY) = (BIGINT'2')) AND ((ORDERS_COMMENT) = (VARCHAR'abc'))) " +
+                                                        "OR (((ORDERS_ORDER_KEY) = (BIGINT'3')) AND ((ORDERS_COMMENT) = (VARCHAR'def')))) " +
+                                                        "OR (((ORDERS_ORDER_KEY) = (BIGINT'4')) AND ((ORDERS_COMMENT) = (VARCHAR'ghi'))))",
+                                                tableScan("orders", ImmutableMap.of(
+                                                        "ORDERS_ORDER_KEY", "orderkey",
+                                                        "ORDERS_COMMENT", "comment")))))));
     }
 
     @Test
@@ -554,5 +579,136 @@ public class TestPredicatePushdown
                                                                 ImmutableMap.of(
                                                                         "N_NATIONKEY", "nationkey",
                                                                         "N_NAME", "name")))))));
+    }
+
+    @Test
+    public void testDomainFiltersCanBeInferredForLargeDisjunctiveFilters()
+    {
+        RuleTester tester = new RuleTester(emptyList(), ImmutableMap.of(GENERATE_DOMAIN_FILTERS, "true"));
+        PredicatePushDown predicatePushDownOptimizer = new PredicatePushDown(tester.getMetadata(), tester.getSqlParser());
+
+        // For Inner Join
+        tester.assertThat(predicatePushDownOptimizer)
+                // Query has more than 2 disjunctions in its predicate; SimplifyRowExpressions will not convert this into a CNF form
+                // Because of this, we do not get predicates on 's.phone' and 'l.orderkey' pushed down
+                // However when 'generate_domain_filters=true', these predicates are generated and pushed down
+                .on("select 1 FROM supplier s INNER JOIN lineitem l on s.suppkey = l.suppkey " +
+                        "WHERE (s.phone = '424242' AND l.orderkey = 5 ) " +
+                        "OR (s.phone = '242424' AND l.orderkey = 10) " +
+                        "OR (s.phone = '32424' AND l.orderkey = 150)")
+                .matches(
+                        anyTree(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("S_SUPPKEY", "L_SUPPKEY")),
+                                        Optional.of("(S_PHONE = '424242' AND L_ORDERKEY = 5) OR (S_PHONE = '242424' AND L_ORDERKEY = 10) OR (S_PHONE = '32424' AND L_ORDERKEY = 150)"),
+                                        project(
+                                                filter("S_PHONE IN ('242424','32424','424242')",
+                                                        tableScan("supplier",
+                                                                ImmutableMap.of(
+                                                                        "S_SUPPKEY", "suppkey",
+                                                                        "S_PHONE", "phone")))),
+                                        project(
+                                                filter("L_ORDERKEY IN (5,10,150)",
+                                                        tableScan("lineitem",
+                                                                ImmutableMap.of(
+                                                                        "L_SUPPKEY", "suppkey",
+                                                                        "L_ORDERKEY", "orderkey")))))));
+
+        // For an outer join, if an inner-side predicate is not pushing down an ISNULL; we can pushdown the full inner-side range predicate
+        tester.assertThat(predicatePushDownOptimizer)
+                .on("select 1 FROM supplier s LEFT JOIN lineitem l on s.suppkey = l.suppkey " +
+                        "WHERE (s.phone = '424242' AND l.orderkey = 5 ) " +
+                        "OR (s.phone = '242424' AND l.orderkey = 10) " +
+                        "OR (s.phone = '32424' AND l.orderkey = 150)")
+                .matches(
+                        anyTree(
+                                filter("(S_PHONE = '424242' AND L_ORDERKEY = 5) OR (S_PHONE = '242424' AND L_ORDERKEY = 10) OR (S_PHONE = '32424' AND L_ORDERKEY = 150)",
+                                        join(LEFT,
+                                                ImmutableList.of(equiJoinClause("S_SUPPKEY", "L_SUPPKEY")),
+                                                project(
+                                                        filter("S_PHONE IN ('242424','32424','424242')",
+                                                                tableScan("supplier",
+                                                                        ImmutableMap.of(
+                                                                                "S_SUPPKEY", "suppkey",
+                                                                                "S_PHONE", "phone")))),
+                                                project(
+                                                        filter("L_ORDERKEY IN (5,10,150)",
+                                                                tableScan("lineitem",
+                                                                        ImmutableMap.of(
+                                                                                "L_SUPPKEY", "suppkey",
+                                                                                "L_ORDERKEY", "orderkey"))))))));
+
+        // For an outer join, if an inner-side predicate *is* pushing down an ISNULL; we cannot push any inner side predicates
+        tester.assertThat(predicatePushDownOptimizer)
+                .on("select 1 FROM supplier s LEFT JOIN lineitem l on s.suppkey = l.suppkey " +
+                        "WHERE (s.phone = '424242' AND l.orderkey = 5 ) " +
+                        "OR (s.phone = '242424' AND l.orderkey = 10) " +
+                        "OR (s.phone = '32424' AND l.orderkey IS NULL)")
+                .matches(
+                        anyTree(
+                                filter("(S_PHONE = '424242' AND L_ORDERKEY = 5) OR (S_PHONE = '242424' AND L_ORDERKEY = 10) OR (S_PHONE = '32424' AND L_ORDERKEY IS NULL)",
+                                        join(LEFT,
+                                                ImmutableList.of(equiJoinClause("S_SUPPKEY", "L_SUPPKEY")),
+                                                project(
+                                                        filter("S_PHONE IN ('242424','32424','424242')",
+                                                                tableScan("supplier",
+                                                                        ImmutableMap.of(
+                                                                                "S_SUPPKEY", "suppkey",
+                                                                                "S_PHONE", "phone")))),
+                                                project(
+                                                        tableScan("lineitem",
+                                                                ImmutableMap.of(
+                                                                        "L_SUPPKEY", "suppkey",
+                                                                        "L_ORDERKEY", "orderkey")))))));
+    }
+
+    @Test
+    public void testDomainFiltersAppliedOnSemiJoinOutputFilterHaveNoImpact()
+    {
+        // No impact on SemiJoin
+        Session generateDomainFilterSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(GENERATE_DOMAIN_FILTERS, "true")
+                .build();
+
+        // Query is subquery of TPCH Q20
+        assertPlan(" SELECT  " +
+                        "      ps.suppkey  " +
+                        "    FROM  " +
+                        "      partsupp ps " +
+                        "    WHERE  " +
+                        "      ps.partkey IN ( " +
+                        "        SELECT  " +
+                        "          p.partkey  " +
+                        "        FROM  " +
+                        "          part p " +
+                        "        WHERE  " +
+                        "          p.name like 'forest%' " +
+                        "      )  " +
+                        "      AND ps.availqty > ( " +
+                        "        SELECT  " +
+                        "          0.5*sum(l.quantity)  " +
+                        "        FROM  " +
+                        "          lineitem l " +
+                        "        WHERE  " +
+                        "          l.partkey = ps.partkey  " +
+                        "          AND l.suppkey = ps.suppkey  " +
+                        "          AND l.shipdate >= date('1994-01-01') " +
+                        "          AND l.shipdate < date('1994-01-01') + interval '1' YEAR " +
+                        "      )",
+                generateDomainFilterSession,
+                output(
+                        join(
+                                anyTree(
+                                        // During filter pushdown of the boolean predicate SEMI_JOIN_RESULT through the InnerJoin, we produce the
+                                        // redundant domain filter (SEMI_JOIN_RESULT = BOOLEAN'true'). This however does not have any impact on how
+                                        // this filter is pushed down through the SemiJoin
+                                        filter("SEMI_JOIN_RESULT AND (SEMI_JOIN_RESULT = BOOLEAN'true')",
+                                                anyTree(
+                                                        semiJoin("PS_PARTKEY", "P_PART", "SEMI_JOIN_RESULT",
+                                                                anyTree(
+                                                                        tableScan("partsupp", ImmutableMap.of("PS_PARTKEY", "partkey"))),
+                                                                anyTree(
+                                                                        tableScan("part", ImmutableMap.of("P_PART", "partkey"))))))),
+                                anyTree(tableScan("lineitem")))));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdownWithDynamicFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdownWithDynamicFilter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.google.common.collect.ImmutableList;
@@ -20,11 +21,13 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
+import static com.facebook.presto.SystemSessionProperties.GENERATE_DOMAIN_FILTERS;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -148,10 +151,62 @@ public class TestPredicatePushdownWithDynamicFilter
                         semiJoin("LINE_ORDER_KEY", "ORDERS_ORDER_KEY", "SEMI_JOIN_RESULT",
                                 // NO filter here
                                 project(tableScan(
-                                                "lineitem",
-                                                ImmutableMap.of("LINE_ORDER_KEY", "orderkey"))),
+                                        "lineitem",
+                                        ImmutableMap.of("LINE_ORDER_KEY", "orderkey"))),
                                 anyTree(
                                         filter("ORDERS_ORDER_KEY > BIGINT '2'",
                                                 tableScan("orders", ImmutableMap.of("ORDERS_ORDER_KEY", "orderkey")))))));
+    }
+
+    @Override
+    public void testDomainFiltersAppliedOnSemiJoinOutputFilterHaveNoImpact()
+    {
+        // No impact on SemiJoin
+        Session generateDomainFilterSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(GENERATE_DOMAIN_FILTERS, "true")
+                .build();
+
+        // Query is subquery of TPCH Q20
+        assertPlan(" SELECT  " +
+                        "      ps.suppkey  " +
+                        "    FROM  " +
+                        "      partsupp ps " +
+                        "    WHERE  " +
+                        "      ps.partkey IN ( " +
+                        "        SELECT  " +
+                        "          p.partkey  " +
+                        "        FROM  " +
+                        "          part p " +
+                        "        WHERE  " +
+                        "          p.name like 'forest%' " +
+                        "      )  " +
+                        "      AND ps.availqty > ( " +
+                        "        SELECT  " +
+                        "          0.5*sum(l.quantity)  " +
+                        "        FROM  " +
+                        "          lineitem l " +
+                        "        WHERE  " +
+                        "          l.partkey = ps.partkey  " +
+                        "          AND l.suppkey = ps.suppkey  " +
+                        "          AND l.shipdate >= date('1994-01-01') " +
+                        "          AND l.shipdate < date('1994-01-01') + interval '1' YEAR " +
+                        "      )",
+                generateDomainFilterSession,
+                output(
+                        join(
+                                // Join order with lineitem is flipped when dynamic filtering is applied as compared
+                                // to super#testDomainFiltersAppliedOnSemiJoinOutputFilterHaveNoImpact
+                                anyTree(tableScan("lineitem")),
+                                anyTree(
+                                        // During filter pushdown of the boolean predicate SEMI_JOIN_RESULT through the InnerJoin, we produce the
+                                        // redundant domain filter (SEMI_JOIN_RESULT = BOOLEAN'true'). This however does not have any impact on how
+                                        // this filter is pushed down through the SemiJoin
+                                        filter("SEMI_JOIN_RESULT AND (SEMI_JOIN_RESULT = BOOLEAN'true')",
+                                                anyTree(
+                                                        semiJoin("PS_PARTKEY", "P_PART", "SEMI_JOIN_RESULT",
+                                                                anyTree(
+                                                                        tableScan("partsupp", ImmutableMap.of("PS_PARTKEY", "partkey"))),
+                                                                anyTree(
+                                                                        tableScan("part", ImmutableMap.of("P_PART", "partkey"))))))))));
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -96,6 +96,7 @@ import static io.airlift.tpch.TpchTable.ORDERS;
 import static io.airlift.tpch.TpchTable.PART;
 import static io.airlift.tpch.TpchTable.PART_SUPPLIER;
 import static io.airlift.tpch.TpchTable.REGION;
+import static io.airlift.tpch.TpchTable.SUPPLIER;
 import static java.lang.String.format;
 import static java.util.Collections.nCopies;
 
@@ -193,6 +194,17 @@ public class H2QueryRunner
                 "    comment VARCHAR(117) NOT NULL    \n" +
                 " ) ");
         insertRows(tpchMetadata, CUSTOMER);
+
+        handle.execute(" CREATE TABLE supplier ( \n" +
+                "    suppkey bigint NOT NULL,         \n" +
+                "    name varchar(25) NOT NULL,       \n" +
+                "    address varchar(40) NOT NULL,    \n" +
+                "    nationkey bigint NOT NULL,       \n" +
+                "    phone varchar(15) NOT NULL,      \n" +
+                "    acctbal double NOT NULL,         \n" +
+                "    comment varchar(101) NOT NULL    \n" +
+                " ) ");
+        insertRows(tpchMetadata, SUPPLIER);
     }
 
     private void insertRows(TpchMetadata tpchMetadata, TpchTable tpchTable)

--- a/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
+++ b/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
@@ -286,6 +286,8 @@ public class ThriftTpchService
                 return createPageSource(TpchTable.REGION, columnNames, splitInfo);
             case "part":
                 return createPageSource(TpchTable.PART, columnNames, splitInfo);
+            case "supplier":
+                return createPageSource(TpchTable.SUPPLIER, columnNames, splitInfo);
             default:
                 throw new IllegalArgumentException("Table not setup: " + splitInfo.getTableName());
         }


### PR DESCRIPTION
Adds the ability to extract domain filters during predicate pushdown through joins. This is helpful for complex predicates which cannot be broken apart and pushed down through Join nodes in its entirety
See the linked issue for an example.

For queries where the filters can be broken apart, some redundant filters are added, but for most queries these are eliminated by other rules later in the optimization pipeline

## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/20512

## Test Plan & Results
- New unit test added
- Tested TPCDS plan changes against a Hive ORC schema with `pushdown_filter_enabled`, results are here
https://aaneja.github.io/mypages/PR_21353_joinDiff_off_on_hiveOrcSchema.html

Shown in this are the row count estimate reduction on TableScanNodes with this optimization
Improvements observed for 4 queries -Q13, Q48, Q69, Q85
For Q89 & Q91, we saw a increase in estimated row count for `customer_demographics`; this was due to how the redundant filters got rewritten and estimated. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve predicate pushdown through Joins
```
