### PR TITLE
enhancing compatibility with legacy ORC files

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -749,7 +749,7 @@ public class HiveClientConfig
     }
 
     @Config("hive.orc.use-column-names")
-    @ConfigDescription("Access ORC columns using names from the file")
+    @ConfigDescription("Access ORC columns using names from the file first, and fallback to Hive schema column names if not found to ensure backward compatibility with old data")
     public HiveClientConfig setUseOrcColumnNames(boolean useOrcColumnNames)
     {
         this.useOrcColumnNames = useOrcColumnNames;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -876,6 +876,13 @@ public abstract class AbstractTestHiveFileFormats
             return partitionKey;
         }
 
+        public TestColumn withName(String newName)
+        {
+            return new TestColumn(newName, this.objectInspector,
+                    this.writeValue, this.expectedValue,
+                    this.partitionKey);
+        }
+
         @Override
         public String toString()
         {


### PR DESCRIPTION
## Description
This PR modifies the handling of the hive.orc.use-column-names configuration setting in Presto to allow for improved compatibility with older ORC data that may not contain column names in the file. The new strategy uses ORC file column names by default and falls back to Hive schema column names when ORC names are not present.


## Motivation and Context
The ability for Presto to flexibly handle column names in ORC files is critical for accessing a wide range of data, including legacy datasets that may not contain embedded column names. The original hive.orc.use-column-names configuration setting only allowed access via column names and did not account for files without them. This approach helps mitigate issues with reading old ORC data and ensures that users can access their datasets consistently without manual intervention.



## Impact
The changes to hive.orc.use-column-names represent an enhancement to the existing functionality rather than a breaking change. Users specifying this option will now benefit from an intelligent fallback mechanism. There should be no performance impact as the fallback only occurs when required, and there are no changes to the public API.


## Test Plan
The changes have been tested using both new and old ORC files—both those with embedded column names and those without. The Presto cluster correctly accessed column data using the appropriate naming strategy in each case. 


## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Changes
* Improves the `hive.orc.use-column-names` configuration setting to no longer fail on reading ORC files 
  without column names but falls back to using Hive's schema, enhancing compatibility with legacy ORC files.
```

