### PR TITLE
Improve checks readibility

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
@@ -103,11 +103,11 @@ public class TupleDomainParquetPredicate
             return Domain.all(type);
         }
 
-        if (statistics.getNumNulls() == rowCount) {
+        if (statistics.isNumNullsSet() && statistics.getNumNulls() == rowCount) {
             return Domain.onlyNull(type);
         }
 
-        boolean hasNullValue = statistics.getNumNulls() != 0L;
+        boolean hasNullValue = !statistics.isNumNullsSet() || statistics.getNumNulls() != 0L;
 
         if (!statistics.hasNonNullValue() || statistics.genericGetMin() == null || statistics.genericGetMax() == null) {
             return Domain.create(ValueSet.all(type), hasNullValue);


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/commit/980eb8b489e379468c1b2ac7a0cce36ec83dcd14(trinodb/trino#7384)

## Description
Improve readibility

## Motivation and Context
When `! isNumNullsSet()` then `getNumNulls() == -1`, so this doesn't
change the effect, but makes the code more readable.

## Impact
No impact

## Test Plan
UT FOR presto-parquet

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

