### PR TITLE
Add KLL Sketch Functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2207,7 +2207,7 @@
             <dependency>
                 <groupId>org.apache.datasketches</groupId>
                 <artifactId>datasketches-java</artifactId>
-                <version>4.2.0</version>
+                <version>5.0.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-common/src/main/java/com/facebook/presto/common/type/KllSketchParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/KllSketchParametricType.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.List;
+
+public class KllSketchParametricType
+        implements ParametricType
+{
+    public static final KllSketchParametricType KLL_SKETCH = new KllSketchParametricType();
+
+    @Override
+    public String getName()
+    {
+        return StandardTypes.KLL_SKETCH;
+    }
+
+    @Override
+    public Type createType(List<TypeParameter> parameters)
+    {
+        return new KllSketchType(parameters.get(0).getType());
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/KllSketchType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/KllSketchType.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import static com.facebook.presto.common.type.StandardTypes.KLL_SKETCH;
+
+public class KllSketchType
+        extends StatisticalDigestType
+{
+    public KllSketchType(Type type)
+    {
+        super(KLL_SKETCH, type);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
@@ -33,6 +33,7 @@ public final class StandardTypes
     public static final String HYPER_LOG_LOG = "HyperLogLog";
     public static final String QDIGEST = "qdigest";
     public static final String TDIGEST = "tdigest";
+    public static final String KLL_SKETCH = "kllsketch";
     public static final String P4_HYPER_LOG_LOG = "P4HyperLogLog";
     public static final String INTERVAL_DAY_TO_SECOND = "interval day to second";
     public static final String INTERVAL_YEAR_TO_MONTH = "interval year to month";
@@ -70,6 +71,7 @@ public final class StandardTypes
             MAP,
             QDIGEST,
             TDIGEST,
+            KLL_SKETCH,
             BIGINT_ENUM,
             VARCHAR_ENUM,
             DISTINCT_TYPE)));

--- a/presto-docs/src/main/sphinx/functions/sketch.rst
+++ b/presto-docs/src/main/sphinx/functions/sketch.rst
@@ -10,7 +10,14 @@ functions which result in full accuracy.
 Presto provides support for computing some sketches available in the `Apache
 DataSketches`_ library. 
 
-.. function:: sketch_theta(data) -> varbinary
+Theta Sketches
+--------------
+
+Theta sketches enable distinct value counting on datasets and also provide the
+ability to perform set operations. For more information on Theta sketches,
+please see the Apache Datasketches `Theta sketch documentation`_.
+
+.. function:: sketch_theta(x) -> varbinary
 
     Computes a `theta sketch`_ from an input dataset. The output from
     this function can be used as an input to any of the other ``sketch_theta_*``
@@ -28,5 +35,44 @@ DataSketches`_ library.
     the number of retained entries in the sketch.
 
 
+KLL Sketches
+------------
+
+Kll Sketches are an implementation of a quantiles sketch. For more information
+about the KLL sketch, see the Apache Datasketches `KLL Sketch documentation`_.
+
+
+.. function:: sketch_kll[T](x: T) -> kllsketch[T]
+
+    This computes a KLL Sketch. The stored form is the little-endian serialized
+    version of the Apache DataSketches KLL Sketch.
+
+.. function:: sketch_kll_with_k[T](x: T, k: int) -> kllsketch[T]
+
+    This computes a KLL Sketch using the supplied value for ``k``. The ``k`` parameter must be in
+    the range [8..65535]. It controls the accuracy of the sketch. Smaller ``k`` is less accurate but
+    consumes less storage. A larger ``k`` will be more accurate but consume more storage. For more
+    information on the ``k`` parameter, refer to the `KLL Sketch documentation`_. The serialized
+    form of the sketch returned by this function is the same as the `sketch_kll` function.
+
+.. function:: sketch_kll_quantile[T](sketch: kllsketch[T], rank: double[, inclusivity: boolean]) -> T
+
+    Computes the value in the sketch that occurs at a particular quantile. The
+    third argument refers to the inclusivity of the query. This function returns
+    values strictly less than the quantile when inclusivity is false or values
+    less than or equal to the quantile when inclusivity true. If omitted, the
+    default inclusivity is true.
+
+.. function:: sketch_kll_rank[T](sketch: kllsketch[T], quantile: T[, inclusivity: boolean]) -> double
+
+    Computes the quantile that a particular value occurs at in the sketch. The
+    third argument refers to the inclusivity of the query. Given that the sketch
+    represents a distribution of data ``X``, this function returns quantiles
+    representing ``P(T < X)`` when inclusivity is false and ``P(T <= X)`` when
+    inclusivity is true. If omitted, the default inclusivity is true.
+
+
 .. _Apache DataSketches: https://datasketches.apache.org/
 .. _theta sketch: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html
+.. _Theta sketch documentation: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html
+.. _KLL Sketch documentation: https://datasketches.apache.org/docs/KLL/KLLSketch.html

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -378,3 +378,21 @@ T-Digest
     <http://dx.doi.org/10.1145/347090.347195>`_ to represent the approximate distribution of a set
     of numbers. T-digest has better performance than quantile digests but only supports the
     ``DOUBLE`` type. See :doc:`/functions/tdigest`.
+
+KLL Sketch
+----------
+
+.. _kll_sketch_type:
+
+``KLL Sketch``
+^^^^^^^^^^^^^^
+
+    A KLL sketch is similar to the :ref:`qdigest <qdigest_type>`, but, like the
+    T-Digest uses a `different algorithm
+    <https://datasketches.apache.org/docs/KLL/KLLSketch.html>`_ to represent the
+    approximate distribution of a set of values. The KLL sketch in Presto
+    supports int, bigint, double, varchar, and boolean types. See
+    :doc:`/functions/sketch` for more information. In serialized form, the
+    ``kllsketch`` type stored by Presto can be read directly by any other
+    application which utilizes the Apache DataSketches library to read KLL
+    sketches.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -104,6 +104,8 @@ import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyApproximat
 import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountIfGaussianAggregation;
 import com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchMergeAggregation;
 import com.facebook.presto.operator.aggregation.reservoirsample.ReservoirSampleFunction;
+import com.facebook.presto.operator.aggregation.sketch.kll.KllSketchAggregationFunction;
+import com.facebook.presto.operator.aggregation.sketch.kll.KllSketchWithKAggregationFunction;
 import com.facebook.presto.operator.aggregation.sketch.theta.ThetaSketchAggregationFunction;
 import com.facebook.presto.operator.scalar.ArrayAllMatchFunction;
 import com.facebook.presto.operator.scalar.ArrayAnyMatchFunction;
@@ -163,6 +165,7 @@ import com.facebook.presto.operator.scalar.JoniRegexpFunctions;
 import com.facebook.presto.operator.scalar.JoniRegexpReplaceLambdaFunction;
 import com.facebook.presto.operator.scalar.JsonFunctions;
 import com.facebook.presto.operator.scalar.JsonOperators;
+import com.facebook.presto.operator.scalar.KllSketchFunctions;
 import com.facebook.presto.operator.scalar.MapCardinalityFunction;
 import com.facebook.presto.operator.scalar.MapDistinctFromOperator;
 import com.facebook.presto.operator.scalar.MapEntriesFunction;
@@ -248,6 +251,7 @@ import com.facebook.presto.type.IntervalDayTimeOperators;
 import com.facebook.presto.type.IntervalYearMonthOperators;
 import com.facebook.presto.type.IpAddressOperators;
 import com.facebook.presto.type.IpPrefixOperators;
+import com.facebook.presto.type.KllSketchOperators;
 import com.facebook.presto.type.LikeFunctions;
 import com.facebook.presto.type.LongEnumOperators;
 import com.facebook.presto.type.MapParametricType;
@@ -311,6 +315,7 @@ import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.JsonType.JSON;
 import static com.facebook.presto.common.type.KdbTreeType.KDB_TREE;
+import static com.facebook.presto.common.type.KllSketchParametricType.KLL_SKETCH;
 import static com.facebook.presto.common.type.P4HyperLogLogType.P4_HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.QuantileDigestParametricType.QDIGEST;
 import static com.facebook.presto.common.type.RealType.REAL;
@@ -650,6 +655,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         addParametricType(FUNCTION);
         addParametricType(QDIGEST);
         addParametricType(TDIGEST);
+        addParametricType(KLL_SKETCH);
         addParametricType(BIGINT_ENUM);
         addParametricType(VARCHAR_ENUM);
     }
