### PR TITLE
Use non-blocking SecureRandom in noisy aggregators

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountAggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyCountAggregationUtils.java
@@ -15,8 +15,8 @@ package com.facebook.presto.operator.aggregation.noisyaggregation;
 
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.util.SecureRandomGeneration;
 
-import java.security.SecureRandom;
 import java.util.Random;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -71,7 +71,7 @@ public class NoisyCountAggregationUtils
 
     public static double getNoise(NoisyCountState state)
     {
-        Random random = new SecureRandom();
+        Random random = SecureRandomGeneration.getNonBlocking();
         if (!state.isNullRandomSeed()) {
             random = new Random(state.getRandomSeed());
         }


### PR DESCRIPTION
## Description

As a follow-up to https://github.com/prestodb/presto/pull/21290, this one-(ish)-line change ensures that the remaining noisy aggregators (noisy_count_gaussian, noisy_count_if_gaussian, noisy_avg_gaussian, noisy_sum_gaussian) all use a SecureRandom provider that will not block and cause performance degradation.

## Motivation and Context

The importance of using a non-blocking SecureRandom provider for the noisyaggregation suite was raised in https://github.com/prestodb/presto/pull/21290, where we standardized on using the same providers as in the secure_random scalar functions. This PR addresses the outstanding functions in the noisyaggregation suite.

## Impact

This does not change any existing functionality, except to avoid possible performance issues when a SecureRandom provider could block while waiting for entropy.

## Test Plan

All unit tests in `noisyaggregation` pass.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```
