### PR TITLE
[native] Report TableWrite stats using Java operator name

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -89,6 +89,9 @@ std::string toPrestoOperatorType(const std::string& operatorType) {
   if (operatorType == "TableScan") {
     return "TableScanOperator";
   }
+  if (operatorType == "TableWrite") {
+    return "TableWriterOperator";
+  }
   return operatorType;
 }
 


### PR DESCRIPTION
Report TableWrite stats using TableWriterOperator name to allow these stats to be processed correctly by com.facebook.presto.execution.QueryStats#create. This would help show these stats in the coordinator UI and have them populated in QueryCompletedEvent.

```
if (plan.isOutputTableWriterFragment()) {
    writtenOutputPositions += stageExecutionStats.getOperatorSummaries().stream()
            .filter(stats -> stats.getOperatorType().equals(TableWriterOperator.class.getSimpleName()))
            .mapToLong(OperatorStats::getInputPositions)
            .sum();
    writtenOutputLogicalDataSize += stageExecutionStats.getOperatorSummaries().stream()
            .filter(stats -> stats.getOperatorType().equals(TableWriterOperator.class.getSimpleName()))
            .mapToLong(stats -> stats.getInputDataSize().toBytes())
            .sum();
    writtenOutputPhysicalDataSize += stageExecutionStats.getPhysicalWrittenDataSize().toBytes();
}
else {
    writtenIntermediatePhysicalDataSize += stageExecutionStats.getPhysicalWrittenDataSize().toBytes();
}

```


```
== NO RELEASE NOTE ==
```

