### PR TITLE
Support udt when forcing values from Jackson to have expected type

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
@@ -101,6 +101,9 @@ final class FixJsonDataUtils
         if (signature.isDistinctType()) {
             return fixValue(signature.getDistinctTypeInfo().getBaseType(), value);
         }
+        if (signature.getTypeSignatureBase().hasTypeName() && signature.getTypeSignatureBase().hasStandardType()) {
+            return fixValue(signature.getStandardTypeSignature(), value);
+        }
         if (signature.getBase().equals(ARRAY)) {
             if (List.class.isAssignableFrom(value.getClass())) {
                 List<Object> fixedValue = new ArrayList<>();

--- a/presto-client/src/test/java/com/facebook/presto/client/TestFixJsonDataUtils.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestFixJsonDataUtils.java
@@ -30,44 +30,55 @@ public class TestFixJsonDataUtils
     @Test
     public void testFixData()
     {
-        assertQueryResult("bigint", 1000, 1000L);
-        assertQueryResult("integer", 100, 100);
-        assertQueryResult("smallint", 10, (short) 10);
-        assertQueryResult("tinyint", 1, (byte) 1);
-        assertQueryResult("boolean", true, true);
-        assertQueryResult("date", "2017-07-01", "2017-07-01");
-        assertQueryResult("decimal", "2.15", "2.15");
-        assertQueryResult("real", 100.23456, (float) 100.23456);
-        assertQueryResult("double", 100.23456D, 100.23456);
-        assertQueryResult("interval day to second", "INTERVAL '2' DAY", "INTERVAL '2' DAY");
-        assertQueryResult("interval year to month", "INTERVAL '3' MONTH", "INTERVAL '3' MONTH");
-        assertQueryResult("timestamp", "2001-08-22 03:04:05.321", "2001-08-22 03:04:05.321");
-        assertQueryResult("timestamp with time zone", "2001-08-22 03:04:05.321 America/Los_Angeles", "2001-08-22 03:04:05.321 America/Los_Angeles");
-        assertQueryResult("time", "01:02:03.456", "01:02:03.456");
-        assertQueryResult("time with time zone", "01:02:03.456 America/Los_Angeles", "01:02:03.456 America/Los_Angeles");
-        assertQueryResult("varbinary", "garbage", Base64.getDecoder().decode("garbage"));
-        assertQueryResult("varchar", "teststring", "teststring");
-        assertQueryResult("char", "abc", "abc");
-        assertQueryResult("row(foo bigint,bar bigint)", ImmutableList.of(1, 2), ImmutableMap.of("foo", 1L, "bar", 2L));
-        assertQueryResult("array(bigint)", ImmutableList.of(1, 2, 4), ImmutableList.of(1L, 2L, 4L));
-        assertQueryResult("map(bigint,bigint)", ImmutableMap.of(1, 3, 2, 4), ImmutableMap.of(1L, 3L, 2L, 4L));
-        assertQueryResult("json", "{\"json\": {\"a\": 1}}", "{\"json\": {\"a\": 1}}");
-        assertQueryResult("ipaddress", "1.2.3.4", "1.2.3.4");
-        assertQueryResult("ipprefix", "1.2.3.4/32", "1.2.3.4/32");
-        assertQueryResult("Geometry", "POINT (1.2 3.4)", "POINT (1.2 3.4)");
-        assertQueryResult("map(BingTile,bigint)", ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1), ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1L));
+        testFixDataWithTypePrefix("");
+    }
+
+    @Test
+    public void testFixDataForUserDefinedType()
+    {
+        testFixDataWithTypePrefix("example.test.type_alt:");
+    }
+
+    private void testFixDataWithTypePrefix(String typePrefix)
+    {
+        assertQueryResult(typePrefix + "bigint", 1000, 1000L);
+        assertQueryResult(typePrefix + "integer", 100, 100);
+        assertQueryResult(typePrefix + "smallint", 10, (short) 10);
+        assertQueryResult(typePrefix + "tinyint", 1, (byte) 1);
+        assertQueryResult(typePrefix + "boolean", true, true);
+        assertQueryResult(typePrefix + "date", "2017-07-01", "2017-07-01");
+        assertQueryResult(typePrefix + "decimal", "2.15", "2.15");
+        assertQueryResult(typePrefix + "real", 100.23456, (float) 100.23456);
+        assertQueryResult(typePrefix + "double", 100.23456D, 100.23456);
+        assertQueryResult(typePrefix + "interval day to second", "INTERVAL '2' DAY", "INTERVAL '2' DAY");
+        assertQueryResult(typePrefix + "interval year to month", "INTERVAL '3' MONTH", "INTERVAL '3' MONTH");
+        assertQueryResult(typePrefix + "timestamp", "2001-08-22 03:04:05.321", "2001-08-22 03:04:05.321");
+        assertQueryResult(typePrefix + "timestamp with time zone", "2001-08-22 03:04:05.321 America/Los_Angeles", "2001-08-22 03:04:05.321 America/Los_Angeles");
+        assertQueryResult(typePrefix + "time", "01:02:03.456", "01:02:03.456");
+        assertQueryResult(typePrefix + "time with time zone", "01:02:03.456 America/Los_Angeles", "01:02:03.456 America/Los_Angeles");
+        assertQueryResult(typePrefix + "varbinary", "garbage", Base64.getDecoder().decode("garbage"));
+        assertQueryResult(typePrefix + "varchar", "test string", "test string");
+        assertQueryResult(typePrefix + "char", "abc", "abc");
+        assertQueryResult(typePrefix + "row(foo bigint,bar bigint)", ImmutableList.of(1, 2), ImmutableMap.of("foo", 1L, "bar", 2L));
+        assertQueryResult(typePrefix + "array(bigint)", ImmutableList.of(1, 2, 4), ImmutableList.of(1L, 2L, 4L));
+        assertQueryResult(typePrefix + "map(bigint,bigint)", ImmutableMap.of(1, 3, 2, 4), ImmutableMap.of(1L, 3L, 2L, 4L));
+        assertQueryResult(typePrefix + "json", "{\"json\": {\"a\": 1}}", "{\"json\": {\"a\": 1}}");
+        assertQueryResult(typePrefix + "ipaddress", "1.2.3.4", "1.2.3.4");
+        assertQueryResult(typePrefix + "ipprefix", "1.2.3.4/32", "1.2.3.4/32");
+        assertQueryResult(typePrefix + "Geometry", "POINT (1.2 3.4)", "POINT (1.2 3.4)");
+        assertQueryResult(typePrefix + "map(BingTile,bigint)", ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1), ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1L));
         // test nested map structure
