### PR TITLE
Add prestoVersion to session

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1198,6 +1198,12 @@ public abstract class AbstractTestHiveClient
             {
                 return WarningCollector.NOOP;
             }
+
+            @Override
+            public String getPrestoVersion()
+            {
+                return "test_version";
+            }
         };
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -192,4 +192,10 @@ public class FullConnectorSession
     {
         return session.getWarningCollector();
     }
+
+    @Override
+    public String getPrestoVersion()
+    {
+        return session.getPrestoVersion();
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -93,6 +93,7 @@ public final class Session
     private final AccessControlContext context;
     private final Optional<Tracer> tracer;
     private final WarningCollector warningCollector;
+    private final String prestoVersion;
 
     private final RuntimeStats runtimeStats = new RuntimeStats();
     private final OptimizerInformationCollector optimizerInformationCollector = new OptimizerInformationCollector();
@@ -123,7 +124,8 @@ public final class Session
             Map<String, String> preparedStatements,
             Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions,
             Optional<Tracer> tracer,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            String prestoVersion)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
@@ -164,6 +166,7 @@ public final class Session
         this.context = new AccessControlContext(queryId, clientInfo, source);
         this.tracer = requireNonNull(tracer, "tracer is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
+        this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
     }
 
     public QueryId getQueryId()
@@ -319,6 +322,11 @@ public final class Session
         return warningCollector;
     }
 
+    public String getPrestoVersion()
+    {
+        return prestoVersion;
+    }
+
     public OptimizerInformationCollector getOptimizerInformationCollector()
     {
         return optimizerInformationCollector;
@@ -427,7 +435,8 @@ public final class Session
                 preparedStatements,
                 sessionFunctions,
                 tracer,
-                warningCollector);
+                warningCollector,
+                prestoVersion);
     }
 
     public Session withDefaultProperties(
@@ -482,7 +491,8 @@ public final class Session
                 preparedStatements,
                 sessionFunctions,
                 tracer,
-                warningCollector);
+                warningCollector,
+                prestoVersion);
     }
 
     public ConnectorSession toConnectorSession()
@@ -544,7 +554,8 @@ public final class Session
                 unprocessedCatalogProperties,
                 identity.getRoles(),
                 preparedStatements,
-                sessionFunctions);
+                sessionFunctions,
+                prestoVersion);
     }
 
     @Override
@@ -607,6 +618,7 @@ public final class Session
         private final Map<String, String> preparedStatements = new HashMap<>();
         private final Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions = new HashMap<>();
         private WarningCollector warningCollector = WarningCollector.NOOP;
+        private String prestoVersion;
 
         private SessionBuilder(SessionPropertyManager sessionPropertyManager)
         {
@@ -639,6 +651,7 @@ public final class Session
             this.sessionFunctions.putAll(session.sessionFunctions);
             this.tracer = requireNonNull(session.tracer, "tracer is null");
             this.warningCollector = requireNonNull(session.warningCollector, "warningCollector is null");
+            this.prestoVersion = requireNonNull(session.prestoVersion, "prestoVersion is null");
         }
 
         public SessionBuilder setQueryId(QueryId queryId)
@@ -789,6 +802,12 @@ public final class Session
             return this;
         }
 
+        public SessionBuilder setPrestoVersion(String prestoVersion)
+        {
+            this.prestoVersion = prestoVersion;
+            return this;
+        }
+
         public <T> T getSystemProperty(String name, Class<T> type)
         {
             return sessionPropertyManager.decodeSystemPropertyValue(name, systemProperties.get(name), type);
@@ -820,7 +839,8 @@ public final class Session
                     preparedStatements,
                     sessionFunctions,
                     tracer,
-                    warningCollector);
+                    warningCollector,
+                    prestoVersion);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
@@ -68,6 +68,7 @@ public final class SessionRepresentation
     private final Map<String, SelectedRole> roles;
     private final Map<String, String> preparedStatements;
     private final Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions;
+    private final String prestoVersion;
 
     @ThriftConstructor
     @JsonCreator
