### PR TITLE
Add release notes for 0.285

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -730,6 +730,21 @@ The following operations are not supported when ``avro_schema_url`` is set:
 * Using partitioning(``partitioned_by``) or bucketing(``bucketed_by``) columns are not supported in ``CREATE TABLE``.
 * ``ALTER TABLE`` commands modifying columns are not supported.
 
+Parquet Writer Version
+----------------------
+
+Presto now supports Parquet writer versions V1 and V2 for Hive catalog.
+It can be toggled using session property ``parquet_writer_version`` and config property ``hive.parquet.writer.version``.
+Valid values for these properties are PARQUET_1_0 and PARQUET_2_0. Default is PARQUET_2_0.
+
+E.g., To set for a session, use below command by replacing <catalog-name> with actual catalog name:
+
+* ``set session <catalog-name>.parquet_writer_version=PARQUET_1_0``
+
+or in Hive connector properties file, add line as so:
+
+* ``hive.parquet.writer.version=PARQUET_1_0``
+
 Procedures
 ----------
 

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -577,6 +577,21 @@ schema evolution, such as adding, dropping, and renaming columns. With schema
 evolution, users can evolve a table schema with SQL after enabling the Presto
 Iceberg connector.
 
+Parquet Writer Version
+----------------------
+
+Presto now supports Parquet writer versions V1 and V2 for Iceberg catalog.
+It can be toggled using session property ``parquet_writer_version`` and config property ``hive.parquet.writer.version``.
+Valid values for these properties are PARQUET_1_0 and PARQUET_2_0. Default is PARQUET_2_0.
+
+E.g., To set for a session, use below command by replacing <catalog-name> with actual catalog name:
+
+* ``set session <catalog-name>.parquet_writer_version=PARQUET_1_0``
+
+or in Iceberg connector properties file, add line as so:
+
+* ``hive.parquet.writer.version=PARQUET_1_0``
+
 Example Queries
 ^^^^^^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,7 +5,8 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
-    release/release-0.284
+    Release-0.285 [2023-12-08] <release/release-0.285>
+    Release-0.284 [2023-10-11] <release/release-0.284>
     Release-0.283 [2023-08-08] <release/release-0.283>
     release/release-0.282
     release/release-0.281

--- a/presto-docs/src/main/sphinx/release/release-0.285.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.285.rst
@@ -43,7 +43,7 @@ _______________
 Hive Connector Changes
 ____________
 * Changes in ParquetPageSourceFactory so that the type-check does not fail with the new widenings supported.
-* Support for Parquet writer versions V1 and V2 is now added for Hive and Iceberg catalogs. It can be toggled using session property `parquet_writer_version` and config property `hive.parquet.writer.version`. Valid values for these properties are PARQUET_1_0 and PARQUET_2_0. Default is PARQUET_2_0. E.g., set session parquet_writer_version=PARQUET_1_0 / hive.parquet.writer.version=PARQUET_1_0.
+* Support for Parquet writer versions V1 and V2 is now added for Hive and Iceberg catalogs. For usage, see `Parquet Writer Version <../connector/hive.html#parquet-writer-version>`_.
 
 Iceberg Connector Changes
 _______________

--- a/presto-docs/src/main/sphinx/release/release-0.285.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.285.rst
@@ -1,0 +1,68 @@
+=============
+Release 0.285
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix High Memory Task killer to kill highest memory consuming query.
+* Fix logging of optimizer triggering, eliminating false positives where optimizer is logged as triggered but actually not. The PlanOptimizer now return both result plan and whether the plan changed or not.
+* Fix the simplify plan with empty input rule to also work for union node with empty input but more than one non-empty input.
+* Fix typo in high memory task killer strategy config `experiemental.task.high-memory-task-killer-strategy` to `experimental.task.high-memory-task-killer-stragtegy`.
+* Improve history optimizer latency for queries which timeout during query registration in history optimizer.
+* Improve latency of history based optimizer.
+* Add High Memory Task Killer which troggers if worker is running out of memory and garbage collection not able to reclaim enough memory. The feature is enabled by `experimental.task.high-memory-task-killer-enabled`.  There are two strategies for the task killer which can be set via `experiemental.task.high-memory-task-killer-strategy`. (default: `FREE_MEMORY_ON_FULL_GC`, `FREE_MEMORY_ON_FREQUENT_FULL_GC`).
+* Add a session property `history_input_table_statistics_matching_threshold` to set the threshold for input statistics match in HBO.
+* Add an optimization, which removes the redundant cast to varchar expression in join condition. The optimizer is controlled by session property `remove_redundant_cast_to_varchar_in_join` and enabled by default.
+* Add config to enable memory based split processing slow down. This can be enabled via `task.memory-based-slowdown-threshold`.
+* Add optimization for scaled writers with HBO, it can improve latency for query with scaled writer enabled. It's controlled by session property `enable_hbo_for_scaled_writer` and default to false.
+* Added links for the REST API resource pages to the Presto documentation.
+* Added type widening support to the parquet column readers (int, bigint, and float) to be able to perform type conversions between inmediate numerical types.
+* Change PushPartialAggregationThroughExchange optimization to use partial aggregation statistics when available, and when use_partial_aggregation_history=true.
+* Enable optimization of values node followed by false filter to empty values node.
+* Enhance join-reordering to work with non-simple equi-join predicates.
+* Extends HBO to track statistics of execution partial aggregation nodes.
+* Free memory on frequent full garbage collection strategy triggers task killer if worker is having frequent garbage collection and enough memory is not reclaimed during the garbage collections. Frequent garbage collection is identified via `experimental.task.high-memory-task-killer-frequent-full-gc-duration-threshold` and reclaim memory threshold is configured via `experimental.task.high-memory-task-killer-reclaim-memory-threshold`.
+* Free memory on full garbage collection strategy triggers task killer if worker is running low memory and full GC is not able to reclaim enough memory. Low memory threhold is set by  `experimental.task.high-memory-task-killer-heap-memory-threshold`  and Full GC reclaim memory threhold is set by `experimental.task.high-memory-task-killer-reclaim-memory-threshold`.
+* Iceberg connector now supports ANALYZE when configured with a Hive catalog and the table is unpartitioned.
+* Introduces a new flag use_partial_aggregation_history, which controls whether or not partial aggregation histories are used in deciding whether to split aggregates into partial and final.
+* MinbyN/maxbyN's third argument (N) is now checked to be unique.
+* Print information about cost-based optimizers and the source of stats they use (CBO/HBO) in explain plans when session property verbose_optimizer_info_enabled=true.
+* The Iceberg connector now supports `ALTER TABLE <table> ADD COLUMN <column> [WITH (partitioning = '<transform_func>')]` statements to indicate partition transform when add column to table.
+* The Iceberg connector now supports `DELETE FROM <table> [where <filter>]` statements to delete one or more entire partitions.
+* Track null probe keys in join and use it to enable outer join null salt in history based optimization.
+* Update Babel and related npm packages to solve critical vulnerability: https://github.com/advisories/GHSA-67hx-6x53-jw92 The Babel packages are used to generate the JavaScript files for Presto UI. The update prevents the build servers or developers' machines from running arbitrary code while building the JavaScript files.
+* Update Joda-Time to 2.12.5 to use 2023c tzdata. Note: a corresponding update to the Java runtime should also be made to ensure consistent timezone data. For example, Oracle JDK 8u381, tzdata-java-2023c rpm for OpenJDK, or use Timezone Updater Tool to apply 2023c tzdata to existing JVM.
+* Updated docs accordingly (hive connector - schema evolution).
+* When partial aggregation statistics are used in PushPartialAggregationThroughExchange, the optimization also applies to multi-key aggregations (as opposed to single-key only when CBO is used).
+
+Hive Changes
+____________
+* Changes in ParquetPageSourceFactory so that the type-check does not fail with the new widenings supported.
+* Support for Parquet writer versions V1 and V2 is now added for Hive and Iceberg catalogs. It can be toggled using session property `parquet_writer_version` and config property `hive.parquet.writer.version`. Valid values for these properties are PARQUET_1_0 and PARQUET_2_0. Default is PARQUET_2_0. E.g., set session parquet_writer_version=PARQUET_1_0 / hive.parquet.writer.version=PARQUET_1_0.
+
+Iceberg Changes
+_______________
+* Fix iceberg table creation using glue metastore.
+* SHOW STATS command will support timestamp column based on user session's time zone.
+* Support view creation via Iceberg connector.
+* Timestamp with time zone data type is not allowed in create table and alter table statements.
+* Update Iceberg version from 1.3.1 to 1.4.1.
+
+Pinot Changes
+_____________
+* Fix pinot single quote literal push down issue.
+
+Prestissimo (native Execution) Changes
+______________________________________
+* Add support for internal authentication using JWT. It can be configured using configs "internal-communication.jwt.enabled=[true/false]", "internal-communication.shared-secret=<shared-secret-value>" and "internal-communication.jwt.expiration-seconds=<value in seconds>".
+
+**Credits**
+===========
+
+Ajay George, Ajay Gupte, Amit Dutta, Anant Aneja, Andrii Rosa, Arjun Gupta, Avinash Jain, Beinan, Bikramjeet Vig, Chandrashekhar Kumar Singh, Christian Zentgraf, Chunxu Tang, Deepak Majeti, Eduard Tudenhoefner, James Xu, Jialiang Tan, JiamingMai, Jimmy Lu, Jonathan Hehir, Karteekmurthys, Ke, Kevin Wilfong, Krishna Pai, Lyublena Antova, Mahadevuni Naveen Kumar, Masha Basmanova, Michael Shang, Miguel Blanco Godón, Nikhil Collooru, Pedro Pedreira, Pranjal Shankhdhar, Pratyush Verma, Ruslan Mardugalliamov, Sergey Pershin, Sergii Druzkin, Shrinidhi Joshi, Sotirios Delimanolis, Sreeni Viswanadha, Steve Burnett, Sudheesh, Swapnil Tailor, Tim Meehan, Xiang Fu, Yihong Wang, Zac Blanco, aditi-pandit, feilong-liu, kedia,Akanksha, kiersten-stokes, mmorgan98, pratyakshsharma, wangd, wypb, xiaoxmeng, yingsu00

