### PR TITLE
[native] Share HTTP connection pools between HTTP clients

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
@@ -67,6 +67,7 @@ class PeriodicServiceInventoryManager {
   const double backOffjitterParam_{0.1};
 
   folly::EventBaseThread eventBaseThread_;
+  std::unique_ptr<proxygen::SessionPool> sessionPool_;
   folly::SocketAddress serviceAddress_;
   std::shared_ptr<http::HttpClient> client_;
   std::atomic_bool stopped_{true};

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -24,6 +24,38 @@
 
 namespace facebook::presto {
 
+// HTTP connection pool for a specific endpoint with its associated event base.
+// All the operations on the SessionPool must be performed on the corresponding
+// EventBase.
+struct ConnectionPool {
+  folly::EventBase* eventBase;
+  std::unique_ptr<proxygen::SessionPool> sessionPool;
+};
+
+// Connection pools used by HTTP client in PrestoExchangeSource.  It should be
+// held living longer than all the PrestoExchangeSources and will be passed when
+// we creating the exchange sources.
+class ConnectionPools {
+ public:
+  ~ConnectionPools() {
+    destroy();
+  }
+
+  const ConnectionPool& get(
+      const proxygen::Endpoint& endpoint,
+      folly::IOThreadPoolExecutor* ioExecutor);
+
+  void destroy();
+
+ private:
+  folly::Synchronized<folly::F14FastMap<
+      proxygen::Endpoint,
+      std::unique_ptr<ConnectionPool>,
+      proxygen::EndpointHash,
+      proxygen::EndpointEqual>>
+      pools_;
+};
+
 class PrestoExchangeSource : public velox::exec::ExchangeSource {
  public:
   class RetryState {
@@ -48,10 +80,14 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
           .count();
     }
 
+    int64_t durationMs() const {
+      return velox::getCurrentTimeMs() - startMs_;
+    }
+
     // Returns whether we have exhausted all retries. We only retry if we spent
     // less than maxWaitMs_ time after we first started.
     bool isExhausted() const {
-      return velox::getCurrentTimeMs() - startMs_ > maxWaitMs_;
+      return durationMs() > maxWaitMs_;
     }
 
    private:
@@ -70,7 +106,8 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
       const std::shared_ptr<velox::exec::ExchangeQueue>& queue,
       velox::memory::MemoryPool* pool,
       folly::CPUThreadPoolExecutor* driverExecutor,
-      folly::IOThreadPoolExecutor* httpExecutor,
+      folly::EventBase* ioEventBase,
+      proxygen::SessionPool* sessionPool,
       const std::string& clientCertAndKeyPath_ = "",
       const std::string& ciphers_ = "");
 
@@ -100,13 +137,15 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
       uint32_t maxBytes,
       uint32_t maxWaitSeconds) override;
 
-  static std::shared_ptr<ExchangeSource> create(
+  // Create an exchange source using pooled connections.
+  static std::shared_ptr<PrestoExchangeSource> create(
       const std::string& url,
       int destination,
       const std::shared_ptr<velox::exec::ExchangeQueue>& queue,
-      velox::memory::MemoryPool* pool,
+      velox::memory::MemoryPool* memoryPool,
       folly::CPUThreadPoolExecutor* cpuExecutor,
-      folly::IOThreadPoolExecutor* ioExecutor);
+      folly::IOThreadPoolExecutor* ioExecutor,
+      ConnectionPools& connectionPools);
 
   /// Completes the future returned by 'request()' if it hasn't completed
   /// already.
@@ -179,8 +218,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
       const std::string& path,
       uint32_t maxBytes,
       uint32_t maxWaitSeconds,
-      const std::string& error,
-      bool retry = true);
+      const std::string& error);
 
   void acknowledgeResults(int64_t ackSequence);
 
@@ -218,7 +256,6 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   const bool immediateBufferTransfer_;
 
   folly::CPUThreadPoolExecutor* const driverExecutor_;
-  folly::IOThreadPoolExecutor* const httpExecutor_;
 
   std::shared_ptr<http::HttpClient> httpClient_;
   RetryState dataRequestRetryState_;

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -20,7 +20,6 @@
 #include "CoordinatorDiscoverer.h"
 #include "presto_cpp/main/Announcer.h"
 #include "presto_cpp/main/PeriodicTaskManager.h"
-#include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/SignalHandler.h"
 #include "presto_cpp/main/TaskResource.h"
 #include "presto_cpp/main/common/ConfigReader.h"
