### PR TITLE
convert circleci workflows to github actions

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,23 @@
+name: format-check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'presto-native-execution/**'
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    container:
+      image: prestocpp/velox-check:mikesh-20210609
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Update velox
+        run: |
+          cd presto-native-execution
+          make velox-submodule
+      - name: Check formatting
+        run: |
+          cd presto-native-execution
+          make format-check

--- a/.github/workflows/header-check.yml
+++ b/.github/workflows/header-check.yml
@@ -1,0 +1,23 @@
+name: header-check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'presto-native-execution/**'
+
+jobs:
+  header-check:
+    runs-on: ubuntu-latest
+    container:
+      image: prestocpp/velox-check:mikesh-20210609
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Update velox
+        run: |
+          cd presto-native-execution
+          make velox-submodule
+      - name: Check license headers
+        run: |
+          cd presto-native-execution
+          make header-check

--- a/.github/workflows/linux-build-all.yml
+++ b/.github/workflows/linux-build-all.yml
@@ -1,0 +1,51 @@
+name: linux-build-all
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'presto-native-execution/**'
+
+jobs:
+  linux-build-all:
+    runs-on: 16-core
+    container:
+      image: prestocpp/prestocpp-avx-centos:root-20230613
+    env:
+      MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+      MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Update velox
+        run: |
+          cd presto-native-execution
+          make velox-submodule
+      - name: Install all adapter dependencies
+        run: |
+          mkdir -p ${GITHUB_WORKSPACE}/adapter-deps/install
+          source /opt/rh/gcc-toolset-9/enable
+          set -xu
+          cd presto-native-execution
+          DEPENDENCY_DIR=${GITHUB_WORKSPACE}/adapter-deps PROMPT_ALWAYS_RESPOND=n ./velox/scripts/setup-adapters.sh
+          DEPENDENCY_DIR=${GITHUB_WORKSPACE}/adapter-deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-adapters.sh jwt
+      - name: Build All
+        run: |
+          source /opt/rh/gcc-toolset-9/enable
+          cd presto-native-execution
+          cmake \
+            -B _build/release \
+            -GNinja \
+            -DAWSSDK_ROOT_DIR=${GITHUB_WORKSPACE}/adapter-deps/install \
+            -DTREAT_WARNINGS_AS_ERRORS=1 \
+            -DENABLE_ALL_WARNINGS=1 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPRESTO_ENABLE_PARQUET=ON \
+            -DPRESTO_ENABLE_S3=ON \
+            -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
+            -DPRESTO_ENABLE_JWT=ON \
+            -DCMAKE_PREFIX_PATH=/usr/local \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DMAX_LINK_JOBS=2
+          ninja -C _build/release -j 8

