### PR TITLE
Update Iceberg Document for SELECT Sql Support

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -608,10 +608,13 @@ SELECT table operations are supported for Iceberg format version 1 and version 2
 
     SELECT * FROM iceberg.web.page_views_v2;
 
-.. note::
+Table with delete files
+~~~~~~~~~~~~~~~~~~~~~~~
 
-    The ``SELECT`` operations on Iceberg Tables with format version 2 do not read the delete files and
-    remove the deleted rows as of now (:issue:`20492`).
+Iceberg V2 tables support row-level deletion. For more information see
+`Row-level deletes <https://iceberg.apache.org/spec/#row-level-deletes>`_ in the Iceberg Table Spec.
+Presto supports reading delete files, including Position Delete Files and Equality Delete Files.
+When reading, Presto merges these delete files to read the latest results.
 
 ALTER TABLE
 ^^^^^^^^^^^^
@@ -956,11 +959,3 @@ In the following query, the expression CURRENT_TIMESTAMP returns the current tim
             20 | canada        |         2 | comment
             30 | mexico        |         3 | comment
     (3 rows)
-
-Table with delete files
------------------------
-
-Iceberg V2 tables support row-level deletion. For more information see
-`Row-level deletes <https://iceberg.apache.org/spec/#row-level-deletes>`_ in the Iceberg Table Spec.
-Presto supports reading delete files, including Position Delete Files and Equality Delete Files.
-When reading, Presto merges these delete files to read the latest results.


### PR DESCRIPTION
## Description
Update Iceberg Document for SELECT Sql Support

## Motivation and Context
Since reading v2 row level deletes in Iceberg connector support is added in the connector as part of https://github.com/prestodb/presto/pull/21189 So updated Iceberg document accordingly

## Impact
None

## Test Plan
Na

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

