### PR TITLE
[native] Add floating point aggregate tests with NaN

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -289,6 +289,21 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertQueryFails(queryRunner, session, sql, expectedMessageRegExp);
     }
 
+    protected void assertQueryError(QueryRunner queryRunner, Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
+    {
+        try {
+            queryRunner.execute(session, sql);
+        }
+        catch (AssertionError e) {
+            assertErrorMessage(sql, e, expectedMessageRegExp);
+        }
+    }
+
+    protected void assertQueryError(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
+    {
+        assertQueryError(queryRunner, getSession(), sql, expectedMessageRegExp);
+    }
+
     protected void assertQueryReturnsEmptyResult(@Language("SQL") String sql)
     {
         QueryAssertions.assertQueryReturnsEmptyResult(queryRunner, getSession(), sql);
@@ -387,6 +402,13 @@ public abstract class AbstractTestQueryFramework
         assertUpdate(session, "DROP TABLE " + table);
 
         assertFalse(getQueryRunner().tableExists(session, table));
+    }
+
+    private static void assertErrorMessage(String sql, AssertionError error, @Language("RegExp") String regex)
+    {
+        if (!nullToEmpty(error.getMessage()).matches(regex)) {
+            fail(format("Expected error message '%s' to match '%s' for query: %s", error.getMessage(), regex, sql), error);
+        }
     }
 
     protected MaterializedResult computeExpected(@Language("SQL") String sql, List<? extends Type> resultTypes)


### PR DESCRIPTION
## Description
This PR is adding E2E tests to test floating point NaN values in the various structs and to ensure the RowContainer in Velox works properly.

## Motivation and Context
There was and still is an issue handling NaN values in Velox due to the fact NaN is a special value and the C++ behavior does not match the desired database behavior.

## Impact
N/A

## Test Plan
Adding new tests.

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

