### PR TITLE
[native] Add key_sampling_percent Prestissimo function

### DIFF
--- a/presto-native-execution/presto_cpp/docs/functions.rst
+++ b/presto-native-execution/presto_cpp/docs/functions.rst
@@ -1,0 +1,10 @@
+**********************
+Prestissimo Functions
+**********************
+
+Unicode Functions
+------------------
+.. function:: key_sampling_percent(varchar) -> double
+
+    Generates a double value between 0.0 and 1.0 based on the hash of the given ``varchar``.
+    This function is useful for deterministic sampling of data.

--- a/presto-native-execution/presto_cpp/docs/index.rst
+++ b/presto-native-execution/presto_cpp/docs/index.rst
@@ -6,4 +6,5 @@ Presto Native Execution Documentation
     :maxdepth: 2
 
     develop
+    functions
 

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -34,8 +34,14 @@ add_library(
   PeriodicHeartbeatManager.cpp
   PeriodicServiceInventoryManager.cpp)
 
-add_dependencies(presto_server_lib presto_operators presto_protocol
-                 presto_types presto_thrift-cpp2 presto_thrift_extra)
+add_dependencies(
+  presto_server_lib
+  presto_functions
+  presto_operators
+  presto_protocol
+  presto_types
+  presto_thrift-cpp2
+  presto_thrift_extra)
 
 target_include_directories(presto_server_lib PRIVATE ${presto_thrift_INCLUDES})
 target_link_libraries(

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(types)
 add_subdirectory(http)
 add_subdirectory(common)
 add_subdirectory(thrift)
+add_subdirectory(functions)
 
 add_library(
   presto_server_lib
@@ -46,6 +47,7 @@ target_link_libraries(
   presto_exception
   presto_http
   presto_operators
+  presto_functions
   velox_aggregates
   velox_core
   velox_dwio_common_exception

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -41,6 +41,7 @@
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "presto_cpp/presto_protocol/Connectors.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
+#include "presto_cpp/main/functions/KeySamplingPercentFunctionRegistration.h"
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/caching/CacheTTLController.h"
@@ -900,6 +901,7 @@ void PrestoServer::registerFunctions() {
     velox::aggregate::prestosql::registerAllAggregateFunctions(
         "json.test_schema.");
   }
+  facebook::presto::functions::registerKeySamplingPercentFunction(kPrestoDefaultPrefix);
 }
 
 void PrestoServer::registerRemoteFunctions() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -41,8 +41,7 @@
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "presto_cpp/presto_protocol/Connectors.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
-#include "presto_cpp/main/functions/KeySamplingPercentFunctionRegistration.h"
-#include "velox/common/base/Counters.h"
+#include "presto_cpp/main/functions/registration/RegistrationFunctions.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/caching/CacheTTLController.h"
 #include "velox/common/caching/SsdCache.h"
@@ -901,7 +900,7 @@ void PrestoServer::registerFunctions() {
     velox::aggregate::prestosql::registerAllAggregateFunctions(
         "json.test_schema.");
   }
-  facebook::presto::functions::registerKeySamplingPercentFunction(kPrestoDefaultPrefix);
+  facebook::presto::functions::registerAllPrestoFunctions(kPrestoDefaultPrefix);
 }
 
 void PrestoServer::registerRemoteFunctions() {

--- a/presto-native-execution/presto_cpp/main/functions/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/CMakeLists.txt
@@ -10,28 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(presto_functions_impl
-KeySamplingPercentFunction.cpp)
-
-target_link_libraries(
-  presto_functions_impl
-  presto_common
-  velox_functions_prestosql
-  velox_functions_json
-  velox_functions_lib
-  velox_expression
-  md5
-  velox_type_tz
-  velox_presto_types
-  velox_functions_util
-  ${ANTLR4_RUNTIME}
-  Folly::folly)
-
-set_property(TARGET presto_functions_impl PROPERTY JOB_POOL_COMPILE presto_link_job_pool)
-
-# if(PRESTO_ENABLE_TESTING)
-   add_subdirectory(tests)
-# endif()
-
 add_subdirectory(registration)
 
+if(PRESTO_ENABLE_TESTING)
+   add_subdirectory(tests)
+endif()

--- a/presto-native-execution/presto_cpp/main/functions/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(presto_functions_impl
+KeySamplingPercentFunction.cpp)
+
+target_link_libraries(
+  presto_functions_impl
+  presto_common
+  velox_functions_prestosql
+  velox_functions_json
+  velox_functions_lib
+  velox_expression
+  md5
+  velox_type_tz
+  velox_presto_types
+  velox_functions_util
+  ${ANTLR4_RUNTIME}
+  Folly::folly)
+
+set_property(TARGET presto_functions_impl PROPERTY JOB_POOL_COMPILE presto_link_job_pool)
+
+# if(PRESTO_ENABLE_TESTING)
+   add_subdirectory(tests)
+# endif()
+
+add_subdirectory(registration)
+

--- a/presto-native-execution/presto_cpp/main/functions/KeySamplingPercentFunction.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/KeySamplingPercentFunction.cpp
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define XXH_INLINE_ALL
+#include "presto_cpp/external/xxhash.h"
+#include "velox/functions/Macros.h"
+
+using namespace facebook::velox;
+namespace facebook::presto::functions {
+
+template <typename T>
+struct keySamplingPercentFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<double>& result,
+      const arg_type<Varchar>& string) {
+    int64_t hash =
+        folly::Endian::swap64(XXH64(string.data(), string.size(), 0));
+    memcpy(&result, &hash, sizeof(int64_t));
+    result = fmod(abs(folly::Endian::big(result)), 100) / 100;
+  }
+};
+} // namespace facebook::presto::functions

