### PR TITLE
Add raw and storage size to DWRF column statistics

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -47,11 +47,15 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
+import it.unimi.dsi.fastutil.ints.Int2LongMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -85,6 +89,7 @@ import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toStripeEncryp
 import static com.facebook.presto.orc.metadata.OrcType.createNodeIdToColumnMap;
 import static com.facebook.presto.orc.metadata.OrcType.mapColumnToNode;
 import static com.facebook.presto.orc.metadata.PostScript.MAGIC;
+import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
 import static com.facebook.presto.orc.writer.ColumnWriters.createColumnWriter;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -151,6 +156,7 @@ public class OrcWriter
     private long rawSize;
     private List<ColumnStatistics> unencryptedStats;
     private final Map<Integer, Integer> nodeIdToColumn;
+    private final StreamSizeHelper streamSizeHelper;
 
     public OrcWriter(
             DataSink dataSink,
@@ -246,6 +252,7 @@ public class OrcWriter
         this.metadataWriter = new CompressedMetadataWriter(orcEncoding.createMetadataWriter(), columnWriterOptions, Optional.empty());
         this.hiveStorageTimeZone = requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
         this.stats = requireNonNull(stats, "stats is null");
+        this.streamSizeHelper = new StreamSizeHelper(orcTypes, columnWriterOptions.getFlattenedNodes(), columnWriterOptions.isMapStatisticsEnabled());
 
         recordValidation(validation -> validation.setColumnNames(columnNames));
 
@@ -533,19 +540,20 @@ public class OrcWriter
             return ImmutableList.of();
         }
 
-        List<DataOutput> outputData = new ArrayList<>();
         List<Stream> unencryptedStreams = new ArrayList<>(columnWriters.size() * 3);
         Multimap<Integer, Stream> encryptedStreams = ArrayListMultimap.create();
+        List<StreamDataOutput> indexStreams = new ArrayList<>(columnWriters.size());
 
         // get index streams
         long indexLength = 0;
         long offset = 0;
         int previousEncryptionGroup = -1;
         for (ColumnWriter columnWriter : columnWriters) {
-            for (StreamDataOutput indexStream : columnWriter.getIndexStreams(Optional.empty())) {
+            List<StreamDataOutput> streams = columnWriter.getIndexStreams(Optional.empty());
+            indexStreams.addAll(streams);
+            for (StreamDataOutput indexStream : streams) {
                 // The ordering is critical because the stream only contain a length with no offset.
                 // if the previous stream was part of a different encryption group, need to specify an offset so we know the column order
-                outputData.add(indexStream);
                 Optional<Integer> encryptionGroup = dwrfEncryptionInfo.getGroupByNodeId(indexStream.getStream().getColumn());
                 if (encryptionGroup.isPresent()) {
                     Stream stream = previousEncryptionGroup == encryptionGroup.get() ? indexStream.getStream() : indexStream.getStream().withOffset(offset);
@@ -563,7 +571,7 @@ public class OrcWriter
         }
 
         if (dwrfStripeCacheWriter.isPresent()) {
-            dwrfStripeCacheWriter.get().addIndexStreams(ImmutableList.copyOf(outputData), indexLength);
+            dwrfStripeCacheWriter.get().addIndexStreams(ImmutableList.copyOf(indexStreams), indexLength);
         }
 
         // data streams (sorted by size)
@@ -576,17 +584,20 @@ public class OrcWriter
                     .mapToLong(StreamDataOutput::size)
                     .sum();
         }
+
         ImmutableMap.Builder<Integer, ColumnEncoding> columnEncodingsBuilder = ImmutableMap.builder();
         columnEncodingsBuilder.put(0, new ColumnEncoding(DIRECT, 0));
         columnWriters.forEach(columnWriter -> columnEncodingsBuilder.putAll(columnWriter.getColumnEncodings()));
         Map<Integer, ColumnEncoding> columnEncodings = columnEncodingsBuilder.build();
+
+        // reorder data streams
         streamLayout.reorder(dataStreams, nodeIdToColumn, columnEncodings);
+        streamSizeHelper.collectStreamSizes(Iterables.concat(indexStreams, dataStreams), columnEncodings);
 
         // add data streams
         for (StreamDataOutput dataStream : dataStreams) {
             // The ordering is critical because the stream only contains a length with no offset.
             // if the previous stream was part of a different encryption group, need to specify an offset so we know the column order
-            outputData.add(dataStream);
             Optional<Integer> encryptionGroup = dwrfEncryptionInfo.getGroupByNodeId(dataStream.getStream().getColumn());
             if (encryptionGroup.isPresent()) {
                 Stream stream = previousEncryptionGroup == encryptionGroup.get() ? dataStream.getStream() : dataStream.getStream().withOffset(offset);
@@ -605,7 +616,7 @@ public class OrcWriter
         columnWriters.forEach(columnWriter -> columnStatistics.putAll(columnWriter.getColumnStripeStatistics()));
 
         // the 0th column is a struct column for the whole row
-        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, null));
+        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, null, stripeRawSize, null));
 
         Map<Integer, ColumnEncoding> unencryptedColumnEncodings = columnEncodings.entrySet().stream()
                 .filter(entry -> !dwrfEncryptionInfo.getGroupByNodeId(entry.getKey()).isPresent())
@@ -618,7 +629,7 @@ public class OrcWriter
 
         StripeFooter stripeFooter = new StripeFooter(unencryptedStreams, unencryptedColumnEncodings, encryptedGroups);
         Slice footer = metadataWriter.writeStripeFooter(stripeFooter);
-        outputData.add(createDataOutput(footer));
+        DataOutput footerDataOutput = createDataOutput(footer);
         dwrfStripeCacheWriter.ifPresent(stripeCacheWriter -> stripeCacheWriter.addStripeFooter(createDataOutput(footer)));
 
         // create final stripe statistics
@@ -640,7 +651,11 @@ public class OrcWriter
                 dictionaryCompressionOptimizer.getDictionaryMemoryBytes(),
                 stripeInformation);
 
-        return outputData;
+        return ImmutableList.<DataOutput>builder()
+                .addAll(indexStreams)
+                .addAll(dataStreams)
+                .add(footerDataOutput)
+                .build();
     }
 
     private List<Slice> createEncryptedGroups(Multimap<Integer, Stream> encryptedStreams, Map<Integer, ColumnEncoding> encryptedColumnEncodings)
@@ -706,7 +721,9 @@ public class OrcWriter
                 closedStripes.stream()
                         .map(ClosedStripe::getStatistics)
                         .map(StripeStatistics::getColumnStatistics)
-                        .collect(toList()));
+                        .collect(toList()),
+                streamSizeHelper.getNodeSizes(),
+                streamSizeHelper.getMapKeySizes());
         recordValidation(validation -> validation.setFileStatistics(fileStats));
 
         Map<String, Slice> userMetadata = this.userMetadata.entrySet().stream()
@@ -790,7 +807,9 @@ public class OrcWriter
             nodeAndSubNodeStats.computeIfAbsent(group, x -> new ArrayList<>()).add(columnStatistics);
             unencryptedStats.add(new ColumnStatistics(
                     columnStatistics.getNumberOfValues(),
-                    null));
+                    null,
+                    columnStatistics.hasRawSize() ? columnStatistics.getRawSize() : null,
+                    columnStatistics.hasStorageSize() ? columnStatistics.getStorageSize() : null));
             for (Integer fieldIndex : orcTypes.get(index).getFieldTypeIndexes()) {
                 addStatsRecursive(allStats, fieldIndex, nodeAndSubNodeStats, unencryptedStats, encryptedStats);
             }
@@ -885,20 +904,25 @@ public class OrcWriter
         return denseList.build();
     }
 
