### PR TITLE
[native] Remove unused config node.memory_gb

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -598,7 +598,6 @@ NodeConfig::NodeConfig() {
           NONE_PROP(kNodeIp),
           NONE_PROP(kNodeInternalAddress),
           NONE_PROP(kNodeLocation),
-          NONE_PROP(kNodeMemoryGb),
       };
 }
 
@@ -636,26 +635,6 @@ std::string NodeConfig::nodeInternalAddress(
         "Node Internal Address or IP was not found in NodeConfigs. Default IP was not provided "
         "either.");
   }
-}
-
-uint64_t NodeConfig::nodeMemoryGb(
-    const std::function<uint64_t()>& defaultNodeMemoryGb) const {
-  auto resultOpt = optionalProperty<uint64_t>(kNodeMemoryGb);
-  uint64_t result = 0;
-  if (resultOpt.has_value()) {
-    result = resultOpt.value();
-  } else if (defaultNodeMemoryGb != nullptr) {
-    result = defaultNodeMemoryGb();
-  } else {
-    VELOX_FAIL(
-        "Node memory GB was not found in NodeConfigs. Default node memory was "
-        "not provided either.");
-  }
-  if (result == 0) {
-    LOG(ERROR) << "Bad node memory size.";
-    exit(1);
-  }
-  return result;
 }
 
 BaseVeloxQueryConfig::BaseVeloxQueryConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -653,7 +653,6 @@ class NodeConfig : public ConfigBase {
   static constexpr std::string_view kNodeInternalAddress{
       "node.internal-address"};
   static constexpr std::string_view kNodeLocation{"node.location"};
-  static constexpr std::string_view kNodeMemoryGb{"node.memory_gb"};
 
   NodeConfig();
 
@@ -669,9 +668,6 @@ class NodeConfig : public ConfigBase {
       const std::function<std::string()>& defaultIp = nullptr) const;
 
   std::string nodeLocation() const;
-
-  uint64_t nodeMemoryGb(
-      const std::function<uint64_t()>& defaultNodeMemoryGb = nullptr) const;
 };
 
 /// Used only in the single instance as the source of the initial properties for


### PR DESCRIPTION
The use of node.memory_gb was removed here https://github.com/prestodb/presto/pull/20351

Resolves https://github.com/prestodb/presto/issues/21293

```
== NO RELEASE NOTE ==
```

