### PR TITLE
Refactor set_agg and set_union function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -90,6 +90,7 @@ import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggregationFunction;
 import com.facebook.presto.operator.aggregation.arrayagg.SetAggregationFunction;
+import com.facebook.presto.operator.aggregation.arrayagg.SetUnionFunction;
 import com.facebook.presto.operator.aggregation.differentialentropy.DifferentialEntropyAggregation;
 import com.facebook.presto.operator.aggregation.histogram.Histogram;
 import com.facebook.presto.operator.aggregation.multimapagg.AlternativeMultimapAggregationFunction;
@@ -340,7 +341,6 @@ import static com.facebook.presto.operator.aggregation.TDigestAggregationFunctio
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG_WITH_WEIGHT;
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG_WITH_WEIGHT_AND_COMPRESSION;
 import static com.facebook.presto.operator.aggregation.approxmostfrequent.ApproximateMostFrequent.APPROXIMATE_MOST_FREQUENT;
-import static com.facebook.presto.operator.aggregation.arrayagg.SetUnionFunction.SET_UNION;
 import static com.facebook.presto.operator.aggregation.minmaxby.AlternativeMaxByAggregationFunction.ALTERNATIVE_MAX_BY;
 import static com.facebook.presto.operator.aggregation.minmaxby.AlternativeMinByAggregationFunction.ALTERNATIVE_MIN_BY;
 import static com.facebook.presto.operator.aggregation.minmaxby.MaxByAggregationFunction.MAX_BY;
@@ -869,7 +869,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .function(ARRAY_CONCAT_FUNCTION)
                 .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_TO_JSON, JSON_TO_ARRAY, JSON_STRING_TO_ARRAY)
                 .aggregate(SetAggregationFunction.class)
-                .function(SET_UNION)
+                .aggregate(SetUnionFunction.class)
                 .function(new ArrayAggregationFunction(featuresConfig.isLegacyArrayAgg(), featuresConfig.getArrayAggGroupImplementation()))
                 .functions(new MapSubscriptOperator(featuresConfig.isLegacyMapSubscript()))
                 .functions(MAP_CONSTRUCTOR, MAP_TO_JSON, JSON_TO_MAP, JSON_STRING_TO_MAP)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -89,6 +89,7 @@ import com.facebook.presto.operator.aggregation.ReduceAggregationFunction;
 import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggregationFunction;
+import com.facebook.presto.operator.aggregation.arrayagg.SetAggregationFunction;
 import com.facebook.presto.operator.aggregation.differentialentropy.DifferentialEntropyAggregation;
 import com.facebook.presto.operator.aggregation.histogram.Histogram;
 import com.facebook.presto.operator.aggregation.multimapagg.AlternativeMultimapAggregationFunction;
@@ -339,7 +340,6 @@ import static com.facebook.presto.operator.aggregation.TDigestAggregationFunctio
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG_WITH_WEIGHT;
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG_WITH_WEIGHT_AND_COMPRESSION;
 import static com.facebook.presto.operator.aggregation.approxmostfrequent.ApproximateMostFrequent.APPROXIMATE_MOST_FREQUENT;
-import static com.facebook.presto.operator.aggregation.arrayagg.SetAggregationFunction.SET_AGG;
 import static com.facebook.presto.operator.aggregation.arrayagg.SetUnionFunction.SET_UNION;
 import static com.facebook.presto.operator.aggregation.minmaxby.AlternativeMaxByAggregationFunction.ALTERNATIVE_MAX_BY;
 import static com.facebook.presto.operator.aggregation.minmaxby.AlternativeMinByAggregationFunction.ALTERNATIVE_MIN_BY;
@@ -868,7 +868,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .function(ARRAY_FLATTEN_FUNCTION)
                 .function(ARRAY_CONCAT_FUNCTION)
                 .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_TO_JSON, JSON_TO_ARRAY, JSON_STRING_TO_ARRAY)
-                .function(SET_AGG)
+                .aggregate(SetAggregationFunction.class)
                 .function(SET_UNION)
                 .function(new ArrayAggregationFunction(featuresConfig.isLegacyArrayAgg(), featuresConfig.getArrayAggGroupImplementation()))
                 .functions(new MapSubscriptOperator(featuresConfig.isLegacyMapSubscript()))

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationFunction.java
@@ -13,124 +13,32 @@
  */
 package com.facebook.presto.operator.aggregation.arrayagg;
 