--- a/.github/workflows/linux-build-and-unit-test.yml
+++ b/.github/workflows/linux-build-and-unit-test.yml
@@ -1,0 +1,198 @@
+name: linux-build-and-unit-test
+
+on:
+  pull_request:
+
+jobs:
+  linux-build-and-unit-test:
+    runs-on: 16-core
+    container:
+      image: prestocpp/prestocpp-avx-centos:root-20230613
+    env:
+      MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+      MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Update velox
+        run: |
+          cd presto-native-execution
+          make velox-submodule
+      - name: Install JWT adapter dependency
+        run: |
+          mkdir -p ${HOME}/adapter-deps/install
+          source /opt/rh/gcc-toolset-9/enable
+          set -xu
+          cd presto-native-execution
+          DEPENDENCY_DIR=${HOME}/adapter-deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-adapters.sh jwt
+      - name: Calculate merge-base date for CCache
+        run: git show -s --format=%cd --date="format:%Y%m%d" $(git merge-base origin/master HEAD) | tee merge-base-date
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.10
+        with:
+          key: native-exe-linux-ccache-${{ runner.os }}-${{ hashFiles('merge-base-date') }}
+      - name: Build
+        run: |
+          mkdir -p .ccache
+          export CCACHE_DIR=$(realpath .ccache)
+          ccache -sz -M 8Gi
+          source /opt/rh/gcc-toolset-9/enable
+          cd presto-native-execution
+          cmake \
+            -B _build/debug \
+            -GNinja \
+            -DTREAT_WARNINGS_AS_ERRORS=1 \
+            -DENABLE_ALL_WARNINGS=1 \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DPRESTO_ENABLE_PARQUET=ON \
+            -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
+            -DPRESTO_ENABLE_JWT=ON \
+            -DCMAKE_PREFIX_PATH=/usr/local \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DMAX_LINK_JOBS=2
+          ninja -C _build/debug -j 8
+      - name: Run Unit Tests
+        run: |
+          cd presto-native-execution/_build/debug
+          ctest -j 10 -VV --output-on-failure --exclude-regex velox.*
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: presto-native-build
+          path: |
+            presto-native-execution/_build/debug/presto_cpp/main/presto_server
+            presto-native-execution/_build/debug/velox/velox/functions/remote/server/velox_functions_remote_server_main
+  
+  linux-presto-e2e-tests:
+    needs: linux-build-and-unit-test
+    runs-on: 16-core
+    container:
+      image: prestocpp/prestocpp-avx-centos:root-20230613
+    env:
+      MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+      MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: presto-native-build
+          path: presto-native-execution/_build/debug
+      - name: Install OpenJDK8
+        uses: actions/setup-java@v4.0.0
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Cache local Maven repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-2-
+      - name: Populate maven cache
+        if: steps.cache-maven.outputs.cache-hit != 'true'
+        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      - name: Maven install
+        env:
+          MAVEN_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+          MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+        run: |
+          for i in $(seq 1 3); do ./mvnw clean install $MAVEN_FAST_INSTALL -pl 'presto-native-execution' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
+      - name: Run presto-native e2e tests
+        run: |
+          export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
+          export TESTFILES=`find ./presto-native-execution/src/test -type f -name 'TestPrestoNative*.java'`
+
+          # Convert file paths to comma separated class names
+          export TESTCLASSES=
+          for test_file in $TESTFILES
+          do
+            tmp=${test_file##*/}
+            test_class=${tmp%%\.*}
+            export TESTCLASSES="${TESTCLASSES},$test_class"
+          done
+          export TESTCLASSES=${TESTCLASSES#,}
+          echo "TESTCLASSES = $TESTCLASSES"
+
+          # TODO: neeed to enable remote function tests with
+          # "-Ppresto-native-execution-remote-functions" once
+          # > https://github.com/facebookincubator/velox/discussions/6163
+          # is fixed.
+          
+          mvn test \
+            ${MAVEN_TEST} \
+            -pl 'presto-native-execution' \
+            -Dtest="${TESTCLASSES}" \
+            -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
+            -DDATA_DIR=${RUNNER_TEMP} \
+            -Duser.timezone=America/Bahia_Banderas \
+            -T1C
+
+  linux-spark-e2e-tests:
+    needs: linux-build-and-unit-test
+    runs-on: 16-core
+    container:
+      image: prestocpp/prestocpp-avx-centos:root-20230613
+    env:
+      MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+      MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: presto-native-build
+          path: presto-native-execution/_build/debug
+      - name: Install OpenJDK8
+        uses: actions/setup-java@v4.0.0
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Cache local Maven repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-2-
+      - name: Populate maven cache
+        if: steps.cache-maven.outputs.cache-hit != 'true'
+        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      - name: Maven install
+        env:
+          MAVEN_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+          MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+        run: |
+          for i in $(seq 1 3); do ./mvnw clean install $MAVEN_FAST_INSTALL -pl 'presto-native-execution' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
+      - name: Run spark e2e tests
+        run: |
+          export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
+          export TESTFILES=`find ./presto-native-execution/src/test -type f -name 'TestPrestoSpark*.java'`
+
+          # Convert file paths to comma separated class names
+          export TESTCLASSES=
+          for test_file in $TESTFILES
+          do
+            tmp=${test_file##*/}
+            test_class=${tmp%%\.*}
+            export TESTCLASSES="${TESTCLASSES},$test_class"
+          done
+          export TESTCLASSES=${TESTCLASSES#,}
+          echo "TESTCLASSES = $TESTCLASSES"
+
+          mvn test \
+            ${MAVEN_TEST} \
+            -pl 'presto-native-execution' \
+            -Dtest="${TESTCLASSES}" \
+            -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
+            -DDATA_DIR=${RUNNER_TEMP} \
+            -Duser.timezone=America/Bahia_Banderas \
+            -T1C

--- a/.github/workflows/native-specific-macos.yml
+++ b/.github/workflows/native-specific-macos.yml
@@ -1,0 +1,36 @@
+name: native-specific-macos
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'presto-native-execution/**'
+
+jobs:
+  native-specific-macos:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Update submodules
+        run: |
+          cd presto-native-execution
+          make submodules
+      - uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: 14.3.1
+      - name: "Setup MacOS"
+        run: |
+          set -xu
+          mkdir ~/deps ~/deps-src
+          git clone --depth 1 https://github.com/Homebrew/brew ~/deps
+          PATH=~/deps/bin:${PATH} DEPENDENCY_DIR=~/deps-src INSTALL_PREFIX=~/deps PROMPT_ALWAYS_RESPOND=n ./presto-native-execution/scripts/setup-macos.sh
+          # Calculate the prefix path before we delete brew's repos and taps.
+          echo "$(pwd)/deps;$(brew --prefix openssl@1.1);$(brew --prefix icu4c)" > ~/deps/PREFIX_PATH
+          rm -rf ~/deps/.git ~/deps/Library/Taps/  # Reduce cache size by 70%.
+          rm -rf ~/deps-src
+      - name: "Build presto_cpp on MacOS"
+        run: |
+          export PATH=~/deps/bin:${PATH}
+          cd presto-native-execution
+          cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(cat ~/deps/PREFIX_PATH) -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          ninja -C _build/debug


### PR DESCRIPTION
## Description
This pull request converts the CircleCI workflows to GitHub actions workflows.

## Motivation and Context
This pull request converts the CircleCI workflows to GitHub actions workflows.

The GitHub actions workflows need runner groups with [larger runners configured for the organization](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/managing-larger-runners).

The following runner group is needed:
- 16-core

For my testing, I have these runner groups populated with the following runners:
| Group       | Runner size                         | OS            |
|-------------|-------------------------------------|---------------|
| 16-core     | 32-cores · 128 GB RAM · 1200 GB SSD | Ubuntu Latest |

**Issues**  
There are issue with some of the workflow that someone smarter than me needs to address.  
1. linux-build-and-unit-test > linux-presto-e2e-tests  
This seems to run more tests than it should. Permission errors on executing the presto-server
```
java.io.UncheckedIOException: java.io.IOException: Cannot run program "/__w/presto/presto/presto-native-execution/_build/debug/presto_cpp/main/presto_server"
```

2. linux-build-and-unit-test > linux-spark-e2e-tests  
This seems to run more tests than it should. Permission errors on executing the presto-server
```
2023-12-12T14:52:44.779-0600	ERROR	Executor task launch worker-0	org.apache.spark.executor.Executor	Exception in task 0.0 in stage 0.0 (TID 0)
com.facebook.presto.spark.classloader_interface.PrestoSparkRetryableExecutionException: Cannot start [/__w/presto/presto/presto-native-execution/_build/debug/presto_cpp/main/presto_server, --logtostderr=1, --minloglevel=3, --etc_dir, /tmp/spark-8955e73f-ff89-421e-a699-c73cf7eab02f/userFiles-dd30f680-a6ae-4e6e-8356-a0f8d7acca98/./43751] | ExecutionFailureInfo[eJztVVuP0zgU/itVxEORJk7btElawUqzJexWQFqlHUACFLnOSZttGke2MwtC/Pc9zmXoQOeGYB92+5LL8fm+c7F9vs+G+lSAMTEY35OEMlhzviOFAKk4kUVKFtWn/5FBoVKeG2fGHqSkG42Z0jznqiMVFarzzoqiv60aef1l5lSll2DCR2ClJrGidZlmsRXDutw0ThErCmtP07z9lyAuQZx1TDPjG8WlikGIp31t2Kc52jK4hOyprQ2gWBSn6GypfWHJgoqd6Y1HI3DtxEwSb2wOB30wqTMem8y1WeICXfcGiVVilOdpBtKMY7uXOF4PnSiYQ3DA9OyRY9Je4sUuZYyOPYtYQ9sd9T9gFxhFrDH53PbvL3pJScrJbH5rr0SZdwrBN4LuO++NX9Ky98akg63i2CxszgLEPpUSKTox5CnEP5D77WyyLHR8iT+Tdx/wX1G2w8+aNqP5hlwEs7cLwRl6kYSL3Xke+1hZN6iq7LwCteXxY+Q6DnmS5qn6rXto0o6TwdC9DmpWZ/siI9Wp7B5aKkzfHh7F/K7bC+I6rDXWyN5grKHHbwoeOXK1W6TevqJJti7Tb1fbGupQNyweJnufiIrKXXNZl3qppl2htabm4jll+PxEmACqALdgqeMfD9+9F1OV47Dn/PwcYz6tsnxAHgNv8Kt69ZAsBnd0g2VUyoxTPFZRmisQ2u0wGU3d7AIXpPh+P647VFHvKv3OoF+rCuOYIFFR3lS2dmjuw0hH5WJDaEHZFppgAh3CZ89alrkIgcbTLbBdwTF4V69JRjM6sfvjWxlSzJRibw8gA88+CpH4GZcZ3tXltkySDF7RQmdLcODqd/cbc83mHo//Y2T1MLqFrKXoHoA85ygImrNF2kP2qGp9mefIoylae9sW9+tUwzOeYfNzVgoBuSKrLR7ieMF5dgVChjc4hkF0jyzWm9sfjh/A+Kimq6u7gdIZfDN5a8cDTO3njnqPDdSRSnWmPK6UilVvZzSynTMjp3stS3/4gR/OptEsWPlhcP4y8sNwHmKIRta+swtQIqXrDBcTmkn40gap9dC4CF4E8zeB8eVeovYA4Rh6J+E4CcdJOE7CcRKO/6tw/KvT/956c5r+p+l/mv6n6f+fnv59u9/z3KvxH5yvZq/9yH/rTy9Ws3kQLcL51F8uo5fnF8H0z5+nBv8A9x+88w==] |
```

3. native-specific-macos  
This buid fails with the following error:

<details>
  <summary>Errors</summary>

```
[79/85] Linking CXX executable bin/fizz-bogoshim
FAILED: bin/fizz-bogoshim 
: && /Applications/Xcode_14.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17 -mbmi2 -fvisibility=hidden -fvisibility-inlines-hidden -isysroot /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/BogoShim.dir/test/BogoShim.cpp.o -o bin/fizz-bogoshim  -Wl,-rpath,/Users/runner/deps/lib  lib/libfizz.a  /Users/runner/deps/lib/libsodium.dylib  /Users/runner/deps/lib/libfolly.a  /Users/runner/deps/lib/libfmt.a  /Users/runner/deps/lib/libboost_context-mt.dylib  /Users/runner/deps/lib/libboost_filesystem-mt.dylib  /Users/runner/deps/lib/libboost_atomic-mt.dylib  /Users/runner/deps/lib/libboost_program_options-mt.dylib  /Users/runner/deps/lib/libboost_regex-mt.dylib  /Users/runner/deps/lib/libboost_system-mt.dylib  /Users/runner/deps/lib/libboost_thread-mt.dylib  /Users/runner/deps/lib/libevent.dylib  /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/lib/libz.tbd  /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/lib/libbz2.tbd  /Users/runner/deps/lib/liblz4.dylib  /Users/runner/deps/lib/libsnappy.dylib  /Users/runner/deps/lib/libsodium.dylib  -lc++abi  /Users/runner/deps/opt/openssl@1.1/lib/libssl.dylib  /Users/runner/deps/opt/openssl@1.1/lib/libcrypto.dylib  /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/lib/libz.tbd  /Users/runner/deps/lib/libzstd.dylib  /Users/runner/deps/lib/libglog.dylib  /Users/runner/deps/lib/libgflags.2.2.2.dylib  /Users/runner/deps/lib/libdouble-conversion.a && :
Undefined symbols for architecture x86_64:
  "_EVP_DigestSignUpdate", referenced from:
      fizz::detail::rsaPssSign(folly::Range<unsigned char const*>, std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&, int) in libfizz.a(Signature.cpp.o)
  "_EVP_DigestVerifyUpdate", referenced from:
      fizz::detail::rsaPssVerify(folly::Range<unsigned char const*>, folly::Range<unsigned char const*>, std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&, int) in libfizz.a(Signature.cpp.o)
  "_EVP_MD_get_size", referenced from:
      folly::ssl::OpenSSLHash::Digest::hash_final(folly::Range<unsigned char*>) in BogoShim.cpp.o
      folly::ssl::OpenSSLHash::Hmac::hash_final(folly::Range<unsigned char*>) in BogoShim.cpp.o
      folly::ssl::OpenSSLHash::Hmac::hash_final(folly::Range<unsigned char*>) in libfizz.a(AeadTokenCipher.cpp.o)
      folly::ssl::OpenSSLHash::Digest::hash_final(folly::Range<unsigned char*>) in libfizz.a(Encryption.cpp.o)
      folly::ssl::OpenSSLHash::Hmac::hash_final(folly::Range<unsigned char*>) in libfizz.a(Utils.cpp.o)
  "_EVP_PKEY_CTX_set_rsa_padding", referenced from:
      fizz::detail::rsaPssSign(folly::Range<unsigned char const*>, std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&, int) in libfizz.a(Signature.cpp.o)
      fizz::detail::rsaPssVerify(folly::Range<unsigned char const*>, folly::Range<unsigned char const*>, std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&, int) in libfizz.a(Signature.cpp.o)
  "_EVP_PKEY_CTX_set_rsa_pss_saltlen", referenced from:
      fizz::detail::rsaPssSign(folly::Range<unsigned char const*>, std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&, int) in libfizz.a(Signature.cpp.o)
      fizz::detail::rsaPssVerify(folly::Range<unsigned char const*>, folly::Range<unsigned char const*>, std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&, int) in libfizz.a(Signature.cpp.o)
  "_EVP_PKEY_get_base_id", referenced from:
      fizz::detail::validateEdKey(std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&, int) in libfizz.a(OpenSSLKeyUtils.cpp.o)
  "_EVP_PKEY_get_bits", referenced from:
      folly::AsyncSSLSocket::getSSLCertSize() const in libfolly.a(AsyncSSLSocket.cpp.o)
  "_EVP_PKEY_get_id", referenced from:
      readSelfCert() in BogoShim.cpp.o
      fizz::OpenSSLSignature<(fizz::KeyType)0>::setKey(std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>>) in BogoShim.cpp.o
      fizz::CertUtils::makePeerCert(std::__1::unique_ptr<x509_st, folly::static_function_deleter<x509_st, &X509_free>>) in libfizz.a(Certificate.cpp.o)
      fizz::CertUtils::getKeyType(std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&) in libfizz.a(Certificate.cpp.o)
      fizz::OpenSSLSignature<(fizz::KeyType)0>::setKey(std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>>) in libfizz.a(Certificate.cpp.o)
  "_EVP_PKEY_get_size", referenced from:
      fizz::detail::ecSign(folly::Range<unsigned char const*>, std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&, int) in libfizz.a(Signature.cpp.o)
      fizz::detail::edSign(folly::Range<unsigned char const*>, std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&) in libfizz.a(Signature.cpp.o)
      fizz::detail::rsaPssSign(folly::Range<unsigned char const*>, std::__1::unique_ptr<evp_pkey_st, folly::static_function_deleter<evp_pkey_st, &EVP_PKEY_free>> const&, int) in libfizz.a(Signature.cpp.o)
  "_SSL_get1_peer_certificate", referenced from:
      folly::AsyncSSLSocket::getPeerCertificate() const in libfolly.a(AsyncSSLSocket.cpp.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

</details>

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
This has been tested in a forked repo. See issues above.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* no changes to functionality of presto
* new GitHub actions workflows that mirror circleci workflows

Hive Changes
* none
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

https://fburl.com/workplace/f6mz6tmw