### PR TITLE
fix the issue of `hudi-connector` getting no partitions.

### DIFF
--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPartitionManager.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPartitionManager.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import javax.inject.Inject;
 
 import java.time.ZoneId;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -71,7 +71,7 @@ public class HudiPartitionManager
             return ImmutableList.of("");
         }
 
-        Map<Column, Domain> partitionPredicate = new HashMap<>();
+        Map<Column, Domain> partitionPredicate = new LinkedHashMap<>();
         Map<ColumnHandle, Domain> domains = constraintSummary.getDomains().orElseGet(ImmutableMap::of);
         List<HudiColumnHandle> hudiColumnHandles = fromPartitionColumns(partitionColumns);
         for (int i = 0; i < hudiColumnHandles.size(); i++) {


### PR DESCRIPTION
…tionPredicates use HashMap.

## Description
fix the issue of `hudi-connector` getting no partitions, due to partitionPredicates use HashMap, domains in incorrect order.

## Motivation and Context
When I execute a SQL to query Hudi data, HudiPartitionManager#getEffectivePartitions return 0 partitions, but 2 partitions exist. ThriftHiveMetastore#getPartitionNamesByFilter convert Predicate to parts, but items order of parts is incorrect, do not match the partition order, the root case is HudiPartitionManager using HashMap to partitionPredicate.

## Impact
public List<String> getEffectivePartitions(
            ConnectorSession connectorSession,
            ExtendedHiveMetastore metastore,
            SchemaTableName schemaTableName,
            TupleDomain<ColumnHandle> constraintSummary)
{}