### PR TITLE
Support year/month/day/hour transform when add partition column in Iceberg

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -599,9 +599,13 @@ The table is partitioned by the transformed value of the column::
 
      ALTER TABLE iceberg.web.page_views ADD COLUMN location VARCHAR WITH (partitioning = 'bucket(8)');
 
-.. note::
+     ALTER TABLE iceberg.web.page_views ADD COLUMN dt date WITH (partitioning = 'year');
 
-    ``Day``, ``Month``, ``Year``, ``Hour`` partition column transform functions are not supported in the Presto Iceberg connector.
+     ALTER TABLE iceberg.web.page_views ADD COLUMN ts timestamp WITH (partitioning = 'month');
+
+     ALTER TABLE iceberg.web.page_views ADD COLUMN dt date WITH (partitioning = 'day');
+
+     ALTER TABLE iceberg.web.page_views ADD COLUMN ts timestamp WITH (partitioning = 'hour');
 
 TRUNCATE
 ^^^^^^^^

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
@@ -28,8 +28,12 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static org.apache.iceberg.expressions.Expressions.bucket;
+import static org.apache.iceberg.expressions.Expressions.day;
+import static org.apache.iceberg.expressions.Expressions.hour;
+import static org.apache.iceberg.expressions.Expressions.month;
 import static org.apache.iceberg.expressions.Expressions.ref;
 import static org.apache.iceberg.expressions.Expressions.truncate;
+import static org.apache.iceberg.expressions.Expressions.year;
 
 public final class PartitionFields
 {
@@ -126,10 +130,13 @@ public final class PartitionFields
             case "identity":
                 return ref(columnName);
             case "year":
+                return year(columnName);
             case "month":
+                return month(columnName);
             case "day":
+                return day(columnName);
             case "hour":
-                throw new UnsupportedOperationException("Currently unsupported partition transform: " + transform);
+                return hour(columnName);
         }
 
         Matcher matcher = COLUMN_BUCKET_PATTERN.matcher(transform);


### PR DESCRIPTION
## Description

As we have supported year, month, day & hour transform for Iceberg table when creating in PR #21303 , we could also support year, month, day & hour transform when altering table to add a partition column. 

## Impact
- Presto Iceberg connector will support these partition transform functions when altering table to add partition columns.

## Test Plan

 - Enhanced test case in IcebergDistributedTestBase.testAddPartitionColumn()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==


Iceberg Changes
* Day, Month, Year & Hour partition column transform functions are supported when altering table to add columns in Presto Iceberg connector.
```
