### PR TITLE
Use @TypeParameter to simplify array_agg aggregation function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -895,7 +895,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_TO_JSON, JSON_TO_ARRAY, JSON_STRING_TO_ARRAY)
                 .aggregate(SetAggregationFunction.class)
                 .aggregate(SetUnionFunction.class)
-                .function(new ArrayAggregationFunction(featuresConfig.isLegacyArrayAgg(), featuresConfig.getArrayAggGroupImplementation()))
+                .aggregate(ArrayAggregationFunction.class)
                 .functions(new MapSubscriptOperator(featuresConfig.isLegacyMapSubscript()))
                 .functions(MAP_CONSTRUCTOR, MAP_TO_JSON, JSON_TO_MAP, JSON_STRING_TO_MAP)
                 .functions(MAP_AGG, MAP_UNION, MAP_UNION_SUM)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/ArrayAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/ArrayAggregationFunction.java
@@ -13,133 +13,50 @@
  */
 package com.facebook.presto.operator.aggregation.arrayagg;
 
-import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
-import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.metadata.BoundVariables;
-import com.facebook.presto.metadata.FunctionAndTypeManager;
-import com.facebook.presto.metadata.SqlAggregationFunction;
-import com.facebook.presto.operator.aggregation.AccumulatorCompiler;
-import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
-import com.facebook.presto.spi.function.AccumulatorState;
-import com.facebook.presto.spi.function.AccumulatorStateFactory;
-import com.facebook.presto.spi.function.AccumulatorStateSerializer;
-import com.facebook.presto.spi.function.aggregation.Accumulator;
-import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
-import com.facebook.presto.spi.function.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
-import com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
-import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
-import com.google.common.collect.ImmutableList;
+import com.facebook.presto.operator.aggregation.NullablePosition;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
 
-import java.lang.invoke.MethodHandle;
-import java.util.List;
-
-import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
-import static com.facebook.presto.spi.function.Signature.typeVariable;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
-import static com.facebook.presto.util.Reflection.methodHandle;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.util.Objects.requireNonNull;
-
+@SuppressWarnings("checkstyle:HideUtilityClassConstructor")
+@AggregationFunction(value = "array_agg", isCalledOnNullInput = true)
+@Description("return an array of values")
 public class ArrayAggregationFunction