--- a/presto-native-execution/presto_cpp/main/functions/KeySamplingPercentFunction.h
+++ b/presto-native-execution/presto_cpp/main/functions/KeySamplingPercentFunction.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#define XXH_INLINE_ALL
+#include "presto_cpp/external/xxhash.h"
+#include "velox/functions/Macros.h"
+
+using namespace facebook::velox;
+namespace facebook::presto::functions {
+
+template <typename T>
+struct KeySamplingPercentFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<double>& result,
+      const arg_type<Varchar>& string) {
+    static constexpr auto kTypeLength = sizeof(int64_t);
+    static_assert(
+        sizeof(result) == kTypeLength,
+        "Incorrect result size, expected 8-bytes ");
+
+    int64_t hash =
+        folly::Endian::swap64(XXH64(string.data(), string.size(), 0));
+    memcpy(&result, &hash, kTypeLength);
+    result = fmod(abs(folly::Endian::big(result)), 100) / 100;
+  }
+};
+} // namespace facebook::presto::functions

--- a/presto-native-execution/presto_cpp/main/functions/registration/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/registration/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(
+  presto_functions
+  KeySamplingPercentFunctionRegistration.cpp)
+
+# GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
+# up failing compilation in an openssl header included by a hash-related
+# function.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(presto_functions
+                         PRIVATE -Wno-deprecated-declarations)
+endif()
+
+target_link_libraries(presto_functions presto_functions_impl simdjson::simdjson)
+
+set_property(TARGET presto_functions PROPERTY JOB_POOL_COMPILE
+presto_link_job_pool)
+

--- a/presto-native-execution/presto_cpp/main/functions/registration/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/registration/CMakeLists.txt
@@ -1,5 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,18 +12,8 @@
 
 add_library(
   presto_functions
-  KeySamplingPercentFunctionRegistration.cpp)
+  KeySamplingPercentFunctionRegistration.cpp
+  RegistrationFunctions.cpp)
 
-# GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
-# up failing compilation in an openssl header included by a hash-related
-# function.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  target_compile_options(presto_functions
-                         PRIVATE -Wno-deprecated-declarations)
-endif()
-
-target_link_libraries(presto_functions presto_functions_impl simdjson::simdjson)
-
-set_property(TARGET presto_functions PROPERTY JOB_POOL_COMPILE
-presto_link_job_pool)
+target_link_libraries(presto_functions xsimd)
 

--- a/presto-native-execution/presto_cpp/main/functions/registration/KeySamplingPercentFunctionRegistration.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/registration/KeySamplingPercentFunctionRegistration.cpp
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/functions/registration/KeySamplingPercentFunctionRegistration.h"
+#include "presto_cpp/main/functions/KeySamplingPercentFunction.cpp"
+
+namespace facebook::presto::functions {
+
+using namespace facebook::velox;
+
+void registerKeySamplingPercentFunction(const std::string& prefix) {
+  registerFunction<keySamplingPercentFunction, double, Varchar>(
+        {prefix + "key_sampling_percent"});
+ }
+}; // namespace facebook::presto::functions

--- a/presto-native-execution/presto_cpp/main/functions/registration/KeySamplingPercentFunctionRegistration.h
+++ b/presto-native-execution/presto_cpp/main/functions/registration/KeySamplingPercentFunctionRegistration.h
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/Registerer.h"
+
+namespace facebook::presto::functions {
+void registerKeySamplingPercentFunction(const std::string& prefix);
+}; // namespace facebook::presto::functions

