### PR TITLE
Fix bug for LIKE pattern with multiple-byte characters

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestConditions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestConditions.java
@@ -70,6 +70,13 @@ public class TestConditions
         assertFunction("'monkey' not like 'monkey' escape null", BOOLEAN, null);
 
         assertInvalidFunction("'monkey' like 'monkey' escape 'foo'", "Escape string must be a single character");
+
+        assertFunction("'你好a世界' like '你好%'", BOOLEAN, true);
+        assertFunction("'你好a世界' like '你好a%'", BOOLEAN, true);
+        assertFunction("'你好a世界' like '%世界'", BOOLEAN, true);
+        assertFunction("'你好a世界' like '%好a世%'", BOOLEAN, true);
+        assertFunction("'你好a世界' not like '你好b%'", BOOLEAN, true);
+        assertFunction("'你好a世界' not like null", BOOLEAN, null);
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #21577 .

In UTF8, many characters like Chinese characters are represented by more than one bytes, so we shouldn't simply use  the characters length of a string to handle it's corresponding slice. This PR fix the problem.

## Test Plan

 - Enhanced test case TestConditions.testLike()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