@@ -94,7 +95,8 @@ public final class SessionRepresentation
             @JsonProperty("unprocessedCatalogProperties") Map<String, Map<String, String>> unprocessedCatalogProperties,
             @JsonProperty("roles") Map<String, SelectedRole> roles,
             @JsonProperty("preparedStatements") Map<String, String> preparedStatements,
-            @JsonProperty("sessionFunctions") Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions)
+            @JsonProperty("sessionFunctions") Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions,
+            @JsonProperty("prestoVersion") String prestoVersion)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
@@ -117,6 +119,7 @@ public final class SessionRepresentation
         this.roles = ImmutableMap.copyOf(roles);
         this.preparedStatements = ImmutableMap.copyOf(preparedStatements);
         this.sessionFunctions = ImmutableMap.copyOf(sessionFunctions);
+        this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
 
         ImmutableMap.Builder<ConnectorId, Map<String, String>> catalogPropertiesBuilder = ImmutableMap.builder();
         for (Entry<ConnectorId, Map<String, String>> entry : catalogProperties.entrySet()) {
@@ -292,6 +295,13 @@ public final class SessionRepresentation
         return sessionFunctions;
     }
 
+    @ThriftField(24)
+    @JsonProperty
+    public String getPrestoVersion()
+    {
+        return prestoVersion;
+    }
+
     public Session toSession(SessionPropertyManager sessionPropertyManager)
     {
         return toSession(sessionPropertyManager, emptyMap(), emptyMap());
@@ -336,6 +346,7 @@ public final class SessionRepresentation
                 sessionFunctions,
                 Optional.empty(),
                 // we use NOOP to create a session from the representation as worker does not require warning collectors
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                prestoVersion);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
@@ -44,6 +44,7 @@ public final class SystemConnectorSessionUtil
                 .setTimeZoneKey(session.getSqlFunctionProperties().getTimeZoneKey())
                 .setLocale(session.getLocale())
                 .setStartTime(session.getStartTime())
+                .setPrestoVersion(session.getPrestoVersion())
                 .build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -340,6 +340,7 @@ public class DispatchManager
                         .setQueryId(queryId)
                         .setIdentity(sessionContext.getIdentity())
                         .setSource(sessionContext.getSource())
+                        .setPrestoVersion(sessionContext.getPrestoVersion())
                         .build();
             }
             DispatchQuery failedDispatchQuery = failedDispatchQueryFactory.createFailedDispatchQuery(session, query, Optional.empty(), throwable);

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -121,10 +121,11 @@ public final class HttpRequestSessionContext
 
     private final Optional<SessionPropertyManager> sessionPropertyManager;
     private final Optional<Tracer> tracer;
+    private final String prestoVersion;
 
-    public HttpRequestSessionContext(HttpServletRequest servletRequest, SqlParserOptions sqlParserOptions)
+    public HttpRequestSessionContext(HttpServletRequest servletRequest, SqlParserOptions sqlParserOptions, String prestoVersion)
     {
-        this(servletRequest, sqlParserOptions, NoopTracerProvider.NOOP_TRACER_PROVIDER, Optional.empty());
+        this(servletRequest, sqlParserOptions, NoopTracerProvider.NOOP_TRACER_PROVIDER, Optional.empty(), prestoVersion);
     }
 
     /**
@@ -136,7 +137,12 @@ public final class HttpRequestSessionContext
      * session context creation stage.
      * @throws WebApplicationException
      */
-    public HttpRequestSessionContext(HttpServletRequest servletRequest, SqlParserOptions sqlParserOptions, TracerProvider tracerProvider, Optional<SessionPropertyManager> sessionPropertyManager)
+    public HttpRequestSessionContext(
+            HttpServletRequest servletRequest,
+            SqlParserOptions sqlParserOptions,
+            TracerProvider tracerProvider,
+            Optional<SessionPropertyManager> sessionPropertyManager,
+            String prestoVersion)
             throws WebApplicationException
     {
         catalog = trimEmptyToNull(servletRequest.getHeader(PRESTO_CATALOG));
@@ -234,6 +240,7 @@ public final class HttpRequestSessionContext
                 traceToken = Optional.ofNullable(tracerHandle.getTraceToken());
             }
         }
