### PR TITLE
MapUnionSum should writeLong when value is RealType

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionSumResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionSumResult.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -75,7 +76,7 @@ public abstract class MapUnionSumResult
     static void appendValue(Type valueType, Block block, int position, BlockBuilder blockBuilder)
     {
         if (block.isNull(position)) {
-            if (isExactNumericType(valueType)) {
+            if (isExactNumericType(valueType) || valueType instanceof RealType) {
                 valueType.writeLong(blockBuilder, 0L);
             }
             else {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6028,6 +6028,10 @@ public abstract class AbstractTestQueries
         assertEquals(actual.getRowCount(), 1);
         assertEquals(actual.getMaterializedRows().get(0).getField(1), ImmutableMap.of("x", 1L, "y", 20L, "z", 30L));
 
+        actual = computeActual("select y, map_union_sum(x) from (select 1 y, map(array['x', 'z', 'y'], cast(array[null,30,20] as array<real>)) x union all select 1 y, map(array['x', 'y'], cast(array[1,null] as array<real>))x) group by y");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(1), ImmutableMap.of("x", 1.0f, "y", 20.0f, "z", 30.0f));
+
         actual = computeActual("select y, map_union_sum(x) from (select 1 y, map(array['x', 'y'], cast(array[1,null] as array<bigint>)) x " +
                 "union all select 1 y, map(array['x', 'z', 'y'], cast(array[null,30,20] as array<bigint>)) " +
                 "union all select 1 y, map(array['a', 'y', 'x'], cast(array[100, 400, 200] as array<bigint>)) " +


### PR DESCRIPTION
## Description
Fix issue #20951 
A simple fix, RealType is not isExactNumericType, and doesn't have 'writeDouble' method implemented.

## Motivation and Context
#20951 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Unit Test in local env

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

== NO RELEASE NOTE ==


