### PR TITLE
[native] Fix master on TaskManagerTest

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -144,6 +144,11 @@ void setAggregationSpillConfig(
 static const uint64_t kGB = 1024 * 1024 * 1024ULL;
 
 class TaskManagerTest : public testing::Test {
+ public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
  protected:
   void SetUp() override {
     FLAGS_velox_memory_leak_check_enabled = true;


### PR DESCRIPTION
Recent refactor of memory manager splitted init and get. The test needs to update to have explicit init for it to run.
```
== NO RELEASE NOTE ==
```

