### PR TITLE
[native]Add to handle empty data case in ShuffleReader::next

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -128,8 +128,6 @@ class LocalPersistentShuffleReader : public ShuffleReader {
       std::vector<std::string> partitionIds_,
       velox::memory::MemoryPool* FOLLY_NONNULL pool);
 
-  bool hasNext() override;
-
   velox::BufferPtr next() override;
 
   void noMoreData(bool success) override;

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -37,10 +37,13 @@ class ShuffleReader {
  public:
   virtual ~ShuffleReader() = default;
 
-  /// Check by the reader to see if more blocks are available
-  virtual bool hasNext() = 0;
+  /// Deprecate, do not use!
+  virtual bool hasNext() {
+    return true;
+  }
 
-  /// Read the next block of data.
+  /// Reads the next block of data. The function returns null if it has read all
+  /// the data. The function throws if run into any error.
   virtual velox::BufferPtr next() = 0;
 
   /// Tell the shuffle system the reader is done. May be called with 'success'

--- a/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
@@ -40,15 +40,12 @@ UnsafeRowExchangeSource::request(
       return folly::makeFuture(Response{0, true});
     }
 
-    bool hasNext;
-    CALL_SHUFFLE(hasNext = shuffle_->hasNext(), "hasNext");
-
-    if (!hasNext) {
+    velox::BufferPtr buffer;
+    CALL_SHUFFLE(buffer = shuffle_->next(), "next");
+    if (buffer == nullptr) {
       atEnd_ = true;
       queue_->enqueueLocked(nullptr, promises);
     } else {
-      velox::BufferPtr buffer;
-      CALL_SHUFFLE(buffer = shuffle_->next(), "next");
       totalBytes = buffer->size();
 
       ++numBatches_;


### PR DESCRIPTION
Add to handle empty data case in ShuffleReader::next and update UnsafeRowExchangeSource
to remove the use of hasNext(). The followup is to deprecate hasNext.