### PR TITLE
[native] Enable unit tests in CI

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -125,7 +125,7 @@ jobs:
           name: 'Run Unit Tests'
           command: |
             cd presto-native-execution/_build/debug
-            ctest -j 10 -VV --output-on-failure --exclude-regex velox.*
+            ctest -j 10 -VV --output-on-failure --no-tests=error
       - persist_to_workspace:
           root: presto-native-execution
           paths:

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -190,6 +190,7 @@ set(VELOX_GTEST_INCUDE_DIR "velox/third_party/googletest/googletest/include")
 add_subdirectory(velox)
 
 if(PRESTO_ENABLE_TESTING)
+  set(BUILD_TESTING ON) # some third-party dependency could have disabled this.
   include(CTest) # include after project() but before add_subdirectory()
   include_directories(${VELOX_GTEST_INCUDE_DIR})
 else()


### PR DESCRIPTION
## Description
Prestissimo unit tests are not being run in CI. This is now fixed.
An error will now be thrown if no tests are detected.

## Motivation and Context
Resolves https://github.com/prestodb/presto/issues/21505

```
== NO RELEASE NOTE ==
```

