### PR TITLE
Manifest file caching support for Iceberg Native Catalogs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -269,6 +269,40 @@ and a file system location of ``s3://test_bucket/test_schema/test_table``:
         location = 's3://test_bucket/test_schema/test_table')
     )
 
+Caching Support
+----------------
+
+Manifest File Caching
+^^^^^^^^^^^^^^^^^^^^^^
+
+As of Iceberg version 1.1.0, Apache Iceberg provides a mechanism to cache the contents of Iceberg manifest files in memory. This feature helps
+to reduce repeated reads of small Iceberg manifest files from remote storage.
+
+.. note::
+
+    Currently, manifest file caching is supported for Hadoop and Nessie catalogs in the Presto Iceberg connector.
+
+The following configuration properties are available:
+
+====================================================   =============================================================   ============
+Property Name                                          Description                                                     Default
+====================================================   =============================================================   ============
+``iceberg.io.manifest.cache-enabled``                  Enable or disable the manifest caching feature. This feature    ``false``
+                                                       is only available if ``iceberg.catalog.type`` is ``hadoop``
+                                                       or ``nessie``.
+
+``iceberg.io-impl``                                    Custom FileIO implementation to use in a catalog. It must       ``org.apache.iceberg.hadoop.HadoopFileIO``
+                                                       be set to enable manifest caching.
+
+``iceberg.io.manifest.cache.max-total-bytes``          Maximum size of cache size in bytes.                            ``104857600``
+
+``iceberg.io.manifest.cache.expiration-interval-ms``   Maximum time duration in milliseconds for which an entry        ``60000``
+                                                       stays in the manifest cache.
+
+``iceberg.io.manifest.cache.max-content-length``       Maximum length of a manifest file to be considered for          ``8388608``
+                                                       caching in bytes. Manifest files with a length exceeding
+                                                       this size will not be cached.
+====================================================   =============================================================   ============
 
 Extra Hidden Metadata Tables
 ----------------------------

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -20,6 +20,7 @@ import com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.hadoop.HadoopFileIO;
 
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
@@ -31,6 +32,9 @@ import java.util.List;
 import static com.facebook.presto.hive.HiveCompressionCodec.GZIP;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.iceberg.IcebergFileFormat.PARQUET;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
 
 public class IcebergConfig
 {
@@ -48,7 +52,11 @@ public class IcebergConfig
     private boolean pushdownFilterEnabled;
 
     private HiveStatisticsMergeStrategy hiveStatisticsMergeStrategy = HiveStatisticsMergeStrategy.NONE;
-
+    private String fileIOImpl = HadoopFileIO.class.getName();
+    private boolean manifestCachingEnabled;
+    private long maxManifestCacheSize = IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
+    private long manifestCacheExpireDuration = IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT;
+    private long manifestCacheMaxContentLength = IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT;
     @NotNull
     public FileFormat getFileFormat()
     {
@@ -225,5 +233,74 @@ public class IcebergConfig
     public boolean isPushdownFilterEnabled()
     {
         return pushdownFilterEnabled;
+    }
+
+    public boolean getManifestCachingEnabled()
+    {
+        return manifestCachingEnabled;
+    }
+
+    @Config("iceberg.io.manifest.cache-enabled")
+    @ConfigDescription("Enable/disable the manifest caching feature")
+    public IcebergConfig setManifestCachingEnabled(boolean manifestCachingEnabled)
+    {
+        this.manifestCachingEnabled = manifestCachingEnabled;
+        return this;
+    }
+
+    public String getFileIOImpl()
+    {
+        return fileIOImpl;
+    }
+
+    @NotNull
+    @Config("iceberg.io-impl")
+    @ConfigDescription("Custom FileIO implementation to use in a catalog")
+    public IcebergConfig setFileIOImpl(String fileIOImpl)
+    {
+        this.fileIOImpl = fileIOImpl;
+        return this;
+    }
+
+    public long getMaxManifestCacheSize()
+    {
+        return maxManifestCacheSize;
+    }
+
+    @Min(1)
+    @Config("iceberg.io.manifest.cache.max-total-bytes")
+    @ConfigDescription("Maximum total amount of bytes to cache in the manifest cache")
+    public IcebergConfig setMaxManifestCacheSize(long maxManifestCacheSize)
+    {
+        this.maxManifestCacheSize = maxManifestCacheSize;
+        return this;
+    }
+
+    public long getManifestCacheExpireDuration()
+    {
+        return manifestCacheExpireDuration;
+    }
+
+    @Min(0)
+    @Config("iceberg.io.manifest.cache.expiration-interval-ms")
+    @ConfigDescription("Maximum duration for which an entry stays in the manifest cache")
+    public IcebergConfig setManifestCacheExpireDuration(long manifestCacheExpireDuration)
+    {
+        this.manifestCacheExpireDuration = manifestCacheExpireDuration;
+        return this;
+    }
+
+    public long getManifestCacheMaxContentLength()
+    {
+        return manifestCacheMaxContentLength;
+    }
+
+    @Min(0)
+    @Config("iceberg.io.manifest.cache.max-content-length")
+    @ConfigDescription("Maximum length of a manifest file to be considered for caching in bytes")
+    public IcebergConfig setManifestCacheMaxContentLength(long manifestCacheMaxContentLength)
+    {
+        this.manifestCacheMaxContentLength = manifestCacheMaxContentLength;
+        return this;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergResourceFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergResourceFactory.java
@@ -17,7 +17,6 @@ import com.facebook.presto.hive.s3.S3ConfigurationUpdater;
 import com.facebook.presto.iceberg.nessie.NessieConfig;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -99,25 +98,7 @@ public class IcebergResourceFactory
     private String getCatalogCacheKey(ConnectorSession session)
     {
         StringBuilder sb = new StringBuilder();
-        ConnectorIdentity identity = session.getIdentity();
-        sb.append("User:");
-        sb.append(identity.getUser());
-        if (identity.getPrincipal().isPresent()) {
-            sb.append(",Principle:");
-            sb.append(identity.getPrincipal());
-        }
-        if (identity.getRole().isPresent()) {
-            sb.append(",Role:");
-            sb.append(identity.getRole());
-        }
-        if (identity.getExtraCredentials() != null) {
-            identity.getExtraCredentials().forEach((key, value) -> {
-                sb.append(",");
-                sb.append(key);
-                sb.append(":");
-                sb.append(value);
-            });
-        }
+        sb.append(catalogName);
 
         if (catalogType == NESSIE) {
             sb.append(getNessieReferenceName(session));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -146,6 +146,10 @@ import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_ENABLED;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES;
 import static org.apache.iceberg.LocationProviders.locationsFor;
 import static org.apache.iceberg.MetadataTableUtils.createMetadataTableInstance;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
@@ -711,5 +715,13 @@ public final class IcebergUtil
         });
 
         return Collections.unmodifiableMap(partitionKeys);
+    }
+
+    public static void loadCachingProperties(Map<String, String> properties, IcebergConfig icebergConfig)
+    {
+        properties.put(IO_MANIFEST_CACHE_ENABLED, "true");
+        properties.put(IO_MANIFEST_CACHE_MAX_TOTAL_BYTES, String.valueOf(icebergConfig.getMaxManifestCacheSize()));
+        properties.put(IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH, String.valueOf(icebergConfig.getManifestCacheMaxContentLength()));
+        properties.put(IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS, String.valueOf(icebergConfig.getManifestCacheExpireDuration()));
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy;
 import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -29,6 +30,9 @@ import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.iceberg.IcebergFileFormat.ORC;
 import static com.facebook.presto.iceberg.IcebergFileFormat.PARQUET;
 import static com.facebook.presto.iceberg.util.HiveStatisticsMergeStrategy.USE_NDV;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT;
+import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
 
 public class TestIcebergConfig
 {
@@ -48,7 +52,12 @@ public class TestIcebergConfig
                 .setMinimumAssignedSplitWeight(0.05)
                 .setParquetDereferencePushdownEnabled(true)
                 .setMergeOnReadModeEnabled(true)
-                .setPushdownFilterEnabled(false));
+                .setPushdownFilterEnabled(false)
+                .setManifestCachingEnabled(false)
+                .setFileIOImpl(HadoopFileIO.class.getName())
+                .setMaxManifestCacheSize(IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT)
+                .setManifestCacheExpireDuration(IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT)
+                .setManifestCacheMaxContentLength(IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT));
     }
 
     @Test
@@ -68,6 +77,11 @@ public class TestIcebergConfig
                 .put("iceberg.statistic-snapshot-record-difference-weight", "1.0")
                 .put("iceberg.hive-statistics-merge-strategy", "USE_NDV")
                 .put("iceberg.pushdown-filter-enabled", "true")
+                .put("iceberg.io.manifest.cache-enabled", "true")
+                .put("iceberg.io-impl", "com.facebook.presto.iceberg.HdfsFileIO")
+                .put("iceberg.io.manifest.cache.max-total-bytes", "1048576000")
+                .put("iceberg.io.manifest.cache.expiration-interval-ms", "600000")
+                .put("iceberg.io.manifest.cache.max-content-length", "10485760")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -83,7 +97,12 @@ public class TestIcebergConfig
                 .setParquetDereferencePushdownEnabled(false)
                 .setMergeOnReadModeEnabled(false)
                 .setHiveStatisticsMergeStrategy(USE_NDV)
-                .setPushdownFilterEnabled(true);
+                .setPushdownFilterEnabled(true)
+                .setManifestCachingEnabled(true)
+                .setFileIOImpl("com.facebook.presto.iceberg.HdfsFileIO")
+                .setMaxManifestCacheSize(1048576000)
+                .setManifestCacheExpireDuration(600000)
+                .setManifestCacheMaxContentLength(10485760);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
This PR introduces the below addition to Iceberg Connector:

- Change catalog cache key to catalog name + catalog session properties, since the current catalog cache key is `User:<user-name>,<Principle:>,Role:`, which would load cache entry i.e. catalog [CatalogUtil.loadCatalog()](https://github.com/apache/iceberg/blob/apache-iceberg-1.3.1/core/src/main/java/org/apache/iceberg/CatalogUtil.java#L216) for every new user & catalog file while loading cache.
- Add Manifest file caching support for Iceberg Native Catalogs (Hadoop & Nessie)

Adding support for - https://github.com/prestodb/presto/pull/20820

## Motivation and Context

Starting from Iceberg version 1.1.0, Apache Iceberg provides a mechanism to cache the contents of Iceberg manifest files in memory. This manifest caching feature helps to reduce repeated reads of small Iceberg manifest files from remote storage.
Reference: https://github.com/apache/iceberg/pull/4518

## Impact

No Impact. Default behaviour, Disabled. Feature can be enabled via catalog configuration changes.

## Test Plan

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
Iceberg Changes
* Add Manifest file caching support for Iceberg Native Catalogs
```


