### PR TITLE
[native] Add parquet test group for parquet specific tests.

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -253,7 +253,8 @@ public abstract class AbstractTestNativeGeneralQueries
             dropTableIfExists(tmpTableName);
         }
     }
-    @Test
+
+    @Test(groups = {"parquet"})
     public void testAnalyzeStatsOnDecimals()
     {
         String tmpTableName = generateRandomTableName();
@@ -1226,7 +1227,7 @@ public abstract class AbstractTestNativeGeneralQueries
         }
     }
 
-    @Test
+    @Test(groups = {"parquet"})
     public void testDecimalApproximateAggregates()
     {
         // Actual session is for the native query runner.


### PR DESCRIPTION
Two `parquet` specific tests were added in https://github.com/prestodb/presto/pull/21464. Adding test groups to classify them as `parquet` tests so that build systems can optionally exclude running test.