### PR TITLE
Fix a build break with older version of testng

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/reservoirsample/TestReservoirSampleAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/reservoirsample/TestReservoirSampleAggregation.java
@@ -201,7 +201,7 @@ public class TestReservoirSampleAggregation
         assertTrue(result instanceof List);
         List<Object> resultItems = (List<Object>) result;
         Long processedCount = (Long) resultItems.get(0);
-        assertEquals(processedCount, items.size());
+        assertEquals(processedCount, Long.valueOf(items.size()));
         List<Object> sample = (List<Object>) resultItems.get(1);
         assertTrue(items.containsAll(sample));
     }


### PR DESCRIPTION
## Description
Fix a build break with older version of testng to use a code that works with all versions of testng. The existing test code would failed if built with testng 6.10 with errors:
```
fbcode/github/presto-trunk/presto-main/src/test/java/com/facebook/presto/operator/aggregation/reservoirsample/TestReservoirSampleAggregation.java:204: error: reference to assertEquals is ambiguous
        assertEquals(processedCount, items.size());
        ^
  both method assertEquals(long,long) in Assert and method assertEquals(Object,Object) in Assert match
```
So converting items.size() to Long so it will force invocation of assertEquals(Object,Object) which will work on all versions of testng 

## Motivation and Context
We have to run unit testsusing an older version of testng.

## Impact
N/AA

## Test Plan
Make sure all existing CI runs are green

```
== NO RELEASE NOTE ==
```

