### PR TITLE
[Iceberg]Fix filtering by unmatched value with Iceberg filter pushdown enabled

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -239,6 +239,17 @@ public abstract class IcebergAbstractMetadata
             return new ConnectorTableLayout(handle);
         }
 
+        if (!icebergTableLayoutHandle.getPartitions().isPresent()) {
+            return new ConnectorTableLayout(
+                    icebergTableLayoutHandle,
+                    Optional.empty(),
+                    TupleDomain.none(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    ImmutableList.of(),
+                    Optional.empty());
+        }
         List<ColumnHandle> partitionColumns = ImmutableList.copyOf(icebergTableLayoutHandle.getPartitionColumns());
         List<HivePartition> partitions = icebergTableLayoutHandle.getPartitions().get();
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -550,9 +550,16 @@ public final class IcebergUtil
             List<IcebergColumnHandle> partitionColumns)
     {
         IcebergTableName name = ((IcebergTableHandle) tableHandle).getTableName();
+
+        // Empty iceberg table would cause `snapshotId` not present
+        Optional<Long> snapshotId = resolveSnapshotIdByName(icebergTable, name);
+        if (!snapshotId.isPresent()) {
+            return ImmutableList.of();
+        }
+
         TableScan tableScan = icebergTable.newScan()
                 .filter(toIcebergExpression(constraint.getSummary().simplify().transform(IcebergColumnHandle.class::cast)))
-                .useSnapshot(resolveSnapshotIdByName(icebergTable, name).get());
+                .useSnapshot(snapshotId.get());
 
         Set<HivePartition> partitions = new HashSet<>();
 


### PR DESCRIPTION
## Description

When filter pushdown is enabled, trying to query from an empty Iceberg table  or query with filter which do not match any partition would lead in an error. This PR fix the problem.

## Test Plan

 - Newly added test case TestIcebergLogicalPlanner.testFilterByUnmatchedValueWithFilterPushdown()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

