### PR TITLE
[native]Fix duplicate root memory pool in case of background arbitration

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.h
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.h
@@ -87,6 +87,8 @@ class QueryContextCache {
     return queryCtxs_;
   }
 
+  void testingClear();
+
  private:
   size_t capacity_;
 
@@ -106,10 +108,13 @@ class QueryContextManager {
       const protocol::TaskId& taskId,
       const protocol::SessionRepresentation& session);
 
-  // Calls the given functor for every present query context.
+  /// Calls the given functor for every present query context.
   void visitAllContexts(std::function<void(
                             const protocol::QueryId&,
                             const velox::core::QueryCtx*)> visitor) const;
+
+  /// Test method to clear the query context cache.
+  void testingClearCache();
 
  private:
   std::shared_ptr<velox::core::QueryCtx> findOrCreateQueryCtx(


### PR DESCRIPTION
If a task from a query completes before the other tasks get scheduled on the same
worker, then the query context might have been destroyed before creating the other
tasks from the same query. The query context manager maintains a query context
cache but it only holds the weak pointer. So that when the next task from the same
query comes, it will create a new query context with the same query id and creates
a root memory pool with the same name from the memory manager. If there is a
background memory arbitration process, then the old memory pool instance might 
still be held by the memory arbitration process and run into duplicate root memory pool
issue.
This PR fixes this issue by appending a monotonically increasing id to root memory
pool name to ensure the instance name is unique.