### PR TITLE
Remove ref hash session property for Iceberg Nessie catalog

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergResourceFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergResourceFactory.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
-import static com.facebook.presto.iceberg.IcebergSessionProperties.getNessieReferenceHash;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getNessieReferenceName;
 import static com.facebook.presto.iceberg.nessie.AuthenticationType.BASIC;
 import static com.facebook.presto.iceberg.nessie.AuthenticationType.BEARER;
@@ -121,8 +120,6 @@ public class IcebergResourceFactory
 
         if (catalogType == NESSIE) {
             sb.append(getNessieReferenceName(session));
-            sb.append("@");
-            sb.append(getNessieReferenceHash(session));
         }
 
         return sb.toString();
@@ -157,10 +154,6 @@ public class IcebergResourceFactory
         if (catalogType == NESSIE) {
             properties.put("ref", getNessieReferenceName(session));
             properties.put("uri", nessieConfig.getServerUri().orElseThrow(() -> new IllegalStateException("iceberg.nessie.uri must be set for Nessie")));
-            String hash = getNessieReferenceHash(session);
-            if (hash != null) {
-                properties.put("ref.hash", hash);
-            }
             nessieConfig.getReadTimeoutMillis().ifPresent(val -> properties.put("transport.read-timeout", val.toString()));
             nessieConfig.getConnectTimeoutMillis().ifPresent(val -> properties.put("transport.connect-timeout", val.toString()));
             nessieConfig.getClientBuilderImpl().ifPresent(val -> properties.put("client-builder-impl", val));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -77,7 +77,6 @@ public final class IcebergSessionProperties
     private static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
     private static final String NODE_SELECTION_STRATEGY = "node_selection_strategy";
     private static final String NESSIE_REFERENCE_NAME = "nessie_reference_name";
-    private static final String NESSIE_REFERENCE_HASH = "nessie_reference_hash";
     public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
     public static final String PARQUET_DEREFERENCE_PUSHDOWN_ENABLED = "parquet_dereference_pushdown_enabled";
     public static final String MERGE_ON_READ_MODE_ENABLED = "merge_on_read_enabled";
@@ -275,11 +274,6 @@ public final class IcebergSessionProperties
                         "Nessie reference name to use",
                         nessieConfig.getDefaultReferenceName(),
                         false),
-                stringProperty(
-                        NESSIE_REFERENCE_HASH,
-                        "Nessie reference hash to use",
-                        null,
-                        false),
                 booleanProperty(
                         READ_MASKED_VALUE_ENABLED,
                         "Return null when access is denied for an encrypted parquet column",
@@ -456,11 +450,6 @@ public final class IcebergSessionProperties
     public static String getNessieReferenceName(ConnectorSession session)
     {
         return session.getProperty(NESSIE_REFERENCE_NAME, String.class);
-    }
-
-    public static String getNessieReferenceHash(ConnectorSession session)
-    {
-        return session.getProperty(NESSIE_REFERENCE_HASH, String.class);
     }
 
     public static double getMinimumAssignedSplitWeight(ConnectorSession session)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
@@ -157,24 +157,11 @@ public class TestNessieMultiBranching
         // retrieve the second to the last commit hash and query the table with that hash
         List<LogResponse.LogEntry> logEntries = nessieApiV1.getCommitLog().refName(two.getName()).get().getLogEntries();
         assertThat(logEntries).isNotEmpty();
-        String hash = logEntries.get(1).getCommitMeta().getHash();
-        Session sessionTwoAtHash = sessionOnRef(two.getName(), hash);
-
-        // at this hash there were only 3 rows
-        assertThat(computeScalar(sessionTwoAtHash, "SELECT count(*) FROM namespace_one.tbl")).isEqualTo(3L);
-        rows = computeActual(sessionTwoAtHash, "SELECT * FROM namespace_one.tbl");
-        assertThat(rows.getMaterializedRows()).hasSize(3);
-        assertEqualsIgnoreOrder(rows.getMaterializedRows(), resultBuilder(sessionTwoAtHash, rows.getTypes()).row(1).row(2).row(5).build().getMaterializedRows());
     }
 
     private Session sessionOnRef(String reference)
     {
         return Session.builder(getSession()).setCatalogSessionProperty("iceberg", "nessie_reference_name", reference).build();
-    }
-
-    private Session sessionOnRef(String reference, String hash)
-    {
-        return Session.builder(getSession()).setCatalogSessionProperty("iceberg", "nessie_reference_name", reference).setCatalogSessionProperty("iceberg", "nessie_reference_hash", hash).build();
     }
 
     private Reference createBranch(String branchName)


### PR DESCRIPTION
## Description
Remove ref hash session property for Iceberg Nessie catalog

## Motivation and Context
This came from the discussion in https://github.com/prestodb/presto/pull/21399#discussion_r1408930533
We can discuss if we want to remove ref hash as session property from Presto or we want to modify existing support.

## Impact
None

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