-        assertQueryResult("map(map(bigint,bigint),bigint)", ImmutableMap.of("{\n  \"1\" : \"2\",\n  \"3\" : \"4\",\n  \"5\" : \"6\"\n}", "3"), ImmutableMap.of(ImmutableMap.of(1L, 2L, 3L, 4L, 5L, 6L), 3L));
-        assertQueryResult("map(row(foo bigint,bar double),bigint)", ImmutableMap.of("[ \"4\", \"5.0\" ]", "6", "[ \"1\", \"2.0\" ]", "3"), ImmutableMap.of(ImmutableMap.of("foo", 1L, "bar", 2.0), 3L, ImmutableMap.of("foo", 4L, "bar", 5.0), 6L));
-        assertQueryResult("map(array(bigint),bigint)", ImmutableMap.of("[ \"1\", \"3\", \"2\", \"3\" ]", "3"), ImmutableMap.of(ImmutableList.of(1L, 3L, 2L, 3L), 3L));
+        assertQueryResult(typePrefix + "map(map(bigint,bigint),bigint)", ImmutableMap.of("{\n  \"1\" : \"2\",\n  \"3\" : \"4\",\n  \"5\" : \"6\"\n}", "3"), ImmutableMap.of(ImmutableMap.of(1L, 2L, 3L, 4L, 5L, 6L), 3L));
+        assertQueryResult(typePrefix + "map(row(foo bigint,bar double),bigint)", ImmutableMap.of("[ \"4\", \"5.0\" ]", "6", "[ \"1\", \"2.0\" ]", "3"), ImmutableMap.of(ImmutableMap.of("foo", 1L, "bar", 2.0), 3L, ImmutableMap.of("foo", 4L, "bar", 5.0), 6L));
+        assertQueryResult(typePrefix + "map(array(bigint),bigint)", ImmutableMap.of("[ \"1\", \"3\", \"2\", \"3\" ]", "3"), ImmutableMap.of(ImmutableList.of(1L, 3L, 2L, 3L), 3L));
         // test nested array structure
