### PR TITLE
[WIP] Support fragment result cache with Alluxio

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -344,6 +344,23 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>org.alluxio</groupId>
+                            <artifactId>alluxio-shaded-client</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>skip-accumulo-tests</id>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -351,6 +351,19 @@
                     </excludes>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>org.alluxio</groupId>
+                            <artifactId>alluxio-shaded-client</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -373,4 +373,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>org.alluxio</groupId>
+                            <artifactId>alluxio-shaded-client</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-google-sheets/pom.xml
+++ b/presto-google-sheets/pom.xml
@@ -164,4 +164,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>org.alluxio</groupId>
+                            <artifactId>alluxio-shaded-client</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -235,6 +235,19 @@
                     <allowedProvidedDependencies>org.apache.yetus:audience-annotations</allowedProvidedDependencies>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>org.alluxio</groupId>
+                            <artifactId>alluxio-shaded-client</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -479,6 +479,34 @@
             <artifactId>ratis-common</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-shaded-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testing-docker</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -515,6 +543,10 @@
                         <dependency>
                             <groupId>org.apache.ratis</groupId>
                             <artifactId>ratis-server-api</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.alluxio</groupId>
+                            <artifactId>alluxio-shaded-client</artifactId>
                         </dependency>
                     </ignoredDependencies>
                 </configuration>

--- a/presto-main/src/main/java/com/facebook/presto/operator/FragmentResultCacheConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FragmentResultCacheConfig.java
@@ -28,8 +28,10 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.DAYS;
 
