### PR TITLE
Handle case of table with no supported columns

### DIFF
--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -128,14 +128,13 @@ public class TestPostgreSqlIntegrationSmokeTest
                 AutoCloseable ignore2 = withTable("tpch.supported_columns", format("(good %s)", supportedDataType));
                 AutoCloseable ignore3 = withTable("tpch.no_columns", "()")) {
             assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains("orders", "no_supported_columns", "supported_columns", "no_columns");
+            assertQueryFails("SELECT c FROM tpch.no_supported_columns", "\\QTable 'tpch.no_supported_columns" + "' has no supported columns (all 1 columns are not supported)");
+            assertQueryFails("SELECT * FROM tpch.no_supported_columns", "\\QTable 'tpch.no_supported_columns" + "' has no supported columns (all 1 columns are not supported)");
+            assertQueryFails("SELECT 'a' FROM tpch.no_supported_columns", "\\QTable 'tpch.no_supported_columns" + "' has no supported columns (all 1 columns are not supported)");
 
-            assertQueryFails("SELECT c FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
-            assertQueryFails("SELECT * FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
-            assertQueryFails("SELECT 'a' FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
-
-            assertQueryFails("SELECT c FROM no_columns", "Table 'tpch.no_columns' not found");
-            assertQueryFails("SELECT * FROM no_columns", "Table 'tpch.no_columns' not found");
-            assertQueryFails("SELECT 'a' FROM no_columns", "Table 'tpch.no_columns' not found");
+            assertQueryFails("SELECT c FROM tpch.no_columns", "\\QTable 'tpch.no_columns" + "' has no supported columns (all 0 columns are not supported)");
+            assertQueryFails("SELECT * FROM tpch.no_columns", "\\QTable 'tpch.no_columns" + "' has no supported columns (all 0 columns are not supported)");
+            assertQueryFails("SELECT 'a' FROM tpch.no_columns", "\\QTable 'tpch.no_columns" + "' has no supported columns (all 0 columns are not supported)");
 
             assertQueryFails("SELECT c FROM non_existent", ".*Table .*tpch.non_existent.* does not exist");
             assertQueryFails("SELECT * FROM non_existent", ".*Table .*tpch.non_existent.* does not exist");


### PR DESCRIPTION
Handle case of table with no supported columns

Your Environment :
Presto version used:0.285
Storage (HDFS/S3/GCS..):postgresql
Data source and connector used:postgresql
Deployment (Cloud or On-prem):mac

Expected Behavior :
Table 'public.no_column_table' has no supported columns (all %s columns are not supported)

Current Behavior :
presto:public> show tables;
Table
example_table
example_table1
mm
no_column_table
sample_table
(5 rows)

Query 20231120_100558_00026_suqwa, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:03, server-side: 0:03] [5 rows, 136B] [1 rows/s, 50B/s]

presto:public> select * from no_column_table;
Query 20231120_100747_00027_suqwa failed: Table 'public.no_column_table' not found

presto:public> show tables;
Table
example_table
example_table1
mm
no_column_table
sample_table
unsupported_type_table
(6 rows)

Query 20231120_102515_00028_suqwa, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:02, server-side: 0:02] [6 rows, 174B] [2 rows/s, 75B/s]

presto:public> select * from unsupported_type_table;
Query 20231120_102529_00029_suqwa failed: Table 'public.unsupported_type_table' not found

Possible Solution
throw new TableNotFoundException(
 tableHandle.getSchemaTableName(),
 format("Table '%s' has no supported columns (all %s columns are not supported)", 



Steps to Reproduce :

postgresql connector
2.create
mydatabase=# CREATE TABLE no_column_table();
CREATE TABLE
mydatabase=# CREATE TABLE unsupported_type_table (
data_point point
);
CREATE TABLE
mydatabase=#
from presto cli, select * from <table_name>

After changes :
Screenshots (if appropriate)
presto> use public;
USE
presto:public> select * from unsupported_type_table;
Query 20231120_102910_00004_35dqb failed: Table 'public.unsupported_type_table' has no supported columns (all 1 columns are not supported)

presto:public> select * from no_column_table;
Query 20231120_102918_00005_35dqb failed: Table 'public.no_column_table' has no supported columns (all 0 columns are not supported)

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

