### PR TITLE
[native] Translate presto properties to Velox.

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -54,6 +54,7 @@ void ConfigBase::initialize(const std::string& filePath) {
   auto values = util::readConfig(fs::path(filePath));
   filePath_ = filePath;
   checkRegisteredProperties(values);
+  updateLoadedValues(values);
 
   bool mutableConfig{false};
   auto it = values.find(std::string(kMutableConfig));
@@ -66,6 +67,12 @@ void ConfigBase::initialize(const std::string& filePath) {
   } else {
     config_ = std::make_unique<velox::core::MemConfig>(values);
   };
+}
+
+std::string ConfigBase::capacityPropertyAsBytesString(
+    std::string_view propertyName) const {
+  return folly::to<std::string>(toCapacity(
+      optionalProperty(propertyName).value(), velox::core::CapacityUnit::BYTE));
 }
 
 bool ConfigBase::registerProperty(
@@ -204,6 +211,8 @@ SystemConfig::SystemConfig() {
           STR_PROP(kInternalCommunicationSharedSecret, ""),
           NUM_PROP(kInternalCommunicationJwtExpirationSeconds, 300),
           BOOL_PROP(kUseLegacyArrayAgg, false),
+          STR_PROP(kSinkMaxBufferSize, "32GB"),
+          STR_PROP(kDriverMaxPagePartitioningBufferSize, "32GB"),
       };
 }
 
@@ -708,8 +717,13 @@ BaseVeloxQueryConfig::BaseVeloxQueryConfig() {
               QueryConfig::kSpillableReservationGrowthPct,
               c.spillableReservationGrowthPct()),
           BOOL_PROP(
-              QueryConfig::kSparkLegacySizeOfNull, c.sparkLegacySizeOfNull())};
-  update(*SystemConfig::instance());
+              QueryConfig::kSparkLegacySizeOfNull, c.sparkLegacySizeOfNull()),
+          BOOL_PROP(
+              QueryConfig::kPrestoArrayAggIgnoreNulls,
+              c.prestoArrayAggIgnoreNulls()),
+          NUM_PROP(
+              QueryConfig::kMaxArbitraryBufferSize, c.maxArbitraryBufferSize()),
+      };
 }
 
 BaseVeloxQueryConfig* BaseVeloxQueryConfig::instance() {
@@ -718,14 +732,34 @@ BaseVeloxQueryConfig* BaseVeloxQueryConfig::instance() {
   return instance.get();
 }
 
-void BaseVeloxQueryConfig::initialize(const std::string& filePath) {
-  ConfigBase::initialize(filePath);
-  update(*SystemConfig::instance());
-}
+void BaseVeloxQueryConfig::updateLoadedValues(
+    std::unordered_map<std::string, std::string>& values) const {
+  /// Update velox config with values from presto system config.
+  auto systemConfig = SystemConfig::instance();
 
-void BaseVeloxQueryConfig::update(const SystemConfig& systemConfig) {
-  registeredProps_[velox::core::QueryConfig::kPrestoArrayAggIgnoreNulls] =
-      bool2String(systemConfig.useLegacyArrayAgg());
+  using namespace velox::core;
+  const std::unordered_map<std::string, std::string> updatedValues{
+      {QueryConfig::kPrestoArrayAggIgnoreNulls,
+       bool2String(systemConfig->useLegacyArrayAgg())},
+      {QueryConfig::kMaxArbitraryBufferSize,
+       systemConfig->capacityPropertyAsBytesString(
+           SystemConfig::kSinkMaxBufferSize)},
+      {QueryConfig::kMaxPartitionedOutputBufferSize,
+       systemConfig->capacityPropertyAsBytesString(
+           SystemConfig::kDriverMaxPagePartitioningBufferSize)},
+  };
+
+  std::stringstream updated;
+  for (const auto& pair : updatedValues) {
+    updated << "  " << pair.first << "=" << pair.second << "\n";
+    values[pair.first] = pair.second;
+  }
+  auto str = updated.str();
+  if (!str.empty()) {
+    PRESTO_STARTUP_LOG(INFO)
+        << "Updated in '" << filePath_ << "' from SystemProperties:\n"
+        << str;
+  }
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
@@ -45,6 +45,10 @@ class BaseVeloxQueryConfigTest : public testing::Test {
           fileSystem->openFileForWrite(systemConfigFilePath);
       systemConfigFile->append(
           fmt::format("{}=true\n", SystemConfig::kUseLegacyArrayAgg));
+      systemConfigFile->append(
+          fmt::format("{}=17MB\n", SystemConfig::kSinkMaxBufferSize));
+      systemConfigFile->append(fmt::format(
+          "{}=6MB\n", SystemConfig::kDriverMaxPagePartitioningBufferSize));
       systemConfigFile->close();
       SystemConfig::instance()->initialize(systemConfigFilePath);
     }
@@ -108,15 +112,19 @@ TEST_F(BaseVeloxQueryConfigTest, mutableConfig) {
 }
 
 TEST_F(BaseVeloxQueryConfigTest, fromSystemConfig) {
+#define GET_VAL(_name_) cfg->optionalProperty(std::string(_name_))
+
   auto cfg = BaseVeloxQueryConfig::instance();
-  ASSERT_FALSE(cfg->optionalProperty<bool>(
-                      std::string(QueryConfig::kPrestoArrayAggIgnoreNulls))
-                   .value());
+  ASSERT_EQ("false", GET_VAL(QueryConfig::kPrestoArrayAggIgnoreNulls));
+
   setUpConfigFile(true, true);
   cfg->initialize(configFilePath);
-  ASSERT_TRUE(cfg->optionalProperty<bool>(
-                     std::string(QueryConfig::kPrestoArrayAggIgnoreNulls))
-                  .value());
+
+  ASSERT_EQ("true", GET_VAL(QueryConfig::kPrestoArrayAggIgnoreNulls));
+  ASSERT_EQ("17825792", GET_VAL(QueryConfig::kMaxArbitraryBufferSize));
+  ASSERT_EQ("6291456", GET_VAL(QueryConfig::kMaxPartitionedOutputBufferSize));
+
+#undef GET_VAL
 }
 
 } // namespace facebook::presto::test

--- a/presto-native-execution/presto_cpp/main/tests/PrestoQueryRunner.h
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoQueryRunner.h
@@ -17,7 +17,7 @@
 #include <folly/io/async/EventBaseThread.h>
 #include "presto_cpp/main/http/HttpClient.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/exec/tests/utils/ReferenceQueryRunner.h"
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::presto::test {

--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(presto_type_converter OBJECT TypeParser.cpp)
+add_library(presto_type_converter TypeParser.cpp)
 
 target_link_libraries(presto_type_converter velox_type_parser)
 


### PR DESCRIPTION
## Description
Prestissimo needs to translate Presto's worker configs sink.max-buffer-size and
driver.max-page-partitioning-buffer-size to corresponding Velox configs
max_arbitrary_buffer_size and max_page_partitioning_buffer_size.

Also advance Velox version.

Fixes #21543 

```
== NO RELEASE NOTE ==
```