@@ -973,7 +979,11 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .functions(DISTINCT_TYPE_HASH_CODE_OPERATOR, DISTINCT_TYPE_XX_HASH_64_OPERATOR)
                 .function(DISTINCT_TYPE_INDETERMINATE_OPERATOR)
                 .codegenScalars(MapFilterFunction.class)
-                .aggregate(ReservoirSampleFunction.class);
+                .aggregate(ReservoirSampleFunction.class)
+                .aggregate(KllSketchAggregationFunction.class)
+                .aggregate(KllSketchWithKAggregationFunction.class)
+                .scalars(KllSketchFunctions.class)
+                .scalars(KllSketchOperators.class);
 
         switch (featuresConfig.getRegexLibrary()) {
             case JONI:

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchAggregationFunction.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.sketch.kll;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import io.airlift.slice.Slice;
+
+@AggregationFunction(value = "sketch_kll")
+public class KllSketchAggregationFunction
+{
+    /**
+     * In the case the underlying library changes the default value for k, we use our own default
+     * here.
+     */
+    private static final int DEFAULT_K = 200;
+    private KllSketchAggregationFunction()
+    {
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") long value)
+    {
+        KllSketchWithKAggregationFunction.input(state, value, DEFAULT_K);
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") double value)
+    {
+        KllSketchWithKAggregationFunction.input(state, value, DEFAULT_K);
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") Slice value)
+    {
+        KllSketchWithKAggregationFunction.input(state, value, DEFAULT_K);
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") boolean value)
+    {
+        KllSketchWithKAggregationFunction.input(state, value, DEFAULT_K);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState KllSketchAggregationState state, @AggregationState KllSketchAggregationState otherState)
+    {
+        KllSketchWithKAggregationFunction.combine(state, otherState);
+    }
+
+    @TypeParameter("T")
+    @OutputFunction("kllsketch(T)")
+    public static void output(@AggregationState KllSketchAggregationState state, BlockBuilder out)
+    {
+        KllSketchWithKAggregationFunction.output(state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchAggregationState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchAggregationState.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.sketch.kll;
+
+import com.facebook.presto.common.array.ObjectBigArray;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.sketch.theta.ThetaSketchStateFactory;
+import com.facebook.presto.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import org.apache.datasketches.common.ArrayOfBooleansSerDe;
+import org.apache.datasketches.common.ArrayOfDoublesSerDe;
+import org.apache.datasketches.common.ArrayOfItemsSerDe;
+import org.apache.datasketches.common.ArrayOfLongsSerDe;
+import org.apache.datasketches.common.ArrayOfStringsSerDe;
+import org.apache.datasketches.kll.KllItemsSketch;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.util.Comparator;
+import java.util.Map;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static java.util.Objects.requireNonNull;
+
+@AccumulatorStateMetadata(stateFactoryClass = KllSketchStateFactory.class, stateSerializerClass = KllSketchStateSerializer.class)
+public interface KllSketchAggregationState
+        extends AccumulatorState
+{
+    /**
+     * These parameters were created by running a linear regression against the current datasketches
+     * library version and the true in-memory size with k = 200. Upgrades to the datasketches
+     * library should attempt to re-compute these parameters.
+     */
+    Map<Class<?>, double[]> SIZE_ESTIMATOR_PARAMETERS = ImmutableMap.<Class<?>, double[]>builder()
+            .put(double.class, new double[] {929.0746716729514, 3.3328879969131457})
+            .put(long.class, new double[] {929.920850240635, 3.3325974295999283})
+            .put(Slice.class, new double[] {1008.5483794752541, 4.234749475485517})
+            .put(boolean.class, new double[] {345.60095530779705, 14.12193288555095})
+            .build();
+
+    long SKETCH_INSTANCE_SIZE = ClassLayout.parseClass(KllItemsSketch.class).instanceSize();
+
+    @Nullable
+    <T> KllItemsSketch<T> getSketch();
+
+    void addMemoryUsage(long value);
+
+    Type getType();
+
+    <T> void setSketch(KllItemsSketch<T> sketch);
+
+    class SketchParameters<T>
+    {
+        private final Comparator<T> comparator;
+        private final ArrayOfItemsSerDe<T> serde;
+
+        public SketchParameters(Comparator<T> comparator, ArrayOfItemsSerDe<T> serde)
+        {
+            this.comparator = comparator;
+            this.serde = serde;
+        }
+
+        public Comparator<T> getComparator()
+        {
+            return comparator;
+        }
+
+        public ArrayOfItemsSerDe<T> getSerde()
+        {
+            return serde;
+        }
+    }
+
+    class Single
+            implements KllSketchAggregationState
+    {
+        private static final long INSTANCE_SIZE = ClassLayout.parseClass(Single.class).instanceSize();
+        @Nullable
+        private KllItemsSketch sketch;
+        private final Type type;
+
+        public Single(Type type)
+        {
+            this.type = requireNonNull(type, "type is null");
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> KllItemsSketch<T> getSketch()
+        {
+            return sketch;
+        }
+
+        @Override
+        public <T> void setSketch(KllItemsSketch<T> sketch)
+        {
+            this.sketch = sketch;
+        }
+
+        @Override
+        public void addMemoryUsage(long value)
+        {
+            // noop
+        }
+
+        @Override
+        public Type getType()
+        {
+            return type;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            if (sketch != null) {
+                return SKETCH_INSTANCE_SIZE +
+                        INSTANCE_SIZE +
+                        getEstimatedKllInMemorySize(sketch, type.getJavaType());
+            }
+
+            return INSTANCE_SIZE;
+        }
+    }
+
+    class Grouped
+            extends AbstractGroupedAccumulatorState
+            implements KllSketchAggregationState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(ThetaSketchStateFactory.GroupedThetaSketchState.class).instanceSize();
+        private final ObjectBigArray<KllItemsSketch> sketches = new ObjectBigArray<>();
+        private long accumulatedSizeInBytes;
+
+        private final Type type;
+
+        public Grouped(Type type)
+        {
+            this.type = requireNonNull(type, "type is null");
+        }
+
+        @Override
+        public <T> KllItemsSketch<T> getSketch()
+        {
+            return sketches.get(getGroupId());
+        }
+
+        @Override
+        public void addMemoryUsage(long value)
+        {
+            accumulatedSizeInBytes += value;
+        }
+
+        @Override
+        public Type getType()
+        {
+            return type;
+        }
+
+        @Override
+        public <T> void setSketch(KllItemsSketch<T> sketch)
+        {
+            sketches.set(getGroupId(), requireNonNull(sketch, "kll sketch is null"));
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return sketches.sizeOf() + INSTANCE_SIZE + accumulatedSizeInBytes;
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            sketches.ensureCapacity(size);
+        }
+    }
+
+    static long getEstimatedKllInMemorySize(@Nullable KllItemsSketch<?> sketch, Class<?> type)
+    {
+        if (sketch == null) {
+            return 0;
+        }
+        double[] parameters = SIZE_ESTIMATOR_PARAMETERS.get(type);
+        if (parameters == null) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "unsupported parameter class: " + type.getName());
+        }
+        double linear = parameters[1];
+        double constant = parameters[0];
+        return (long) ((linear * sketch.getSerializedSizeBytes()) + constant);
+    }
+
+    static SketchParameters<?> getSketchParameters(Type type)
+    {
+        if (type.getJavaType().equals(double.class)) {
+            return new SketchParameters<>(Double::compareTo, new ArrayOfDoublesSerDe());
+        }
+        else if (type.getJavaType().equals(long.class)) {
+            return new SketchParameters<>(Long::compareTo, new ArrayOfLongsSerDe());
+        }
+        else if (type.getJavaType().equals(Slice.class)) {
+            return new SketchParameters<>(String::compareTo, new ArrayOfStringsSerDe());
+        }
+        else if (type.getJavaType().equals(boolean.class)) {
+            return new SketchParameters<>(Boolean::compareTo, new ArrayOfBooleansSerDe());
+        }
+        else {
+            throw new PrestoException(INVALID_ARGUMENTS, "failed to deserialize KLL Sketch. No suitable type found for " + type);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchStateFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.sketch.kll;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.spi.function.TypeParameter;
+
+public class KllSketchStateFactory
+        implements AccumulatorStateFactory<KllSketchAggregationState>
+{
+    private final Type type;
+
+    public KllSketchStateFactory(@TypeParameter("T") Type type)
+    {
+        this.type = type;
+    }
+
+    @Override
+    public KllSketchAggregationState createSingleState()
+    {
+        return new KllSketchAggregationState.Single(type);
+    }
+
+    @Override
+    public Class<? extends KllSketchAggregationState> getSingleStateClass()
+    {
+        return KllSketchAggregationState.Single.class;
+    }
+
+    @Override
+    public KllSketchAggregationState createGroupedState()
+    {
+        return new KllSketchAggregationState.Grouped(type);
+    }
+
+    @Override
+    public Class<? extends KllSketchAggregationState> getGroupedStateClass()
+    {
+        return KllSketchAggregationState.Grouped.class;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchStateSerializer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.sketch.kll;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.function.TypeParameter;
+import io.airlift.slice.Slices;
+import org.apache.datasketches.kll.KllItemsSketch;
+import org.apache.datasketches.memory.Memory;
+
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.operator.aggregation.sketch.kll.KllSketchAggregationState.getEstimatedKllInMemorySize;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.util.Objects.requireNonNull;
+
+public class KllSketchStateSerializer
+        implements AccumulatorStateSerializer<KllSketchAggregationState>
+{
+    private final Type type;
+
+    public KllSketchStateSerializer(@TypeParameter("T") Type type)
+    {
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(KllSketchAggregationState state, BlockBuilder out)
+    {
+        if (state.getSketch() == null) {
+            out.appendNull();
+            return;
+        }
+
+        VARBINARY.writeSlice(out, Slices.wrappedBuffer(state.getSketch().toByteArray()));
+    }
+
+    @Override
+    public void deserialize(Block block, int index, KllSketchAggregationState state)
+    {
+        if (block.isNull(index)) {
+            state.setSketch(null);
+            return;
+        }
+        Memory memory = Memory.wrap(VARBINARY.getSlice(block, index).toByteBuffer(), LITTLE_ENDIAN);
+        KllSketchAggregationState.SketchParameters parameters = KllSketchAggregationState.getSketchParameters(type);
+        // use heapify over wrap in order to get a writable sketch for updates and merges
+        KllItemsSketch sketch = KllItemsSketch.heapify(memory, parameters.getComparator(), parameters.getSerde());
+        state.addMemoryUsage(-getEstimatedKllInMemorySize(state.getSketch(), type.getJavaType()));
+        state.setSketch(sketch);
+        state.addMemoryUsage(getEstimatedKllInMemorySize(state.getSketch(), type.getJavaType()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchWithKAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchWithKAggregationFunction.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.sketch.kll;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.datasketches.common.ArrayOfBooleansSerDe;
+import org.apache.datasketches.common.ArrayOfDoublesSerDe;
+import org.apache.datasketches.common.ArrayOfItemsSerDe;
+import org.apache.datasketches.common.ArrayOfLongsSerDe;
+import org.apache.datasketches.common.ArrayOfStringsSerDe;
+import org.apache.datasketches.kll.KllItemsSketch;
+
+import java.util.Comparator;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.operator.aggregation.sketch.kll.KllSketchAggregationState.getEstimatedKllInMemorySize;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static java.lang.String.format;
+import static org.apache.datasketches.kll.KllSketch.MAX_K;
+
+@AggregationFunction(value = "sketch_kll_with_k")
+public class KllSketchWithKAggregationFunction
+{
+    private KllSketchWithKAggregationFunction()
+    {
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") long value, @SqlType(BIGINT) long k)
+    {
+        initializeSketch(state, () -> Long::compareTo, ArrayOfLongsSerDe::new, k);
+        KllItemsSketch<Long> sketch = state.getSketch();
+        state.addMemoryUsage(-getEstimatedKllInMemorySize(sketch, long.class));
+        state.getSketch().update(value);
+        state.addMemoryUsage(getEstimatedKllInMemorySize(sketch, long.class));
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") double value, @SqlType(BIGINT) long k)
+    {
+        initializeSketch(state, () -> Double::compareTo, ArrayOfDoublesSerDe::new, k);
+        KllItemsSketch<Double> sketch = state.getSketch();
+        state.addMemoryUsage(-getEstimatedKllInMemorySize(sketch, double.class));
+        state.getSketch().update(value);
+        state.addMemoryUsage(getEstimatedKllInMemorySize(sketch, double.class));
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") Slice value, @SqlType(BIGINT) long k)
+    {
+        initializeSketch(state, () -> String::compareTo, ArrayOfStringsSerDe::new, k);
+        KllItemsSketch sketch = state.getSketch();
+        state.addMemoryUsage(-getEstimatedKllInMemorySize(sketch, Slice.class));
+        state.getSketch().update(value.toStringUtf8());
+        state.addMemoryUsage(getEstimatedKllInMemorySize(sketch, Slice.class));
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") boolean value, @SqlType(BIGINT) long k)
+    {
+        initializeSketch(state, () -> Boolean::compareTo, ArrayOfBooleansSerDe::new, k);
+        KllItemsSketch<Boolean> sketch = state.getSketch();
+        state.addMemoryUsage(-getEstimatedKllInMemorySize(sketch, boolean.class));
+        state.getSketch().update(value);
+        state.addMemoryUsage(getEstimatedKllInMemorySize(sketch, boolean.class));
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState KllSketchAggregationState state, @AggregationState KllSketchAggregationState otherState)
+    {
+        if (state.getSketch() != null && otherState.getSketch() != null) {
+            state.addMemoryUsage(-getEstimatedKllInMemorySize(state.getSketch(), state.getType().getJavaType()));
+            state.getSketch().merge(otherState.getSketch());
+            state.addMemoryUsage(getEstimatedKllInMemorySize(state.getSketch(), state.getType().getJavaType()));
+        }
+        else if (state.getSketch() == null) {
+            state.setSketch(otherState.getSketch());
+            state.addMemoryUsage(getEstimatedKllInMemorySize(otherState.getSketch(), state.getType().getJavaType()));
+        }
+    }
+
+    @TypeParameter("T")
+    @OutputFunction("kllsketch(T)")
+    public static void output(@AggregationState KllSketchAggregationState state, BlockBuilder out)
+    {
+        if (state.getSketch() == null) {
+            out.appendNull();
+            return;
+        }
+        VARBINARY.writeSlice(out, Slices.wrappedBuffer(state.getSketch().toByteArray()));
+    }
+
+    private static <T> void initializeSketch(KllSketchAggregationState state, Supplier<Comparator<T>> comparator, Supplier<ArrayOfItemsSerDe<T>> serdeSupplier, long k)
+    {
+        if (k < 8 || k > MAX_K) {
+            throw new PrestoException(INVALID_ARGUMENTS, format("k value must satisfy 8 <= k <= %d: %d", MAX_K, k));
+        }
+        if (state.getSketch() == null) {
+            KllItemsSketch<T> sketch = KllItemsSketch.newHeapInstance((int) k, comparator.get(), serdeSupplier.get());
+            state.setSketch(sketch);
+            state.addMemoryUsage(getEstimatedKllInMemorySize(sketch, state.getType().getJavaType()));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/KllSketchFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/KllSketchFunctions.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.datasketches.common.ArrayOfBooleansSerDe;
+import org.apache.datasketches.common.ArrayOfDoublesSerDe;
+import org.apache.datasketches.common.ArrayOfLongsSerDe;
+import org.apache.datasketches.common.ArrayOfStringsSerDe;
+import org.apache.datasketches.kll.KllItemsSketch;
+import org.apache.datasketches.memory.Memory;
+import org.apache.datasketches.quantilescommon.QuantileSearchCriteria;
+
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+
+public class KllSketchFunctions
+{
+    private KllSketchFunctions()
+    {
+    }
+
+    @ScalarFunction("sketch_kll_quantile")
+    @Description("Calculates the quantile for a given value with the provided inclusivity. If inclusive is true, the given rank includes all quantiles ≤ the quantile directly corresponding to the given rank. If false, the given rank includes all quantiles < the quantile directly corresponding to the given rank.")
+    @SqlType(DOUBLE)
+    public static double sketchQuantileDouble(
+            @SqlType("kllsketch(double)") Slice rawSketch,
+            @SqlType(DOUBLE) double rank,
+            @SqlType(BOOLEAN) boolean inclusive)
+
+    {
+        KllItemsSketch<Double> sketch = KllItemsSketch.wrap(Memory.wrap(rawSketch.toByteBuffer(), LITTLE_ENDIAN), Double::compareTo, new ArrayOfDoublesSerDe());
+        return sketch.getQuantile(rank, inclusive ? QuantileSearchCriteria.INCLUSIVE : QuantileSearchCriteria.EXCLUSIVE);
+    }
+
+    @ScalarFunction("sketch_kll_quantile")
+    @SqlType(DOUBLE)
+    public static double sketchQuantileDouble(
+            @SqlType("kllsketch(double)") Slice rawSketch,
+            @SqlType(DOUBLE) double rank)
+
+    {
+        return sketchQuantileDouble(rawSketch, rank, true);
+    }
+
+    @ScalarFunction("sketch_kll_quantile")
+    @SqlType(BIGINT)
+    public static long sketchQuantileBigint(
+            @SqlType("kllsketch(bigint)") Slice rawSketch,
+            @SqlType(DOUBLE) double rank,
+            @SqlType(BOOLEAN) boolean inclusive)
+
+    {
+        KllItemsSketch<Long> sketch = KllItemsSketch.wrap(Memory.wrap(rawSketch.toByteBuffer(), LITTLE_ENDIAN), Long::compareTo, new ArrayOfLongsSerDe());
+        return sketch.getQuantile(rank, inclusive ? QuantileSearchCriteria.INCLUSIVE : QuantileSearchCriteria.EXCLUSIVE);
+    }
+
+    @ScalarFunction("sketch_kll_quantile")
+    @SqlType(BIGINT)
+    public static long sketchQuantileBigint(
+            @SqlType("kllsketch(bigint)") Slice rawSketch,
+            @SqlType(DOUBLE) double rank)
+
+    {
+        return sketchQuantileBigint(rawSketch, rank, true);
+    }
+
+    @ScalarFunction("sketch_kll_quantile")
+    @SqlType(VARCHAR)
+    public static Slice sketchQuantileString(
+            @SqlType("kllsketch(varchar)") Slice rawSketch,
+            @SqlType(DOUBLE) double rank,
+            @SqlType(BOOLEAN) boolean inclusive)
+
+    {
+        KllItemsSketch<String> sketch = KllItemsSketch.wrap(Memory.wrap(rawSketch.toByteBuffer(), LITTLE_ENDIAN), String::compareTo, new ArrayOfStringsSerDe());
+        return Slices.utf8Slice(sketch.getQuantile(rank, inclusive ? QuantileSearchCriteria.INCLUSIVE : QuantileSearchCriteria.EXCLUSIVE));
+    }
+
+    @ScalarFunction("sketch_kll_quantile")
+    @SqlType(VARCHAR)
+    public static Slice sketchQuantileString(
+            @SqlType("kllsketch(varchar)") Slice rawSketch,
+            @SqlType(DOUBLE) double rank)
+
+    {
+        return sketchQuantileString(rawSketch, rank, true);
+    }
+
+    @ScalarFunction("sketch_kll_quantile")
+    @SqlType(BOOLEAN)
+    public static boolean sketchQuantileBoolean(
+            @SqlType("kllsketch(boolean)") Slice rawSketch,
+            @SqlType(DOUBLE) double rank,
+            @SqlType(BOOLEAN) boolean inclusive)
+
+    {
+        KllItemsSketch<Boolean> sketch = KllItemsSketch.wrap(Memory.wrap(rawSketch.toByteBuffer(), LITTLE_ENDIAN), Boolean::compareTo, new ArrayOfBooleansSerDe());
+        return sketch.getQuantile(rank, inclusive ? QuantileSearchCriteria.INCLUSIVE : QuantileSearchCriteria.EXCLUSIVE);
+    }
+
+    @ScalarFunction("sketch_kll_quantile")
+    @SqlType(BOOLEAN)
+    public static boolean sketchQuantileBoolean(
+            @SqlType("kllsketch(boolean)") Slice rawSketch,
+            @SqlType(DOUBLE) double rank)
+
+    {
+        return sketchQuantileBoolean(rawSketch, rank, true);
+    }
+
+    @ScalarFunction("sketch_kll_rank")
+    @Description("Calculates the rank of a quantile; An estimate of the value which occurs at a particular quantile in the distribution")
+    @SqlType(DOUBLE)
+    public static double sketchRank(
+            @SqlType("kllsketch(double)") Slice rawSketch,
+            @SqlType(DOUBLE) double quantile,
+            @SqlType(BOOLEAN) boolean inclusive)
+
+    {
+        KllItemsSketch<Double> sketch = KllItemsSketch.wrap(Memory.wrap(rawSketch.toByteBuffer(), LITTLE_ENDIAN), Double::compareTo, new ArrayOfDoublesSerDe());
+        return sketch.getRank(quantile, inclusive ? QuantileSearchCriteria.INCLUSIVE : QuantileSearchCriteria.EXCLUSIVE);
+    }
+
+    @ScalarFunction("sketch_kll_rank")
+    @SqlType(DOUBLE)
+    public static double sketchRank(
+            @SqlType("kllsketch(double)") Slice rawSketch,
+            @SqlType(DOUBLE) double quantile)
+
+    {
+        return sketchRank(rawSketch, quantile, true);
+    }
+
+    @ScalarFunction("sketch_kll_rank")
+    @SqlType(DOUBLE)
+    public static double sketchRank(
+            @SqlType("kllsketch(bigint)") Slice rawSketch,
+            @SqlType(BIGINT) long quantile,
+            @SqlType(BOOLEAN) boolean inclusive)
+
+    {
+        KllItemsSketch<Long> sketch = KllItemsSketch.wrap(Memory.wrap(rawSketch.toByteBuffer(), LITTLE_ENDIAN), Long::compareTo, new ArrayOfLongsSerDe());
+        return sketch.getRank(quantile, inclusive ? QuantileSearchCriteria.INCLUSIVE : QuantileSearchCriteria.EXCLUSIVE);
+    }
+
+    @ScalarFunction("sketch_kll_rank")
+    @SqlType(DOUBLE)
+    public static double sketchRank(
+            @SqlType("kllsketch(bigint)") Slice rawSketch,
+            @SqlType(BIGINT) long quantile)
+
+    {
+        return sketchRank(rawSketch, quantile, true);
+    }
+
+    @ScalarFunction("sketch_kll_rank")
+    @SqlType(DOUBLE)
+    public static double sketchRank(
+            @SqlType("kllsketch(varchar)") Slice rawSketch,
+            @SqlType(VARCHAR) Slice rank,
+            @SqlType(BOOLEAN) boolean inclusive)
+
+    {
+        KllItemsSketch<String> sketch = KllItemsSketch.wrap(Memory.wrap(rawSketch.toByteBuffer(), LITTLE_ENDIAN), String::compareTo, new ArrayOfStringsSerDe());
+        return sketch.getRank(rank.toStringUtf8(), inclusive ? QuantileSearchCriteria.INCLUSIVE : QuantileSearchCriteria.EXCLUSIVE);
+    }
+
+    @ScalarFunction("sketch_kll_rank")
+    @SqlType(DOUBLE)
+    public static double sketchRank(
+            @SqlType("kllsketch(varchar)") Slice rawSketch,
+            @SqlType(VARCHAR) Slice quantile)
+
+    {
+        return sketchRank(rawSketch, quantile, true);
+    }
+
+    @ScalarFunction("sketch_kll_rank")
+    @SqlType(DOUBLE)
+    public static double sketchRank(
+            @SqlType("kllsketch(boolean)") Slice rawSketch,
+            @SqlType(BOOLEAN) boolean rank,
+            @SqlType(BOOLEAN) boolean inclusive)
+
+    {
+        KllItemsSketch<Boolean> sketch = KllItemsSketch.wrap(Memory.wrap(rawSketch.toByteBuffer(), LITTLE_ENDIAN), Boolean::compareTo, new ArrayOfBooleansSerDe());
+        return sketch.getRank(rank, inclusive ? QuantileSearchCriteria.INCLUSIVE : QuantileSearchCriteria.EXCLUSIVE);
+    }
+
+    @ScalarFunction("sketch_kll_rank")
+    @SqlType(DOUBLE)
+    public static double sketchRank(
+            @SqlType("kllsketch(boolean)") Slice rawSketch,
+            @SqlType(BOOLEAN) boolean quantile)
+
+    {
+        return sketchRank(rawSketch, quantile, true);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/KllSketchOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/KllSketchOperators.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.common.function.OperatorType.CAST;
+
+public class KllSketchOperators
+{
+    private KllSketchOperators()
+    {
+    }
+
+    @ScalarOperator(CAST)
+    @TypeParameter("T")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice castToBinary(@SqlType("kllsketch(T)") Slice slice)
+    {
+        return slice;
+    }
+
+    @ScalarOperator(CAST)
+    @TypeParameter("T")
+    @SqlType("kllsketch(T)")
+    public static Slice castFromVarbinary(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return slice;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestKllSketchAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestKllSketchAggregationFunction.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import org.apache.datasketches.common.ArrayOfBooleansSerDe;
+import org.apache.datasketches.common.ArrayOfDoublesSerDe;
+import org.apache.datasketches.common.ArrayOfLongsSerDe;
+import org.apache.datasketches.common.ArrayOfStringsSerDe;
+import org.apache.datasketches.kll.KllItemsSketch;
+import org.apache.datasketches.memory.Memory;
+import org.apache.datasketches.memory.WritableMemory;
+import org.intellij.lang.annotations.Language;
+import org.testng.Assert.ThrowingRunnable;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestKllSketchAggregationFunction
+        extends AbstractTestFunctions
+{
+    private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+    private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = metadata.getFunctionAndTypeManager();
+    private static final JavaAggregationFunctionImplementation DOUBLE_FUNCTION = getFunction(DOUBLE);
+    private static final JavaAggregationFunctionImplementation DOUBLE_WITH_K_FUNCTION = getFunction("sketch_kll_with_k", DOUBLE, BIGINT);
+    private static final JavaAggregationFunctionImplementation BIGINT_FUNCTION = getFunction(BIGINT);
+    private static final JavaAggregationFunctionImplementation VARCHAR_FUNCTION = getFunction(VARCHAR);
+    private static final JavaAggregationFunctionImplementation BOOLEAN_FUNCTION = getFunction(BOOLEAN);
+
+    @Test
+    public void testDouble()
+    {
+        double[] items = DoubleStream.iterate(0, i -> i + ThreadLocalRandom.current().nextDouble()).limit(100).toArray();
+        BlockBuilder out = DOUBLE.createBlockBuilder(null, items.length);
+        KllItemsSketch<Double> sketch = KllItemsSketch.newHeapInstance(Double::compareTo, new ArrayOfDoublesSerDe());
+        Arrays.stream(items).forEach(item -> {
+            DOUBLE.writeDouble(out, item);
+            sketch.update(item);
+        });
+        Block input = out.build();
+        SqlVarbinary result = (SqlVarbinary) AggregationTestUtils.executeAggregation(
+                DOUBLE_FUNCTION,
+                input);
+        KllItemsSketch<Double> recreated = KllItemsSketch.wrap(WritableMemory.writableWrap((result.getBytes())), Double::compareTo, new ArrayOfDoublesSerDe());
+        checkSketchesEqual(DoubleStream.of(items).boxed().toArray(Double[]::new), sketch, recreated);
+    }
+
+    @Test
+    public void testDoubleWithK()
+    {
+        double[] items = DoubleStream.iterate(0, i -> i + ThreadLocalRandom.current().nextDouble()).limit(100).toArray();
+        BlockBuilder out = DOUBLE.createBlockBuilder(null, items.length);
+        BlockBuilder kBlock = BIGINT.createBlockBuilder(null, items.length);
+        int k = 150;
+        KllItemsSketch<Double> sketch = KllItemsSketch.newHeapInstance(k, Double::compareTo, new ArrayOfDoublesSerDe());
+        Arrays.stream(items).forEach(item -> {
+            DOUBLE.writeDouble(out, item);
+            sketch.update(item);
+            BIGINT.writeLong(kBlock, k);
+        });
+        Block input = out.build();
+        SqlVarbinary result = (SqlVarbinary) AggregationTestUtils.executeAggregation(
+                DOUBLE_WITH_K_FUNCTION,
+                input,
+                kBlock.build());
+        KllItemsSketch<Double> recreated = KllItemsSketch.wrap(WritableMemory.writableWrap((result.getBytes())), Double::compareTo, new ArrayOfDoublesSerDe());
+        checkSketchesEqual(DoubleStream.of(items).boxed().toArray(Double[]::new), sketch, recreated);
+    }
+
+    @Test
+    public void testInvalidK()
+    {
+        double[] items = DoubleStream.iterate(0, i -> i + ThreadLocalRandom.current().nextDouble()).limit(10).toArray();
+        BlockBuilder inputBlock = DOUBLE.createBlockBuilder(null, items.length);
+        BlockBuilder kBlockLow = BIGINT.createBlockBuilder(null, items.length);
+        Arrays.stream(items).forEach(item -> {
+            DOUBLE.writeDouble(inputBlock, item);
+            BIGINT.writeLong(kBlockLow, 7);
+        });
+        Block input = inputBlock.build();
+        assertThrows(() -> AggregationTestUtils.executeAggregation(
+                DOUBLE_WITH_K_FUNCTION,
+                inputBlock.build(),
+                kBlockLow.build()), PrestoException.class, "k value must satisfy 8 <= k <= 65535: 7");
+
+        BlockBuilder kBlockHigh = BIGINT.createBlockBuilder(null, items.length);
+        Arrays.stream(items).forEach(item -> {
+            BIGINT.writeLong(kBlockHigh, 65536);
+        });
+        assertThrows(() -> AggregationTestUtils.executeAggregation(
+                DOUBLE_WITH_K_FUNCTION,
+                input,
+                kBlockHigh.build()), PrestoException.class, "k value must satisfy 8 <= k <= 65535: 65536");
+    }
+
+    @Test
+    public void testBigint()
+    {
+        Long[] items = LongStream.iterate(0, i -> i + ThreadLocalRandom.current().nextLong(0, 100)).limit(100).boxed().toArray(Long[]::new);
+        BlockBuilder out = BIGINT.createBlockBuilder(null, items.length);
+        KllItemsSketch<Long> sketch = KllItemsSketch.newHeapInstance(Long::compareTo, new ArrayOfLongsSerDe());
+        Arrays.stream(items).forEach(item -> {
+            BIGINT.writeLong(out, item);
+            sketch.update(item);
+        });
+        Block input = out.build();
+        SqlVarbinary result = (SqlVarbinary) AggregationTestUtils.executeAggregation(
+                BIGINT_FUNCTION,
+                input);
+        KllItemsSketch<Long> recreated = KllItemsSketch.wrap(WritableMemory.writableWrap((result.getBytes())), Long::compareTo, new ArrayOfLongsSerDe());
+        checkSketchesEqual(items, sketch, recreated);
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        String[] items = "abcdefghijklmnopqrstuvwxyz".split("");
+        BlockBuilder out = VARCHAR.createBlockBuilder(null, items.length);
+        KllItemsSketch<String> sketch = KllItemsSketch.newHeapInstance(String::compareTo, new ArrayOfStringsSerDe());
+        Arrays.stream(items).forEach(item -> {
+            VARCHAR.writeString(out, item);
+            sketch.update(item);
+        });
+        Block input = out.build();
+        SqlVarbinary result = (SqlVarbinary) AggregationTestUtils.executeAggregation(
+                VARCHAR_FUNCTION,
+                input);
+        KllItemsSketch<String> recreated = KllItemsSketch.wrap(Memory.wrap(result.getBytes()), String::compareTo, new ArrayOfStringsSerDe());
+        checkSketchesEqual(items, sketch, recreated);
+    }
+
+    @Test
+    public void testBoolean()
+    {
+        Boolean[] items = IntStream.iterate(0, i -> i + 1).limit(10).mapToObj(i -> i % 2 == 0).toArray(Boolean[]::new);
+        BlockBuilder out = BOOLEAN.createBlockBuilder(null, items.length);
+        KllItemsSketch<Boolean> sketch = KllItemsSketch.newHeapInstance(Boolean::compareTo, new ArrayOfBooleansSerDe());
+        Arrays.stream(items).forEach(item -> {
+            sketch.update(item);
+            BOOLEAN.writeBoolean(out, item);
+        });
+        Block input = out.build();
+        SqlVarbinary result = (SqlVarbinary) AggregationTestUtils.executeAggregation(
+                BOOLEAN_FUNCTION,
+                input);
+        KllItemsSketch<Boolean> recreated = KllItemsSketch.wrap(Memory.wrap(result.getBytes()), Boolean::compareTo, new ArrayOfBooleansSerDe());
+        checkSketchesEqual(items, sketch, recreated);
+    }
+
+    @Test
+    public void testEmptyInput()
+    {
+        AggregationTestUtils.assertAggregation(DOUBLE_FUNCTION,
+                null,
+                DOUBLE.createBlockBuilder(null, 0).build());
+    }
+
+    private static void assertThrows(ThrowingRunnable runnable, Class<?> exceptionType, @Language("regexp") String regex)
+    {
+        try {
+            runnable.run();
+            throw new AssertionError("no exception was thrown");
+        }
+        catch (Throwable e) {
+            assertEquals(e.getClass(), exceptionType);
+            assertTrue(Optional.ofNullable(e.getMessage()).orElse("").matches(regex), format("Error message: '%s' didn't match regex: '%s'", e.getMessage(), regex));
+        }
+    }
+
+    private static <T> void checkSketchesEqual(T[] items, KllItemsSketch<T> expected, KllItemsSketch<T> actual)
+    {
+        Arrays.stream(items).forEach(item -> assertEquals(actual.getRank(item), expected.getRank(item), 1E-8));
+
+        assertEquals(actual.getSortedView().getCumulativeWeights(), expected.getSortedView().getCumulativeWeights(), "weights are not equal");
+        assertEquals(actual.getSortedView().getQuantiles(), expected.getSortedView().getQuantiles(), "quantiles are not equal");
+    }
+
+    private static JavaAggregationFunctionImplementation getFunction(Type... types)
+    {
+        return getFunction("sketch_kll", types);
+    }
+
+    private static JavaAggregationFunctionImplementation getFunction(String name, Type... types)
+    {
+        return FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
+                metadata.getFunctionAndTypeManager()
+                        .lookupFunction(name, fromTypes(types)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestKllSketchStateSerializer.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestKllSketchStateSerializer.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.sketch.kll.KllSketchAggregationState;
+import com.facebook.presto.operator.aggregation.sketch.kll.KllSketchStateSerializer;
+import com.google.common.collect.ImmutableList;
+import org.apache.datasketches.common.ArrayOfBooleansSerDe;
+import org.apache.datasketches.common.ArrayOfDoublesSerDe;
+import org.apache.datasketches.common.ArrayOfLongsSerDe;
+import org.apache.datasketches.common.ArrayOfStringsSerDe;
+import org.apache.datasketches.kll.KllItemsSketch;
+import org.openjdk.jol.info.GraphLayout;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestKllSketchStateSerializer
+{
+    @Test
+    public void testDouble()
+    {
+        testSerializer(DOUBLE,
+                () -> KllItemsSketch.newHeapInstance(Double::compareTo, new ArrayOfDoublesSerDe()),
+                DoubleStream.iterate(0, i -> i + 1).limit(10).boxed().collect(toImmutableList()));
+    }
+
+    @Test
+    public void testString()
+    {
+        testSerializer(VARCHAR,
+                () -> KllItemsSketch.newHeapInstance(String::compareTo, new ArrayOfStringsSerDe()),
+                Arrays.asList("abcdefghijklmnopqrstuvwxyz".split("")));
+    }
+
+    @Test
+    public void testBigint()
+    {
+        testSerializer(BIGINT,
+                () -> KllItemsSketch.newHeapInstance(Long::compareTo, new ArrayOfLongsSerDe()),
+                LongStream.iterate(0, i -> i + 1).limit(10).boxed().collect(toImmutableList()));
+    }
+
+    @Test
+    public void testBoolean()
+    {
+        testSerializer(BOOLEAN,
+                () -> KllItemsSketch.newHeapInstance(Boolean::compareTo, new ArrayOfBooleansSerDe()),
+                LongStream.iterate(0, i -> i + 1).limit(10).mapToObj(i -> i % 2 == 0).collect(toImmutableList()));
+    }
+
+    @Test
+    public void testEstimatedMemorySizeDouble()
+    {
+        testEstimatedMemorySize(DOUBLE, i -> (double) i, .05);
+    }
+
+    @Test
+    public void testEstimatedMemorySizeLong()
+    {
+        testEstimatedMemorySize(BIGINT, i -> (long) i, .05);
+    }
+
+    @Test
+    public void testEstimatedMemorySizeString()
+    {
+        testEstimatedMemorySize(VARCHAR, i -> "abcdefghijklmnopqrstuvwxyz".substring(0, i.hashCode() % 26), .05);
+    }
+
+    @Test
+    public void testEstimatedMemorySizeBoolean()
+    {
+        testEstimatedMemorySize(BOOLEAN, i -> i % 2 == 0, 0.5);
+    }
+
+    private <T> void testEstimatedMemorySize(Type type, Function<Integer, T> generator, double tolerance)
+    {
+        KllSketchAggregationState state = new KllSketchAggregationState.Single(type);
+        KllSketchAggregationState.SketchParameters parameters = KllSketchAggregationState.getSketchParameters(type);
+        KllItemsSketch<T> sketch = KllItemsSketch.newHeapInstance(parameters.getComparator(), parameters.getSerde());
+        List<Integer> sizes = ImmutableList.of(512, 2048, 4096, 16384);
+        for (int size : sizes) {
+            IntStream.range(0, size).boxed().map(generator).forEach(sketch::update);
+            long trueSize = GraphLayout.parseInstance(sketch).totalSize();
+            state.setSketch(sketch);
+            long estimatedSize = state.getEstimatedSize();
+            // size should be within margin of the actual size
+            double errorPercent = (double) Math.abs(estimatedSize - trueSize) / trueSize;
+            assertTrue(errorPercent < tolerance, String.format("estimated memory size error for sketch stream size %d was > 5%%: %.2f", size, errorPercent));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> void testSerializer(Type type, Supplier<KllItemsSketch<?>> sketchSupplier, Collection<T> sketchInputs)
+    {
+        KllSketchStateSerializer serializer = new KllSketchStateSerializer(type);
+        KllSketchAggregationState state = new KllSketchAggregationState.Single(type);
+
+        // serialize empty
+        state.setSketch(sketchSupplier.get());
+        BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(null, 1);
+        serializer.serialize(state, blockBuilder);
+        KllSketchAggregationState deserialized = new KllSketchAggregationState.Single(type);
+        serializer.deserialize(blockBuilder.build(), 0, deserialized);
+
+        // serialize with data
+        KllItemsSketch sketch = state.getSketch();
+        KllItemsSketch actual = sketchSupplier.get();
+        sketchInputs.stream().forEach(i -> {
+            sketch.update(i);
+            actual.update(i);
+        });
+        blockBuilder = VARBINARY.createBlockBuilder(null, 1);
+        state.setSketch(sketch);
+        serializer.serialize(state, blockBuilder);
+        Block serializedBlock = blockBuilder.build();
+        KllSketchAggregationState newState = new KllSketchAggregationState.Single(type);
+        serializer.deserialize(serializedBlock, 0, newState);
+        verifySketches(actual, newState.getSketch());
+    }
+
+    private static void verifySketches(KllItemsSketch<?> expected, KllItemsSketch<?> actual)
+    {
+        assertEquals(actual.getSortedView().getCumulativeWeights(), expected.getSortedView().getCumulativeWeights(), "weights are not equal");
+        assertEquals(actual.getSortedView().getQuantiles(), expected.getSortedView().getQuantiles(), "quantiles are not equal");
+        assertEquals(actual.toByteArray(), expected.toByteArray());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestKllSketchFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestKllSketchFunctions.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.google.common.base.Joiner;
+import org.apache.datasketches.common.ArrayOfBooleansSerDe;
+import org.apache.datasketches.common.ArrayOfDoublesSerDe;
+import org.apache.datasketches.common.ArrayOfLongsSerDe;
+import org.apache.datasketches.common.ArrayOfStringsSerDe;
+import org.apache.datasketches.kll.KllItemsSketch;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.stream.DoubleStream;
+import java.util.stream.LongStream;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+public class TestKllSketchFunctions
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testDoubles()
+    {
+        KllItemsSketch<Double> sketch = KllItemsSketch.newHeapInstance(Double::compareTo, new ArrayOfDoublesSerDe());
+        DoubleStream.iterate(0, i -> i + 1).limit(100).forEach(sketch::update);
+        String sketchProjection = getSketchProjection(sketch, "double");
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.0 as DOUBLE)"), DOUBLE, 0.0);
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.5 as DOUBLE)"), DOUBLE, 49.0);
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.5 as DOUBLE)", false), DOUBLE, 50.0);
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(1.0 as DOUBLE)"), DOUBLE, 99.0);
+
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "CAST(-1 as DOUBLE)"), DOUBLE, 0.0);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "CAST(49 as DOUBLE)"), DOUBLE, 0.5);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "CAST(50 as DOUBLE)", false), DOUBLE, 0.5);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "CAST(99 as DOUBLE)"), DOUBLE, 1.0);
+    }
+
+    @Test
+    public void testInts()
+    {
+        KllItemsSketch<Long> sketch = KllItemsSketch.newHeapInstance(Long::compareTo, new ArrayOfLongsSerDe());
+        LongStream.iterate(0, i -> i + 1).limit(100).forEach(sketch::update);
+        String sketchProjection = getSketchProjection(sketch, "bigint");
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.0 as DOUBLE)"), BIGINT, 0L);
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.5 as DOUBLE)"), BIGINT, 49L);
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.5 as DOUBLE)", false), BIGINT, 50L);
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(1.0 as DOUBLE)"), BIGINT, 99L);
+
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "CAST(-1 as BIGINT)"), DOUBLE, 0.0);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "CAST(49 as BIGINT)"), DOUBLE, 0.5);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "CAST(50 as BIGINT)", false), DOUBLE, 0.5);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "CAST(99 as BIGINT)"), DOUBLE, 1.0);
+    }
+
+    @Test
+    public void testStrings()
+    {
+        KllItemsSketch<String> sketch = KllItemsSketch.newHeapInstance(String::compareTo, new ArrayOfStringsSerDe());
+        Arrays.stream("abcdefghijklmnopqrstuvwxyz".split("")).forEach(sketch::update);
+        String sketchProjection = getSketchProjection(sketch, "varchar");
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.0 as DOUBLE)"), VARCHAR, "a");
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.5 as DOUBLE)"), VARCHAR, "m");
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.5 as DOUBLE)", false), VARCHAR, "n");
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(1.0 as DOUBLE)"), VARCHAR, "z");
+
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "'1'"), DOUBLE, 0.0);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "'m'"), DOUBLE, 0.5);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "'n'", false), DOUBLE, 0.5);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "'z'"), DOUBLE, 1.0);
+    }
+
+    @Test
+    public void testBooleans()
+    {
+        KllItemsSketch<Boolean> sketch = KllItemsSketch.newHeapInstance(Boolean::compareTo, new ArrayOfBooleansSerDe());
+        LongStream.iterate(0, i -> i + 1).limit(100).mapToObj(i -> i % 3 == 0).forEach(sketch::update);
+        String sketchProjection = getSketchProjection(sketch, "boolean");
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.5 as DOUBLE)"), BOOLEAN, false);
+        assertFunction(getProjection("sketch_kll_quantile", sketchProjection, "CAST(0.5 as DOUBLE)", false), BOOLEAN, false);
+
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "false", false), DOUBLE, 0.0);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "true", false), DOUBLE, 0.66);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "false"), DOUBLE, 0.66);
+        assertFunction(getProjection("sketch_kll_rank", sketchProjection, "true"), DOUBLE, 1.0);
+    }
+
+    private String getProjection(String functionName, String sketch, Object... args)
+    {
+        String otherArgs = Joiner.on(",").join(args);
+        return String.format("%s(%s)", functionName, Joiner.on(",").join(sketch, otherArgs));
+    }
+
+    private String getSketchProjection(KllItemsSketch sketch, String type)
+    {
+        return getByteArrayProjection(sketch.toByteArray(), type);
+    }
+
+    private String getByteArrayProjection(byte[] arr, String type)
+    {
+        String sqlSerializedSketch = new SqlVarbinary(arr).toString().replaceAll("\\s+", " ");
+        return String.format("CAST(X'%s' AS kllsketch(%s))", sqlSerializedSketch, type);
+    }
+}


### PR DESCRIPTION
## Description

This change adds KLL Sketch support from the Apache DataSketches library. One of the benefits of KLL sketches is that the implementation supports more datatypes than the existing quantile digest and T-Digest implementations. It also has provably-bounded error compared to the T-Digest

The following datatype is added

- `kllsketch(T)`: Basically a wrapper around `varbinary`, similar to `tdigest` and `qdigest` types

The following functions are added

- `sketch_kll`: computes a KLL sketch
- `sketch_kll_with_k`: computes a kll sketch with the given value for k
- `sketch_kll_quantile`: queries the sketch for a particular quantile
- `sketch_kll_rank`: queries the sketch for a particular rank (inverse of the quantile function)

## Motivation and Context

Eventual use by the optimizer after #21236. But also good to have since HMS is [releasing support for them soon](https://issues.apache.org/jira/browse/HIVE-26221).

## Impact

Two new aggregation functions, two new scalar functions

## Test Plan

Standard aggregation unit tests and scalar function unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* New support for Apache DataSketches KLL sketch with the sketch_kll and related family of functions
```
