### PR TITLE
[native] Enable hive.allow-drop-table in NativeQueryRunner

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -151,6 +151,12 @@ public class PrestoNativeQueryRunnerUtils
             boolean addStorageFormatToPath)
             throws Exception
     {
+        // The property "hive.allow-drop-table" needs to be set to true because security is always "legacy" in NativeQueryRunner.
+        ImmutableMap<String, String> hiveProperties = ImmutableMap.<String, String>builder()
+                .putAll(getNativeWorkerHiveProperties(storageFormat))
+                .put("hive.allow-drop-table", "true")
+                .build();
+
         // Make query runner with external workers for tests
         return HiveQueryRunner.createQueryRunner(
                 ImmutableList.of(),
@@ -162,7 +168,7 @@ public class PrestoNativeQueryRunnerUtils
                         .build(),
                 ImmutableMap.of(),
                 "legacy",
-                getNativeWorkerHiveProperties(storageFormat),
+                hiveProperties,
                 workerCount,
                 Optional.of(Paths.get(addStorageFormatToPath ? dataDirectory + "/" + storageFormat : dataDirectory)),
                 Optional.of((workerIndex, discoveryUri) -> {


### PR DESCRIPTION
Allow NativeQueryRunner to drop tables. We need this for writing CTAS tests via the NativeQueryRunner.

Resolves: https://github.com/prestodb/presto/issues/21659