### PR TITLE
Fix memory accounting for Theta Sketch Aggregation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -105,6 +105,7 @@ import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyApproximat
 import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountIfGaussianAggregation;
 import com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchMergeAggregation;
 import com.facebook.presto.operator.aggregation.reservoirsample.ReservoirSampleFunction;
+import com.facebook.presto.operator.aggregation.sketch.theta.ThetaSketchAggregationFunction;
 import com.facebook.presto.operator.scalar.ArrayAllMatchFunction;
 import com.facebook.presto.operator.scalar.ArrayAnyMatchFunction;
 import com.facebook.presto.operator.scalar.ArrayCardinalityFunction;
@@ -370,7 +371,6 @@ import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySum
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumGaussianClippingAggregation.NOISY_SUM_GAUSSIAN_CLIPPING_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumGaussianClippingRandomSeedAggregation.NOISY_SUM_GAUSSIAN_CLIPPING_RANDOM_SEED_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.noisyaggregation.NoisySumGaussianRandomSeedAggregation.NOISY_SUM_GAUSSIAN_RANDOM_SEED_AGGREGATION;
-import static com.facebook.presto.operator.aggregation.sketch.theta.ThetaSketchAggregationFunction.THETA_SKETCH;
 import static com.facebook.presto.operator.scalar.ArrayConcatFunction.ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
 import static com.facebook.presto.operator.scalar.ArrayFlattenFunction.ARRAY_FLATTEN_FUNCTION;
@@ -951,7 +951,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalars(TDigestOperators.class)
                 .scalars(TDigestFunctions.class)
                 .functions(TDIGEST_AGG, TDIGEST_AGG_WITH_WEIGHT, TDIGEST_AGG_WITH_WEIGHT_AND_COMPRESSION)
-                .function(THETA_SKETCH)
+                .aggregate(ThetaSketchAggregationFunction.class)
                 .scalars(ThetaSketchFunctions.class)
                 .function(MergeTDigestFunction.MERGE)
                 .sqlInvokedScalar(MapNormalizeFunction.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/theta/ThetaSketchAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/theta/ThetaSketchAggregationFunction.java
@@ -13,127 +13,79 @@
  */
 package com.facebook.presto.operator.aggregation.sketch.theta;
 
-import com.facebook.airlift.log.Logger;
-import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.metadata.BoundVariables;
-import com.facebook.presto.metadata.FunctionAndTypeManager;
-import com.facebook.presto.metadata.SqlAggregationFunction;
-import com.facebook.presto.operator.aggregation.AccumulatorCompiler;
-import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
-import com.facebook.presto.operator.aggregation.state.StateCompiler;
-import com.facebook.presto.spi.function.aggregation.Accumulator;
-import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
-import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
-import com.google.common.collect.ImmutableList;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import org.apache.datasketches.theta.Union;
 
-import java.lang.invoke.MethodHandle;
-import java.util.List;
-
-import static com.facebook.presto.common.type.BigintType.BIGINT;
-import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
-import static com.facebook.presto.spi.function.Signature.typeVariable;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
-import static com.facebook.presto.util.Reflection.methodHandle;
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.facebook.presto.operator.aggregation.sketch.theta.ThetaSketchStateFactory.getEstimatedMemoryUsage;
 
+@AggregationFunction(value = "sketch_theta", isCalledOnNullInput = true)
+@Description("calculates a theta sketch of the selected input column")
 public class ThetaSketchAggregationFunction
-        extends SqlAggregationFunction
 {
-    private static final Logger log = Logger.get(ThetaSketchAggregationFunction.class);
     public static final String NAME = "sketch_theta";
-
-    public static final ThetaSketchAggregationFunction THETA_SKETCH = new ThetaSketchAggregationFunction();
-
-    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(ThetaSketchAggregationFunction.class, "output", ThetaSketchAggregationState.class, BlockBuilder.class);
-    private static final MethodHandle INPUT_FUNCTION = methodHandle(ThetaSketchAggregationFunction.class, "input", Type.class, ThetaSketchAggregationState.class, Block.class, int.class);
-    private static final MethodHandle MERGE_FUNCTION = methodHandle(ThetaSketchAggregationFunction.class, "merge", ThetaSketchAggregationState.class, ThetaSketchAggregationState.class);
-
-    public ThetaSketchAggregationFunction()
+    private ThetaSketchAggregationFunction()
     {
-        super(NAME,
-                ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
-                parseTypeSignature(StandardTypes.VARBINARY),
-                ImmutableList.of(parseTypeSignature("T")));
     }
 
-    @Override
-    public String getDescription()
-    {
-        return "calculates a theta sketch of the selected input column";
-    }
-
-    @Override
-    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
-    {
-        DynamicClassLoader classLoader = new DynamicClassLoader(ThetaSketchAggregationFunction.class.getClassLoader());
-        Type type = boundVariables.getTypeVariable("T");
-        List<Type> inputTypes = ImmutableList.of(type);
-
-        AggregationMetadata metadata = new AggregationMetadata(
-                generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
-                createInputParameterMetadata(type),
-                INPUT_FUNCTION.bindTo(type),
-                MERGE_FUNCTION,
-                OUTPUT_FUNCTION,
-                ImmutableList.of(new AggregationMetadata.AccumulatorStateDescriptor(
-                        ThetaSketchAggregationState.class,
-                        StateCompiler.generateStateSerializer(ThetaSketchAggregationState.class, classLoader),
-                        StateCompiler.generateStateFactory(ThetaSketchAggregationState.class, classLoader))),
-                VARBINARY);
-
-        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
-                Accumulator.class,
-                metadata,
-                classLoader);
-        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
-                GroupedAccumulator.class,
-                metadata,
-                classLoader);
-        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(BIGINT), VARBINARY,
-                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
-    }
-
-    private static List<AggregationMetadata.ParameterMetadata> createInputParameterMetadata(Type type)
-    {
-        return ImmutableList.of(new AggregationMetadata.ParameterMetadata(STATE), new AggregationMetadata.ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, type), new AggregationMetadata.ParameterMetadata(BLOCK_INDEX));
-    }
-
-    public static void input(Type type, ThetaSketchAggregationState state, Block block, int position)
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(
+            @TypeParameter("T") Type type,
+            @AggregationState ThetaSketchAggregationState state,
+            @SqlType("T") @BlockPosition Block block,
+            @BlockIndex int position)
     {
         if (block.isNull(position)) {
             return;
         }
+        Union sketch = state.getSketch();
+        state.addMemoryUsage(-getEstimatedMemoryUsage(sketch));
         if (type.getJavaType().equals(Long.class) || type.getJavaType() == long.class) {
-            state.getSketch().update(type.getLong(block, position));
+            sketch.update(type.getLong(block, position));
         }
         else if (type.getJavaType().equals(Double.class) || type.getJavaType() == double.class) {
-            state.getSketch().update(type.getDouble(block, position));
+            sketch.update(type.getDouble(block, position));
         }
         else if (type.getJavaType().equals(String.class) || type.getJavaType().equals(Slice.class)) {
-            state.getSketch().update(type.getSlice(block, position).getBytes());
+            sketch.update(type.getSlice(block, position).getBytes());
         }
         else {
             throw new RuntimeException("unsupported sketch column type: " + type + " (java type: " + type.getJavaType() + ")");
         }
+        state.addMemoryUsage(getEstimatedMemoryUsage(sketch));
     }
 