--- a/presto-native-execution/presto_cpp/main/functions/registration/RegistrationFunctions.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/registration/RegistrationFunctions.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,8 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/Registerer.h"
+#include <string>
 
 namespace facebook::presto::functions {
-void registerKeySamplingPercentFunction(const std::string& prefix);
-}; // namespace facebook::presto::functions
+
+extern void registerKeySamplingPercentFunction(const std::string& prefix);
+
+void registerAllPrestoFunctions(const std::string& prefix) {
+  registerKeySamplingPercentFunction(prefix);
+}
+} // namespace facebook::presto::functions
+

--- a/presto-native-execution/presto_cpp/main/functions/registration/RegistrationFunctions.h
+++ b/presto-native-execution/presto_cpp/main/functions/registration/RegistrationFunctions.h
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,15 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
+#include <string>
 
-#include "presto_cpp/main/functions/KeySamplingPercentFunction.h"
-#include "velox/functions/Registerer.h"
-
-using namespace facebook::velox;
 namespace facebook::presto::functions {
+    void registerAllPrestoFunctions(const std::string& prefix);
+} // namespace facebook::presto::functions
 
-void registerKeySamplingPercentFunction(const std::string& prefix) {
-  registerFunction<KeySamplingPercentFunction, double, Varchar>(
-      {prefix + "key_sampling_percent"});
-}
-}; // namespace facebook::presto::functions

--- a/presto-native-execution/presto_cpp/main/functions/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/tests/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(presto_functions_test KeySamplingPercentFunctionTests.cpp)
+
+add_test(presto_functions_test presto_functions_test)
+
+target_link_libraries(
+  presto_functions_test
+  presto_functions
+  velox_type
+  velox_exec
+  velox_expression
+  velox_functions_lib
+  velox_exec_test_lib
+  velox_functions_test_lib
+  velox_dwio_common_test_utils
+  velox_vector_fuzzer
+  gtest
+  gtest_main
+  gflags::gflags
+  gmock
+  gmock_main
+  simdjson::simdjson
+  presto_type_converter
+  ${ANTLR4_RUNTIME})
+
+  set_property(TARGET presto_functions_test PROPERTY JOB_POOL_COMPILE presto_link_job_pool)
+
+

--- a/presto-native-execution/presto_cpp/main/functions/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/tests/CMakeLists.txt
@@ -17,23 +17,4 @@ add_test(presto_functions_test presto_functions_test)
 target_link_libraries(
   presto_functions_test
   presto_functions
-  velox_type
-  velox_exec
-  velox_expression
-  velox_functions_lib
-  velox_exec_test_lib
-  velox_functions_test_lib
-  velox_dwio_common_test_utils
-  velox_vector_fuzzer
-  gtest
-  gtest_main
-  gflags::gflags
-  gmock
-  gmock_main
-  simdjson::simdjson
-  presto_type_converter
-  ${ANTLR4_RUNTIME})
-
-  set_property(TARGET presto_functions_test PROPERTY JOB_POOL_COMPILE presto_link_job_pool)
-
-
+  velox_functions_test_lib)

--- a/presto-native-execution/presto_cpp/main/functions/tests/KeySamplingPercentFunctionTests.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/tests/KeySamplingPercentFunctionTests.cpp
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/functions/registration/KeySamplingPercentFunctionRegistration.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::presto::functions::test {
+
+class KeySamplingPercentFunctionTest : public velox::functions::test::FunctionBaseTest {
+ public:
+   void SetUp() override {
+     facebook::presto::functions::registerKeySamplingPercentFunction("");
+   }
+ };
+
+  TEST_F(KeySamplingPercentFunctionTest, keySamplingPercent) {
+    const auto keySamplingPercent = [&](std::optional<std::string> string) {
+      return evaluateOnce<double>("key_sampling_percent(c0)", string);
+    };
+
+    EXPECT_EQ(std::nullopt, keySamplingPercent(std::nullopt));
+    EXPECT_EQ(0.56, keySamplingPercent("abc"));
+    EXPECT_EQ(6.11561179120687E-153, keySamplingPercent("abcdefghskwkjadhwd"));
+    EXPECT_EQ(2.393674127734674E-93, keySamplingPercent("001yxzuj"));
+    EXPECT_EQ(0.48, keySamplingPercent("56wfythjhdhvgewuikwemn"));
+    EXPECT_EQ(0.7520703125, keySamplingPercent("special_#@,$|%/^~?{}+-"));
+    EXPECT_EQ(0.4, keySamplingPercent("     "));
+    EXPECT_EQ(0.28, keySamplingPercent(""));
+    EXPECT_EQ(
+        4.143659858002825E-274, keySamplingPercent("Hello World from Velox!"));
+  }
+}
+// namespace facebook::presto::functions::test

