### PR TITLE
Refactor ResumableTask to rename TaskStatus

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -109,11 +109,11 @@ public class BackgroundHiveSplitLoader
             implements ResumableTask
     {
         @Override
-        public TaskStatus process()
+        public ResumableTaskStatus process()
         {
             while (true) {
                 if (stopped) {
-                    return TaskStatus.finished();
+                    return ResumableTaskStatus.finished();
                 }
                 ListenableFuture<?> future;
                 taskExecutionLock.readLock().lock();
@@ -131,14 +131,14 @@ public class BackgroundHiveSplitLoader
                     // Otherwise, a race could occur where the split source is completed before we fail it.
                     hiveSplitSource.fail(e);
                     checkState(stopped);
-                    return TaskStatus.finished();
+                    return ResumableTaskStatus.finished();
                 }
                 finally {
                     taskExecutionLock.readLock().unlock();
                 }
                 invokeNoMoreSplitsIfNecessary();
                 if (!future.isDone()) {
-                    return TaskStatus.continueOn(future);
+                    return ResumableTaskStatus.continueOn(future);
                 }
             }
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/ResumableTask.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/ResumableTask.java
@@ -24,27 +24,27 @@ public interface ResumableTask
      * @return a finished status if the task is complete, otherwise includes a continuation future to indicate
      * when it should be continued to be processed.
      */
-    TaskStatus process();
+    ResumableTaskStatus process();
 
-    class TaskStatus
+    class ResumableTaskStatus
     {
         private final boolean finished;
         private final ListenableFuture<?> continuationFuture;
 
-        private TaskStatus(boolean finished, ListenableFuture<?> continuationFuture)
+        private ResumableTaskStatus(boolean finished, ListenableFuture<?> continuationFuture)
         {
             this.finished = finished;
             this.continuationFuture = continuationFuture;
         }
 
-        public static TaskStatus finished()
+        public static ResumableTaskStatus finished()
         {
-            return new TaskStatus(true, Futures.immediateFuture(null));
+            return new ResumableTaskStatus(true, Futures.immediateFuture(null));
         }
 
-        public static TaskStatus continueOn(ListenableFuture<?> continuationFuture)
+        public static ResumableTaskStatus continueOn(ListenableFuture<?> continuationFuture)
         {
-            return new TaskStatus(false, continuationFuture);
+            return new ResumableTaskStatus(false, continuationFuture);
         }
 
         public boolean isFinished()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/ResumableTasks.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/ResumableTasks.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.util;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.hive.util.ResumableTask.ResumableTaskStatus;
 
 import java.util.concurrent.Executor;
 
@@ -32,7 +33,7 @@ public final class ResumableTasks
             @Override
             public void run()
             {
-                ResumableTask.TaskStatus status = safeProcessTask(task);
+                ResumableTaskStatus status = safeProcessTask(task);
                 if (!status.isFinished()) {
                     // if task is not complete, schedule it it to run again when the future finishes
                     status.getContinuationFuture().addListener(this, executor);
@@ -41,14 +42,14 @@ public final class ResumableTasks
         });
     }
 
-    private static ResumableTask.TaskStatus safeProcessTask(ResumableTask task)
+    private static ResumableTaskStatus safeProcessTask(ResumableTask task)
     {
         try {
             return task.process();
         }
         catch (Throwable t) {
             log.warn(t, "ResumableTask completed exceptionally");
-            return ResumableTask.TaskStatus.finished();
+            return ResumableTaskStatus.finished();
         }
     }
 }


### PR DESCRIPTION
## Description
Refactor ResumableTask to rename TaskStatus 
## Motivation and Context
TaskStatus is associated with coordinator worker communication in Presto. This commit is to rename TaskStatus in ResumableTask as ResumableTaskStatus to avoid confusion.

## Test Plan
Unit Tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== NO RELEASE NOTE ==
```

