### PR TITLE
Add alias any_value for arbitrary

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -22,6 +22,10 @@ an :ref:`order-by-clause` within the aggregate function::
 General Aggregate Functions
 ---------------------------
 
+.. function:: any_value(x) -> [same as input]
+
+    This is an alias for :func:`arbitrary`.
+
 .. function:: arbitrary(x) -> [same as input]
 
     Returns an arbitrary non-null value of ``x``, if one exists.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -319,6 +319,7 @@ import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
 import static com.facebook.presto.operator.aggregation.AlternativeArbitraryAggregationFunction.ALTERNATIVE_ARBITRARY_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.AlternativeMaxAggregationFunction.ALTERNATIVE_MAX;
 import static com.facebook.presto.operator.aggregation.AlternativeMinAggregationFunction.ALTERNATIVE_MIN;
+import static com.facebook.presto.operator.aggregation.ArbitraryAggregationFunction.ANY_VALUE_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ArbitraryAggregationFunction.ARBITRARY_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ChecksumAggregationFunction.CHECKSUM_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
@@ -893,6 +894,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .function(CHECKSUM_AGGREGATION)
                 .function(IDENTITY_CAST)
                 .function(ARBITRARY_AGGREGATION)
+                .function(ANY_VALUE_AGGREGATION)
                 .functions(GREATEST, LEAST)
                 .functions(MAX_BY, MIN_BY, MAX_BY_N_AGGREGATION, MIN_BY_N_AGGREGATION)
                 .functions(MAX_AGGREGATION, MIN_AGGREGATION, MAX_N_AGGREGATION, MIN_N_AGGREGATION)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
@@ -53,6 +53,9 @@ public class ArbitraryAggregationFunction
     public static final ArbitraryAggregationFunction ARBITRARY_AGGREGATION = new ArbitraryAggregationFunction();
     private static final String NAME = "arbitrary";
 
+    private static final String ANY_VALUE_NAME = "any_value";
+    public static final ArbitraryAggregationFunction ANY_VALUE_AGGREGATION = new ArbitraryAggregationFunction(ANY_VALUE_NAME);
+
     private static final MethodHandle LONG_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, NullableLongState.class, Block.class, int.class);
     private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, NullableDoubleState.class, Block.class, int.class);
     private static final MethodHandle BOOLEAN_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, NullableBooleanState.class, Block.class, int.class);
@@ -70,7 +73,12 @@ public class ArbitraryAggregationFunction
 
     protected ArbitraryAggregationFunction()
     {
-        super(NAME,
+        this(NAME);
+    }
+
+    protected ArbitraryAggregationFunction(String name)
+    {
+        super(name,
                 ImmutableList.of(typeVariable("T")),
                 ImmutableList.of(),
                 parseTypeSignature("T"),

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestAnyValueAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestAnyValueAggregation.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+
+public class TestAnyValueAggregation
+        extends TestArbitraryAggregation
+{
+    private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = metadata.getFunctionAndTypeManager();
+
+    @Override
+    protected JavaAggregationFunctionImplementation getAggregation(Type... arguments)
+    {
+        return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(FUNCTION_AND_TYPE_MANAGER.lookupFunction("any_value", fromTypes(arguments)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryAggregation.java
@@ -165,7 +165,7 @@ public class TestArbitraryAggregation
                 createIntsBlock(3, 3, null));
     }
 
-    private static JavaAggregationFunctionImplementation getAggregation(Type... arguments)
+    protected JavaAggregationFunctionImplementation getAggregation(Type... arguments)
     {
         return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(FUNCTION_AND_TYPE_MANAGER.lookupFunction("arbitrary", fromTypes(arguments)));
     }


### PR DESCRIPTION
## Description
There is any_value in mysql, which returns any value in a group. It has the same semantics as presto's arbitrary, so we hope to add an alias any_value to arbitrary.

## Motivation and Context
Some users are accustomed to the syntax of MySQL. When using presto, they find that the any_value function does not exist and can only be replaced by arbitrary. If any_value exists, it will be more friendly to users who are accustomed to the MySQL syntax.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

