### PR TITLE
Check arguments in StageExecutionId, TaskId, StageId

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionId.java
@@ -50,6 +50,7 @@ public class StageExecutionId
     public StageExecutionId(StageId stageId, int id)
     {
         this.stageId = requireNonNull(stageId, "stageId is null");
+        checkArgument(id >= 0, "id is negative: %s", id);
         this.id = id;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageId.java
@@ -48,6 +48,7 @@ public class StageId
     public StageId(QueryId queryId, int id)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
+        checkArgument(id >= 0, "id is negative: %s", id);
         this.id = id;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskId.java
@@ -52,7 +52,7 @@ public class TaskId
     {
         this.stageExecutionId = requireNonNull(stageExecutionId, "stageExecutionId");
         this.attemptNumber = attemptNumber;
-        checkArgument(id >= 0, "id is negative");
+        checkArgument(id >= 0, "id is negative: %s", id);
         this.id = id;
     }
 


### PR DESCRIPTION
## Description
This update involves adding argument checks in the constructors of `StageExecutionId`, `TaskId`, and `StageId` classes in the `presto-main` module. The purpose of these checks is to ensure that the arguments passed to these constructors are valid and to prevent any potential issues due to invalid arguments.

## Motivation and Context
Check arguments in StageId constructor
Also improve message in TaskId constructor checks


## Impact
There is no significant impact on the system as a whole. The changes are confined to the `presto-main` module and do not affect the functionality of other parts of the system. The build was successful, as indicated by the log messages:

SNAPSHOT-test-sources.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:18 min
[INFO] Finished at: 2023-12-14T16:38:42+05:30
[INFO] ------------------------------------------------------------------------


## Test Plan
UT FOR PRESTO-MAIN 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

