### PR TITLE
[native] Fix PartitionAndSerialize with constant keys

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -213,6 +213,9 @@ class PartitionAndSerializeOperator : public Operator {
     decodedVectors_.resize(keyChannels_.size());
 
     for (auto partitionKey : keyChannels_) {
+      if (partitionKey == kConstantChannel) {
+        continue;
+      }
       auto& keyVector = input_->childAt(partitionKey);
       if (keyVector->mayHaveNulls()) {
         decodedVectors_[partitionKey].decode(*keyVector);

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1163,14 +1163,6 @@ core::WindowNode::BoundType toVeloxBoundType(protocol::BoundType boundType) {
   }
 }
 
-// Stores partitioned output channels.
-// For each 'kConstantChannel', there is an entry in 'constValues'.
-struct PartitionedOutputChannels {
-  std::vector<column_index_t> channels;
-  // Each vector holding a single value for a constant channel.
-  std::vector<VectorPtr> constValues;
-};
-
 core::LocalPartitionNode::Type toLocalExchangeType(
     protocol::ExchangeNodeType type) {
   switch (type) {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
@@ -82,6 +82,17 @@ public abstract class AbstractTestNativeJoinQueries
         assertQuery(joinTypeSession, "SELECT * FROM lineitem WHERE orderkey NOT IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
         assertQuery(joinTypeSession, "SELECT * FROM lineitem " +
                 "WHERE linenumber = 3 OR orderkey NOT IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
+
+        assertQuery("WITH mapping AS (\n" +
+                "  SELECT orderkey, custkey FROM orders GROUP BY 1, 2\n" +
+                ")\n" +
+                "SELECT \n" +
+                "  custkey\n" +
+                "FROM \n" +
+                "  mapping m \n" +
+                "WHERE \n" +
+                "  m.custkey = 38 \n" +
+                "  AND m.orderkey NOT IN (SELECT orderkey FROM lineitem)");
     }
 
     @Test(dataProvider = "joinTypeProvider")


### PR DESCRIPTION
PartitionAndSerialize operator used to fail if some of the partitioning keys are constant.

```
VeloxRuntimeError: index < childrenSize_ (4294967295 vs. 1) Trying to access non-existing child in RowVector: [ROW ROW<foo_id_665:BIGINT>: 1024 elements, no nulls]
...
	at Unknown.# 2  facebook::velox::RowVector::childAt(unsigned int)(Unknown Source)
	at Unknown.# 3  facebook::presto::operators::(anonymous namespace)::PartitionAndSerializeOperator::addInput(std::shared_ptr<facebook::velox::RowVector>)(Unknown Source)
```

```
== NO RELEASE NOTE ==
```

