### PR TITLE
Add better check argument message for duration nanos

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SplitConcurrencyController.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SplitConcurrencyController.java
@@ -20,6 +20,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Double.isFinite;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 @NotThreadSafe
@@ -38,14 +39,14 @@ public class SplitConcurrencyController
         this.adjustmentIntervalNanos = adjustmentInterval.roundTo(NANOSECONDS);
     }
 
-    public void update(long nanos, double utilization, int currentConcurrency)
+    public void update(long durationNanos, double utilization, int currentConcurrency)
     {
-        checkArgument(nanos >= 0, "nanos is negative");
+        checkArgument(durationNanos >= 0, format("durationNanos=%d is negative", durationNanos));
         checkArgument(isFinite(utilization), "utilization must be finite");
-        checkArgument(utilization >= 0, "utilization is negative");
-        checkArgument(currentConcurrency >= 0, "currentConcurrency is negative");
+        checkArgument(utilization >= 0, format("utilization=%f is negative", utilization));
+        checkArgument(currentConcurrency >= 0, format("currentConcurrency=%d is negative", currentConcurrency));
 
-        threadNanosSinceLastAdjustment += nanos;
+        threadNanosSinceLastAdjustment += durationNanos;
         if (threadNanosSinceLastAdjustment >= adjustmentIntervalNanos && utilization < TARGET_UTILIZATION && currentConcurrency >= targetConcurrency) {
             threadNanosSinceLastAdjustment = 0;
             targetConcurrency++;


### PR DESCRIPTION
## Description
Occassionally duration nanos ends up as negative.
See stacktrace below. 
```
java.lang.IllegalArgumentException: nanos is negative
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
	at com.facebook.presto.execution.SplitConcurrencyController.update(SplitConcurrencyController.java:43)
	at com.facebook.presto.execution.executor.TaskHandle.addScheduledNanos(TaskHandle.java:74)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:172)
```
This commit tries to add some more detail to the error message.

## Motivation and Context
Logging change

## Test Plan
Unit Test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.


```
== NO RELEASE NOTE ==
```

