### PR TITLE
[native] Change HTTP executor num threads config param to HW multiplier.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -114,7 +114,6 @@ void PrestoServer::run() {
   auto nodeConfig = NodeConfig::instance();
   auto baseVeloxQueryConfig = BaseVeloxQueryConfig::instance();
   int httpPort{0};
-  int httpExecThreads{0};
 
   std::string certPath;
   std::string keyPath;
@@ -173,7 +172,6 @@ void PrestoServer::run() {
     }
 
     nodeVersion_ = systemConfig->prestoVersion();
-    httpExecThreads = systemConfig->httpExecThreads();
     environment_ = nodeConfig->nodeEnvironment();
     nodeId_ = nodeConfig->nodeId();
     address_ = nodeConfig->nodeInternalAddress(
@@ -311,7 +309,8 @@ void PrestoServer::run() {
       systemConfig->numIoThreads(),
       std::make_shared<folly::NamedThreadFactory>("PrestoWorkerNetwork"));
 
-  PRESTO_STARTUP_LOG(INFO) << "Exchange Http executor has "
+  PRESTO_STARTUP_LOG(INFO) << "Exchange Http IO executor '"
+                           << exchangeHttpExecutor_->getName() << "' has "
                            << exchangeHttpExecutor_->numThreads()
                            << " threads.";
 
@@ -391,16 +390,23 @@ void PrestoServer::run() {
         prestoServerOperations_->runOperation(message, downstream);
       });
 
-  PRESTO_STARTUP_LOG(INFO) << "Driver CPU executor has "
+  PRESTO_STARTUP_LOG(INFO) << "Driver CPU executor '"
+                           << driverExecutor_->getName() << "' has "
                            << driverExecutor_->numThreads() << " threads.";
   if (httpServer_->getExecutor()) {
     PRESTO_STARTUP_LOG(INFO)
-        << "HTTP Server executor has "
-        << httpServer_->getExecutor()->numThreads() << " threads.";
+        << "HTTP Server IO executor '" << httpServer_->getExecutor()->getName()
+        << "' has " << httpServer_->getExecutor()->numThreads() << " threads.";
+  }
+  if (httpSrvCpuExecutor_ != nullptr) {
+    PRESTO_STARTUP_LOG(INFO)
+        << "HTTP Server CPU executor '" << httpSrvCpuExecutor_->getName()
+        << "' has " << httpSrvCpuExecutor_->numThreads() << " threads.";
   }
   if (spillerExecutor_ != nullptr) {
-    PRESTO_STARTUP_LOG(INFO) << "Spill executor has "
-                             << spillerExecutor_->numThreads() << " threads.";
+    PRESTO_STARTUP_LOG(INFO)
+        << "Spiller CPU executor '" << spillerExecutor_->getName() << "', has "
+        << spillerExecutor_->numThreads() << " threads.";
   } else {
     PRESTO_STARTUP_LOG(INFO) << "Spill executor was not configured.";
   }
@@ -453,7 +459,7 @@ void PrestoServer::run() {
   unregisterConnectors();
 
   PRESTO_SHUTDOWN_LOG(INFO)
-      << "Joining driver CPU Executor '" << driverExecutor_->getName()
+      << "Joining Driver CPU Executor '" << driverExecutor_->getName()
       << "': threads: " << driverExecutor_->numActiveThreads() << "/"
       << driverExecutor_->numThreads()
       << ", task queue: " << driverExecutor_->getTaskQueueSize();
@@ -461,7 +467,7 @@ void PrestoServer::run() {
 
   if (connectorIoExecutor_) {
     PRESTO_SHUTDOWN_LOG(INFO)
-        << "Joining connector IO Executor '" << connectorIoExecutor_->getName()
+        << "Joining Connector IO Executor '" << connectorIoExecutor_->getName()
         << "': threads: " << connectorIoExecutor_->numActiveThreads() << "/"
         << connectorIoExecutor_->numThreads();
     connectorIoExecutor_->join();
@@ -470,8 +476,26 @@ void PrestoServer::run() {
   PRESTO_SHUTDOWN_LOG(INFO) << "Releasing HTTP connection pools";
   exchangeSourceConnectionPools_.destroy();
 
+  if (httpSrvCpuExecutor_ != nullptr) {
+    PRESTO_SHUTDOWN_LOG(INFO)
+        << "Joining HTTP Server CPU Executor '"
+        << httpSrvCpuExecutor_->getName()
+        << "': threads: " << httpSrvCpuExecutor_->numActiveThreads() << "/"
+        << httpSrvCpuExecutor_->numThreads()
+        << ", task queue: " << httpSrvCpuExecutor_->getTaskQueueSize();
+    httpSrvCpuExecutor_->join();
+  }
+  if (httpSrvIOExecutor_ != nullptr) {
+    PRESTO_SHUTDOWN_LOG(INFO)
+        << "Joining HTTP Server IO Executor '" << httpSrvIOExecutor_->getName()
+        << "': threads: " << httpSrvIOExecutor_->numActiveThreads() << "/"
+        << httpSrvIOExecutor_->numThreads();
+    httpSrvIOExecutor_->join();
+  }
+
   PRESTO_SHUTDOWN_LOG(INFO)
-      << "Joining exchange Http executor '" << exchangeHttpExecutor_->getName()
+      << "Joining Exchange Http IO executor '"
+      << exchangeHttpExecutor_->getName()
       << "': threads: " << exchangeHttpExecutor_->numActiveThreads() << "/"
       << exchangeHttpExecutor_->numThreads();
   exchangeHttpExecutor_->join();
@@ -525,13 +549,17 @@ void PrestoServer::initializeThreadPools() {
       systemConfig->numQueryThreads(),
       std::make_shared<folly::NamedThreadFactory>("Driver"));
 
-  httpSrvIOExecutor_ = std::make_shared<folly::IOThreadPoolExecutor>(
-      systemConfig->httpExecThreads(),
-      std::make_shared<folly::NamedThreadFactory>("HTTPSrvIO"));
+  const auto hwConcurrency = std::thread::hardware_concurrency();
 
+  const auto numIoThreads = std::max<size_t>(
+      systemConfig->numHttpIoThreadsHwMultiplier() * hwConcurrency, 1);
+  httpSrvIOExecutor_ = std::make_shared<folly::IOThreadPoolExecutor>(
+      numIoThreads, std::make_shared<folly::NamedThreadFactory>("HTTPSrvIO"));
+
+  const auto numCpuThreads = std::max<size_t>(
+      systemConfig->numHttpCpuThreadsHwMultiplier() * hwConcurrency, 1);
   httpSrvCpuExecutor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
-      systemConfig->numHttpCpuThreads(),
-      std::make_shared<folly::NamedThreadFactory>("HTTPSrvCpu"));
+      numCpuThreads, std::make_shared<folly::NamedThreadFactory>("HTTPSrvCpu"));
 
   const int32_t numSpillThreads = systemConfig->numSpillThreads();
   if (numSpillThreads > 0) {
@@ -621,9 +649,12 @@ void PrestoServer::stop() {
   // Make sure we only go here once.
   auto shutdownOnsetSec = SystemConfig::instance()->shutdownOnsetSec();
   if (!shuttingDown_.exchange(true)) {
-    PRESTO_SHUTDOWN_LOG(INFO) << "Initiating shutdown. Will wait for "
-                              << shutdownOnsetSec << " seconds.";
-    this->setNodeState(NodeState::SHUTTING_DOWN);
+    PRESTO_SHUTDOWN_LOG(INFO) << "Shutdown has been requested. "
+                                 "Setting node state to 'shutting down'.";
+    setNodeState(NodeState::SHUTTING_DOWN);
+    PRESTO_SHUTDOWN_LOG(INFO)
+        << "Waiting for " << shutdownOnsetSec
+        << " second(s) before proceeding with the shutdown...";
 
     // Give coordinator some time to receive our new node state and stop sending
     // any tasks.

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -137,8 +137,8 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kDiscoveryUri),
           NUM_PROP(kMaxDriversPerTask, 16),
           NUM_PROP(kConcurrentLifespansPerTask, 1),
-          NUM_PROP(kHttpExecThreads, std::thread::hardware_concurrency()),
-          NUM_PROP(kNumHttpCpuThreads, std::thread::hardware_concurrency()),
+          NUM_PROP(kHttpServerNumIoThreadsHwMultiplier, 1.0),
+          NUM_PROP(kHttpServerNumCpuThreadsHwMultiplier, 1.0),
           NONE_PROP(kHttpServerHttpsPort),
           STR_PROP(kHttpServerHttpsEnabled, "false"),
           STR_PROP(
@@ -304,12 +304,12 @@ int32_t SystemConfig::concurrentLifespansPerTask() const {
   return optionalProperty<int32_t>(kConcurrentLifespansPerTask).value();
 }
 
-int32_t SystemConfig::httpExecThreads() const {
-  return optionalProperty<int32_t>(kHttpExecThreads).value();
+double SystemConfig::numHttpIoThreadsHwMultiplier() const {
+  return optionalProperty<double>(kHttpServerNumIoThreadsHwMultiplier).value();
 }
 
-int32_t SystemConfig::numHttpCpuThreads() const {
-  return optionalProperty<int32_t>(kNumHttpCpuThreads).value();
+double SystemConfig::numHttpCpuThreadsHwMultiplier() const {
+  return optionalProperty<double>(kHttpServerNumCpuThreadsHwMultiplier).value();
 }
 
 int32_t SystemConfig::numIoThreads() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -164,8 +164,17 @@ class SystemConfig : public ConfigBase {
       "task.max-drivers-per-task"};
   static constexpr std::string_view kConcurrentLifespansPerTask{
       "task.concurrent-lifespans-per-task"};
-  static constexpr std::string_view kHttpExecThreads{"http_exec_threads"};
-  static constexpr std::string_view kNumHttpCpuThreads{"num-http-cpu-threads"};
+
+  /// Floating point number used in calculating how many threads we would use
+  /// for HTTP IO executor: hw_concurrency x multiplier. 1.0 is default.
+  static constexpr std::string_view kHttpServerNumIoThreadsHwMultiplier{
+      "http-server.num-io-threads-hw-multiplier"};
+
+  /// Floating point number used in calculating how many threads we would use
+  /// for HTTP CPU executor: hw_concurrency x multiplier. 1.0 is default.
+  static constexpr std::string_view kHttpServerNumCpuThreadsHwMultiplier{
+      "http-server.num-cpu-threads-hw-multiplier"};
+
   static constexpr std::string_view kHttpServerHttpsPort{
       "http-server.https.port"};
   static constexpr std::string_view kHttpServerHttpsEnabled{
@@ -429,9 +438,9 @@ class SystemConfig : public ConfigBase {
 
   int32_t concurrentLifespansPerTask() const;
 
-  int32_t httpExecThreads() const;
+  double numHttpIoThreadsHwMultiplier() const;
 
-  int32_t numHttpCpuThreads() const;
+  double numHttpCpuThreadsHwMultiplier() const;
 
   /// Size of global IO executor.
   int32_t numIoThreads() const;


### PR DESCRIPTION
* Change HTTP executor num threads config param to be HW multiplier, instead of
being the number of threads.
* Made startup and shutdown messages more friendly.
* Joining two HTTP executors during shutdown, so if they have some threads stuck, we will see which executor is affected.


```
== NO RELEASE NOTE ==
```

