### PR TITLE
[native] Make HTTP client connection pool configurable and disable by default

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -141,7 +141,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
       velox::memory::MemoryPool* memoryPool,
       folly::CPUThreadPoolExecutor* cpuExecutor,
       folly::IOThreadPoolExecutor* ioExecutor,
-      ConnectionPools& connectionPools);
+      ConnectionPools* connectionPools);
 
   /// Completes the future returned by 'request()' if it hasn't completed
   /// already.

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -189,7 +189,7 @@ class PrestoServer {
   // Executor for spilling.
   std::shared_ptr<folly::CPUThreadPoolExecutor> spillerExecutor_;
 
-  ConnectionPools exchangeSourceConnectionPools_;
+  std::unique_ptr<ConnectionPools> exchangeSourceConnectionPools_;
 
   // Instance of MemoryAllocator used for all query memory allocations.
   std::shared_ptr<velox::memory::MemoryAllocator> allocator_;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -190,6 +190,7 @@ SystemConfig::SystemConfig() {
           STR_PROP(kExchangeMaxErrorDuration, "3m"),
           STR_PROP(kExchangeRequestTimeout, "10s"),
           STR_PROP(kExchangeConnectTimeout, "20s"),
+          BOOL_PROP(kExchangeEnableConnectionPool, false),
           BOOL_PROP(kExchangeImmediateBufferTransfer, true),
           NUM_PROP(kTaskRunTimeSliceMicros, 50'000),
           BOOL_PROP(kIncludeNodeInSpillPath, false),
@@ -492,6 +493,10 @@ std::chrono::duration<double> SystemConfig::exchangeRequestTimeoutMs() const {
 std::chrono::duration<double> SystemConfig::exchangeConnectTimeoutMs() const {
   return velox::core::toDuration(
       optionalProperty(kExchangeConnectTimeout).value());
+}
+
+bool SystemConfig::exchangeEnableConnectionPool() const {
+  return optionalProperty<bool>(kExchangeEnableConnectionPool).value();
 }
 
 bool SystemConfig::exchangeImmediateBufferTransfer() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -322,6 +322,10 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kExchangeConnectTimeout{
       "exchange.http-client.connect-timeout"};
 
+  /// Whether connection pool should be enabled for exchange HTTP client.
+  static constexpr std::string_view kExchangeEnableConnectionPool{
+      "exchange.http-client.enable-connection-pool"};
+
   /// The maximum timeslice for a task on thread if there are threads queued.
   static constexpr std::string_view kTaskRunTimeSliceMicros{
       "task-run-timeslice-micros"};
@@ -520,6 +524,8 @@ class SystemConfig : public ConfigBase {
   std::chrono::duration<double> exchangeRequestTimeoutMs() const;
 
   std::chrono::duration<double> exchangeConnectTimeoutMs() const;
+
+  bool exchangeEnableConnectionPool() const;
 
   bool exchangeImmediateBufferTransfer() const;
 

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -124,6 +124,8 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
       const std::string& ciphers = "",
       std::function<void(int)>&& reportOnBodyStatsFunc = nullptr);
 
+  ~HttpClient();
+
   // TODO Avoid copy by using IOBuf for body
   folly::SemiFuture<std::unique_ptr<HttpResponse>> sendRequest(
       const proxygen::HTTPMessage& request,
@@ -136,7 +138,6 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
 
  private:
   folly::EventBase* const eventBase_;
-  proxygen::SessionPool* const sessionPool_;
   const folly::SocketAddress address_;
   const proxygen::WheelTimerInstance transactionTimer_;
   const std::chrono::milliseconds connectTimeout_;
@@ -150,6 +151,9 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
   const std::string ciphers_;
   const std::function<void(int)> reportOnBodyStatsFunc_;
   const uint64_t maxResponseAllocBytes_;
+  proxygen::SessionPool* sessionPool_;
+  // Create if sessionPool_ is not received from the contructor.
+  std::unique_ptr<proxygen::SessionPool> sessionPoolHolder_;
 };
 
 class RequestBuilder {

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -441,7 +441,7 @@ class PrestoExchangeSourceTest : public ::testing::TestWithParam<Params> {
         pool != nullptr ? pool : pool_.get(),
         exchangeCpuExecutor_.get(),
         exchangeIoExecutor_.get(),
-        connectionPools_);
+        &connectionPools_);
   }
 
   void requestNextPage(

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -165,7 +165,7 @@ class TaskManagerTest : public testing::Test {
               pool,
               cpuExecutor.get(),
               ioExecutor.get(),
-              *connectionPools);
+              connectionPools.get());
         });
     if (!isRegisteredVectorSerde()) {
       serializer::presto::PrestoVectorSerde::registerVectorSerde();


### PR DESCRIPTION
If too many endpoints are pinned to the same event base, it will create some congestions on these connections.  Make it default to disabled for now until we find a smarter way to balance the event bases and connections.