-    public static void merge(ThetaSketchAggregationState state, ThetaSketchAggregationState otherState)
+    @CombineFunction
+    public static void merge(
+            @AggregationState ThetaSketchAggregationState state,
+            @AggregationState ThetaSketchAggregationState otherState)
     {
-        state.getSketch().union(otherState.getSketch().getResult());
+        Union sketch = state.getSketch();
+        state.addMemoryUsage(-getEstimatedMemoryUsage(sketch));
+        sketch.union(otherState.getSketch().getResult());
+        state.addMemoryUsage(getEstimatedMemoryUsage(sketch));
     }
 
-    public static void output(ThetaSketchAggregationState state, BlockBuilder out)
+    @OutputFunction(StandardTypes.VARBINARY)
+    public static void output(
+            @AggregationState ThetaSketchAggregationState state,
+            BlockBuilder out)
     {
         Slice output = Slices.wrappedBuffer(state.getSketch().getResult().toByteArray());
         VARBINARY.writeSlice(out, output);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/theta/ThetaSketchAggregationState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/theta/ThetaSketchAggregationState.java
@@ -13,13 +13,17 @@
  */
 package com.facebook.presto.operator.aggregation.sketch.theta;
 
+import com.facebook.presto.spi.function.AccumulatorState;
 import com.facebook.presto.spi.function.AccumulatorStateMetadata;
 import org.apache.datasketches.theta.Union;
 
 @AccumulatorStateMetadata(stateSerializerClass = ThetaSketchStateSerializer.class, stateFactoryClass = ThetaSketchStateFactory.class)
 public interface ThetaSketchAggregationState
+        extends AccumulatorState
 {
     Union getSketch();
 
     void setSketch(Union value);
+
+    void addMemoryUsage(long memoryBytes);
 }


### PR DESCRIPTION

## Description

Fixed memory accounting for grouped aggregation state, plus refactored the function to use the annotation framework.

## Motivation and Context

Group-by queries would likely have incorrect memory accounting metrics. Could cause crashes or failures.

## Impact

N/A

## Test Plan

Existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

