### PR TITLE
[native] Enable IN predicate with non-constant in-list

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -564,7 +564,7 @@ velox::ArrayVectorPtr toArrayOfComplexTypeVector(
     auto constant =
         dynamic_cast<const ConstantTypedExpr*>((*(begin + i)).get());
     if (constant == nullptr) {
-      VELOX_UNSUPPORTED("IN predicate supports only constant list of values");
+      return nullptr;
     }
     elements->copy(constant->valueVector().get(), i, 0, 1);
   }
@@ -588,7 +588,7 @@ velox::ArrayVectorPtr toArrayVector(
     auto constant =
         dynamic_cast<const ConstantTypedExpr*>((*(begin + i)).get());
     if (constant == nullptr) {
-      VELOX_UNSUPPORTED("IN predicate supports only constant list of values");
+      return nullptr;
     }
     const auto& value = constant->value();
     if (value.isNull()) {
@@ -631,6 +631,10 @@ TypedExprPtr convertInExpr(
           args.begin() + 1,
           args.end(),
           pool);
+  }
+
+  if (arrayVector == nullptr) {
+    return std::make_shared<CallTypedExpr>(velox::BOOLEAN(), args, "in");
   }
 
   auto constantVector =

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -492,6 +492,12 @@ public abstract class AbstractTestNativeGeneralQueries
     }
 
     @Test
+    public void testIn()
+    {
+        assertQuery("SELECT linenumber IN (orderkey % 7, partkey % 5, suppkey % 3) FROM lineitem");
+    }
+
+    @Test
     public void testRegexp()
     {
         assertQuery("SELECT regexp_extract(key, '[^\\.]+'), regexp_extract(key, '([^\\.]+)\\.([^\\.]+)', 1), regexp_extract(key, '([^\\.]+)\\.([^\\.]+)', 2) FROM (" +


### PR DESCRIPTION

```
== NO RELEASE NOTE ==
```