-public class FileFragmentResultCacheConfig
+public class FragmentResultCacheConfig
 {
+    private FragmentResultCacheType cacheType;
+
     private boolean cachingEnabled;
     private URI baseDirectory;
     private boolean blockEncodingCompressionEnabled;
@@ -40,6 +42,19 @@ public class FileFragmentResultCacheConfig
     private DataSize maxSinglePagesSize = new DataSize(500, MEGABYTE);
     private DataSize maxCacheSize = new DataSize(100, GIGABYTE);
 
+    public FragmentResultCacheType getCacheType()
+    {
+        return cacheType;
+    }
+
+    @Config("fragment-result-cache.type")
+    @ConfigDescription("Type of fragment result caching")
+    public FragmentResultCacheConfig setCacheType(FragmentResultCacheType cacheType)
+    {
+        this.cacheType = cacheType;
+        return this;
+    }
+
     public boolean isCachingEnabled()
     {
         return cachingEnabled;
@@ -47,7 +62,7 @@ public class FileFragmentResultCacheConfig
 
     @Config("fragment-result-cache.enabled")
     @ConfigDescription("Enable fragment result caching")
-    public FileFragmentResultCacheConfig setCachingEnabled(boolean cachingEnabled)
+    public FragmentResultCacheConfig setCachingEnabled(boolean cachingEnabled)
     {
         this.cachingEnabled = cachingEnabled;
         return this;
@@ -60,7 +75,7 @@ public class FileFragmentResultCacheConfig
 
     @Config("fragment-result-cache.base-directory")
     @ConfigDescription("Base URI to cache data")
-    public FileFragmentResultCacheConfig setBaseDirectory(URI baseDirectory)
+    public FragmentResultCacheConfig setBaseDirectory(URI baseDirectory)
     {
         this.baseDirectory = baseDirectory;
         return this;
@@ -73,7 +88,7 @@ public class FileFragmentResultCacheConfig
 
     @Config("fragment-result-cache.block-encoding-compression-enabled")
     @ConfigDescription("Enable compression for block encoding")
-    public FileFragmentResultCacheConfig setBlockEncodingCompressionEnabled(boolean blockEncodingCompressionEnabled)
+    public FragmentResultCacheConfig setBlockEncodingCompressionEnabled(boolean blockEncodingCompressionEnabled)
     {
         this.blockEncodingCompressionEnabled = blockEncodingCompressionEnabled;
         return this;
@@ -87,7 +102,7 @@ public class FileFragmentResultCacheConfig
 
     @Config("fragment-result-cache.max-cached-entries")
     @ConfigDescription("Number of entries allowed in cache")
-    public FileFragmentResultCacheConfig setMaxCachedEntries(int maxCachedEntries)
+    public FragmentResultCacheConfig setMaxCachedEntries(int maxCachedEntries)
     {
         this.maxCachedEntries = maxCachedEntries;
         return this;
@@ -101,7 +116,7 @@ public class FileFragmentResultCacheConfig
 
     @Config("fragment-result-cache.cache-ttl")
     @ConfigDescription("Time-to-live for a cache entry")
-    public FileFragmentResultCacheConfig setCacheTtl(Duration cacheTtl)
+    public FragmentResultCacheConfig setCacheTtl(Duration cacheTtl)
     {
         this.cacheTtl = cacheTtl;
         return this;
@@ -115,7 +130,7 @@ public class FileFragmentResultCacheConfig
 
     @Config("fragment-result-cache.max-in-flight-size")
     @ConfigDescription("Maximum size of pages in memory waiting to be flushed")
-    public FileFragmentResultCacheConfig setMaxInFlightSize(DataSize maxInFlightSize)
+    public FragmentResultCacheConfig setMaxInFlightSize(DataSize maxInFlightSize)
     {
         this.maxInFlightSize = maxInFlightSize;
         return this;
@@ -129,7 +144,7 @@ public class FileFragmentResultCacheConfig
 
     @Config("fragment-result-cache.max-single-pages-size")
     @ConfigDescription("Maximum size of pages write to flushed")
-    public FileFragmentResultCacheConfig setMaxSinglePagesSize(DataSize maxSinglePagesSize)
+    public FragmentResultCacheConfig setMaxSinglePagesSize(DataSize maxSinglePagesSize)
     {
         this.maxSinglePagesSize = maxSinglePagesSize;
         return this;
@@ -143,7 +158,7 @@ public class FileFragmentResultCacheConfig
 
     @Config("fragment-result-cache.max-cache-size")
     @ConfigDescription("Maximum on-disk size of this fragment result cache")
-    public FileFragmentResultCacheConfig setMaxCacheSize(DataSize maxCacheSize)
+    public FragmentResultCacheConfig setMaxCacheSize(DataSize maxCacheSize)
     {
         this.maxCacheSize = maxCacheSize;
         return this;

--- a/presto-main/src/main/java/com/facebook/presto/operator/FragmentResultCacheType.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FragmentResultCacheType.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+public enum FragmentResultCacheType
+{
+    ALLUXIO,
+    FILE
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/AlluxioLocalCluster.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/AlluxioLocalCluster.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.testing.docker.DockerContainer;
+import com.google.common.collect.ImmutableList;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class AlluxioLocalCluster
+        implements Closeable
+{
+    private final DockerContainer masterDockerContainer;
+
+    private final DockerContainer workerDockerContainer;
+
+    public AlluxioLocalCluster()
+    {
+        Map<String, String> masterEnv = new HashMap<>();
+        masterEnv.put("ALLUXIO_JAVA_OPTS", "-Dalluxio.master.hostname=alluxio-master");
+        masterDockerContainer = new DockerContainer("alluxio/alluxio:2.8.1",
+                ImmutableList.of(19999, 19998),
+                masterEnv,
+                AlluxioLocalCluster::masterHealthCheck,
+                Optional.of("master"),
+                Optional.empty(),
+                Optional.empty(),
+                true);
+        masterDockerContainer.executeCmd("root", new String[] {"/bin/sh", "-c", "echo '127.0.0.1 alluxio-master' >> /etc/hosts"});
+        masterDockerContainer.executeCmd("alluxio", new String[] {"/bin/sh", "-c", "/opt/alluxio/bin/alluxio fs chmod 777 /"});
+
+        String masterIp = masterDockerContainer.getHostIp();
+        String masterHostname = masterDockerContainer.getHostname();
+        Map<String, String> workerEnv = new HashMap<>();
+        workerEnv.put("ALLUXIO_JAVA_OPTS", "-Dalluxio.worker.tieredstore.level0.alias=HDD " +
+                "-Dalluxio.worker.tieredstore.level0.dirs.path=/mnt -Dalluxio.master.hostname=alluxio-master -Dalluxio.master.port=19998");
+        workerDockerContainer = new DockerContainer("alluxio/alluxio:2.8.1",
+                ImmutableList.of(29999, 30000),
+                workerEnv,
+                AlluxioLocalCluster::workerHealthCheck,
+                Optional.of("worker"),
+                Optional.of("alluxio-master:" + masterIp),
+                Optional.of("localhost"),
+                true);
+        workerDockerContainer.executeCmd("root", new String[] {"/bin/sh", "-c", "echo '" + masterIp + " " + masterHostname + "' >> /etc/hosts"});
+
+        String workerHostname = workerDockerContainer.getHostname();
+        String workerHostIp = workerDockerContainer.getHostIp();
+        masterDockerContainer.executeCmd("root", new String[] {"/bin/sh", "-c", "echo '" + workerHostIp + " " + workerHostname + "' >> /etc/hosts"});
+
+        //Security.setProperty(workerHostname, "127.0.0.1");
+    }
+
+    private static void masterHealthCheck(DockerContainer.HostPortProvider hostPortProvider)
+            throws URISyntaxException, IOException
+    {
+        int masterWebPort = hostPortProvider.getHostPort(19999);
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        URIBuilder uriBuilder = new URIBuilder("http://127.0.0.1:" + masterWebPort);
+        HttpGet httpGet = new HttpGet(uriBuilder.build());
+        CloseableHttpResponse response = httpClient.execute(httpGet);
+        StatusLine statusLine = response.getStatusLine();
+        if (statusLine.getStatusCode() != 200) {
+            throw new RuntimeException("Master is not started");
+        }
+    }
+
+    private static void workerHealthCheck(DockerContainer.HostPortProvider hostPortProvider)
+            throws URISyntaxException, IOException
+    {
+        int workerWebPort = hostPortProvider.getHostPort(30000);
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        URIBuilder uriBuilder = new URIBuilder("http://127.0.0.1:" + workerWebPort);
+        HttpGet httpGet = new HttpGet(uriBuilder.build());
+        CloseableHttpResponse response = httpClient.execute(httpGet);
+        StatusLine statusLine = response.getStatusLine();
+        if (statusLine.getStatusCode() != 200) {
+            throw new RuntimeException("Worker is not started");
+        }
+    }
+
+    public int getMasterWebPort()
+    {
+        return masterDockerContainer.getHostPort(19999);
+    }
+
+    public int getMasterRpcPort()
+    {
+        return masterDockerContainer.getHostPort(19998);
+    }
+
+    public int getWorkerWebPort()
+    {
+        return workerDockerContainer.getHostPort(30000);
+    }
+
+    public int getWorkerRpcPort()
+    {
+        return workerDockerContainer.getHostPort(29999);
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        workerDockerContainer.close();
+        masterDockerContainer.close();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFragmentResultCacheConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFragmentResultCacheConfig.java
@@ -28,12 +28,12 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.DAYS;
 
-public class TestFileFragmentResultCacheConfig
+public class TestFragmentResultCacheConfig
 {
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(FileFragmentResultCacheConfig.class)
+        assertRecordedDefaults(recordDefaults(FragmentResultCacheConfig.class)
                 .setCachingEnabled(false)
                 .setBaseDirectory(null)
                 .setBlockEncodingCompressionEnabled(false)
@@ -59,7 +59,7 @@ public class TestFileFragmentResultCacheConfig
                 .put("fragment-result-cache.max-cache-size", "200GB")
                 .build();
 
-        FileFragmentResultCacheConfig expected = new FileFragmentResultCacheConfig()
+        FragmentResultCacheConfig expected = new FragmentResultCacheConfig()
                 .setCachingEnabled(true)
                 .setBaseDirectory(new URI("tcp://abc"))
                 .setBlockEncodingCompressionEnabled(true)

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -718,6 +718,10 @@
                                 <groupId>org.slf4j</groupId>
                                 <artifactId>slf4j-jdk14</artifactId>
                             </dependency>
+                            <dependency>
+                                <groupId>org.alluxio</groupId>
+                                <artifactId>alluxio-shaded-client</artifactId>
+                            </dependency>
                         </ignoredDependencies>
                     </configuration>
                 </plugin>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -185,6 +185,10 @@
                                 <groupId>org.slf4j</groupId>
                                 <artifactId>slf4j-jdk14</artifactId>
                             </dependency>
+                            <dependency>
+                                <groupId>org.alluxio</groupId>
+                                <artifactId>alluxio-shaded-client</artifactId>
+                            </dependency>
                         </ignoredDependencies>
                     </configuration>
                 </plugin>

--- a/presto-singlestore/pom.xml
+++ b/presto-singlestore/pom.xml
@@ -164,6 +164,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>org.alluxio</groupId>
+                            <artifactId>alluxio-shaded-client</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -80,9 +80,9 @@ import com.facebook.presto.metadata.StaticCatalogStoreConfig;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStoreConfig;
 import com.facebook.presto.metadata.TablePropertyManager;
-import com.facebook.presto.operator.FileFragmentResultCacheConfig;
 import com.facebook.presto.operator.FileFragmentResultCacheManager;
 import com.facebook.presto.operator.FragmentCacheStats;
+import com.facebook.presto.operator.FragmentResultCacheConfig;
 import com.facebook.presto.operator.FragmentResultCacheManager;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
@@ -439,7 +439,7 @@ public class PrestoSparkModule
         binder.bind(AdaptivePlanOptimizers.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPlanOptimizerManager.class).in(Scopes.SINGLETON);
         binder.bind(LocalExecutionPlanner.class).in(Scopes.SINGLETON);
-        configBinder(binder).bindConfig(FileFragmentResultCacheConfig.class);
+        configBinder(binder).bindConfig(FragmentResultCacheConfig.class);
         binder.bind(FragmentCacheStats.class).in(Scopes.SINGLETON);
         binder.bind(IndexJoinLookupStats.class).in(Scopes.SINGLETON);
         binder.bind(QueryIdGenerator.class).in(Scopes.SINGLETON);
@@ -551,7 +551,7 @@ public class PrestoSparkModule
 
     @Provides
     @Singleton
-    public static FragmentResultCacheManager createFragmentResultCacheManager(FileFragmentResultCacheConfig config, BlockEncodingSerde blockEncodingSerde, FragmentCacheStats fragmentCacheStats)
+    public static FragmentResultCacheManager createFragmentResultCacheManager(FragmentResultCacheConfig config, BlockEncodingSerde blockEncodingSerde, FragmentCacheStats fragmentCacheStats)
     {
         if (config.isCachingEnabled()) {
             return new FileFragmentResultCacheManager(

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -355,6 +355,10 @@
                             <groupId>org.apache.ratis</groupId>
                             <artifactId>ratis-server-api</artifactId>
                         </dependency>
+                        <dependency>
+                            <groupId>org.alluxio</groupId>
+                            <artifactId>alluxio-shaded-client</artifactId>
+                        </dependency>
                     </ignoredDependencies>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Description
Support fragment result cache with Alluxio.

## Motivation and Context
The default implementation of fragment result cache uses local file system to cache fragment results. The space of local disk is limited. Enable Alluxio to cache fragment results allows us to take full advantage of Alluxio as it maximizes the use of storage space and has high performance in distributed caching.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

