### PR TITLE
deprecated hive.orc.use-column-names

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -767,6 +767,7 @@ public class HiveClientConfig
         return this;
     }
 
+    @Deprecated
     public boolean isUseOrcColumnNames()
     {
         return useOrcColumnNames;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -772,6 +772,7 @@ public class HiveClientConfig
         return useOrcColumnNames;
     }
 
+    @Deprecated
     @Config("hive.orc.use-column-names")
     @ConfigDescription("Access ORC columns using names from the file")
     public HiveClientConfig setUseOrcColumnNames(boolean useOrcColumnNames)


### PR DESCRIPTION
## Description
This patch refines Presto's approach to reading ORC files by prioritizing the embedded ORC schema when available and falling back to the Hive schema if an embedded schema is absent. The patch also deprecates the hive.orc.use-column-names configuration option, replacing it with this new, more robust default behavior.


## Motivation and Context
The primary motivation for this change is to address compatibility issues related to field order discrepancies between ORC file schemas and Hive table schemas, as well as to handle ORC files without embedded schema information. This improvement ensures consistent data reading across varied datasets and better handles legacy data written by older versions of Hive. Deprecating the hive.orc.use-column-names option simplifies configuration management and user experience by making intelligent schema selection the standard behavior.


## Impact
The patch constitutes an enhancement to the existing ORC file reading functionality without introducing breaking changes to the public API. Users will benefit from improved robustness in ORC file reads without requiring manual configuration tweaks. The deprecation of hive.orc.use-column-names will not affect users immediately, as the option will remain functional but discouraged until its eventual removal.


## Test Plan
Although no new tests have been added, current tests ensure that reading ORC files with embedded schema information continues to function correctly. The existing suite should be examined to ensure coverage of scenarios where the ORC file lacks schema information, and supplemental tests should be considered to cover the deprecation message when using the old configuration option.


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
General Changes
* Deprecated the `hive.orc.use-column-names` configuration option, as Presto now automatically uses the ORC file schema if present, and falls back to the Hive schema if not.

Hive Changes
* Enhanced reading of ORC files in Presto to prioritize the embedded ORC schema, improving compatibility and resolving field order issues. This change also deprecates the `hive.orc.use-column-names` configuration option.
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