--- a/presto-docs/src/main/sphinx/release/release-0.285.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.285.rst
@@ -29,7 +29,6 @@ _______________
 * Extends HBO to track statistics of execution partial aggregation nodes.
 * Free memory on frequent full garbage collection strategy triggers task killer if worker is having frequent garbage collection and enough memory is not reclaimed during the garbage collections. Frequent garbage collection is identified via `experimental.task.high-memory-task-killer-frequent-full-gc-duration-threshold` and reclaim memory threshold is configured via `experimental.task.high-memory-task-killer-reclaim-memory-threshold`.
 * Free memory on full garbage collection strategy triggers task killer if worker is running low memory and full GC is not able to reclaim enough memory. Low memory threhold is set by  `experimental.task.high-memory-task-killer-heap-memory-threshold`  and Full GC reclaim memory threhold is set by `experimental.task.high-memory-task-killer-reclaim-memory-threshold`.
-* Iceberg connector now supports ANALYZE when configured with a Hive catalog and the table is unpartitioned.
 * Introduces a new flag use_partial_aggregation_history, which controls whether or not partial aggregation histories are used in deciding whether to split aggregates into partial and final.
 * MinbyN/maxbyN's third argument (N) is now checked to be unique.
 * Print information about cost-based optimizers and the source of stats they use (CBO/HBO) in explain plans when session property verbose_optimizer_info_enabled=true.
@@ -41,20 +40,21 @@ _______________
 * Updated docs accordingly (hive connector - schema evolution).
 * When partial aggregation statistics are used in PushPartialAggregationThroughExchange, the optimization also applies to multi-key aggregations (as opposed to single-key only when CBO is used).
 
-Hive Changes
+Hive Connector Changes
 ____________
 * Changes in ParquetPageSourceFactory so that the type-check does not fail with the new widenings supported.
 * Support for Parquet writer versions V1 and V2 is now added for Hive and Iceberg catalogs. It can be toggled using session property `parquet_writer_version` and config property `hive.parquet.writer.version`. Valid values for these properties are PARQUET_1_0 and PARQUET_2_0. Default is PARQUET_2_0. E.g., set session parquet_writer_version=PARQUET_1_0 / hive.parquet.writer.version=PARQUET_1_0.
 
-Iceberg Changes
+Iceberg Connector Changes
 _______________
-* Fix iceberg table creation using glue metastore.
+* Support ANALYZE when configured with a Hive catalog and the table is unpartitioned.
+* Support iceberg table creation using glue metastore.
 * SHOW STATS command will support timestamp column based on user session's time zone.
 * Support view creation via Iceberg connector.
-* Timestamp with time zone data type is not allowed in create table and alter table statements.
+* Disable timestamp with time zone type in create table and alter table statements.
 * Update Iceberg version from 1.3.1 to 1.4.1.
 
-Pinot Changes
+Pinot Connector Changes
 _____________
 * Fix pinot single quote literal push down issue.
 


### PR DESCRIPTION
# Missing Release Notes
## Avinash Jain
- [x] https://github.com/prestodb/presto/pull/20752 Add support for array_least_frequent UDF (Merged by: Nikhil Collooru)