@@ -328,7 +327,8 @@ void PrestoServer::run() {
             queue,
             pool,
             driverExecutor_.get(),
-            exchangeHttpExecutor_.get());
+            exchangeHttpExecutor_.get(),
+            exchangeSourceConnectionPools_);
       });
 
   facebook::velox::exec::ExchangeSource::registerFactory(
@@ -451,6 +451,9 @@ void PrestoServer::run() {
   httpServer_.reset();
 
   unregisterConnectors();
+
+  PRESTO_SHUTDOWN_LOG(INFO) << "Releasing HTTP connection pools";
+  exchangeSourceConnectionPools_.destroy();
 
   PRESTO_SHUTDOWN_LOG(INFO)
       << "Joining driver CPU Executor '" << driverExecutor_->getName()

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -22,6 +22,7 @@
 #include "presto_cpp/main/CPUMon.h"
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
 #include "presto_cpp/main/PeriodicHeartbeatManager.h"
+#include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/PrestoServerOperations.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/MemoryAllocator.h"
@@ -187,6 +188,8 @@ class PrestoServer {
 
   // Executor for spilling.
   std::shared_ptr<folly::CPUThreadPoolExecutor> spillerExecutor_;
+
+  ConnectionPools exchangeSourceConnectionPools_;
 
   // Instance of MemoryAllocator used for all query memory allocations.
   std::shared_ptr<velox::memory::MemoryAllocator> allocator_;

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -114,7 +114,8 @@ class HttpResponse {
 class HttpClient : public std::enable_shared_from_this<HttpClient> {
  public:
   HttpClient(
-      folly::EventBase* FOLLY_NONNULL eventBase,
+      folly::EventBase* eventBase,
+      proxygen::SessionPool* sessionPool,
       const folly::SocketAddress& address,
       std::chrono::milliseconds transactionTimeout,
       std::chrono::milliseconds connectTimeout,
@@ -122,8 +123,6 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
       const std::string& clientCertAndKeyPath = "",
       const std::string& ciphers = "",
       std::function<void(int)>&& reportOnBodyStatsFunc = nullptr);
-
-  ~HttpClient();
 
   // TODO Avoid copy by using IOBuf for body
   folly::SemiFuture<std::unique_ptr<HttpResponse>> sendRequest(
@@ -137,8 +136,9 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
 
  private:
   folly::EventBase* const eventBase_;
+  proxygen::SessionPool* const sessionPool_;
   const folly::SocketAddress address_;
-  const folly::HHWheelTimer::UniquePtr transactionTimer_;
+  const proxygen::WheelTimerInstance transactionTimer_;
   const std::chrono::milliseconds connectTimeout_;
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
   // clientCertAndKeyPath_ Points to a file (usually with pem extension) which
@@ -150,7 +150,6 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
   const std::string ciphers_;
   const std::function<void(int)> reportOnBodyStatsFunc_;
   const uint64_t maxResponseAllocBytes_;
-  std::unique_ptr<proxygen::SessionPool> sessionPool_;
 };
 
 class RequestBuilder {

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -369,21 +369,15 @@ static std::unique_ptr<http::HttpServer> createHttpServer(
   }
 }
 
-folly::Uri makeProducerUri(const folly::SocketAddress& address, bool useHttps) {
+std::string makeProducerUri(
+    const folly::SocketAddress& address,
+    bool useHttps) {
   std::string protocol = useHttps ? "https" : "http";
-  return folly::Uri(fmt::format(
+  return fmt::format(
       "{}://{}:{}/v1/task/20201007_190402_00000_r5erw.1.0.0/results/3",
       protocol,
       address.getAddressStr(),
-      address.getPort()));
-}
-
-static std::string getCiphers(bool useHttps) {
-  return useHttps ? "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384" : "";
-}
-
-static std::string getClientCa(bool useHttps) {
-  return useHttps ? getCertsPath("client_ca.pem") : "";
+      address.getPort());
 }
 
 struct Params {
@@ -415,6 +409,12 @@ class PrestoExchangeSourceTest : public ::testing::TestWithParam<Params> {
     SystemConfig::instance()->setValue(
         std::string(SystemConfig::kExchangeImmediateBufferTransfer),
         GetParam().immediateBufferTransfer ? "true" : "false");
+    SystemConfig::instance()->setValue(
+        std::string(SystemConfig::kHttpsClientCertAndKeyPath),
+        getCertsPath("client_ca.pem"));
+    SystemConfig::instance()->setValue(
+        std::string(SystemConfig::kHttpsSupportedCiphers),
+        "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384");
   }
 
   void TearDown() override {
@@ -435,15 +435,14 @@ class PrestoExchangeSourceTest : public ::testing::TestWithParam<Params> {
       int destination,
       const std::shared_ptr<exec::ExchangeQueue>& queue,
       memory::MemoryPool* pool = nullptr) {
-    return std::make_shared<PrestoExchangeSource>(
+    return PrestoExchangeSource::create(
         makeProducerUri(producerAddress, useHttps),
         destination,
         queue,
         pool != nullptr ? pool : pool_.get(),
         exchangeCpuExecutor_.get(),
         exchangeIoExecutor_.get(),
-        getClientCa(useHttps),
-        getCiphers(useHttps));
+        connectionPools_);
   }
 
   void requestNextPage(
@@ -460,6 +459,7 @@ class PrestoExchangeSourceTest : public ::testing::TestWithParam<Params> {
   std::unique_ptr<memory::MemoryAllocator> allocator_;
   std::shared_ptr<folly::CPUThreadPoolExecutor> exchangeCpuExecutor_;
   std::shared_ptr<folly::IOThreadPoolExecutor> exchangeIoExecutor_;
+  ConnectionPools connectionPools_;
 };
 
 int64_t totalBytes(const std::vector<std::string>& pages) {

--- a/presto-native-execution/presto_cpp/main/tests/PrestoQueryRunner.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoQueryRunner.cpp
@@ -462,11 +462,13 @@ std::multiset<std::vector<variant>> PrestoQueryRunner::execute(
 }
 
 std::vector<RowVectorPtr> PrestoQueryRunner::execute(const std::string& sql) {
+  auto sessionPool = std::make_unique<proxygen::SessionPool>();
   auto client = std::make_shared<http::HttpClient>(
       eventBaseThread_.getEventBase(),
+      sessionPool.get(),
       coordinatorUri_,
       std::chrono::milliseconds(10'000),
-      std::chrono::milliseconds(0),
+      std::chrono::milliseconds(20'000),
       pool_);
 
   auto response = ServerResponse(startQuery(sql, *client));
@@ -488,6 +490,8 @@ std::vector<RowVectorPtr> PrestoQueryRunner::execute(const std::string& sql) {
     response.throwIfFailed();
   }
 
+  eventBaseThread_.getEventBase()->runInEventBaseThread(
+      [sessionPool = std::move(sessionPool)] {});
   return queryResults;
 }
 

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -152,7 +152,9 @@ class TaskManagerTest : public testing::Test {
     aggregate::prestosql::registerAllAggregateFunctions();
     parse::registerTypeResolver();
     exec::ExchangeSource::registerFactory(
-        [cpuExecutor = exchangeCpuExecutor_, ioExecutor = exchangeIoExecutor_](
+        [cpuExecutor = exchangeCpuExecutor_,
+         ioExecutor = exchangeIoExecutor_,
+         connectionPools = connectionPools_](
             const std::string& taskId,
             int destination,
             std::shared_ptr<exec::ExchangeQueue> queue,
@@ -163,7 +165,8 @@ class TaskManagerTest : public testing::Test {
               queue,
               pool,
               cpuExecutor.get(),
-              ioExecutor.get());
+              ioExecutor.get(),
+              *connectionPools);
         });
     if (!isRegisteredVectorSerde()) {
       serializer::presto::PrestoVectorSerde::registerVectorSerde();
@@ -619,6 +622,8 @@ class TaskManagerTest : public testing::Test {
           8,
           std::make_shared<folly::NamedThreadFactory>("HTTPSrvIO"));
   long splitSequenceId_{0};
+  std::shared_ptr<ConnectionPools> connectionPools_ =
+      std::make_shared<ConnectionPools>();
 };
 
 // Runs "select * from t where c0 % 5 = 0" query.


### PR DESCRIPTION
Currently each exchange source owns one unique `SessionPool`, so the connection is only reused for one specific point to point communication.  This creates many connections between the same upstream and downstream nodes (for different tasks), decreasing the performance, increasing the chance of network error, and wasting precious ephemeral TCP ports (can only have 32K of them on one host) on client side.

Fix this by pooling the connections, decreasing the open socket count from 52K to 15K during peak, and have consistently lower socket usage during all time (see image attached).
![ods_pxlcld_jimmy_lu_2023_11_10t15_21_56_724z_](https://github.com/prestodb/presto/assets/1740215/02f527e0-2d9b-4ca1-a299-9493acc22933)

Also set a connect time out and increase the error duration so that connection error can be retried.