### PR TITLE
Add comma for number in printed query plan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -272,7 +272,7 @@ public class TextRenderer
     public static String formatAsLong(double value)
     {
         if (isFinite(value)) {
-            return format(Locale.US, "%d", Math.round(value));
+            return format(Locale.US, "%,d", Math.round(value));
         }
 
         return "?";
@@ -281,7 +281,7 @@ public class TextRenderer
     public static String formatDouble(double value)
     {
         if (isFinite(value)) {
-            return format(Locale.US, "%.2f", value);
+            return format(Locale.US, "%,.2f", value);
         }
 
         return "?";
@@ -290,7 +290,7 @@ public class TextRenderer
     static String formatPositions(long positions)
     {
         String noun = (positions == 1) ? "row" : "rows";
-        return positions + " " + noun;
+        return format(Locale.US, "%,d %s", positions, noun);
     }
 
     static String indentString(int indent)


### PR DESCRIPTION
## Description
In the printed plan, add comma in the number so that it's more readable, for example
from `rows: 15000 (1.86MB), cpu: 1948552.00, memory: 0.00, network: 1948552.00` to `rows: 15,000 (1.86MB), cpu: 1,948,552.00, memory: 0.00, network: 1,948,552.00`

## Motivation and Context
To debug a query, we often need to compare the output for each operator, however the current format is hard to read for big numbers. This will make it more readable.

## Impact
Make the printed query plan more readable.

## Test Plan
Run query end to end to verify the new format is expected.

```
presto:tpch> explain select * from orders;
                                                                                                                                                                                                 Qu>
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 - Output[PlanNodeId 5][orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment] => [orderkey:bigint, custkey:bigint, orderstatus:varchar(1), totalprice>
         Estimates: {source: CostBasedSourceInfo, rows: 15,000 (1.86MB), cpu: 1,948,552.00, memory: 0.00, network: 1,948,552.00}                                                                   >
     - RemoteStreamingExchange[PlanNodeId 95][GATHER] => [orderkey:bigint, custkey:bigint, orderstatus:varchar(1), totalprice:double, orderdate:date, orderpriority:varchar(15), clerk:varchar(15),>
             Estimates: {source: CostBasedSourceInfo, rows: 15,000 (1.86MB), cpu: 1,948,552.00, memory: 0.00, network: 1,948,552.00}                                                               >
         - TableScan[PlanNodeId 0][TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartitionValues=Optional.empty}', layout='Optional[t>
                 Estimates: {source: CostBasedSourceInfo, rows: 15,000 (1.86MB), cpu: 1,948,552.00, memory: 0.00, network: 0.00}                                                                   >
                 LAYOUT: tpch.orders{}                                                                                                                                                             >
                 orderpriority := orderpriority:varchar(15):5:REGULAR (1:23)                                                                                                                       >
                 orderstatus := orderstatus:varchar(1):2:REGULAR (1:23)                                                                                                                            >
                 orderdate := orderdate:date:4:REGULAR (1:23)                                                                                                                                      >
                 custkey := custkey:bigint:1:REGULAR (1:23)                                                                                                                                        >
                 comment := comment:varchar(79):8:REGULAR (1:23)                                                                                                                                   >
                 shippriority := shippriority:int:7:REGULAR (1:23)                                                                                                                                 >
                 clerk := clerk:varchar(15):6:REGULAR (1:23)                                                                                                                                       >
                 orderkey := orderkey:bigint:0:REGULAR (1:23)                                                                                                                                      >
                 totalprice := totalprice:double:3:REGULAR (1:23)                                                                                                                                  >
                                                                                                                                                                                                   >
(1 row)

```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve the readability of query plan by making the number printed in query plan to be comma separated.
```


