### PR TITLE
Fix bug for testing udt in TestJdbcResultSet

### DIFF
--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcResultSet.java
@@ -21,7 +21,6 @@ import com.facebook.presto.functionNamespace.testing.InMemoryFunctionNamespaceMa
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.function.FunctionImplementationType;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -229,7 +228,7 @@ public class TestJdbcResultSet
 
         statement.execute("CREATE TYPE cat.sch.pair AS (fst integer, snd varchar)");
         checkRepresentation("CAST((1,'1001') AS cat.sch.pair)", Types.JAVA_OBJECT, (rs, column) -> {
-            assertEquals(rs.getObject(1), Lists.newArrayList(1, "1001"));
+            assertEquals(rs.getObject(1), ImmutableMap.of("fst", 1, "snd", "1001"));
         });
     }
 


### PR DESCRIPTION
## Description

Fix bug in issue #21533.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