+        this.prestoVersion = trimEmptyToNull(prestoVersion);
     }
 
     private static Map<String, String> getRequestHeaders(HttpServletRequest servletRequest)
@@ -514,6 +521,12 @@ public final class HttpRequestSessionContext
     public Optional<Tracer> getTracer()
     {
         return tracer;
+    }
+
+    @Override
+    public String getPrestoVersion()
+    {
+        return prestoVersion;
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -99,7 +99,8 @@ public class QuerySessionSupplier
                 .setClientTags(context.getClientTags())
                 .setTraceToken(context.getTraceToken())
                 .setResourceEstimates(context.getResourceEstimates())
-                .setTracer(context.getTracer());
+                .setTracer(context.getTracer())
+                .setPrestoVersion(context.getPrestoVersion());
 
         if (forcedSessionTimeZone.isPresent()) {
             sessionBuilder.setTimeZoneKey(forcedSessionTimeZone.get());

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionContext.java
@@ -80,4 +80,6 @@ public interface SessionContext
     boolean supportClientTransaction();
 
     Map<SqlFunctionId, SqlInvokedFunction> getSessionFunctions();
+
+    String getPrestoVersion();
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
@@ -118,7 +118,8 @@ public class SessionPropertyDefaults
                 session.getClientTags(),
                 queryType,
                 resourceGroupId,
-                session.getClientInfo());
+                session.getClientInfo(),
+                session.getPrestoVersion());
 
         SystemSessionPropertyConfiguration systemPropertyConfiguration = configurationManager.getSystemSessionProperties(context);
         Map<String, Map<String, String>> catalogPropertyOverrides = configurationManager.getCatalogSessionProperties(context);

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
@@ -24,6 +24,7 @@ import com.facebook.presto.dispatcher.DispatchInfo;
 import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.QueryState;
+import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.server.HttpRequestSessionContext;
 import com.facebook.presto.server.ServerConfig;
@@ -133,6 +134,8 @@ public class QueuedStatementResource
 
     private final QueryBlockingRateLimiter queryRateLimiter;
 
+    private final String prestoVersion;
+
     @Inject
     public QueuedStatementResource(
             DispatchManager dispatchManager,
@@ -142,7 +145,8 @@ public class QueuedStatementResource
             ServerConfig serverConfig,
             TracerProviderManager tracerProviderManager,
             SessionPropertyManager sessionPropertyManager,
-            QueryBlockingRateLimiter queryRateLimiter)
+            QueryBlockingRateLimiter queryRateLimiter,
+            InternalNodeManager nodeManager)
     {
         this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
         this.queryResultsProvider = queryResultsProvider;
@@ -171,6 +175,7 @@ public class QueuedStatementResource
                 200,
                 200,
                 MILLISECONDS);
+        this.prestoVersion = requireNonNull(nodeManager, "nodeManager is null").getCurrentNode().getVersion();
     }
 
     @Managed
@@ -220,7 +225,8 @@ public class QueuedStatementResource
                 servletRequest,
                 sqlParserOptions,
                 tracerProviderManager.getTracerProvider(),
-                Optional.of(sessionPropertyManager));
+                Optional.of(sessionPropertyManager),
+                prestoVersion);
         Query query = new Query(statement, sessionContext, dispatchManager, queryResultsProvider, 0);
         queries.put(query.getQueryId(), query);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -103,6 +103,7 @@ public final class MaterializedViewUtils
                 .setUserAgent(session.getUserAgent().orElse(null))
                 .setClientInfo(session.getClientInfo().orElse(null))
                 .setStartTime(session.getStartTime())
+                .setPrestoVersion(session.getPrestoVersion())
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2823,7 +2823,8 @@ class StatementAnalyzer
                         .setRemoteUserAddress(session.getRemoteUserAddress().orElse(null))
                         .setUserAgent(session.getUserAgent().orElse(null))
                         .setClientInfo(session.getClientInfo().orElse(null))
