### PR TITLE
Fix getting type signature for UDT from uppercase type string

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureBase.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureBase.java
@@ -35,7 +35,7 @@ public class TypeSignatureBase
     {
         int pos = name.indexOf(":");
         if (pos >= 0) {
-            return new TypeSignatureBase(QualifiedObjectName.valueOf(name.substring(0, pos)), name.substring(pos + 1));
+            return new TypeSignatureBase(QualifiedObjectName.valueOf(name.substring(0, pos).toLowerCase(ENGLISH)), name.substring(pos + 1));
         }
         if (name.chars().noneMatch(c -> c == '.')) {
             return new TypeSignatureBase(name);

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeSignature.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeSignature.java
@@ -48,6 +48,24 @@ public class TestTypeSignature
     }
 
     @Test
+    public void parseNamedTypeSignature()
+    {
+        assertRowSignature(
+                "cat.sch.pair:row(a bigint,b array(bigint),c row(a bigint))",
+                namedRowSignature("cat.sch.pair",
+                        namedParameter("a", false, signature("bigint")),
+                        namedParameter("b", false, array(signature("bigint"))),
+                        namedParameter("c", false, rowSignature(namedParameter("a", false, signature("bigint"))))));
+
+        // the UDT's name would be translated to lower case, and it's base type name case would be preserve
+        assertSignature(
+                "CAT.SCH.TROW:ROW(a CAT.SCH.TV:VARCHAR,b ARRAY(BIGINT),c ROW(a BIGINT))",
+                "cat.sch.trow:ROW",
+                ImmutableList.of("a cat.sch.tv:VARCHAR", "b ARRAY(BIGINT)", "c ROW(a BIGINT)"),
+                "cat.sch.trow:ROW(a cat.sch.tv:VARCHAR,b ARRAY(BIGINT),c ROW(a BIGINT))");
+    }
+
+    @Test
     public void parseRowSignature()
     {
         // row signature with named fields
@@ -195,6 +213,11 @@ public class TestTypeSignature
     private static TypeSignature rowSignature(NamedTypeSignature... columns)
     {
         return new TypeSignature("row", transform(asList(columns), TypeSignatureParameter::of));
+    }
+
+    private static TypeSignature namedRowSignature(String distinctTypeName, NamedTypeSignature... columns)
+    {
+        return new TypeSignature(distinctTypeName + ":row", transform(asList(columns), TypeSignatureParameter::of));
     }
 
     private static NamedTypeSignature namedParameter(String name, boolean delimited, TypeSignature value)

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -34,6 +34,12 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-function-namespace-managers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Description

In some cases, we might want to get a type signature from an uppercase type define string, for example in `PrestoResultSet.getColumnInfo()`. That would cause some exception for user defined type, as QualifiedObjectName accept name string in lowercase. This PR fix the problem.

## Test Plan

 - enhanced test case `TestJdbcResultSet.testObjectTypes()`
 - newly added test case `TestTypeSignature.parseNamedTypeSignature()`

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

