### PR TITLE
Fix Hive Partition exception message to add schema and table name

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -693,7 +693,7 @@ public class HiveSplitManager
         for (Map.Entry<String, Optional<Partition>> entry : partitions.entrySet()) {
             ImmutableSet.Builder<ColumnHandle> redundantColumnDomainsBuilder = ImmutableSet.builder();
             if (!entry.getValue().isPresent()) {
-                throw new PrestoException(HIVE_PARTITION_DROPPED_DURING_QUERY, "Partition no longer exists: " + entry.getKey());
+                throw new PrestoException(HIVE_PARTITION_DROPPED_DURING_QUERY, format("Partition no longer exists: %s.%s/%s", tableName.getSchemaName(), tableName.getTableName(), entry.getKey()));
             }
             boolean pruned = false;
             if (partitionStatistics.containsKey(entry.getKey())) {


### PR DESCRIPTION
## Description
Logging change

## Motivation and Context
Fix Hive Partition exception message to add schema and table name At present we only show the partition name. For queries with multiple tables it becomes difficult to correlate the partition to schema and table. This commit tries to address this issue.

## Impact
Clearer error logging

## Test Plan
Unit Tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.


```
== NO RELEASE NOTE ==
```