-import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
-import com.facebook.presto.common.type.ArrayType;
-import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeSignatureParameter;
-import com.facebook.presto.metadata.BoundVariables;
-import com.facebook.presto.metadata.FunctionAndTypeManager;
-import com.facebook.presto.metadata.SqlAggregationFunction;
-import com.facebook.presto.operator.aggregation.AccumulatorCompiler;
-import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
+import com.facebook.presto.operator.aggregation.NullablePosition;
 import com.facebook.presto.operator.aggregation.SetOfValues;
 import com.facebook.presto.operator.aggregation.state.SetAggregationState;
-import com.facebook.presto.operator.aggregation.state.SetAggregationStateFactory;
-import com.facebook.presto.spi.function.AccumulatorState;
-import com.facebook.presto.spi.function.AccumulatorStateFactory;
-import com.facebook.presto.spi.function.AccumulatorStateSerializer;
-import com.facebook.presto.spi.function.aggregation.Accumulator;
-import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
-import com.facebook.presto.spi.function.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
-import com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
-import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
-import com.google.common.collect.ImmutableList;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
 
-import java.lang.invoke.MethodHandle;
-import java.util.List;
-
-import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
-import static com.facebook.presto.spi.function.Signature.typeVariable;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
-import static com.facebook.presto.util.Reflection.methodHandle;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
+@AggregationFunction(value = "set_agg", isCalledOnNullInput = true)
 public class SetAggregationFunction
