### PR TITLE
Update hive-apache to 3.0.0-10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -774,7 +774,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>3.0.0-8</version>
+                <version>3.0.0-10</version>
             </dependency>
 
             <dependency>
@@ -880,7 +880,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>0.15</version>
+                <version>0.21</version>
             </dependency>
 
             <dependency>

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -306,6 +306,16 @@
                     </ignoredDependencies>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredClassPatterns>
+                        <ignoredClassPattern>module-info</ignoredClassPattern>
+                        <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                    </ignoredClassPatterns>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -192,6 +192,7 @@
                             <ignoredClassPatterns>
                                 <ignoredClassPattern>shaded.parquet.it.unimi.dsi.fastutil.*</ignoredClassPattern>
                                 <ignoredClassPattern>module-info</ignoredClassPattern>
+                                <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                             </ignoredClassPatterns>
                         </configuration>
                     </plugin>
@@ -220,6 +221,10 @@
                                 <ignoredResourcePattern>about.html</ignoredResourcePattern>
                                 <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
                             </ignoredResourcePatterns>
+                            <ignoredClassPatterns>
+                                <ignoredClassPattern>module-info</ignoredClassPattern>
+                                <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                            </ignoredClassPatterns>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -249,6 +254,10 @@
                                 <ignoredResourcePattern>about.html</ignoredResourcePattern>
                                 <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
                             </ignoredResourcePatterns>
+                            <ignoredClassPatterns>
+                                <ignoredClassPattern>module-info</ignoredClassPattern>
+                                <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                            </ignoredClassPatterns>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -277,6 +286,10 @@
                                 <ignoredResourcePattern>about.html</ignoredResourcePattern>
                                 <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
                             </ignoredResourcePatterns>
+                            <ignoredClassPatterns>
+                                <ignoredClassPattern>module-info</ignoredClassPattern>
+                                <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                            </ignoredClassPatterns>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -473,6 +473,7 @@
                     <ignoredClassPatterns>
                         <ignoredClassPattern>shaded.parquet.it.unimi.dsi.fastutil.*</ignoredClassPattern>
                         <ignoredClassPattern>module-info</ignoredClassPattern>
+                        <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                     </ignoredClassPatterns>
                 </configuration>
             </plugin>

--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -228,4 +228,21 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoredClassPatterns>
+                            <ignoredClassPattern>module-info</ignoredClassPattern>
+                            <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                        </ignoredClassPatterns>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -555,6 +555,7 @@
                             <ignoredClassPattern>org.apache.avro.*</ignoredClassPattern>
                             <ignoredClassPattern>org.apache.parquet.*</ignoredClassPattern>
                             <ignoredClassPattern>com.github.benmanes.caffeine.*</ignoredClassPattern>
+                            <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                         </ignoredClassPatterns>
                     </configuration>
                 </plugin>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -208,6 +208,7 @@
                     <ignoredClassPatterns>
                         <ignoredClassPattern>shaded.parquet.it.unimi.dsi.fastutil.*</ignoredClassPattern>
                         <ignoredClassPattern>module-info</ignoredClassPattern>
+                        <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                     </ignoredClassPatterns>
                 </configuration>
             </plugin>

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -183,6 +183,7 @@
                         <ignoredClassPattern>com.esotericsoftware.minlog.Log</ignoredClassPattern>
                         <ignoredClassPattern>com.esotericsoftware.reflectasm.*</ignoredClassPattern>
                         <ignoredClassPattern>module-info</ignoredClassPattern>
+                        <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                     </ignoredClassPatterns>
                 </configuration>
             </plugin>

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -315,6 +315,7 @@
                         <ignoredClassPattern>com.esotericsoftware.kryo.*</ignoredClassPattern>
                         <ignoredClassPattern>com.esotericsoftware.minlog.Log</ignoredClassPattern>
                         <ignoredClassPattern>com.esotericsoftware.reflectasm.*</ignoredClassPattern>
+                        <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                     </ignoredClassPatterns>
                 </configuration>
             </plugin>

--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -141,6 +141,7 @@
                     <ignoredClassPatterns>
                         <ignoredClassPattern>shaded.parquet.it.unimi.dsi.fastutil.*</ignoredClassPattern>
                         <ignoredClassPattern>module-info</ignoredClassPattern>
+                        <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                     </ignoredClassPatterns>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Update hive-apache to 3.0.0-10, because https://github.com/prestodb/presto/pull/21189 relies on it.
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

CC: @tdcmeehan 

