### PR TITLE
Updated the snappy version to 1.1.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1883,7 +1883,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.7.1</version>
+                <version>1.1.10.4</version>
             </dependency>
 
             <dependency>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.1.7</version>
+            <version>1.1.10.4</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Description
Upgrade the version of snappy-java.

Motivation and Context
Address vulnerabilities present in the current version.

Impact
The changes will impact the presto-record-decoder module.

Test Plan
The effectiveness of the updates will be confirmed by executing the unit tests for the presto-record-decoder module and all other related modules.

[INFO] Running TestSuite
[INFO] Tests run: 71, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.936 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 71, Failures: 0, Errors: 0, Skipped: 0

Release Note :

Updated the snappy version to 1.1.10.4



## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
Updated the snappy version to 1.1.10.4


If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```


