### PR TITLE
Refactor NodeScheduler to use addAll instead of iterate and add

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -373,8 +373,7 @@ public class NodeScheduler
                 // `coordinatorIds.contains(node.getNodeIdentifier())`. But checking the condition isn't necessary
                 // because every node satisfies it. Otherwise, `chosen` wouldn't have been empty.
 
-                nodeMap.getAllNodesByHostAndPort().get(host).stream()
-                        .forEach(chosen::add);
+                chosen.addAll(nodeMap.getAllNodesByHostAndPort().get(host));
 
                 // consider a split with a host without a port as being accessible by all nodes in that host
                 if (!host.hasPort()) {
@@ -387,8 +386,7 @@ public class NodeScheduler
                         continue;
                     }
 
-                    nodeMap.getAllNodesByHost().get(address).stream()
-                            .forEach(chosen::add);
+                    chosen.addAll(nodeMap.getAllNodesByHost().get(address));
                 }
             }
         }


### PR DESCRIPTION
## Description
Refactor NodeScheduler to use addAll instead of iterate and add 

## Motivation and Context
Refactoring change to simplify code.

## Test Plan
Unit Tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

