### PR TITLE
Remove deprecated Nessie basic authentication type

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -69,14 +69,8 @@ Property Name                                        Description
                                                      Example: ``https://localhost:19120/api/v1``
 
 ``iceberg.nessie.auth.type``                         The authentication type to use.
-                                                     Available values are ``BASIC`` or ``BEARER``.
-                                                     Example: ``BEARER``
-
-``iceberg.nessie.auth.basic.username``               The username to use with ``BASIC`` authentication.
-                                                     Example: ``test_user``
-
-``iceberg.nessie.auth.basic.password``               The password to use with ``BASIC`` authentication.
-                                                     Example: ``my$ecretPass``
+                                                     Available values are ``NONE`` or ``BEARER``.
+                                                     Default: ``NONE``
 
 ``iceberg.nessie.auth.bearer.token``                 The token to use with ``BEARER`` authentication.
                                                      Example: ``SXVLUXUhIExFQ0tFUiEK``

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergResourceFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergResourceFactory.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutionException;
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getNessieReferenceHash;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getNessieReferenceName;
-import static com.facebook.presto.iceberg.nessie.AuthenticationType.BASIC;
 import static com.facebook.presto.iceberg.nessie.AuthenticationType.BEARER;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
@@ -165,13 +164,7 @@ public class IcebergResourceFactory
             nessieConfig.getConnectTimeoutMillis().ifPresent(val -> properties.put("transport.connect-timeout", val.toString()));
             nessieConfig.getClientBuilderImpl().ifPresent(val -> properties.put("client-builder-impl", val));
             nessieConfig.getAuthenticationType().ifPresent(type -> {
-                if (type == BASIC) {
-                    properties.put("authentication.username", nessieConfig.getUsername()
-                            .orElseThrow(() -> new IllegalStateException("iceberg.nessie.auth.basic.username must be set with BASIC authentication")));
-                    properties.put("authentication.password", nessieConfig.getPassword()
-                            .orElseThrow(() -> new IllegalStateException("iceberg.nessie.auth.basic.password must be set with BASIC authentication")));
-                }
-                else if (type == BEARER) {
+                if (type == BEARER) {
                     properties.put("authentication.token", nessieConfig.getBearerToken()
                             .orElseThrow(() -> new IllegalStateException("iceberg.nessie.auth.bearer.token must be set with BEARER authentication")));
                 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/AuthenticationType.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/AuthenticationType.java
@@ -15,6 +15,6 @@ package com.facebook.presto.iceberg.nessie;
 
 public enum AuthenticationType
 {
-    BASIC,
+    NONE,
     BEARER
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/NessieConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/NessieConfig.java
@@ -20,13 +20,13 @@ import javax.validation.constraints.NotEmpty;
 
 import java.util.Optional;
 
+import static com.facebook.presto.iceberg.nessie.AuthenticationType.NONE;
+
 public class NessieConfig
 {
     private String defaultReferenceName = "main";
     private String serverUri;
-    private AuthenticationType authenticationType;
-    private String username;
-    private String password;
+    private AuthenticationType authenticationType = NONE;
     private String bearerToken;
     private Integer readTimeoutMillis;
     private Integer connectTimeoutMillis;
@@ -61,7 +61,7 @@ public class NessieConfig
     }
 
     @Config("iceberg.nessie.auth.type")
-    @ConfigDescription("The authentication type to use. Available values are BASIC | BEARER")
+    @ConfigDescription("The authentication type to use. Available values are NONE | BEARER")
     public NessieConfig setAuthenticationType(AuthenticationType authenticationType)
     {
         this.authenticationType = authenticationType;
@@ -71,32 +71,6 @@ public class NessieConfig
     public Optional<AuthenticationType> getAuthenticationType()
     {
         return Optional.ofNullable(authenticationType);
-    }
-
-    @Config("iceberg.nessie.auth.basic.username")
-    @ConfigDescription("The username to use with BASIC authentication")
-    public NessieConfig setUsername(String username)
-    {
-        this.username = username;
-        return this;
-    }
-
-    public Optional<String> getUsername()
-    {
-        return Optional.ofNullable(username);
-    }
-
-    @Config("iceberg.nessie.auth.basic.password")
-    @ConfigDescription("The password to use with BASIC authentication")
-    public NessieConfig setPassword(String password)
-    {
-        this.password = password;
-        return this;
-    }
-
-    public Optional<String> getPassword()
-    {
-        return Optional.ofNullable(password);
     }
 
     @Config("iceberg.nessie.auth.bearer.token")

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieConfig.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static com.facebook.presto.iceberg.nessie.AuthenticationType.NONE;
 
 public class TestNessieConfig
 {
@@ -29,16 +30,14 @@ public class TestNessieConfig
     {
         assertRecordedDefaults(recordDefaults(NessieConfig.class)
                 .setClientBuilderImpl(null)
-                .setAuthenticationType(null)
+                .setAuthenticationType(NONE)
                 .setBearerToken(null)
                 .setCompressionEnabled(true)
                 .setDefaultReferenceName("main")
                 .setConnectTimeoutMillis(null)
-                .setPassword(null)
                 .setReadTimeoutMillis(null)
                 .setReadTimeoutMillis(null)
-                .setServerUri(null)
-                .setUsername(null));
+                .setServerUri(null));
     }
 
     @Test
@@ -47,9 +46,7 @@ public class TestNessieConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("iceberg.nessie.uri", "http://localhost:xxx/api/v1")
                 .put("iceberg.nessie.ref", "someRef")
-                .put("iceberg.nessie.auth.type", "BASIC")
-                .put("iceberg.nessie.auth.basic.username", "user")
-                .put("iceberg.nessie.auth.basic.password", "pass")
+                .put("iceberg.nessie.auth.type", "BEARER")
                 .put("iceberg.nessie.auth.bearer.token", "bearerToken")
                 .put("iceberg.nessie.compression-enabled", "false")
                 .put("iceberg.nessie.connect-timeout-ms", "123")
@@ -60,9 +57,7 @@ public class TestNessieConfig
         NessieConfig expected = new NessieConfig()
                 .setServerUri("http://localhost:xxx/api/v1")
                 .setDefaultReferenceName("someRef")
-                .setAuthenticationType(AuthenticationType.BASIC)
-                .setUsername("user")
-                .setPassword("pass")
+                .setAuthenticationType(AuthenticationType.BEARER)
                 .setBearerToken("bearerToken")
                 .setCompressionEnabled(false)
                 .setConnectTimeoutMillis(123)


### PR DESCRIPTION
## Description
Remove deprecated Nessie basic authentication type

## Motivation and Context
Remove deprecated Nessie basic authentication type
https://projectnessie.org/tools/client_config/#authentication-settings
https://github.com/projectnessie/nessie/blob/nessie-0.59.0/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java#L34

## Impact
None

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

