### PR TITLE
Add presto server version to SessionConfigurationContext

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.node.NodeInfo;
 import com.facebook.presto.Session;
+import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.resourceGroups.SessionPropertyConfigurationManagerContext;
 import com.facebook.presto.spi.session.SessionConfigurationContext;
@@ -39,6 +40,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public class SessionPropertyDefaults
 {
@@ -49,11 +51,13 @@ public class SessionPropertyDefaults
     private final SessionPropertyConfigurationManagerContext configurationManagerContext;
     private final Map<String, SessionPropertyConfigurationManagerFactory> factories = new ConcurrentHashMap<>();
     private final AtomicReference<SessionPropertyConfigurationManager> delegate = new AtomicReference<>();
+    private final String prestoServerVersion;
 
     @Inject
-    public SessionPropertyDefaults(NodeInfo nodeInfo)
+    public SessionPropertyDefaults(NodeInfo nodeInfo, NodeVersion nodeVersion)
     {
         this.configurationManagerContext = new SessionPropertyConfigurationManagerContextInstance(nodeInfo.getEnvironment());
+        this.prestoServerVersion = requireNonNull(nodeVersion.getVersion(), "prestoServerVersion is null");
     }
 
     public void addConfigurationManagerFactory(SessionPropertyConfigurationManagerFactory sessionConfigFactory)
@@ -118,7 +122,8 @@ public class SessionPropertyDefaults
                 session.getClientTags(),
                 queryType,
                 resourceGroupId,
-                session.getClientInfo());
+                session.getClientInfo(),
+                prestoServerVersion);
 
         SystemSessionPropertyConfiguration systemPropertyConfiguration = configurationManager.getSystemSessionProperties(context);
         Map<String, Map<String, String>> catalogPropertyOverrides = configurationManager.getCatalogSessionProperties(context);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -18,6 +18,7 @@ import com.facebook.presto.GroupByHashPageIndexerFactory;
 import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.analyzer.PreparedQuery;
 import com.facebook.presto.common.block.BlockEncodingManager;
@@ -450,6 +451,7 @@ public class LocalQueryRunner
         this.joinFilterFunctionCompiler = new JoinFilterFunctionCompiler(metadata);
 
         NodeInfo nodeInfo = new NodeInfo("test");
+        NodeVersion nodeVersion = new NodeVersion("testversion");
         this.connectorManager = new ConnectorManager(
                 metadata,
                 catalogManager,
@@ -501,7 +503,7 @@ public class LocalQueryRunner
                 blockEncodingManager,
                 new TestingTempStorageManager(),
                 new QueryPrerequisitesManager(),
-                new SessionPropertyDefaults(nodeInfo),
+                new SessionPropertyDefaults(nodeInfo, nodeVersion),
                 new ThrowingNodeTtlFetcherManager(),
                 new ThrowingClusterTtlProviderManager(),
                 historyBasedPlanStatisticsManager,

--- a/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
@@ -15,6 +15,7 @@ package com.facebook.presto.server;
 
 import com.facebook.airlift.node.NodeInfo;
 import com.facebook.presto.Session;
+import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
@@ -36,11 +37,12 @@ public class TestSessionPropertyDefaults
 {
     private static final ResourceGroupId TEST_RESOURCE_GROUP_ID = new ResourceGroupId("test");
     private static final NodeInfo TEST_NODE_INFO = new NodeInfo("test");
+    private static final NodeVersion TEST_NODE_VERSION = new NodeVersion("testversion");
 
     @Test
     public void testApplyDefaultProperties()
     {
-        SessionPropertyDefaults sessionPropertyDefaults = new SessionPropertyDefaults(TEST_NODE_INFO);
+        SessionPropertyDefaults sessionPropertyDefaults = new SessionPropertyDefaults(TEST_NODE_INFO, TEST_NODE_VERSION);
         SessionPropertyConfigurationManagerFactory factory = new TestingSessionPropertyConfigurationManagerFactory(
                 new SystemSessionPropertyConfiguration(
                     ImmutableMap.<String, String>builder()

--- a/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
@@ -44,7 +44,8 @@ public class TestFileSessionPropertyManager
             ImmutableSet.of("tag1", "tag2"),
             Optional.of(QueryType.DATA_DEFINITION.toString()),
             Optional.of(new ResourceGroupId(ImmutableList.of("global", "pipeline", "user_foo", "bar"))),
-            Optional.of("bar"));
+            Optional.of("bar"),
+            "testversion");
 
     @Test
     public void testResourceGroupMatch()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionConfigurationContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionConfigurationContext.java
@@ -30,6 +30,7 @@ public final class SessionConfigurationContext
     private final Optional<String> queryType;
     private final Optional<ResourceGroupId> resourceGroupId;
     private final Optional<String> clientInfo;
+    private final String prestoServerVersion;
 
     public SessionConfigurationContext(
             String user,
@@ -37,7 +38,8 @@ public final class SessionConfigurationContext
             Set<String> clientTags,
             Optional<String> queryType,
             Optional<ResourceGroupId> resourceGroupId,
-            Optional<String> clientInfo)
+            Optional<String> clientInfo,
+            String prestoServerVersion)
     {
         this.user = requireNonNull(user, "user is null");
         this.source = requireNonNull(source, "source is null");
@@ -45,6 +47,7 @@ public final class SessionConfigurationContext
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.resourceGroupId = requireNonNull(resourceGroupId, "resourceGroupId");
         this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
+        this.prestoServerVersion = requireNonNull(prestoServerVersion, "prestoServerVersion is null");
     }
 
     public String getUser()
@@ -75,5 +78,10 @@ public final class SessionConfigurationContext
     public Optional<String> getClientInfo()
     {
         return clientInfo;
+    }
+
+    public String getPrestoServerVersion()
+    {
+        return prestoServerVersion;
     }
 }


### PR DESCRIPTION
## Description
This PR adds presto server version to the `SessionConfigurationContext`.

## Motivation and Context
Currently we apply session properties via SessionPropertyConfigurationManager. But we want to apply these session properties based on the server version. To do this we should have the presto server version in the `SessionConfigurationContext` so that the implementers of `SessionPropertyConfigurationManager.getCatalogSessionProperties() `can make a decision based on the presto version
We want to handle the scenario where we have a single file that specifies all the session properties to be applied but have multiple server deployments with different presto versions . So we want to be able to specify the minimum version from which the session property should be added.

## Impact
None

## Release Notes

```
== NO RELEASE NOTE ==
```

