### PR TITLE
Iceberg Table Layout and Split Manager Changes

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -16,8 +16,6 @@ package com.facebook.presto.iceberg;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HdfsEnvironment;
-import com.facebook.presto.hive.HiveType;
-import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
@@ -42,18 +40,15 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.util.Tasks;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -69,9 +64,9 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.TABLE_COMMENT;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.isPrestoView;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static com.facebook.presto.iceberg.IcebergUtil.isIcebergTable;
+import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -438,16 +433,5 @@ public class HiveTableOperations
             log.warn(e, "Unable to parse version from metadata location: %s", metadataLocation);
             return -1;
         }
-    }
-
-    private static List<Column> toHiveColumns(List<NestedField> columns)
-    {
-        return columns.stream()
-                .map(column -> new Column(
-                        column.name(),
-                        HiveType.toHiveType(HiveSchemaUtil.convert(column.type())),
-                        Optional.empty(),
-                        Optional.empty()))
-                .collect(toImmutableList());
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -115,6 +115,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.getPartitionKeyColumnHandl
 import static com.facebook.presto.iceberg.IcebergUtil.getSnapshotIdAsOfTime;
 import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
+import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetSchema;
 import static com.facebook.presto.iceberg.IcebergUtil.validateTableMode;
 import static com.facebook.presto.iceberg.PartitionFields.getPartitionColumnName;
@@ -193,6 +194,7 @@ public abstract class IcebergAbstractMetadata
                 session,
                 new IcebergTableLayoutHandle.Builder()
                         .setPartitionColumns(getPartitionKeyColumnHandles(icebergTable, typeManager))
+                        .setDataColumns(toHiveColumns(icebergTable.schema().columns()))
                         .setDomainPredicate(constraint.getSummary().transform(IcebergAbstractMetadata::toSubfield))
                         .setRemainingPredicate(TRUE_CONSTANT)
                         .setPredicateColumns(predicateColumns)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.hive.BaseHiveTableLayoutHandle;
 import com.facebook.presto.hive.HivePartition;
+import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -35,6 +36,7 @@ public class IcebergTableLayoutHandle
         extends BaseHiveTableLayoutHandle
 {
     private final List<IcebergColumnHandle> partitionColumns;
+    private final List<Column> dataColumns;
     private final Map<String, IcebergColumnHandle> predicateColumns;
     private final Optional<Set<IcebergColumnHandle>> requestedColumns;
     private final IcebergTableHandle table;
@@ -42,6 +44,7 @@ public class IcebergTableLayoutHandle
     @JsonCreator
     public IcebergTableLayoutHandle(
             @JsonProperty("partitionColumns") List<IcebergColumnHandle> partitionColumns,
+            @JsonProperty("dataColumns") List<Column> dataColumns,
             @JsonProperty("domainPredicate") TupleDomain<Subfield> domainPredicate,
             @JsonProperty("remainingPredicate") RowExpression remainingPredicate,
             @JsonProperty("predicateColumns") Map<String, IcebergColumnHandle> predicateColumns,
@@ -52,6 +55,7 @@ public class IcebergTableLayoutHandle
     {
         this(
                 partitionColumns,
+                dataColumns,
                 domainPredicate,
                 remainingPredicate,
                 predicateColumns,
@@ -64,6 +68,7 @@ public class IcebergTableLayoutHandle
 
     protected IcebergTableLayoutHandle(
             List<IcebergColumnHandle> partitionColumns,
+            List<Column> dataColumns,
             TupleDomain<Subfield> domainPredicate,
             RowExpression remainingPredicate,
             Map<String, IcebergColumnHandle> predicateColumns,
@@ -76,6 +81,7 @@ public class IcebergTableLayoutHandle
         super(domainPredicate, remainingPredicate, pushdownFilterEnabled, partitionColumnPredicate, partitions);
 
         this.partitionColumns = ImmutableList.copyOf(requireNonNull(partitionColumns, "partitionColumns is null"));
+        this.dataColumns = ImmutableList.copyOf(requireNonNull(dataColumns, "dataColumns is null"));
         this.predicateColumns = requireNonNull(predicateColumns, "predicateColumns is null");
         this.requestedColumns = requireNonNull(requestedColumns, "requestedColumns is null");
         this.table = requireNonNull(table, "table is null");
@@ -85,6 +91,12 @@ public class IcebergTableLayoutHandle
     public List<IcebergColumnHandle> getPartitionColumns()
     {
         return partitionColumns;
+    }
+
+    @JsonProperty
+    public List<Column> getDataColumns()
+    {
+        return dataColumns;
     }
 
     @JsonProperty
@@ -140,6 +152,7 @@ public class IcebergTableLayoutHandle
     public static class Builder
     {
         private List<IcebergColumnHandle> partitionColumns;
+        private List<Column> dataColumns;
         private TupleDomain<Subfield> domainPredicate;
         private RowExpression remainingPredicate;
         private Map<String, IcebergColumnHandle> predicateColumns;
@@ -152,6 +165,12 @@ public class IcebergTableLayoutHandle
         public Builder setPartitionColumns(List<IcebergColumnHandle> partitionColumns)
         {
             this.partitionColumns = partitionColumns;
+            return this;
+        }
+
+        public Builder setDataColumns(List<Column> dataColumns)
+        {
+            this.dataColumns = dataColumns;
             return this;
         }
 
@@ -207,6 +226,7 @@ public class IcebergTableLayoutHandle
         {
             return new IcebergTableLayoutHandle(
                     partitionColumns,
+                    dataColumns,
                     domainPredicate,
                     remainingPredicate,
                     predicateColumns,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergFilterPushdown.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergFilterPushdown.java
@@ -60,6 +60,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitionKeyColumnHandles;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitions;
+import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -192,6 +193,7 @@ public class IcebergFilterPushdown
                             session,
                             new IcebergTableLayoutHandle.Builder()
                                     .setPartitionColumns(partitionColumns)
+                                    .setDataColumns(toHiveColumns(icebergTable.schema().columns()))
                                     .setDomainPredicate(domainPredicate)
                                     .setRemainingPredicate(remainingExpressions.getRemainingExpression())
                                     .setPredicateColumns(predicateColumns)


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
- [x] This PR enhances Iceberg Split Manager by making use of IcebergTableLayoutHandle.partitionColumnPredicate for partition pruning when Iceberg Filter Pushdown is enabled
- [x] This PR also introduces a new argument IcebergTableLayoutHandle.dataColumns which is required for integration with Prestissimo

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
As part of adding support for Iceberg in Prestissimo

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