-                        .setStartTime(session.getStartTime());
+                        .setStartTime(session.getStartTime())
+                        .setPrestoVersion(session.getPrestoVersion());
                 session.getConnectorProperties().forEach((connectorId, properties) -> properties.forEach((k, v) -> viewSessionBuilder.setConnectionProperty(connectorId, k, v)));
                 Session viewSession = viewSessionBuilder.build();
                 StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, viewAccessControl, viewSession, warningCollector);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -539,7 +539,8 @@ public class LocalQueryRunner
                 defaultSession.getPreparedStatements(),
                 defaultSession.getSessionFunctions(),
                 defaultSession.getTracer(),
-                defaultSession.getWarningCollector());
+                defaultSession.getWarningCollector(),
+                defaultSession.getPrestoVersion());
 
         dataDefinitionTask = ImmutableMap.<Class<? extends Statement>, DataDefinitionTask<?>>builder()
                 .put(CreateTable.class, new CreateTableTask())

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -207,6 +207,12 @@ public class TestingConnectorSession
     }
 
     @Override
+    public String getPrestoVersion()
+    {
+        return "test_version";
+    }
+
+    @Override
     public String toString()
     {
         return toStringHelper(this)

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingSession.java
@@ -68,7 +68,8 @@ public final class TestingSession
                 .setTimeZoneKey(DEFAULT_TIME_ZONE_KEY)
                 .setLocale(ENGLISH)
                 .setRemoteUserAddress("address")
-                .setUserAgent("agent");
+                .setUserAgent("agent")
+                .setPrestoVersion("test_version");
     }
 
     public static Catalog createBogusTestingCatalog(String catalogName)

--- a/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionContext.java
@@ -108,7 +108,7 @@ public class TestHttpRequestSessionContext
                 "testRemote",
                 ImmutableMap.of());
 
-        HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions());
+        HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions(), "test_version");
         assertEquals(context.getSource(), "testSource");
         assertEquals(context.getCatalog(), "testCatalog");
         assertEquals(context.getSchema(), "testSchema");
@@ -148,7 +148,7 @@ public class TestHttpRequestSessionContext
                         .build(),
                 "testRemote",
                 ImmutableMap.of());
-        new HttpRequestSessionContext(request, new SqlParserOptions());
+        new HttpRequestSessionContext(request, new SqlParserOptions(), "test_version");
     }
 
     @Test
@@ -170,7 +170,7 @@ public class TestHttpRequestSessionContext
         SqlParserOptions options = new SqlParserOptions();
         options.allowIdentifierSymbol(EnumSet.allOf(IdentifierSymbol.class));
 
-        new HttpRequestSessionContext(request, options);
+        new HttpRequestSessionContext(request, options, "test_version");
     }
 
     @Test
@@ -199,7 +199,7 @@ public class TestHttpRequestSessionContext
                 "testRemote",
                 ImmutableMap.of());
 
-        HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions());
+        HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions(), "test_version");
         assertEquals(
                 context.getIdentity().getExtraCredentials(),
                 ImmutableMap.builder()

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
@@ -86,7 +86,7 @@ public class TestQuerySessionSupplier
     @Test
     public void testCreateSession()
     {
-        HttpRequestSessionContext context = new HttpRequestSessionContext(TEST_REQUEST, new SqlParserOptions());
+        HttpRequestSessionContext context = new HttpRequestSessionContext(TEST_REQUEST, new SqlParserOptions(), "test_version");
         QuerySessionSupplier sessionSupplier = new QuerySessionSupplier(
                 createTestTransactionManager(),
                 new AllowAllAccessControl(),
@@ -133,7 +133,7 @@ public class TestQuerySessionSupplier
                         .build(),
                 "remoteAddress",
                 ImmutableMap.of());
-        HttpRequestSessionContext context1 = new HttpRequestSessionContext(request1, new SqlParserOptions());
+        HttpRequestSessionContext context1 = new HttpRequestSessionContext(request1, new SqlParserOptions(), "test_version");
         assertEquals(context1.getClientTags(), ImmutableSet.of());
 
         HttpServletRequest request2 = new MockHttpServletRequest(
@@ -143,7 +143,7 @@ public class TestQuerySessionSupplier
                         .build(),
                 "remoteAddress",
                 ImmutableMap.of());
-        HttpRequestSessionContext context2 = new HttpRequestSessionContext(request2, new SqlParserOptions());
+        HttpRequestSessionContext context2 = new HttpRequestSessionContext(request2, new SqlParserOptions(), "test_version");
         assertEquals(context2.getClientTags(), ImmutableSet.of());
     }
 
@@ -157,7 +157,7 @@ public class TestQuerySessionSupplier
                         .build(),
                 "testRemote",
                 ImmutableMap.of());
