### PR TITLE
Preserve original page objects when region remains unchanged

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -164,12 +164,19 @@ public final class Page
         return wrapBlocksWithoutCopy(1, singleValueBlocks);
     }
 
+    // getRegion() is used to get a sub-page or region of a page based on the given positionOffset and length
     public Page getRegion(int positionOffset, int length)
     {
         if (positionOffset < 0 || length < 0 || positionOffset + length > positionCount) {
             throw new IndexOutOfBoundsException(format("Invalid position %s and length %s in page with %s positions", positionOffset, length, positionCount));
         }
 
+        // Avoid creating new objects when region is same as original page
+        if (positionOffset == 0 && length == positionCount) {
+            return this;
+        }
+
+        // Create a new page view with the specified region
         int channelCount = getChannelCount();
         Block[] slicedBlocks = new Block[channelCount];
         for (int i = 0; i < channelCount; i++) {

--- a/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
@@ -33,6 +33,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 public class TestPage
@@ -40,14 +41,19 @@ public class TestPage
     @Test
     public void testGetRegion()
     {
-        assertEquals(new Page(10).getRegion(5, 5).getPositionCount(), 5);
+        Page page = new Page(10);
+        Page region = page.getRegion(0, 10);
+        assertEquals(page.getRegion(5, 5).getPositionCount(), 5);
+        assertEquals(region.getPositionCount(), 10);
+        assertSame(page, region);
     }
 
     @Test
     public void testGetEmptyRegion()
     {
+        Page page = new Page(10);
         assertEquals(new Page(0).getRegion(0, 0).getPositionCount(), 0);
-        assertEquals(new Page(10).getRegion(5, 0).getPositionCount(), 0);
+        assertEquals(page.getRegion(5, 0).getPositionCount(), 0);
     }
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class, expectedExceptionsMessageRegExp = "Invalid position 1 and length 1 in page with 0 positions")


### PR DESCRIPTION
## Description
Optimized code to preserve the original page objects when the region remains unchanged. This means that new objects will no longer be created unnecessarily when the region is the same as the original page.



## Motivation and Context
By avoiding the creation of new objects when the region is the same as the original page, we can reduce memory usage

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
NO MAJOR IMPACT, PRESTO-COMMON MODULE
Unit tests to verify that new objects are not created when the region remains unchanged in presto-common module.
[INFO] Tests run: 261, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.106 s - in TestSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 261, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 41.197 s
[INFO] Finished at: 2023-12-15T14:43:24+05:30
[INFO] ------------------------------------------------------------------------

[INFO] Tests run: 264, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.527 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 264, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  56.268 s
[INFO] Finished at: 2023-12-18T22:53:56+05:30
[INFO] ------------------------------------------------------------------------
akedia@WM-TQRH2J4TPW presto-common % git status


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

