### PR TITLE
[native] Add e2e tests for any_value aggregate.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -329,6 +329,7 @@ import static com.facebook.presto.geospatial.SphericalGeographyType.SPHERICAL_GE
 import static com.facebook.presto.geospatial.type.BingTileType.BING_TILE;
 import static com.facebook.presto.geospatial.type.GeometryType.GEOMETRY;
 import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
+import static com.facebook.presto.operator.aggregation.AlternativeArbitraryAggregationFunction.ALTERNATIVE_ANY_VALUE_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.AlternativeArbitraryAggregationFunction.ALTERNATIVE_ARBITRARY_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.AlternativeMaxAggregationFunction.ALTERNATIVE_MAX;
 import static com.facebook.presto.operator.aggregation.AlternativeMinAggregationFunction.ALTERNATIVE_MIN;
@@ -992,6 +993,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         // Replace some aggregations for Velox to override intermediate aggregation type.
         if (featuresConfig.isUseAlternativeFunctionSignatures()) {
             builder.override(ARBITRARY_AGGREGATION, ALTERNATIVE_ARBITRARY_AGGREGATION);
+            builder.override(ANY_VALUE_AGGREGATION, ALTERNATIVE_ANY_VALUE_AGGREGATION);
             builder.override(MAX_AGGREGATION, ALTERNATIVE_MAX);
             builder.override(MIN_AGGREGATION, ALTERNATIVE_MIN);
             builder.override(MAX_BY, ALTERNATIVE_MAX_BY);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeArbitraryAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeArbitraryAggregationFunction.java
@@ -20,9 +20,16 @@ public class AlternativeArbitraryAggregationFunction
 {
     public static final AlternativeArbitraryAggregationFunction ALTERNATIVE_ARBITRARY_AGGREGATION = new AlternativeArbitraryAggregationFunction();
 
+    public static final AlternativeArbitraryAggregationFunction ALTERNATIVE_ANY_VALUE_AGGREGATION = new AlternativeArbitraryAggregationFunction(ArbitraryAggregationFunction.getAnyValueName());
+
     public AlternativeArbitraryAggregationFunction()
     {
         super();
+    }
+
+    public AlternativeArbitraryAggregationFunction(String name)
+    {
+        super(name);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
@@ -85,6 +85,11 @@ public class ArbitraryAggregationFunction
                 ImmutableList.of(parseTypeSignature("T")));
     }
 
+    protected static String getAnyValueName()
+    {
+        return ANY_VALUE_NAME;
+    }
+
     @Override
     public String getDescription()
     {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -337,11 +337,11 @@ public abstract class AbstractTestNativeAggregations
     public void testArbitrary()
     {
         // Non-deterministic queries
-        assertQuerySucceeds("SELECT orderkey, arbitrary(comment) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds("SELECT orderkey, any_value(comment) FROM lineitem GROUP BY 1");
         assertQuerySucceeds("SELECT orderkey, arbitrary(discount) FROM lineitem GROUP BY 1");
-        assertQuerySucceeds("SELECT orderkey, arbitrary(linenumber) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds("SELECT orderkey, any_value(linenumber) FROM lineitem GROUP BY 1");
         assertQuerySucceeds("SELECT orderkey, arbitrary(linenumber_as_smallint) FROM lineitem GROUP BY 1");
-        assertQuerySucceeds("SELECT orderkey, arbitrary(linenumber_as_tinyint) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds("SELECT orderkey, any_value(linenumber_as_tinyint) FROM lineitem GROUP BY 1");
         assertQuerySucceeds("SELECT orderkey, arbitrary(tax_as_real) FROM lineitem GROUP BY 1");
     }
 


### PR DESCRIPTION
We have added any_value alias for arbitrary aggregate in https://github.com/facebookincubator/velox/pull/7689. Here adding e2e tests for this.