### PR TITLE
Remove ahanaio/prestodb-sandbox reference

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -419,8 +419,7 @@ Run the Presto server:
 An Example Deployment with Docker
 ---------------------------------
 
-Let's take a look at getting a Docker image together for Presto (though they already exist on Dockerhub,
-e.g. `ahanaio/prestodb-sandbox <https://hub.docker.com/r/ahanaio/prestodb-sandbox>`_).
+Let's take a look at getting a Docker image together for Presto.
 We can see below how relatively easy it is to get Presto up and running.
 For demonstration purposes, this configuration is a single-node Presto installation where the scheduler will include the Coordinator as a Worker.
 We will configure one catalog, `TPCH <https://prestodb.io/docs/current/connector/tpch.html>`_.


### PR DESCRIPTION
## Description
The container image no longer exists, so I removed the reference

## Motivation and Context
It won't guide the user to a dead link

## Impact
None

## Test Plan
Not needed

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

