### PR TITLE
[native] Clean old tasks based on termination time

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -638,7 +638,10 @@ size_t TaskManager::cleanOldTasks() {
       bool eraseTask{false};
       if (prestoTask->task != nullptr) {
         if (prestoTask->task->state() != exec::TaskState::kRunning) {
-          if (prestoTask->task->timeSinceEndMs() >= oldTaskCleanUpMs_) {
+          // Since the state is not running, we know the task has been
+          // terminated. We use termination time instead of end time as the
+          // former does not include time waiting for results to be consumed.
+          if (prestoTask->task->timeSinceTerminationMs() >= oldTaskCleanUpMs_) {
             // Not running and old.
             eraseTask = true;
           }


### PR DESCRIPTION
Currently we clean old tasks based on end time. End time is set when the task finishes processing. Significant time may pass between that point and when downstream workers finish consuming results, when the task is terminated. In such situations the task is cleaned up immediately after being terminated, leading to race conditions with in flight status requests.

Using the termination time is safer and a closer analog to what is used in Java.
