### PR TITLE
[native pos] Fix sendUpdateRequest retry logic

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
@@ -218,8 +218,8 @@ public class NativeExecutionTask
             try {
                 errorTracker.startRequest();
                 BaseResponse<TaskInfo> response = doSendUpdateRequest();
-                errorTracker.requestSucceeded();
                 if (response.hasValue()) {
+                    errorTracker.requestSucceeded();
                     return response.getValue();
                 }
                 else {


### PR DESCRIPTION
## Description

Do not mark non 200 responses as success

## Motivation and Context

To avoid running into an endless loop as `errorTracker.requestSucceeded` resets the error counters.

## Impact

Some queries may be timing out instead of failing with an exception

## Test Plan

CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

