### PR TITLE
Relax methods visibility for Meta's internal classes' access

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
@@ -465,7 +465,7 @@ public abstract class BaseSubfieldExtractionRewriter
         }
     }
 
-    private static Set<VariableReferenceExpression> extractVariableExpressions(RowExpression expression)
+    protected static Set<VariableReferenceExpression> extractVariableExpressions(RowExpression expression)
     {
         ImmutableSet.Builder<VariableReferenceExpression> builder = ImmutableSet.builder();
         expression.accept(new VariableReferenceBuilderVisitor(), builder);
@@ -485,7 +485,7 @@ public abstract class BaseSubfieldExtractionRewriter
         }
     }
 
-    public static boolean useDynamicFilter(
+    public boolean useDynamicFilter(
             RowExpression expression,
             ConnectorTableHandle tableHandle,
             Map<String, ColumnHandle> columnHandleMap)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
@@ -83,7 +83,7 @@ public class HiveFilterPushdown
     private final RowExpressionService rowExpressionService;
     private final StandardFunctionResolution functionResolution;
     private final FunctionMetadataManager functionMetadataManager;
-    private final HiveTransactionManager transactionManager;
+    protected final HiveTransactionManager transactionManager;
     private final HivePartitionManager partitionManager;
 
     public HiveFilterPushdown(
@@ -125,7 +125,7 @@ public class HiveFilterPushdown
         }
 
         @Override
-        protected ConnectorPushdownFilterResult getConnectorPushdownFilterResult(
+        public ConnectorPushdownFilterResult getConnectorPushdownFilterResult(
                 Map<String, ColumnHandle> columnHandles,
                 ConnectorMetadata metadata,
                 ConnectorSession session,


### PR DESCRIPTION
## Description

* Recent refactoring around HiveFilterPushdown has broken Meta's internal build. In order to fix it, we have done some refactoring and it requires the change of the visibility/staticness on a few base methods.

## Motivation and Context

* To fix the broken master for Meta's internal repo.

## Impact

* No impact to open source.

## Test Plan

* Unit tests

## Contributor checklist

- [ x ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ x ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ x ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ x ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ x ] Adequate tests were added if applicable.
- [ x ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

