### PR TITLE
Add simple settings to prestodb/presto image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,11 @@ RUN dnf install -y java-11-openjdk less procps python3 \
         # Download jmx prometheus exporter \
         && curl -o /usr/lib/presto/utils/jmx_prometheus_javaagent-0.20.0.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.20.0/jmx_prometheus_javaagent-0.20.0.jar
 
-COPY etc $PRESTO_HOME/etc
+COPY etc/config.properties.example $PRESTO_HOME/etc/config.properties
+COPY etc/jvm.config.example $PRESTO_HOME/etc/jvm.config
+COPY etc/node.properties $PRESTO_HOME/etc/node.properties
 COPY entrypoint.sh /opt
+
+EXPOSE 8080
 
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ "$#" != "1" ]; then
+    echo "usage: build.sh <version>"
+    exit 1
+fi
+
+VERSION=$1
+TAG="${TAG:-latest}"
+
+wget https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${VERSION}/presto-server-${VERSION}.tar.gz
+wget https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/${VERSION}/presto-cli-${VERSION}-executable.jar
+
+docker build -t prestodb/presto:${TAG} --build-arg="PRESTO_VERSION=${VERSION}" -f Dockerfile .
+
+# docker push?

--- a/docker/etc/catalog/jmx.properties
+++ b/docker/etc/catalog/jmx.properties
@@ -1,0 +1,1 @@
+connector.name=jmx

--- a/docker/etc/catalog/memory.properties
+++ b/docker/etc/catalog/memory.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/docker/etc/catalog/tpcds.properties
+++ b/docker/etc/catalog/tpcds.properties
@@ -1,0 +1,1 @@
+connector.name=tpcds

--- a/docker/etc/catalog/tpch.properties
+++ b/docker/etc/catalog/tpch.properties
@@ -1,0 +1,1 @@
+connector.name=tpch


### PR DESCRIPTION
## Description
Update the Dockerfile to add `config.properties` and `jvm.config`.
Then users can bring up a Presto server without extra configurations.

This change makes the image can be used out of the box.

## Motivation and Context
fixed: #21383

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Users who use `prestodb/presto` docker image can launch the presto server without extra configurations. The image is embedded with simple configurations and can be overridden if needed.

## Test Plan
verified the image manually:
```
$ docker run --rm --name testing -d prestodb/presto:latest
268b23cb81b10540cd4c4dedef51963e57acfb5cf40c46e8b9d6db5bd73049f3

$ docker logs testing -n 10
2023-11-16T05:19:25.771Z        INFO    main    com.facebook.presto.server.PluginManager        Installing com.facebook.presto.nodettlfetchers.PrestoNodeTtlFetcherPlugin
2023-11-16T05:19:25.782Z        INFO    main    com.facebook.presto.server.PluginManager        Registering Ttl fetcher factory infinite
2023-11-16T05:19:25.782Z        INFO    main    com.facebook.presto.server.PluginManager        -- Finished loading plugin /var/lib/presto/data/plugin/ttl-fetchers --
2023-11-16T05:19:25.804Z        INFO    main    com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager       -- Loading resource group configuration manager --
2023-11-16T05:19:25.805Z        INFO    main    com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager       -- Loaded resource group configuration manager legacy --
2023-11-16T05:19:25.805Z        INFO    main    com.facebook.presto.security.AccessControlManager       -- Loading system access control --
2023-11-16T05:19:25.806Z        INFO    main    com.facebook.presto.security.AccessControlManager       -- Loaded system access control allow-all --
2023-11-16T05:19:25.807Z        INFO    main    com.facebook.presto.storage.TempStorageManager  -- Loading temp storage local --
2023-11-16T05:19:25.816Z        INFO    main    com.facebook.presto.storage.TempStorageManager  -- Loaded temp storage local --
2023-11-16T05:19:25.843Z        INFO    main    com.facebook.presto.server.PrestoServer ======== SERVER STARTED ========

$ docker exec -ti testing presto-cli
presto> show catalogs;
 Catalog
---------
 system
(1 row)

Query 20231116_052013_00000_wrpg9, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:02, server-side: 0:01] [0 rows, 0B] [0 rows/s, 0B/s]

presto>
```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add simple configurations to prestodb/presto docker image and make the image easier to use, including
  ``config.properties`` and ``jvm.config``
```