-        HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions());
+        HttpRequestSessionContext context = new HttpRequestSessionContext(request, new SqlParserOptions(), "test_version");
         QuerySessionSupplier sessionSupplier = new QuerySessionSupplier(
                 createTestTransactionManager(),
                 new AllowAllAccessControl(),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
@@ -65,6 +65,7 @@ public class TestSessionPropertyDefaults
                 .setSystemProperty(HASH_PARTITION_COUNT, "43")
                 .setSystemProperty("override", "should be overridden")
                 .setCatalogSessionProperty("testCatalog", "explicit_set", "explicit_set")
+                .setPrestoVersion("test_version")
                 .build();
 
         assertEquals(session.getSystemProperties(), ImmutableMap.<String, String>builder()

--- a/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
@@ -44,7 +44,8 @@ public class TestFileSessionPropertyManager
             ImmutableSet.of("tag1", "tag2"),
             Optional.of(QueryType.DATA_DEFINITION.toString()),
             Optional.of(new ResourceGroupId(ImmutableList.of("global", "pipeline", "user_foo", "bar"))),
-            Optional.of("bar"));
+            Optional.of("bar"),
+            "test_version");
 
     @Test
     public void testResourceGroupMatch()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
@@ -52,6 +52,7 @@ public class PrestoSparkSessionContext
     private final Map<String, String> systemProperties;
     private final Map<String, Map<String, String>> catalogSessionProperties;
     private final Optional<String> traceToken;
+    private final String prestoVersion;
 
     public static PrestoSparkSessionContext createFromSessionInfo(
             PrestoSparkSession prestoSparkSession,
@@ -84,7 +85,8 @@ public class PrestoSparkSessionContext
                 prestoSparkSession.getLanguage().orElse(null),
                 prestoSparkSession.getSystemProperties(),
                 prestoSparkSession.getCatalogSessionProperties(),
-                prestoSparkSession.getTraceToken());
+                prestoSparkSession.getTraceToken(),
+                prestoSparkSession.getPrestoVersion());
     }
 
     public PrestoSparkSessionContext(
@@ -99,7 +101,8 @@ public class PrestoSparkSessionContext
             String language,
             Map<String, String> systemProperties,
             Map<String, Map<String, String>> catalogSessionProperties,
-            Optional<String> traceToken)
+            Optional<String> traceToken,
+            String prestoVersion)
     {
         this.identity = requireNonNull(identity, "identity is null");
         this.catalog = catalog;
@@ -113,6 +116,7 @@ public class PrestoSparkSessionContext
         this.systemProperties = ImmutableMap.copyOf(requireNonNull(systemProperties, "systemProperties is null"));
         this.catalogSessionProperties = ImmutableMap.copyOf(requireNonNull(catalogSessionProperties, "catalogSessionProperties is null"));
         this.traceToken = requireNonNull(traceToken, "traceToken is null");
+        this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
     }
 
     @Override
@@ -238,5 +242,11 @@ public class PrestoSparkSessionContext
     {
         // presto on spark does not support session functions
         return ImmutableMap.of();
+    }
+
+    @Override
+    public String getPrestoVersion()
+    {
+        return prestoVersion;
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -619,7 +619,8 @@ public class PrestoSparkQueryRunner
                 Optional.empty(),
                 session.getSystemProperties(),
                 catalogSessionProperties.build(),
-                session.getTraceToken());
+                session.getTraceToken(),
+                session.getPrestoVersion());
     }
 
     @Override

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkSession.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkSession.java
@@ -44,6 +44,7 @@ public class PrestoSparkSession
     private final Map<String, String> systemProperties;
     private final Map<String, Map<String, String>> catalogSessionProperties;
     private final Optional<String> traceToken;
