### PR TITLE
Support insert values with batch line of parameters

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -41,7 +41,6 @@ import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.Offset;
 import com.facebook.presto.sql.tree.OrderBy;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
@@ -94,7 +93,7 @@ public class Analysis
 {
     @Nullable
     private final Statement root;
-    private final Map<NodeRef<Parameter>, Expression> parameters;
+    private final MultiLineParameters parameters;
     private String updateType;
 
     private final Map<NodeRef<Table>, NamedQuery> namedQueries = new LinkedHashMap<>();
@@ -189,10 +188,10 @@ public class Analysis
     // Keeps track of the subquery we are visiting, so we have access to base query information when processing materialized view status
     private Optional<QuerySpecification> currentQuerySpecification = Optional.empty();
 
-    public Analysis(@Nullable Statement root, Map<NodeRef<Parameter>, Expression> parameters, boolean isDescribe)
+    public Analysis(@Nullable Statement root, MultiLineParameters parameters, boolean isDescribe)
     {
         this.root = root;
-        this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameterMap is null"));
+        this.parameters = requireNonNull(parameters, "parameterMap is null");
         this.isDescribe = isDescribe;
     }
 
@@ -797,7 +796,7 @@ public class Analysis
                 .orElse(emptyList());
     }
 
-    public Map<NodeRef<Parameter>, Expression> getParameters()
+    public MultiLineParameters getParameters()
     {
         return parameters;
     }

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/MultiLineParameters.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/MultiLineParameters.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.sql.tree.Parameter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static java.util.Objects.requireNonNull;
+
+public class MultiLineParameters
+{
+    public static final MultiLineParameters EMPTY = new MultiLineParameters(ImmutableList.of(), ImmutableList.of());
+
+    private final List<NodeRef<Parameter>> parameterRefs;
+    private final List<List<Expression>> parameterExpressions;
+
+    public MultiLineParameters(List<NodeRef<Parameter>> parameterRefs, List<List<Expression>> parameterExpressions)
+    {
+        this.parameterRefs = requireNonNull(parameterRefs, "parameterRefs is null");
+        this.parameterExpressions = requireNonNull(parameterExpressions, "parameterExpressions is null");
+        for (List<Expression> expressions : parameterExpressions) {
+            if (expressions.size() != parameterRefs.size()) {
+                throw new PrestoException(INVALID_ARGUMENTS, "Parameters not compatible");
+            }
+        }
+    }
+
+    public static MultiLineParameters from(Map<NodeRef<Parameter>, Expression> parameters)
+    {
+        requireNonNull(parameters, "parameters is null");
+        if (parameters.isEmpty()) {
+            return EMPTY;
+        }
+        ImmutableList.Builder refsBuilder = ImmutableList.builder();
+        ImmutableList.Builder expressionsBuilder = ImmutableList.builder();
+        parameters.entrySet().stream().forEach(entry -> {
+            refsBuilder.add(entry.getKey());
+            expressionsBuilder.add(entry.getValue());
+        });
+        return new MultiLineParameters(refsBuilder.build(), expressionsBuilder.build());
+    }
+
+    public int size()
+    {
+        return parameterExpressions.size();
+    }
+
+    public Map<NodeRef<Parameter>, Expression> getFirstRowOfParametersIfExists()
+    {
+        if (parameterExpressions.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        List<Expression> singleRowExpressions = parameterExpressions.get(0);
+        Builder mapBuilder = ImmutableMap.builder();
+        for (int i = 0; i < parameterRefs.size(); i++) {
+            mapBuilder.put(parameterRefs.get(i), singleRowExpressions.get(i));
+        }
+        return mapBuilder.build();
+    }
+
+    public Map<NodeRef<Parameter>, Expression> getRowOfParameters(int rowIdx)
+    {
+        if (rowIdx >= parameterExpressions.size()) {
+            throw new PrestoException(INVALID_ARGUMENTS, "Invalidate rowIdx: " + rowIdx);
+        }
+
+        // rowIdx < 0 implies no parameters exists
+        if (rowIdx < 0) {
+            return ImmutableMap.of();
+        }
+
+        List<Expression> singleRowExpressions = parameterExpressions.get(rowIdx);
+        Builder mapBuilder = ImmutableMap.builder();
+        for (int i = 0; i < parameterRefs.size(); i++) {
+            mapBuilder.put(parameterRefs.get(i), singleRowExpressions.get(i));
+        }
+        return mapBuilder.build();
+    }
+}

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/InsertValuesExtractor.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/InsertValuesExtractor.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer.utils;
+
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Insert;
+import com.facebook.presto.sql.tree.Select;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.sql.tree.Values;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InsertValuesExtractor
+{
+    private InsertValuesExtractor() {}
+
+    public static InsertValuesMessage getInsertValuesMessage(Statement statement)
+    {
+        InsertValuesExtractingVisitor insertValuesExtractingVisitor = new InsertValuesExtractingVisitor();
+        insertValuesExtractingVisitor.process(statement, null);
+        return insertValuesExtractingVisitor.getInsertValuesMessage();
+    }
+
+    public static class InsertValuesMessage
+    {
+        private final boolean insertValues;
+        private final int rowsCount;
+
+        public InsertValuesMessage(boolean insertValues, int rowsCount)
+        {
+            this.insertValues = insertValues;
+            this.rowsCount = rowsCount;
+        }
+
+        public boolean isInsertValues()
+        {
+            return insertValues;
+        }
+
+        public int getRowsCount()
+        {
+            return rowsCount;
+        }
+    }
+
+    private static class InsertValuesExtractingVisitor
+            extends DefaultTraversalVisitor<Void, Void>
+    {
+        private final List<Expression> rows = new ArrayList<>();
+        boolean hasInsert;
+        boolean hasSelect;
+
+        public InsertValuesMessage getInsertValuesMessage()
+        {
+            boolean insertValues = hasInsert && !hasSelect && !rows.isEmpty();
+            return new InsertValuesMessage(insertValues, insertValues ? rows.size() : -1);
+        }
+
+        @Override
+        protected Void visitInsert(Insert node, Void context)
+        {
+            hasInsert = true;
+            process(node.getQuery(), context);
+            return null;
+        }
+
+        @Override
+        protected Void visitSelect(Select node, Void context)
+        {
+            // there exists 'select' in this statement, stop handling
+            hasSelect = true;
+            return null;
+        }
+
+        @Override
+        public Void visitValues(Values node, Void context)
+        {
+            if (hasInsert && !hasSelect) {
+                rows.addAll(node.getRows());
+            }
+            return null;
+        }
+    }
+}

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/ParameterUtils.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/ParameterUtils.java
@@ -38,7 +38,7 @@ public class ParameterUtils
 
     public static MultiLineParameters parameterExtractor(Statement statement, List<Expression> parameters, boolean isBatch)
     {
-        List<NodeRef<Parameter>> refsList = ParameterExtractor.getParameters(statement).stream()
+        List<NodeRef<Parameter>> nodeRefList = ParameterExtractor.getParameters(statement).stream()
                 .sorted(Comparator.comparing(
                         parameter -> parameter.getLocation().get(),
                         Comparator.comparing(NodeLocation::getLineNumber)
@@ -51,16 +51,16 @@ public class ParameterUtils
             if (!parameters.isEmpty() && parameters.get(0) instanceof Row) {
                 for (Expression rowExpression : parameters) {
                     ImmutableList.Builder<Expression> builder = ImmutableList.builder();
-                    List<Expression> exprs = ((Row) rowExpression).getItems();
-                    for (Expression expr : exprs) {
-                        builder.add(expr);
+                    List<Expression> expressions = ((Row) rowExpression).getItems();
+                    for (Expression expression : expressions) {
+                        builder.add(expression);
                     }
                     parameterExpressions.add(builder.build());
                 }
             }
             else {
-                for (Expression expr : parameters) {
-                    parameterExpressions.add(ImmutableList.of(expr));
+                for (Expression expression : parameters) {
+                    parameterExpressions.add(ImmutableList.of(expression));
                 }
             }
         }
@@ -71,6 +71,6 @@ public class ParameterUtils
             }
             parameterExpressions.add(builder.build());
         }
-        return new MultiLineParameters(refsList, parameterExpressions.build());
+        return new MultiLineParameters(nodeRefList, parameterExpressions.build());
     }
 }

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/ParameterUtils.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/ParameterUtils.java
@@ -13,39 +13,50 @@
  */
 package com.facebook.presto.sql.analyzer.utils;
 
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.Parameter;
+import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.Statement;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
-import static com.facebook.presto.sql.analyzer.utils.ParameterExtractor.getParameters;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class ParameterUtils
 {
     private ParameterUtils() {}
 
-    public static Map<NodeRef<Parameter>, Expression> parameterExtractor(Statement statement, List<Expression> parameters)
+    public static MultiLineParameters parameterExtractor(Statement statement, List<Expression> parameters)
     {
-        List<Parameter> parametersList = getParameters(statement).stream()
+        List<NodeRef<Parameter>> refsList = ParameterExtractor.getParameters(statement).stream()
                 .sorted(Comparator.comparing(
                         parameter -> parameter.getLocation().get(),
                         Comparator.comparing(NodeLocation::getLineNumber)
                                 .thenComparing(NodeLocation::getColumnNumber)))
+                .map(NodeRef::of)
                 .collect(toImmutableList());
 
-        ImmutableMap.Builder<NodeRef<Parameter>, Expression> builder = ImmutableMap.builder();
-        Iterator<Expression> iterator = parameters.iterator();
-        for (Parameter parameter : parametersList) {
-            builder.put(NodeRef.of(parameter), iterator.next());
+        ImmutableList.Builder<List<Expression>> parameterExpressions = ImmutableList.builder();
+        if (!parameters.isEmpty() && parameters.get(0) instanceof Row) {
+            for (Expression rowExpression : parameters) {
+                ImmutableList.Builder<Expression> builder = ImmutableList.builder();
+                List<Expression> exprs = ((Row) rowExpression).getItems();
+                for (Expression expr : exprs) {
+                    builder.add(expr);
+                }
+                parameterExpressions.add(builder.build());
+            }
         }
-        return builder.build();
+        else {
+            for (Expression expr : parameters) {
+                parameterExpressions.add(ImmutableList.of(expr));
+            }
+        }
+        return new MultiLineParameters(refsList, parameterExpressions.build());
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/ResultForPrepare.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ResultForPrepare.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class ResultForPrepare
+{
+    private final boolean insertValuesWithParameter;
+    private final List<String> typesForValidate;
+
+    @JsonCreator
+    public ResultForPrepare(
+            @JsonProperty("insertValuesWithParameter") final boolean insertValuesWithParameter,
+            @JsonProperty("typesForValidate") List<String> typesForValidate)
+    {
+        this.insertValuesWithParameter = insertValuesWithParameter;
+        this.typesForValidate = typesForValidate;
+    }
+
+    @JsonProperty
+    public boolean isInsertValuesWithParameter()
+    {
+        return this.insertValuesWithParameter;
+    }
+
+    @JsonProperty
+    public List<String> getTypesForValidate()
+    {
+        return typesForValidate;
+    }
+}

--- a/presto-client/src/test/java/com/facebook/presto/client/TestResultForPrepare.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestResultForPrepare.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.VarcharType;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static org.testng.Assert.assertEquals;
+
+public class TestResultForPrepare
+{
+    private static final JsonCodec<ResultForPrepare> RESULT_FOR_PREPARE_CODEC = jsonCodec(ResultForPrepare.class);
+
+    @Test
+    public void testCompatibility()
+    {
+        ResultForPrepare resultForPrepare = new ResultForPrepare(true,
+                ImmutableList.of(
+                        IntegerType.INTEGER.getTypeSignature().toString(),
+                        BigintType.BIGINT.getTypeSignature().toString(),
+                        VarcharType.createVarcharType(1024).getTypeSignature().toString()));
+        String jsonStrValue = RESULT_FOR_PREPARE_CODEC.toJson(resultForPrepare);
+        ResultForPrepare results = RESULT_FOR_PREPARE_CODEC.fromJson(jsonStrValue);
+
+        assertEquals(results.isInsertValuesWithParameter(), true);
+        assertEquals(results.getTypesForValidate(), ImmutableList.of(
+                IntegerType.INTEGER.getTypeSignature().toString(),
+                BigintType.BIGINT.getTypeSignature().toString(),
+                VarcharType.createVarcharType(1024).getTypeSignature().toString()));
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/QueryTypeAndExecutionExtraMessage.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/QueryTypeAndExecutionExtraMessage.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage.ExecutionExtraMessage;
+
+import java.util.List;
+
+public class QueryTypeAndExecutionExtraMessage<T extends ExecutionExtraMessage>
+{
+    final String updateType;
+    final T executionExtraMessage;
+
+    public QueryTypeAndExecutionExtraMessage(
+            String updateType,
+            T executionExtraMessage)
+    {
+        this.updateType = updateType;
+        this.executionExtraMessage = executionExtraMessage;
+    }
+
+    public String getUpdateType()
+    {
+        return updateType;
+    }
+
+    public T getExecutionExtraMessage()
+    {
+        return executionExtraMessage;
+    }
+
+    public static interface ExecutionExtraMessage
+    {}
+
+    public static class ExtraMessageForExecuteBatch
+            implements ExecutionExtraMessage
+    {
+        final int rowsForEachBatchLine;
+
+        public ExtraMessageForExecuteBatch(int rowsForEachBatchLine)
+        {
+            this.rowsForEachBatchLine = rowsForEachBatchLine;
+        }
+
+        public int getRowsForEachBatchLine()
+        {
+            return rowsForEachBatchLine;
+        }
+    }
+
+    public static class ExtraMessageForPrepare
+            implements ExecutionExtraMessage
+    {
+        final boolean insertValuesWithParameter;
+        final List<String> typesForValidate;
+
+        public ExtraMessageForPrepare(
+                boolean insertValuesWithParameter,
+                List<String> typesForValidate)
+        {
+            this.insertValuesWithParameter = insertValuesWithParameter;
+            this.typesForValidate = typesForValidate;
+        }
+
+        public boolean isInsertValuesWithParameter()
+        {
+            return this.insertValuesWithParameter;
+        }
+
+        public List<String> getTypesForValidate()
+        {
+            return typesForValidate;
+        }
+    }
+}

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ColumnInfo.java
@@ -206,7 +206,7 @@ class ColumnInfo
         }
     }
 
-    private static int getType(TypeSignature type)
+    static int getType(TypeSignature type)
     {
         switch (type.getBase()) {
             case "array":

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoPreparedStatement.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoPreparedStatement.java
@@ -145,16 +145,15 @@ public class PrestoPreparedStatement
             return new int[] {};
         }
         super.executeBatch(batchExecuteSql);
-        ResultSet rs = getResultSet();
-
-        // executeBatch() would get a result of Array[Integer] type from server, and transform it to a int[]
         int[] res = new int[0];
-        while (rs.next()) {
-            res = Arrays.stream((Object[]) (rs.getArray(1).getArray()))
-                    .map(Integer.class::cast)
-                    .mapToInt(Integer::valueOf).toArray();
+        try (ResultSet rs = getResultSet()) {
+            // executeBatch() would get a result of Array[Integer] type from server, and transform it to a int[]
+            while (rs.next()) {
+                res = Arrays.stream((Object[]) (rs.getArray(1).getArray()))
+                        .map(Integer.class::cast)
+                        .mapToInt(Integer::valueOf).toArray();
+            }
         }
-        rs.close();
         return res;
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoPreparedStatement.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoPreparedStatement.java
@@ -846,11 +846,7 @@ public class PrestoPreparedStatement
             }
             values.add(currentParameters.get(index));
         }
-        if (!values.isEmpty()) {
-            builder.append("(");
-            Joiner.on(", ").appendTo(builder, values);
-            builder.append(")");
-        }
+        Joiner.on(", ").appendTo(builder, values);
     }
 
     private void formatBatchParametersTo(StringBuilder builder)

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatementBatch.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatementBatch.java
@@ -214,7 +214,7 @@ public class TestJdbcPreparedStatementBatch
     {
         try (Connection connection = createConnection()) {
             try (Statement statement = connection.createStatement()) {
-                statement.execute("CREATE TABLE test_execute_batch (" +
+                statement.execute("CREATE TABLE test_execute_batch_set_parameter (" +
                         "c_boolean boolean, " +
                         "c_bigint bigint, " +
                         "c_double double, " +
@@ -225,7 +225,7 @@ public class TestJdbcPreparedStatementBatch
             }
 
             try (PreparedStatement statement = connection.prepareStatement(
-                    "INSERT INTO test_execute_batch VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+                    "INSERT INTO test_execute_batch_set_parameter VALUES (?, ?, ?, ?, ?, ?, ?)")) {
                 statement.setBoolean(1, true);
                 statement.setLong(2, 5L);
                 statement.setDouble(3, 7.0d);
@@ -274,10 +274,10 @@ public class TestJdbcPreparedStatementBatch
             }
 
             try (Statement statement = connection.createStatement();
-                    ResultSet rs = statement.executeQuery("SELECT count(*) from test_execute_batch")) {
+                    ResultSet rs = statement.executeQuery("SELECT count(*) from test_execute_batch_set_parameter")) {
                 assertTrue(rs.next());
                 assertEquals(rs.getLong(1), 4);
-                statement.execute("DROP TABLE test_execute_batch");
+                statement.execute("DROP TABLE test_execute_batch_set_parameter");
             }
         }
     }
@@ -288,7 +288,7 @@ public class TestJdbcPreparedStatementBatch
     {
         try (Connection connection = createConnection()) {
             try (Statement statement = connection.createStatement()) {
-                statement.execute("CREATE TABLE test_execute_batch (" +
+                statement.execute("CREATE TABLE test_execute_batch_non_insert_values (" +
                         "c_boolean boolean, " +
                         "c_double double, " +
                         "c_decimal decimal, " +
@@ -299,7 +299,7 @@ public class TestJdbcPreparedStatementBatch
             }
 
             try (PreparedStatement statement = connection.prepareStatement(
-                    "INSERT INTO test_execute_batch VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+                    "INSERT INTO test_execute_batch_non_insert_values VALUES (?, ?, ?, ?, ?, ?, ?)")) {
                 statement.setBoolean(1, true);
                 statement.setDouble(2, 7.0d);
                 statement.setBigDecimal(3, BigDecimal.valueOf(8L));
@@ -331,7 +331,7 @@ public class TestJdbcPreparedStatementBatch
             }
 
             try (PreparedStatement statement = connection.prepareStatement(
-                    "SELECT * FROM test_execute_batch where c_bigint = ?")) {
+                    "SELECT * FROM test_execute_batch_non_insert_values where c_bigint = ?")) {
                 statement.setLong(1, 6);
                 ResultSet rs = statement.executeQuery();
                 assertTrue(rs.next());
@@ -367,7 +367,7 @@ public class TestJdbcPreparedStatementBatch
             }
 
             try (PreparedStatement statement = connection.prepareStatement(
-                    "CREATE TABLE test_execute_batch_2 as SELECT * FROM test_execute_batch where c_bigint = ?")) {
+                    "CREATE TABLE test_execute_batch_2 as SELECT * FROM test_execute_batch_non_insert_values where c_bigint = ?")) {
                 statement.setLong(1, 5);
 
                 try {
@@ -399,7 +399,7 @@ public class TestJdbcPreparedStatementBatch
             }
 
             try (PreparedStatement statement = connection.prepareStatement(
-                    "INSERT INTO test_execute_batch_2 SELECT * FROM test_execute_batch where c_bigint = ?")) {
+                    "INSERT INTO test_execute_batch_2 SELECT * FROM test_execute_batch_non_insert_values where c_bigint = ?")) {
                 statement.setLong(1, 6);
 
                 try {
@@ -431,7 +431,7 @@ public class TestJdbcPreparedStatementBatch
             }
 
             try (PreparedStatement statement = connection.prepareStatement(
-                    "DELETE FROM test_execute_batch where c_bigint = ?")) {
+                    "DELETE FROM test_execute_batch_non_insert_values where c_bigint = ?")) {
                 statement.setLong(1, 5);
 
                 try {
@@ -458,10 +458,10 @@ public class TestJdbcPreparedStatementBatch
             }
 
             try (Statement statement = connection.createStatement();
-                    ResultSet rs = statement.executeQuery("SELECT count(*) from test_execute_batch")) {
+                    ResultSet rs = statement.executeQuery("SELECT count(*) from test_execute_batch_non_insert_values")) {
                 assertTrue(rs.next());
                 assertEquals(rs.getLong(1), 1);
-                statement.execute("DROP TABLE test_execute_batch");
+                statement.execute("DROP TABLE test_execute_batch_non_insert_values");
             }
         }
     }

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatementBatch.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatementBatch.java
@@ -1,0 +1,481 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import com.facebook.airlift.log.Logging;
+import com.facebook.presto.hive.HiveHadoop2Plugin;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+
+import static com.facebook.presto.jdbc.TestPrestoDriver.closeQuietly;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestJdbcPreparedStatementBatch
+{
+    private TestingPrestoServer server;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Logging.initialize();
+        server = new TestingPrestoServer();
+        server.installPlugin(new HiveHadoop2Plugin());
+        server.createCatalog("hive", "hive-hadoop2", ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", server.getDataDirectory().resolve("hive").toFile().toURI().toString())
+                .put("hive.security", "sql-standard")
+                .build());
+
+        try (Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("SET ROLE admin");
+            statement.executeUpdate("CREATE SCHEMA hive.default");
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeQuietly(server);
+    }
+
+    @Test
+    public void testBasicExecuteBatchForInsertValues()
+            throws Exception
+    {
+        try (Connection connection = createConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE TABLE test_execute_batch (" +
+                        "c_boolean boolean, " +
+                        "c_bigint bigint, " +
+                        "c_double double, " +
+                        "c_decimal decimal, " +
+                        "c_varchar varchar, " +
+                        "c_varbinary varbinary, " +
+                        "c_null bigint)");
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO test_execute_batch VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+                statement.setBoolean(1, true);
+                statement.setLong(2, 5L);
+                statement.setDouble(3, 7.0d);
+                statement.setBigDecimal(4, BigDecimal.valueOf(8L));
+                statement.setString(5, "abc'xyz");
+                statement.setBytes(6, "xyz".getBytes(UTF_8));
+                statement.setNull(7, Types.BIGINT);
+                statement.addBatch();
+
+                statement.setBoolean(1, false);
+                statement.setLong(2, 6L);
+                statement.setDouble(3, 8.0d);
+                statement.setBigDecimal(4, BigDecimal.valueOf(9L));
+                statement.setString(5, "abc'xyz");
+                statement.setBytes(6, "xyz".getBytes(UTF_8));
+                statement.setNull(7, Types.BIGINT);
+                statement.addBatch();
+
+                assertEquals(statement.executeBatch(), new int[] {1, 1});
+                // executeBatch() would clear the parameter lines added to batch
+                assertEquals(statement.executeBatch(), new int[0]);
+
+                // current parameter line would not be cleared automatically
+                assertFalse(statement.execute());
+                assertEquals(statement.getUpdateCount(), 1);
+                assertEquals(statement.getLargeUpdateCount(), 1);
+
+                statement.clearParameters();
+                try {
+                    statement.execute();
+                    fail("expected exception");
+                }
+                catch (Exception e) {
+                    assertTrue(e.getMessage().contains("Incorrect number of parameters: expected 7 but found 0"));
+                }
+            }
+
+            try (Statement statement = connection.createStatement();
+                    ResultSet rs = statement.executeQuery("SELECT count(*) from test_execute_batch")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getLong(1), 3);
+                statement.execute("DROP TABLE test_execute_batch");
+            }
+        }
+    }
+
+    @Test
+    public void testInsertMultipleRowInABatchLine()
+            throws Exception
+    {
+        try (Connection connection = createConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE TABLE test_execute_batch_multiple_line (" +
+                        "c_boolean boolean, " +
+                        "c_bigint bigint, " +
+                        "c_double double, " +
+                        "c_decimal decimal, " +
+                        "c_varchar varchar, " +
+                        "c_varbinary varbinary, " +
+                        "c_null bigint)");
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO test_execute_batch_multiple_line VALUES (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?)")) {
+                statement.setBoolean(1, true);
+                statement.setLong(2, 5L);
+                statement.setDouble(3, 7.0d);
+                statement.setBigDecimal(4, BigDecimal.valueOf(8L));
+                statement.setString(5, "abc'xyz");
+                statement.setBytes(6, "xyz".getBytes(UTF_8));
+                statement.setNull(7, Types.BIGINT);
+                statement.setBoolean(8, false);
+                statement.setLong(9, 6L);
+                statement.setDouble(10, 8.0d);
+                statement.setBigDecimal(11, BigDecimal.valueOf(9L));
+                statement.setString(12, "abc'xyz");
+                statement.setBytes(13, "xyz".getBytes(UTF_8));
+                statement.setNull(14, Types.BIGINT);
+                statement.addBatch();
+
+                statement.setBoolean(1, true);
+                statement.setLong(2, 7L);
+                statement.setDouble(3, 9.0d);
+                statement.setBigDecimal(4, BigDecimal.valueOf(10L));
+                statement.setString(5, "abc'xyz");
+                statement.setBytes(6, "xyz".getBytes(UTF_8));
+                statement.setNull(7, Types.BIGINT);
+                statement.setBoolean(8, false);
+                statement.setLong(9, 8L);
+                statement.setDouble(10, 10.0d);
+                statement.setBigDecimal(11, BigDecimal.valueOf(11L));
+                statement.setString(12, "abc'xyz");
+                statement.setBytes(13, "xyz".getBytes(UTF_8));
+                statement.setNull(14, Types.BIGINT);
+                statement.addBatch();
+
+                assertEquals(statement.executeBatch(), new int[] {2, 2});
+                assertEquals(statement.executeBatch(), new int[0]);
+
+                assertFalse(statement.execute());
+                assertEquals(statement.getUpdateCount(), 2);
+                assertEquals(statement.getLargeUpdateCount(), 2);
+
+                statement.clearParameters();
+                try {
+                    statement.execute();
+                    fail("expected exception");
+                }
+                catch (Exception e) {
+                    assertTrue(e.getMessage().contains("Incorrect number of parameters: expected 14 but found 0"));
+                }
+            }
+
+            try (Statement statement = connection.createStatement();
+                    ResultSet rs = statement.executeQuery("SELECT count(*) from test_execute_batch_multiple_line")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getLong(1), 6);
+                statement.execute("DROP TABLE test_execute_batch_multiple_line");
+            }
+        }
+    }
+
+    @Test
+    public void testMustSetAllParametersWhenAddBatch()
+            throws Exception
+    {
+        try (Connection connection = createConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE TABLE test_execute_batch (" +
+                        "c_boolean boolean, " +
+                        "c_bigint bigint, " +
+                        "c_double double, " +
+                        "c_decimal decimal, " +
+                        "c_varchar varchar, " +
+                        "c_varbinary varbinary, " +
+                        "c_null bigint)");
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO test_execute_batch VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+                statement.setBoolean(1, true);
+                statement.setLong(2, 5L);
+                statement.setDouble(3, 7.0d);
+                statement.setString(5, "abc'xyz");
+                statement.setNull(7, Types.BIGINT);
+                try {
+                    statement.addBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Parameters is not compatible");
+                }
+                statement.setBigDecimal(4, BigDecimal.valueOf(8L));
+                statement.setBytes(6, "xyz".getBytes(UTF_8));
+                statement.addBatch();
+
+                // addBatch() do not clear current line of parameters, so we manually clear it
+                statement.clearParameters();
+                statement.setDouble(3, 8.0d);
+                statement.setBigDecimal(4, BigDecimal.valueOf(9L));
+                statement.setString(5, "abc'xyz");
+                statement.setBytes(6, "xyz".getBytes(UTF_8));
+                statement.setNull(7, Types.BIGINT);
+                try {
+                    statement.addBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Parameters is not compatible");
+                }
+
+                statement.setBoolean(1, false);
+                statement.setLong(2, 6L);
+                statement.addBatch();
+
+                assertEquals(statement.executeBatch(), new int[] {1, 1});
+                assertEquals(statement.executeBatch(), new int[0]);
+
+                assertFalse(statement.execute());
+                assertEquals(statement.getUpdateCount(), 1);
+                assertEquals(statement.getLargeUpdateCount(), 1);
+
+                assertFalse(statement.execute());
+                assertEquals(statement.getUpdateCount(), 1);
+                assertEquals(statement.getLargeUpdateCount(), 1);
+            }
+
+            try (Statement statement = connection.createStatement();
+                    ResultSet rs = statement.executeQuery("SELECT count(*) from test_execute_batch")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getLong(1), 4);
+                statement.execute("DROP TABLE test_execute_batch");
+            }
+        }
+    }
+
+    @Test
+    public void testNoneInsertValuesStatement()
+            throws Exception
+    {
+        try (Connection connection = createConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE TABLE test_execute_batch (" +
+                        "c_boolean boolean, " +
+                        "c_double double, " +
+                        "c_decimal decimal, " +
+                        "c_varchar varchar, " +
+                        "c_varbinary varbinary, " +
+                        "c_null bigint, " +
+                        "c_bigint bigint) with (partitioned_by = ARRAY['c_bigint'])");
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO test_execute_batch VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+                statement.setBoolean(1, true);
+                statement.setDouble(2, 7.0d);
+                statement.setBigDecimal(3, BigDecimal.valueOf(8L));
+                statement.setString(4, "abc'xyz1");
+                statement.setBytes(5, "xyz1".getBytes(UTF_8));
+                statement.setNull(6, Types.BIGINT);
+                statement.setLong(7, 5L);
+                statement.addBatch();
+
+                statement.setBoolean(1, true);
+                statement.setDouble(2, 8.0d);
+                statement.setBigDecimal(3, BigDecimal.valueOf(9L));
+                statement.setString(4, "abc'xyz2");
+                statement.setBytes(5, "xyz2".getBytes(UTF_8));
+                statement.setNull(6, Types.BIGINT);
+                statement.setLong(7, 5L);
+                statement.addBatch();
+
+                statement.setBoolean(1, false);
+                statement.setDouble(2, 9.0d);
+                statement.setBigDecimal(3, BigDecimal.valueOf(10L));
+                statement.setString(4, "abc'xyz3");
+                statement.setBytes(5, "xyz3".getBytes(UTF_8));
+                statement.setNull(6, Types.BIGINT);
+                statement.setLong(7, 6L);
+                statement.addBatch();
+
+                assertEquals(statement.executeBatch(), new int[]{1, 1, 1});
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "SELECT * FROM test_execute_batch where c_bigint = ?")) {
+                statement.setLong(1, 6);
+                ResultSet rs = statement.executeQuery();
+                assertTrue(rs.next());
+                assertEquals(rs.getDouble(2), 9.0d);
+                assertEquals(rs.getString(4), "abc'xyz3");
+                assertEquals(rs.getLong(6), 0);
+                assertFalse(rs.next());
+                rs.close();
+                try {
+                    statement.addBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Add batch is only supported for insert values with parameter statement");
+                }
+
+                try {
+                    statement.executeBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Execute batch is only supported for insert values with parameter statement");
+                }
+
+                boolean queryFlag = statement.execute();
+                assertTrue(queryFlag);
+                ResultSet rs2 = statement.getResultSet();
+                assertTrue(rs2.next());
+                assertEquals(rs2.getDouble(2), 9.0d);
+                assertEquals(rs2.getString(4), "abc'xyz3");
+                assertEquals(rs2.getLong(6), 0);
+                rs2.close();
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "CREATE TABLE test_execute_batch_2 as SELECT * FROM test_execute_batch where c_bigint = ?")) {
+                statement.setLong(1, 5);
+
+                try {
+                    statement.addBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Add batch is only supported for insert values with parameter statement");
+                }
+
+                try {
+                    statement.executeBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Execute batch is only supported for insert values with parameter statement");
+                }
+
+                boolean queryFlag = statement.execute();
+                assertFalse(queryFlag);
+                assertEquals(statement.getUpdateCount(), 2);
+
+                try (Statement innerStatement = connection.createStatement();
+                        ResultSet rs = innerStatement.executeQuery("SELECT count(*) from test_execute_batch_2")) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getLong(1), 2);
+                    //innerStatement.execute("DROP TABLE test_execute_batch_2");
+                }
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO test_execute_batch_2 SELECT * FROM test_execute_batch where c_bigint = ?")) {
+                statement.setLong(1, 6);
+
+                try {
+                    statement.addBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Add batch is only supported for insert values with parameter statement");
+                }
+
+                try {
+                    statement.executeBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Execute batch is only supported for insert values with parameter statement");
+                }
+
+                boolean queryFlag = statement.execute();
+                assertFalse(queryFlag);
+                assertEquals(statement.getUpdateCount(), 1);
+
+                try (Statement innerStatement = connection.createStatement();
+                        ResultSet rs = innerStatement.executeQuery("SELECT count(*) from test_execute_batch_2")) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getLong(1), 3);
+                    innerStatement.execute("DROP TABLE test_execute_batch_2");
+                }
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "DELETE FROM test_execute_batch where c_bigint = ?")) {
+                statement.setLong(1, 5);
+
+                try {
+                    statement.addBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Add batch is only supported for insert values with parameter statement");
+                }
+
+                try {
+                    statement.executeBatch();
+                    fail("expected exception");
+                }
+                catch (SQLException e) {
+                    assertEquals(e.getMessage(), "Execute batch is only supported for insert values with parameter statement");
+                }
+
+                boolean queryFlag = statement.execute();
+                assertFalse(queryFlag);
+
+                //Fixme: it should be 2 follows the java.sql interface, but hive haven't support returning the count
+                assertEquals(statement.getUpdateCount(), 0);
+            }
+
+            try (Statement statement = connection.createStatement();
+                    ResultSet rs = statement.executeQuery("SELECT count(*) from test_execute_batch")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getLong(1), 1);
+                statement.execute("DROP TABLE test_execute_batch");
+            }
+        }
+    }
+
+    private Connection createConnection()
+            throws SQLException
+    {
+        return createConnection("");
+    }
+
+    private Connection createConnection(String extra)
+            throws SQLException
+    {
+        String url = format("jdbc:presto://%s/hive/default?%s", server.getAddress(), extra);
+        return DriverManager.getConnection(url, "admin", null);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -113,7 +113,7 @@ public class AddColumnTask
                 sqlProperties,
                 session,
                 metadata,
-                parameterExtractor(statement, parameters));
+                parameterExtractor(statement, parameters).getFirstRowOfParametersIfExists());
 
         ColumnMetadata column = new ColumnMetadata(
                 element.getName().getValue(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/AlterFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AlterFunctionTask.java
@@ -22,18 +22,16 @@ import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
 import com.facebook.presto.spi.function.RoutineCharacteristics.NullCallClause;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.Analyzer;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.AlterFunction;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
@@ -68,7 +66,7 @@ public class AlterFunctionTask
     @Override
     public ListenableFuture<?> execute(AlterFunction statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, Session session, List<Expression> parameters, WarningCollector warningCollector)
     {
-        Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(statement, parameters);
+        MultiLineParameters parameterLookup = parameterExtractor(statement, parameters);
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.empty(), parameters, parameterLookup, warningCollector);
         analyzer.analyze(statement);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
@@ -131,7 +131,7 @@ public class CallTask
 
         // get argument values
         Object[] values = new Object[procedure.getArguments().size()];
-        Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(call, parameters).getFirstRowOfParametersIfExists();
+        Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(call, parameters).getFirstRowOfParametersOrThrowException();
         for (Entry<String, CallArgument> entry : names.entrySet()) {
             CallArgument callArgument = entry.getValue();
             int index = positions.get(entry.getKey());

--- a/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
@@ -131,7 +131,7 @@ public class CallTask
 
         // get argument values
         Object[] values = new Object[procedure.getArguments().size()];
-        Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(call, parameters);
+        Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(call, parameters).getFirstRowOfParametersIfExists();
         for (Entry<String, CallArgument> entry : names.entrySet()) {
             CallArgument callArgument = entry.getValue();
             int index = positions.get(entry.getKey());

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
@@ -27,13 +27,13 @@ import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CreateFunction;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
-import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.Return;
 import com.facebook.presto.sql.tree.RoutineBody;
 import com.facebook.presto.transaction.TransactionManager;
@@ -42,7 +42,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
@@ -83,7 +82,7 @@ public class CreateFunctionTask
     @Override
     public ListenableFuture<?> execute(CreateFunction statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
-        Map<NodeRef<com.facebook.presto.sql.tree.Parameter>, Expression> parameterLookup = parameterExtractor(statement, parameters);
+        MultiLineParameters parameterLookup = parameterExtractor(statement, parameters);
         Session session = stateMachine.getSession();
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.empty(), parameters, parameterLookup, stateMachine.getWarningCollector());
         Analysis analysis = analyzer.analyze(statement);

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
@@ -28,12 +28,11 @@ import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
 import com.facebook.presto.sql.analyzer.MaterializedViewColumnMappingExtractor;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.CreateMaterializedView;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -89,7 +88,7 @@ public class CreateMaterializedViewTask
         accessControl.checkCanCreateTable(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), viewName);
         accessControl.checkCanCreateView(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), viewName);
 
-        Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(statement, parameters);
+        MultiLineParameters parameterLookup = parameterExtractor(statement, parameters);
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.empty(), parameters, parameterLookup, warningCollector);
         Analysis analysis = analyzer.analyze(statement);
 
@@ -107,7 +106,7 @@ public class CreateMaterializedViewTask
                 sqlProperties,
                 session,
                 metadata,
-                parameterLookup);
+                parameterLookup.getFirstRowOfParametersIfExists());
 
         ConnectorTableMetadata viewMetadata = new ConnectorTableMetadata(
                 toSchemaTableName(viewName),

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateSchemaTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateSchemaTask.java
@@ -77,7 +77,7 @@ public class CreateSchemaTask
                 mapFromProperties(statement.getProperties()),
                 session,
                 metadata,
-                parameterExtractor(statement, parameters));
+                parameterExtractor(statement, parameters).getFirstRowOfParametersIfExists());
 
         metadata.createSchema(session, schema, properties);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -92,7 +92,7 @@ public class CreateTableTask
     {
         checkArgument(!statement.getElements().isEmpty(), "no columns for table");
 
-        Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(statement, parameters);
+        Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(statement, parameters).getFirstRowOfParametersIfExists();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
         Optional<TableHandle> tableHandle = metadata.getMetadataResolver(session).getTableHandle(tableName);
         if (tableHandle.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -14,10 +14,12 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage.ExecutionExtraMessage;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.protocol.ExecuteAndOutputHandler;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
 import com.facebook.presto.spi.security.AccessControl;
@@ -300,6 +302,12 @@ public abstract class DataDefinitionExecution<T extends Statement>
     public QueryInfo getQueryInfo()
     {
         return stateMachine.getFinalQueryInfo().orElseGet(() -> stateMachine.updateQueryInfo(Optional.empty()));
+    }
+
+    @Override
+    public Optional<ExecuteAndOutputHandler<? extends ExecutionExtraMessage>> getStatementExecuteAndOutputHandler()
+    {
+        return stateMachine.getStatementExecuteAndOutputHandler();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropFunctionTask.java
@@ -19,18 +19,16 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.Analyzer;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.DropFunction;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
@@ -68,7 +66,7 @@ public class DropFunctionTask
     @Override
     public ListenableFuture<?> execute(DropFunction statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
-        Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(statement, parameters);
+        MultiLineParameters parameterLookup = parameterExtractor(statement, parameters);
         Analyzer analyzer = new Analyzer(stateMachine.getSession(), metadata, sqlParser, accessControl, Optional.empty(), parameters, parameterLookup, stateMachine.getWarningCollector());
         analyzer.analyze(statement);
         Optional<List<TypeSignature>> parameterTypes = statement.getParameterTypes().map(types -> types.stream().map(TypeSignature::parseTypeSignature).collect(toImmutableList()));

--- a/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
@@ -67,7 +67,8 @@ public class PrepareTask
             String type = statement.getClass().getSimpleName().toUpperCase(ENGLISH);
             throw new PrestoException(NOT_SUPPORTED, "Invalid statement type for prepared statement: " + type);
         }
-
+        queryStateMachine.getStatementExecuteAndOutputHandler()
+                .ifPresent(handler -> handler.executeInTask(statement, Optional.empty(), metadata, queryStateMachine.getSession()));
         String sql = getFormattedSql(statement, sqlParser, Optional.empty());
         queryStateMachine.addPreparedStatement(prepare.getName().getValue(), sql);
         return immediateFuture(null);

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage.ExecutionExtraMessage;
 import com.facebook.presto.common.analyzer.PreparedQuery;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.common.type.Type;
@@ -20,6 +21,7 @@ import com.facebook.presto.execution.QueryTracker.TrackedQuery;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.protocol.ExecuteAndOutputHandler;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.AnalyzerProvider;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
@@ -58,6 +60,11 @@ public interface QueryExecution
     BasicQueryInfo getBasicQueryInfo();
 
     QueryInfo getQueryInfo();
+
+    default Optional<ExecuteAndOutputHandler<? extends ExecutionExtraMessage>> getStatementExecuteAndOutputHandler()
+    {
+        return Optional.empty();
+    }
 
     String getSlug();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -14,13 +14,16 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage.ExecutionExtraMessage;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.protocol.ExecuteAndOutputHandler;
 import com.facebook.presto.spi.QueryId;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public interface QueryManager
@@ -64,6 +67,12 @@ public interface QueryManager
      */
     QueryInfo getFullQueryInfo(QueryId queryId)
             throws NoSuchElementException;
+
+    default Optional<ExecuteAndOutputHandler<? extends ExecutionExtraMessage>> getStatementExecuteAndOutputHandler(QueryId queryId)
+            throws NoSuchElementException
+    {
+        return Optional.empty();
+    }
 
     /**
      * @throws NoSuchElementException if query does not exist

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.ErrorCode;
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage.ExecutionExtraMessage;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.common.type.Type;
@@ -26,6 +27,7 @@ import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.BasicQueryStats;
+import com.facebook.presto.server.protocol.ExecuteAndOutputHandler;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SchemaTableName;
@@ -144,6 +146,7 @@ public class QueryStateMachine
 
     private final Map<String, String> addedPreparedStatements = new ConcurrentHashMap<>();
     private final Set<String> deallocatedPreparedStatements = Sets.newConcurrentHashSet();
+    private Optional<ExecuteAndOutputHandler<? extends ExecutionExtraMessage>> statementExecuteAndOutputHandler = Optional.empty();
 
     private final AtomicReference<TransactionId> startedTransactionId = new AtomicReference<>();
     private final AtomicBoolean clearTransactionId = new AtomicBoolean();
@@ -197,6 +200,17 @@ public class QueryStateMachine
         this.finalQueryInfo = new StateMachine<>("finalQueryInfo-" + queryId, executor, Optional.empty());
         this.outputManager = new QueryOutputManager(executor);
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
+    }
+
+    public Optional<ExecuteAndOutputHandler<? extends ExecutionExtraMessage>> getStatementExecuteAndOutputHandler()
+    {
+        return statementExecuteAndOutputHandler;
+    }
+
+    public void setStatementExecuteAndOutputHandler(ExecuteAndOutputHandler<? extends ExecutionExtraMessage> statementExecuteAndOutputHandler)
+    {
+        requireNonNull(statementExecuteAndOutputHandler);
+        this.statementExecuteAndOutputHandler = Optional.of(statementExecuteAndOutputHandler);
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/execution/SetSessionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SetSessionTask.java
@@ -76,7 +76,7 @@ public class SetSessionTask
         Object objectValue;
 
         try {
-            objectValue = evaluatePropertyValue(statement.getValue(), type, session, metadata, parameterExtractor(statement, parameters));
+            objectValue = evaluatePropertyValue(statement.getValue(), type, session, metadata, parameterExtractor(statement, parameters).getFirstRowOfParametersIfExists());
         }
         catch (SemanticException e) {
             throw new PrestoException(StandardErrorCode.INVALID_SESSION_PROPERTY,

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.ExceededCpuLimitException;
 import com.facebook.presto.ExceededOutputSizeLimitException;
 import com.facebook.presto.ExceededScanLimitException;
 import com.facebook.presto.Session;
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage.ExecutionExtraMessage;
 import com.facebook.presto.cost.HistoryBasedPlanStatisticsManager;
 import com.facebook.presto.cost.HistoryBasedPlanStatisticsTracker;
 import com.facebook.presto.event.QueryMonitor;
@@ -28,6 +29,7 @@ import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.memory.ClusterMemoryManager;
 import com.facebook.presto.resourcemanager.ClusterQueryTrackerService;
 import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.protocol.ExecuteAndOutputHandler;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
@@ -236,6 +238,13 @@ public class SqlQueryManager
             throws NoSuchElementException
     {
         return queryTracker.getQuery(queryId).getQueryInfo();
+    }
+
+    @Override
+    public Optional<ExecuteAndOutputHandler<? extends ExecutionExtraMessage>> getStatementExecuteAndOutputHandler(QueryId queryId)
+            throws NoSuchElementException
+    {
+        return queryTracker.getQuery(queryId).getStatementExecuteAndOutputHandler();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecuteAndOutputHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecuteAndOutputHandler.java
@@ -34,7 +34,7 @@ import static java.util.Objects.requireNonNull;
 
 public abstract class ExecuteAndOutputHandler<T extends ExecutionExtraMessage>
 {
-    // intermediary information calculated and set during execution, and maybe used in order to refactor output
+    // intermediary information calculated and set during execution, and maybe used in order to reconstruct output
     QueryTypeAndExecutionExtraMessage<T> queryExtraMessage;
 
     public void executeInTask(Statement statement, Optional<BuiltInQueryAnalysis> queryAnalysis, Metadata metadata, Session session)
@@ -65,18 +65,18 @@ public abstract class ExecuteAndOutputHandler<T extends ExecutionExtraMessage>
     public static class OutputResultData
     {
         public static final OutputResultData EMPTY = new OutputResultData(false, ImmutableList.of());
-        private final boolean needRefactor;
+        private final boolean needOverwrite;
         private final Iterable<List<Object>> value;
 
-        public OutputResultData(boolean needRefactor, Iterable<List<Object>> value)
+        public OutputResultData(boolean needOverwrite, Iterable<List<Object>> value)
         {
-            this.needRefactor = needRefactor;
+            this.needOverwrite = needOverwrite;
             this.value = requireNonNull(value, "value is null");
         }
 
-        public boolean isNeedRefactor()
+        public boolean isNeedOverwrite()
         {
-            return needRefactor;
+            return needOverwrite;
         }
 
         public Iterable<List<Object>> getValue()
@@ -88,20 +88,20 @@ public abstract class ExecuteAndOutputHandler<T extends ExecutionExtraMessage>
     public static class OutputColumn
     {
         public static final OutputColumn EMPTY = new OutputColumn(false, ImmutableList.of(), ImmutableList.of());
-        private final boolean needRefactor;
+        private final boolean needOverwrite;
         private final List<String> columnNames;
         private final List<Type> columnTypes;
 
-        public OutputColumn(boolean needRefactor, List<String> columnNames, List<Type> columnTypes)
+        public OutputColumn(boolean needOverwrite, List<String> columnNames, List<Type> columnTypes)
         {
-            this.needRefactor = needRefactor;
+            this.needOverwrite = needOverwrite;
             this.columnNames = requireNonNull(columnNames, "columnNames is null");
             this.columnTypes = requireNonNull(columnTypes, "columnTypes is null");
         }
 
-        public boolean isNeedRefactor()
+        public boolean isNeedOverwrite()
         {
-            return needRefactor;
+            return needOverwrite;
         }
 
         public List<String> getColumnNames()

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecuteAndOutputHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecuteAndOutputHandler.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.protocol;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.client.Column;
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage;
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage.ExecutionExtraMessage;
+import com.facebook.presto.common.resourceGroups.QueryType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.analyzer.BuiltInQueryAnalysis;
+import com.facebook.presto.sql.analyzer.utils.StatementUtils;
+import com.facebook.presto.sql.tree.Statement;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class ExecuteAndOutputHandler<T extends ExecutionExtraMessage>
+{
+    // intermediary information calculated and set during execution, and maybe used in order to refactor output
+    QueryTypeAndExecutionExtraMessage<T> queryExtraMessage;
+
+    public void executeInTask(Statement statement, Optional<BuiltInQueryAnalysis> queryAnalysis, Metadata metadata, Session session)
+    {
+        String updateType = StatementUtils.getQueryType(statement.getClass()).map(QueryType::toString)
+                .orElse("UNKNOWN");
+        this.queryExtraMessage = new QueryTypeAndExecutionExtraMessage(updateType, execute(statement, queryAnalysis, metadata, session));
+    }
+
+    public OutputResultData handleOutputWithResult(List<Column> columns, Iterable<List<Object>> value,
+                                                   Predicate predicate, Consumer<Long> consumer)
+    {
+        return OutputResultData.EMPTY;
+    }
+
+    public OutputColumn getOutputColumns()
+    {
+        return OutputColumn.EMPTY;
+    }
+
+    public OutputResultData handleOutputWithoutResult()
+    {
+        return OutputResultData.EMPTY;
+    }
+
+    abstract T execute(Statement statement, Optional<BuiltInQueryAnalysis> queryAnalysis, Metadata metadata, Session session);
+
+    public static class OutputResultData
+    {
+        public static final OutputResultData EMPTY = new OutputResultData(false, ImmutableList.of());
+        private final boolean needRefactor;
+        private final Iterable<List<Object>> value;
+
+        public OutputResultData(boolean needRefactor, Iterable<List<Object>> value)
+        {
+            this.needRefactor = needRefactor;
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        public boolean isNeedRefactor()
+        {
+            return needRefactor;
+        }
+
+        public Iterable<List<Object>> getValue()
+        {
+            return value;
+        }
+    }
+
+    public static class OutputColumn
+    {
+        public static final OutputColumn EMPTY = new OutputColumn(false, ImmutableList.of(), ImmutableList.of());
+        private final boolean needRefactor;
+        private final List<String> columnNames;
+        private final List<Type> columnTypes;
+
+        public OutputColumn(boolean needRefactor, List<String> columnNames, List<Type> columnTypes)
+        {
+            this.needRefactor = needRefactor;
+            this.columnNames = requireNonNull(columnNames, "columnNames is null");
+            this.columnTypes = requireNonNull(columnTypes, "columnTypes is null");
+        }
+
+        public boolean isNeedRefactor()
+        {
+            return needRefactor;
+        }
+
+        public List<String> getColumnNames()
+        {
+            return columnNames;
+        }
+
+        public List<Type> getColumnTypes()
+        {
+            return columnTypes;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecuteAndOutputHandlerForExecuteBatch.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecuteAndOutputHandlerForExecuteBatch.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.protocol;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.client.Column;
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage.ExtraMessageForExecuteBatch;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.sql.analyzer.BuiltInQueryAnalysis;
+import com.facebook.presto.sql.analyzer.utils.InsertValuesExtractor;
+import com.facebook.presto.sql.analyzer.utils.InsertValuesExtractor.InsertValuesMessage;
+import com.facebook.presto.sql.tree.Statement;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.primitives.Ints.saturatedCast;
+
+public class ExecuteAndOutputHandlerForExecuteBatch
+        extends ExecuteAndOutputHandler<ExtraMessageForExecuteBatch>
+{
+    @Override
+    ExtraMessageForExecuteBatch execute(Statement statement, Optional<BuiltInQueryAnalysis> queryAnalysis, Metadata metadata, Session session)
+    {
+        // get the rows count for each values line in a ``insert value`` statement
+        //  for example, ``insert into test values (?, ?), (?, ?)`` contains 2 rows in a single values line
+        InsertValuesMessage insertValuesMessage = InsertValuesExtractor.getInsertValuesMessage(statement);
+        if (!insertValuesMessage.isInsertValues()) {
+            throw new PrestoException(NOT_SUPPORTED, "Execute batch is only supported for insert values");
+        }
+        return new ExtraMessageForExecuteBatch(insertValuesMessage.getRowsCount());
+    }
+
+    @Override
+    public OutputResultData handleOutputWithResult(List<Column> columns, Iterable<List<Object>> data,
+                                                   Predicate predicate, Consumer<Long> consumer)
+    {
+        int rowCountForEachBatchLine = queryExtraMessage.getExecutionExtraMessage().getRowsForEachBatchLine();
+        long totalCount = 0L;
+        Iterator<List<Object>> iterator = data.iterator();
+        if (iterator.hasNext()) {
+            Number number = (Number) iterator.next().get(0);
+            if (number != null) {
+                totalCount = number.longValue();
+            }
+        }
+
+        if (predicate.test(null)) {
+            consumer.accept(totalCount);
+        }
+        Builder<Integer> arrayDataBuilder = ImmutableList.builder();
+        for (int i = 0; i < saturatedCast(totalCount) / rowCountForEachBatchLine; i++) {
+            arrayDataBuilder.add(rowCountForEachBatchLine);
+        }
+        Iterable<List<Object>> newResultData = ImmutableSet.of(ImmutableList.of(arrayDataBuilder.build()));
+        return new OutputResultData(true, newResultData);
+    }
+
+    @Override
+    public OutputColumn getOutputColumns()
+    {
+        return new OutputColumn(true, ImmutableList.of("result"), ImmutableList.of(new ArrayType(INTEGER)));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecuteAndOutputHandlerForPrepare.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecuteAndOutputHandlerForPrepare.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.protocol;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.Session;
+import com.facebook.presto.client.ResultForPrepare;
+import com.facebook.presto.common.QueryTypeAndExecutionExtraMessage.ExtraMessageForPrepare;
+import com.facebook.presto.common.type.UnknownType;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.analyzer.BuiltInQueryAnalysis;
+import com.facebook.presto.sql.analyzer.utils.InsertValuesExtractor;
+import com.facebook.presto.sql.analyzer.utils.ParameterExtractor;
+import com.facebook.presto.sql.tree.Parameter;
+import com.facebook.presto.sql.tree.Statement;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+
+public class ExecuteAndOutputHandlerForPrepare
+        extends ExecuteAndOutputHandler<ExtraMessageForPrepare>
+{
+    private static final JsonCodec<ResultForPrepare> QUERY_RESULT_FOR_PREPARE_CODEC = jsonCodec(ResultForPrepare.class);
+
+    @Override
+    public ExtraMessageForPrepare execute(Statement statement, Optional<BuiltInQueryAnalysis> analysis, Metadata metadata, Session session)
+    {
+        boolean isInsertValues = InsertValuesExtractor.getInsertValuesMessage(statement).isInsertValues();
+        List<Parameter> parameterLists = ParameterExtractor.getParameters(statement);
+
+        // TODO: return the explicit type for validate in jdbc client
+        Builder<String> typesForValidateBuilder = ImmutableList.builder();
+        parameterLists.stream()
+                .map(parameter -> UnknownType.UNKNOWN)
+                .map(type -> type.getTypeSignature().toString())
+                .forEach(typeStr -> typesForValidateBuilder.add(typeStr));
+        return new ExtraMessageForPrepare(isInsertValues && !parameterLists.isEmpty(), typesForValidateBuilder.build());
+    }
+
+    @Override
+    public OutputColumn getOutputColumns()
+    {
+        return new OutputColumn(true, ImmutableList.of("result"), ImmutableList.of(VARBINARY));
+    }
+
+    @Override
+    public OutputResultData handleOutputWithoutResult()
+    {
+        ResultForPrepare resultForPrepare = new ResultForPrepare(queryExtraMessage.getExecutionExtraMessage().isInsertValuesWithParameter(),
+                queryExtraMessage.getExecutionExtraMessage().getTypesForValidate());
+        Iterable<List<Object>> data = ImmutableSet.of(ImmutableList.of(QUERY_RESULT_FOR_PREPARE_CODEC.toBytes(resultForPrepare)));
+        return new OutputResultData(true, data);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -513,7 +513,7 @@ class Query
                 OutputResultData outputResultData = handler.get().handleOutputWithResult(columns, data,
                         ignored -> false,
                         totalCount -> {});
-                if (outputResultData.isNeedRefactor()) {
+                if (outputResultData.isNeedOverwrite()) {
                     data = outputResultData.getValue();
                 }
             }
@@ -538,7 +538,7 @@ class Query
             Optional<ExecuteAndOutputHandler<? extends ExecutionExtraMessage>> handler = queryManager.getStatementExecuteAndOutputHandler(queryId);
             if (handler.isPresent()) {
                 OutputColumn outputColumn = handler.get().getOutputColumns();
-                if (outputColumn.isNeedRefactor()) {
+                if (outputColumn.isNeedOverwrite()) {
                     List<String> columnNames = outputColumn.getColumnNames();
                     List<Type> columnTypes = outputColumn.getColumnTypes();
                     checkArgument(columnNames.size() == columnTypes.size(), "Column names and types size mismatch");
@@ -551,7 +551,7 @@ class Query
                     types = columnTypes;
                 }
                 OutputResultData outputResultData = handler.get().handleOutputWithoutResult();
-                if (outputResultData.isNeedRefactor()) {
+                if (outputResultData.isNeedOverwrite()) {
                     data = outputResultData.getValue();
                 }
             }
@@ -645,7 +645,7 @@ class Query
             Optional<ExecuteAndOutputHandler<? extends ExecutionExtraMessage>> handler = queryManager.getStatementExecuteAndOutputHandler(queryId);
             if (handler.isPresent()) {
                 OutputColumn outputColumn = handler.get().getOutputColumns();
-                if (outputColumn.isNeedRefactor()) {
+                if (outputColumn.isNeedOverwrite()) {
                     columnNames = outputColumn.getColumnNames();
                     columnTypes = outputColumn.getColumnTypes();
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -114,6 +114,7 @@ class AggregationAnalyzer
 
     private final FunctionAndTypeResolver functionAndTypeResolver;
     private final Analysis analysis;
+    private final Map<NodeRef<Parameter>, Expression> parameters;
 
     private final Scope sourceScope;
     private final Optional<Scope> orderByScope;
@@ -176,11 +177,12 @@ class AggregationAnalyzer
         this.orderByScope = orderByScope;
         this.functionAndTypeResolver = functionAndTypeResolver;
         this.analysis = analysis;
+        this.parameters = analysis.getParameters().getFirstRowOfParametersIfExists();
         this.warningCollector = warningCollector;
         this.session = session;
         this.functionResolution = new FunctionResolution(functionAndTypeResolver);
         this.expressions = groupByExpressions.stream()
-                .map(e -> ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters()), e))
+                .map(e -> ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(parameters), e))
                 .collect(toImmutableList());
 
         this.columnReferences = analysis.getColumnReferenceFields();
@@ -679,7 +681,6 @@ class AggregationAnalyzer
             if (analysis.isDescribe()) {
                 return true;
             }
-            Map<NodeRef<Parameter>, Expression> parameters = analysis.getParameters();
             checkArgument(node.getPosition() < parameters.size(), "Invalid parameter number %s, max values is %s", node.getPosition(), parameters.size() - 1);
             return process(parameters.get(NodeRef.of(node)), context);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -24,7 +24,6 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupingOperation;
 import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Statement;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -54,7 +53,7 @@ public class Analyzer
     private final Session session;
     private final Optional<QueryExplainer> queryExplainer;
     private final List<Expression> parameters;
-    private final Map<NodeRef<Parameter>, Expression> parameterLookup;
+    private final MultiLineParameters parameterLookup;
     private final WarningCollector warningCollector;
     private final MetadataExtractor metadataExtractor;
 
@@ -65,7 +64,7 @@ public class Analyzer
             AccessControl accessControl,
             Optional<QueryExplainer> queryExplainer,
             List<Expression> parameters,
-            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            MultiLineParameters parameterLookup,
             WarningCollector warningCollector)
     {
         this(session, metadata, sqlParser, accessControl, queryExplainer, parameters, parameterLookup, warningCollector, Optional.empty());
@@ -78,7 +77,7 @@ public class Analyzer
             AccessControl accessControl,
             Optional<QueryExplainer> queryExplainer,
             List<Expression> parameters,
-            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            MultiLineParameters parameterLookup,
             WarningCollector warningCollector,
             Optional<ExecutorService> metadataExtractorExecutor)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
@@ -26,6 +26,8 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.LogicalPlanner;
+import com.facebook.presto.sql.tree.Execute;
+import com.facebook.presto.sql.tree.Statement;
 import com.google.inject.Inject;
 
 import java.util.Optional;
@@ -79,6 +81,8 @@ public class BuiltInQueryAnalyzer
         BuiltInQueryPreparer.BuiltInPreparedQuery builtInPreparedQuery = (BuiltInQueryPreparer.BuiltInPreparedQuery) preparedQuery;
         Session session = ((BuiltInAnalyzerContext) analyzerContext).getSession();
 
+        Statement wrappedStatement = builtInPreparedQuery.getWrappedStatement();
+        boolean isBatch = wrappedStatement instanceof Execute && ((Execute) wrappedStatement).isBatchExecution();
         Analyzer analyzer = new Analyzer(
                 session,
                 metadata,
@@ -86,7 +90,7 @@ public class BuiltInQueryAnalyzer
                 accessControl,
                 queryExplainer,
                 builtInPreparedQuery.getParameters(),
-                parameterExtractor(builtInPreparedQuery.getStatement(), builtInPreparedQuery.getParameters()),
+                parameterExtractor(builtInPreparedQuery.getStatement(), builtInPreparedQuery.getParameters(), isBatch),
                 session.getWarningCollector(),
                 Optional.of(metadataExtractorExecutor));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalyzer.java
@@ -90,7 +90,7 @@ public class BuiltInQueryAnalyzer
                 session.getWarningCollector(),
                 Optional.of(metadataExtractorExecutor));
 
-        Analysis analysis = analyzer.analyzeSemantic(((BuiltInQueryPreparer.BuiltInPreparedQuery) preparedQuery).getStatement(), false);
+        Analysis analysis = analyzer.analyzeSemantic(builtInPreparedQuery.getStatement(), false);
         return new BuiltInQueryAnalysis(analysis);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1859,7 +1859,7 @@ public class ExpressionAnalyzer
     {
         // expressions at this point can not have sub queries so deny all access checks
         // in the future, we will need a full access controller here to verify access to functions
-        Analysis analysis = new Analysis(null, parameters, isDescribe);
+        Analysis analysis = new Analysis(null, MultiLineParameters.from(parameters), isDescribe);
         ExpressionAnalyzer analyzer = create(analysis, session, metadata, sqlParser, new DenyAllAccessControl(), types, warningCollector);
         for (Expression expression : expressions) {
             analyzer.analyze(expression, Scope.builder().withRelationType(RelationId.anonymous(), new RelationType()).build());
@@ -1995,7 +1995,7 @@ public class ExpressionAnalyzer
                 session.getTransactionId(),
                 session.getSqlFunctionProperties(),
                 types,
-                analysis.getParameters(),
+                analysis.getParameters().getFirstRowOfParametersIfExists(),
                 warningCollector,
                 analysis.isDescribe(),
                 ImmutableMap.of());
@@ -2018,7 +2018,7 @@ public class ExpressionAnalyzer
                 session.getTransactionId(),
                 session.getSqlFunctionProperties(),
                 types,
-                analysis.getParameters(),
+                analysis.getParameters().getFirstRowOfParametersIfExists(),
                 warningCollector,
                 analysis.isDescribe(),
                 outerScopeSymbolTypes);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -771,7 +771,7 @@ public class MaterializedViewQueryOptimizer
                     accessControl,
                     sqlParser,
                     scope,
-                    new Analysis(null, ImmutableMap.of(), false),
+                    new Analysis(null, MultiLineParameters.EMPTY, false),
                     expression,
                     WarningCollector.NOOP);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -611,7 +611,7 @@ class StatementAnalyzer
                     mapFromProperties(node.getProperties()),
                     session,
                     metadata,
-                    analysis.getParameters());
+                    analysis.getParameters().getFirstRowOfParametersIfExists());
             TableHandle tableHandle = metadata.getTableHandleForStatisticsCollection(session, tableName, analyzeProperties)
                     .orElseThrow(() -> (new SemanticException(MISSING_TABLE, node, "Table '%s' does not exist", tableName)));
 
@@ -936,7 +936,7 @@ class StatementAnalyzer
         protected Scope visitProperty(Property node, Optional<Scope> scope)
         {
             // Property value expressions must be constant
-            createConstantAnalyzer(metadata, session, analysis.getParameters(), warningCollector, analysis.isDescribe())
+            createConstantAnalyzer(metadata, session, analysis.getParameters().getFirstRowOfParametersIfExists(), warningCollector, analysis.isDescribe())
                     .analyze(node.getValue(), createScope(scope));
             return createAndAssignScope(node, scope);
         }
@@ -1360,7 +1360,7 @@ class StatementAnalyzer
             if (asOfExprType == UNKNOWN) {
                 throw new PrestoException(INVALID_ARGUMENTS, format("Table version AS OF expression cannot be NULL for %s", name.toString()));
             }
-            Object evalAsOfExpr = evaluateConstantExpression(asOfExpr, asOfExprType, metadata, session, analysis.getParameters());
+            Object evalAsOfExpr = evaluateConstantExpression(asOfExpr, asOfExprType, metadata, session, analysis.getParameters().getFirstRowOfParametersIfExists());
             if (tableVersionType == TIMESTAMP) {
                 if (!(asOfExprType instanceof TimestampWithTimeZoneType)) {
                     throw new SemanticException(TYPE_MISMATCH, asOfExpr,
@@ -1622,7 +1622,7 @@ class StatementAnalyzer
                     sqlParser,
                     TypeProvider.empty(),
                     relation.getSamplePercentage(),
-                    analysis.getParameters(),
+                    analysis.getParameters().getFirstRowOfParametersIfExists(),
                     warningCollector,
                     analysis.isDescribe());
             ExpressionInterpreter samplePercentageEval = expressionOptimizer(relation.getSamplePercentage(), metadata, session, expressionTypes);
@@ -1632,7 +1632,7 @@ class StatementAnalyzer
             });
             try {
                 samplePercentageObject = evaluateConstantExpression(relation.getSamplePercentage(), DOUBLE, metadata, session,
-                        analysis.getParameters());
+                        analysis.getParameters().getFirstRowOfParametersIfExists());
             }
             catch (SemanticException e) {
                 if (e.getCode() == TYPE_MISMATCH) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -251,7 +251,7 @@ public class LogicalPlanner
                 destination,
                 getOutputTableColumns(plan, analysis.getColumnAliases()),
                 analysis.getCreateTableProperties(),
-                analysis.getParameters(),
+                analysis.getParameters().getFirstRowOfParametersIfExists(),
                 analysis.getCreateTableComment());
         Optional<NewTableLayout> newTableLayout = metadata.getNewTableLayout(session, destination.getCatalogName(), tableMetadata);
         Optional<NewTableLayout> preferredShuffleLayout = metadata.getPreferredShuffleLayoutForNewTable(session, destination.getCatalogName(), tableMetadata);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ParameterRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ParameterRewriter.java
@@ -43,7 +43,13 @@ public class ParameterRewriter
     public ParameterRewriter(Analysis analysis)
     {
         this.analysis = analysis;
-        this.parameters = analysis.getParameters();
+        this.parameters = analysis.getParameters().getFirstRowOfParametersIfExists();
+    }
+
+    public ParameterRewriter(Analysis analysis, int rowIdx)
+    {
+        this.analysis = analysis;
+        this.parameters = analysis.getParameters().getRowOfParameters(rowIdx);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ParameterRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ParameterRewriter.java
@@ -46,10 +46,10 @@ public class ParameterRewriter
         this.parameters = analysis.getParameters().getFirstRowOfParametersIfExists();
     }
 
-    public ParameterRewriter(Analysis analysis, int rowIdx)
+    public ParameterRewriter(Analysis analysis, int rowIndex)
     {
         this.analysis = analysis;
-        this.parameters = analysis.getParameters().getRowOfParameters(rowIdx);
+        this.parameters = analysis.getParameters().getRowOfParameters(rowIndex);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -785,7 +785,7 @@ class RelationPlanner
         return new RelationPlan(valuesNode, scope, outputVariablesBuilder.build());
     }
 
-    private void buildRow(Values node, int rowIdx,
+    private void buildRow(Values node, int rowIndex,
                           ImmutableList.Builder<List<RowExpression>> rowsBuilder,
                           SqlPlannerContext context, Scope scope)
     {
@@ -793,17 +793,17 @@ class RelationPlanner
             ImmutableList.Builder<RowExpression> values = ImmutableList.builder();
             if (row instanceof Row) {
                 for (Expression item : ((Row) row).getItems()) {
-                    values.add(rewriteRow(item, context, rowIdx));
+                    values.add(rewriteRow(item, context, rowIndex));
                 }
             }
             else {
-                values.add(rewriteRow(row, context, rowIdx));
+                values.add(rewriteRow(row, context, rowIndex));
             }
             rowsBuilder.add(values.build());
         }
     }
 
-    private RowExpression rewriteRow(Expression row, SqlPlannerContext context, int rowIdx)
+    private RowExpression rewriteRow(Expression row, SqlPlannerContext context, int rowIndex)
     {
         // resolve enum literals
         Expression expression = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
@@ -820,7 +820,7 @@ class RelationPlanner
             }
         }, row);
         expression = Coercer.addCoercions(expression, analysis);
-        expression = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis, rowIdx), expression);
+        expression = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis, rowIndex), expression);
         return rowExpression(expression, context);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
@@ -265,8 +265,9 @@ class TranslationMap
             @Override
             public Expression rewriteParameter(Parameter node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
-                checkState(analysis.getParameters().size() > node.getPosition(), "Too few parameter values");
-                return coerceIfNecessary(node, analysis.getParameters().get(NodeRef.of(node)));
+                Map<NodeRef<Parameter>, Expression> parameters = analysis.getParameters().getFirstRowOfParametersIfExists();
+                checkState(parameters.size() > node.getPosition(), "Too few parameter values");
+                return coerceIfNecessary(node, parameters.get(NodeRef.of(node)));
             }
 
             private Expression coerceIfNecessary(Expression original, Expression rewritten)

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -28,7 +29,6 @@ import com.facebook.presto.sql.tree.DescribeInput;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Row;
@@ -37,7 +37,6 @@ import com.facebook.presto.sql.tree.StringLiteral;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
@@ -64,7 +63,7 @@ final class DescribeInputRewrite
             Optional<QueryExplainer> queryExplainer,
             Statement node,
             List<Expression> parameters,
-            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            MultiLineParameters parameterLookup,
             AccessControl accessControl,
             WarningCollector warningCollector)
     {
@@ -79,7 +78,7 @@ final class DescribeInputRewrite
         private final Metadata metadata;
         private final Optional<QueryExplainer> queryExplainer;
         private final List<Expression> parameters;
-        private final Map<NodeRef<Parameter>, Expression> parameterLookup;
+        private final MultiLineParameters parameterLookup;
         private final AccessControl accessControl;
         private final WarningCollector warningCollector;
 
@@ -89,7 +88,7 @@ final class DescribeInputRewrite
                 Metadata metadata,
                 Optional<QueryExplainer> queryExplainer,
                 List<Expression> parameters,
-                Map<NodeRef<Parameter>, Expression> parameterLookup,
+                MultiLineParameters parameterLookup,
                 AccessControl accessControl,
                 WarningCollector warningCollector)
         {

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
 import com.facebook.presto.sql.analyzer.Field;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.AstVisitor;
@@ -30,16 +31,13 @@ import com.facebook.presto.sql.tree.DescribeOutput;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.NullLiteral;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.QueryUtil.aliased;
@@ -62,7 +60,7 @@ final class DescribeOutputRewrite
             Optional<QueryExplainer> queryExplainer,
             Statement node,
             List<Expression> parameters,
-            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            MultiLineParameters parameterLookup,
             AccessControl accessControl,
             WarningCollector warningCollector)
     {
@@ -77,7 +75,7 @@ final class DescribeOutputRewrite
         private final Metadata metadata;
         private final Optional<QueryExplainer> queryExplainer;
         private final List<Expression> parameters;
-        private final Map<NodeRef<Parameter>, Expression> parameterLookup;
+        private final MultiLineParameters parameterLookup;
         private final AccessControl accessControl;
         private final WarningCollector warningCollector;
 
@@ -87,7 +85,7 @@ final class DescribeOutputRewrite
                 Metadata metadata,
                 Optional<QueryExplainer> queryExplainer,
                 List<Expression> parameters,
-                Map<NodeRef<Parameter>, Expression> parameterLookup,
+                MultiLineParameters parameterLookup,
                 AccessControl accessControl,
                 WarningCollector warningCollector)
         {

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ExplainRewrite.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.analyzer.AnalyzerOptions;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer;
 import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer.BuiltInPreparedQuery;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -30,12 +31,9 @@ import com.facebook.presto.sql.tree.ExplainOption;
 import com.facebook.presto.sql.tree.ExplainType;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Statement;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.QueryUtil.singleValueQuery;
@@ -58,7 +56,7 @@ final class ExplainRewrite
             Optional<QueryExplainer> queryExplainer,
             Statement node,
             List<Expression> parameter,
-            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            MultiLineParameters parameterLookup,
             AccessControl accessControl,
             WarningCollector warningCollector)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/MaterializedViewOptimizationRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/MaterializedViewOptimizationRewrite.java
@@ -19,19 +19,17 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.MaterializedViewQueryOptimizer;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Statement;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.common.RuntimeMetricName.OPTIMIZED_WITH_MATERIALIZED_VIEW_COUNT;
@@ -49,7 +47,7 @@ public class MaterializedViewOptimizationRewrite
             Optional<QueryExplainer> queryExplainer,
             Statement node,
             List<Expression> parameters,
-            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            MultiLineParameters parameterLookup,
             AccessControl accessControl,
             WarningCollector warningCollector)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -38,6 +38,7 @@ import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.QueryUtil;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.ParsingException;
@@ -58,9 +59,7 @@ import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.OrderBy;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
@@ -168,7 +167,7 @@ final class ShowQueriesRewrite
             Optional<QueryExplainer> queryExplainer,
             Statement node,
             List<Expression> parameters,
-            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            MultiLineParameters parameterLookup,
             AccessControl accessControl,
             WarningCollector warningCollector)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.statistics.DoubleRange;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.sql.QueryUtil;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -50,9 +51,7 @@ import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.NullLiteral;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
@@ -106,7 +105,7 @@ public class ShowStatsRewrite
             Optional<QueryExplainer> queryExplainer,
             Statement node,
             List<Expression> parameters,
-            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            MultiLineParameters parameterLookup,
             AccessControl accessControl,
             WarningCollector warningCollector)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/StatementRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/StatementRewrite.java
@@ -17,16 +17,14 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.sql.analyzer.MultiLineParameters;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Statement;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -50,7 +48,7 @@ public final class StatementRewrite
             Optional<QueryExplainer> queryExplainer,
             Statement node,
             List<Expression> parameters,
-            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            MultiLineParameters parameterLookup,
             AccessControl accessControl,
             WarningCollector warningCollector)
     {
@@ -69,7 +67,7 @@ public final class StatementRewrite
                 Optional<QueryExplainer> queryExplainer,
                 Statement node,
                 List<Expression> parameters,
-                Map<NodeRef<Parameter>, Expression> parameterLookup,
+                MultiLineParameters parameterLookup,
                 AccessControl accessControl,
                 WarningCollector warningCollector);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
@@ -84,7 +84,7 @@ public class TestPrepareTask
     @Test
     public void testPrepareInvalidStatement()
     {
-        Statement statement = new Execute(identifier("foo"), emptyList());
+        Statement statement = new Execute(identifier("foo"), emptyList(), false);
         String sqlString = "PREPARE my_query FROM EXECUTE foo";
         try {
             executePrepare("my_query", statement, sqlString, TEST_SESSION);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
@@ -86,7 +86,6 @@ import static com.facebook.presto.transaction.InMemoryTransactionManager.createT
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.testng.Assert.fail;
 
 public class AbstractAnalyzerTest
@@ -467,7 +466,7 @@ public class AbstractAnalyzerTest
                 new AllowAllAccessControl(),
                 Optional.empty(),
                 emptyList(),
-                emptyMap(),
+                MultiLineParameters.EMPTY,
                 warningCollector);
     }
 

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -133,7 +133,8 @@ statement
     | ROLLBACK WORK?                                                   #rollback
     | PREPARE identifier FROM statement                                #prepare
     | DEALLOCATE PREPARE identifier                                    #deallocate
-    | EXECUTE identifier (USING expression (',' expression)*)?         #execute
+    | EXECUTE (BATCH)? identifier
+         (USING expression (',' expression)*)?                         #execute
     | DESCRIBE INPUT identifier                                        #describeInput
     | DESCRIBE OUTPUT identifier                                       #describeOutput
     ;
@@ -646,6 +647,7 @@ ESCAPE: 'ESCAPE';
 EXCEPT: 'EXCEPT';
 EXCLUDING: 'EXCLUDING';
 EXECUTE: 'EXECUTE';
+BATCH: 'BATCH';
 EXISTS: 'EXISTS';
 EXPLAIN: 'EXPLAIN';
 EXTRACT: 'EXTRACT';

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -569,7 +569,7 @@ number
 nonReserved
     // IMPORTANT: this rule must only contain tokens. Nested rules are not supported. See SqlParser.exitNonReserved
     : ADD | ADMIN | ALL | ANALYZE | ANY | ARRAY | ASC | AT
-    | BERNOULLI
+    | BATCH | BERNOULLI
     | CALL | CALLED | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | CURRENT | CURRENT_ROLE
     | DATA | DATE | DAY | DEFINER | DESC | DETERMINISTIC | DISTRIBUTED
     | EXCLUDING | EXPLAIN | EXTERNAL

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -221,7 +221,7 @@ public final class SqlFormatter
         @Override
         protected Void visitExecute(Execute node, Integer indent)
         {
-            append(indent, "EXECUTE ");
+            append(indent, "EXECUTE " + (node.isBatchExecution() ? "BATCH " : ""));
             builder.append(node.getName());
             List<Expression> parameters = node.getParameters();
             if (!parameters.isEmpty()) {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -660,7 +660,8 @@ class AstBuilder
         return new Execute(
                 getLocation(context),
                 (Identifier) visit(context.identifier()),
-                visit(context.expression(), Expression.class));
+                visit(context.expression(), Expression.class),
+                context.BATCH() != null);
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Execute.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Execute.java
@@ -27,22 +27,24 @@ public class Execute
 {
     private final Identifier name;
     private final List<Expression> parameters;
+    private final boolean batchExecution;
 
-    public Execute(NodeLocation location, Identifier name, List<Expression> parameters)
+    public Execute(NodeLocation location, Identifier name, List<Expression> parameters, boolean batchExecution)
     {
-        this(Optional.of(location), name, parameters);
+        this(Optional.of(location), name, parameters, batchExecution);
     }
 
-    public Execute(Identifier name, List<Expression> parameters)
+    public Execute(Identifier name, List<Expression> parameters, boolean batchExecution)
     {
-        this(Optional.empty(), name, parameters);
+        this(Optional.empty(), name, parameters, batchExecution);
     }
 
-    private Execute(Optional<NodeLocation> location, Identifier name, List<Expression> parameters)
+    private Execute(Optional<NodeLocation> location, Identifier name, List<Expression> parameters, boolean batchExecution)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
         this.parameters = requireNonNull(ImmutableList.copyOf(parameters), "parameters is null");
+        this.batchExecution = batchExecution;
     }
 
     public Identifier getName()
@@ -53,6 +55,11 @@ public class Execute
     public List<Expression> getParameters()
     {
         return parameters;
+    }
+
+    public boolean isBatchExecution()
+    {
+        return batchExecution;
     }
 
     @Override
@@ -70,7 +77,7 @@ public class Execute
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, parameters);
+        return Objects.hash(name, parameters, batchExecution);
     }
 
     @Override
@@ -84,7 +91,8 @@ public class Execute
         }
         Execute o = (Execute) obj;
         return Objects.equals(name, o.name) &&
-                Objects.equals(parameters, o.parameters);
+                Objects.equals(parameters, o.parameters) &&
+                batchExecution == o.batchExecution;
     }
 
     @Override
@@ -93,6 +101,7 @@ public class Execute
         return toStringHelper(this)
                 .add("name", name)
                 .add("parameters", parameters)
+                .add("batchExecution", batchExecution)
                 .toString();
     }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -2262,14 +2262,25 @@ public class TestSqlParser
     @Test
     public void testExecute()
     {
-        assertStatement("EXECUTE myquery", new Execute(identifier("myquery"), emptyList()));
+        assertStatement("EXECUTE myquery", new Execute(identifier("myquery"), emptyList(), false));
+        assertStatement("EXECUTE BATCH myquery", new Execute(identifier("myquery"), emptyList(), true));
     }
 
     @Test
     public void testExecuteWithUsing()
     {
         assertStatement("EXECUTE myquery USING 1, 'abc', ARRAY ['hello']",
-                new Execute(identifier("myquery"), ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new ArrayConstructor(ImmutableList.of(new StringLiteral("hello"))))));
+                new Execute(identifier("myquery"), ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new ArrayConstructor(ImmutableList.of(new StringLiteral("hello")))), false));
+        assertStatement("EXECUTE BATCH myquery USING 1, 'abc', ARRAY ['hello']",
+                new Execute(identifier("myquery"), ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new ArrayConstructor(ImmutableList.of(new StringLiteral("hello")))), true));
+        assertStatement("EXECUTE BATCH myquery USING (1, 'abc', ARRAY ['hello'])",
+                new Execute(identifier("myquery"), ImmutableList.of(new Row(ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new ArrayConstructor(ImmutableList.of(new StringLiteral("hello")))))), true));
+        assertStatement("EXECUTE BATCH myquery USING (1, 'abc', ARRAY ['hello']), (2, 'bcd', ARRAY ['hello2'])",
+                new Execute(identifier("myquery"),
+                        ImmutableList.of(
+                                new Row(ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new ArrayConstructor(ImmutableList.of(new StringLiteral("hello"))))),
+                                new Row(ImmutableList.of(new LongLiteral("2"), new StringLiteral("bcd"), new ArrayConstructor(ImmutableList.of(new StringLiteral("hello2")))))),
+                        true));
     }
 
     @Test

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
@@ -283,7 +283,7 @@ public class DefaultTreeRewriter<C>
             return node;
         }
 
-        return new Execute(node.getName(), parameters);
+        return new Execute(node.getName(), parameters, node.isBatchExecution());
     }
 
     @Override


### PR DESCRIPTION
## Description

This PR support PreparedStatement.addBatch()/PreparedStatement.executeBatch() for ``insert values`` statement.

The change are broken into 4 commits, corresponding 4 main parts.

1. Add syntax support for execute batch using multiple row of data
2. Support multiple line parameters in Analysis, and make corresponding adjustment
3. Customize the execution & output refactor logic for ``Prepare/ExecuteBatch``
4. Refactor jdbc client to support ``PreparedStatement.addBatch()/PreparedStatement.executeBatch()`` for insert values

### Syntax Support

Support syntax ``EXECUTE BATCH <queryId> USING (v1, v2), (v3, v4), (v5, v6)``. It is necessary to let the server aware that the current executing statement is a ``execute batch``, so it could customize the return result.

### Internal Support Multiple Line Parameters

Use data structure ``MultiLineParameters`` to replace originally ``Map<NodeRef<Parameter>, Expression>``, and parameters are parsed and maintained in a multiple line form.

Refactor the logic involving ``ValuesNode`` to support multiple line parameters, and leave other statement logic unaffected by using ``MultiLineParameters.getFirstRowOfParametersIfExists()``.

### Execution & Output Refactor Logic for ``Prepare/Execute batch``

``Prepare`` statement would return a result of type VarbinaryType to jdbc client, which could be deserialized to an object instance of ``ResultForPrepare``. It contains message ``insertValuesWithParameter`` and ``typesForValidate``, which could support the jdbc client to perform verification in advance.

``Execute batch`` statement would return a result of type ArrayType[Integer], which would be transformed to a int[] by jdbc client and return to end users.

So we designed an extra architecture to support statements of different categories to register their own ``ExecuteAndOutputHandler`` at dispatch stage, run their customized execution logic and store the intermediate message at running stage, and eventually use the intermediate message to refactor the output result.

### Refactor JDBC Client

Currently we support ``PreparedStatement.addBatch()/PreparedStatement.executeBatch()`` only for insert values. The function behavior is comply with java.sql api and try to consistent with MySQL.

## Motivation and Context

We would want the support by PreparedStatement.addBatch()/PreparedStatement.executeBatch() when we try to load data from somewhere else like a stream datasource or some other storages unsupported by presto engine yet. We would read and collect a batch of data and insert them all at once rather than insert the data one single row at a time. 

Concatenating an insert values string for multiple rows is inefficient and fragile, especially when involving various data types. So, it is very necessary to support addBatch()/executeBatch() for ``insert values`` PreparedStatement.

## Impact

- New PreparedStatement functions support
- Internal refactors to support multiple row parameters
- An extra architecture to support the customized logic of execution and return result refactor

## Test Plan

 - Newly added test class ``TestJdbcPreparedStatementBatch``
 - Should not affect existing test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
