### PR TITLE
[native pos] Allow termination with core on allocation failure

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -614,6 +614,8 @@ void PrestoServer::initializeVeloxMemory() {
   options.checkUsageLeak = systemConfig->enableMemoryLeakCheck();
   options.trackDefaultUsage =
       systemConfig->enableSystemMemoryPoolUsageTracking();
+  options.coreOnAllocationFailureEnabled =
+      systemConfig->coreOnAllocationFailureEnabled();
   if (!systemConfig->memoryArbitratorKind().empty()) {
     options.arbitratorKind = systemConfig->memoryArbitratorKind();
     const uint64_t queryMemoryGb = systemConfig->queryMemoryGb();

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -498,6 +498,11 @@ bool SystemConfig::enableMemoryLeakCheck() const {
   return optionalProperty<bool>(kEnableMemoryLeakCheck).value();
 }
 
+bool SystemConfig::coreOnAllocationFailureEnabled() const {
+  return optionalProperty<bool>(kCoreOnAllocationFailureEnabled)
+      .value_or(false);
+}
+
 bool SystemConfig::skipRuntimeStatsInRunningTaskInfo() const {
   return optionalProperty<bool>(kSkipRuntimeStatsInRunningTaskInfo).value();
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -348,6 +348,10 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kEnableMemoryLeakCheck{
       "enable-memory-leak-check"};
 
+  /// Terminates the process and generates a core file on an allocation failure
+  static constexpr std::string_view kCoreOnAllocationFailureEnabled{
+      "core-on-allocation-failure-enabled"};
+
   /// Do not include runtime stats in the returned task info if the task is
   /// in running state.
   static constexpr std::string_view kSkipRuntimeStatsInRunningTaskInfo{
@@ -599,6 +603,8 @@ class SystemConfig : public ConfigBase {
   uint64_t queryMaxMemoryPerNode() const;
 
   bool enableMemoryLeakCheck() const;
+
+  bool coreOnAllocationFailureEnabled() const;
 
   bool skipRuntimeStatsInRunningTaskInfo() const;
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcess.java
@@ -18,7 +18,6 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
-import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import io.airlift.units.Duration;
 
@@ -46,7 +45,6 @@ public class DetachedNativeExecutionProcess
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             Duration maxErrorDuration,
-            TaskManagerConfig taskManagerConfig,
             WorkerProperty<?, ?, ?, ?> workerProperty) throws IOException
     {
         super(session,
@@ -55,7 +53,6 @@ public class DetachedNativeExecutionProcess
                 errorRetryScheduledExecutor,
                 serverInfoCodec,
                 maxErrorDuration,
-                taskManagerConfig,
                 workerProperty);
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcessFactory.java
@@ -17,7 +17,6 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
-import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import com.facebook.presto.spark.execution.task.ForNativeExecutionTask;
 import com.facebook.presto.spi.PrestoException;
@@ -40,7 +39,6 @@ public class DetachedNativeExecutionProcessFactory
     private final HttpClient httpClient;
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final JsonCodec<ServerInfo> serverInfoCodec;
-    private final TaskManagerConfig taskManagerConfig;
     private final WorkerProperty<?, ?, ?, ?> workerProperty;
 
     @Inject
@@ -49,14 +47,12 @@ public class DetachedNativeExecutionProcessFactory
             ExecutorService coreExecutor,
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
-            TaskManagerConfig taskManagerConfig,
             WorkerProperty<?, ?, ?, ?> workerProperty)
     {
-        super(httpClient, coreExecutor, errorRetryScheduledExecutor, serverInfoCodec, taskManagerConfig, workerProperty);
+        super(httpClient, coreExecutor, errorRetryScheduledExecutor, serverInfoCodec, workerProperty);
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
         this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
-        this.taskManagerConfig = requireNonNull(taskManagerConfig, "taskManagerConfig is null");
         this.workerProperty = requireNonNull(workerProperty, "workerProperty is null");
     }
 
@@ -82,7 +78,6 @@ public class DetachedNativeExecutionProcessFactory
                     errorRetryScheduledExecutor,
                     serverInfoCodec,
                     maxErrorDuration,
-                    taskManagerConfig,
                     workerProperty);
         }
         catch (IOException e) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -380,7 +380,7 @@ public class NativeExecutionProcess
             populateConfigurationFiles(configPath);
         }
         ImmutableList<String> commandList = command.build();
-        log.info("Launching native process using command: %s %s", executablePath, String.join(" ", commandList));
+        log.info("Launching native process using command: %s", String.join(" ", commandList));
         return commandList;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -19,7 +19,6 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.client.ServerInfo;
-import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.server.RequestErrorTracker;
 import com.facebook.presto.server.smile.BaseResponse;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkFatalException;
@@ -77,7 +76,6 @@ public class NativeExecutionProcess
     private final PrestoSparkHttpServerClient serverClient;
     private final URI location;
     private final int port;
-    private final TaskManagerConfig taskManagerConfig;
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final RequestErrorTracker errorTracker;
     private final HttpClient httpClient;
@@ -92,7 +90,6 @@ public class NativeExecutionProcess
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             Duration maxErrorDuration,
-            TaskManagerConfig taskManagerConfig,
             WorkerProperty<?, ?, ?, ?> workerProperty)
             throws IOException
     {
@@ -104,7 +101,6 @@ public class NativeExecutionProcess
                 this.httpClient,
                 location,
                 serverInfoCodec);