## Beinan
- [x] f89299ab9707a6fbfedabbe158e5b675697674b4 Upgrade Alluxio to 304

## Bikramjeet Vig
- [ ] https://github.com/prestodb/presto/pull/21382 [native] Rename session property to confirm to Presto standard (Merged by: Ke)
- [ ] https://github.com/prestodb/presto/pull/21266 [native] Add static mapping of native query configs (Merged by: Xiaoxuan)
- [x] https://github.com/prestodb/presto/pull/21036 [Native] Add debug config for native engine execution (Merged by: Deepak Majeti)
- [ ] https://github.com/prestodb/presto/pull/21039 [native] Advance velox version (Merged by: Deepak Majeti)

## JiamingMai
- [x] https://github.com/prestodb/presto/pull/21034 Add HANA connector (Merged by: Beinan)

## Jimmy Lu
- [ ] https://github.com/prestodb/presto/pull/21367 [native] Share HTTP connection pools between HTTP clients (Merged by: spershin)
- [ ] https://github.com/prestodb/presto/pull/21379 [native] Set connection time out so connection error can be retried timely (Merged by: spershin)
- [ ] https://github.com/prestodb/presto/pull/20969 [native-pos] Disable AsyncDataCache (thus prefetching) (Merged by: Maria Basmanova)

## Ke
- [ ] https://github.com/prestodb/presto/pull/21023 [Native] Trim native prefix for system session property (Merged by: Nikhil Collooru)

## Kevin Wilfong
- [ ] https://github.com/prestodb/presto/pull/21265 [native] Convert input field names to lower case in plan conversion (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21325 [native] Add caching of parsed Types (Merged by: Xiaoxuan)
- [x] https://github.com/prestodb/presto/pull/21368 [native] Clean old tasks based on termination time (Merged by: spershin)
- [ ] https://github.com/prestodb/presto/pull/21354 [native] Advance Velox (Merged by: Amit Dutta)

## Lyublena Antova
- [ ] https://github.com/prestodb/presto/pull/19904 Extend payload join optimization for cases without map columns; fix b… (Merged by: Lyublena Antova)

## Pratyush Verma
- [ ] https://github.com/prestodb/presto/pull/21133 Revert "Fix memory reservation accounting problem about InMemoryHashAggregationBuilder inside SpillableHashAggregationBuilder." (Merged by: Pratyush Verma)

## Sotirios Delimanolis
- [ ] https://github.com/prestodb/presto/pull/21333 Update Drift dependency to use Header transport by default (2nd attempt) (Merged by: Ajay George)

## Zac Blanco
- [x] https://github.com/prestodb/presto/pull/20993 [Iceberg] Write NDVs to Iceberg table format (Merged by: Timothy Meehan)

## kedia,Akanksha
- [x] https://github.com/prestodb/presto/pull/21171 Add docs for Prestodb to MySQL type mapping in MySQL Connector (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/21129 Update AWS SDK 1.12.261 to 1.12.560 (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/21214 Fix Typo in PageBuilder (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/21112 Improve layout of table for SHOW STATS in docs (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/21174 Update Avro version 1.11.3 (Merged by: Sudheesh)
- [ ] https://github.com/prestodb/presto/pull/21057 Improve documentation of Presto Resource Groups (Merged by: Timothy Meehan)

## xiaoxmeng
- [ ] https://github.com/prestodb/presto/pull/21385 [native]Fix duplicate root memory pool in case of background arbitration (Merged by: Xiaoxuan)

# Extracted Release Notes
- #19872 (Author: pratyakshsharma): Add views support in iceberg connector
  - Support view creation via Iceberg connector.
- #19983 (Author: Miguel Blanco Godón): Match hive support for type widening in the hive connector
  - Added type widening support to the parquet column readers (int, bigint, and float) to be able to perform type conversions between inmediate numerical types.
  - Updated docs accordingly (hive connector - schema evolution).
  - Changes in ParquetPageSourceFactory so that the type-check does not fail with the new widenings supported.
- #20290 (Author: Christian Zentgraf): [native] Add JWT processing when using http(s) comms
  - Add support for internal authentication using JWT. It can be configured using configs "internal-communication.jwt.enabled=[true/false]", "internal-communication.shared-secret=<shared-secret-value>" and "internal-communication.jwt.expiration-seconds=<value in seconds>".
- #20699 (Author: pratyakshsharma): Fix iceberg table creation using glue metastore
  - Fix iceberg table creation using glue metastore.
- #20720 (Author: Zac Blanco): [Iceberg] Implement ANALYZE when Hive is configured
  - Iceberg connector now supports ANALYZE when configured with a Hive catalog and the table is unpartitioned.
- #20901 (Author: feilong-liu): Set initial number of tasks for scaled writer with HBO
  - Add optimization for scaled writers with HBO, it can improve latency for query with scaled writer enabled. It's controlled by session property `enable_hbo_for_scaled_writer` and default to false.
- #20946 (Author: Swapnil Tailor): Heap Memory Based Worker Flag to stop processing new split when in low memory
  - Add config to enable memory based split processing slow down. This can be enabled via `task.memory-based-slowdown-threshold`.
- #20957 (Author: Mahadevuni Naveen Kumar): Support Parquet writer versions V1 and V2
  - Support for Parquet writer versions V1 and V2 is now added for Hive and Iceberg catalogs. It can be toggled using session property `parquet_writer_version` and config property `hive.parquet.writer.version`. Valid values for these properties are PARQUET_1_0 and PARQUET_2_0. Default is PARQUET_2_0. E.g., set session parquet_writer_version=PARQUET_1_0 / hive.parquet.writer.version=PARQUET_1_0.
- #20990 (Author: Lyublena Antova): Track whether an optimization decision was cost-based
  - Print information about cost-based optimizers and the source of stats they use (CBO/HBO) in explain plans when session property verbose_optimizer_info_enabled=true.
- #21020 (Author: Xiang Fu): [pinot connector] Fix pinot single quote literal push down issue
  - Fix pinot single quote literal push down issue.
- #21048 (Author: wangd): Support deleting whole partitions in Iceberg table
  - The Iceberg connector now supports `DELETE FROM <table> [where <filter>]` statements to delete one or more entire partitions.
- #21050 (Author: feilong-liu): Remove redundant cast to varchar in join clause
  - Add an optimization, which removes the redundant cast to varchar expression in join condition. The optimizer is controlled by session property `remove_redundant_cast_to_varchar_in_join` and enabled by default.
- #21063 (Author: feilong-liu): Add session property to set input table matching threshold
  - Add a session property `history_input_table_statistics_matching_threshold` to set the threshold for input statistics match in HBO.
- #21096 (Author: Ajay Gupte): Disable timestamp with time zone type for ddl
  - Timestamp with time zone data type is not allowed in create table and alter table statements.
