### PR TITLE
[native] Resolve antlr dependency for CTest on Apple Silicon

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -215,4 +215,9 @@ else()
 endif()
 set(CMAKE_JOB_POOL_LINK presto_link_job_pool)
 
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64" AND ${CMAKE_SYSTEM_NAME} MATCHES
+                                                 "Darwin")
+  set(ON_APPLE_SILICON True)
+endif()
+
 add_subdirectory(presto_cpp)

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -41,3 +41,8 @@ target_link_libraries(
 
 set_property(TARGET presto_operators_test PROPERTY JOB_POOL_LINK
                                                    presto_link_job_pool)
+if(ON_APPLE_SILICON)
+  set_tests_properties(
+    presto_operators_test PROPERTIES ENVIRONMENT
+                                     "DYLD_LIBRARY_PATH=/usr/local/lib")
+endif()

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -87,3 +87,8 @@ target_link_libraries(
 
 set_property(TARGET presto_query_runner_test PROPERTY JOB_POOL_LINK
                                                       presto_link_job_pool)
+if(ON_APPLE_SILICON)
+  set_tests_properties(
+    presto_server_test presto_query_runner_test
+    PROPERTIES ENVIRONMENT "DYLD_LIBRARY_PATH=/usr/local/lib")
+endif()

--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -81,3 +81,8 @@ target_link_libraries(
 
 set_property(TARGET presto_expressions_test PROPERTY JOB_POOL_LINK
                                                      presto_link_job_pool)
+if(ON_APPLE_SILICON)
+  set_tests_properties(
+    presto_expressions_test PROPERTIES ENVIRONMENT
+                                       "DYLD_LIBRARY_PATH=/usr/local/lib")
+endif()


### PR DESCRIPTION
## Description
On Apple M1 antlr is installed to /usr/local/lib. When running Ctest (e.g. make unittest) some tests fail due to antlr library not being found. Executing the tests manually on a terminal works as expected. The issue is only in Ctest. Setting the DYLD_LIBRARY_PATH explicitly in the environment does not resolve the issue and the CMakeLists.txt for each affected test needs to be modified.

## Motivation and Context
This fixes an issue when attempting to run the unittests on Apple Silicon.

Error produced for one of the tests
```
2/8 Test #6: presto_server_test ...............Subprocess aborted***Exception:   0.05 sec
dyld[49652]: Library not loaded: libantlr4-runtime.4.9.3.dylib
  Referenced from: <5641000F-DB8B-371C-84CE-C248C2A7B353> /Users/czentgr/gitspace/presto/presto-native-execution/_build/debug/presto_cpp/main/tests/presto_server_test
  Reason: tried: 'libantlr4-runtime.4.9.3.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibantlr4-runtime.4.9.3.dylib' (no such file), 'libantlr4-runtime.4.9.3.dylib' (no such file), '/Users/czentgr/gitspace/presto/presto-native-execution/presto_cpp/main/tests/libantlr4-runtime.4.9.3.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/czentgr/gitspace/presto/presto-native-execution/presto_cpp/main/tests/libantlr4-runtime.4.9.3.dylib' (no such file), '/Users/czentgr/gitspace/presto/presto-native-execution/presto_cpp/main/tests/libantlr4-runtime.4.9.3.dylib' (no such file)
```

## Impact
No external impact.

## Test Plan
N/A

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