-        extends SqlAggregationFunction
 {
-    public static final SetAggregationFunction SET_AGG = new SetAggregationFunction();
-
-    private static final String NAME = "set_agg";
-    private static final MethodHandle INPUT_FUNCTION = methodHandle(SetAggregationFunction.class, "input", Type.class, SetAggregationState.class, Block.class, int.class);
-    private static final MethodHandle COMBINE_FUNCTION = methodHandle(SetAggregationFunction.class, "combine", SetAggregationState.class, SetAggregationState.class);
-    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(SetAggregationFunction.class, "output", SetAggregationState.class, BlockBuilder.class);
-
-    public SetAggregationFunction()
+    private SetAggregationFunction()
     {
-        super(NAME,
-                ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
-                parseTypeSignature("array(T)"),
-                ImmutableList.of(parseTypeSignature("T")));
     }
 
-    @Override
-    public String getDescription()
-    {
-        return "return an array of values";
-    }
-
-    @Override
-    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
-    {
-        Type type = boundVariables.getTypeVariable("T");
-        ArrayType outputType = (ArrayType) functionAndTypeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(
-                TypeSignatureParameter.of(type.getTypeSignature())));
-        return generateAggregation(type, outputType);
-    }
-
-    @Override
-    public boolean isCalledOnNullInput()
-    {
-        return true;
-    }
-
-    private static BuiltInAggregationFunctionImplementation generateAggregation(Type type, ArrayType outputType)
-    {
-        DynamicClassLoader classLoader = new DynamicClassLoader(SetAggregationFunction.class.getClassLoader());
-
-        List<Type> inputTypes = ImmutableList.of(type);
-        AccumulatorStateSerializer<?> stateSerializer = new SetAggregationStateSerializer(outputType);
-        AccumulatorStateFactory<?> stateFactory = new SetAggregationStateFactory(type);
-
-        Type intermediateType = stateSerializer.getSerializedType();
-        List<ParameterMetadata> inputParameterMetadata = createInputParameterMetadata(type);
-        Class<? extends AccumulatorState> stateInterface = SetAggregationState.class;
-        AggregationMetadata metadata = new AggregationMetadata(
-                generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
-                inputParameterMetadata,
-                INPUT_FUNCTION.bindTo(type),
-                COMBINE_FUNCTION,
-                OUTPUT_FUNCTION,
-                ImmutableList.of(new AccumulatorStateDescriptor(
-                        stateInterface,
-                        stateSerializer,
-                        stateFactory)),
-                outputType);
-
-        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
-                Accumulator.class,
-                metadata,
-                classLoader);
-        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
-                GroupedAccumulator.class,
-                metadata,
-                classLoader);
-        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType),
-                outputType, true, true, metadata, accumulatorClass, groupedAccumulatorClass);
-    }
-
-    private static List<ParameterMetadata> createInputParameterMetadata(Type value)
-    {
-        return ImmutableList.of(new ParameterMetadata(STATE), new ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, value), new ParameterMetadata(BLOCK_INDEX));
-    }
-
-    public static void input(Type type, SetAggregationState state, Block block, int position)
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@TypeParameter("T") Type type, @AggregationState SetAggregationState state, @BlockPosition @SqlType("T") @NullablePosition Block block, @BlockIndex int position)
     {
         SetOfValues set = state.get();
         if (set == null) {
@@ -143,7 +51,8 @@ public class SetAggregationFunction
         state.addMemoryUsage(set.estimatedInMemorySize() - startSize);
     }
 
-    public static void combine(SetAggregationState state, SetAggregationState otherState)
+    @CombineFunction
+    public static void combine(@AggregationState SetAggregationState state, @AggregationState SetAggregationState otherState)
     {
         if (state.get() != null && otherState.get() != null) {
             SetOfValues otherSet = otherState.get();
@@ -161,7 +70,8 @@ public class SetAggregationFunction
         }
     }
 
-    public static void output(SetAggregationState state, BlockBuilder out)
+    @OutputFunction("array(T)")
+    public static void output(@AggregationState SetAggregationState state, BlockBuilder out)
     {
         SetOfValues set = state.get();
         if (set == null) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationFunction.java
@@ -38,7 +38,11 @@ public class SetAggregationFunction
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@TypeParameter("T") Type type, @AggregationState SetAggregationState state, @BlockPosition @SqlType("T") @NullablePosition Block block, @BlockIndex int position)
+    public static void input(
+            @TypeParameter("T") Type type,
+            @AggregationState SetAggregationState state,
+            @BlockPosition @SqlType("T") @NullablePosition Block block,
+            @BlockIndex int position)
     {
         SetOfValues set = state.get();
         if (set == null) {
@@ -52,7 +56,9 @@ public class SetAggregationFunction
     }
 
     @CombineFunction
-    public static void combine(@AggregationState SetAggregationState state, @AggregationState SetAggregationState otherState)
+    public static void combine(
+            @AggregationState SetAggregationState state,
+            @AggregationState SetAggregationState otherState)
     {
         if (state.get() != null && otherState.get() != null) {
             SetOfValues otherSet = otherState.get();
@@ -71,7 +77,9 @@ public class SetAggregationFunction
     }
 
     @OutputFunction("array(T)")
-    public static void output(@AggregationState SetAggregationState state, BlockBuilder out)
+    public static void output(
+            @AggregationState SetAggregationState state,
+            BlockBuilder out)
     {
         SetOfValues set = state.get();
         if (set == null) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationStateSerializer.java
@@ -20,15 +20,16 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.operator.aggregation.SetOfValues;
 import com.facebook.presto.operator.aggregation.state.SetAggregationState;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.function.TypeParameter;
 
 public class SetAggregationStateSerializer
         implements AccumulatorStateSerializer<SetAggregationState>
 {
     private final ArrayType arrayType;
 
-    public SetAggregationStateSerializer(ArrayType arrayType)
+    public SetAggregationStateSerializer(@TypeParameter("T") Type elementType)
     {
-        this.arrayType = arrayType;
+        this.arrayType = new ArrayType(elementType);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/SetAggregationStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/SetAggregationStateFactory.java
@@ -17,16 +17,17 @@ import com.facebook.presto.common.array.ObjectBigArray;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.operator.aggregation.SetOfValues;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.spi.function.TypeParameter;
 import org.openjdk.jol.info.ClassLayout;
 
 import static java.util.Objects.requireNonNull;
 
 public class SetAggregationStateFactory
-        implements AccumulatorStateFactory
+        implements AccumulatorStateFactory<SetAggregationState>
 {
     private final Type elementType;
 
-    public SetAggregationStateFactory(Type elementType)
+    public SetAggregationStateFactory(@TypeParameter("T") Type elementType)
     {
         this.elementType = elementType;
     }


### PR DESCRIPTION
## Description
Resolve #21362 & #21363. This commit refactors `set_agg` and `set_union` function using the [function annotation framework](http://prestodb.io/docs/0.284/develop/functions.html) 

## Motivation and Context
This will simplify the implementation and improve maintainability

## Impact
None.

## Test Plan
Unit tests have been written before

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

