### PR TITLE
[Native] Don't propagate errors in getResults

### DIFF
--- a/presto-docs/src/main/sphinx/develop/worker-protocol.rst
+++ b/presto-docs/src/main/sphinx/develop/worker-protocol.rst
@@ -83,6 +83,11 @@ along with the results. Then, the client uses that sequence number to request
 the next chunk of results. The client keeps fetching results until it receives
 ``X-Presto-Buffer-Complete`` HTTP header with the value of "true".
 
+If the worker times out populating a response, or the task has already failed
+or been aborted, the worker will return empty results. The client can attempt
+to retry the request. In the case where the task is in a terminal state, it
+is assumed that the Control Plane will eventually handle the state change.
+
 If the client missed a response it can repeat the request and the worker will
 send the results again. Upon receiving an ack for a sequence number, the worker
 deletes all results with the sequence number less than that and the client can

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -109,6 +109,9 @@ public interface TaskManager
      * task or buffer has not been created yet, an uninitialized task is
      * created and a future is returned.
      * <p>
+     * Returns empty results if the Task is destroyed, e.g. because it fails
+     * or is aborted, or another request is made for the same data.
+     * <p>
      * NOTE: this design assumes that only tasks and buffers that will
      * eventually exist are queried.
      */


### PR DESCRIPTION
Today, the native TaskManager will throw an exception if getResults is called on a failed or aborted task. In Presto Java, it looks like the Worker will return empty results rather than an error in these cases.

Looking at ClientBuffer in the Java code, it creates a future for getResults that will be fulfilled when the Task enqueues results. If the Task does not enqueue results, e.g. because it's failed or aborted, the future is fulfilled with empty results, either when getResults is called again or when the ClientBuffer is destroyed.

This behavior makes sense to me.  By propagating the exception, there's a race condition in the Cooridinator resulting in the actual exception that caused the Task to fail, depending on whether the producer or consumer Task is marked as failed first in the Coordinator. If the Task is failed/aborted then the Coordinator should eventually realize this through the getTaskStatus call. Put another way, the purpose of getResults is to propagate data, and the purpose of getTaskStatus is to propagate errors.
