### PR TITLE
[native]Add server memory pushback configs

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -154,6 +154,9 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kSpillerSpillPath),
           NUM_PROP(kShutdownOnsetSec, 10),
           NUM_PROP(kSystemMemoryGb, 40),
+          STR_PROP(kSystemMemPushbackEnabled, "false"),
+          NUM_PROP(kSystemMemLimitGb, 55),
+          NUM_PROP(kSystemMemShrinkGb, 8),
           STR_PROP(kAsyncDataCacheEnabled, "true"),
           NUM_PROP(kAsyncCacheSsdGb, 0),
           NUM_PROP(kAsyncCacheSsdCheckpointGb, 0),
@@ -333,8 +336,20 @@ int32_t SystemConfig::shutdownOnsetSec() const {
   return optionalProperty<int32_t>(kShutdownOnsetSec).value();
 }
 
-int32_t SystemConfig::systemMemoryGb() const {
-  return optionalProperty<int32_t>(kSystemMemoryGb).value();
+uint32_t SystemConfig::systemMemoryGb() const {
+  return optionalProperty<uint32_t>(kSystemMemoryGb).value();
+}
+
+uint32_t SystemConfig::systemMemLimitGb() const {
+  return optionalProperty<uint32_t>(kSystemMemLimitGb).value();
+}
+
+uint32_t SystemConfig::systemMemShrinkGb() const {
+  return optionalProperty<uint32_t>(kSystemMemShrinkGb).value();
+}
+
+bool SystemConfig::systemMemPushbackEnabled() const {
+  return optionalProperty<bool>(kSystemMemPushbackEnabled).value();
 }
 
 uint64_t SystemConfig::asyncCacheSsdGb() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -196,6 +196,20 @@ class SystemConfig : public ConfigBase {
   /// NOTE: the query memory capacity is enforced by memory arbitrator so that
   /// this config only applies if the memory arbitration has been enabled.
   static constexpr std::string_view kQueryMemoryGb{"query-memory-gb"};
+
+  /// If true, enable memory pushback when the server is under low memory
+  /// condition.
+  static constexpr std::string_view kSystemMemPushbackEnabled{
+      "system-mem-pushback-enabled"};
+  /// Specifies the system memory limit and triggers memory pushback if the
+  /// server memory usage exceeds this limit. This only applies if
+  /// 'system-mem-pushback-enabled' is true.
+  static constexpr std::string_view kSystemMemLimitGb{"system-mem-limit-gb"};
+  /// Specifies the memory to shrink when memory pushback is triggered to help
+  /// get the server out of low memory condition. This only applies if
+  /// 'system-mem-pushback-enabled' is true.
+  static constexpr std::string_view kSystemMemShrinkGb{"system-mem-shrink-gb"};
+
   static constexpr std::string_view kAsyncDataCacheEnabled{
       "async-data-cache-enabled"};
   static constexpr std::string_view kAsyncCacheSsdGb{"async-cache-ssd-gb"};
@@ -433,7 +447,13 @@ class SystemConfig : public ConfigBase {
 
   int32_t shutdownOnsetSec() const;
 
-  int32_t systemMemoryGb() const;
+  uint32_t systemMemoryGb() const;
+
+  bool systemMemPushbackEnabled() const;
+
+  uint32_t systemMemLimitGb() const;
+
+  uint32_t systemMemShrinkGb() const;
 
   bool asyncDataCacheEnabled() const;
 


### PR DESCRIPTION
Add server memory pushback configs:

- system-mem-pushback-enabled is set to enable or disable server memory pushback
- system-mem-limit-gb specifies the server memory limit to trigger server memory pushback
- system-mem-shrink-gb specifies the memory to shrink when server memory pushback is
- triggered.

Server memory pushback is reclaim server memory usage to help get the server out of memory
condition. Since getting the server memory is platform dependent, the actual low memory 
condition detection can be implemented by deriving presto server's addAdditionalPeriodicTasks
to add a periodic running task to detect and trigger server memory pushback.
And we can reclaim memory by shrinking the async data cache: AsyncDataCache::shrink