-        extends SqlAggregationFunction
 {
-    private static final String NAME = "array_agg";
-    private static final MethodHandle INPUT_FUNCTION = methodHandle(ArrayAggregationFunction.class, "input", Type.class, ArrayAggregationState.class, Block.class, int.class);
-    private static final MethodHandle COMBINE_FUNCTION = methodHandle(ArrayAggregationFunction.class, "combine", Type.class, ArrayAggregationState.class, ArrayAggregationState.class);
-    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(ArrayAggregationFunction.class, "output", Type.class, ArrayAggregationState.class, BlockBuilder.class);
-
-    private final boolean legacyArrayAgg;
-    private final ArrayAggGroupImplementation groupMode;
-
-    public ArrayAggregationFunction(boolean legacyArrayAgg, ArrayAggGroupImplementation groupMode)
-    {
-        super(NAME,
-                ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
-                parseTypeSignature("array(T)"),
-                ImmutableList.of(parseTypeSignature("T")));
-        this.legacyArrayAgg = legacyArrayAgg;
-        this.groupMode = requireNonNull(groupMode, "groupMode is null");
-    }
-
-    @Override
-    public String getDescription()
-    {
-        return "return an array of values";
-    }
-
-    @Override
-    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
-    {
-        Type type = boundVariables.getTypeVariable("T");
-        return generateAggregation(type, legacyArrayAgg, groupMode);
-    }
-
-    private static BuiltInAggregationFunctionImplementation generateAggregation(Type type, boolean legacyArrayAgg, ArrayAggGroupImplementation groupMode)
-    {
-        DynamicClassLoader classLoader = new DynamicClassLoader(ArrayAggregationFunction.class.getClassLoader());
-
-        AccumulatorStateSerializer<?> stateSerializer = new ArrayAggregationStateSerializer(type);
-        AccumulatorStateFactory<?> stateFactory = new ArrayAggregationStateFactory(type, groupMode);
-
-        List<Type> inputTypes = ImmutableList.of(type);
-        Type outputType = new ArrayType(type);
-        Type intermediateType = stateSerializer.getSerializedType();
-        List<ParameterMetadata> inputParameterMetadata = createInputParameterMetadata(type, legacyArrayAgg);
-
-        MethodHandle inputFunction = INPUT_FUNCTION.bindTo(type);
-        MethodHandle combineFunction = COMBINE_FUNCTION.bindTo(type);
-        MethodHandle outputFunction = OUTPUT_FUNCTION.bindTo(type);
-        Class<? extends AccumulatorState> stateInterface = ArrayAggregationState.class;
-
-        AggregationMetadata metadata = new AggregationMetadata(
-                generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
-                inputParameterMetadata,
-                inputFunction,
-                combineFunction,
-                outputFunction,
-                ImmutableList.of(new AccumulatorStateDescriptor(
-                        stateInterface,
-                        stateSerializer,
-                        stateFactory)),
-                outputType);
-
-        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
-                Accumulator.class,
-                metadata,
-                classLoader);
-        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
-                GroupedAccumulator.class,
-                metadata,
-                classLoader);
-
-        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), outputType,
-                true, true, metadata, accumulatorClass, groupedAccumulatorClass);
-    }
-
-    private static List<ParameterMetadata> createInputParameterMetadata(Type value, boolean legacyArrayAgg)
-    {
-        return ImmutableList.of(new ParameterMetadata(STATE), new ParameterMetadata(legacyArrayAgg ? BLOCK_INPUT_CHANNEL : NULLABLE_BLOCK_INPUT_CHANNEL, value), new ParameterMetadata(BLOCK_INDEX));
-    }
-
-    public static void input(Type type, ArrayAggregationState state, Block value, int position)
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(
+            @TypeParameter("T") Type type,
+            @AggregationState ArrayAggregationState state,
+            @BlockPosition @SqlType("T") @NullablePosition Block value,
+            @BlockIndex int position)
     {
         state.add(value, position);
     }
 
-    public static void combine(Type type, ArrayAggregationState state, ArrayAggregationState otherState)
+    @CombineFunction
+    public static void combine(
+            @AggregationState ArrayAggregationState state,
+            @AggregationState ArrayAggregationState otherState)
     {
         state.merge(otherState);
     }
 
-    public static void output(Type elementType, ArrayAggregationState state, BlockBuilder out)
+    @OutputFunction("array(T)")
+    public static void output(
+            @TypeParameter("array(T)") Type elementType,
+            @AggregationState ArrayAggregationState state,
+            BlockBuilder out)
     {
         if (state.isEmpty()) {
             out.appendNull();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/ArrayAggregationStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/ArrayAggregationStateFactory.java
@@ -16,6 +16,8 @@ package com.facebook.presto.operator.aggregation.arrayagg;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.TypeParameter;
 
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
 import static java.lang.String.format;
@@ -26,7 +28,9 @@ public class ArrayAggregationStateFactory
     private final Type type;
     private final ArrayAggGroupImplementation mode;
 
-    public ArrayAggregationStateFactory(Type type, ArrayAggGroupImplementation mode)
+    public ArrayAggregationStateFactory(
+            @TypeParameter("T") Type type,
+            @AggregationState ArrayAggGroupImplementation mode)
     {
         this.type = type;
         this.mode = mode;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/ArrayAggregationStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/ArrayAggregationStateSerializer.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.function.TypeParameter;
 
 public class ArrayAggregationStateSerializer
         implements AccumulatorStateSerializer<ArrayAggregationState>
@@ -25,7 +26,7 @@ public class ArrayAggregationStateSerializer
     private final Type elementType;
     private final Type arrayType;
 
-    public ArrayAggregationStateSerializer(Type elementType)
+    public ArrayAggregationStateSerializer(@TypeParameter("T") Type elementType)
     {
         this.elementType = elementType;
         this.arrayType = new ArrayType(elementType);


### PR DESCRIPTION
## Description
Use @TypeParameter to simplify array_agg aggregation function

## Motivation and Context
fix issue https://github.com/prestodb/presto/issues/21361

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.