-        this.taskManagerConfig = requireNonNull(taskManagerConfig, "taskManagerConfig is null");
         this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
         this.errorTracker = new RequestErrorTracker(
                 "NativeExecution",

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -136,6 +136,7 @@ public class NativeExecutionProcess
 
         ProcessBuilder processBuilder = new ProcessBuilder(getLaunchCommand());
         processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        processBuilder.environment().put("INIT_PRESTO_QUERY_ID", session.getQueryId().toString());
         try {
             process = processBuilder.start();
             processOutputPipe = new ProcessOutputPipe(

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -119,7 +119,7 @@ public class NativeExecutionProcess
     public synchronized void start()
             throws ExecutionException, InterruptedException, IOException
     {
-        if (process != null && process.isAlive()) {
+        if (process != null) {
             return;
         }
 
@@ -208,7 +208,12 @@ public class NativeExecutionProcess
     @Override
     public void close()
     {
-        if (process != null && process.isAlive()) {
+        Process process = this.process;
+        if (process == null) {
+            return;
+        }
+
+        if (process.isAlive()) {
             long pid = getPid(process);
             log.info("Destroying process: %s", pid);
             process.destroy();
@@ -230,9 +235,8 @@ public class NativeExecutionProcess
                 }
             }
         }
-        else if (process != null) {
+        else {
             log.info("Process is dead: %s", getPid(process));
-            process = null;
         }
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcessFactory.java
@@ -17,7 +17,6 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
-import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import com.facebook.presto.spark.execution.task.ForNativeExecutionTask;
 import com.facebook.presto.spi.PrestoException;
@@ -45,7 +44,6 @@ public class NativeExecutionProcessFactory
     private final ExecutorService coreExecutor;
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final JsonCodec<ServerInfo> serverInfoCodec;
-    private final TaskManagerConfig taskManagerConfig;
     private final WorkerProperty<?, ?, ?, ?> workerProperty;
 
     private static NativeExecutionProcess process;
@@ -56,7 +54,6 @@ public class NativeExecutionProcessFactory
             ExecutorService coreExecutor,
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
-            TaskManagerConfig taskManagerConfig,
             WorkerProperty<?, ?, ?, ?> workerProperty)
 
     {
@@ -64,7 +61,6 @@ public class NativeExecutionProcessFactory
         this.coreExecutor = requireNonNull(coreExecutor, "coreExecutor is null");
         this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
         this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
-        this.taskManagerConfig = requireNonNull(taskManagerConfig, "taskManagerConfig is null");
         this.workerProperty = requireNonNull(workerProperty, "workerProperty is null");
     }
 
@@ -91,7 +87,6 @@ public class NativeExecutionProcessFactory
                     errorRetryScheduledExecutor,
                     serverInfoCodec,
                     maxErrorDuration,
-                    taskManagerConfig,
                     workerProperty);
         }
         catch (IOException e) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -100,6 +100,8 @@ public class NativeExecutionSystemConfig
     private static final String SHUFFLE_NAME = "shuffle.name";
     // Feature flag for access log on presto-native http server
     private static final String HTTP_SERVER_ACCESS_LOGS = "http-server.enable-access-log";
+    // Terminates the native process and generates a core file on an allocation failure
+    private static final String CORE_ON_ALLOCATION_FAILURE_ENABLED = "core-on-allocation-failure-enabled";
     private boolean enableSerializedPageChecksum = true;
     private boolean enableVeloxExpressionLogging;
     private boolean enableVeloxTaskLogging = true;
@@ -133,6 +135,7 @@ public class NativeExecutionSystemConfig
     private String shuffleName = "local";
     private boolean registerTestFunctions;
     private boolean enableHttpServerAccessLog = true;
+    private boolean coreOnAllocationFailureEnabled;
 
     public Map<String, String> getAllProperties()
     {
@@ -168,6 +171,7 @@ public class NativeExecutionSystemConfig
                 .put(ENABLE_OLD_TASK_CLEANUP, String.valueOf(getOldTaskCleanupMs()))
                 .put(SHUFFLE_NAME, getShuffleName())
                 .put(HTTP_SERVER_ACCESS_LOGS, String.valueOf(isEnableHttpServerAccessLog()))
+                .put(CORE_ON_ALLOCATION_FAILURE_ENABLED, String.valueOf(isCoreOnAllocationFailureEnabled()))
                 .build();
     }
 
@@ -541,5 +545,17 @@ public class NativeExecutionSystemConfig
     public boolean isEnableHttpServerAccessLog()
     {
         return enableHttpServerAccessLog;
+    }
+
+    public boolean isCoreOnAllocationFailureEnabled()
+    {
+        return coreOnAllocationFailureEnabled;
+    }
+
+    @Config(CORE_ON_ALLOCATION_FAILURE_ENABLED)
+    public NativeExecutionSystemConfig setCoreOnAllocationFailureEnabled(boolean coreOnAllocationFailureEnabled)
+    {
+        this.coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled;
+        return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
@@ -27,7 +27,6 @@ import com.facebook.presto.server.smile.BaseResponse;
 import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
 import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTaskInfoFetcher;
 import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTaskResultFetcher;
-import com.facebook.presto.spi.PrestoTransportException;
 import com.facebook.presto.spi.page.SerializedPage;
 import com.facebook.presto.spi.security.TokenAuthenticator;
 import com.facebook.presto.sql.planner.PlanFragment;
@@ -245,10 +244,5 @@ public class NativeExecutionTask
                 broadcastBasePath,
                 session,
                 outputBuffers);
-    }
-
-    public static boolean isNativeExecutionTaskError(RuntimeException ex)
-    {
-        return ex instanceof PrestoTransportException;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -669,6 +669,10 @@ public class PrestoSparkNativeTaskExecutorFactory
             }
             else {
                 message = "Native execution process is dead";
+                String crashReport = process.getCrashReport();
+                if (!crashReport.isEmpty()) {
+                    message += ":\n" + crashReport;
+                }
             }
 
             return new PrestoTransportException(

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
@@ -17,7 +17,6 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.execution.TaskId;
-import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkFatalException;
 import com.facebook.presto.spark.execution.http.TestPrestoSparkHttpClient;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcess;
@@ -106,7 +105,6 @@ public class TestNativeExecutionProcess
                 newSingleThreadExecutor(),
                 errorScheduler,
                 SERVER_INFO_JSON_CODEC,
-                new TaskManagerConfig(),
                 workerProperty);
         return factory;
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -282,8 +282,7 @@ public class TestPrestoSparkHttpClient
         Duration maxTimeout = new Duration(1, TimeUnit.MINUTES);
         NativeExecutionProcess process = createNativeExecutionProcess(
                 maxTimeout,
-                new TestingResponseManager(taskId.toString(), new FailureRetryResponseManager(5)),
-                new TaskManagerConfig());
+                new TestingResponseManager(taskId.toString(), new FailureRetryResponseManager(5)));
 
         SettableFuture<ServerInfo> future = process.getServerInfoWithRetry();
         try {
@@ -303,8 +302,7 @@ public class TestPrestoSparkHttpClient
         Duration maxTimeout = new Duration(0, TimeUnit.MILLISECONDS);
         NativeExecutionProcess process = createNativeExecutionProcess(
                 maxTimeout,
-                new TestingResponseManager(taskId.toString(), new FailureRetryResponseManager(5)),
-                new TaskManagerConfig());
+                new TestingResponseManager(taskId.toString(), new FailureRetryResponseManager(5)));
 
         SettableFuture<ServerInfo> future = process.getServerInfoWithRetry();
         Exception exception = expectThrows(ExecutionException.class, future::get);
@@ -772,8 +770,7 @@ public class TestPrestoSparkHttpClient
 
     private NativeExecutionProcess createNativeExecutionProcess(
             Duration maxErrorDuration,
-            TestingResponseManager responseManager,
-            TaskManagerConfig config)
+            TestingResponseManager responseManager)
     {
         ScheduledExecutorService errorScheduler = newScheduledThreadPool(4);
         PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
@@ -786,7 +783,6 @@ public class TestPrestoSparkHttpClient
                 newSingleThreadExecutor(),
                 errorScheduler,
                 SERVER_INFO_JSON_CODEC,
-                config,
                 workerProperty);
         return factory.createNativeExecutionProcess(
                 testSessionBuilder().build(),

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -90,7 +90,8 @@ public class TestNativeExecutionSystemConfig
                 .setPrestoVersion("dummy.presto.version")
                 .setShuffleName("local")
                 .setRegisterTestFunctions(false)
-                .setEnableHttpServerAccessLog(true));
+                .setEnableHttpServerAccessLog(true)
+                .setCoreOnAllocationFailureEnabled(false));
 
         // Test explicit property mapping. Also makes sure properties returned by getAllProperties() covers full property list.
         NativeExecutionSystemConfig expected = new NativeExecutionSystemConfig()
@@ -124,7 +125,8 @@ public class TestNativeExecutionSystemConfig
                 .setOldTaskCleanupMs(true)
                 .setShuffleName("custom")
                 .setRegisterTestFunctions(true)
-                .setEnableHttpServerAccessLog(false);
+                .setEnableHttpServerAccessLog(false)
+                .setCoreOnAllocationFailureEnabled(true);
         Map<String, String> properties = expected.getAllProperties();
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Add `core-on-allocation-failure-enabled` flag. When enabled native process will terminate with core when MemoryPool is exhausted.

## Motivation and Context

By default Velox throws an exception when MemoryPool is exhausted. This behaviour is preferred for long running multitenant processes. In Sapphire native processes are short running and single tenant, hence it is fine to terminate a process when it runs out of memory. Having a coredump available makes it easier to diagnose OOMs as it provides a complete view of active allocations and ownership.

## Impact

The failure message will change with this flag enabled. To simplify debugging the PR also includes changes necessary to include output of a dying process in the task failure error message.

## Test Plan

- Simulate memory pool exhaustion
- Make sure the coredump is triggered and correct error message is present

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

