### PR TITLE
Preserve original page objects when region remains unchanged

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -164,12 +164,17 @@ public final class Page
         return wrapBlocksWithoutCopy(1, singleValueBlocks);
     }
 
+    // getRegion() is used to get a sub-page or region of a page based on the given positionOffset and length
     public Page getRegion(int positionOffset, int length)
     {
         if (positionOffset < 0 || length < 0 || positionOffset + length > positionCount) {
             throw new IndexOutOfBoundsException(format("Invalid position %s and length %s in page with %s positions", positionOffset, length, positionCount));
         }
-
+        //Avoid creating new objects when region is same as original page
+        if (positionOffset == 0 && length == positionCount) {
+            return this;
+        }
+        //It creates a new page with the specified region.
         int channelCount = getChannelCount();
         Block[] slicedBlocks = new Block[channelCount];
         for (int i = 0; i < channelCount; i++) {

--- a/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
@@ -33,6 +33,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 public class TestPage
@@ -44,7 +45,7 @@ public class TestPage
         Page region = page.getRegion(0, 10);
         assertEquals(page.getRegion(5, 5).getPositionCount(), 5);
         assertEquals(region.getPositionCount(), 10);
-        assertEquals(page, region);
+        assertSame(page, region);
     }
 
     @Test

--- a/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
@@ -40,14 +40,19 @@ public class TestPage
     @Test
     public void testGetRegion()
     {
-        assertEquals(new Page(10).getRegion(5, 5).getPositionCount(), 5);
+        Page page = new Page(10);
+        Page region = page.getRegion(0, 10);
+        assertEquals(page.getRegion(5, 5).getPositionCount(), 5);
+        assertEquals(region.getPositionCount(), 10);
+        assertEquals(page, region);
     }
 
     @Test
     public void testGetEmptyRegion()
     {
+        Page page = new Page(10);
         assertEquals(new Page(0).getRegion(0, 0).getPositionCount(), 0);
-        assertEquals(new Page(10).getRegion(5, 0).getPositionCount(), 0);
+        assertEquals(page.getRegion(5, 0).getPositionCount(), 0);
     }
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class, expectedExceptionsMessageRegExp = "Invalid position 1 and length 1 in page with 0 positions")

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -641,11 +641,7 @@ class AggregationAnalyzer
                 }
             }
 
-            if (node.getDefaultValue().isPresent() && !process(node.getDefaultValue().get(), context)) {
-                return false;
-            }
-
-            return true;
+            return !node.getDefaultValue().isPresent() || process(node.getDefaultValue().get(), context);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -343,11 +343,7 @@ public class OptimizeMixedDistinctAggregations
                 }
             }
 
-            if (!aggregateInfo.getMask().getType().isComparable()) {
-                return false;
-            }
-
-            return true;
+            return aggregateInfo.getMask().getType().isComparable();
         }
 
         /*

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
@@ -135,10 +135,7 @@ public class TupleDomainOrcPredicate<C>
         }
 
         // if none of the discrete predicate values are found in the bloom filter, there is no overlap and the section should be skipped
-        if (discreteValues.get().stream().noneMatch(value -> checkInBloomFilter(bloomFilter, value, stripeDomain.getType()))) {
-            return false;
-        }
-        return true;
+        return discreteValues.get().stream().allMatch(value -> checkInBloomFilter(bloomFilter, value, stripeDomain.getType()));
     }
 
     @VisibleForTesting

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanInputStream.java
@@ -116,9 +116,9 @@ public class BooleanInputStream
         }
 
         // count remaining bits
-        for (int i = 0; i < items; i++) {
-            count += nextBit() ? 1 : 0;
-        }
+        int count = IntStream.range(0, items)
+                .map(i -> nextBit() ? 1 : 0)
+                .sum();
 
         return count;
     }
@@ -397,9 +397,9 @@ public class BooleanInputStream
             throws IOException
     {
         int count = 0;
-        for (int i = 0; i < batchSize; i++) {
-            count += nextBit() ? 0 : 1;
-        }
+        int count = IntStream.range(0, batchSize)
+                .map(i -> nextBit() ? 0 : 1)
+                .sum();
         return count;
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1468,8 +1468,8 @@ public class OrcTester
 
     public static void assertColumnValueEquals(Type type, Object actual, Object expected)
     {
-        if (actual == null) {
-            assertEquals(actual, expected);
+        if (assertNull(actual)) {
+            assertNull(expected);
             return;
         }
         String baseType = type.getTypeSignature().getBase();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -241,11 +241,7 @@ public final class TestingOrcPredicate
         protected boolean chunkMatchesStats(List<T> chunk, ColumnStatistics columnStatistics)
         {
             // verify non null count
-            if (columnStatistics.getNumberOfValues() != Iterables.size(filter(chunk, notNull()))) {
-                return false;
-            }
-
-            return true;
+            return columnStatistics.getNumberOfValues() == Iterables.size(filter(chunk, notNull()));
         }
     }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
@@ -542,11 +542,7 @@ public class TupleDomainParquetPredicate
         @Override
         public boolean keep(T value)
         {
-            if (value == null && !columnDomain.isNullAllowed()) {
-                return false;
-            }
-
-            return true;
+            return !(value == null && !columnDomain.isNullAllowed());
         }
 
         @Override


### PR DESCRIPTION
## Description
Optimized  code to preserve the original page objects when the region remains unchanged. This means that new objects will no longer be created unnecessarily when the region is the same as the original page. 

## Motivation and Context
 By avoiding the creation of new objects when the region is the same as the original page, we can reduce memory usage

## Impact
NO MAJOR IMPACT, PRESTO-COMMON MODULE

## Test Plan
Unit tests to verify that new objects are not created when the region remains unchanged in presto-common module.
[INFO] Tests run: 261, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.106 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 261, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  41.197 s
[INFO] Finished at: 2023-12-15T14:43:24+05:30
[INFO] ------------------------------------------------------------------------


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

== NO RELEASE NOTE ==


