### PR TITLE
Preserve case for RowType's field name and JSON content when ``CAST``

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
@@ -83,6 +83,11 @@ public class RowType
         return new Field(Optional.empty(), type);
     }
 
+    public static Field field(String name, Type type, boolean delimited)
+    {
+        return new Field(Optional.of(name), type, delimited);
+    }
+
     private static TypeSignature makeSignature(List<Field> fields)
     {
         int size = fields.size();

--- a/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
@@ -54,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -1324,7 +1323,7 @@ public final class JsonUtil
                 if (parser.currentToken() != FIELD_NAME) {
                     throw new JsonCastException(format("Expected a json field name, but got %s", parser.getText()));
                 }
-                String fieldName = parser.getText().toLowerCase(Locale.ENGLISH);
+                String fieldName = parser.getText();
                 Integer fieldIndex = fieldNameToIndex.get().get(fieldName);
                 parser.nextToken();
                 if (fieldIndex != null) {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.operator.scalar.FunctionAssertions;
 import com.facebook.presto.spi.StandardErrorCode;
@@ -408,17 +409,17 @@ public class TestRowOperators
                         "\"array2\": [1, 2, null, 3], " +
                         "\"array1\": [], " +
                         "\"array3\": null, " +
-                        "\"map3\": {\"a\": 1, \"b\": 2, \"none\": null, \"three\": 3}, " +
+                        "\"map3\": {\"a\": 1, \"b\": 2, \"none\": null, \"Three\": 3}, " +
                         "\"map1\": {}, " +
                         "\"map2\": null, " +
                         "\"rowAsJsonArray1\": [1, 2, null, 3], " +
                         "\"rowAsJsonArray2\": null, " +
-                        "\"rowAsJsonObject2\": {\"a\": 1, \"b\": 2, \"none\": null, \"three\": 3}, " +
+                        "\"rowAsJsonObject2\": {\"a\": 1, \"b\": 2, \"none\": null, \"Three\": 3}, " +
                         "\"rowAsJsonObject1\": null}' " +
-                        "AS ROW(array1 ARRAY<BIGINT>, array2 ARRAY<BIGINT>, array3 ARRAY<BIGINT>, " +
-                        "map1 MAP<VARCHAR, BIGINT>, map2 MAP<VARCHAR, BIGINT>, map3 MAP<VARCHAR, BIGINT>, " +
-                        "rowAsJsonArray1 ROW(BIGINT, BIGINT, BIGINT, BIGINT), rowAsJsonArray2 ROW(BIGINT)," +
-                        "rowAsJsonObject1 ROW(nothing BIGINT), rowAsJsonObject2 ROW(a BIGINT, b BIGINT, three BIGINT, none BIGINT)))",
+                        "AS ROW(array1 array<BIGINT>, array2 ARRAY<bigint>, array3 ARRAY<BIGINT>, " +
+                        "map1 MAP<VARCHAR, BIGINT>, map2 map<varchar, BIGINT>, map3 MAP<VARCHAR, BIGINT>, " +
+                        "\"rowAsJsonArray1\" row(BIGINT, bigint, BIGINT, BIGINT), \"rowAsJsonArray2\" ROW(BIGINT)," +
+                        "\"rowAsJsonObject1\" ROW(nothing BIGINT), \"rowAsJsonObject2\" ROW(a BIGINT, b BIGINT, \"Three\" BIGINT, none BIGINT)))",
                 RowType.from(ImmutableList.of(
                         RowType.field("array1", new ArrayType(BIGINT)),
                         RowType.field("array2", new ArrayType(BIGINT)),
@@ -426,17 +427,17 @@ public class TestRowOperators
                         RowType.field("map1", mapType(VARCHAR, BIGINT)),
                         RowType.field("map2", mapType(VARCHAR, BIGINT)),
                         RowType.field("map3", mapType(VARCHAR, BIGINT)),
-                        RowType.field("rowasjsonarray1", RowType.anonymous(ImmutableList.of(BIGINT, BIGINT, BIGINT, BIGINT))),
-                        RowType.field("rowasjsonarray2", RowType.anonymous(ImmutableList.of(BIGINT))),
-                        RowType.field("rowasjsonobject1", RowType.from(ImmutableList.of(RowType.field("nothing", BIGINT)))),
-                        RowType.field("rowasjsonobject2", RowType.from(ImmutableList.of(
+                        RowType.field("rowAsJsonArray1", RowType.anonymous(ImmutableList.of(BIGINT, BIGINT, BIGINT, BIGINT)), true),
+                        RowType.field("rowAsJsonArray2", RowType.anonymous(ImmutableList.of(BIGINT)), true),
+                        RowType.field("rowAsJsonObject1", RowType.from(ImmutableList.of(RowType.field("nothing", BIGINT))), true),
+                        RowType.field("rowAsJsonObject2", RowType.from(ImmutableList.of(
                                 RowType.field("a", BIGINT),
                                 RowType.field("b", BIGINT),
-                                RowType.field("three", BIGINT),
-                                RowType.field("none", BIGINT)))))),
+                                RowType.field("Three", BIGINT, true),
+                                RowType.field("none", BIGINT))), true))),
                 asList(
                         emptyList(), asList(1L, 2L, null, 3L), null,
-                        ImmutableMap.of(), null, asMap(ImmutableList.of("a", "b", "none", "three"), asList(1L, 2L, null, 3L)),
+                        ImmutableMap.of(), null, asMap(ImmutableList.of("a", "b", "none", "Three"), asList(1L, 2L, null, 3L)),
                         asList(1L, 2L, null, 3L), null,
                         null, asList(1L, 2L, 3L, null)));
 
