### PR TITLE
[native] Remove 'http_exec_threads' from config Props in PrestoNativeQueryRunnerUtils

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -175,7 +175,6 @@ public class PrestoNativeQueryRunnerUtils
                         Files.write(tempDirectoryPath.resolve("velox.properties"), "".getBytes());
                         String configProperties = format("discovery.uri=%s%n" +
                                 "presto.version=testversion%n" +
-                                "http_exec_threads=8%n" +
                                 "system-memory-gb=4%n" +
                                 "http-server.http.port=%d", discoveryUri, port);
 


### PR DESCRIPTION
The parameter has been replaced by "http-server.num-io-threads-hw-multiplier".


```
== NO RELEASE NOTE ==
```

