### PR TITLE
Pass cat token for view definer mode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -109,7 +109,7 @@ public final class MaterializedViewUtils
     public static Identity getOwnerIdentity(Optional<String> owner, Session session)
     {
         if (owner.isPresent() && !owner.get().equals(session.getIdentity().getUser())) {
-            return new Identity(owner.get(), Optional.empty());
+            return new Identity(owner.get(), Optional.empty(), session.getIdentity().getExtraCredentials());
         }
         return session.getIdentity();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2803,7 +2803,7 @@ class StatementAnalyzer
                 Identity identity;
                 AccessControl viewAccessControl;
                 if (owner.isPresent() && !owner.get().equals(session.getIdentity().getUser())) {
-                    identity = new Identity(owner.get(), Optional.empty());
+                    identity = new Identity(owner.get(), Optional.empty(), session.getIdentity().getExtraCredentials());
                     viewAccessControl = new ViewAccessControl(accessControl);
                 }
                 else {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
@@ -56,6 +56,11 @@ public class Identity
         this(user, principal, emptyMap(), emptyMap(), emptyMap(), Optional.empty(), Optional.empty());
     }
 
+    public Identity(String user, Optional<Principal> principal, Map<String, String> extraCredentials)
+    {
+        this(user, principal, emptyMap(), extraCredentials, emptyMap(), Optional.empty(), Optional.empty());
+    }
+
     public Identity(
             String user,
             Optional<Principal> principal,


### PR DESCRIPTION
Currently, for view definer mode in Presto, extra credentials such as CAT tokens are not passed. This change ensures that all extra credentials are passed in the view definer mode.



```
== RELEASE NOTES ==

General Changes
* Pass extra credentials such as CAT tokens for definer mode in views.

```