@@ -525,6 +526,14 @@ public class TestRowOperators
                         RowType.field("d", VARCHAR),
                         RowType.field("e", new ArrayType(BIGINT)))),
                 asList(2L, 1.5, true, "abc", ImmutableList.of(1L, 2L)));
+
+        assertFunction(
+                "MAP(ARRAY['myFirstRow', 'mySecondRow'], ARRAY[cast(row('row1FieldValue1', 'row1FieldValue2') as row(\"firstField\" varchar, \"secondField\" varchar)), cast(row('row2FieldValue1', 'row2FieldValue2') as row(\"firstField\" varchar, \"secondField\" varchar))])",
+                mapType(VarcharType.createVarcharType(11), RowType.from(ImmutableList.of(
+                        RowType.field("firstField", VARCHAR, true),
+                        RowType.field("secondField", VARCHAR, true)))),
+                ImmutableMap.of("myFirstRow", asList("row1FieldValue1", "row1FieldValue2"),
+                        "mySecondRow", asList("row2FieldValue1", "row2FieldValue2")));
     }
 
     @Test

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cast.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cast.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public final class Cast
@@ -67,7 +66,7 @@ public final class Cast
         requireNonNull(type, "type is null");
 
         this.expression = expression;
-        this.type = type.toLowerCase(ENGLISH);
+        this.type = transformCase(type);
         this.safe = safe;
         this.typeOnly = typeOnly;
     }
@@ -90,6 +89,34 @@ public final class Cast
     public boolean isTypeOnly()
     {
         return typeOnly;
+    }
+
+    /**
+     * We uniformly change the whole type string to lower case,
+     *  except field names which are enclosed in double quotation marks
+     * */
+    private static String transformCase(String input)
+    {
+        if (input == null) {
+            return null;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        boolean insideQuotes = false;
+        for (int i = 0, l = input.length(); i < l; i++) {
+            char ch = input.charAt(i);
+            if (ch == '"') {
+                insideQuotes = !insideQuotes;
+            }
+
+            if (insideQuotes) {
+                sb.append(ch);
+            }
+            else {
+                sb.append(Character.toLowerCase(ch));
+            }
+        }
+        return sb.toString();
     }
 
     @Override


### PR DESCRIPTION
## Description

Fixes issue #20701 .

In parsing stage, when we try to build a `CAST` expression, we should not simply translate the target type string to lower case, as the target type string may have some quoted field names which should retain their original case.

So as to json string, when we try to `CAST` it to other type like `RowType`, we should not roughly translate it to lower case, that would corrupt the json data.

This PR try to fix the problems above.


## Test Plan

 - Enhanced test case TestRowOperators.testJsonToRow(), adding case reservation verify for json cast to other type
 - Enhanced test case TestRowOperators.testRowCast(), adding the example mentioned in issue #20701 
 - Make sure this fix do not affect existing test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
