### PR TITLE
Adding documentation for Handle case of table with no supported columns

### DIFF
--- a/presto-docs/src/main/sphinx/connector/postgresql.rst
+++ b/presto-docs/src/main/sphinx/connector/postgresql.rst
@@ -184,6 +184,14 @@ The connector maps PrestoDB types to the corresponding PostgreSQL types:
 
 No other types are supported.
 
+Tables with Unsupported Columns
+-------------------------------
+
+If you query a PostgreSQL table with the Presto connector, and the table either has no supported columns or contains
+only unsupported data types, Presto returns an error similar to the following example:
+
+``Query 20231120_102910_00004_35dqb failed: Table 'public.unsupported_type_table' has no supported columns (all 1 columns are not supported).``
+
 PostgreSQL Connector Limitations
 --------------------------------
 


### PR DESCRIPTION
Description
Adding documentation for Handle case of table with no supported columns

Motivation and Context
(https://github.com/prestodb/presto/pull/21422)

Impact
No imapct its a documentation enhancement

Test Plan
Handle case of table with no supported columns

Your Environment :
Presto version used:0.285
Storage (HDFS/S3/GCS..):postgresql
Data source and connector used:postgresql
Deployment (Cloud or On-prem):mac

Expected Behavior :
Table 'public.no_column_table' has no supported columns (all %s columns are not supported)

Current Behavior :
presto:public> show tables;
Table
example_table
example_table1
mm
no_column_table
sample_table
(5 rows)

Query 20231120_100558_00026_suqwa, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:03, server-side: 0:03] [5 rows, 136B] [1 rows/s, 50B/s]

presto:public> select * from no_column_table;
Query 20231120_100747_00027_suqwa failed: Table 'public.no_column_table' not found

presto:public> show tables;
Table
example_table
example_table1
mm
no_column_table
sample_table
unsupported_type_table
(6 rows)

Query 20231120_102515_00028_suqwa, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:02, server-side: 0:02] [6 rows, 174B] [2 rows/s, 75B/s]

presto:public> select * from unsupported_type_table;
Query 20231120_102529_00029_suqwa failed: Table 'public.unsupported_type_table' not found

Possible Solution
throw new TableNotFoundException(
tableHandle.getSchemaTableName(),
format("Table '%s' has no supported columns (all %s columns are not supported)",

Steps to Reproduce :

postgresql connector
2.create
mydatabase=# CREATE TABLE no_column_table();
CREATE TABLE
mydatabase=# CREATE TABLE unsupported_type_table (
data_point point
);
CREATE TABLE
mydatabase=#
from presto cli, select * from <table_name>

After changes :
Screenshots (if appropriate)
presto> use public;
USE
presto:public> select * from unsupported_type_table;
Query 20231120_102910_00004_35dqb failed: Table 'public.unsupported_type_table' has no supported columns (all 1 columns are not supported)

presto:public> select * from no_column_table;
Query 20231120_102918_00005_35dqb failed: Table 'public.no_column_table' has no supported columns (all 0 columns are not supported)

Contributor checklist
 Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
 PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
 Documented new properties (with its default value), SQL syntax, functions, or other functionality.
 If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
 Adequate tests were added if applicable.
 CI passed.
Release Notes
== NO RELEASE NOTE ==