### PR TITLE
[native] Ensure graceful shutdown of exchange source connection pools

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -452,9 +452,6 @@ void PrestoServer::run() {
 
   unregisterConnectors();
 
-  PRESTO_SHUTDOWN_LOG(INFO) << "Releasing HTTP connection pools";
-  exchangeSourceConnectionPools_.destroy();
-
   PRESTO_SHUTDOWN_LOG(INFO)
       << "Joining driver CPU Executor '" << driverExecutor_->getName()
       << "': threads: " << driverExecutor_->numActiveThreads() << "/"
@@ -469,6 +466,9 @@ void PrestoServer::run() {
         << connectorIoExecutor_->numThreads();
     connectorIoExecutor_->join();
   }
+
+  PRESTO_SHUTDOWN_LOG(INFO) << "Releasing HTTP connection pools";
+  exchangeSourceConnectionPools_.destroy();
 
   PRESTO_SHUTDOWN_LOG(INFO)
       << "Joining exchange Http executor '" << exchangeHttpExecutor_->getName()

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -504,6 +504,7 @@ TEST_P(PrestoExchangeSourceTest, basic) {
   EXPECT_EQ(deltaPool, deltaQueue);
 
   producer->waitForDeleteResults();
+  exchangeCpuExecutor_->stop();
   serverWrapper.stop();
   EXPECT_EQ(pool_->currentBytes(), 0);
 


### PR DESCRIPTION
CPU executor needs to be joined before we destroy the connection pools and HTTP IO executors, because there might be still operations in flight need to be finished/aborted using the IO pools.