### PR TITLE
Optimize Table Metadata calls for Iceberg tables

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -469,6 +469,18 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-cache</artifactId>
             <scope>compile</scope>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -176,7 +176,7 @@ public class IcebergHiveMetadata
     }
 
     @Override
-    protected org.apache.iceberg.Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
+    protected org.apache.iceberg.Table getRawIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
         return getHiveIcebergTable(metastore, hdfsEnvironment, session, schemaTableName);
     }
@@ -456,7 +456,7 @@ public class IcebergHiveMetadata
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
         TableStatistics icebergStatistics = TableStatisticsMaker.getTableStatistics(session, constraint, handle, icebergTable, columnHandles.stream().map(IcebergColumnHandle.class::cast).collect(Collectors.toList()));
         HiveStatisticsMergeStrategy mergeStrategy = getHiveStatisticsMergeStrategy(session);
         return tableLayoutHandle.map(IcebergTableLayoutHandle.class::cast).map(layoutHandle -> {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -90,7 +90,7 @@ public class IcebergNativeMetadata
     }
 
     @Override
-    protected Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
+    protected Table getRawIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
         return getNativeIcebergTable(resourceFactory, session, schemaTableName);
     }
@@ -99,10 +99,8 @@ public class IcebergNativeMetadata
     protected boolean tableExists(ConnectorSession session, SchemaTableName schemaTableName)
     {
         IcebergTableName name = IcebergTableName.from(schemaTableName.getTableName());
-        TableIdentifier tableIdentifier = toIcebergTableIdentifier(schemaTableName.getSchemaName(), name.getTableName());
-
         try {
-            resourceFactory.getCatalog(session).loadTable(tableIdentifier);
+            getIcebergTable(session, new SchemaTableName(schemaTableName.getSchemaName(), name.getTableName()));
         }
         catch (NoSuchTableException e) {
             // return null to throw

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHadoopCatalog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHadoopCatalog.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.OptionalInt;
+
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.iceberg.FileFormat.PARQUET;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Benchmark;
+
+@State(Benchmark)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(2)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class BenchmarkIcebergHadoopCatalog
+        extends IcebergBaseBenchmark
+{
+    @Override
+    public DistributedQueryRunner getQueryRunner()
+    {
+        try {
+            return createIcebergQueryRunner(
+                    ImmutableMap.of(),
+                    ImmutableMap.of("iceberg.catalog.type", HADOOP.name()),
+                    PARQUET,
+                    false,
+                    true,
+                    OptionalInt.of(1));
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkIcebergHadoopCatalog.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHiveCatalog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHiveCatalog.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.OptionalInt;
+
+import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.iceberg.FileFormat.PARQUET;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Benchmark;
+
+@State(Benchmark)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(2)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class BenchmarkIcebergHiveCatalog
+        extends IcebergBaseBenchmark
+{
+    @Override
+    public DistributedQueryRunner getQueryRunner()
+    {
+        try {
+            return createIcebergQueryRunner(
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    PARQUET,
+                    false,
+                    true,
+                    OptionalInt.of(1));
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkIcebergHiveCatalog.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergBaseBenchmark.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergBaseBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+
+public abstract class IcebergBaseBenchmark
+{
+    protected DistributedQueryRunner queryRunner;
+
+    protected IcebergBaseBenchmark()
+    {
+        queryRunner = getQueryRunner();
+    }
+
+    protected abstract DistributedQueryRunner getQueryRunner();
+
+    @Setup
+    public void setUp()
+    {
+        queryRunner.execute("CREATE SCHEMA iceberg.test_db");
+        queryRunner.execute("CREATE TABLE iceberg.test_db.region AS SELECT * from tpch.sf1.region");
+        queryRunner.execute("CREATE TABLE iceberg.test_db.orders AS SELECT * from tpch.sf1.orders");
+        queryRunner.execute("CREATE TABLE iceberg.test_db.lineitem AS SELECT * from tpch.sf1.lineitem");
+    }
+
+    @TearDown
+    public void tearDown()
+    {
+        queryRunner.execute("DROP TABLE IF EXISTS iceberg.test_db.region");
+        queryRunner.execute("DROP TABLE IF EXISTS iceberg.test_db.orders");
+        queryRunner.execute("DROP TABLE IF EXISTS iceberg.test_db.lineitem");
+        queryRunner.execute("DROP SCHEMA IF EXISTS iceberg.test_db");
+        queryRunner.close();
+        queryRunner = null;
+    }
+
+    @Benchmark
+    public MaterializedResult benchmarkIcebergTableSelect()
+    {
+        return queryRunner
+                .execute("SELECT * FROM iceberg.test_db.region");
+    }
+
+    @Benchmark
+    public MaterializedResult benchmarkIcebergTableTpchQ4()
+    {
+        return queryRunner
+                .execute("SELECT o.orderpriority, " +
+                        "    count(*) AS order_count " +
+                        "FROM iceberg.test_db.orders o " +
+                        "WHERE o.orderdate >= DATE '1993-07-01' " +
+                        "    AND o.orderdate < DATE '1993-07-01' + interval '3' month " +
+                        "    AND EXISTS (SELECT * " +
+                        "                FROM iceberg.test_db.lineitem l " +
+                        "                WHERE l.orderkey = o.orderkey " +
+                        "                    AND l.commitdate < l.receiptdate) " +
+                        "GROUP  BY o.orderpriority " +
+                        "ORDER  BY o.orderpriority ");
+    }
+}


### PR DESCRIPTION
## Description
https://github.com/prestodb/presto/issues/21628

## Motivation and Context
Avoid redundant calls to getIcebergTable for a single query for the same table.

## Impact
Avoid redundant calls to getIcebergTable for a single query for the same table.

## Environment
Presto cluster - Local Mac
Data Size - tpch.tiny
Data source - S3

## Results
## Performance Improvement for TPCH Q4 - Tiny

```jsx
SELECT
  o.orderpriority,
  count(*) AS order_count
FROM
  iceberg.tpch.orders o
WHERE 
  o.orderdate >= DATE '1993-07-01'
  AND o.orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
  AND EXISTS (
    SELECT
      *
    FROM
      iceberg.tpch.lineitem l
    WHERE
      l.orderkey = o.orderkey
      AND l.commitdate < l.receiptdate
  )
GROUP BY
  o.orderpriority
ORDER BY
  o.orderpriority;
```

### Native Catalog

**Current Execution Time,**

![image](https://github.com/prestodb/presto/assets/7887476/d5156ab6-a4c8-4857-b6b4-ff9b20504fa2)


**After optimization,**

![image](https://github.com/prestodb/presto/assets/7887476/b7527f69-0ff4-4efc-a371-ac1a8e828758)


### Hive Catalog

**Current Execution Time,**

![image](https://github.com/prestodb/presto/assets/7887476/c4fc0178-bfe9-463f-a9b4-9678cd2d61d2)


**After optimization,**

![image](https://github.com/prestodb/presto/assets/7887476/e22d91e1-19ba-4073-a5fe-36190ca93353)

## JMH Benchmarks Results
**Environment:**
Presto cluster - Local Presto Query Runner
Data - Local

### Before
**Native Catalog,**
`Benchmark                                                  Mode  Cnt     Score     Error  Units
BenchmarkIcebergHadoopCatalog.benchmarkIcebergTableSelect  avgt   20   176.927 ±  76.529  ms/op
BenchmarkIcebergHadoopCatalog.benchmarkIcebergTableTpchQ4  avgt   20  2161.647 ± 127.355  ms/op`

**Hive Catalog,**
`Benchmark                                                Mode  Cnt     Score     Error  Units
BenchmarkIcebergHiveCatalog.benchmarkIcebergTableSelect  avgt   20   143.555 ±  50.956  ms/op
BenchmarkIcebergHiveCatalog.benchmarkIcebergTableTpchQ4  avgt   20  2147.876 ± 147.937  ms/op`

### After
**Native Catalog,**
`Benchmark                                                  Mode  Cnt     Score     Error  Units
BenchmarkIcebergHadoopCatalog.benchmarkIcebergTableSelect  avgt   20   118.736 ±  37.819  ms/op
BenchmarkIcebergHadoopCatalog.benchmarkIcebergTableTpchQ4  avgt   20  2038.915 ± 109.773  ms/op`

**Hive Catalog,**
`Benchmark                                                Mode  Cnt     Score    Error  Units
BenchmarkIcebergHiveCatalog.benchmarkIcebergTableSelect  avgt   20   138.459 ± 57.796  ms/op
BenchmarkIcebergHiveCatalog.benchmarkIcebergTableTpchQ4  avgt   20  2017.693 ± 96.666  ms/op`

**Note:**
In the benchmark, improvement numbers are not big since all the metadata is fetched from the local itself via QueryRunner. Earlier result screenshots are accessing tables from s3.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Changes
* Optimize Table Metadata calls for Iceberg tables
```



