### PR TITLE
[Native] Advance velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -39,7 +39,7 @@ class ConfigTest : public testing::Test {
     sysConfigFile->append(
         fmt::format("{}={}\n", SystemConfig::kPrestoVersion, prestoVersion));
     sysConfigFile->append(
-        fmt::format("{}=11kB\n", SystemConfig::kQueryMaxMemoryPerNode));
+        fmt::format("{}=11KB\n", SystemConfig::kQueryMaxMemoryPerNode));
     if (isMutable) {
       sysConfigFile->append(
           fmt::format("{}={}\n", ConfigBase::kMutableConfig, "true"));
@@ -86,7 +86,7 @@ TEST_F(ConfigTest, mutableSystemConfig) {
           .value());
   ASSERT_EQ(prestoVersion2, systemConfig->prestoVersion());
   ASSERT_EQ(
-      "11kB",
+      "11KB",
       systemConfig
           ->setValue(std::string(SystemConfig::kQueryMaxMemoryPerNode), "5GB")
           .value());


### PR DESCRIPTION
## Description
Advances velox version to include https://github.com/facebookincubator/velox/pull/7794.

## Motivation and Context
This change is required for running `analyze` on decimal columns.

```
== NO RELEASE NOTE ==
```

