### PR TITLE
Fix filtering by subfield of RowType column in Iceberg table

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -893,6 +893,23 @@ public class IcebergDistributedSmokeTestBase
         dropTable(session, tableName);
     }
 
+    @Test
+    public void testFilterBySubfieldOfRowType()
+    {
+        Session session = getSession();
+        String tableName = "test_filter_by_subfieldofrow";
+
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, r row(a integer, b varchar))");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, (1, '1001'))", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (2, (2, '1002'))", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES (3, (3, '1003'))", 1);
+
+        assertQuery("SELECT * FROM " + tableName + " WHERE r.a = 1", "VALUES (1, (1, '1001'))");
+        assertQuery("SELECT * FROM " + tableName + " WHERE r.b = '1003'", "VALUES (3, (3, '1003'))");
+        assertQuery("SELECT * FROM " + tableName + " WHERE r.a > 1 and r.b < '1003'", "VALUES (2, (2, '1002'))");
+        dropTable(session, tableName);
+    }
+
     protected String getLocation(String schema, String table)
     {
         return null;

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -66,6 +66,7 @@ import static com.facebook.presto.common.predicate.ValueSet.ofRanges;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.isEntireColumn;
@@ -110,6 +111,56 @@ public class TestIcebergLogicalPlanner
             throws Exception
     {
         return createIcebergQueryRunner(ImmutableMap.of("experimental.pushdown-subfields-enabled", "true"), ImmutableMap.of());
+    }
+
+    @Test
+    public void testFiltersWithPushdownDisable()
+    {
+        // The filter pushdown session property is disabled by default
+        Session sessionWithoutFilterPushdown = getQueryRunner().getDefaultSession();
+
+        assertUpdate("CREATE TABLE test_filters_with_pushdown_disable(id int, name varchar, r row(a int, b varchar)) with (partitioning = ARRAY['id'])");
+
+        // Only identity partition column predicates, would be enforced totally by tableScan
+        assertPlan(sessionWithoutFilterPushdown, "SELECT name, r FROM test_filters_with_pushdown_disable WHERE id = 10",
+                output(exchange(
+                        strictTableScan("test_filters_with_pushdown_disable", identityMap("name", "r")))),
+                plan -> assertTableLayout(
+                        plan,
+                        "test_filters_with_pushdown_disable",
+                        withColumnDomains(ImmutableMap.of(new Subfield(
+                                        "id",
+                                        ImmutableList.of()),
+                                singleValue(INTEGER, 10L))),
+                        TRUE_CONSTANT,
+                        ImmutableSet.of("id")));
+
+        // Only normal column predicates, would not be enforced by tableScan
+        assertPlan(sessionWithoutFilterPushdown, "SELECT id, r FROM test_filters_with_pushdown_disable WHERE name = 'adam'",
+                output(exchange(project(
+                        filter("name='adam'",
+                                strictTableScan("test_filters_with_pushdown_disable", identityMap("id", "name", "r")))))));
+
+        // Only subfield column predicates, would not be enforced by tableScan
+        assertPlan(sessionWithoutFilterPushdown, "SELECT id, name FROM test_filters_with_pushdown_disable WHERE r.a = 10",
+                output(exchange(project(
+                        filter("r.a=10",
+                                strictTableScan("test_filters_with_pushdown_disable", identityMap("id", "name", "r")))))));
+
+        // Predicates with identity partition column and normal column, would not be enforced by tableScan
+        // TODO: The predicate could be enforced partially by tableScan, so the filterNode could drop it's filter condition `id=10`
+        assertPlan(sessionWithoutFilterPushdown, "SELECT name, r FROM test_filters_with_pushdown_disable WHERE id = 10 and name = 'adam'",
+                output(exchange(project(
+                        filter("id=10 AND name='adam'",
+                                strictTableScan("test_filters_with_pushdown_disable", identityMap("id", "name", "r")))))));
+
+        // Predicates with identity partition column and subfield column, would not be enforced by tableScan
+        assertPlan(sessionWithoutFilterPushdown, "SELECT name FROM test_filters_with_pushdown_disable WHERE id = 10 and r.b = 'adam'",
+                output(exchange(project(
+                        filter("id=10 AND r.b='adam'",
+                                strictTableScan("test_filters_with_pushdown_disable", identityMap("id", "name", "r")))))));
+
+        assertUpdate("DROP TABLE test_filters_with_pushdown_disable");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ColumnReference.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ColumnReference.java
@@ -81,9 +81,12 @@ public class ColumnReference
     {
         Optional<VariableReferenceExpression> result = Optional.empty();
         for (Map.Entry<VariableReferenceExpression, ColumnHandle> entry : assignments.entrySet()) {
-            if (entry.getValue().equals(columnHandle)) {
+            ColumnHandle targetColumnHandle = entry.getValue();
+            if (targetColumnHandle.equals(columnHandle) ||
+                    targetColumnHandle.equals(columnHandle.withRequiredSubfields(targetColumnHandle.getRequiredSubfields()))) {
                 checkState(!result.isPresent(), "Multiple ColumnHandles found for %s:%s in table scan assignments", tableName, columnName);
                 result = Optional.of(entry.getKey());
+                break;
             }
         }
         return result;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ColumnHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ColumnHandle.java
@@ -18,6 +18,8 @@ import com.facebook.presto.spi.api.Experimental;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
+
 public interface ColumnHandle
 {
     /**
@@ -40,5 +42,11 @@ public interface ColumnHandle
     default ColumnHandle withRequiredSubfields(List<Subfield> subfields)
     {
         return this;
+    }
+
+    @Experimental
+    default List<Subfield> getRequiredSubfields()
+    {
+        return emptyList();
     }
 }


### PR DESCRIPTION
## Description

When we try to query iceberg table using filters about the subfield of row type columns, the filtering condition would fail. For example, with an Iceberg table as follow:

``create table iceberg.default.test(id int, r row(a int, b varchar));``

When we query the table with sql statement ``select * from iceberg.default.test where r.a = 1``, we would get all rows in the table.

The PR fix this problem.

## Test Plan

 - Newly added test case IcebergDistributedSmokeTestBase.testFilterBySubfieldOfRowType()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

