### PR TITLE
fix indentation format on develop/presto-native.rst

### DIFF
--- a/presto-docs/src/main/sphinx/develop/presto-native.rst
+++ b/presto-docs/src/main/sphinx/develop/presto-native.rst
@@ -54,68 +54,68 @@ The following properties allow the configuration of remote function execution:
 ``remote-function-server.signature.files.directory.path``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type:** ``string``
-    * **Default value:** ``""``
+* **Type:** ``string``
+* **Default value:** ``""``
 
-    The local filesystem path where JSON files containing remote function
-    signatures are located. If not empty, the Presto native worker will
-    recursively search, open, parse, and register function definitions from
-    these JSON files.
+The local filesystem path where JSON files containing remote function
+signatures are located. If not empty, the Presto native worker will
+recursively search, open, parse, and register function definitions from
+these JSON files.
 
 ``remote-function-server.catalog-name``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type:** ``string``
-    * **Default value:** ``""``
+* **Type:** ``string``
+* **Default value:** ``""``
 
-    The catalog name to be added as a prefix to the function names registered
-    in Velox. The function name pattern registered is
-    ``catalog.schema.function_name``, where ``catalog`` is defined by this
-    parameter, and ``schema`` and ``function_name`` are read from the input
-    JSON file.
+The catalog name to be added as a prefix to the function names registered
+in Velox. The function name pattern registered is
+``catalog.schema.function_name``, where ``catalog`` is defined by this
+parameter, and ``schema`` and ``function_name`` are read from the input
+JSON file.
 
-    If empty, the function is registered as ``schema.function_name``.
+If empty, the function is registered as ``schema.function_name``.
 
 ``remote-function-server.serde``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type:** ``string``
-    * **Default value:** ``"presto_page"``
+* **Type:** ``string``
+* **Default value:** ``"presto_page"``
 
-    The serialization/deserialization method to use when communicating with
-    the remote function server. Supported values are ``presto_page`` or
-    ``spark_unsafe_row``.
+The serialization/deserialization method to use when communicating with
+the remote function server. Supported values are ``presto_page`` or
+``spark_unsafe_row``.
 
 ``remote-function-server.thrift.address``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type:** ``string``
-    * **Default value:** ``""``
+* **Type:** ``string``
+* **Default value:** ``""``
 
-    The location (ip address or hostname) that hosts the remote function
-    server, if any remote functions were registered using
-    ``remote-function-server.signature.files.directory.path``.
-    If not specified, falls back to the loopback interface (``::1``)
+The location (ip address or hostname) that hosts the remote function
+server, if any remote functions were registered using
+``remote-function-server.signature.files.directory.path``.
+If not specified, falls back to the loopback interface (``::1``)
 
 ``remote-function-server.thrift.port``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type:** ``integer``
-    * **Default value:** ``0``
+* **Type:** ``integer``
+* **Default value:** ``0``
 
-    The port that hosts the remote function server. If not specified and remote
-    functions are trying to be registered, an exception is thrown.
+The port that hosts the remote function server. If not specified and remote
+functions are trying to be registered, an exception is thrown.
 
 ``remote-function-server.thrift.uds-path``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type:** ``string``
-    * **Default value:** ``""``
+* **Type:** ``string``
+* **Default value:** ``""``
 
-    The UDS (unix domain socket) path to communicate with a local remote
-    function server. If specified, takes precedence over
-    ``remote-function-server.thrift.address`` and
-    ``remote-function-server.thrift.port``.
+The UDS (unix domain socket) path to communicate with a local remote
+function server. If specified, takes precedence over
+``remote-function-server.thrift.address`` and
+``remote-function-server.thrift.port``.
 
 JWT authentication support
 --------------------------
@@ -128,15 +128,15 @@ There is also an additional parameter:
 ``internal-communication.jwt.expiration-seconds``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type** ``integer``
-    * **Default value:** ``300``
+* **Type** ``integer``
+* **Default value:** ``300``
 
