### PR TITLE
[native pos] Ensure BroadcastFileReader#next is called outside the lock

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -34,26 +34,28 @@ folly::SemiFuture<BroadcastExchangeSource::Response>
 BroadcastExchangeSource::request(
     uint32_t /*maxBytes*/,
     uint32_t /*maxWaitSeconds*/) {
-  std::vector<velox::ContinuePromise> promises;
-  int64_t totalBytes = 0;
-  {
-    std::lock_guard<std::mutex> l(queue_->mutex());
-    if (atEnd_) {
-      return folly::makeFuture(Response{0, true});
-    }
+  if (atEnd_) {
+    return folly::makeFuture(Response{0, true});
+  }
 
-    if (!reader_->hasNext()) {
-      atEnd_ = true;
-      queue_->enqueueLocked(nullptr, promises);
-    } else {
-      auto buffer = reader_->next();
-      totalBytes = buffer->size();
-      auto ioBuf = folly::IOBuf::wrapBuffer(buffer->as<char>(), buffer->size());
-      queue_->enqueueLocked(
-          std::make_unique<velox::exec::SerializedPage>(
-              std::move(ioBuf), [buffer](auto& /*unused*/) {}),
-          promises);
-    }
+  atEnd_ = !reader_->hasNext();
+  int64_t totalBytes = 0;
+  std::unique_ptr<velox::exec::SerializedPage> page;
+  if (!atEnd_) {
+    // Read outside the lock to avoid a potential deadlock
+    // ExchangeClient guarantees not to call ExchangeSource#request concurrently
+    auto buffer = reader_->next();
+    totalBytes = buffer->size();
+    auto ioBuf = folly::IOBuf::wrapBuffer(buffer->as<char>(), buffer->size());
+    page = std::make_unique<velox::exec::SerializedPage>(
+        std::move(ioBuf), [buffer](auto& /*unused*/) {});
+  }
+
+  std::vector<velox::ContinuePromise> promises;
+  {
+    // Limit locking scope to queue manipulation
+    std::lock_guard<std::mutex> l(queue_->mutex());
+    queue_->enqueueLocked(std::move(page), promises);
   }
   for (auto& promise : promises) {
     promise.setValue();


### PR DESCRIPTION
## Description

Delayed locking till we have a page to return

## Motivation and Context

Deadlock is possible in a following scenario:

- BroadcastExchangeSource::request acquires ExchangeQueue#mutex
- BroadcastFileReader#next tries to allocate some memory when ExchangeQueue#mutex is acquired
- MemoryManager initiates memory revoke via SharedArbitrator
- SharedArbitrator waits for all task drivers to be suspended
- The driver initiated an arbitration is considered suspended via MemoryReclaimer#enterArbitration
- Yet other drivers waiting on the shared ExchangeQueue#mutex are not considered suspended
- SharedArbitrator ends up waiting for the other threads to get suspended, hence a deadlock

## Impact

Some Presto on Spark queries are timing out when running with native execution enabled

## Test Plan

- CI
- TBD

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [] Adequate tests were added if applicable.
- [] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

