### PR TITLE
Deprecate hive config `hive.s3.use-instance-credentials`

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -283,6 +283,8 @@ Property Name                                Description
 ``hive.s3.use-instance-credentials``         Use the EC2 metadata service to retrieve API credentials
                                              (defaults to ``false``). This works with IAM roles in EC2.
 
+                                              **Note:** This property is deprecated.
+
 ``hive.s3.aws-access-key``                   Default AWS access key to use.
 
 ``hive.s3.aws-secret-key``                   Default AWS secret key to use.
@@ -348,15 +350,18 @@ S3 Credentials
 ^^^^^^^^^^^^^^
 
 If you are running Presto on Amazon EC2 using EMR or another facility,
-you can set ``hive.s3.use-instance-credentials``
-to ``true`` and use IAM Roles for EC2 to govern access to S3. If this is
-the case, your EC2 instances will need to be assigned an IAM Role which
-grants appropriate access to the data stored in the S3 bucket(s) you wish
-to use. It's also possible to configure an IAM role with ``hive.s3.iam-role``
-that will be assumed for accessing any S3 bucket. This is much cleaner than
-setting AWS access and secret keys in the ``hive.s3.aws-access-key``
-and ``hive.s3.aws-secret-key`` settings, and also allows EC2 to automatically
-rotate credentials on a regular basis without any additional work on your part.
+it is recommended that you use IAM Roles for EC2 to govern access to S3. To enable this,
+your EC2 instances will need to be assigned an IAM Role which grants appropriate
+access to the data stored in the S3 bucket(s) you wish to use. It's also possible
+to configure an IAM role with ``hive.s3.iam-role`` that will be assumed for accessing
+any S3 bucket. This is much cleaner than setting AWS access and secret keys in the
+``hive.s3.aws-access-key`` and ``hive.s3.aws-secret-key`` settings, and also allows
+EC2 to automatically rotate credentials on a regular basis without any additional
+work on your part.
+
+After the introduction of DefaultAWSCredentialsProviderChain, if neither IAM role nor
+IAM credentials are configured, instance credentials will be used as they are the last item
+in the DefaultAWSCredentialsProviderChain.
 
 Custom S3 Credentials Provider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Config.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Config.java
@@ -138,11 +138,13 @@ public class HiveS3Config
         return this;
     }
 
+    @Deprecated
     public boolean isS3UseInstanceCredentials()
     {
         return s3UseInstanceCredentials;
     }
 
+    @Deprecated
     @Config("hive.s3.use-instance-credentials")
     public HiveS3Config setS3UseInstanceCredentials(boolean s3UseInstanceCredentials)
     {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
After the introduction of DefaultAWSCredentialsProviderChain, this config has become redundant as instance credentials can still be used even if this config is false, as they are the last item in the DefaultAWSCredentialsProviderChain.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
#21633 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Deprecation of config `hive.s3.use-instance-credentials`

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Changes
* Deprecate hive config ``hive.s3.use-instance-credentials``. This config will be removed in the upcoming release (:issue:`21633`)
```
