### PR TITLE
[native] Remove unnecessary flags from fuzzer test

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -597,9 +597,9 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     VectorFuzzer::Options opts;
     opts.vectorSize = 1000;
     opts.nullRatio = 0.1;
-    opts.containerHasNulls = false;
     opts.dictionaryHasNulls = false;
     opts.stringVariableLength = true;
+
     // UnsafeRows use microseconds to store timestamp.
     opts.timestampPrecision =
         VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
@@ -611,8 +611,6 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     // assertEqualResults:
     // Limitations of assertEqualResults:
     // https://github.com/facebookincubator/velox/issues/2859
-    // Fuzzer issues with null-key maps:
-    // https://github.com/facebookincubator/velox/issues/2848
     auto rowType = ROW({
         {"c0", INTEGER()},
         {"c1", TINYINT()},
@@ -630,6 +628,7 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
         {"c13", ARRAY(INTEGER())},
         {"c14", ARRAY(TINYINT())},
         {"c15", ROW({INTEGER(), VARCHAR(), ARRAY(INTEGER())})},
+        {"c16", MAP(TINYINT(), REAL())},
     });
 
     // Create a local file system storage based shuffle.
@@ -682,7 +681,6 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     opts.vectorSize = 10;
     opts.nullRatio = 0;
     opts.dictionaryHasNulls = false;
-    opts.containerHasNulls = false;
     opts.stringLength = 10000;
     opts.containerLength = 10000;
     opts.stringVariableLength = false;


### PR DESCRIPTION
Removing unnecessary containerHasNull flag since we only care about top level row, and that is already guaranteed by fuzInputRow(). Also adding a map() to the task since the limitation linked has been long fixed.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

