### PR TITLE
[DOCUMENTATION] fix formatting in kurtosis entry of aggregate function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -576,9 +576,9 @@ Statistical Aggregate Functions
 
     .. math::
 
-        \mathrm{kurtosis}(x) = {n(n+1) \over (n-1)(n-2)(n-3)} { \sum[(x_i-\mu)^4] \over \sigma^4} -3{ (n-1)^2 \over (n-2)(n-3) },
+        \mathrm{kurtosis}(x) = {n(n+1) \over (n-1)(n-2)(n-3)} { \sum[(x_i-\mu)^4] \over \sigma^4} -3{ (n-1)^2 \over (n-2)(n-3) }
 
-   where :math:`\mu` is the mean, and :math:`\sigma` is the standard deviation.
+    where :math:`\mu` is the mean, and :math:`\sigma` is the standard deviation.
 
 .. function:: regr_intercept(y, x) -> double
 


### PR DESCRIPTION
## Description
Noticed that the kurtosis entry in [Aggregate Functions](https://prestodb.io/docs/0.284/functions/aggregate.html) was incorrectly formatted. See screenshot of [Aggregate Functions](https://prestodb.io/docs/0.284/functions/aggregate.html). 
<img width="930" alt="Screenshot 2024-01-09 at 2 44 02 PM" src="https://github.com/prestodb/presto/assets/7013443/1dff647c-12bb-4fe3-9dc3-7f1feef0499f">

Edited [aggregate.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/functions/aggregate.rst) and built presto-docs locally until I found and corrected the error. See screenshot of local build:
<img width="909" alt="Screenshot 2024-01-09 at 2 45 44 PM" src="https://github.com/prestodb/presto/assets/7013443/70b76d94-7e0a-4366-8160-ed48236452de">

## Motivation and Context
Improves the documentation by correcting a typo in the formatting. No open issue. 

## Impact
None. 

## Test Plan
Local builds of presto-docs until I found how to fix the formatting error. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

