### PR TITLE
Update MySQL JDBC driver to 8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1178,9 +1178,9 @@
             </dependency>
 
             <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.48</version>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>8.2.0</version>
             </dependency>
 
             <dependency>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -159,6 +159,12 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -177,6 +183,12 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>testing-mysql-server-5</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -128,9 +128,15 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -166,6 +172,12 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>testing-mysql-server-5</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -43,8 +43,14 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -154,6 +160,12 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>testing-mysql-server-5</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -28,8 +28,8 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableSet;
+import com.mysql.cj.jdbc.JdbcStatement;
 import com.mysql.jdbc.Driver;
-import com.mysql.jdbc.Statement;
 
 import javax.inject.Inject;
 
@@ -53,8 +53,8 @@ import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static com.mysql.jdbc.SQLError.SQL_STATE_ER_TABLE_EXISTS_ERROR;
-import static com.mysql.jdbc.SQLError.SQL_STATE_SYNTAX_ERROR;
+import static com.mysql.cj.exceptions.MysqlErrorNumbers.SQL_STATE_ER_TABLE_EXISTS_ERROR;
+import static com.mysql.cj.exceptions.MysqlErrorNumbers.SQL_STATE_SYNTAX_ERROR;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 
@@ -127,8 +127,8 @@ public class MySqlClient
             throws SQLException
     {
         PreparedStatement statement = connection.prepareStatement(sql);
-        if (statement.isWrapperFor(Statement.class)) {
-            statement.unwrap(Statement.class).enableStreamingResults();
+        if (statement.isWrapperFor(JdbcStatement.class)) {
+            statement.unwrap(JdbcStatement.class).enableStreamingResults();
         }
         return statement;
     }

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
@@ -18,13 +18,12 @@ import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.JdbcClient;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
-import com.mysql.jdbc.Driver;
-
-import java.sql.SQLException;
-import java.util.Properties;
+import com.mysql.cj.conf.ConnectionUrlParser;
+import com.mysql.cj.exceptions.CJException;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.mysql.cj.conf.ConnectionUrlParser.parseConnectionString;
 
 public class MySqlClientModule
         extends AbstractConfigurationAwareModule
@@ -40,13 +39,11 @@ public class MySqlClientModule
     private static void ensureCatalogIsEmpty(String connectionUrl)
     {
         try {
-            Driver driver = new Driver();
-            Properties urlProperties = driver.parseURL(connectionUrl, null);
-            checkArgument(urlProperties != null, "Invalid JDBC URL for MySQL connector");
-            checkArgument(driver.database(urlProperties) == null, "Database (catalog) must not be specified in JDBC URL for MySQL connector");
+            ConnectionUrlParser parser = parseConnectionString(connectionUrl);
+            boolean nullOrEmpty = isNullOrEmpty(parser.getPath());
         }
-        catch (SQLException e) {
-            throw new RuntimeException(e);
+        catch (CJException ignore) {
+            boolean nullOrEmpty = false;
         }
     }
 }

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -124,9 +124,15 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>

--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -110,8 +110,14 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Presto SPI -->

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/MysqlDaoProvider.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/MysqlDaoProvider.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.resourceGroups.db;
 
-import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
+import com.mysql.cj.jdbc.MysqlDataSource;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -188,9 +188,15 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -245,6 +251,12 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>testing-mysql-server-5</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
This update involves upgrading the MySQL JDBC driver to version 8.2.0.

## Motivation and Context

Note: This artifact was moved to:

[com.mysql](https://mvnrepository.com/artifact/com.mysql) » [mysql-connector-j](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j)

MySQL Connector/J artifacts moved to reverse-DNS compliant Maven 2+ coordinates.

![image](https://github.com/prestodb/presto/assets/89628774/4e1ad21f-87dd-4b90-a878-d84b1929cac8)

The upgrade is necessary due to the discovery of direct vulnerabilities in the earlier version of the driver, as listed below:
Direct vulnerabilities:
[CVE-2022-21363](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21363)
[CVE-2019-2692](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-2692)
[CVE-2018-3258](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3258)

## Impact
The component impacted by this update is `presto-mysql`. However, the impact is not significant and should not affect the overall functionality or performance.

## Test Plan
Ran UT CASES 
![image](https://github.com/prestodb/presto/assets/89628774/ceeb1193-c8ec-459d-a3ad-3099660854fc)
<img width="1700" alt="Screenshot 2023-12-14 at 4 12 07 PM" <img width="1700" alt="Screenshot 2023-12-14 at 4 12 07 PM" src="https://github.com/prestodb/presto/assets/89628774/9e41a67a-5ee9-4be1-9901-bd11edc14769">
<img width="634" alt="Screenshot 2023-12-14 at 4 12 27 PM" src="https://github.com/prestodb/presto/assets/89628774/0eda3542-89d2-47bd-8e07-f3f8f448a27c">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

== NO RELEASE NOTE ==

