### PR TITLE
Remove redundant sort columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -106,7 +106,9 @@ import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantDistinctLim
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantLimit;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantSort;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantSortColumns;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantTopN;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantTopNColumns;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveTrivialFilters;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveUnreferencedScalarApplyNodes;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveUnreferencedScalarLateralNodes;
@@ -557,7 +559,9 @@ public class PlanOptimizers
                         ImmutableSet.of(
                                 new RemoveRedundantDistinct(),
                                 new RemoveRedundantTopN(),
+                                new RemoveRedundantTopNColumns(),
                                 new RemoveRedundantSort(),
+                                new RemoveRedundantSortColumns(),
                                 new RemoveRedundantLimit(),
                                 new RemoveRedundantDistinctLimit(),
                                 new RemoveRedundantAggregateDistinct(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantSortColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantSortColumns.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.LogicalProperties;
+import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.sql.planner.iterative.GroupReference;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.SortNode;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneOrderingColumns;
+import static com.facebook.presto.sql.planner.plan.Patterns.sort;
+
+/**
+ * Removes sort columns from input if the source has a Key that refers to the ordering columns
+ */
+public class RemoveRedundantSortColumns
+        implements Rule<SortNode>
+{
+    private static final Pattern<SortNode> PATTERN = sort().matching(p -> ((GroupReference) p.getSource()).getLogicalProperties().isPresent());
+
+    @Override
+    public Pattern<SortNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(SortNode node, Captures captures, Context context)
+    {
+        OrderingScheme orderingScheme = node.getOrderingScheme();
+
+        LogicalProperties sourceLogicalProperties = ((GroupReference) node.getSource()).getLogicalProperties().get();
+        OrderingScheme newOrderingScheme = pruneOrderingColumns(orderingScheme, sourceLogicalProperties);
+
+        if (newOrderingScheme.equals(orderingScheme)) {
+            return Result.empty();
+        }
+
+        return Result.ofPlanNode(new SortNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), node.getSource(), newOrderingScheme, node.isPartial()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantTopNColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantTopNColumns.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.LogicalProperties;
+import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.sql.planner.iterative.GroupReference;
+import com.facebook.presto.sql.planner.iterative.Rule;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneOrderingColumns;
+import static com.facebook.presto.sql.planner.plan.Patterns.topN;
+
+/**
+ * Removes TopN columns from input if the source has a Key that refers to the ordering columns
+ */
+public class RemoveRedundantTopNColumns
+        implements Rule<TopNNode>
+{
+    private static final Pattern<TopNNode> PATTERN = topN().matching(p -> ((GroupReference) p.getSource()).getLogicalProperties().isPresent());
+
+    @Override
+    public Pattern<TopNNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(TopNNode node, Captures captures, Context context)
+    {
+        OrderingScheme orderingScheme = node.getOrderingScheme();
+
+        LogicalProperties sourceLogicalProperties = ((GroupReference) node.getSource()).getLogicalProperties().get();
+        OrderingScheme newOrderingScheme = pruneOrderingColumns(orderingScheme, sourceLogicalProperties);
+
+        if (newOrderingScheme.equals(orderingScheme)) {
+            return Result.empty();
+        }
+
+        return Result.ofPlanNode(new TopNNode(node.getSourceLocation(), node.getId(), node.getSource(), node.getCount(), newOrderingScheme, node.getStep()));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
@@ -105,7 +105,7 @@ public class OptimizerAssert
     {
         checkState(plan == null, "plan has already been set");
 
-        //get an initial plan and apply a minimal set of optimizers in preparation foor applying the specific rules to be tested
+        //get an initial plan and apply a minimal set of optimizers in preparation for applying the specific rules to be tested
         Plan result = queryRunner.inTransaction(session -> queryRunner.createPlan(session, sql, getMinimalOptimizers(), Optimizer.PlanStage.OPTIMIZED, WarningCollector.NOOP));
         plan = result.getRoot();
         types = result.getTypes();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRedundantSortColumnsRemoval.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRedundantSortColumnsRemoval.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.properties.LogicalPropertiesProviderImpl;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topN;
+import static com.facebook.presto.sql.tree.SortItem.NullOrdering.LAST;
+import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
+import static com.facebook.presto.sql.tree.SortItem.Ordering.DESCENDING;
+import static java.util.Collections.emptyList;
+
+public class TestRedundantSortColumnsRemoval
+        extends BaseRuleTest
+{
+    private LogicalPropertiesProviderImpl logicalPropertiesProvider;
+
+    @BeforeClass
+    public final void setUp()
+    {
+        tester = new RuleTester(emptyList(), ImmutableMap.of("exploit_constraints", Boolean.toString(true)));
+        logicalPropertiesProvider = new LogicalPropertiesProviderImpl(new FunctionResolution(tester.getMetadata().getFunctionAndTypeManager().getFunctionAndTypeResolver()));
+    }
+
+    @Test
+    public void testRemoveRedundantColumnsFromTopN()
+    {
+        // OrderBy prefix matches GroupBy columns clause exactly
+        tester().assertThat(ImmutableSet.of(new MergeLimitWithSort(), new RemoveRedundantTopNColumns()), logicalPropertiesProvider)
+                .on("SELECT orderkey, custkey, sum(totalprice), min(orderdate) FROM orders GROUP BY orderkey, custkey " +
+                        "ORDER BY orderkey, custkey, sum(totalprice), min(orderdate) LIMIT 10")
+                .matches(topNMatchWith(ImmutableList.of(sort("ORDERKEY", ASCENDING, LAST), sort("CUSTKEY", ASCENDING, LAST))));
+
+        // Flipped order matches too since the Grouping set remains the same
+        tester().assertThat(ImmutableSet.of(new MergeLimitWithSort(), new RemoveRedundantTopNColumns()), logicalPropertiesProvider)
+                .on("SELECT orderkey, custkey, sum(totalprice), min(orderdate) FROM orders GROUP BY orderkey, custkey " +
+                        "ORDER BY custkey, orderkey, sum(totalprice), min(orderdate) LIMIT 10")
+                .matches(topNMatchWith(ImmutableList.of(sort("CUSTKEY", ASCENDING, LAST), sort("ORDERKEY", ASCENDING, LAST))));
+
+        // No impact due to sort direction
+        tester().assertThat(ImmutableSet.of(new MergeLimitWithSort(), new RemoveRedundantTopNColumns()), logicalPropertiesProvider)
+                .on("SELECT orderkey, custkey, sum(totalprice), min(orderdate) FROM orders GROUP BY orderkey, custkey " +
+                        "ORDER BY custkey DESC, orderkey ASC, sum(totalprice), min(orderdate) LIMIT 10")
+                .matches(topNMatchWith(ImmutableList.of(sort("CUSTKEY", DESCENDING, LAST), sort("ORDERKEY", ASCENDING, LAST))));
+
+        // Negative test - No prefix matches the grouping set, so TopN columns are not pruned
+        tester().assertThat(ImmutableSet.of(new MergeLimitWithSort(), new RemoveRedundantTopNColumns()), logicalPropertiesProvider)
+                .on("SELECT orderkey, custkey, sum(totalprice), min(orderdate) FROM orders GROUP BY orderkey, custkey " +
+                        "ORDER BY orderkey, sum(totalprice), custkey, min(orderdate) LIMIT 10")
+                .doesNotMatch(topNMatchWith(ImmutableList.of(sort("ORDERKEY", ASCENDING, LAST), sort("CUSTKEY", ASCENDING, LAST))));
+    }
+
+    @Test
+    public void testRemoveRedundantColumnsFromSort()
+    {
+        // OrderBy prefix matches GroupBy columns clause exactly
+        tester().assertThat(ImmutableSet.of(new RemoveRedundantSortColumns()), logicalPropertiesProvider)
+                .on("SELECT orderkey, custkey, sum(totalprice), min(orderdate) FROM orders GROUP BY orderkey, custkey " +
+                        "ORDER BY orderkey, custkey, sum(totalprice), min(orderdate)")
+                .matches(sortWith(ImmutableList.of(sort("ORDERKEY", ASCENDING, LAST), sort("CUSTKEY", ASCENDING, LAST))));
+
+        // Flipped order matches too since the Grouping set remains the same
+        tester().assertThat(ImmutableSet.of(new RemoveRedundantSortColumns()), logicalPropertiesProvider)
+                .on("SELECT orderkey, custkey, sum(totalprice), min(orderdate) FROM orders GROUP BY orderkey, custkey " +
+                        "ORDER BY custkey, orderkey, sum(totalprice), min(orderdate)")
+                .matches(sortWith(ImmutableList.of(sort("CUSTKEY", ASCENDING, LAST), sort("ORDERKEY", ASCENDING, LAST))));
+
+        // No impact due to sort direction
+        tester().assertThat(ImmutableSet.of(new RemoveRedundantSortColumns()), logicalPropertiesProvider)
+                .on("SELECT orderkey, custkey, sum(totalprice), min(orderdate) FROM orders GROUP BY orderkey, custkey " +
+                        "ORDER BY custkey DESC, orderkey ASC, sum(totalprice), min(orderdate)")
+                .matches(sortWith(ImmutableList.of(sort("CUSTKEY", DESCENDING, LAST), sort("ORDERKEY", ASCENDING, LAST))));
+
+        // Negative test - No prefix matches the grouping set, so TopN columns are not pruned
+        tester().assertThat(ImmutableSet.of(new RemoveRedundantSortColumns()), logicalPropertiesProvider)
+                .on("SELECT orderkey, custkey, sum(totalprice), min(orderdate) FROM orders GROUP BY orderkey, custkey " +
+                        "ORDER BY orderkey, sum(totalprice), custkey, min(orderdate)")
+                .doesNotMatch(sortWith(ImmutableList.of(sort("ORDERKEY", ASCENDING, LAST), sort("CUSTKEY", ASCENDING, LAST))));
+    }
+
+    private static PlanMatchPattern topNMatchWith(ImmutableList<PlanMatchPattern.Ordering> orderBy)
+    {
+        return output(
+                topN(10, orderBy,
+                        anyTree(
+                                tableScan("orders", ImmutableMap.of(
+                                        "ORDERKEY", "orderkey",
+                                        "CUSTKEY", "custkey")))));
+    }
+
+    private static PlanMatchPattern sortWith(ImmutableList<PlanMatchPattern.Ordering> orderBy)
+    {
+        return output(
+                sort(orderBy,
+                        anyTree(
+                                tableScan("orders", ImmutableMap.of(
+                                        "ORDERKEY", "orderkey",
+                                        "CUSTKEY", "custkey")))));
+    }
+}


### PR DESCRIPTION
## Description
Use the logical properties from constraint framework to remove redundant sort columns

## Motivation and Context
Queries can have GROUP + ORDER BY columns that are redundant. Example from TPCDS Q43 :

```
 GROUP BY s_store_name, s_store_id
 ORDER BY s_store_name, s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales
```

## Impact
When we run with the constraints framework switched on (`SET SESSION exploit_constraints=true`), we see redundant columns removed, see examples below -

### TPCDS Q43 :
Query has - 

```
 GROUP BY s_store_name, s_store_id
 ORDER BY s_store_name, s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales

```

Orig Plan (relevant portion) - 
```
 - TopNPartial[PlanNodeId 605][100 by (s_store_name ASC_NULLS_LAST, s_store_id ASC_NULLS_LAST, sum ASC_NULLS_LAST, sum_14 ASC_NULLS_LAST, sum_15 ASC_NULLS_LAST, sum_16 ASC_NULLS_LAST, sum_17 ASC_NULLS_LAST, sum_18 ASC_NULLS_LAST, sum_19 ASC_NULLS_LAST)] => [s_stor>
                     - Project[PlanNodeId 913][projectLocality = LOCAL] => [s_store_name:varchar(50), s_store_id:char(16), sum_18:decimal(38,2), sum_17:decimal(38,2), sum_16:decimal(38,2), sum_15:decimal(38,2), sum_19:decimal(38,2), sum_14:decimal(38,2), sum:decimal(38,2)]       >
                         - Aggregate(FINAL)[s_store_name, s_store_id][$hashvalue][PlanNodeId 8] => [s_store_name:varchar(50), s_store_id:char(16), $hashvalue:bigint, sum_18:decimal(38,2), sum_17:decimal(38,2), sum_16:decimal(38,2), sum_15:decimal(38,2), sum_19:decimal(38,2), sum_>
                                 sum_18 := "presto.default.sum"((sum_56)) (2:451)                                                                                                                                                                                                       >
                                 sum_17 := "presto.default.sum"((sum_55)) (2:367)                                                                                                                                                                                                       >
                                 sum_16 := "presto.default.sum"((sum_54)) (2:282)                                                                                                                                                                                                       >
                                 sum_15 := "presto.default.sum"((sum_53)) (2:199)                                                                                                                                                                                                       >
                                 sum_19 := "presto.default.sum"((sum_57)) (2:533)                                                                                                                                                                                                       >
                                 sum_14 := "presto.default.sum"((sum_52)) (2:117)                                                                                                                                                                                                       >
                                 sum := "presto.default.sum"((sum_51)) (2:35)      
```

Orderings are : `(s_store_name ASC_NULLS_LAST, s_store_id ASC_NULLS_LAST, sum ASC_NULLS_LAST, sum_14 ASC_NULLS_LAST, sum_15 ASC_NULLS_LAST, sum_16 ASC_NULLS_LAST, sum_17 ASC_NULLS_LAST, sum_18 ASC_NULLS_LAST, sum_19 ASC_NULLS_LAST)`

With this rewrite, we see that the plan changes to :
```
 - TopNPartial[PlanNodeId 606][100 by (s_store_name ASC_NULLS_LAST, s_store_id ASC_NULLS_LAST)] => [s_store_name:varchar(50), s_store_id:char(16), sum_18:decimal(38,2), sum_17:decimal(38,2), sum_16:decimal(38,2), sum_15:decimal(38,2), sum_19:decimal(38,2), sum_14:>
                     - Project[PlanNodeId 914][projectLocality = LOCAL] => [s_store_name:varchar(50), s_store_id:char(16), sum_18:decimal(38,2), sum_17:decimal(38,2), sum_16:decimal(38,2), sum_15:decimal(38,2), sum_19:decimal(38,2), sum_14:decimal(38,2), sum:decimal(38,2)]       >
                         - Aggregate(FINAL)[s_store_name, s_store_id][$hashvalue][PlanNodeId 8] => [s_store_name:varchar(50), s_store_id:char(16), $hashvalue:bigint, sum_18:decimal(38,2), sum_17:decimal(38,2), sum_16:decimal(38,2), sum_15:decimal(38,2), sum_19:decimal(38,2), sum_>
                                 sum_18 := "presto.default.sum"((sum_56)) (8:9)                                                                                                                                                                                                         >
                                 sum_17 := "presto.default.sum"((sum_55)) (7:9)                                                                                                                                                                                                         >
                                 sum_16 := "presto.default.sum"((sum_54)) (6:9)                                                                                                                                                                                                         >
                                 sum_15 := "presto.default.sum"((sum_53)) (5:9)                                                                                                                                                                                                         >
                                 sum_19 := "presto.default.sum"((sum_57)) (9:9)                                                                                                                                                                                                         >
                                 sum_14 := "presto.default.sum"((sum_52)) (4:9)                                                                                                                                                                                                         >
                                 sum := "presto.default.sum"((sum_51)) (3:9)            
```

Orderings are : `(s_store_name ASC_NULLS_LAST, s_store_id ASC_NULLS_LAST)`


### TPCDS Q3 :
Query has :
```
 GROUP BY dt.d_year, item.i_brand, item.i_brand_id
 ORDER BY dt.d_year, sum_agg desc, brand_id
```

No redundant columns here, no impact on sorting observed
```
2023-11-13T14:51:00.735+0530	DEBUG	Query-20231113_092100_00005_hyt9h-301	com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantTopNColumns	[11] TopNNode : com.facebook.presto.spi.plan.TopNNode@4c85148
2023-11-13T14:51:00.735+0530	DEBUG	Query-20231113_092100_00005_hyt9h-301	com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantSortColumns	Current Node order variables: [d_year, i_brand_id, sum]
Logical properties for source [379] : LogicalPropertiesImpl{KeyProperty=KeyProperty{keys=Key{variables=d_year,i_brand_id,i_brand}}, EquivalenceClassProperty=EquivalenceClassProperty{EquivalenceClassHeads=, EquivalenceClasses=}, MaxCardProperty=MaxCardProperty{value=null}}
2023-11-13T14:51:00.735+0530	DEBUG	Query-20231113_092100_00005_hyt9h-301	com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantSortColumns	No key variables found
```



## Testing
- New unit test and presto-test added
- Changes orderings and plans for below TPCDS queries
```
Q43
Q54
Q60
Q83
Q78
Q58
```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Remove redundant sort columns from Plan nodes if a unique constraint can be identified for a prefix of the ordering list
```


