### PR TITLE
Enhance web UX dev experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ To simplify iteration, you can also run in `watch` mode, which automatically re-
 
     yarn --cwd presto-main/src/main/resources/webapp/src run watch
 
+You can launch an HTTP server to serve the web UI and proxy the server APIs to an external Presto server:
+
+    yarn --cwd presto-main/src/main/resources/webapp/src run serve --env=apiHost=<ip address> --env=apiPort=<port>
+
+Replace the `<ip address>` and `<port>` to point to your Presto server. The default values are: `localhost` and `8080`.
+
 To iterate quickly, simply re-build the project in IntelliJ after packaging is complete. Project resources will be hot-reloaded and changes are reflected on browser refresh.
 
 ## Release Notes

--- a/presto-main/src/main/resources/webapp/src/package.json
+++ b/presto-main/src/main/resources/webapp/src/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "install": "webpack --env=production --config webpack.config.js",
     "package": "webpack --env=production --config webpack.config.js",
-    "watch": "webpack --config webpack.config.js --watch"
+    "watch": "webpack --config webpack.config.js --watch",
+    "serve": "webpack serve --config webpack.config.js"
   }
 }

--- a/presto-main/src/main/resources/webapp/src/webpack.config.js
+++ b/presto-main/src/main/resources/webapp/src/webpack.config.js
@@ -4,7 +4,9 @@ const path = require('node:path');
 const TerserPlugin = require("terser-webpack-plugin");
 
 module.exports = (env) => {
-    var mode = env.production ? 'production' : 'development';
+    const mode = env.production ? 'production' : 'development';
+    const apiHost = env.apiHost || 'localhost';
+    const apiPort = env.apiPort || '8080';
     return {
         entry: {
             'index': path.join(__dirname, 'index.jsx'),
@@ -60,5 +62,13 @@ module.exports = (env) => {
               }),
             , '...'],
           },
+        devServer: {
+            static: {
+                directory: path.join(__dirname, '..'),
+              },
+            proxy: {
+                '/v1': `http://${apiHost}:${apiPort}`,
+            },
+        },
     };
 };


### PR DESCRIPTION
## Description
Use `webpack-dev-server` to serve the web UI
and proxy the server APIs to a Presto server.
In this case, you can leverage an external Presto
server or use docker to spin up a Presto server and
focus on UX development.

Related to: #21062

## Motivation and Context
When working on pure UX changes, No need to build the whole project to run the presto-server.
Instead, you can use docker to run a presto-server to handle the API calls.
This could be used in the verification of UX changes as well.

## Impact
N/A

## Test Plan
Manually verify the webpack dev server with an external Presto server

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```