### PR TITLE
Fix bug in tracking partial aggregation stats tracking when the query is a group by on a partitioning key

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsTracker.java
@@ -248,8 +248,9 @@ public class HistoryBasedPlanStatisticsTracker
         PlanNodeStats childNodeStats = planNodeStatsMap.get(childNode.getId());
         if (childNodeStats != null) {
             double partialAggregationInputBytes = adjustedOutputBytes(childNode, childNodeStats);
-            return new PartialAggregationStatistics(Estimate.of(partialAggregationInputBytes),
-                    Estimate.of(outputBytes),
+            return new PartialAggregationStatistics(
+                    Double.isNaN(partialAggregationInputBytes) ? Estimate.unknown() : Estimate.of(partialAggregationInputBytes),
+                    Double.isNaN(outputBytes) ? Estimate.unknown() : Estimate.of(outputBytes),
                     Estimate.of(childNodeStats.getPlanNodeOutputPositions()),
                     Estimate.of(outputPositions));
         }


### PR DESCRIPTION


## Description
<!---Describe your changes in detail-->

During tracking of histories, we adjust the output byte count to account for hash variables introduced during planning. In certain cases, the reported byte count is 0. For example in queries like the following, the grouping key is a partition key, its value does not contribute to the byte count:
```
select ds from lineitem group by ds;
```

After accounting for hash variables, the 0 becomes a negative number, which raises a NaN exception that looks like this: 
```
java.lang.IllegalArgumentException: value is NaN
	at com.facebook.presto.spi.statistics.Estimate.of(Estimate.java:54)
	at com.facebook.presto.cost.HistoryBasedPlanStatisticsTracker.constructAggregationNodeStatistics(HistoryBasedPlanStatisticsTracker.java:250)
	at com.facebook.presto.cost.HistoryBasedPlanStatisticsTracker.getQueryStats(HistoryBasedPlanStatisticsTracker.java:164)
```

This PR fixes that by turning NaN values into unknown like it is done in a few other places of the HBO tracker code.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