- #21153 (Author: Anant Aneja): Enhance join reordering to work with non-simple equi-join clauses
  - Enhance join-reordering to work with non-simple equi-join predicates.
- #21160 (Author: Lyublena Antova): Track result sizes of partial aggregate evaluation in HBO
  - Extends HBO to track statistics of execution partial aggregation nodes.
  - Introduces a new flag use_partial_aggregation_history, which controls whether or not partial aggregation histories are used in deciding whether to split aggregates into partial and final.
  - Change PushPartialAggregationThroughExchange optimization to use partial aggregation statistics when available, and when use_partial_aggregation_history=true.
  - When partial aggregation statistics are used in PushPartialAggregationThroughExchange, the optimization also applies to multi-key aggregations (as opposed to single-key only when CBO is used).
- #21183 (Author: Steve Burnett): add REST API to docs index
  - Added links for the REST API resource pages to the Presto documentation.
- #21186 (Author: feilong-liu): Simplify union node with empty input
  - Fix the simplify plan with empty input rule to also work for union node with empty input but more than one non-empty input.
- #21203 (Author: feilong-liu): Add null stats for join probe
  - Track null probe keys in join and use it to enable outer join null salt in history based optimization.
- #21206 (Author: wangd): Support indicating partition transform when add column to Iceberg table
  - The Iceberg connector now supports `ALTER TABLE <table> ADD COLUMN <column> [WITH (partitioning = '<transform_func>')]` statements to indicate partition transform when add column to table.
- #21226 (Author: feilong-liu): Fix logging of plan optimizer
  - Fix logging of optimizer triggering, eliminating false positives where optimizer is logged as triggered but actually not. The PlanOptimizer now return both result plan and whether the plan changed or not.
- #21230 (Author: Eduard Tudenhoefner): Update Iceberg from 1.3.1 to 1.4.1
  - Update Iceberg version from 1.3.1 to 1.4.1.
- #21254 (Author: Swapnil Tailor): Worker Low Heap Memory Task Killer
  - Add High Memory Task Killer which troggers if worker is running out of memory and garbage collection not able to reclaim enough memory. The feature is enabled by `experimental.task.high-memory-task-killer-enabled`.  There are two strategies for the task killer which can be set via `experiemental.task.high-memory-task-killer-strategy`. (default: `FREE_MEMORY_ON_FULL_GC`, `FREE_MEMORY_ON_FREQUENT_FULL_GC`).
  - Free memory on full garbage collection strategy triggers task killer if worker is running low memory and full GC is not able to reclaim enough memory. Low memory threhold is set by  `experimental.task.high-memory-task-killer-heap-memory-threshold`  and Full GC reclaim memory threhold is set by `experimental.task.high-memory-task-killer-reclaim-memory-threshold`.
  - Free memory on frequent full garbage collection strategy triggers task killer if worker is having frequent garbage collection and enough memory is not reclaimed during the garbage collections. Frequent garbage collection is identified via `experimental.task.high-memory-task-killer-frequent-full-gc-duration-threshold` and reclaim memory threshold is configured via `experimental.task.high-memory-task-killer-reclaim-memory-threshold`.
- #21275 (Author: feilong-liu): Convert values node followed by false filter to empty values node
  - Enable optimization of values node followed by false filter to empty values node.
- #21286 (Author: Ajay Gupte): Enable timestamp type for SHOW STATS command
  - SHOW STATS command will support timestamp column based on user session's time zone.
- #21297 (Author: feilong-liu): Improve latency for HBO optimizer
  - Improve latency of history based optimizer.
- #21306 (Author: mmorgan98): Check consistency of param N for min_byN/max_byN
  - MinbyN/maxbyN's third argument (N) is now checked to be unique.
- #21308 (Author: feilong-liu): Skip history optimizer query registration if previous registration timeout
  - Improve history optimizer latency for queries which timeout during query registration in history optimizer.
- #21322 (Author: Yihong Wang): Solve critical vulnerability of Presto UI from `@babel/traverse` npm package
  - Update Babel and related npm packages to solve critical vulnerability: https://github.com/advisories/GHSA-67hx-6x53-jw92 The Babel packages are used to generate the JavaScript files for Presto UI. The update prevents the build servers or developers' machines from running arbitrary code while building the JavaScript files.
- #21327 (Author: Swapnil Tailor): Fix Typo in High Memory Task Manager Config
  - Fix typo in high memory task killer strategy config `experiemental.task.high-memory-task-killer-strategy` to `experimental.task.high-memory-task-killer-stragtegy`.
- #21329 (Author: Yihong Wang): Update Joda-Time to 2.12.5
  - Update Joda-Time to 2.12.5 to use 2023c tzdata. Note: a corresponding update to the Java runtime should also be made to ensure consistent timezone data. For example, Oracle JDK 8u381, tzdata-java-2023c rpm for OpenJDK, or use Timezone Updater Tool to apply 2023c tzdata to existing JVM.
- #21349 (Author: Swapnil Tailor): Fix High Memory Task Killer to kill highest memory consuming query
  - Fix High Memory Task killer to kill highest memory consuming query.