--- a/presto-native-execution/presto_cpp/main/functions/tests/KeySamplingPercentFunctionTests.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/tests/KeySamplingPercentFunctionTests.cpp
@@ -11,37 +11,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "presto_cpp/main/functions/registration/KeySamplingPercentFunctionRegistration.h"
+
+#include "presto_cpp/main/functions/registration/RegistrationFunctions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
 using namespace facebook::velox;
-using namespace facebook::velox::functions::test;
 
 namespace facebook::presto::functions::test {
 
-class KeySamplingPercentFunctionTest : public velox::functions::test::FunctionBaseTest {
- public:
-   void SetUp() override {
-     facebook::presto::functions::registerKeySamplingPercentFunction("");
-   }
- };
-
-  TEST_F(KeySamplingPercentFunctionTest, keySamplingPercent) {
-    const auto keySamplingPercent = [&](std::optional<std::string> string) {
-      return evaluateOnce<double>("key_sampling_percent(c0)", string);
-    };
-
-    EXPECT_EQ(std::nullopt, keySamplingPercent(std::nullopt));
-    EXPECT_EQ(0.56, keySamplingPercent("abc"));
-    EXPECT_EQ(6.11561179120687E-153, keySamplingPercent("abcdefghskwkjadhwd"));
-    EXPECT_EQ(2.393674127734674E-93, keySamplingPercent("001yxzuj"));
-    EXPECT_EQ(0.48, keySamplingPercent("56wfythjhdhvgewuikwemn"));
-    EXPECT_EQ(0.7520703125, keySamplingPercent("special_#@,$|%/^~?{}+-"));
-    EXPECT_EQ(0.4, keySamplingPercent("     "));
-    EXPECT_EQ(0.28, keySamplingPercent(""));
-    EXPECT_EQ(
-        4.143659858002825E-274, keySamplingPercent("Hello World from Velox!"));
+class KeySamplingPercentFunctionTest
+    : public velox::functions::test::FunctionBaseTest {
+  void SetUp() override {
+    facebook::presto::functions::registerAllPrestoFunctions("");
   }
+};
+
+TEST_F(KeySamplingPercentFunctionTest, keySamplingPercent) {
+  const auto keySamplingPercent = [&](std::optional<std::string> string) {
+    return evaluateOnce<double>("key_sampling_percent(c0)", string);
+  };
+
+  EXPECT_EQ(std::nullopt, keySamplingPercent(std::nullopt));
+  EXPECT_EQ(0.56, keySamplingPercent("abc"));
+  EXPECT_EQ(6.11561179120687E-153, keySamplingPercent("abcdefghskwkjadhwd"));
+  EXPECT_EQ(2.393674127734674E-93, keySamplingPercent("001yxzuj"));
+  EXPECT_EQ(0.48, keySamplingPercent("56wfythjhdhvgewuikwemn"));
+  EXPECT_EQ(0.7520703125, keySamplingPercent("special_#@,$|%/^~?{}+-"));
+  EXPECT_EQ(0.4, keySamplingPercent("     "));
+  EXPECT_EQ(0.28, keySamplingPercent(""));
+  EXPECT_EQ(
+      4.143659858002825E-274, keySamplingPercent("Hello World from Velox!"));
 }
-// namespace facebook::presto::functions::test
+} // namespace facebook::presto::functions::test

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -38,13 +38,16 @@ target_link_libraries(
   velox_tpch_connector
   velox_presto_serializer
   velox_functions_prestosql
+  presto_functions
   velox_aggregates
   velox_hive_partition_function
   ${RE2}
   Folly::folly
   gmock
   gtest
-  gtest_main)
+  gtest_main
+  velox_functions_test_lib
+  )
 
 set_property(TARGET presto_server_test PROPERTY JOB_POOL_LINK
                                                 presto_link_job_pool)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1291,6 +1291,14 @@ public abstract class AbstractTestNativeGeneralQueries
     }
 
     @Test
+    public void testKeySamplingPercentFunction()
+    {
+        assertQuery("SELECT key_sampling_percent('10')");
+        assertQuery("SELECT key_sampling_percent(comment) FROM nation");
+        assertQuery("SELECT key_sampling_percent(shipinstruct) FROM lineitem");
+    }
+
+    @Test
     public void testSystemTables()
     {
         String tableName = generateRandomTableName();


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