-    private static List<ColumnStatistics> toFileStats(List<List<ColumnStatistics>> stripes)
+    private static List<ColumnStatistics> toFileStats(List<List<ColumnStatistics>> stripes, Int2LongMap nodeSizes, Int2ObjectMap<Object2LongMap<DwrfProto.KeyInfo>> mapKeySizes)
     {
         if (stripes.isEmpty()) {
             return ImmutableList.of();
         }
+
         int columnCount = stripes.get(0).size();
         checkArgument(stripes.stream().allMatch(stripe -> columnCount == stripe.size()));
 
         ImmutableList.Builder<ColumnStatistics> fileStats = ImmutableList.builder();
         for (int i = 0; i < columnCount; i++) {
             int column = i;
-            fileStats.add(ColumnStatistics.mergeColumnStatistics(stripes.stream()
+            List<ColumnStatistics> stripeColumnStats = stripes.stream()
                     .map(stripe -> stripe.get(column))
-                    .collect(toList())));
+                    .collect(toList());
+            long storageSize = nodeSizes.getOrDefault(column, 0L);
+            Object2LongMap<DwrfProto.KeyInfo> keySizes = mapKeySizes.get(column);
+            ColumnStatistics columnStats = mergeColumnStatistics(stripeColumnStats, storageSize, keySizes);
+            fileStats.add(columnStats);
         }
         return fileStats.build();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StreamSizeHelper.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StreamSizeHelper.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.DwrfSequenceEncoding;
+import com.facebook.presto.orc.metadata.OrcType;
+import com.facebook.presto.orc.metadata.Stream;
+import com.facebook.presto.orc.proto.DwrfProto;
+import com.facebook.presto.orc.stream.StreamDataOutput;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2LongMap;
+import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class StreamSizeHelper
+{
+    private final List<OrcType> orcTypes;
+
+    // flag indicating whether to collect flat map key size stats or not
+    private final boolean collectKeyStats;
+
+    // contains the node of the flattened column, it does not contain sub-nodes
+    private final Set<Integer> flatMapNodes;
+
+    // contains the mapping of all map value nodes to the top-level (column) map
+    // node for flattened nodes
+    private final Int2IntMap flatMapNodeTrees;
+
+    // contains self node sizes (not rolled up)
+    private final long[] nodeSizes;
+
+    // key sizes by flat map node
+    private final Int2ObjectMap<Object2LongMap<DwrfProto.KeyInfo>> keySizes = new Int2ObjectOpenHashMap<>();
+
+    public StreamSizeHelper(List<OrcType> orcTypes, Set<Integer> flatMapNodes, boolean mapStatisticsEnabled)
+    {
+        this.orcTypes = requireNonNull(orcTypes, "orcTypes is null");
+        this.flatMapNodes = requireNonNull(flatMapNodes, "flattenedNodes is null");
+        this.collectKeyStats = mapStatisticsEnabled && !flatMapNodes.isEmpty();
+        this.nodeSizes = new long[orcTypes.size()];
+        this.flatMapNodeTrees = buildFlattenedNodeTrees();
+    }
+
+    private Int2IntMap buildFlattenedNodeTrees()
+    {
+        Int2IntMap flattenedNodeTrees = new Int2IntOpenHashMap();
+        if (!collectKeyStats) {
+            return flattenedNodeTrees;
+        }
+
+        // map all map values nodes to their top-level map node
+        for (Integer mapNode : flatMapNodes) {
+            OrcType mapType = orcTypes.get(mapNode);
+            checkArgument(mapType.getOrcTypeKind() == OrcType.OrcTypeKind.MAP, "flat map node %s must be a map, but was %s", mapNode, mapType.getOrcTypeKind());
+            checkArgument(mapType.getFieldCount() == 2, "flat map node %s must have exactly 2 sub-fields but had %s", mapNode, mapType.getFieldCount());
+            int mapValueNode = mapType.getFieldTypeIndex(1);
+            IntList deepValueNodes = collectDeepTreeNodes(orcTypes, mapValueNode);
+            deepValueNodes.intStream().forEach(valueNode -> flattenedNodeTrees.put(valueNode, mapNode.intValue()));
+        }
+
+        return flattenedNodeTrees;
+    }
+
+    public void collectStreamSizes(Iterable<StreamDataOutput> streamDataOutputs, Map<Integer, ColumnEncoding> columnEncodings)
+    {
+        // collect node sizes first
+        for (StreamDataOutput streamDataOutput : streamDataOutputs) {
+            requireNonNull(streamDataOutput, "streamDataOutput is null");
+            Stream stream = streamDataOutput.getStream();
+            int node = stream.getColumn();
+            nodeSizes[node] += streamDataOutput.size();
+        }
+
+        // collect map key sizes only if flat maps and map statistics are enabled
+        if (collectKeyStats) {
+            // flatMapNodeSizes contains total stream sizes by flat map node and sequence,
+            // all value sub-nodes are mapped to the flat map node
+            Int2ObjectMap<Int2LongMap> flatMapNodeSizes = new Int2ObjectOpenHashMap<>();
+
+            // collect stream sizes aggregated by flat map node and sequence
+            for (StreamDataOutput streamDataOutput : streamDataOutputs) {
+                Stream stream = streamDataOutput.getStream();
+                int node = stream.getColumn();
+
+                // check if this node belongs to the flat map tree
+                int flatMapNode = flatMapNodeTrees.getOrDefault(node, -1);
+                if (flatMapNode != -1) {
+                    Int2LongMap sequenceToSize = flatMapNodeSizes.computeIfAbsent(flatMapNode, Int2LongOpenHashMap::new);
+                    sequenceToSize.mergeLong(stream.getSequence(), stream.getLength(), Long::sum);
+                }
+            }
+
+            // merge stripe level sizes into the file level sizes
+            for (int flatMapNode : flatMapNodeSizes.keySet()) {
+                int flatMapValueNode = orcTypes.get(flatMapNode).getFieldTypeIndex(1);
+                ColumnEncoding columnEncoding = columnEncodings.get(flatMapValueNode);
+                checkArgument(columnEncoding != null, "columnEncoding for flat map node %s is null", flatMapNode);
+                checkArgument(columnEncoding.getAdditionalSequenceEncodings().isPresent(), "columnEncoding for flat map node %s does not have keys", flatMapNode);
+
+                SortedMap<Integer, DwrfSequenceEncoding> sequenceToKey = columnEncoding.getAdditionalSequenceEncodings().get();
+                Int2LongMap sequenceToSize = flatMapNodeSizes.get(flatMapNode);
+                Object2LongMap<DwrfProto.KeyInfo> keyToSize = keySizes.computeIfAbsent(flatMapNode, (ignore) -> new Object2LongOpenHashMap<>());
+
+                // set the flat map node storage size in the map column statistics
+                for (Map.Entry<Integer, DwrfSequenceEncoding> entry : sequenceToKey.entrySet()) {
+                    int sequence = entry.getKey();
+                    DwrfProto.KeyInfo key = entry.getValue().getKey();
+                    long size = sequenceToSize.getOrDefault(sequence, 0);
+                    keyToSize.mergeLong(key, size, Long::sum);
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns flat map key sizes by flat map node.
+     */
+    public Int2ObjectMap<Object2LongMap<DwrfProto.KeyInfo>> getMapKeySizes()
+    {
+        return keySizes;
+    }
+
+    /**
+     * Returns rolled up node sizes.
+     */
+    public Int2LongMap getNodeSizes()
+    {
+        Int2LongMap result = new Int2LongOpenHashMap(nodeSizes.length);
+        rollupNodeSizes(result, 0);
+        return result;
+    }
+
+    private long rollupNodeSizes(Int2LongMap result, int node)
+    {
+        long size = nodeSizes[node];
+        List<Integer> subFieldIndexes = orcTypes.get(node).getFieldTypeIndexes();
+        for (Integer subNode : subFieldIndexes) {
+            size += rollupNodeSizes(result, subNode);
+        }
+        result.put(node, size);
+        return size;
+    }
+
+    private static IntList collectDeepTreeNodes(List<OrcType> orcTypes, int startNode)
+    {
+        IntList result = new IntArrayList();
+        result.add(startNode);
+
+        for (int i = 0; i < result.size(); i++) {
+            int node = result.getInt(i);
+            OrcType orcType = orcTypes.get(node);
+            for (int j = 0; j < orcType.getFieldCount(); j++) {
+                result.add(orcType.getFieldTypeIndex(j));
+            }
+        }
+
+        return result;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -219,6 +219,14 @@ public class DwrfMetadataWriter
             builder.setNumberOfValues(columnStatistics.getNumberOfValues());
         }
 
+        if (columnStatistics.hasRawSize()) {
+            builder.setRawSize(columnStatistics.getRawSize());
+        }
+
+        if (columnStatistics.hasStorageSize()) {
+            builder.setSize(columnStatistics.getStorageSize());
+        }
+
         if (columnStatistics.getBooleanStatistics() != null) {
             builder.setBucketStatistics(DwrfProto.BucketStatistics.newBuilder()
                     .addCount(columnStatistics.getBooleanStatistics().getTrueValueCount())

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryColumnStatistics.java
@@ -31,9 +31,11 @@ public class BinaryColumnStatistics
     public BinaryColumnStatistics(
             Long numberOfValues,
             HiveBloomFilter bloomFilter,
+            Long rawSize,
+            Long storageSize,
             BinaryStatistics binaryStatistics)
     {
-        super(numberOfValues, bloomFilter);
+        super(numberOfValues, bloomFilter, rawSize, storageSize);
         requireNonNull(binaryStatistics, "binaryStatistics is null");
         this.binaryStatistics = binaryStatistics;
     }
@@ -48,15 +50,6 @@ public class BinaryColumnStatistics
     public long getTotalValueSizeInBytes()
     {
         return BINARY_VALUE_BYTES_OVERHEAD * getNumberOfValues() + binaryStatistics.getSum();
-    }
-
-    @Override
-    public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
-    {
-        return new BinaryColumnStatistics(
-                getNumberOfValues(),
-                bloomFilter,
-                binaryStatistics);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
@@ -25,7 +25,7 @@ public class BinaryStatisticsBuilder
         implements SliceColumnStatisticsBuilder
 {
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
     private long sum;
 
@@ -59,9 +59,9 @@ public class BinaryStatisticsBuilder
         Optional<BinaryStatistics> binaryStatistics = buildBinaryStatistics();
         if (binaryStatistics.isPresent()) {
             verify(nonNullValueCount > 0);
-            return new BinaryColumnStatistics(nonNullValueCount, null, binaryStatistics.get());
+            return new BinaryColumnStatistics(nonNullValueCount, null, rawSize, storageSize, binaryStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -71,9 +71,9 @@ public class BinaryStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 
     public static Optional<BinaryStatistics> mergeBinaryStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanColumnStatistics.java
@@ -31,9 +31,11 @@ public class BooleanColumnStatistics
     public BooleanColumnStatistics(
             Long numberOfValues,
             HiveBloomFilter bloomFilter,
+            Long rawSize,
+            Long storageSize,
             BooleanStatistics booleanStatistics)
     {
-        super(numberOfValues, bloomFilter);
+        super(numberOfValues, bloomFilter, rawSize, storageSize);
         requireNonNull(booleanStatistics, "booleanStatistics is null");
         this.booleanStatistics = booleanStatistics;
     }
@@ -48,15 +50,6 @@ public class BooleanColumnStatistics
     public long getTotalValueSizeInBytes()
     {
         return getNumberOfValues() * BOOLEAN_VALUE_BYTES;
-    }
-
-    @Override
-    public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
-    {
-        return new BooleanColumnStatistics(
-                getNumberOfValues(),
-                bloomFilter,
-                booleanStatistics);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -25,7 +25,7 @@ public class BooleanStatisticsBuilder
         implements StatisticsBuilder
 {
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
     private long trueValueCount;
 
@@ -68,9 +68,9 @@ public class BooleanStatisticsBuilder
     {
         Optional<BooleanStatistics> booleanStatistics = buildBooleanStatistics();
         if (booleanStatistics.isPresent()) {
-            return new BooleanColumnStatistics(nonNullValueCount, null, booleanStatistics.get());
+            return new BooleanColumnStatistics(nonNullValueCount, null, rawSize, storageSize, booleanStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -80,9 +80,9 @@ public class BooleanStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 
     public static Optional<BooleanStatistics> mergeBooleanStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/CountStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/CountStatisticsBuilder.java
@@ -20,7 +20,7 @@ public class CountStatisticsBuilder
         implements StatisticsBuilder
 {
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
 
     @Override
@@ -49,7 +49,7 @@ public class CountStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -59,8 +59,8 @@ public class CountStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateColumnStatistics.java
@@ -31,9 +31,11 @@ public class DateColumnStatistics
     public DateColumnStatistics(
             Long numberOfValues,
             HiveBloomFilter bloomFilter,
+            Long rawSize,
+            Long storageSize,
             DateStatistics dateStatistics)
     {
-        super(numberOfValues, bloomFilter);
+        super(numberOfValues, bloomFilter, rawSize, storageSize);
         requireNonNull(dateStatistics, "dateStatistics is null");
         this.dateStatistics = dateStatistics;
     }
@@ -48,15 +50,6 @@ public class DateColumnStatistics
     public long getTotalValueSizeInBytes()
     {
         return getNumberOfValues() * DATE_VALUE_BYTES;
-    }
-
-    @Override
-    public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
-    {
-        return new DateColumnStatistics(
-                getNumberOfValues(),
-                bloomFilter,
-                dateStatistics);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
@@ -23,7 +23,7 @@ public class DateStatisticsBuilder
         implements LongValueStatisticsBuilder
 {
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
     private int minimum = Integer.MAX_VALUE;
     private int maximum = Integer.MIN_VALUE;
@@ -62,9 +62,9 @@ public class DateStatisticsBuilder
     {
         Optional<DateStatistics> dateStatistics = buildDateStatistics();
         if (dateStatistics.isPresent()) {
-            return new DateColumnStatistics(nonNullValueCount, null, dateStatistics.get());
+            return new DateColumnStatistics(nonNullValueCount, null, rawSize, storageSize, dateStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -74,9 +74,9 @@ public class DateStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 
     public static Optional<DateStatistics> mergeDateStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalColumnStatistics.java
@@ -30,9 +30,11 @@ public class DecimalColumnStatistics
     public DecimalColumnStatistics(
             Long numberOfValues,
             HiveBloomFilter bloomFilter,
+            Long rawSize,
+            Long storageSize,
             DecimalStatistics decimalStatistics)
     {
-        super(numberOfValues, bloomFilter);
+        super(numberOfValues, bloomFilter, rawSize, storageSize);
         requireNonNull(decimalStatistics, "decimalStatistics is null");
         this.decimalStatistics = decimalStatistics;
     }
@@ -47,15 +49,6 @@ public class DecimalColumnStatistics
     public long getTotalValueSizeInBytes()
     {
         return getNumberOfValues() * decimalStatistics.getMinAverageValueSizeInBytes();
-    }
-
-    @Override
-    public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
-    {
-        return new DecimalColumnStatistics(
-                getNumberOfValues(),
-                bloomFilter,
-                decimalStatistics);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleColumnStatistics.java
@@ -31,9 +31,11 @@ public class DoubleColumnStatistics
     public DoubleColumnStatistics(
             Long numberOfValues,
             HiveBloomFilter bloomFilter,
+            Long rawSize,
+            Long storageSize,
             DoubleStatistics doubleStatistics)
     {
-        super(numberOfValues, bloomFilter);
+        super(numberOfValues, bloomFilter, rawSize, storageSize);
         requireNonNull(doubleStatistics, "doubleStatistics is null");
         this.doubleStatistics = doubleStatistics;
     }
@@ -48,15 +50,6 @@ public class DoubleColumnStatistics
     public long getTotalValueSizeInBytes()
     {
         return getNumberOfValues() * DOUBLE_VALUE_BYTES;
-    }
-
-    @Override
-    public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
-    {
-        return new DoubleColumnStatistics(
-                getNumberOfValues(),
-                bloomFilter,
-                doubleStatistics);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -26,7 +26,7 @@ public class DoubleStatisticsBuilder
         implements StatisticsBuilder
 {
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
     private boolean hasNan;
     private double minimum = Double.POSITIVE_INFINITY;
@@ -84,9 +84,9 @@ public class DoubleStatisticsBuilder
     {
         Optional<DoubleStatistics> doubleStatistics = buildDoubleStatistics();
         if (doubleStatistics.isPresent()) {
-            return new DoubleColumnStatistics(nonNullValueCount, null, doubleStatistics.get());
+            return new DoubleColumnStatistics(nonNullValueCount, null, rawSize, storageSize, doubleStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -96,9 +96,9 @@ public class DoubleStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 
     public static Optional<DoubleStatistics> mergeDoubleStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerColumnStatistics.java
@@ -31,9 +31,11 @@ public class IntegerColumnStatistics
     public IntegerColumnStatistics(
             Long numberOfValues,
             HiveBloomFilter bloomFilter,
+            Long rawSize,
+            Long storageSize,
             IntegerStatistics integerStatistics)
     {
-        super(numberOfValues, bloomFilter);
+        super(numberOfValues, bloomFilter, rawSize, storageSize);
         requireNonNull(integerStatistics, "integerStatistics is null");
         this.integerStatistics = integerStatistics;
     }
@@ -48,15 +50,6 @@ public class IntegerColumnStatistics
     public long getTotalValueSizeInBytes()
     {
         return getNumberOfValues() * INTEGER_VALUE_BYTES;
-    }
-
-    @Override
-    public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
-    {
-        return new IntegerColumnStatistics(
-                getNumberOfValues(),
-                bloomFilter,
-                integerStatistics);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
@@ -23,7 +23,7 @@ public class IntegerStatisticsBuilder
         implements LongValueStatisticsBuilder
 {
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
     private long minimum = Long.MAX_VALUE;
     private long maximum = Long.MIN_VALUE;
@@ -90,9 +90,9 @@ public class IntegerStatisticsBuilder
     {
         Optional<IntegerStatistics> integerStatistics = buildIntegerStatistics();
         if (integerStatistics.isPresent()) {
-            return new IntegerColumnStatistics(nonNullValueCount, null, integerStatistics.get());
+            return new IntegerColumnStatistics(nonNullValueCount, null, rawSize, storageSize, integerStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -102,9 +102,9 @@ public class IntegerStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 
     public static Optional<IntegerStatistics> mergeIntegerStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -33,7 +33,7 @@ public class LongDecimalStatisticsBuilder
     public static final long LONG_DECIMAL_VALUE_BYTES = 16L;
 
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
     private BigDecimal minimum;
     private BigDecimal maximum;
@@ -97,9 +97,9 @@ public class LongDecimalStatisticsBuilder
     {
         Optional<DecimalStatistics> decimalStatistics = buildDecimalStatistics(LONG_DECIMAL_VALUE_BYTES);
         if (decimalStatistics.isPresent()) {
-            return new DecimalColumnStatistics(nonNullValueCount, null, decimalStatistics.get());
+            return new DecimalColumnStatistics(nonNullValueCount, null, rawSize, storageSize, decimalStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -109,9 +109,9 @@ public class LongDecimalStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 
     public static Optional<DecimalStatistics> mergeDecimalStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/MapColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/MapColumnStatistics.java
@@ -26,9 +26,14 @@ public class MapColumnStatistics
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapColumnStatistics.class).instanceSize();
     private final MapStatistics mapStatistics;
 
-    public MapColumnStatistics(Long numberOfValues, HiveBloomFilter bloomFilter, MapStatistics mapStatistics)
+    public MapColumnStatistics(
+            Long numberOfValues,
+            HiveBloomFilter bloomFilter,
+            Long rawSize,
+            Long storageSize,
+            MapStatistics mapStatistics)
     {
-        super(numberOfValues, bloomFilter);
+        super(numberOfValues, bloomFilter, rawSize, storageSize);
         this.mapStatistics = requireNonNull(mapStatistics, "mapStatistics is null");
     }
 
@@ -46,12 +51,6 @@ public class MapColumnStatistics
             size += entry.getColumnStatistics().getTotalValueSizeInBytes();
         }
         return size;
-    }
-
-    @Override
-    public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
-    {
-        return new MapColumnStatistics(getNumberOfValues(), bloomFilter, mapStatistics);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/MapColumnStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/MapColumnStatisticsBuilder.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.proto.DwrfProto;
 import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -35,7 +36,7 @@ public class MapColumnStatisticsBuilder
     private final boolean collectKeyStats;
 
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
     private boolean hasEntries;
 
@@ -85,9 +86,9 @@ public class MapColumnStatisticsBuilder
     {
         if (hasEntries && collectKeyStats) {
             MapStatistics mapStatistics = new MapStatistics(entries.build());
-            return new MapColumnStatistics(nonNullValueCount, null, mapStatistics);
+            return new MapColumnStatistics(nonNullValueCount, null, rawSize, storageSize, mapStatistics);
         }
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -97,12 +98,12 @@ public class MapColumnStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 
-    public static Optional<MapStatistics> mergeMapStatistics(List<ColumnStatistics> stats)
+    public static Optional<MapStatistics> mergeMapStatistics(List<ColumnStatistics> stats, Object2LongMap<DwrfProto.KeyInfo> keySizes)
     {
         Map<DwrfProto.KeyInfo, List<ColumnStatistics>> columnStatisticsByKey = new LinkedHashMap<>();
         long nonNullValueCount = 0;
@@ -127,8 +128,9 @@ public class MapColumnStatisticsBuilder
         // merge all column stats for each key
         MapColumnStatisticsBuilder mapStatisticsBuilder = new MapColumnStatisticsBuilder(true);
         for (Map.Entry<DwrfProto.KeyInfo, List<ColumnStatistics>> entry : columnStatisticsByKey.entrySet()) {
-            ColumnStatistics mergedColumnStatistics = mergeColumnStatistics(entry.getValue());
             DwrfProto.KeyInfo key = entry.getKey();
+            Long keySize = keySizes != null ? keySizes.getLong(key) : null;
+            ColumnStatistics mergedColumnStatistics = mergeColumnStatistics(entry.getValue(), keySize, null);
             mapStatisticsBuilder.addMapStatistics(key, mergedColumnStatistics);
         }
         mapStatisticsBuilder.increaseValueCount(nonNullValueCount);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -25,7 +25,7 @@ public class ShortDecimalStatisticsBuilder
     private final int scale;
 
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
     private long minimum = Long.MAX_VALUE;
     private long maximum = Long.MIN_VALUE;
@@ -60,9 +60,9 @@ public class ShortDecimalStatisticsBuilder
     {
         Optional<DecimalStatistics> decimalStatistics = buildDecimalStatistics();
         if (decimalStatistics.isPresent()) {
-            return new DecimalColumnStatistics(nonNullValueCount, null, decimalStatistics.get());
+            return new DecimalColumnStatistics(nonNullValueCount, null, rawSize, storageSize, decimalStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -72,8 +72,8 @@ public class ShortDecimalStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringColumnStatistics.java
@@ -31,9 +31,11 @@ public class StringColumnStatistics
     public StringColumnStatistics(
             Long numberOfValues,
             HiveBloomFilter bloomFilter,
+            Long rawSize,
+            Long storageSize,
             StringStatistics stringStatistics)
     {
-        super(numberOfValues, bloomFilter);
+        super(numberOfValues, bloomFilter, rawSize, storageSize);
         requireNonNull(stringStatistics, "stringStatistics is null");
         this.stringStatistics = stringStatistics;
     }
@@ -48,15 +50,6 @@ public class StringColumnStatistics
     public long getTotalValueSizeInBytes()
     {
         return STRING_VALUE_BYTES_OVERHEAD * getNumberOfValues() + stringStatistics.getSum();
-    }
-
-    @Override
-    public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
-    {
-        return new StringColumnStatistics(
-                getNumberOfValues(),
-                bloomFilter,
-                stringStatistics);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -32,7 +32,7 @@ public class StringStatisticsBuilder
     private final int stringStatisticsLimitInBytes;
 
     private long nonNullValueCount;
-    private long size;
+    private long storageSize;
     private long rawSize;
     private Slice minimum;
     private Slice maximum;
@@ -128,9 +128,9 @@ public class StringStatisticsBuilder
         Optional<StringStatistics> stringStatistics = buildStringStatistics();
         if (stringStatistics.isPresent()) {
             verify(nonNullValueCount > 0);
-            return new StringColumnStatistics(nonNullValueCount, null, stringStatistics.get());
+            return new StringColumnStatistics(nonNullValueCount, null, rawSize, storageSize, stringStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, null);
+        return new ColumnStatistics(nonNullValueCount, null, rawSize, storageSize);
     }
 
     @Override
@@ -140,9 +140,9 @@ public class StringStatisticsBuilder
     }
 
     @Override
-    public void incrementSize(long size)
+    public void incrementSize(long storageSize)
     {
-        this.size += size;
+        this.storageSize += storageSize;
     }
 
     public static Optional<StringStatistics> mergeStringStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -58,7 +58,7 @@ public class ByteColumnWriter
     private final boolean compressed;
     private final ByteOutputStream dataStream;
     private final PresentOutputStream presentStream;
-    private CompressedMetadataWriter metadataWriter;
+    private final CompressedMetadataWriter metadataWriter;
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
     private long columnStatisticsRetainedSizeInBytes;
@@ -125,7 +125,7 @@ public class ByteColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, rawSize, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -161,7 +161,7 @@ public class ListColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, rawSize, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -138,6 +138,11 @@ public class LongColumnWriter
         presentStream = updatedPresentStream;
     }
 
+    void updateRawSize(long rawSize)
+    {
+        statisticsBuilder.incrementRawSize(rawSize);
+    }
+
     @Override
     public long writeBlock(Block block)
     {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
@@ -206,6 +206,12 @@ public class LongDictionaryColumnWriter
     }
 
     @Override
+    protected void updateRawSizeInDirectWriter(long rawSize)
+    {
+        directColumnWriter.updateRawSize(rawSize);
+    }
+
+    @Override
     protected Optional<int[]> writeDictionary()
     {
         long[] elements = dictionary.elements();
@@ -268,6 +274,7 @@ public class LongDictionaryColumnWriter
     @Override
     protected ColumnStatistics createColumnStatistics()
     {
+        statisticsBuilder.incrementRawSize(rawSize);
         ColumnStatistics statistics = statisticsBuilder.buildColumnStatistics();
         statisticsBuilder = new IntegerStatisticsBuilder();
         return statistics;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -169,7 +169,7 @@ public class MapColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, rawSize, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatValueWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatValueWriter.java
@@ -39,10 +39,12 @@ class MapFlatValueWriter
     private final ColumnWriter valueWriter;
     private final DwrfProto.KeyInfo dwrfKey;
     private final InMapOutputStream inMapStream;
+    private final int keyRawSize;
 
     public MapFlatValueWriter(
             int nodeIndex,
             int sequence,
+            int keyRawSize,
             DwrfProto.KeyInfo dwrfKey,
             ColumnWriter valueWriter,
             ColumnWriterOptions columnWriterOptions,
@@ -50,11 +52,14 @@ class MapFlatValueWriter
     {
         checkArgument(nodeIndex > 0, "nodeIndex is invalid: %s", nodeIndex);
         checkArgument(sequence > 0, "sequence must be positive: %s", sequence);
+        checkArgument(keyRawSize >= 0, "keyRawSize must be non-negative: %s", keyRawSize);
+
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
 
         this.nodeIndex = nodeIndex;
         this.sequence = sequence;
+        this.keyRawSize = keyRawSize;
         this.dwrfKey = requireNonNull(dwrfKey, "dwrfKey is null");
         this.valueWriter = requireNonNull(valueWriter, "valueWriter is null");
         this.inMapStream = new InMapOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -63,6 +68,11 @@ class MapFlatValueWriter
     public int getSequence()
     {
         return sequence;
+    }
+
+    public int getKeyRawSize()
+    {
+        return keyRawSize;
     }
 
     public ColumnWriter getValueWriter()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -192,6 +192,7 @@ public class SliceDictionaryColumnWriter
     @Override
     protected ColumnStatistics createColumnStatistics()
     {
+        statisticsBuilder.incrementRawSize(rawSize);
         ColumnStatistics statistics = statisticsBuilder.buildColumnStatistics();
         statisticsBuilder = newStringStatisticsBuilder();
         return statistics;
@@ -218,6 +219,12 @@ public class SliceDictionaryColumnWriter
     protected void movePresentStreamToDirectWriter(PresentOutputStream presentStream)
     {
         directColumnWriter.updatePresentStream(presentStream);
+    }
+
+    @Override
+    protected void updateRawSizeInDirectWriter(long rawSize)
+    {
+        directColumnWriter.updateRawSize(rawSize);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -130,6 +130,11 @@ public class SliceDirectColumnWriter
         presentStream = updatedPresentStream;
     }
 
+    void updateRawSize(long rawSize)
+    {
+        statisticsBuilder.incrementRawSize(rawSize);
+    }
+
     @Override
     public long writeBlock(Block block)
     {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -158,7 +158,7 @@ public class StructColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, rawSize, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -207,7 +207,7 @@ public class TimestampColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, rawSize, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcWrite.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcWrite.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.metadata.CompressionKind;
+
+import java.io.Closeable;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
+import static com.facebook.presto.orc.OrcTester.createOrcWriter;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class OrcWrite
+        implements Closeable
+{
+    private enum State
+    {
+        INITIALIZING,
+        WRITING,
+        FAILED,
+        CLOSED;
+    }
+
+    private final File outputFile;
+    private OrcWriterOptions writerOptions = OrcWriterOptions.getDefaultOrcWriterOptions();
+    private List<Type> types;
+    private List<String> columnNames;
+    private CompressionKind compressionKind = CompressionKind.ZLIB;
+    private OrcEncoding encoding = OrcEncoding.DWRF;
+    private State state = State.INITIALIZING;
+    private OrcWriter orcWriter;
+
+    public OrcWrite(File outputFile)
+    {
+        this.outputFile = requireNonNull(outputFile, "outputFile is null");
+    }
+
+    public OrcWrite withTypes(Type... types)
+    {
+        return withTypes(Arrays.stream(types).collect(toList()));
+    }
+
+    public OrcWrite withTypes(List<Type> types)
+    {
+        checkIsInitializing();
+        this.types = requireNonNull(types, "types is null");
+        return this;
+    }
+
+    public OrcWrite withColumnNames(List<String> columnNames)
+    {
+        checkIsInitializing();
+        this.columnNames = requireNonNull(columnNames, "columnNames is null");
+        return this;
+    }
+
+    public OrcWrite withWriterOptions(OrcWriterOptions writerOptions)
+    {
+        checkIsInitializing();
+        this.writerOptions = requireNonNull(writerOptions, "writerOptions is null");
+        return this;
+    }
+
+    public OrcWrite withWriterOptions(BiConsumer<DefaultOrcWriterFlushPolicy.Builder, OrcWriterOptions.Builder> consumer)
+    {
+        checkIsInitializing();
+
+        DefaultOrcWriterFlushPolicy.Builder flushPolicyBuilder = DefaultOrcWriterFlushPolicy.builder();
+        OrcWriterOptions.Builder writerOptionsBuilder = OrcWriterOptions.builder();
+        consumer.accept(flushPolicyBuilder, writerOptionsBuilder);
+        writerOptionsBuilder.withFlushPolicy(flushPolicyBuilder.build());
+        return withWriterOptions(writerOptionsBuilder.build());
+    }
+
+    public OrcWrite withCompressionKind(CompressionKind compressionKind)
+    {
+        checkIsInitializing();
+        this.compressionKind = requireNonNull(compressionKind, "compressionKind is null");
+        return this;
+    }
+
+    public OrcWrite withEncoding(OrcEncoding encoding)
+    {
+        checkIsInitializing();
+        this.encoding = requireNonNull(encoding, "encoding is null");
+        return this;
+    }
+
+    public OrcWrite writePage(Page page)
+    {
+        maybeCreateWriter();
+        try {
+            orcWriter.write(page);
+        }
+        catch (Exception e) {
+            state = State.FAILED;
+            forceClose();
+            throw new RuntimeException("Failed to write a page", e);
+        }
+        return this;
+    }
+
+    public OrcWrite writePages(List<Page> pages)
+    {
+        maybeCreateWriter();
+        try {
+            for (Page page : pages) {
+                orcWriter.write(page);
+            }
+        }
+        catch (Exception e) {
+            state = State.FAILED;
+            forceClose();
+            throw new RuntimeException("Failed to write pages", e);
+        }
+        return this;
+    }
+
+    public OrcWrite writePages(Page... pages)
+    {
+        return writePages(Arrays.stream(pages).collect(toList()));
+    }
+
+    public void close()
+    {
+        if (state == State.INITIALIZING) {
+            maybeCreateWriter();
+        }
+        checkState(state == State.WRITING, "Must be in the WRITING state");
+        try {
+            orcWriter.close();
+            state = State.CLOSED;
+        }
+        catch (Exception e) {
+            state = State.FAILED;
+            throw new RuntimeException("Failed to close the writer", e);
+        }
+    }
+
+    private void forceClose()
+    {
+        if (orcWriter != null) {
+            try {
+                orcWriter.close();
+            }
+            catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    private void maybeCreateWriter()
+    {
+        checkState(state == State.INITIALIZING || state == State.WRITING, "Must be either in the INITIALIZING or WRITING state");
+
+        requireNonNull(types, "types is not set");
+        if (columnNames == null) {
+            columnNames = makeColumnNames(types.size());
+        }
+
+        if (state == State.INITIALIZING) {
+            try {
+                this.orcWriter = createOrcWriter(
+                        outputFile,
+                        encoding,
+                        compressionKind,
+                        Optional.empty(),
+                        types,
+                        writerOptions,
+                        NOOP_WRITER_STATS);
+                state = State.WRITING;
+            }
+            catch (Exception e) {
+                state = State.FAILED;
+                throw new RuntimeException("Failed to create a writer", e);
+            }
+        }
+    }
+
+    private static List<String> makeColumnNames(int columnCount)
+    {
+        return IntStream.range(0, columnCount)
+                .mapToObj(i -> "test" + i)
+                .collect(toList());
+    }
+
+    private void checkIsInitializing()
+    {
+        checkState(state == State.INITIALIZING, "Must be in the INITIALIZING state");
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnStatistics.java
@@ -15,36 +15,75 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.block.ArrayBlockBuilder;
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.ByteArrayBlock;
+import com.facebook.presto.common.block.IntArrayBlock;
+import com.facebook.presto.common.block.LongArrayBlock;
 import com.facebook.presto.common.block.MapBlockBuilder;
+import com.facebook.presto.common.block.RowBlockBuilder;
+import com.facebook.presto.common.block.ShortArrayBlock;
+import com.facebook.presto.common.block.VariableWidthBlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
+import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.DwrfSequenceEncoding;
+import com.facebook.presto.orc.metadata.Footer;
+import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
+import com.facebook.presto.orc.metadata.Stream;
+import com.facebook.presto.orc.metadata.StripeFooter;
+import com.facebook.presto.orc.metadata.StripeInformation;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.IntegerColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
 import com.facebook.presto.orc.metadata.statistics.MapColumnStatisticsBuilder;
+import com.facebook.presto.orc.metadata.statistics.MapStatistics;
+import com.facebook.presto.orc.metadata.statistics.MapStatisticsEntry;
 import com.facebook.presto.orc.proto.DwrfProto.KeyInfo;
 import com.facebook.presto.orc.protobuf.ByteString;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
 import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
@@ -54,7 +93,11 @@ import static com.facebook.presto.orc.OrcTester.createOrcWriter;
 import static com.facebook.presto.orc.OrcTester.mapType;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
 import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
+import static com.facebook.presto.orc.writer.ColumnWriter.NULL_SIZE;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -64,9 +107,11 @@ import static org.testng.Assert.assertTrue;
 
 public class TestColumnStatistics
 {
-    private static final int MAP_STATS_TEST_STRIPE_MAX_ROW_COUNT = 4;
-    private static final int MAP_STATS_TEST_ROW_GROUP_MAX_ROW_COUNT = 2;
-    public static final int COLUMN = 1;
+    private static final int STRIPE_MAX_ROW_COUNT = 4;
+    private static final int ROW_GROUP_MAX_ROW_COUNT = 2;
+    private static final int COLUMN = 1;
+    private static final int DICT_ROW_GROUP_SIZE = 4;
+    private static final int DICT_STRIPE_SIZE = 8;
 
     @DataProvider
     public static Object[][] mapKeyTypeProvider()
@@ -77,12 +122,342 @@ public class TestColumnStatistics
         };
     }
 
+    @DataProvider
+    public static Object[][] directEncodingRawAndStorageSizeProvider()
+    {
+        // total six values, the third value is null
+        int size = 3 * ROW_GROUP_MAX_ROW_COUNT;
+
+        Optional<boolean[]> valueIsNull = Optional.of(new boolean[] {false, false, true, false, false, false});
+        Block byteValues = new ByteArrayBlock(size, valueIsNull, new byte[] {1, 1, 1, 1, 1, 1});
+        Block shortValues = new ShortArrayBlock(size, valueIsNull, new short[] {1, 1, 1, 1, 1, 1});
+        Block intValues = new IntArrayBlock(size, valueIsNull, new int[] {1, 1, 1, 1, 1, 1});
+        Block bigIntValues = new LongArrayBlock(size, valueIsNull, new long[] {1L, 1L, 1L, 1L, 1L, 1L});
+
+        Slice slice = utf8Slice("0123456789");
+        Block sliceValues = new VariableWidthBlockBuilder(null, 6, 20)
+                .writeBytes(slice, 0, slice.length()).closeEntry()
+                .writeBytes(slice, 0, slice.length()).closeEntry()
+                .appendNull()
+                .writeBytes(slice, 0, slice.length()).closeEntry()
+                .writeBytes(slice, 0, slice.length()).closeEntry()
+                .writeBytes(slice, 0, slice.length()).closeEntry()
+                .build();
+
+        ArrayType arrayType = new ArrayType(INTEGER);
+        ArrayBlockBuilder arrayBlockBuilder = (ArrayBlockBuilder) arrayType.createBlockBuilder(null, size);
+        for (int i = 0; i < size; i++) {
+            if (i == 2) {
+                arrayBlockBuilder.appendNull();
+            }
+            else {
+                BlockBuilder arrayElementBuilder = arrayBlockBuilder.beginBlockEntry();
+                arrayElementBuilder.writeInt(1);
+                arrayElementBuilder.writeInt(1);
+                arrayBlockBuilder.closeEntry();
+            }
+        }
+        Block arrayBlock = arrayBlockBuilder.build();
+
+        Type mapType = mapType(INTEGER, BIGINT);
+        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) mapType.createBlockBuilder(null, size);
+        BlockBuilder mapKeyBuilder = mapBlockBuilder.getKeyBlockBuilder();
+        BlockBuilder mapValueBuilder = mapBlockBuilder.getValueBlockBuilder();
+        for (int i = 0; i < size; i++) {
+            if (i == 2) {
+                mapBlockBuilder.appendNull();
+            }
+            else {
+                mapBlockBuilder.beginDirectEntry();
+                mapKeyBuilder.writeInt(1);
+                mapValueBuilder.writeLong(2L);
+                mapBlockBuilder.closeEntry();
+            }
+        }
+        Block mapBlock = mapBlockBuilder.build();
+
+        RowType rowType = RowType.withDefaultFieldNames(ImmutableList.of(INTEGER));
+        RowBlockBuilder rowBlockBuilder = new RowBlockBuilder(ImmutableList.of(INTEGER), null, size);
+        for (int i = 0; i < size; i++) {
+            if (i == 2) {
+                rowBlockBuilder.appendNull();
+            }
+            else {
+                BlockBuilder elementBuilder = rowBlockBuilder.beginBlockEntry();
+                elementBuilder.writeInt(1);
+                rowBlockBuilder.closeEntry();
+            }
+        }
+        Block rowBlock = rowBlockBuilder.build();
+
+        return new Object[][] {
+                {BOOLEAN, 2, 2, 2, byteValues},
+                {TINYINT, 2, 2, 2, byteValues},
+                {SMALLINT, 4, 2 + 1, 4, shortValues},
+                {INTEGER, 8, 4 + 1, 8, intValues},
+                {BIGINT, 16, 8 + 1, 16, bigIntValues},
+                {REAL, 8, 4 + 1, 8, intValues},
+                {DOUBLE, 16, 8 + 1, 16, bigIntValues},
+                {TIMESTAMP, 24, 12 + 1, 24, bigIntValues},
+                {TIMESTAMP_MICROSECONDS, 24, 12 + 1, 24, bigIntValues},
+                {VARCHAR, 20, 10 + 1, 20, sliceValues},
+                {VARBINARY, 20, 10 + 1, 20, sliceValues},
+                {arrayType, 16, 8 + 1, 16, arrayBlock},
+                {rowType, 8, 4 + 1, 8, rowBlock},
+                {mapType, 24, 12 + 1, 24, mapBlock},
+        };
+    }
+
+    @DataProvider
+    public static Object[][] rawAndStorageSizeDictionaryEncodingProvider()
+    {
+        // creates a file with two stripes, first stripe has tw row groups of 4 elements,
+        // the second stripe has a single row group with 4 elements
+        int size = DICT_ROW_GROUP_SIZE * 3;
+
+        // prepare blocks with 12 elements, for the "some nulls" case set the last element to null
+        boolean[] valueIsNullValues = new boolean[size];
+        Arrays.fill(valueIsNullValues, false);
+        valueIsNullValues[size - 1] = true;
+        Optional<boolean[]> someNulls = Optional.of(valueIsNullValues);
+
+        boolean[] valueIsNullAllNulls = new boolean[size];
+        Arrays.fill(valueIsNullAllNulls, true);
+        Optional<boolean[]> allNulls = Optional.of(valueIsNullAllNulls);
+
+        int[] intDictArray = new int[size];
+        Arrays.fill(intDictArray, Integer.MAX_VALUE);
+
+        int[] intDirectArray = new int[size];
+        for (int i = 0; i < intDirectArray.length; i++) {
+            intDirectArray[i] = i;
+        }
+
+        long[] longDictArray = new long[size];
+        Arrays.fill(longDictArray, Long.MAX_VALUE);
+
+        long[] longDirectArray = new long[size];
+        for (int i = 0; i < intDirectArray.length; i++) {
+            longDirectArray[i] = i;
+        }
+
+        // build int blocks
+        Block intBlockAllNulls = new IntArrayBlock(size, allNulls, intDictArray);
+        Block intDictBlockSomeNulls = new IntArrayBlock(size, someNulls, intDictArray);
+        Block intDictBlockNoNulls = new IntArrayBlock(size, Optional.empty(), intDictArray);
+        Block intDirectBlockSomeNulls = new IntArrayBlock(size, someNulls, intDirectArray);
+        Block intDirectBlockNoNulls = new IntArrayBlock(size, Optional.empty(), intDirectArray);
+
+        // build long blocks
+        Block longBlockAllNulls = new LongArrayBlock(size, allNulls, longDictArray);
+        Block longDictBlockSomeNulls = new LongArrayBlock(size, someNulls, longDictArray);
+        Block longDictBlockNoNulls = new LongArrayBlock(size, Optional.empty(), longDictArray);
+        Block longDirectBlockSomeNulls = new LongArrayBlock(size, someNulls, longDirectArray);
+        Block longDirectBlockNoNulls = new LongArrayBlock(size, Optional.empty(), longDirectArray);
+
+        // build slice blocks
+        VariableWidthBlockBuilder sliceAllNullsBuilder = new VariableWidthBlockBuilder(null, size, size);
+        for (int i = 0; i < size; i++) {
+            sliceAllNullsBuilder.appendNull();
+        }
+
+        Slice dictSlice = utf8Slice("0123456789"); // use a nice repeating slice for a dictionary
+        VariableWidthBlockBuilder sliceDictSomeNullsBuilder = new VariableWidthBlockBuilder(null, size, size);
+        VariableWidthBlockBuilder sliceDirectSomeNullsBuilder = new VariableWidthBlockBuilder(null, size, size);
+
+        for (int i = 0; i < size; i++) {
+            if (i == size - 1) {
+                sliceDirectSomeNullsBuilder.appendNull();
+                sliceDictSomeNullsBuilder.appendNull();
+            }
+            else {
+                Slice directSlice = utf8Slice(Character.toString((char) ('a' + i))); // no repeats in this slice
+                sliceDirectSomeNullsBuilder.writeBytes(directSlice, 0, directSlice.length()).closeEntry();
+                sliceDictSomeNullsBuilder.writeBytes(dictSlice, 0, dictSlice.length()).closeEntry();
+            }
+        }
+
+        VariableWidthBlockBuilder sliceDictNoNullsBuilder = new VariableWidthBlockBuilder(null, size, size);
+        VariableWidthBlockBuilder sliceDirectNoNullsBuilder = new VariableWidthBlockBuilder(null, size, size);
+
+        for (int i = 0; i < size; i++) {
+            Slice directSlice = utf8Slice(Character.toString((char) ('a' + i))); // no repeats in this slice
+            sliceDirectNoNullsBuilder.writeBytes(directSlice, 0, directSlice.length()).closeEntry();
+            sliceDictNoNullsBuilder.writeBytes(dictSlice, 0, dictSlice.length()).closeEntry();
+        }
+
+        Block sliceBlockAllNulls = sliceAllNullsBuilder.build();
+        Block sliceDictBlockSomeNulls = sliceDictSomeNullsBuilder.build();
+        Block sliceDirectBlockSomeNulls = sliceDirectSomeNullsBuilder.build();
+        Block sliceDictBlockNoNulls = sliceDictNoNullsBuilder.build();
+        Block sliceDirectBlockNoNulls = sliceDirectNoNullsBuilder.build();
+
+        int allNullsSize = (int) (DICT_ROW_GROUP_SIZE * NULL_SIZE); // = 4
+        int intFullRowGroupSize = DICT_ROW_GROUP_SIZE * Integer.BYTES; // = 4 * 4 = 16
+        int intPartialRowGroupSize = (int) ((DICT_ROW_GROUP_SIZE - 1) * Integer.BYTES + NULL_SIZE); // = 4 * 3 + 1 = 13
+
+        int longFullRowGroupSize = DICT_ROW_GROUP_SIZE * Long.BYTES; // = 8 * 4 = 32
+        int longPartialRowGroupSize = (int) ((DICT_ROW_GROUP_SIZE - 1) * Long.BYTES + NULL_SIZE); // = 8 * 3 + 1 = 25
+
+        int sliceDictFullRowGroupSize = DICT_ROW_GROUP_SIZE * 10;
+        int sliceDictPartialRowGroupSize = (int) ((DICT_ROW_GROUP_SIZE - 1) * 10 + NULL_SIZE);
+
+        int sliceDirectFullRowGroupSize = DICT_ROW_GROUP_SIZE;
+        int sliceDirectPartialRowGroupSize = (int) ((DICT_ROW_GROUP_SIZE - 1) + NULL_SIZE);
+
+        return new Object[][] {
+                {INTEGER, allNullsSize, allNullsSize, allNullsSize, ImmutableList.of(intBlockAllNulls)},
+                {INTEGER, intFullRowGroupSize, intFullRowGroupSize, intPartialRowGroupSize, ImmutableList.of(intDictBlockSomeNulls)},
+                {INTEGER, intFullRowGroupSize, intFullRowGroupSize, intFullRowGroupSize, ImmutableList.of(intDictBlockNoNulls)},
+                {INTEGER, allNullsSize, allNullsSize, allNullsSize, partitionBlock(intBlockAllNulls)},
+                {INTEGER, intFullRowGroupSize, intFullRowGroupSize, intPartialRowGroupSize, partitionBlock(intDictBlockSomeNulls)},
+                {INTEGER, intFullRowGroupSize, intFullRowGroupSize, intFullRowGroupSize, partitionBlock(intDictBlockNoNulls)},
+                {INTEGER, intFullRowGroupSize, intFullRowGroupSize, intPartialRowGroupSize, ImmutableList.of(intDirectBlockSomeNulls)},
+                {INTEGER, intFullRowGroupSize, intFullRowGroupSize, intFullRowGroupSize, ImmutableList.of(intDirectBlockNoNulls)},
+                {INTEGER, intFullRowGroupSize, intFullRowGroupSize, intPartialRowGroupSize, partitionBlock(intDirectBlockSomeNulls)},
+                {INTEGER, intFullRowGroupSize, intFullRowGroupSize, intFullRowGroupSize, partitionBlock(intDirectBlockNoNulls)},
+
+                {BIGINT, allNullsSize, allNullsSize, allNullsSize, ImmutableList.of(longBlockAllNulls)},
+                {BIGINT, longFullRowGroupSize, longFullRowGroupSize, longPartialRowGroupSize, ImmutableList.of(longDictBlockSomeNulls)},
+                {BIGINT, longFullRowGroupSize, longFullRowGroupSize, longFullRowGroupSize, ImmutableList.of(longDictBlockNoNulls)},
+                {BIGINT, allNullsSize, allNullsSize, allNullsSize, partitionBlock(longBlockAllNulls)},
+                {BIGINT, longFullRowGroupSize, longFullRowGroupSize, longPartialRowGroupSize, partitionBlock(longDictBlockSomeNulls)},
+                {BIGINT, longFullRowGroupSize, longFullRowGroupSize, longFullRowGroupSize, partitionBlock(longDictBlockNoNulls)},
+                {BIGINT, longFullRowGroupSize, longFullRowGroupSize, longPartialRowGroupSize, ImmutableList.of(longDirectBlockSomeNulls)},
+                {BIGINT, longFullRowGroupSize, longFullRowGroupSize, longFullRowGroupSize, ImmutableList.of(longDirectBlockNoNulls)},
+                {BIGINT, longFullRowGroupSize, longFullRowGroupSize, longPartialRowGroupSize, partitionBlock(longDirectBlockSomeNulls)},
+                {BIGINT, longFullRowGroupSize, longFullRowGroupSize, longFullRowGroupSize, partitionBlock(longDirectBlockNoNulls)},
+
+                {VARCHAR, allNullsSize, allNullsSize, allNullsSize, ImmutableList.of(sliceBlockAllNulls)},
+                {VARCHAR, sliceDictFullRowGroupSize, sliceDictFullRowGroupSize, sliceDictPartialRowGroupSize, ImmutableList.of(sliceDictBlockSomeNulls)},
+                {VARCHAR, sliceDictFullRowGroupSize, sliceDictFullRowGroupSize, sliceDictFullRowGroupSize, ImmutableList.of(sliceDictBlockNoNulls)},
+                {VARCHAR, allNullsSize, allNullsSize, allNullsSize, partitionBlock(sliceBlockAllNulls)},
+                {VARCHAR, sliceDictFullRowGroupSize, sliceDictFullRowGroupSize, sliceDictPartialRowGroupSize, partitionBlock(sliceDictBlockSomeNulls)},
+                {VARCHAR, sliceDictFullRowGroupSize, sliceDictFullRowGroupSize, sliceDictFullRowGroupSize, partitionBlock(sliceDictBlockNoNulls)},
+                {VARCHAR, sliceDirectFullRowGroupSize, sliceDirectFullRowGroupSize, sliceDirectPartialRowGroupSize, ImmutableList.of(sliceDirectBlockSomeNulls)},
+                {VARCHAR, sliceDirectFullRowGroupSize, sliceDirectFullRowGroupSize, sliceDirectFullRowGroupSize, ImmutableList.of(sliceDirectBlockNoNulls)},
+                {VARCHAR, sliceDirectFullRowGroupSize, sliceDirectFullRowGroupSize, sliceDirectPartialRowGroupSize, partitionBlock(sliceDirectBlockSomeNulls)},
+                {VARCHAR, sliceDirectFullRowGroupSize, sliceDirectFullRowGroupSize, sliceDirectFullRowGroupSize, partitionBlock(sliceDirectBlockNoNulls)},
+        };
+    }
+
+    @Test(dataProvider = "directEncodingRawAndStorageSizeProvider")
+    public void testRawAndStorageSizeDirectEncoding(
+            Type type,
+            long expectedRowGroupStatsRawSize1,
+            long expectedRowGroupStatsRawSize2,
+            long expectedRowGroupStatsRawSize3,
+            Block block)
+            throws IOException
+    {
+        boolean stringDictionaryEncodingEnabled = false;
+        boolean integerDictionaryEncodingEnabled = false;
+
+        OrcWriterOptions orcWriterOptions = createOrcWriterOptions(
+                STRIPE_MAX_ROW_COUNT,
+                ROW_GROUP_MAX_ROW_COUNT,
+                stringDictionaryEncodingEnabled,
+                integerDictionaryEncodingEnabled);
+
+        assertRawAndStorageSizeForPrimitiveType(
+                type,
+                expectedRowGroupStatsRawSize1,
+                expectedRowGroupStatsRawSize2,
+                expectedRowGroupStatsRawSize3,
+                ImmutableList.of(block),
+                orcWriterOptions);
+    }
+
+    @Test(dataProvider = "rawAndStorageSizeDictionaryEncodingProvider")
+    public void testRawAndStorageSizeDictionaryEncoding(
+            Type type,
+            long expectedRowGroupStatsRawSize1,
+            long expectedRowGroupStatsRawSize2,
+            long expectedRowGroupStatsRawSize3,
+            List<Block> blocks)
+            throws IOException
+    {
+        boolean stringDictionaryEncodingEnabled = true;
+        boolean integerDictionaryEncodingEnabled = true;
+
+        OrcWriterOptions orcWriterOptions = createOrcWriterOptions(
+                DICT_STRIPE_SIZE,
+                DICT_ROW_GROUP_SIZE,
+                stringDictionaryEncodingEnabled,
+                integerDictionaryEncodingEnabled);
+
+        assertRawAndStorageSizeForPrimitiveType(
+                type,
+                expectedRowGroupStatsRawSize1,
+                expectedRowGroupStatsRawSize2,
+                expectedRowGroupStatsRawSize3,
+                blocks,
+                orcWriterOptions);
+    }
+
+    public void assertRawAndStorageSizeForPrimitiveType(
+            Type type,
+            long expectedRowGroupStatsRawSize1,
+            long expectedRowGroupStatsRawSize2,
+            long expectedRowGroupStatsRawSize3,
+            List<Block> blocks,
+            OrcWriterOptions orcWriterOptions)
+            throws IOException
+    {
+        long expectedFileStatsRawSize = expectedRowGroupStatsRawSize1 + expectedRowGroupStatsRawSize2 + expectedRowGroupStatsRawSize3;
+
+        CapturingOrcFileIntrospector introspector;
+
+        try (TempFile tempFile = new TempFile()) {
+            List<Page> pages = blocks.stream()
+                    .map(block -> new Page(block.getPositionCount(), block))
+                    .collect(toList());
+            new OrcWrite(tempFile.getFile())
+                    .withTypes(type)
+                    .withWriterOptions(orcWriterOptions)
+                    .writePages(pages)
+                    .close();
+            introspector = introspectOrcFile(type, tempFile);
+        }
+
+        // validate file statistics
+        List<ColumnStatistics> allFileStatistics = introspector.getFileFooter().getFileStats();
+        ColumnStatistics actualFileStatistics = allFileStatistics.get(COLUMN);
+        assertEquals(actualFileStatistics.getRawSize(), expectedFileStatsRawSize, "file raw sizes do not match");
+
+        // prepare to validate row group statistics
+        assertEquals(introspector.getStripes().size(), 2);
+        List<StripeInformation> stripeInformations = introspector.getStripeInformations();
+        assertEquals(stripeInformations.size(), 2);
+        assertEquals(introspector.getRowGroupIndexesByStripeOffset().size(), 2);
+
+        long stripeOffset1 = stripeInformations.get(0).getOffset();
+        long stripeOffset2 = stripeInformations.get(1).getOffset();
+
+        Map<StreamId, List<RowGroupIndex>> stripeRowGroupIndexes1 = introspector.getRowGroupIndexesByStripeOffset().get(stripeOffset1);
+        Map<StreamId, List<RowGroupIndex>> stripeRowGroupIndexes2 = introspector.getRowGroupIndexesByStripeOffset().get(stripeOffset2);
+        assertNumberOfRowGroupStatistics(stripeRowGroupIndexes1, 2);
+        assertNumberOfRowGroupStatistics(stripeRowGroupIndexes2, 1);
+
+        // validate row group statistics
+        ColumnStatistics actualRowGroupStats1 = getColumnRowGroupStats(stripeRowGroupIndexes1, 0); // stripe 1, row group 1
+        ColumnStatistics actualRowGroupStats2 = getColumnRowGroupStats(stripeRowGroupIndexes1, 1); // stripe 1, row group 2
+        ColumnStatistics actualRowGroupStats3 = getColumnRowGroupStats(stripeRowGroupIndexes2, 0); // stripe 2, row group 1
+        assertEquals(actualRowGroupStats1.getRawSize(), expectedRowGroupStatsRawSize1);
+        assertEquals(actualRowGroupStats2.getRawSize(), expectedRowGroupStatsRawSize2);
+        assertEquals(actualRowGroupStats3.getRawSize(), expectedRowGroupStatsRawSize3);
+
+        assertTrue(introspector.getFileFooter().getRawSize().isPresent());
+        assertEquals(allFileStatistics.get(0).getRawSize(), expectedFileStatsRawSize);
+
+        assertCommonRawAndStorageSize(introspector);
+    }
+
     @Test
-    public void testRawSize()
+    public void testMergeColumnStatisticsRawSize()
     {
         ColumnStatistics nullStats = withRawSize(null);
         assertFalse(nullStats.hasRawSize());
-        assertEquals(nullStats.getRawSize(), 0);
 
         ColumnStatistics nonNullStats = withRawSize(15L);
         assertTrue(nonNullStats.hasRawSize());
@@ -102,7 +477,6 @@ public class TestColumnStatistics
         // all nulls
         ColumnStatistics mergedStats2 = mergeColumnStatistics(ImmutableList.of(withRawSize(null), withRawSize(null)));
         assertFalse(mergedStats2.hasRawSize());
-        assertEquals(mergedStats2.getRawSize(), 0L);
 
         // some nulls
         ColumnStatistics mergedStats3 = mergeColumnStatistics(ImmutableList.of(withRawSize(null), withRawSize(5L)));
@@ -111,11 +485,10 @@ public class TestColumnStatistics
     }
 
     @Test
-    public void testStorageSize()
+    public void testMergeColumnStatisticsStorageSize()
     {
         ColumnStatistics nullStats = withStorageSize(null);
         assertFalse(nullStats.hasStorageSize());
-        assertEquals(nullStats.getStorageSize(), 0);
 
         ColumnStatistics nonNullStats = withStorageSize(15L);
         assertTrue(nonNullStats.hasStorageSize());
@@ -135,7 +508,6 @@ public class TestColumnStatistics
         // all nulls
         ColumnStatistics mergedStats2 = mergeColumnStatistics(ImmutableList.of(withStorageSize(null), withStorageSize(null)));
         assertFalse(mergedStats2.hasStorageSize());
-        assertEquals(mergedStats2.getStorageSize(), 0L);
 
         // some nulls
         ColumnStatistics mergedStats3 = mergeColumnStatistics(ImmutableList.of(withStorageSize(null), withStorageSize(5L)));
@@ -174,22 +546,22 @@ public class TestColumnStatistics
                 null));
 
         doTestFlatMapStatistics(mapType, emptyMaps,
-                new ColumnStatistics(6L, null, null, null),
-                new ColumnStatistics(2L, null, null, null),
-                new ColumnStatistics(2L, null, null, null),
-                new ColumnStatistics(2L, null, null, null));
+                new ColumnStatistics(6L, null, 0L, 0L),
+                new ColumnStatistics(2L, null, 0L, 0L),
+                new ColumnStatistics(2L, null, 0L, 0L),
+                new ColumnStatistics(2L, null, 0L, 0L));
 
         doTestFlatMapStatistics(mapType, emptyMapsWithNulls,
-                new ColumnStatistics(2L, null, null, null),
-                new ColumnStatistics(1L, null, null, null),
-                new ColumnStatistics(0L, null, null, null),
-                new ColumnStatistics(1L, null, null, null));
+                new ColumnStatistics(2L, null, 4L, 0L),
+                new ColumnStatistics(1L, null, 1L, 0L),
+                new ColumnStatistics(0L, null, 2L, 0L),
+                new ColumnStatistics(1L, null, 1L, 0L));
 
         doTestFlatMapStatistics(mapType, emptyMapsWithAllNulls,
-                new ColumnStatistics(0L, null, null, null),
-                new ColumnStatistics(0L, null, null, null),
-                new ColumnStatistics(0L, null, null, null),
-                new ColumnStatistics(0L, null, null, null));
+                new ColumnStatistics(0L, null, 6L, 0L),
+                new ColumnStatistics(0L, null, 2L, 0L),
+                new ColumnStatistics(0L, null, 2L, 0L),
+                new ColumnStatistics(0L, null, 2L, 0L));
     }
 
     @Test(dataProvider = "mapKeyTypeProvider")
@@ -198,6 +570,10 @@ public class TestColumnStatistics
     {
         MapType mapType = (MapType) mapType(mapKeyType, BIGINT);
         Object[] keys = mapKeyType == BIGINT ? new Object[] {0L, 1L, 2L, 3L, 4L, 5L} : new Object[] {"k0", "k1", "k2", "k3", "k4", "k5"};
+        int entryCount = 12;
+        int keyRawSize = mapKeyType == BIGINT ? Long.BYTES : 2;
+        int keysRawSize = entryCount * keyRawSize;
+        int valuesRawSize = 96;
         Object everyRowKey = keys[0];  // [1, 2, 3, 4, 5, 6]
         Object firstRowGroupKey = keys[1]; // [11]
         Object secondRowGroupKey = keys[2]; // [22]
@@ -220,32 +596,36 @@ public class TestColumnStatistics
 
         MapColumnStatisticsBuilder fileStatistics = new MapColumnStatisticsBuilder(true);
         fileStatistics.increaseValueCount(6);
-        addIntStats(fileStatistics, everyRowKey, 6L, 1L, 6L, 21L);
-        addIntStats(fileStatistics, firstRowGroupKey, 1L, 11L, 11L, 11L);
-        addIntStats(fileStatistics, firstStripeKey, 2L, 100L, 100L, 200L);
-        addIntStats(fileStatistics, secondRowGroupKey, 1L, 22L, 22L, 22L);
-        addIntStats(fileStatistics, thirdRowGroupKey, 1L, 33L, 33L, 33L);
-        addIntStats(fileStatistics, secondStripeKey, 1L, 1000L, 1000L, 1000L);
+        fileStatistics.incrementRawSize(keysRawSize + valuesRawSize);
+        addIntStats(fileStatistics, everyRowKey, 6L, 1L, 6L, 21L, 48L, 0L);
+        addIntStats(fileStatistics, firstRowGroupKey, 1L, 11L, 11L, 11L, 8L, 0L);
+        addIntStats(fileStatistics, firstStripeKey, 2L, 100L, 100L, 200L, 16L, 0L);
+        addIntStats(fileStatistics, secondRowGroupKey, 1L, 22L, 22L, 22L, 8L, 0L);
+        addIntStats(fileStatistics, thirdRowGroupKey, 1L, 33L, 33L, 33L, 8L, 0L);
+        addIntStats(fileStatistics, secondStripeKey, 1L, 1000L, 1000L, 1000L, 8L, 0L);
 
         MapColumnStatisticsBuilder rowGroupStats1 = new MapColumnStatisticsBuilder(true);
         rowGroupStats1.increaseValueCount(2);
-        addIntStats(rowGroupStats1, everyRowKey, 2L, 1L, 2L, 3L);
-        addIntStats(rowGroupStats1, firstRowGroupKey, 1L, 11L, 11L, 11L);
-        addIntStats(rowGroupStats1, firstStripeKey, 1L, 100L, 100L, 100L);
+        rowGroupStats1.incrementRawSize(32 + 4 * keyRawSize);
+        addIntStats(rowGroupStats1, everyRowKey, 2L, 1L, 2L, 3L, 16L, 0L);
+        addIntStats(rowGroupStats1, firstRowGroupKey, 1L, 11L, 11L, 11L, 8L, 0L);
+        addIntStats(rowGroupStats1, firstStripeKey, 1L, 100L, 100L, 100L, 8L, 0L);
 
         // keys from rowGroup1 are carried over as generic ColumnStatistics with 0 number of values
         MapColumnStatisticsBuilder rowGroupStats2 = new MapColumnStatisticsBuilder(true);
         rowGroupStats2.increaseValueCount(2);
-        addIntStats(rowGroupStats2, everyRowKey, 2L, 3L, 4L, 7L);
-        rowGroupStats2.addMapStatistics(keyInfo(firstRowGroupKey), new ColumnStatistics(0L, null, null, null));
-        addIntStats(rowGroupStats2, firstStripeKey, 1L, 100L, 100L, 100L);
-        addIntStats(rowGroupStats2, secondRowGroupKey, 1L, 22L, 22L, 22L);
+        rowGroupStats2.incrementRawSize(32 + 4 * keyRawSize);
+        addIntStats(rowGroupStats2, everyRowKey, 2L, 3L, 4L, 7L, 16L, 0L);
+        rowGroupStats2.addMapStatistics(keyInfo(firstRowGroupKey), new ColumnStatistics(0L, null, 0L, 0L));
+        addIntStats(rowGroupStats2, firstStripeKey, 1L, 100L, 100L, 100L, 8L, 0L);
+        addIntStats(rowGroupStats2, secondRowGroupKey, 1L, 22L, 22L, 22L, 8L, 0L);
 
         MapColumnStatisticsBuilder rowGroupStats3 = new MapColumnStatisticsBuilder(true);
         rowGroupStats3.increaseValueCount(2);
-        addIntStats(rowGroupStats3, everyRowKey, 2L, 5L, 6L, 11L);
-        addIntStats(rowGroupStats3, thirdRowGroupKey, 1L, 33L, 33L, 33L);
-        addIntStats(rowGroupStats3, secondStripeKey, 1L, 1000L, 1000L, 1000L);
+        rowGroupStats3.incrementRawSize(32 + 4 * keyRawSize);
+        addIntStats(rowGroupStats3, everyRowKey, 2L, 5L, 6L, 11L, 16L, 0L);
+        addIntStats(rowGroupStats3, thirdRowGroupKey, 1L, 33L, 33L, 33L, 8L, 0L);
+        addIntStats(rowGroupStats3, secondStripeKey, 1L, 1000L, 1000L, 1000L, 8L, 0L);
 
         doTestFlatMapStatistics(mapType, maps,
                 fileStatistics.buildColumnStatistics(),
@@ -260,6 +640,9 @@ public class TestColumnStatistics
     {
         MapType mapType = (MapType) mapType(mapKeyType, BIGINT);
         Object key = mapKeyType == BIGINT ? 0L : "k0";
+        int entryCount = 4;
+        int keyRawSize = mapKeyType == BIGINT ? Long.BYTES : 2;
+        int keysRawSize = entryCount * keyRawSize;
 
         Page maps = createMapPage(mapType, Arrays.asList(
                 // stripe 1, row group 1
@@ -276,19 +659,23 @@ public class TestColumnStatistics
 
         MapColumnStatisticsBuilder fileStatistics = new MapColumnStatisticsBuilder(true);
         fileStatistics.increaseValueCount(5);
-        addIntStats(fileStatistics, key, 2L, 1L, 2L, 3L);
+        fileStatistics.incrementRawSize(19 + keysRawSize);
+        addIntStats(fileStatistics, key, 2L, 1L, 2L, 3L, 18L, 0L);
 
         MapColumnStatisticsBuilder rowGroupStats1 = new MapColumnStatisticsBuilder(true);
         rowGroupStats1.increaseValueCount(2);
-        addIntStats(rowGroupStats1, key, 1L, 1L, 1L, 1L);
+        rowGroupStats1.incrementRawSize(8 + keyRawSize);
+        addIntStats(rowGroupStats1, key, 1L, 1L, 1L, 1L, 8L, 0L);
 
         MapColumnStatisticsBuilder rowGroupStats2 = new MapColumnStatisticsBuilder(true);
         rowGroupStats2.increaseValueCount(1);
-        rowGroupStats2.addMapStatistics(keyInfo(key), new ColumnStatistics(0L, null, null, null));
+        rowGroupStats2.incrementRawSize(2 + keyRawSize);
+        rowGroupStats2.addMapStatistics(keyInfo(key), new ColumnStatistics(0L, null, 1L, 0L));
 
         MapColumnStatisticsBuilder rowGroupStats3 = new MapColumnStatisticsBuilder(true);
         rowGroupStats3.increaseValueCount(2);
-        addIntStats(rowGroupStats3, key, 1L, 2L, 2L, 2L);
+        rowGroupStats3.incrementRawSize(9 + 2 * keyRawSize);
+        addIntStats(rowGroupStats3, key, 1L, 2L, 2L, 2L, 9L, 0L);
 
         doTestFlatMapStatistics(mapType, maps,
                 fileStatistics.buildColumnStatistics(),
@@ -306,6 +693,9 @@ public class TestColumnStatistics
     {
         MapType mapType = (MapType) mapType(mapKeyType, BIGINT);
         Object key = mapKeyType == BIGINT ? 0L : "k0";
+        int entryCount = 3;
+        int keyRawSize = mapKeyType == BIGINT ? Long.BYTES : 2;
+        int keysRawSize = entryCount * keyRawSize;
 
         Page maps = createMapPage(mapType, Arrays.asList(
                 // stripe 1, row group 1
@@ -323,19 +713,23 @@ public class TestColumnStatistics
 
         MapColumnStatisticsBuilder fileStatistics = new MapColumnStatisticsBuilder(true);
         fileStatistics.increaseValueCount(4);
-        addIntStats(fileStatistics, key, 2L, 1L, 2L, 3L);
+        fileStatistics.incrementRawSize(19 + keysRawSize);
+        addIntStats(fileStatistics, key, 2L, 1L, 2L, 3L, 17L, 0L);
 
         MapColumnStatisticsBuilder rowGroupStats1 = new MapColumnStatisticsBuilder(true);
         rowGroupStats1.increaseValueCount(2);
-        addIntStats(rowGroupStats1, key, 1L, 1L, 1L, 1L);
+        rowGroupStats1.incrementRawSize(8 + keyRawSize);
+        addIntStats(rowGroupStats1, key, 1L, 1L, 1L, 1L, 8L, 0L);
 
         MapColumnStatisticsBuilder rowGroupStats2 = new MapColumnStatisticsBuilder(true);
         rowGroupStats2.increaseValueCount(0);
-        rowGroupStats2.addMapStatistics(keyInfo(key), new ColumnStatistics(0L, null, null, null));
+        rowGroupStats2.incrementRawSize(2L);
+        rowGroupStats2.addMapStatistics(keyInfo(key), new ColumnStatistics(0L, null, 0L, 0L));
 
         MapColumnStatisticsBuilder rowGroupStats3 = new MapColumnStatisticsBuilder(true);
         rowGroupStats3.increaseValueCount(2);
-        addIntStats(rowGroupStats3, key, 1L, 2L, 2L, 2L);
+        rowGroupStats3.incrementRawSize(9L + 2 * keyRawSize);
+        addIntStats(rowGroupStats3, key, 1L, 2L, 2L, 2L, 9L, 0L);
 
         doTestFlatMapStatistics(mapType, maps,
                 fileStatistics.buildColumnStatistics(),
@@ -367,19 +761,20 @@ public class TestColumnStatistics
         // validate file statistics
         List<ColumnStatistics> allFileStatistics = introspector.getFileFooter().getFileStats();
         ColumnStatistics actualFileStatistics = allFileStatistics.get(COLUMN);
-        assertEquals(actualFileStatistics, expectedFileStats);
+        assertColumnStats(actualFileStatistics, expectedFileStats);
 
         // prepare to validate row group statistics
         assertEquals(introspector.getStripes().size(), 2);
-        assertEquals(introspector.getStripeInformations().size(), 2);
+        List<StripeInformation> stripeInformations = introspector.getStripeInformations();
+        assertEquals(stripeInformations.size(), 2);
         assertEquals(introspector.getRowGroupIndexesByStripeOffset().size(), 2);
         Stripe stripe1 = introspector.getStripes().get(0);
         Stripe stripe2 = introspector.getStripes().get(1);
         assertEquals(stripe1.getRowCount(), 4);
         assertEquals(stripe2.getRowCount(), 2);
 
-        long stripeOffset1 = introspector.getStripeInformations().get(0).getOffset();
-        long stripeOffset2 = introspector.getStripeInformations().get(1).getOffset();
+        long stripeOffset1 = stripeInformations.get(0).getOffset();
+        long stripeOffset2 = stripeInformations.get(1).getOffset();
 
         Map<StreamId, List<RowGroupIndex>> stripeRowGroupIndexes1 = introspector.getRowGroupIndexesByStripeOffset().get(stripeOffset1);
         Map<StreamId, List<RowGroupIndex>> stripeRowGroupIndexes2 = introspector.getRowGroupIndexesByStripeOffset().get(stripeOffset2);
@@ -390,9 +785,55 @@ public class TestColumnStatistics
         ColumnStatistics actualRowGroupStats1 = getColumnRowGroupStats(stripeRowGroupIndexes1, 0); // stripe 1, row group 1
         ColumnStatistics actualRowGroupStats2 = getColumnRowGroupStats(stripeRowGroupIndexes1, 1); // stripe 1, row group 2
         ColumnStatistics actualRowGroupStats3 = getColumnRowGroupStats(stripeRowGroupIndexes2, 0); // stripe 2, row group 1
-        assertEquals(actualRowGroupStats1, expectedRowGroupStats1);
-        assertEquals(actualRowGroupStats2, expectedRowGroupStats2);
-        assertEquals(actualRowGroupStats3, expectedRowGroupStats3);
+        assertColumnStats(actualRowGroupStats1, expectedRowGroupStats1);
+        assertColumnStats(actualRowGroupStats2, expectedRowGroupStats2);
+        assertColumnStats(actualRowGroupStats3, expectedRowGroupStats3);
+
+        assertEquals(allFileStatistics.get(0).getRawSize(), introspector.getFileFooter().getRawSize().getAsLong());
+
+        assertCommonRawAndStorageSize(introspector);
+    }
+
+    // compares all fields excluding the storage size, because storage size
+    // is unpredictable for the testing purpose
+    private void assertColumnStats(ColumnStatistics actual, ColumnStatistics expected)
+    {
+        assertEquals(actual.hasNumberOfValues(), expected.hasNumberOfValues());
+        assertEquals(actual.getNumberOfValues(), expected.getNumberOfValues());
+        assertEquals(actual.hasRawSize(), expected.hasRawSize());
+        assertEquals(actual.getRawSize(), expected.getRawSize());
+        assertEquals(actual.getBloomFilter(), expected.getBloomFilter());
+
+        assertEquals(actual.getBooleanStatistics(), expected.getBooleanStatistics());
+        assertEquals(actual.getIntegerStatistics(), expected.getIntegerStatistics());
+        assertEquals(actual.getDoubleStatistics(), expected.getDoubleStatistics());
+        assertEquals(actual.getStringStatistics(), expected.getStringStatistics());
+        assertEquals(actual.getDateStatistics(), expected.getDateStatistics());
+        assertEquals(actual.getDecimalStatistics(), expected.getDecimalStatistics());
+        assertEquals(actual.getBinaryStatistics(), expected.getBinaryStatistics());
+
+        MapStatistics actualMapStatistics = actual.getMapStatistics();
+        MapStatistics expectedMapStatistics = expected.getMapStatistics();
+        assertEquals(actualMapStatistics != null, expectedMapStatistics != null);
+        if (actualMapStatistics != null) {
+            List<MapStatisticsEntry> actualEntries = actualMapStatistics.getEntries();
+            List<MapStatisticsEntry> expectedEntries = expectedMapStatistics.getEntries();
+            assertEquals(actualEntries.size(), expectedEntries.size());
+
+            ImmutableMap.Builder<KeyInfo, ColumnStatistics> actualEntriesByKeyBuilder = ImmutableMap.builder();
+            ImmutableMap.Builder<KeyInfo, ColumnStatistics> expectedEntriesByKeyBuilder = ImmutableMap.builder();
+            for (int i = 0; i < actualEntries.size(); i++) {
+                MapStatisticsEntry actualEntry = actualEntries.get(i);
+                MapStatisticsEntry expectedEntry = expectedEntries.get(i);
+                actualEntriesByKeyBuilder.put(actualEntry.getKey(), actualEntry.getColumnStatistics());
+                expectedEntriesByKeyBuilder.put(expectedEntry.getKey(), expectedEntry.getColumnStatistics());
+            }
+
+            Map<KeyInfo, ColumnStatistics> actualEntriesByKey = actualEntriesByKeyBuilder.build();
+            Map<KeyInfo, ColumnStatistics> expectedEntriesByKey = expectedEntriesByKeyBuilder.build();
+            assertEquals(actualEntriesByKey.keySet(), expectedEntriesByKey.keySet());
+            actualEntriesByKey.forEach((key, value) -> assertColumnStats(value, expectedEntriesByKey.get(key)));
+        }
     }
 
     // make sure the number of row group stats is as expected
@@ -448,12 +889,12 @@ public class TestColumnStatistics
             throws IOException
     {
         DefaultOrcWriterFlushPolicy flushPolicy = DefaultOrcWriterFlushPolicy.builder()
-                .withStripeMaxRowCount(MAP_STATS_TEST_STRIPE_MAX_ROW_COUNT)
+                .withStripeMaxRowCount(STRIPE_MAX_ROW_COUNT)
                 .build();
 
         OrcWriterOptions writerOptions = OrcWriterOptions.builder()
                 .withFlushPolicy(flushPolicy)
-                .withRowGroupMaxRowCount(MAP_STATS_TEST_ROW_GROUP_MAX_ROW_COUNT)
+                .withRowGroupMaxRowCount(ROW_GROUP_MAX_ROW_COUNT)
                 .withFlattenedColumns(ImmutableSet.of(0))
                 .withMapStatisticsEnabled(true)
                 .build();
@@ -468,6 +909,24 @@ public class TestColumnStatistics
                 NOOP_WRITER_STATS)) {
             orcWriter.write(page);
         }
+    }
+
+    private static OrcWriterOptions createOrcWriterOptions(
+            int stripeMaxRowCount,
+            int rowGroupMaxRowCount,
+            boolean stringDictionaryEncodingEnabled,
+            boolean integerDictionaryEncodingEnabled)
+    {
+        DefaultOrcWriterFlushPolicy flushPolicy = DefaultOrcWriterFlushPolicy.builder()
+                .withStripeMaxRowCount(stripeMaxRowCount)
+                .build();
+
+        return OrcWriterOptions.builder()
+                .withFlushPolicy(flushPolicy)
+                .withStringDictionaryEncodingEnabled(stringDictionaryEncodingEnabled)
+                .withIntegerDictionaryEncodingEnabled(integerDictionaryEncodingEnabled)
+                .withRowGroupMaxRowCount(rowGroupMaxRowCount)
+                .build();
     }
 
     private static CapturingOrcFileIntrospector introspectOrcFile(Type type, TempFile file)
@@ -540,9 +999,9 @@ public class TestColumnStatistics
         }
     }
 
-    private static void addIntStats(MapColumnStatisticsBuilder stats, Object key, long numberOfValues, long min, long max, long sum)
+    private static void addIntStats(MapColumnStatisticsBuilder stats, Object key, long numberOfValues, long min, long max, long sum, long rawSize, long storageSize)
     {
-        stats.addMapStatistics(keyInfo(key), new IntegerColumnStatistics(numberOfValues, null, new IntegerStatistics(min, max, sum)));
+        stats.addMapStatistics(keyInfo(key), new IntegerColumnStatistics(numberOfValues, null, rawSize, storageSize, new IntegerStatistics(min, max, sum)));
     }
 
     private static Map<Object, Object> mapOf(Object... values)
@@ -562,5 +1021,278 @@ public class TestColumnStatistics
     private static ColumnStatistics withStorageSize(Long storageSize)
     {
         return new ColumnStatistics(null, null, null, storageSize);
+    }
+
+    /**
+     * Split the block into blockSize regions with a single position.
+     * Used to hit all dictionary fallback to direct cases.
+     */
+    private static List<Block> partitionBlock(Block block)
+    {
+        ImmutableList.Builder<Block> blocks = ImmutableList.builder();
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            blocks.add(block.getRegion(i, 1));
+        }
+        return blocks.build();
+    }
+
+    private static void assertCommonRawAndStorageSize(CapturingOrcFileIntrospector introspector)
+    {
+        Footer fileFooter = introspector.getFileFooter();
+        List<OrcType> orcTypes = fileFooter.getTypes();
+        List<ColumnStatistics> fileStats = fileFooter.getFileStats();
+        // node storage sizes are populated from stripe streams
+        long[] nodeSizes = new long[orcTypes.size()];
+
+        // node raw sizes are populated from row group indexes
+        long[] nodeRawSizes = new long[orcTypes.size()];
+
+        long totalRawSize = 0;
+        List<StripeInformation> stripeInformations = introspector.getStripeInformations();
+        List<Stripe> stripes = introspector.getStripes();
+        assertEquals(stripeInformations.size(), stripes.size());
+
+        // skip raw size + row group index checks for nodes that do not have
+        // index streams: such as root and flat map key nodes
+        Set<Integer> skipRawSizeNodes = new HashSet<>();
+        skipRawSizeNodes.add(0);
+
+        Set<Integer> flatMapNodes = new HashSet<>();
+        Int2ObjectMap<Object2LongMap<KeyInfo>> flatMapKeySizes = new Int2ObjectOpenHashMap<>();
+        Int2ObjectMap<Object2LongMap<KeyInfo>> flatMapKeyRawSizes = new Int2ObjectOpenHashMap<>();
+
+        for (int i = 0; i < stripeInformations.size(); i++) {
+            StripeInformation stripeInformation = stripeInformations.get(i);
+            assertTrue(stripeInformation.getRawDataSize().isPresent());
+            totalRawSize += stripeInformation.getRawDataSize().getAsLong();
+
+            // collect raw sizes from row group indexes, later we'll compare them to file column statistics
+            long stripeOffset = stripeInformation.getOffset();
+            Map<StreamId, List<RowGroupIndex>> rowGroupIndexes = introspector.getRowGroupIndexesByStripeOffset().get(stripeOffset);
+            for (Map.Entry<StreamId, List<RowGroupIndex>> entry : rowGroupIndexes.entrySet()) {
+                StreamId streamId = entry.getKey();
+                int node = streamId.getColumn();
+                List<RowGroupIndex> streamIndexes = entry.getValue();
+
+                for (RowGroupIndex rowGroupIndex : streamIndexes) {
+                    ColumnStatistics columnStatistics = rowGroupIndex.getColumnStatistics();
+                    nodeRawSizes[node] += columnStatistics.getRawSize();
+
+                    // collect flat map key raw sizes
+                    MapStatistics mapStatistics = columnStatistics.getMapStatistics();
+                    if (mapStatistics != null) {
+                        Object2LongMap<KeyInfo> keyRawSizes = flatMapKeyRawSizes.computeIfAbsent(node, (ignore) -> new Object2LongOpenHashMap<>());
+                        for (MapStatisticsEntry mapStatisticsEntry : mapStatistics.getEntries()) {
+                            keyRawSizes.mergeLong(mapStatisticsEntry.getKey(), mapStatisticsEntry.getColumnStatistics().getRawSize(), Long::sum);
+                        }
+                    }
+                }
+            }
+
+            Stripe stripe = stripes.get(i);
+
+            // collect flat map nodes
+            Map<Integer, ColumnEncoding> columnEncodings = stripe.getColumnEncodings();
+            for (Map.Entry<Integer, ColumnEncoding> entry : columnEncodings.entrySet()) {
+                if (entry.getValue().getColumnEncodingKind() == ColumnEncoding.ColumnEncodingKind.DWRF_MAP_FLAT) {
+                    Integer mapNode = entry.getKey();
+                    flatMapNodes.add(mapNode);
+                    int flatMapKeyNode = orcTypes.get(mapNode).getFieldTypeIndex(0);
+
+                    // don't validate flat map key node raw size against the row group
+                    // indexes because there are no checkpoints for flat
+                    skipRawSizeNodes.add(flatMapKeyNode);
+                }
+            }
+
+            // map all flat map values nodes to their top-level map node
+            Map<Integer, Integer> flatMapNodesToColumnNode = mapFlatMapNodesToColumnNode(flatMapNodes, orcTypes);
+
+            StripeFooter stripeFooter = introspector.getStripeFooterByStripeOffset().get(stripeOffset);
+            assertNotNull(stripeFooter);
+
+            Object2LongMap<NodeSequenceKey> stripeNodeSequenceToSize = collectStripeNodeSequenceSizes(stripeFooter, nodeSizes, flatMapNodesToColumnNode);
+
+            // aggregate the stripe level flat map sub-nodes stream sizes into the file level sizes
+            for (Integer flatMapNode : flatMapNodes) {
+                int flatMapValueNode = getMapValueNode(orcTypes, flatMapNode);
+                ColumnEncoding flatMapColumnEncoding = columnEncodings.get(flatMapValueNode);
+
+                // encoding will be absent if there are no streams for a certain node (e.g. no values written)
+                if (flatMapColumnEncoding == null) {
+                    continue;
+                }
+
+                // map statistics must be explicitly enabled through the writer configuration
+                // additionalSequence will be absent if map statistics are not enabled
+                if (flatMapColumnEncoding.getAdditionalSequenceEncodings().isPresent()) {
+                    Object2LongMap<KeyInfo> fileLevelKeySizes = flatMapKeySizes.computeIfAbsent(flatMapNode.intValue(), (ignore) -> new Object2LongOpenHashMap<>());
+                    Map<Integer, DwrfSequenceEncoding> stripeSequenceToKey = flatMapColumnEncoding.getAdditionalSequenceEncodings().get();
+                    for (Map.Entry<Integer, DwrfSequenceEncoding> entry : stripeSequenceToKey.entrySet()) {
+                        Integer sequence = entry.getKey();
+                        KeyInfo flatMapKey = entry.getValue().getKey();
+                        long keySize = stripeNodeSequenceToSize.getLong(new NodeSequenceKey(flatMapNode, sequence));
+                        fileLevelKeySizes.mergeLong(flatMapKey, keySize, Long::sum);
+                    }
+                }
+            }
+        }
+
+        for (Integer flatMapNode : flatMapNodes) {
+            Object2LongMap<KeyInfo> keySizes = flatMapKeySizes.get(flatMapNode);
+            Object2LongMap<KeyInfo> keyRawSizes = flatMapKeyRawSizes.get(flatMapNode);
+            assertEquals(keySizes != null, keyRawSizes != null);
+
+            if (keySizes != null) {
+                ColumnStatistics columnStatistics = fileStats.get(flatMapNode);
+                MapStatistics mapStatistics = columnStatistics.getMapStatistics();
+                assertEquals(keySizes.size(), mapStatistics.getEntries().size());
+
+                for (MapStatisticsEntry entry : mapStatistics.getEntries()) {
+                    ColumnStatistics keyColumnStatistics = entry.getColumnStatistics();
+                    KeyInfo flatMapKey = entry.getKey();
+
+                    // Key size is the total storage size of flat map value nodes
+                    // computed from flat map value streams.
+                    // Let's compare it to what's stored in the file column statistics.
+                    long keySize = keySizes.getLong(flatMapKey);
+                    assertEquals(keyColumnStatistics.getStorageSize(), keySize);
+
+                    // keyRawSize is a total of all raw sizes from row group index
+                    long keyRawSize = keyRawSizes.getLong(flatMapKey);
+                    assertEquals(keyColumnStatistics.getRawSize(), keyRawSize);
+                }
+            }
+        }
+
+        assertTrue(fileFooter.getRawSize().isPresent());
+        assertEquals(totalRawSize, fileStats.get(0).getRawSize());
+        assertEquals(totalRawSize, fileFooter.getRawSize().getAsLong());
+        assertNodeRawAndStorageSize(orcTypes, nodeSizes, fileStats);
+
+        // Compare raw sizes from the row group indexes and file column statistics.
+        // Raw sizes in the row group indexes are already rolled up, so no need to
+        // traverse the tree and collect raw sizes for sub-nodes.
+        for (int i = 0; i < fileStats.size(); i++) {
+            if (skipRawSizeNodes.contains(i)) {
+                continue;
+            }
+
+            ColumnStatistics columnStatistics = fileStats.get(i);
+            long rawSizeFromStats = zeroIfNull(columnStatistics.getRawSize());
+            assertEquals(rawSizeFromStats, nodeRawSizes[i], "mismatched raw size for node " + i);
+        }
+    }
+
+    private static Object2LongMap<NodeSequenceKey> collectStripeNodeSequenceSizes(StripeFooter stripeFooter, long[] nodeSizes, Map<Integer, Integer> flatMapNodesToColumnNode)
+    {
+        Object2LongMap<NodeSequenceKey> stripeNodeSequenceToSize = new Object2LongOpenHashMap<>();
+        for (Stream stream : stripeFooter.getStreams()) {
+            int node = stream.getColumn();
+            nodeSizes[node] += stream.getLength();
+
+            // aggregate stream sizes by flat map key
+            Integer flatMapNode = flatMapNodesToColumnNode.get(node);
+            if (flatMapNode != null) {
+                stripeNodeSequenceToSize.mergeLong(new NodeSequenceKey(flatMapNode, stream.getSequence()), stream.getLength(), Long::sum);
+            }
+        }
+        return stripeNodeSequenceToSize;
+    }
+
+    private static int getMapValueNode(List<OrcType> orcTypes, int mapNode)
+    {
+        OrcType mapType = orcTypes.get(mapNode);
+        assertNotNull(mapType);
+        assertEquals(mapType.getOrcTypeKind(), OrcType.OrcTypeKind.MAP);
+        return mapType.getFieldTypeIndex(1);
+    }
+
+    private static Map<Integer, Integer> mapFlatMapNodesToColumnNode(Set<Integer> flatMapNodes, List<OrcType> orcTypes)
+    {
+        Map<Integer, Integer> flattenedNodeTrees = new HashMap<>();
+        for (Integer mapNode : flatMapNodes) {
+            OrcType mapType = orcTypes.get(mapNode);
+            checkArgument(mapType.getOrcTypeKind() == OrcType.OrcTypeKind.MAP, "flat map node %s must be a map, but was %s", mapNode, mapType.getOrcTypeKind());
+            checkArgument(mapType.getFieldCount() == 2, "flat map node %s must have exactly 2 sub-fields but had %s", mapNode, mapType.getFieldCount());
+            int mapValueNode = mapType.getFieldTypeIndex(1);
+            List<Integer> deepValueNodes = collectDeepTreeNodes(orcTypes, mapValueNode);
+            for (Integer valueNode : deepValueNodes) {
+                flattenedNodeTrees.put(valueNode, mapNode);
+            }
+        }
+        return flattenedNodeTrees;
+    }
+
+    private static void assertNodeRawAndStorageSize(List<OrcType> orcTypes, long[] nodeSizes, List<ColumnStatistics> fileColumnStatistics)
+    {
+        getAndAssertNodeStorageSize(0, orcTypes, nodeSizes, fileColumnStatistics);
+    }
+
+    private static long getAndAssertNodeStorageSize(int nodeId, List<OrcType> orcTypes, long[] nodeSizes, List<ColumnStatistics> fileColumnStatistics)
+    {
+        OrcType node = orcTypes.get(nodeId);
+        long actualStorageSize = nodeSizes[nodeId];
+
+        for (int i = 0; i < node.getFieldCount(); i++) {
+            int subNodeId = node.getFieldTypeIndex(i);
+            actualStorageSize += getAndAssertNodeStorageSize(subNodeId, orcTypes, nodeSizes, fileColumnStatistics);
+        }
+
+        ColumnStatistics columnStatistics = fileColumnStatistics.get(nodeId);
+        assertNotNull(columnStatistics);
+
+        long statisticsStorageSize = zeroIfNull(columnStatistics.getStorageSize());
+        assertEquals(actualStorageSize, statisticsStorageSize, "Storage sizes in streams and file column statistics are different for node " + nodeId);
+
+        return actualStorageSize;
+    }
+
+    private static List<Integer> collectDeepTreeNodes(List<OrcType> orcTypes, int startNode)
+    {
+        LinkedList<Integer> toVisit = new LinkedList<>();
+        List<Integer> result = new ArrayList<>();
+
+        toVisit.add(startNode);
+        while (!toVisit.isEmpty()) {
+            Integer node = toVisit.pop();
+            result.add(node);
+            OrcType orcType = orcTypes.get(node);
+            for (int i = 0; i < orcType.getFieldCount(); i++) {
+                toVisit.push(orcType.getFieldTypeIndex(i));
+            }
+        }
+
+        return result;
+    }
+
+    private static long zeroIfNull(Long value)
+    {
+        return value == null ? 0 : value;
+    }
+
+    private static class NodeSequenceKey
+    {
+        private final int node;
+        private final int sequence;
+
+        public NodeSequenceKey(int node, int sequence)
+        {
+            this.node = node;
+            this.sequence = sequence;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            NodeSequenceKey that = (NodeSequenceKey) o;
+            return node == that.node && sequence == that.sequence;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(node, sequence);
+        }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
@@ -287,14 +287,20 @@ public class TestOrcBloomFilters
         Map<Integer, ColumnStatistics> matchingStatisticsByColumnIndex = ImmutableMap.of(0, new IntegerColumnStatistics(
                 null,
                 toHiveBloomFilter(orcBloomFilter),
+                null,
+                null,
                 new IntegerStatistics(10L, 2000L, null)));
 
         Map<Integer, ColumnStatistics> nonMatchingStatisticsByColumnIndex = ImmutableMap.of(0, new IntegerColumnStatistics(
                 null,
                 toHiveBloomFilter(emptyOrcBloomFilter),
+                null,
+                null,
                 new IntegerStatistics(10L, 2000L, null)));
 
         Map<Integer, ColumnStatistics> withoutBloomFilterStatisticsByColumnIndex = ImmutableMap.of(0, new IntegerColumnStatistics(
+                null,
+                null,
                 null,
                 null,
                 new IntegerStatistics(10L, 2000L, null)));

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeReader.java
@@ -61,10 +61,10 @@ public class TestStripeReader
         int numberOfEntries = 10_000;
         long numRowsInGroup = MILLION;
         IntegerStatistics integerStatistics = new IntegerStatistics(0L, 0L, 0L);
-        ColumnStatistics intColumnStatistics = new IntegerColumnStatistics(numRowsInGroup, null, integerStatistics);
+        ColumnStatistics intColumnStatistics = new IntegerColumnStatistics(numRowsInGroup, null, null, null, integerStatistics);
         ColumnStatistics mapColumnStatistics = new ColumnStatistics(numRowsInGroup, null, null, null);
-        ColumnStatistics mapKeyColumnStatistics = new IntegerColumnStatistics(numRowsInGroup * numberOfEntries, null, integerStatistics);
-        ColumnStatistics mapValueColumnStatistics = new IntegerColumnStatistics(numRowsInGroup * numberOfEntries, null, integerStatistics);
+        ColumnStatistics mapKeyColumnStatistics = new IntegerColumnStatistics(numRowsInGroup * numberOfEntries, null, null, null, integerStatistics);
+        ColumnStatistics mapValueColumnStatistics = new IntegerColumnStatistics(numRowsInGroup * numberOfEntries, null, null, null, integerStatistics);
 
         StreamId intStreamId = new StreamId(1, 0, Stream.StreamKind.ROW_INDEX);
         StreamId mapStreamId = new StreamId(2, 0, Stream.StreamKind.ROW_INDEX);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -93,7 +93,7 @@ public class TestTupleDomainOrcPredicate
         BooleanStatistics booleanStatistics = null;
         if (trueValueCount != null) {
             booleanStatistics = new BooleanStatistics(trueValueCount);
-            return new BooleanColumnStatistics(numberOfValues, null, booleanStatistics);
+            return new BooleanColumnStatistics(numberOfValues, null, null, null, booleanStatistics);
         }
         return new ColumnStatistics(numberOfValues, null, null, null);
     }
@@ -124,7 +124,7 @@ public class TestTupleDomainOrcPredicate
 
     private static IntegerColumnStatistics integerColumnStats(Long numberOfValues, Long minimum, Long maximum)
     {
-        return new IntegerColumnStatistics(numberOfValues, null, new IntegerStatistics(minimum, maximum, null));
+        return new IntegerColumnStatistics(numberOfValues, null, null, null, new IntegerStatistics(minimum, maximum, null));
     }
 
     @Test
@@ -153,7 +153,7 @@ public class TestTupleDomainOrcPredicate
 
     private static DoubleColumnStatistics doubleColumnStats(Long numberOfValues, Double minimum, Double maximum)
     {
-        return new DoubleColumnStatistics(numberOfValues, null, new DoubleStatistics(minimum, maximum));
+        return new DoubleColumnStatistics(numberOfValues, null, 1L, 1L, new DoubleStatistics(minimum, maximum));
     }
 
     @Test
@@ -243,7 +243,7 @@ public class TestTupleDomainOrcPredicate
         Slice minimumSlice = minimum == null ? null : utf8Slice(minimum);
         Slice maximumSlice = maximum == null ? null : utf8Slice(maximum);
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new StringColumnStatistics(numberOfValues, null, new StringStatistics(minimumSlice, maximumSlice, 100L));
+        return new StringColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L));
     }
 
     @Test
@@ -272,7 +272,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics dateColumnStats(Long numberOfValues, Integer minimum, Integer maximum)
     {
-        return new DateColumnStatistics(numberOfValues, null, new DateStatistics(minimum, maximum));
+        return new DateColumnStatistics(numberOfValues, null, null, null, new DateStatistics(minimum, maximum));
     }
 
     @Test
@@ -328,7 +328,7 @@ public class TestTupleDomainOrcPredicate
     {
         BigDecimal minimumDecimal = minimum == null ? null : new BigDecimal(minimum);
         BigDecimal maximumDecimal = maximum == null ? null : new BigDecimal(maximum);
-        return new DecimalColumnStatistics(numberOfValues, null, new DecimalStatistics(minimumDecimal, maximumDecimal, SHORT_DECIMAL_VALUE_BYTES));
+        return new DecimalColumnStatistics(numberOfValues, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal, SHORT_DECIMAL_VALUE_BYTES));
     }
 
     @Test
@@ -350,7 +350,7 @@ public class TestTupleDomainOrcPredicate
     private static ColumnStatistics binaryColumnStats(Long numberOfValues)
     {
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new BinaryColumnStatistics(numberOfValues, null, new BinaryStatistics(100L));
+        return new BinaryColumnStatistics(numberOfValues, null, null, null, new BinaryStatistics(100L));
     }
 
     private static Long shortDecimal(String value)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
@@ -356,11 +356,9 @@ public class TestDwrfMetadataReader
         ColumnStatistics columnStatistics2 = new ColumnStatistics(7L, null, 3L, 5L);
         ColumnStatistics columnStatistics3 = new ColumnStatistics(7L, null, 3L, null);
         ColumnStatistics columnStatistics4 = new ColumnStatistics(7L, null, null, 5L);
-        // DWRF metadata writer does not support writing rawSize and storageSize yet
-        ColumnStatistics columnStatisticsWithoutSize = new ColumnStatistics(7L, null, null, null);
 
-        ColumnStatistics integerColumnStatistics1 = new IntegerColumnStatistics(7L, null, new IntegerStatistics(25L, 95L, 100L));
-        ColumnStatistics integerColumnStatistics2 = new IntegerColumnStatistics(9L, null, new IntegerStatistics(12L, 22L, 32L));
+        ColumnStatistics integerColumnStatistics1 = new IntegerColumnStatistics(7L, null, null, null, new IntegerStatistics(25L, 95L, 100L));
+        ColumnStatistics integerColumnStatistics2 = new IntegerColumnStatistics(9L, null, 3L, 5L, new IntegerStatistics(12L, 22L, 32L));
 
         MapColumnStatisticsBuilder mapStatsIntKeyBuilder = new MapColumnStatisticsBuilder(true);
         mapStatsIntKeyBuilder.addMapStatistics(DwrfProto.KeyInfo.newBuilder().setIntKey(2).build(), integerColumnStatistics1);
@@ -374,7 +372,7 @@ public class TestDwrfMetadataReader
         mapStatsStringKeyBuilder.increaseValueCount(23L);
         ColumnStatistics mapColumnStatisticsStringKey = mapStatsStringKeyBuilder.buildColumnStatistics();
 
-        ColumnStatistics expectedDisabledMapStats = new ColumnStatistics(23L, null, null, null);
+        ColumnStatistics expectedDisabledMapStats = new ColumnStatistics(23L, null, 0L, 0L);
 
         OrcReaderOptions orcReaderOptionsDisabledMapStats = OrcReaderOptions.builder()
                 .withMaxMergeDistance(new DataSize(1, MEGABYTE))
@@ -385,10 +383,10 @@ public class TestDwrfMetadataReader
         DwrfMetadataReader dwrfMetadataReaderDisabledMapStats = new DwrfMetadataReader(new RuntimeStats(), orcReaderOptionsDisabledMapStats);
 
         return new Object[][] {
-                {columnStatistics1, columnStatisticsWithoutSize, dwrfMetadataReader},
-                {columnStatistics2, columnStatisticsWithoutSize, dwrfMetadataReader},
-                {columnStatistics3, columnStatisticsWithoutSize, dwrfMetadataReader},
-                {columnStatistics4, columnStatisticsWithoutSize, dwrfMetadataReader},
+                {columnStatistics1, columnStatistics1, dwrfMetadataReader},
+                {columnStatistics2, columnStatistics2, dwrfMetadataReader},
+                {columnStatistics3, columnStatistics3, dwrfMetadataReader},
+                {columnStatistics4, columnStatistics4, dwrfMetadataReader},
                 {integerColumnStatistics1, integerColumnStatistics1, dwrfMetadataReader},
                 {integerColumnStatistics1, integerColumnStatistics1, dwrfMetadataReaderDisabledMapStats},
                 {mapColumnStatisticsIntKey, mapColumnStatisticsIntKey, dwrfMetadataReader},

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
@@ -171,7 +171,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
     static List<ColumnStatistics> insertEmptyColumnStatisticsAt(List<ColumnStatistics> statisticsList, int index, long numberOfValues)
     {
         List<ColumnStatistics> newStatisticsList = new ArrayList<>(statisticsList);
-        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, null));
+        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, null, null, null));
         return newStatisticsList;
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestMapColumnStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestMapColumnStatistics.java
@@ -43,21 +43,21 @@ public class TestMapColumnStatistics
     public void testEqualsHashCode(KeyInfo[] keys)
     {
         MapColumnStatisticsBuilder builder1 = new MapColumnStatisticsBuilder(true);
-        builder1.addMapStatistics(keys[0], new ColumnStatistics(3L, null));
-        builder1.addMapStatistics(keys[1], new ColumnStatistics(5L, null));
+        builder1.addMapStatistics(keys[0], new ColumnStatistics(3L, null, 1L, 2L));
+        builder1.addMapStatistics(keys[1], new ColumnStatistics(5L, null, 1L, 2L));
         builder1.increaseValueCount(8);
         ColumnStatistics columnStatistics1 = builder1.buildColumnStatistics();
 
         // same as builder1
         MapColumnStatisticsBuilder builder2 = new MapColumnStatisticsBuilder(true);
-        builder2.addMapStatistics(keys[0], new ColumnStatistics(3L, null));
-        builder2.addMapStatistics(keys[1], new ColumnStatistics(5L, null));
+        builder2.addMapStatistics(keys[0], new ColumnStatistics(3L, null, 1L, 2L));
+        builder2.addMapStatistics(keys[1], new ColumnStatistics(5L, null, 1L, 2L));
         builder2.increaseValueCount(8);
         ColumnStatistics columnStatistics2 = builder2.buildColumnStatistics();
 
         MapColumnStatisticsBuilder builder3 = new MapColumnStatisticsBuilder(true);
-        builder3.addMapStatistics(keys[1], new ColumnStatistics(5L, null));
-        builder3.addMapStatistics(keys[2], new ColumnStatistics(6L, null));
+        builder3.addMapStatistics(keys[1], new ColumnStatistics(5L, null, 1L, 2L));
+        builder3.addMapStatistics(keys[2], new ColumnStatistics(6L, null, 1L, 2L));
         builder3.increaseValueCount(11);
         ColumnStatistics columnStatistics3 = builder3.buildColumnStatistics();
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestMapColumnStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestMapColumnStatisticsBuilder.java
@@ -63,8 +63,8 @@ public class TestMapColumnStatisticsBuilder
         KeyInfo key1 = keys[0];
         KeyInfo key2 = keys[1];
 
-        ColumnStatistics columnStatistics1 = new ColumnStatistics(3L, null);
-        ColumnStatistics columnStatistics2 = new ColumnStatistics(5L, null);
+        ColumnStatistics columnStatistics1 = new ColumnStatistics(3L, null, null, null);
+        ColumnStatistics columnStatistics2 = new ColumnStatistics(5L, null, null, null);
 
         MapColumnStatisticsBuilder builder = new MapColumnStatisticsBuilder(true);
         builder.addMapStatistics(key1, columnStatistics1);
@@ -91,8 +91,8 @@ public class TestMapColumnStatisticsBuilder
         KeyInfo key1 = keys[0];
         KeyInfo key2 = keys[1];
 
-        ColumnStatistics columnStatistics1 = new ColumnStatistics(3L, null);
-        ColumnStatistics columnStatistics2 = new ColumnStatistics(5L, null);
+        ColumnStatistics columnStatistics1 = new ColumnStatistics(3L, null, null, null);
+        ColumnStatistics columnStatistics2 = new ColumnStatistics(5L, null, null, null);
 
         MapColumnStatisticsBuilder builder = new MapColumnStatisticsBuilder(true);
         builder.addMapStatistics(key1, columnStatistics1);
@@ -117,18 +117,18 @@ public class TestMapColumnStatisticsBuilder
         // merge two stats with keys: [k0,k1] and [k1,k2]
         // column statistics for k1 should be merged together
         MapColumnStatisticsBuilder builder1 = new MapColumnStatisticsBuilder(true);
-        builder1.addMapStatistics(keys[0], new IntegerColumnStatistics(3L, null, new IntegerStatistics(1L, 2L, 3L)));
-        builder1.addMapStatistics(keys[1], new IntegerColumnStatistics(5L, null, new IntegerStatistics(10L, 20L, 30L)));
+        builder1.addMapStatistics(keys[0], new IntegerColumnStatistics(3L, null, null, null, new IntegerStatistics(1L, 2L, 3L)));
+        builder1.addMapStatistics(keys[1], new IntegerColumnStatistics(5L, null, null, null, new IntegerStatistics(10L, 20L, 30L)));
         builder1.increaseValueCount(8);
         ColumnStatistics columnStatistics1 = builder1.buildColumnStatistics();
 
         MapColumnStatisticsBuilder builder2 = new MapColumnStatisticsBuilder(true);
-        builder2.addMapStatistics(keys[1], new IntegerColumnStatistics(7L, null, new IntegerStatistics(25L, 95L, 100L)));
-        builder2.addMapStatistics(keys[2], new IntegerColumnStatistics(9L, null, new IntegerStatistics(12L, 22L, 32L)));
+        builder2.addMapStatistics(keys[1], new IntegerColumnStatistics(7L, null, null, null, new IntegerStatistics(25L, 95L, 100L)));
+        builder2.addMapStatistics(keys[2], new IntegerColumnStatistics(9L, null, null, null, new IntegerStatistics(12L, 22L, 32L)));
         builder2.increaseValueCount(16);
         ColumnStatistics columnStatistics2 = builder2.buildColumnStatistics();
 
-        MapStatistics mergedMapStatistics = MapColumnStatisticsBuilder.mergeMapStatistics(ImmutableList.of(columnStatistics1, columnStatistics2)).get();
+        MapStatistics mergedMapStatistics = MapColumnStatisticsBuilder.mergeMapStatistics(ImmutableList.of(columnStatistics1, columnStatistics2), null).get();
         assertMergedMapStatistics(keys, mergedMapStatistics);
     }
 
@@ -137,14 +137,14 @@ public class TestMapColumnStatisticsBuilder
     {
         // valid map stat
         MapColumnStatisticsBuilder builder1 = new MapColumnStatisticsBuilder(true);
-        builder1.addMapStatistics(keys[0], new ColumnStatistics(3L, null));
+        builder1.addMapStatistics(keys[0], new ColumnStatistics(3L, null, null, null));
         builder1.increaseValueCount(3);
         ColumnStatistics columnStatistics1 = builder1.buildColumnStatistics();
 
         // invalid map stat
-        ColumnStatistics columnStatistics2 = new ColumnStatistics(7L, null);
+        ColumnStatistics columnStatistics2 = new ColumnStatistics(7L, null, null, null);
 
-        Optional<MapStatistics> mergedMapStats = MapColumnStatisticsBuilder.mergeMapStatistics(ImmutableList.of(columnStatistics1, columnStatistics2));
+        Optional<MapStatistics> mergedMapStats = MapColumnStatisticsBuilder.mergeMapStatistics(ImmutableList.of(columnStatistics1, columnStatistics2), null);
         assertFalse(mergedMapStats.isPresent());
     }
 
@@ -154,14 +154,14 @@ public class TestMapColumnStatisticsBuilder
         // merge two stats with keys: [k0,k1] and [k1,k2]
         // column statistics for k1 should be merged together
         MapColumnStatisticsBuilder builder1 = new MapColumnStatisticsBuilder(true);
-        builder1.addMapStatistics(keys[0], new IntegerColumnStatistics(3L, null, new IntegerStatistics(1L, 2L, 3L)));
-        builder1.addMapStatistics(keys[1], new IntegerColumnStatistics(5L, null, new IntegerStatistics(10L, 20L, 30L)));
+        builder1.addMapStatistics(keys[0], new IntegerColumnStatistics(3L, null, null, null, new IntegerStatistics(1L, 2L, 3L)));
+        builder1.addMapStatistics(keys[1], new IntegerColumnStatistics(5L, null, null, null, new IntegerStatistics(10L, 20L, 30L)));
         builder1.increaseValueCount(10);
         ColumnStatistics columnStatistics1 = builder1.buildColumnStatistics();
 
         MapColumnStatisticsBuilder builder2 = new MapColumnStatisticsBuilder(true);
-        builder2.addMapStatistics(keys[1], new IntegerColumnStatistics(7L, null, new IntegerStatistics(25L, 95L, 100L)));
-        builder2.addMapStatistics(keys[2], new IntegerColumnStatistics(9L, null, new IntegerStatistics(12L, 22L, 32L)));
+        builder2.addMapStatistics(keys[1], new IntegerColumnStatistics(7L, null, null, null, new IntegerStatistics(25L, 95L, 100L)));
+        builder2.addMapStatistics(keys[2], new IntegerColumnStatistics(9L, null, null, null, new IntegerStatistics(12L, 22L, 32L)));
         builder2.increaseValueCount(20);
         ColumnStatistics columnStatistics2 = builder2.buildColumnStatistics();
 
@@ -182,8 +182,8 @@ public class TestMapColumnStatisticsBuilder
             columnStatisticsByKey.put(entry.getKey(), entry.getColumnStatistics());
         }
 
-        assertEquals(columnStatisticsByKey.get(keys[0]), new IntegerColumnStatistics(3L, null, new IntegerStatistics(1L, 2L, 3L)));
-        assertEquals(columnStatisticsByKey.get(keys[1]), new IntegerColumnStatistics(12L, null, new IntegerStatistics(10L, 95L, 130L))); // merged stats
-        assertEquals(columnStatisticsByKey.get(keys[2]), new IntegerColumnStatistics(9L, null, new IntegerStatistics(12L, 22L, 32L)));
+        assertEquals(columnStatisticsByKey.get(keys[0]), new IntegerColumnStatistics(3L, null, null, null, new IntegerStatistics(1L, 2L, 3L)));
+        assertEquals(columnStatisticsByKey.get(keys[1]), new IntegerColumnStatistics(12L, null, null, null, new IntegerStatistics(10L, 95L, 130L))); // merged stats
+        assertEquals(columnStatisticsByKey.get(keys[2]), new IntegerColumnStatistics(9L, null, null, null, new IntegerStatistics(12L, 22L, 32L)));
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
@@ -356,10 +356,12 @@ public class TestStringStatisticsBuilder
     private static ColumnStatistics stringColumnStatistics(Slice minimum, Slice maximum)
     {
         if (minimum == null && maximum == null) {
-            return new ColumnStatistics(100L, null);
+            return new ColumnStatistics(100L, null, null, null);
         }
         return new StringColumnStatistics(
                 100L,
+                null,
+                null,
                 null,
                 new StringStatistics(minimum, maximum, 100));
     }


### PR DESCRIPTION
## Description
Add column raw size to file and row group column statistics. 
Add column storage sizes to file column statistics. 

## Motivation and Context
Missing raw sizes in partitions written by Presto and Spark have been
a concern for observability of the data quality for a long time. The raw 
size is used to verify data quality of a recently landed partition, specifically
it's very important for feature observability.

The column storage size is used to asses how much storage a certain 
column consumes, which is helpful when a table owner goes over a storage
quota and needs to see if their attempts to optimize data succeeded or not. 
It's also used to assess how much space is used by unused columns. 

This change adds missing storage and raw sizes to the file footer, thus 
closing this gap with Velox and BBIO.

## Impact
This change adds missing storage and raw sizes to the file footer, allowing population
of these fields in the Metastore.

## Test Plan
* Update existing unit tests
* Create new unit tests for writers using direct and dictionary encoding
* Inspected new sizes manually and compared them to the sizes produced by Velox for the same data.
* Created a custom Validation Service stage checking raw sizes between Velox and Presto produced files. Ran it against a flat map heavy namespace, with a total of 2.4K files processed. Vader does round robin for all column types and flat map features giving coverage for all situations. Details at P1103168769
* Presto Verifier runs P1104870878

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

