### PR TITLE
[native] Refactor `buildTaskSpillDirectoryPath` to take `NodeConfig` directly.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -129,13 +129,6 @@ class PrestoServer {
   /// In the implementation any extra config properties can be registered.
   virtual void registerExtraConfigProperties() {}
 
-  /// Invoked to get the ip address of the process. In certain deployment
-  /// setup, each process has different ip address. Deployment environment
-  /// may provide there own library to get process specific ip address.
-  /// In such cases, getLocalIp can be overriden to pass process specific
-  /// ip address.
-  virtual std::string getLocalIp() const;
-
   /// Invoked to get the spill directory.
   virtual std::string getBaseSpillDirectory() const;
 

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -367,7 +367,13 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateErrorTask(
   std::string path;
   folly::toAppend(fmt::format("{}/presto_native/", baseSpillPath), &path);
   if (includeNodeInSpillPath) {
-    folly::toAppend(fmt::format("{}_{}/", nodeConfig->nodeInternalAddress(), nodeConfig->nodeId()), &path);
+    folly::toAppend(
+        fmt::format(
+            "{}_{}/",
+            nodeConfig->nodeInternalAddress(
+                std::bind(&NodeConfig::getLocalIp, nodeConfig)),
+            nodeConfig->nodeId()),
+        &path);
   }
   folly::toAppend(fmt::format("{}/{}/{}/", dateString, queryId, taskId), &path);
   return path;

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -51,11 +51,9 @@ static void maybeSetupTaskSpillDirectory(
 
   const auto includeNodeInSpillPath =
       SystemConfig::instance()->includeNodeInSpillPath();
-  auto nodeConfig = NodeConfig::instance();
   const auto taskSpillDirPath = TaskManager::buildTaskSpillDirectoryPath(
       baseSpillDirectory,
-      nodeConfig->nodeInternalAddress(),
-      nodeConfig->nodeId(),
+      NodeConfig::instance(),
       execTask.queryCtx()->queryId(),
       execTask.taskId(),
       includeNodeInSpillPath);
@@ -351,8 +349,7 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateErrorTask(
 
 /*static*/ std::string TaskManager::buildTaskSpillDirectoryPath(
     const std::string& baseSpillPath,
-    const std::string& nodeIp,
-    const std::string& nodeId,
+    const NodeConfig* nodeConfig,
     const std::string& queryId,
     const protocol::TaskId& taskId,
     bool includeNodeInSpillPath) {
@@ -370,7 +367,7 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateErrorTask(
   std::string path;
   folly::toAppend(fmt::format("{}/presto_native/", baseSpillPath), &path);
   if (includeNodeInSpillPath) {
-    folly::toAppend(fmt::format("{}_{}/", nodeIp, nodeId), &path);
+    folly::toAppend(fmt::format("{}_{}/", nodeConfig->nodeInternalAddress(), nodeConfig->nodeId()), &path);
   }
   folly::toAppend(fmt::format("{}/{}/{}/", dateString, queryId, taskId), &path);
   return path;

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -53,7 +53,6 @@ static void maybeSetupTaskSpillDirectory(
       SystemConfig::instance()->includeNodeInSpillPath();
   const auto taskSpillDirPath = TaskManager::buildTaskSpillDirectoryPath(
       baseSpillDirectory,
-      NodeConfig::instance(),
       execTask.queryCtx()->queryId(),
       execTask.taskId(),
       includeNodeInSpillPath);
@@ -349,7 +348,6 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateErrorTask(
 
 /*static*/ std::string TaskManager::buildTaskSpillDirectoryPath(
     const std::string& baseSpillPath,
-    const NodeConfig* nodeConfig,
     const std::string& queryId,
     const protocol::TaskId& taskId,
     bool includeNodeInSpillPath) {
@@ -367,6 +365,7 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateErrorTask(
   std::string path;
   folly::toAppend(fmt::format("{}/presto_native/", baseSpillPath), &path);
   if (includeNodeInSpillPath) {
+    auto nodeConfig = NodeConfig::instance();
     folly::toAppend(
         fmt::format(
             "{}_{}/",

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include "presto_cpp/main/PrestoTask.h"
 #include "presto_cpp/main/QueryContextManager.h"
+#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/exec/OutputBufferManager.h"
@@ -150,8 +151,7 @@ class TaskManager {
   /// Always returns non-empty string.
   static std::string buildTaskSpillDirectoryPath(
       const std::string& baseSpillPath,
-      const std::string& nodeIp,
-      const std::string& nodeId,
+      const NodeConfig* nodeConfig,
       const std::string& queryId,
       const protocol::TaskId& taskId,
       bool includeNodeInSpillPath);

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -151,7 +151,6 @@ class TaskManager {
   /// Always returns non-empty string.
   static std::string buildTaskSpillDirectoryPath(
       const std::string& baseSpillPath,
-      const NodeConfig* nodeConfig,
       const std::string& queryId,
       const protocol::TaskId& taskId,
       bool includeNodeInSpillPath);

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -549,6 +549,13 @@ class NodeConfig : public ConfigBase {
 
   uint64_t nodeMemoryGb(
       const std::function<uint64_t()>& defaultNodeMemoryGb = nullptr) const;
+
+  /// Invoked to get the ip address of the process. In certain deployment
+  /// setup, each process has different ip address. Deployment environment
+  /// may provide there own library to get process specific ip address.
+  /// In such cases, getLocalIp can be overriden to pass process specific
+  /// ip address.
+  virtual std::string getLocalIp() const;
 };
 
 /// Used only in the single instance as the source of the initial properties for

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -595,10 +595,9 @@ class TaskManagerTest : public testing::Test {
         taskId, updateRequest, planFragment, std::move(queryCtx), 0);
   }
 
-  void initNodeConfig(
-      ConfigBase& config,
-      std::unordered_map<std::string, std::string> properties) {
-    config.initialize(std::make_unique<core::MemConfig>(std::move(properties)));
+  void initNodeConfig(std::unordered_map<std::string, std::string> properties) {
+    NodeConfig::instance()->initialize(
+        std::make_unique<core::MemConfig>(std::move(properties)));
   }
 
   std::shared_ptr<memory::MemoryPool> rootPool_;
@@ -1039,45 +1038,41 @@ TEST_F(TaskManagerTest, aggregationSpill) {
 }
 
 TEST_F(TaskManagerTest, buildTaskSpillDirectoryPath) {
-  NodeConfig config;
   initNodeConfig(
-      config,
       {{std::string(NodeConfig::kNodeInternalAddress), "192.168.10.2"},
        {std::string(NodeConfig::kNodeId), "19"}});
   EXPECT_EQ(
       "fs::/base/presto_native/192.168.10.2_19/2022-12-20/20221220-Q/Task1/",
       TaskManager::buildTaskSpillDirectoryPath(
-          "fs::/base", &config, "20221220-Q", "Task1", true));
+          "fs::/base", "20221220-Q", "Task1", true));
   EXPECT_EQ(
       "fs::/base/presto_native/2022-12-20/20221220-Q/Task1/",
       TaskManager::buildTaskSpillDirectoryPath(
-          "fs::/base", &config, "20221220-Q", "Task1", false));
+          "fs::/base", "20221220-Q", "Task1", false));
 
   initNodeConfig(
-      config,
       {{std::string(NodeConfig::kNodeInternalAddress), "192.16.10.2"},
        {std::string(NodeConfig::kNodeId), "sample_node_id"}});
   EXPECT_EQ(
       "fsx::/root/presto_native/192.16.10.2_sample_node_id/1970-01-01/Q100/Task22/",
       TaskManager::buildTaskSpillDirectoryPath(
-          "fsx::/root", &config, "Q100", "Task22", true));
+          "fsx::/root", "Q100", "Task22", true));
   EXPECT_EQ(
       "fsx::/root/presto_native/1970-01-01/Q100/Task22/",
       TaskManager::buildTaskSpillDirectoryPath(
-          "fsx::/root", &config, "Q100", "Task22", false));
+          "fsx::/root", "Q100", "Task22", false));
 
-  initNodeConfig(
-      config, {{std::string(NodeConfig::kNodeId), "sample_node_id"}});
+  initNodeConfig({{std::string(NodeConfig::kNodeId), "sample_node_id"}});
   EXPECT_EQ(
       fmt::format(
           "fsx::/root/presto_native/{}_sample_node_id/1970-01-01/Q100/Task22/",
-          config.getLocalIp()),
+          NodeConfig::instance()->getLocalIp()),
       TaskManager::buildTaskSpillDirectoryPath(
-          "fsx::/root", &config, "Q100", "Task22", true));
+          "fsx::/root", "Q100", "Task22", true));
   EXPECT_EQ(
       "fsx::/root/presto_native/1970-01-01/Q100/Task22/",
       TaskManager::buildTaskSpillDirectoryPath(
-          "fsx::/root", &config, "Q100", "Task22", false));
+          "fsx::/root", "Q100", "Task22", false));
 }
 
 TEST_F(TaskManagerTest, getDataOnAbortedTask) {

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -1060,19 +1060,24 @@ TEST_F(TaskManagerTest, buildTaskSpillDirectoryPath) {
   EXPECT_EQ(
       "fsx::/root/presto_native/192.16.10.2_sample_node_id/1970-01-01/Q100/Task22/",
       TaskManager::buildTaskSpillDirectoryPath(
-          "fsx::/root",
-          &config,
-          "Q100",
-          "Task22",
-          true));
+          "fsx::/root", &config, "Q100", "Task22", true));
   EXPECT_EQ(
       "fsx::/root/presto_native/1970-01-01/Q100/Task22/",
       TaskManager::buildTaskSpillDirectoryPath(
-          "fsx::/root",
-          &config,
-          "Q100",
-          "Task22",
-          false));
+          "fsx::/root", &config, "Q100", "Task22", false));
+
+  initNodeConfig(
+      config, {{std::string(NodeConfig::kNodeId), "sample_node_id"}});
+  EXPECT_EQ(
+      fmt::format(
+          "fsx::/root/presto_native/{}_sample_node_id/1970-01-01/Q100/Task22/",
+          config.getLocalIp()),
+      TaskManager::buildTaskSpillDirectoryPath(
+          "fsx::/root", &config, "Q100", "Task22", true));
+  EXPECT_EQ(
+      "fsx::/root/presto_native/1970-01-01/Q100/Task22/",
+      TaskManager::buildTaskSpillDirectoryPath(
+          "fsx::/root", &config, "Q100", "Task22", false));
 }
 
 TEST_F(TaskManagerTest, getDataOnAbortedTask) {


### PR DESCRIPTION
## Description
We always try to get `node.internal-address` or `node.ip` for building the task spill directory path even if `include-node-in-spill-path` is `false` (the default value is also `false`).

In this case, if `node.internal-address` and `node.ip` are not set, all queries will fail with `VeloxRuntimeError:  Node Internal Address or IP was not found in NodeConfigs. Default IP was not provided either.`. This refactor will prevent the check of `node.internal-address` and `node.ip` if `include-node-in-spill-path` is `false`.

Also, if `node.internal-address` and `node.ip` are not set when `include-node-in-spill-path` is `true`, we will use the local IP as the default value.

## Impact
None

## Test Plan
`TaskManagerTest.buildTaskSpillDirectoryPath` was updated to test this change.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

