### PR TITLE
Upgrade io.grpc to 1.60.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <air.test.parallel>methods</air.test.parallel>
         <air.test.thread-count>2</air.test.thread-count>
         <air.test.jvmsize>4g</air.test.jvmsize>
-        <grpc.version>1.35.0</grpc.version>
+        <grpc.version>1.60.1</grpc.version>
 
         <air.javadoc.lint>-missing</air.javadoc.lint>
     </properties>
@@ -529,7 +529,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.16.3</version>
+                <version>3.25.1</version>
             </dependency>
 
             <dependency>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -105,11 +105,31 @@
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>gax</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-context</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>gax-grpc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-context</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-protobuf</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-netty-shaded</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -161,6 +181,10 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-context</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -175,6 +199,14 @@
                 <exclusion>
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-protobuf-lite</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-context</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.perfmark</groupId>
+                    <artifactId>perfmark-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <grpc.version>1.41.0</grpc.version>
+        <grpc.version>1.60.1</grpc.version>
     </properties>
 
     <dependencies>
@@ -319,7 +319,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.21.7</version>
+            <version>3.25.1</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -375,6 +375,12 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>
@@ -384,7 +390,7 @@
         <dependency>
             <groupId>io.perfmark</groupId>
             <artifactId>perfmark-api</artifactId>
-            <version>0.23.0</version>
+            <version>0.26.0</version>
         </dependency>
 
         <dependency>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <grpc.version>1.41.0</grpc.version>
+        <grpc.version>1.60.1</grpc.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Description
outlines the direct vulnerabilities and vulnerabilities from dependencies for io.grpc and com.google.protobuf.

## Motivation and Context
The io.grpc package, specifically the grpc-protobuf artifact version 1.35.0, has several identified vulnerabilities:

Direct vulnerabilities:

[CVE-2023-32732](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32732)
[CVE-2023-32731](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32731)
[CVE-2023-1428](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1428)
Vulnerabilities from dependencies:

[CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
[CVE-2022-3510](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3510)
[CVE-2022-3509](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3509)
[CVE-2022-3171](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3171)
[CVE-2021-22570](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22570)
[CVE-2021-22569](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569)
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)
The com.google.protobuf package, specifically the protobuf-java artifact version 3.12.0, has several identified vulnerabilities:

Direct vulnerabilities:

[CVE-2022-3510](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3510)
[CVE-2022-3509](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3509)
[CVE-2022-3171](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3171)
[CVE-2021-22570](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22570)
[CVE-2021-22569](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569)
Vulnerabilities from dependencies:

[CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)
[CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)

## Impact
At this time, these vulnerabilities are not expected to have a major impact.

## Test Plan
Unit tests for presto-bigquery and other relevant components will be conducted to ensure system stability.

[INFO] 
[INFO] <<< spotbugs:3.1.10:check (default) < :spotbugs @ presto-bigquery <<<
[INFO] 
[INFO] 
[INFO] --- spotbugs:3.1.10:check (default) @ presto-bigquery ---
[INFO] 
[INFO] >>> pmd:3.11.0:check (default) > :pmd @ presto-bigquery >>>
[INFO] 
[INFO] --- pmd:3.11.0:pmd (pmd) @ presto-bigquery ---
[INFO] 
[INFO] <<< pmd:3.11.0:check (default) < :pmd @ presto-bigquery <<<
[INFO] 
[INFO] 
[INFO] --- pmd:3.11.0:check (default) @ presto-bigquery ---
[INFO] 
[INFO] --- install:2.5.2:install (default-install) @ presto-bigquery ---
[INFO] Installing /Users/akedia/dec2024/prestodb/presto-bigquery/target/presto-bigquery-0.286-SNAPSHOT.zip to /Users/akedia/.m2/prestodb_28/com/facebook/presto/presto-bigquery/0.286-SNAPSHOT/presto-bigquery-0.286-SNAPSHOT.zip
[INFO] Installing /Users/akedia/dec2024/prestodb/presto-bigquery/pom.xml to /Users/akedia/.m2/prestodb_28/com/facebook/presto/presto-bigquery/0.286-SNAPSHOT/presto-bigquery-0.286-SNAPSHOT.pom
[INFO] Installing /Users/akedia/dec2024/prestodb/presto-bigquery/target/presto-bigquery-0.286-SNAPSHOT.jar to /Users/akedia/.m2/prestodb_28/com/facebook/presto/presto-bigquery/0.286-SNAPSHOT/presto-bigquery-0.286-SNAPSHOT.jar
[INFO] Installing /Users/akedia/dec2024/prestodb/presto-bigquery/target/presto-bigquery-0.286-SNAPSHOT-tests.jar to /Users/akedia/.m2/prestodb_28/com/facebook/presto/presto-bigquery/0.286-SNAPSHOT/presto-bigquery-0.286-SNAPSHOT-tests.jar
[INFO] Installing /Users/akedia/dec2024/prestodb/presto-bigquery/target/presto-bigquery-0.286-SNAPSHOT-sources.jar to /Users/akedia/.m2/prestodb_28/com/facebook/presto/presto-bigquery/0.286-SNAPSHOT/presto-bigquery-0.286-SNAPSHOT-sources.jar
[INFO] Installing /Users/akedia/dec2024/prestodb/presto-bigquery/target/presto-bigquery-0.286-SNAPSHOT-test-sources.jar to /Users/akedia/.m2/prestodb_28/com/facebook/presto/presto-bigquery/0.286-SNAPSHOT/presto-bigquery-0.286-SNAPSHOT-test-sources.jar


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.


```
== RELEASE NOTES ==
Security Changes
* Upgrade io.grpc to 1.60.1
* Upgrade com.google.protobuf to 3.25.1