### PR TITLE
Fix QueryError.retriable serialization

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/QueryError.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryError.java
@@ -40,7 +40,7 @@ public class QueryError
             @JsonProperty("errorCode") int errorCode,
             @JsonProperty("errorName") String errorName,
             @JsonProperty("errorType") String errorType,
-            @JsonProperty("boolean") boolean retriable,
+            @JsonProperty("retriable") boolean retriable,
             @JsonProperty("errorLocation") ErrorLocation errorLocation,
             @JsonProperty("failureInfo") FailureInfo failureInfo)
     {


### PR DESCRIPTION
## Description
Fixed a mistake in QueryError.retriable serialization when sending client response. The field name was previously "boolean" instead of "retriable".

## Motivation and Context

## Impact
Applications that make use of this field may need to be updated.

## Test Plan

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

