### PR TITLE
[native] Rename session property to confirm to Presto standard

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -312,7 +312,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_EXECUTION_EXECUTABLE_PATH = "native_execution_executable_path";
     public static final String NATIVE_EXECUTION_PROGRAM_ARGUMENTS = "native_execution_program_arguments";
     public static final String NATIVE_EXECUTION_PROCESS_REUSE_ENABLED = "native_execution_process_reuse_enabled";
-    public static final String NATIVE_DEBUG_VALIDATE_OUTPUT_FROM_OPERATORS = "native_debug.validate_output_from_operators";
+    public static final String NATIVE_DEBUG_VALIDATE_OUTPUT_FROM_OPERATORS = "native_debug_validate_output_from_operators";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -46,7 +46,7 @@ std::string toVeloxConfig(const std::string& name) {
           {"native_spill_write_buffer_size",
            QueryConfig::kSpillWriteBufferSize},
           {"native_join_spill_enabled", QueryConfig::kJoinSpillEnabled},
-          {"native_debug.validate_output_from_operators",
+          {"native_debug_validate_output_from_operators",
            QueryConfig::kValidateOutputFromOperators}};
   auto it = kPrestoToVeloxMapping.find(name);
   return it == kPrestoToVeloxMapping.end() ? name : it->second;

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -45,7 +45,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
           {"native_spill_compression_codec", "NONE"},
           {"native_join_spill_enabled", "false"},
           {"native_spill_write_buffer_size", "1024"},
-          {"native_debug.validate_output_from_operators", "true"},
+          {"native_debug_validate_output_from_operators", "true"},
           {"aggregation_spill_all", "true"}}};
   auto queryCtx = taskManager_->getQueryContextManager()->findOrCreateQueryCtx(
       taskId, session);


### PR DESCRIPTION
Updates the session property `native_debug.validate_output_from_operators`
to `native_debug_validate_output_from_operators`.