### PR TITLE
Support multi-arch docker image

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,16 +1,35 @@
 #!/bin/bash
 
+# Prerequisites:
+#   - the presto-server-${VERSION}.tar.gz and presto-cli-${VERSION}-executable.jar shall exist
+#     in the same directory.
+#   - docker build driver is setup and ready to build multiple platform images. If not
+#     check the documentation here: https://docs.docker.com/build/building/multi-platform/
+#   - login to the container registry where images will be published to
+set -e
+
 if [ "$#" != "1" ]; then
     echo "usage: build.sh <version>"
     exit 1
 fi
 
-VERSION=$1
+VERSION=$1; shift
 TAG="${TAG:-latest}"
+IMAGE_NAME="${IMAGE_NAME:-presto}"
+REG_ORG="${REG_ORG:-docker.io/prestodb}"
+PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64,linux/ppc64le}"
+TMP_IIDFILE=$(mktemp)
+IIDFILE="${IIDFILE:-$TMP_IIDFILE}"
+PUBLISH="${PUBLISH:-false}"
+BUILDER="${BUILDER:-container}"
 
-wget https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${VERSION}/presto-server-${VERSION}.tar.gz
-wget https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/${VERSION}/presto-cli-${VERSION}-executable.jar
+# If PUBLISH=false, images only stores in local cache, otherwise they are pushed to th container registry
+BUILDX_NO_DEFAULT_ATTESTATIONS="" docker buildx build --builder="${BUILDER}" --iidfile "${IIDFILE}" --build-arg="PRESTO_VERSION=${VERSION}" \
+    --output "type=image,name=${REG_ORG}/${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=${PUBLISH}" \
+    --platform "${PLATFORMS}" -f Dockerfile .
 
-docker build -t prestodb/presto:${TAG} --build-arg="PRESTO_VERSION=${VERSION}" -f Dockerfile .
-
-# docker push?
+if [[ "$PUBLISH" = "true" ]]; then
+    # This only happens when push=true, since push-by-digest=true in the above build step, need to tag the images explicitly
+    BUILDX_NO_DEFAULT_ATTESTATIONS="" docker buildx imagetools create --builder="${BUILDER}" \
+    -t "${REG_ORG}/${IMAGE_NAME}:${TAG}" "${REG_ORG}/${IMAGE_NAME}@$(cat "$IIDFILE")"
+fi


### PR DESCRIPTION
## Description
Update the Jenkins pipeline to build multi-arch docker images.

## Motivation and Context
Request from presto users to make docker image multi-platform support, #18750

## Impact
Make Jenkins pipelines build and push multi-arch images

## Test Plan
Need to check the logs from the Jenkins job. Currently, there is no mechanism to pull the images and
verify them. I will verify it manually. But it would be good to have environments to verify that automatically.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