-    There is a time period between creating the JWT on the client
-    and verification by the server.
-    If the time period is less than or equal to the parameter value, the request
-    is valid.
-    If the time period exceeds the parameter value, the request is rejected as
-    authentication failure (HTTP 401).
+There is a time period between creating the JWT on the client
+and verification by the server.
+If the time period is less than or equal to the parameter value, the request
+is valid.
+If the time period exceeds the parameter value, the request is rejected as
+authentication failure (HTTP 401).
 
 Async Data Cache and Prefetching
 --------------------------------
@@ -144,51 +144,51 @@ Async Data Cache and Prefetching
 ``connector.num-io-threads-hw-multiplier``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type** ``double``
-    * **Default value:** ``1.0``
-    * **Presto on Spark default value:** ``0.0``
+* **Type** ``double``
+* **Default value:** ``1.0``
+* **Presto on Spark default value:** ``0.0``
 
-    Size of IO executor for connectors to do preload/prefetch.  Prefetch is
-    disabled if ``connector.num-io-threads-hw-multiplier`` is set to zero.
+Size of IO executor for connectors to do preload/prefetch.  Prefetch is
+disabled if ``connector.num-io-threads-hw-multiplier`` is set to zero.
 
 ``async-data-cache-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type** ``bool``
-    * **Default value:** ``true``
-    * **Presto on Spark default value:** ``false``
+* **Type** ``bool``
+* **Default value:** ``true``
+* **Presto on Spark default value:** ``false``
 
-    Whether async data cache is enabled.  Setting ``async-data-cache-enabled``
-    to ``false`` disables split prefetching in table scan.
+Whether async data cache is enabled.  Setting ``async-data-cache-enabled``
+to ``false`` disables split prefetching in table scan.
 
 ``async-cache-ssd-gb``
 ^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type** ``integer``
-    * **Default value:** ``0``
+* **Type** ``integer``
+* **Default value:** ``0``
 
-    Size of the SSD cache when async data cache is enabled.  Must be zero if
-    ``async-data-cache-enabled`` is ``false``.
+Size of the SSD cache when async data cache is enabled.  Must be zero if
+``async-data-cache-enabled`` is ``false``.
 
 ``enable-old-task-cleanup``
 ^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type** ``bool``
-    * **Default value:** ``true``
-    * **Presto on Spark default value:** ``false``
+* **Type** ``bool``
+* **Default value:** ``true``
+* **Presto on Spark default value:** ``false``
 
-    Enable periodic clean up of old tasks. This is ``true`` for Prestissimo,
-    however for Presto on Spark this defaults to ``false`` as zombie/stuck tasks
-    are handled by spark via speculative execution.
+Enable periodic clean up of old tasks. This is ``true`` for Prestissimo,
+however for Presto on Spark this defaults to ``false`` as zombie/stuck tasks
+are handled by spark via speculative execution.
 
 ``old-task-cleanup-ms``
 ^^^^^^^^^^^^^^^^^^^^^^
 
-    * **Type** ``integer``
-    * **Default value:** ``60000``
+* **Type** ``integer``
+* **Default value:** ``60000``
 
-    Duration after which a task should be considered as old and will be eligible
-    for cleanup. Only applicable when ``enable-old-task-cleanup`` is ``true``.
-    Old task is defined as a PrestoTask which has not received heartbeat for at least
-    ``old-task-cleanup-ms``, or is not running and has an end time more than
-    ``old-task-cleanup-ms`` ago.
+Duration after which a task should be considered as old and will be eligible
+for cleanup. Only applicable when ``enable-old-task-cleanup`` is ``true``.
+Old task is defined as a PrestoTask which has not received heartbeat for at least
+``old-task-cleanup-ms``, or is not running and has an end time more than
+``old-task-cleanup-ms`` ago.


### PR DESCRIPTION
## Description
The function properties on Presto Native - Prestissimo appear to be indented too far, causing vertical lines to mark the indented text. Removed unnecessary indentation on the page. See screenshot showing detail. 
<img width="928" alt="Screenshot 2023-12-01 at 10 14 37 AM" src="https://github.com/prestodb/presto/assets/7013443/d27c3486-2f21-466b-8029-27b14123bcb7">


## Motivation and Context
Fixes formatting in the Presto documentation. 

## Impact
None.

## Test Plan
Built documentation locally, and reviewed page. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