+    private final String prestoVersion;
 
     public PrestoSparkSession(
             String user,
@@ -59,7 +60,8 @@ public class PrestoSparkSession
             Optional<String> language,
             Map<String, String> systemProperties,
             Map<String, Map<String, String>> catalogSessionProperties,
-            Optional<String> traceToken)
+            Optional<String> traceToken,
+            String prestoVersion)
 
     {
         this.user = requireNonNull(user, "user is null");
@@ -77,6 +79,7 @@ public class PrestoSparkSession
         this.catalogSessionProperties = unmodifiableMap(requireNonNull(catalogSessionProperties, "catalogSessionProperties is null").entrySet().stream()
                 .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
         this.traceToken = requireNonNull(traceToken, "traceToken is null");
+        this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
     }
 
     public String getUser()
@@ -147,5 +150,10 @@ public class PrestoSparkSession
     public Optional<String> getTraceToken()
     {
         return traceToken;
+    }
+
+    public String getPrestoVersion()
+    {
+        return prestoVersion;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
@@ -94,7 +94,8 @@ public class PrestoSparkLauncherCommand
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
-                    Optional.empty());
+                    Optional.empty(),
+                    "test_version");
         }
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -97,7 +97,8 @@ public class PrestoSparkRunner
             Optional<String> traceToken,
             Optional<String> sparkQueueName,
             Optional<String> queryStatusInfoOutputLocation,
-            Optional<String> queryDataOutputLocation)
+            Optional<String> queryDataOutputLocation,
+            String prestoVersion)
     {
         IPrestoSparkQueryExecutionFactory queryExecutionFactory = driverPrestoSparkService.getQueryExecutionFactory();
         PrestoSparkRunnerContext prestoSparkRunnerContext = new PrestoSparkRunnerContext(
@@ -120,7 +121,8 @@ public class PrestoSparkRunner
                 sparkQueueName,
                 queryStatusInfoOutputLocation,
                 queryDataOutputLocation,
-                getExecutionStrategies(sessionProperties));
+                getExecutionStrategies(sessionProperties),
+                prestoVersion);
         try {
             execute(queryExecutionFactory, prestoSparkRunnerContext);
         }
@@ -162,7 +164,8 @@ public class PrestoSparkRunner
                 Optional.empty(),
                 prestoSparkRunnerContext.getSessionProperties(),
                 prestoSparkRunnerContext.getCatalogSessionProperties(),
-                prestoSparkRunnerContext.getTraceToken());
+                prestoSparkRunnerContext.getTraceToken(),
+                prestoSparkRunnerContext.getPrestoVersion());
 
         IPrestoSparkQueryExecution queryExecution = queryExecutionFactory.create(
                 distribution.getSparkContext(),

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunnerContext.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunnerContext.java
@@ -45,6 +45,7 @@ public class PrestoSparkRunnerContext
     private final Optional<String> queryStatusInfoOutputLocation;
     private final Optional<String> queryDataOutputLocation;
     private final List<ExecutionStrategy> executionStrategies;
+    private final String prestoVersion;
 
     public PrestoSparkRunnerContext(
             String user,
@@ -66,7 +67,8 @@ public class PrestoSparkRunnerContext
             Optional<String> sparkQueueName,
             Optional<String> queryStatusInfoOutputLocation,
             Optional<String> queryDataOutputLocation,
-            List<ExecutionStrategy> executionStrategies)
+            List<ExecutionStrategy> executionStrategies,
+            String prestoVersion)
     {
         this.user = user;
         this.principal = principal;
@@ -88,6 +90,7 @@ public class PrestoSparkRunnerContext
         this.queryStatusInfoOutputLocation = queryStatusInfoOutputLocation;
         this.queryDataOutputLocation = queryDataOutputLocation;
         this.executionStrategies = executionStrategies;
+        this.prestoVersion = prestoVersion;
     }
 
     public String getUser()
@@ -190,6 +193,11 @@ public class PrestoSparkRunnerContext
         return executionStrategies;
     }
 