# All Commits
- f89299ab9707a6fbfedabbe158e5b675697674b4 Upgrade Alluxio to 304 (Beinan)
- 27c6d9e60618c3607bef6b7732c24b6e739b957d Track result sizes of partial aggregate evaluation in HBO (Lyublena Antova)
- 2229fc4fe5f754853d66975e3c114b2be1aa0525 [Iceberg] Add native NDV read and write support (Zac Blanco)
- fb85091ec4c771a161b484a13f6092eff4312c19 update deploy-docker.rst (Steve Burnett)
- f2f671802ad10124b06d4a53585c784f03eb76ed Update query config to conform to presto standards (Bikramjeet Vig)
- b2fc43cb300d8f3a809f773b12d5a2ce44ad3c8a [native]Fix duplicate root memory pool in case of background arbitration (xiaoxmeng)
- 2c5bdb440b05ba3b0a2fbab63528a6865de1ebd0 Update Drift dependency to use Header transport by default (Sotirios Delimanolis)
- 279cd59051828bff5a2cff47569e44e2a8313157 [native] Share HTTP connection pools between HTTP clients (Jimmy Lu)
- 1e2a5ae00f9347558ca76ed8ea36de9bd45e798b [native] Set connection time out so connection error can be retried timely (Jimmy Lu)
- 4b7cc475fd222cab1286c889fd23b26db1570d18 [native] Advance Velox (Masha Basmanova)
- 7c51fd27e7b1f10234103a70efb9bbeeb79d525a [native] Streamline default number of threads in HTTP thread pools. (Sergey Pershin)
- 4f9bc23afc7f90ae1350962c382138fd2bebf11d Bypass metastore locking in Glue (pratyakshsharma)
- 81850dc03e6835f9f20920435d3fa06efa00960b [native] Convert input field names to lower case in plan conversion (Kevin Wilfong)
- d1c5d8303d1ea0e3f312faf4a387a48f0f0f98c3 [native] Add caching of parsed Types (Kevin Wilfong)
- 6c48ec5d0a6ceac7cd75446d33674bac2ae4199e Solve critical vulnerability of Presto UI (Yihong Wang)
- 1ca0f988156e9d689ee5694a04178e08dcce3eb7 [native] Clean old tasks based on termination time (Kevin Wilfong)
- 820b29fca9e3d8dcff4b2b8c0cad6ee81559ebca Check consistency of param N for min_byN/max_byN (mmorgan98)
- 67d04e073d4a84cf0d996bda4b209e16b27d7e39 [docs] Add documentation on @NullablePosition (Zac Blanco)
- 40d652d14a68019db0aa6f89f2c3adb18507a61a Add docs for Prestodb to MySQL type mapping in MySQL Connector (kedia,Akanksha)
- ec00815a8520cb06bb80edce75b0533a6b2eb578 [native] Advance Velox (Kevin Wilfong)
- 88150762d8a35d1e266c9b8324336a2ad999b36d Fix latency for HBO optimizer (feilong-liu)
- dae8a28f0ee15acee56a2086df5a56c2bb0576ef Skip HBO registration if previous registration timeout (feilong-liu)
- d39ce0ff6e8ec4ce7122a0aa32c771aae286c693 Remove invalid query ID cache from HBO cache manager (feilong-liu)
- 278c2854189ee08e54054d0b128f9b2a67d1ba56 [docs] Add advanced usage for java functions impls (Zac Blanco)
- 8282585616525a64fdb45c09a379a42f621c3058 Fix High Memory Task Killer (Swapnil Tailor)
- 7eb618828836f79372e69e8c9ca0f194f0828715 [native] Add static mapping of native query configs (Bikramjeet Vig)
- 08b771c297d124e41e51b3a7d61066463d9dc0c0 [native] Add serde parameter to remote function server configuration (Pedro Pedreira)
- d35917c8f4d03da157ceca2b0e9fb3d57896963c Update Joda-Time to 2.12.5 (Yihong Wang)
- ed06dfb5730c569f7e366afd88cac518d71fa7b3 x (Swapnil Tailor)
- 641c2693879270996ce463368b0d6afe0b636338 Fix Typo in High Memory Task Manager Config (Swapnil Tailor)
- 43f996d87644921727bbc616457f4d30a67c6451 Allow Type in agg function metadata constructors (Zac Blanco)
- 9a2e540a8bb90bd7a7a1c7ec8c71f1336bcf793b Add support for user provided execution strategy (Chandrashekhar Kumar Singh)
- 02889cdbd7a52bb28a3420119c3f26f98c932013 SQL statements support simple literal, as well as Unicode usage (kedia,Akanksha)
- e4d8fc142e804923e7d99ae868fe646dfd62a734 [native] Ensure all ExchangeSource instances are created via make_shared(). (Sergey Pershin)
- 351244117dd2580b0d631c8c755a045c5fd86193 [native pos] Extend logging in NativeExecutionProcess (Andrii Rosa)
- 0d350c4c643158fa797caa4061549d3571e51679 [native pos] Trigger coredump when native process becomes unresponsive (Andrii Rosa)
- b20986f87e3e052a4db28857b861cf87e073cf18 [native pos] Use RequestErrorTracker to retry task update requests (Andrii Rosa)
- b0542ce560f2a90208ab79a22211e68d16b49ca1 [native pos] Recover Thread#interrupted flag (Andrii Rosa)
- 5530cb65591d3a5d2f0619ba0c446593761c42bc [native pos] Safely publish NativeExecutionProcess#process (Andrii Rosa)
- e8108d165b3ff5b5b46673ffbeef1dab6c4d485d [native] Rename TestNativeProbabilityFunctionQueries to TestPresto... (Michael Shang)
- 4e27cd06a3a98b963f1313a8775f1dd724f79725 Fix comments (aditi-pandit)
- 42f046280b585d4a805c6d09be86acd99d147f61 [native] Fix result for empty global grouping sets (aditi-pandit)
- 32f76b9712859011c99d7d54ab7062b5febd95df [native] Make PrestoServer own the common thread pools (Jialiang Tan)
- 16970a044a55b0da629d20057a7ae909affaa008 [native] Add native-execution-enabled flag to NativeQueryRunnerUtils.getNativeWorkerSystemProperties (aditi-pandit)
- f0bd6a517ddbb048fdcd30d1abd5436487a732b8 [native] add a test case for text reader (Michael Shang)
- 8a0da754c7d84ceb8c5c3dd3b6a11303e2430a6d [native]Change spiller executor to cpu executor (xiaoxmeng)
- 4199cade38534fa4d8a8a53d75ddae8e83182fba [native] Advance Velox (aditi-pandit)
- e9b4ed42c2ab5ec77acd380f3697ecd680737df7 Add test case for deletion in Iceberg table with partition evolution (wangd)
- d1183bc81802ee31bf0ca1b7151db45a4f37d2d6 Disallow dropping partition column in Iceberg table explicitly (wangd)
- 541d7ec8c06d91d16fdf3d140b5972953b391d26 [native]Advance velox version and code cleanup (xiaoxmeng)
- 1e250215f14623d3c1b800775873c981dfe19687 Correct return type of cume_dist() in docs (Jonathan Hehir)
- 8b56666e0e4ab00658341e993d705a3f83c0a15d Enable timestamp type for SHOW STATS command (Ajay Gupte)
- 3b0fb821aa002fe1abd2f9cf8a98ceb09cc8cc90 Upgrade parquet to 1.13.1 (wypb)
- 2e26dea390d27a3e80137401ec55ae37da1db152 Update AWS SDK v1 to 1.12.560 (kedia,Akanksha)
- bd3cf42330a754809248f8a48a5d1c5f408261be Worker Low Heap Memory Task Killer (Swapnil Tailor)
- 14e44e47fd27d5fe31253107608642a78a9cff7f [native] Advance velox version (aditi-pandit)
- b1d33ab0db9a042ec0a51b80b20ffab01623c94d Make the data directory used by QueryRunners in sync (yingsu00)
- 66aab8b7ef886fcebf38fae2d2e9094f12fe3f6b Convert values node followed by false filter to empty values node (feilong-liu)
- a4d40dfc9729354255443837637adfec763a3c1e Use in-memory history provider with HiveQueryRunner (Lyublena Antova)
- a8a88149dba77f7ebef59c85744995e9927c8a25 Update Iceberg from 1.3.1 to 1.4.1 (Eduard Tudenhoefner)
- f2ff4d12f8bc710c09deefa9153c26e6aacbc495 [Iceberg] Clean up TableStatisticsMaker dead code (Zac Blanco)
- 98b9d02eaf3d9b961e10cb65185313f30491e9da Automatically label doc-only PRs (Tim Meehan)
- 28302cd7479841578a02c7e09f5e1b254520f50c [native pos] Unregister shuffle handle on ShuffleWriter#stop (Andrii Rosa)
- 53a46d984425595627ccb1e5f24aaec78c1f1036 [native pos] Rely on Spark to decide if stage writes to shuffle (Andrii Rosa)
- 2172b36f22f450a996ea495efb014eb79cc06375 [native pos] Disable optimized-partition-update-serialization (Andrii Rosa)
- 696abe8e7a96a2f35978609e024c6fa9402a8feb [native] Mitigate partitioning incompatibility for system tables (Andrii Rosa)
- d213e21f866706371c148f1984da8740ef93667f [native] Include native workers in the total number of cluster nodes (Andrii Rosa)
- d2df4437ded872ec3d79fb6240e1be6563ba88b6 Fix bug in recursive assignment resolver (Anant Aneja)
- 7e898513f5c55b30077687a6ee64c7a5e650eb24 test (Jialiang Tan)
- f1cd0305ce10b3a91ab98be42d06bc7010e65752 Increase timeout when starting test query runner (Michael Shang)
- 6376fa02a96aa6cbbbc5463996ee1fa510fec06b [native] Offload work from io thread pool to driver thread pool (Jialiang Tan)
- b138fb50ed56bae25d6f1c391c627d0e3528b6a7 [native] Categorize memory abort exception as insufficient resource (Jialiang Tan)
- d209e378ebf9d00fa982e7f4787f662c5ef488ef Updating documentation of MAP_TOP_N_KEYS (Avinash Jain)
- 409404a505bcd9ea9b94496e2c6acb7ddcdb9504 Remove duplicate code for get Iceberg table of different catalogType (wangd)
- efdd8e09d68e3f9e2fad4e8b3b23c23a1d9163de Enhance join reordering to work with non-simple equi-join clauses (Anant Aneja)
- 061c340e55c9e689bb655d91824533f3ec705b71 [native] Pass serde parameters down to insert table handle (Jialiang Tan)
- 83b20c062d3125d392b8665385c68aa0c2518db7 [native]Advance velox version (xiaoxmeng)
- 7c6bc6e52f7d4895fed40d153caa0e8ec9ea83b0 [native] Translate array agg config to velox (Pranjal Shankhdhar)
- 2a18649d811345d3ecfb96c44b6db28e39be85f5 Add null stats for join probe (feilong-liu)
- 54edca6cf1c6a78fd54f9412eb33185be354c08b Address review comments (James Xu)
- 69bed7f13eabb533cb00a7f2b96d4ddb93c19947 Describe Lead/Lag + Null Offset behavior more clearly (James Xu)
- b67703aecec659dfc6335b5cb42dee2d3b628390 Support indicating partition transform when add column to Iceberg table (wangd)
- 4b4b6dff9ea7e820894055bc9e2b0cf74c067151 Fix the content of Hive security configuration page (pratyakshsharma)
- 4a93220b055436228654346b135a6185c149fa58 [native] Drop redundant sorting keys from Window and TopNRowNumber nodes (Masha Basmanova)
- a627d9b210d0f24b670cfe1a1e1155c04a00ebfd [native] Advance Velox (Masha Basmanova)
- 82a3bc8796321c09a82ac4379cb677383ac86812 Fix logging of plan optimizer (feilong-liu)
- 9bce03a8d2804a40741390aae4d5107a0c08f5dc Disable timestamp with time zone type on create & alter table for iceberg tables. (Ajay Gupte)
- a00fdc61f1a0c12e243741bd5c5047a2b954a38d [native] Add decimal data test for checksum (wypb)
- d4d3ad6bc9126f35a03b2d88db3b4f3be23ed8dc Reduce memory usage of OptimizedPartitionedOutputOperator (Pranjal Shankhdhar)
- 4f3b8ed61a4ad299bd85972a92c81df3a215fad2 Publish query plan when a query is running in AQE (Chandrashekhar Kumar Singh)
- e9adf8c7192ec86aa946967e625aa51cbd28d26d Add PrestoSparkExecutionContext for capturing different runtine info for logging (Arjun Gupta)
- b6a639b419da0435713c5a0761a325c3eab22928 Expand documentation for reduce_agg (Masha Basmanova)
- 4c8704c2825ebfbd00180ab38b973ef117a8d9ea Add HANA connector (JiamingMai)
- 4d52f63320e879b999fbefcc3d3fa51545797560 Silently drop tables with missing filesystem metadata (kiersten-stokes)
- 7bfbf52d849f97e22f925937512bb42239ecc969 Make setup-ubuntu.sh executable (James Xu)
- a87bbc3849ddfdeef7411ceed748ab045fa62f22 Fix Typo in PageBuilder (kedia,Akanksha)
- ff83f1c853851a6ad429a4d6b0b589c15c19d0bd [native] Wrap generation of OkResponse's HTTP message body in try/catch. (Sergey Pershin)
- 580f2e322940fde195e54a7aec1c4d617c745e10 [Native] Remove redundant plan conversion for TableWriteNode (Ke)
- fe56f794f5891031b382a164ce5cc3a21840a5e1 [native] Add google::InstallFailureSignalHandler() (Deepak Majeti)
- 4ecd7928599d397feeed4cd2b039c770846c148a Fix Iceberg table partitioned by columns of VarbinaryType (wangd)
- fa8ed1458c438eba21d782671098f6c46473a2fb [native] Avoid moving Lambda's arguments in toVeloxExpr(). (Sergey Pershin)
- 36186c99607131fba34a130dbae0a326626d3f0f [Native] Use velox's OutputBufferManager instead of old PartitionedOutputBufferManager (Ke)
- 2b2bf2edf305f7e832b21c96e9c1c11d1968ccfb [Native] Advance velox version (Ke)
- cb589d4365e8be84e3a30e767ec89cab091d532a Simplify union node with empty input (feilong-liu)
- d117ff8d0ee62a1a48329e8d4ebcda68bffa3add Build catalog-specific properties for IcebergQueryRunner w static method (kiersten-stokes)
- 16cb5315a4fc30c51c12bb25c2a70cb9e083189a [native] Document enable-old-task-cleanup and old-task-cleanup-ms configs (Pratyush Verma)
- 5e30a4334a026b3045648f7264ee8765d95a98ea Fix Iceberg table partitioned by columns of TimestampType (wangd)
- 8957e66ba60162ae6768a3e5d81d20bab0a148a3 add REST API to docs index (Steve Burnett)
- 6242b0d2d5104964e83bbfbd42408ad3c540aad0 Improve layout of table for statistics in docs (kedia,Akanksha)
- a53e4b18d3ab96d89690f966f64126f92c42b4cf Allow both Java system properties and environment variables for HiveExternalWorkerQueryRunner (yingsu00)
- 1b1f86147e72c6c18b723a856a7cf0f2a0c07175 [native pos] Disable old task cleanup routine (Pratyush Verma)
- 411ea36b3735dd5c4d247a8fc2c99e472a0fda83 [native pos] Process PartitionAndSerialize in batches to reduce memory pressure (Pratyush Verma)
- 70ecc392450b9e4dc2cb08652c630733bea54adb Add cost based decision log for scaled writer optimizer (feilong-liu)
- 4225f39cfed99e4d16bd520b0a9a945a3ed5dbcc [native] Allow exchange payload copy to happen in driver thread (Jialiang Tan)
- abc74916bf099503b625e6d621a8b14685a869ce [native-pos] Disable AsyncDataCache (thus prefetching) (Jimmy Lu)
- 3d3ee496dbb2b29e85627c40860b6b3a652c2359 Update Avro version 1.11.3 (kedia,Akanksha)
- 8caad946577a9bbfa4ee603b0a9915c22863ea96 Use LinkedBlockingQueue to queue requests when all threads are busy (Nikhil Collooru)
- ceffc7e74cf9775171cb0a3d752253ef99b9a57e [Native] Test fetching from finished velox task for scaled writer (Ke)
- 1f4339897089c1a561b3ef5e39b30e3e4716377f [Native] Advance velox version (Ke)
- c2b7f2c56408b6f96157abf76660f9fd9ccac70f [native] Replace DWRF writer creation with common factory creation (Christian Zentgraf)
- 71d564096f83957dcdcf135ead9ef50396910e62 Fix stream ordering in ORC writer (Sergii Druzkin)
- 14f866e7d36dd2f4182882b3aee4b29934cd63ba [Native] Add e2e test for scaled writer (Ke)
- 53f976028a6b5cbab36acd974bcfc2bf80c1cf36 [native] Expose stats on 'Tasks with a stuck operator'. (Sergey Pershin)
- 85e914dfec4235a2d266015172d832550bed959d [Native] Enhance bucketed table writer test (Ke)
- e59a393d2d13a35380f4eed2c0b7efd27a87ff95 Set cache blob size to fix flaky action (Zac Blanco)
- ef0b19988306cd3f040d344afe96cc13dd4254fd [native] QueryRunner env variables as default config source (Zac Blanco)
- afca9b5f4fc7e3c274ab20bdc2c77171c67aa1fc [Native] move native writer related test to dedicated class (Ke)
- 3ab3e09337342e26edb94978eac3ebc8f73500e5 Fix memory accounting in InMemoryHashAggregationBuilder (Pratyush Verma)
- 2a77f6918dd31c98022c8bb3c0dcdfccf81ea8e1 [Native] cosmetic change to use destination instead of bufferId (Ke)
- c2bc8d1192e04ff62dd9ae2699efbe3d1994b678 List all input types for geometric_mean in doc (James Xu)
- 6661a55708e05c5fa26ddc14e2245e28d7c2e753 [native]Add stats counter for the max spill level exceeded count (xiaoxmeng)
- 6791ea4dbe3180584b67c82338aa9906ae33c6dd Fix typo in TaskExecutor (wangd)
- 9378300f592246adb7e8c1f14e6f9ffcaeb7b762 [native]Add to retry get data error on memory allocation failure (xiaoxmeng)
- c6292d05ebf24a6a713deef3021d03941fa8feb3 [native] Set sane defaults for PRESTO_SERVER and DATA_DIR for NativeQueryRunner (Zac Blanco)
- 3a738e94a917a641128192b355344c5118f061fb [native] Advance Velox. (Sergey Pershin)
- 91efd78315826160f6fe4ec889fba8ec1884a8e6 Throw when trying to interpret a non-scalar function (Sreeni Viswanadha)
- a16e1f7e7c9415e0c4f9e18ac7359736de655d1e Adjust the column width of the task list table (Yihong Wang)
- 626b7e7b6900f030084e8a1035d0f39956725a21 Fix NPE in AbstractVarcharType.writeSlice (Sreeni Viswanadha)
- 0e52fc3247542b2753d3f750acc6aa1f8e1ca507 [native] Refactor TypeSignatureTypeConverter and test (Masha Basmanova)
- ca11fd634e851781ed05c43aeeec7d6c0e039b2e [Iceberg] read and combine statistics from the HMS (Zac Blanco)
- 45bcbcf5e852e62339a859472ce80fc3a1e841d8 [Iceberg] Write Presto statistics to HMS (Zac Blanco)
- 6a582e82f15a4aeacdbb0a6bed7f1d6da3ca9bc8 [Native] Fix GROUPING SETS with multiple aliased columns (aditi-pandit)
- bb13af36c2fc4a64d396eaa3d1ead3b5dc774378 Extend payload join optimization for cases without map columns + bug fixes (Lyublena Antova)
- 0892870ebb439236e1d281e6a43da09e5e48df16 Functions for extracting plan id information from json query plans (Lyublena Antova)
- 8d9dfa9afe754e6329a292091d98964a29156721 Remove redundant cast in join clause (feilong-liu)
- 627165a575e7927783d5857f039807792dd78e4b Revert "Fix memory reservation accounting problem about InMemoryHashAggregationBuilder inside SpillableHashAggregationBuilder." (Pratyush Verma)
- adb705b405d52687cd76b170b19ccc491cecd434 Revert "Add unit test for memory limit in spillable hash aggregation operator when trigger rehash." (Pratyush Verma)
- 071794453d79dd95010913723b9492e23302d085 Use the 3rd number of a TaskId as the task number (Yihong Wang)
- deafa0280c2af9d17fca5200a4c03a778f8a5e7f [native]Send completed get data result if velox task has finished (xiaoxmeng)
- c4df72abca0fa8b9c420ae8280b99803b1031538 [native] Populate AggregationNode::Aggregate::rawInputTypes (Masha Basmanova)
- da7b0f2f290a28d5eb4343c111a8df1d148fb873 [native] Add support for parsing FUNCTION types (Masha Basmanova)
- c7818f11572d78fb5e07b67d139a2688bd50aa12 [native]Add non-reclaimable operator memory reclaim attempts (xiaoxmeng)
- 5a08d8a48d37fb512f988fc5825f0a6345a1359c Fix QueryContextManagerTest.defaultSessionProperties (aditi-pandit)
- 035f523389c1efb7f0a6f7637d076c4e72bb6ebb [Native] Advance Velox version (aditi-pandit)
- 1216027f5f7220cf638a55dfea0d7756b5466cae [native] Add spill max file size to session property (Jialiang Tan)
- aa39d9c6f02df90c34009f4bf188e599a907db26 Add session property to set input table matching threshold (feilong-liu)
- bb433ab6b82a45607fb7765b2e9bf35c0a0e7036 Support deleting whole partitions in Iceberg table (wangd)
- 18ac2486b283a2ba3adb69567ac21b550d78805f Use HBO to set number of tasks for scaled writers (feilong-liu)
- 1e249e14e2f3c7bca1c1377f5696ee324dc066c3 Track number of tasks for scaled writer in HBO (feilong-liu)
- 9104d718332913be6dc1f461917cd1b8594b04ec Add numWrittenFiles in RuntimeStats for TableWriter (Ke)
- 5d0ae9eba7053fcd600c223daf79e6f1746a10b6 [native pos] Fail fast on the driver if broadcast size exceeds the limit (Chandrashekhar Kumar Singh)
- 72763e63940415c1dc40008f918d0b3adfb79c38 [native pos] Report estimated size and row count of broadcast data (Chandrashekhar Kumar Singh)
- 627da722e43ca088870b91cd98c237f1cca88a5f Fix RowExpressionTest to be forward compatible with variant.toJson changes. (Krishna Pai)
- b8c2241d48c56442cdf67c5752c52091f144c7f0 [native] Add query memory session override (Jialiang Tan)
- 3ca13392eb413689c3d5f3ce46359170aab85531 [native] Use QueryConfig's default value for base default (Jialiang Tan)
- 01c962ee88395ae702f63e10812828c309055d88 Update Low memory Monitor feature config to experimental (Swapnil Tailor)
- 6bceeae1a1fd9e767267f9157b620444da5f8ce2 [native] Add native_aggregation_spill_all session property (Jialiang Tan)
- 4114f978239695e3cd007560d6a699d4705bfce7 [native] Advance Velox version (Jialiang Tan)
- 384aca5ee699bf70c9afaa941c362a2ba87f58eb Update partition spec when rename partition column in Iceberg table (wangd)
- ef8ea9fb72ccdf749b603291ca33e3148684b64e [native][circleci] Fix native build failure (Michael Shang)
- ce8acd1980d596bab451a331d89018d91eb76799 Support sorting in the task list (Yihong Wang)
- e795320d7a1e75e1b3328ebb92d814d612bd66b8 Use React table instead of reactalbe (Yihong Wang)
- 53e07a1eb55a08e7d4e97b35c3e345593ad7a076 Track whether an optimization decision was cost-based (Lyublena Antova)
- 4583949d9337c46f2f92c957f773db7201474081 Allow hive pushdown filter for Analyze on partitions (Karteekmurthys)
- 2436043889cbddfdc65486653799c9bdec26d15d Improve documentation of Presto Resource Groups (kedia,Akanksha)
- 6c9b45724e1497677621831baef4c89c75206500 [natie]Fix spill query config default setting (xiaoxmeng)
- ca3012ce2e19359cb028ed21a4a56738abcc5295 [TEST][native][circleci] test on build parallemism (Michael Shang)
- 138c6cc8855e5ad0894421a413c0ccc42debc8a1 [native][circle] lower parallelism to avoid an oom issue (Michael Shang)
- a23819ad98d0e610bf4c166c2d678c82f53be7a4 fixing pinot single quote literal push down issue (Xiang Fu)
- 9d121df9c0ed85e41a5b41b0ef19d6e1bf2ff0ff Add support for array_least_frequent UDF (Avinash Jain)
- ed0c6e7ed8996ae5c79984cf95007434a9386994 Skip Javadoc generation for Maven checks (Tim Meehan)
- 13952e27e3474d35029b2104362c780ee7525e23 [native] Stop using PlanBuilder::finalAggregation with resultTypes API (Masha Basmanova)
- 21ab1ea2425e4bc65532ab156c60333e5a72dd09 [native] Add PrestoQueryRunner (Masha Basmanova)
- 09885f6102fcea6e7fb750c54a26dd52de1b2edf [Native] Add debug config for native engine execution (Bikramjeet Vig)
- dab588a6dd61de6306f0f3966767f1e7209baae4 [native]advance velox version and update the code (xiaoxmeng)
- d1ede7cf62fc9f4fdae4cfd459b39f45777954a8 [native pos] Enable TestPrestoSparkNativeGeneralQueries.testOrderBy/Subqueries/TopN (Masha Basmanova)
- 13ab3dc66419b23171e96099be3a5829181f80aa Fix merge conflict in TestHiveTypeWidening (Tim Meehan)
- ac62c0709525a11f6612a08827cfaaa4446239af [native] Advance velox version (Bikramjeet Vig)
- 0010d5527cc94b91f6720c6390218ddd635f0750 Heap Memory Usage Based Worker Split Processing Slow Down (Swapnil Tailor)
- 154ceeb8d18289ae5feea38f93922023dcf14ae9 Add views support in iceberg connector (pratyakshsharma)
- a8d9b52afac8abe28095ea94c82652e0c90c1faf Add TestIcebergHiveMetadataListing.java class (pratyakshsharma)
- 76b25a642fa74630660b33920a484b3a563867f3 Move buildInitialPrivilegeSet to MetastoreUtil (pratyakshsharma)
- 5434a36ff6bfd4acaa10d5dc5ebe6a621c98a00e Support Parquet writer versions V1 and V2 (Mahadevuni Naveen Kumar)
- 92a45920536a9515cb381180473d39cbab064fd0 [native] Add list all task endpoint to server operation (Jialiang Tan)
- ed5727c4701616dffaca62ef10ceebfe846aab53 [native] Add JWT processing when using http(s) comms (Christian Zentgraf)
- 3736f69d8256973f8005660763036739bf600315 [native]Improve spill directory failure handling (xiaoxmeng)
- e4d6044e522a236aaf87d32733da02c47d6b5f36 Remove subfield pruning for lambda for parametric functions (Ruslan Mardugalliamov)
- 7a6f3768b0f5e2ca9c6052cd1e73f28420874aaa Add subfield pruning from lambdas (Ruslan Mardugalliamov)
- aef486095caf4d5337d74b13b5550e51cc07279e Add NoneSubfield subfield path element (Ruslan Mardugalliamov)
- aaf917d7f351a3dbadd8f00a0240979a1a5745b7 Add type widening support to numeric types (Miguel Blanco Godón)
- accd109230a237d49501f12f9f1c177f2f8b2ac7 [Native] Trim native prefix for system session property (Ke)