### PR TITLE
Fix Iceberg session properties

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -21,7 +21,6 @@ import com.facebook.presto.hive.FileFormatDataSourceStats;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HiveDwrfEncryptionProvider;
-import com.facebook.presto.hive.HiveSessionProperties;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.OrcFileWriterConfig;
 import com.facebook.presto.hive.orc.HdfsOrcDataSource;
@@ -50,9 +49,6 @@ import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
-import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterBlockSize;
-import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterPageSize;
-import static com.facebook.presto.hive.HiveSessionProperties.isOrcOptimizedWriterValidate;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_QUERY_ID_NAME;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VERSION_NAME;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_WRITER_OPEN_ERROR;
@@ -60,9 +56,17 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_WRITE_VALIDAT
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcMaxBufferSize;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcMaxMergeDistance;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcOptimizedWriterMaxDictionaryMemory;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcOptimizedWriterMaxStripeRows;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcOptimizedWriterMaxStripeSize;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcOptimizedWriterMinStripeSize;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcOptimizedWriterValidateMode;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcStreamBufferSize;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getOrcStringStatisticsLimit;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getParquetWriterBlockSize;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.getParquetWriterPageSize;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getParquetWriterVersion;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcOptimizedWriterValidate;
 import static com.facebook.presto.iceberg.TypeConverter.toOrcType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.facebook.presto.iceberg.util.PrimitiveTypeMapBuilder.makeTypeMap;
@@ -220,12 +224,12 @@ public class IcebergFileWriterFactory
                     orcFileWriterConfig
                             .toOrcWriterOptionsBuilder()
                             .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
-                                    .withStripeMinSize(HiveSessionProperties.getOrcOptimizedWriterMinStripeSize(session))
-                                    .withStripeMaxSize(HiveSessionProperties.getOrcOptimizedWriterMaxStripeSize(session))
-                                    .withStripeMaxRowCount(HiveSessionProperties.getOrcOptimizedWriterMaxStripeRows(session))
+                                    .withStripeMinSize(getOrcOptimizedWriterMinStripeSize(session))
+                                    .withStripeMaxSize(getOrcOptimizedWriterMaxStripeSize(session))
+                                    .withStripeMaxRowCount(getOrcOptimizedWriterMaxStripeRows(session))
                                     .build())
-                            .withDictionaryMaxMemory(HiveSessionProperties.getOrcOptimizedWriterMaxDictionaryMemory(session))
-                            .withMaxStringStatisticsLimit(HiveSessionProperties.getOrcStringStatisticsLimit(session))
+                            .withDictionaryMaxMemory(getOrcOptimizedWriterMaxDictionaryMemory(session))
+                            .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session))
                             .build(),
                     IntStream.range(0, fileColumnNames.size()).toArray(),
                     ImmutableMap.<String, String>builder()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -120,8 +120,6 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
-import static com.facebook.presto.hive.HiveSessionProperties.isParquetBatchReaderVerificationEnabled;
-import static com.facebook.presto.hive.HiveSessionProperties.isParquetBatchReadsEnabled;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
 import static com.facebook.presto.hive.parquet.ParquetPageSourceFactory.createDecryptor;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.getPushedDownSubfield;
@@ -140,6 +138,8 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.getParquetMax
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getReadNullMaskedParquetEncryptedValue;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcBloomFiltersEnabled;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isOrcZstdJniDecompressionEnabled;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.isParquetBatchReaderVerificationEnabled;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.isParquetBatchReadsEnabled;
 import static com.facebook.presto.iceberg.TypeConverter.ORC_ICEBERG_ID_KEY;
 import static com.facebook.presto.iceberg.TypeConverter.toHiveType;
 import static com.facebook.presto.iceberg.delete.EqualityDeleteFilter.readEqualityDeletes;


### PR DESCRIPTION
## Description
Make use of Iceberg session properties for Iceberg connector instead of Hive.

## Motivation and Context
Make use of Iceberg session properties for Iceberg connector instead of Hive.

## Impact
None

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

