### PR TITLE
Deprecate Nessie BASIC authentication type

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -72,6 +72,9 @@ Property Name                                        Description
                                                      Available values are ``BASIC`` or ``BEARER``.
                                                      Example: ``BEARER``
 
+                                                     **Note:** Nessie BASIC authentication type is deprecated,
+                                                     this will be removed in upcoming release
+
 ``iceberg.nessie.auth.basic.username``               The username to use with ``BASIC`` authentication.
                                                      Example: ``test_user``
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/AuthenticationType.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/AuthenticationType.java
@@ -15,6 +15,11 @@ package com.facebook.presto.iceberg.nessie;
 
 public enum AuthenticationType
 {
+    /**
+     * Nessie BASIC authentication type is deprecated, this auth type will be removed in upcoming release.
+     * https://github.com/projectnessie/nessie/blob/nessie-0.59.0/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java#L34
+     */
+    @Deprecated
     BASIC,
     BEARER
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/NessieConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/NessieConfig.java
@@ -75,12 +75,14 @@ public class NessieConfig
 
     @Config("iceberg.nessie.auth.basic.username")
     @ConfigDescription("The username to use with BASIC authentication")
+    @Deprecated
     public NessieConfig setUsername(String username)
     {
         this.username = username;
         return this;
     }
 
+    @Deprecated
     public Optional<String> getUsername()
     {
         return Optional.ofNullable(username);
@@ -88,12 +90,14 @@ public class NessieConfig
 
     @Config("iceberg.nessie.auth.basic.password")
     @ConfigDescription("The password to use with BASIC authentication")
+    @Deprecated
     public NessieConfig setPassword(String password)
     {
         this.password = password;
         return this;
     }
 
+    @Deprecated
     public Optional<String> getPassword()
     {
         return Optional.ofNullable(password);


### PR DESCRIPTION
## Description
Deprecate Nessie basic authentication type

## Motivation and Context
Deprecate Nessie basic authentication type
https://projectnessie.org/tools/client_config/#authentication-settings
https://github.com/projectnessie/nessie/blob/nessie-0.59.0/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java#L34

## Impact
None

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

