### PR TITLE
[native] Translate presto properties to Velox.

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
@@ -45,6 +45,10 @@ class BaseVeloxQueryConfigTest : public testing::Test {
           fileSystem->openFileForWrite(systemConfigFilePath);
       systemConfigFile->append(
           fmt::format("{}=true\n", SystemConfig::kUseLegacyArrayAgg));
+      systemConfigFile->append(
+          fmt::format("{}=17MB\n", SystemConfig::kSinkMaxBufferSize));
+      systemConfigFile->append(fmt::format(
+          "{}=6MB\n", SystemConfig::kDriverMaxPagePartitioningBufferSize));
       systemConfigFile->close();
       SystemConfig::instance()->initialize(systemConfigFilePath);
     }
@@ -108,15 +112,19 @@ TEST_F(BaseVeloxQueryConfigTest, mutableConfig) {
 }
 
 TEST_F(BaseVeloxQueryConfigTest, fromSystemConfig) {
+#define GET_VAL(_name_) cfg->optionalProperty(std::string(_name_))
+
   auto cfg = BaseVeloxQueryConfig::instance();
-  ASSERT_FALSE(cfg->optionalProperty<bool>(
-                      std::string(QueryConfig::kPrestoArrayAggIgnoreNulls))
-                   .value());
+  ASSERT_EQ("false", GET_VAL(QueryConfig::kPrestoArrayAggIgnoreNulls));
+
   setUpConfigFile(true, true);
   cfg->initialize(configFilePath);
-  ASSERT_TRUE(cfg->optionalProperty<bool>(
-                     std::string(QueryConfig::kPrestoArrayAggIgnoreNulls))
-                  .value());
+
+  ASSERT_EQ("true", GET_VAL(QueryConfig::kPrestoArrayAggIgnoreNulls));
+  ASSERT_EQ("17825792", GET_VAL(QueryConfig::kMaxArbitraryBufferSize));
+  ASSERT_EQ("6291456", GET_VAL(QueryConfig::kMaxPartitionedOutputBufferSize));
+
+#undef GET_VAL
 }
 
 } // namespace facebook::presto::test

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -39,7 +39,7 @@ class ConfigTest : public testing::Test {
     sysConfigFile->append(
         fmt::format("{}={}\n", SystemConfig::kPrestoVersion, prestoVersion));
     sysConfigFile->append(
-        fmt::format("{}=11KB\n", SystemConfig::kQueryMaxMemoryPerNode));
+        fmt::format("{}=11kB\n", SystemConfig::kQueryMaxMemoryPerNode));
     if (isMutable) {
       sysConfigFile->append(
           fmt::format("{}={}\n", ConfigBase::kMutableConfig, "true"));
@@ -86,7 +86,7 @@ TEST_F(ConfigTest, mutableSystemConfig) {
           .value());
   ASSERT_EQ(prestoVersion2, systemConfig->prestoVersion());
   ASSERT_EQ(
-      "11KB",
+      "11kB",
       systemConfig
           ->setValue(std::string(SystemConfig::kQueryMaxMemoryPerNode), "5GB")
           .value());


### PR DESCRIPTION
Prestissimo needs to translate Presto's worker configs sink.max-buffer-size and
driver.max-page-partitioning-buffer-size to corresponding Velox configs
max_arbitrary_buffer_size and max_page_partitioning_buffer_size.

Also advance Velox version.

Fixes #21543 

```
== NO RELEASE NOTE ==
```

