### PR TITLE
Add validator for timezones (issue #21461)

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimeZoneKey.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimeZoneKey.java
@@ -210,7 +210,7 @@ public final class TimeZoneKey
         return normalizeZoneId(zoneId).equals("utc");
     }
 
-    public static String normalizeZoneId(String originalZoneId)
+    private static String normalizeZoneId(String originalZoneId)
     {
         String zoneId = originalZoneId.toLowerCase(ENGLISH);
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimeZoneKey.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimeZoneKey.java
@@ -215,8 +215,8 @@ public final class TimeZoneKey
         String zoneId = originalZoneId.toLowerCase(ENGLISH);
 
         // if zineId is in incorrect format, return null
-        if (!originalZoneId.matches("^ETC/GMT[+-]\\d{1,2}:\\d{2}$")) {
-            return originalZoneId;
+        if (!originalZoneId.matches("^(ETC/)?GMT[+-]\\d{1,2}(:\\d{2})?$")) {
+            return zoneId;
         }
 
         boolean startsWithEtc = zoneId.startsWith("etc/");

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimeZoneKey.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimeZoneKey.java
@@ -210,9 +210,14 @@ public final class TimeZoneKey
         return normalizeZoneId(zoneId).equals("utc");
     }
 
-    private static String normalizeZoneId(String originalZoneId)
+    public static String normalizeZoneId(String originalZoneId)
     {
         String zoneId = originalZoneId.toLowerCase(ENGLISH);
+
+        // if zineId is in incorrect format, return null
+        if (!originalZoneId.matches("^ETC/GMT[+-]\\d{1,2}:\\d{2}$")) {
+            return originalZoneId;
+        }
 
         boolean startsWithEtc = zoneId.startsWith("etc/");
         if (startsWithEtc) {


### PR DESCRIPTION
## Description
A validator for the time zone has been added. If the zone fails validation, return the input parameter

## Motivation and Context
https://github.com/prestodb/presto/issues/21461

## Test Plan
Tested following data:

```
ETC/+06
ETC/UTC*
ETC/GMT+10:00
ETC/GMT+14
ETC
```

and validation passed only 

```
ETC/GMT+10:00
ETC/GMT+14
```

with result 

```
+10:00
-14:00
```