+    public String getPrestoVersion()
+    {
+        return prestoVersion;
+    }
+
     public static class Builder
     {
         private String user;
@@ -212,6 +220,7 @@ public class PrestoSparkRunnerContext
         private Optional<String> queryStatusInfoOutputLocation;
         private Optional<String> queryDataOutputLocation;
         private List<ExecutionStrategy> executionStrategies;
+        private String prestoVersion;
 
         public Builder(PrestoSparkRunnerContext prestoSparkRunnerContext)
         {
@@ -235,6 +244,7 @@ public class PrestoSparkRunnerContext
             this.queryStatusInfoOutputLocation = prestoSparkRunnerContext.getQueryStatusInfoOutputLocation();
             this.queryDataOutputLocation = prestoSparkRunnerContext.getQueryDataOutputLocation();
             this.executionStrategies = prestoSparkRunnerContext.getExecutionStrategies();
+            this.prestoVersion = prestoSparkRunnerContext.getPrestoVersion();
         }
 
         public Builder setExecutionStrategies(List<ExecutionStrategy> executionStrategies)
@@ -265,7 +275,8 @@ public class PrestoSparkRunnerContext
                     sparkQueueName,
                     queryStatusInfoOutputLocation,
                     queryDataOutputLocation,
-                    executionStrategies);
+                    executionStrategies,
+                    prestoVersion);
         }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -63,4 +63,6 @@ public interface ConnectorSession
     }
 
     WarningCollector getWarningCollector();
+
+    String getPrestoVersion();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionConfigurationContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionConfigurationContext.java
@@ -30,6 +30,7 @@ public final class SessionConfigurationContext
     private final Optional<String> queryType;
     private final Optional<ResourceGroupId> resourceGroupId;
     private final Optional<String> clientInfo;
+    private final String prestoVersion;
 
     public SessionConfigurationContext(
             String user,
@@ -37,7 +38,8 @@ public final class SessionConfigurationContext
             Set<String> clientTags,
             Optional<String> queryType,
             Optional<ResourceGroupId> resourceGroupId,
-            Optional<String> clientInfo)
+            Optional<String> clientInfo,
+            String prestoVersion)
     {
         this.user = requireNonNull(user, "user is null");
         this.source = requireNonNull(source, "source is null");
@@ -45,6 +47,7 @@ public final class SessionConfigurationContext
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.resourceGroupId = requireNonNull(resourceGroupId, "resourceGroupId");
         this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
+        this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
     }
 
     public String getUser()
@@ -75,5 +78,10 @@ public final class SessionConfigurationContext
     public Optional<String> getClientInfo()
     {
         return clientInfo;
+    }
+
+    public String getPrestoVersion()
+    {
+        return prestoVersion;
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
@@ -123,6 +123,12 @@ public final class TestingSession
         {
             return WarningCollector.NOOP;
         }
+
+        @Override
+        public String getPrestoVersion()
+        {
+            return "test_version";
+        }
     };
 
     private TestingSession() {}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2978,7 +2978,8 @@ public abstract class AbstractTestQueries
                 getSession().getPreparedStatements(),
                 ImmutableMap.of(),
                 getSession().getTracer(),
-                getSession().getWarningCollector());
+                getSession().getWarningCollector(),
+                getSession().getPrestoVersion());
         MaterializedResult result = computeActual(session, "SHOW SESSION");
 
         ImmutableMap<String, MaterializedRow> properties = Maps.uniqueIndex(result.getMaterializedRows(), input -> {

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
@@ -158,4 +158,10 @@ public class TestingSessionContext
     {
         return session.getSessionFunctions();
     }
+
+    @Override
+    public String getPrestoVersion()
+    {
+        return session.getPrestoVersion();
+    }
 }


### PR DESCRIPTION
## Description
This PR adds presto server version to the session.

## Motivation and Context
Currently we apply session properties via `SessionPropertyConfigurationManager`. But we want to apply these session properties based on the server version. To do this we should have the presto server version in the `SessionConfigurationContext` / `Session` so that the implementers of `SessionPropertyConfigurationManager.getCatalogSessionProperties()` can make a decision based on the presto version
We want to handle the scenario where we have a single file that specifies all the session properties to be applied but have multiple server deployments with different presto versions . So we want to be able to specify the minimum version from which the session property should be added. 

## Impact
None

## Test Plan
Tests already exist.

```
== NO RELEASE NOTE ==
```