-        assertQueryResult("array(array(bigint))", ImmutableList.of("[ \"1\", \"2\", \"3\" ]", "[ \"4\", \"5\", \"6\" ]"), ImmutableList.of(ImmutableList.of(1L, 2L, 3L), ImmutableList.of(4L, 5L, 6L)));
-        assertQueryResult("array(map(bigint,bigint))", ImmutableList.of("{\n  \"1\" : \"2\",\n  \"3\" : \"4\"\n}", "{\n  \"5\" : \"6\",\n  \"7\" : \"8\"\n}"), ImmutableList.of(ImmutableMap.of(1L, 2L, 3L, 4L), ImmutableMap.of(5L, 6L, 7L, 8L)));
-        assertQueryResult("array(row(foo bigint,bar double))", ImmutableList.of("[ \"1\", \"2.0\" ]", "[ \"3\", \"4.0\" ]"), ImmutableList.of(ImmutableMap.of("foo", 1L, "bar", 2.0), ImmutableMap.of("foo", 3L, "bar", 4.0)));
+        assertQueryResult(typePrefix + "array(array(bigint))", ImmutableList.of("[ \"1\", \"2\", \"3\" ]", "[ \"4\", \"5\", \"6\" ]"), ImmutableList.of(ImmutableList.of(1L, 2L, 3L), ImmutableList.of(4L, 5L, 6L)));
+        assertQueryResult(typePrefix + "array(map(bigint,bigint))", ImmutableList.of("{\n  \"1\" : \"2\",\n  \"3\" : \"4\"\n}", "{\n  \"5\" : \"6\",\n  \"7\" : \"8\"\n}"), ImmutableList.of(ImmutableMap.of(1L, 2L, 3L, 4L), ImmutableMap.of(5L, 6L, 7L, 8L)));
+        assertQueryResult(typePrefix + "array(row(foo bigint,bar double))", ImmutableList.of("[ \"1\", \"2.0\" ]", "[ \"3\", \"4.0\" ]"), ImmutableList.of(ImmutableMap.of("foo", 1L, "bar", 2.0), ImmutableMap.of("foo", 3L, "bar", 4.0)));
         // test nested row structure
-        assertQueryResult("row(foo array(bigint),bar double)", ImmutableList.of("[ \"1\", \"2\" ]", "3.0"), ImmutableMap.of("foo", ImmutableList.of(1L, 2L), "bar", 3.0));
-        assertQueryResult("row(foo map(bigint,bigint),bar double)", ImmutableList.of("{\n  \"1\" : \"2\"\n}", "3.0"), ImmutableMap.of("foo", ImmutableMap.of(1L, 2L), "bar", 3.0));
-        assertQueryResult("row(foo row(x bigint,y double),bar double)", ImmutableList.of("[ \"1\", \"2.0\" ]", "3.0"), ImmutableMap.of("foo", ImmutableMap.of("x", 1L, "y", 2.0), "bar", 3.0));
+        assertQueryResult(typePrefix + "row(foo array(bigint),bar double)", ImmutableList.of("[ \"1\", \"2\" ]", "3.0"), ImmutableMap.of("foo", ImmutableList.of(1L, 2L), "bar", 3.0));
+        assertQueryResult(typePrefix + "row(foo map(bigint,bigint),bar double)", ImmutableList.of("{\n  \"1\" : \"2\"\n}", "3.0"), ImmutableMap.of("foo", ImmutableMap.of(1L, 2L), "bar", 3.0));
+        assertQueryResult(typePrefix + "row(foo row(x bigint,y double),bar double)", ImmutableList.of("[ \"1\", \"2.0\" ]", "3.0"), ImmutableMap.of("foo", ImmutableMap.of("x", 1L, "y", 2.0), "bar", 3.0));
     }
 
     private void assertQueryResult(String type, Object data, Object expected)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestUserDefinedTypes.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestUserDefinedTypes.java
@@ -51,5 +51,10 @@ public class TestUserDefinedTypes
         assertQuery("SELECT x FROM (SELECT CAST(4 as testing.type.num) AS x)", "SELECT 4");
         assertQuerySucceeds("CREATE TYPE testing.type.mypair AS (fst testing.type.num, snd integer)");
         assertQuery("SELECT p.fst FROM (SELECT CAST(ROW(CAST(4 AS testing.type.num),3) as testing.type.mypair) AS p)", "SELECT 4");
+
+        assertQuerySucceeds("CREATE TYPE testing.type.str AS varchar");
+        assertQuery("SELECT x FROM (SELECT CAST('hello world' as testing.type.str) AS x)", "SELECT 'hello world'");
+        assertQuerySucceeds("CREATE TYPE testing.type.strpair AS (fst testing.type.str, snd varchar)");
+        assertQuery("SELECT p.fst FROM (SELECT CAST(ROW(CAST('hello world' AS testing.type.str), 'test string') as testing.type.strpair) AS p)", "SELECT 'hello world'");
     }
 }


### PR DESCRIPTION
## Description

This PR support user defined type when we trying to force the values coming from Jackson to have the expected object type.

## Motivation and Context

Current implementation do not support user defined type very well in CLI/JDBC client. For example, if we have created a user defined type by ``CREATE TYPE testing.type.str AS varchar``,  and then we would get an error when executing statement ``SELECT CAST('hello world' as testing.type.str)``. The reason is there exists a space in the result string ``hello world``, and it is wrongly encoded because we assumes it as a base64 encoded binary.

## Test Plan

 - Newly added test case ``TestFixJsonDataUtils.testFixDataForUserDefinedType()``
 - Enhanced test case ``TestUserDefinedTypes.testDistinctType()``

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

