### PR TITLE
Pass cat token for view definer mode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -109,7 +109,7 @@ public final class MaterializedViewUtils
     public static Identity getOwnerIdentity(Optional<String> owner, Session session)
     {
         if (owner.isPresent() && !owner.get().equals(session.getIdentity().getUser())) {
-            return new Identity(owner.get(), Optional.empty());
+            return new Identity(owner.get(), Optional.empty(), session.getIdentity().getExtraCredentials());
         }
         return session.getIdentity();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2803,7 +2803,7 @@ class StatementAnalyzer
                 Identity identity;
                 AccessControl viewAccessControl;
                 if (owner.isPresent() && !owner.get().equals(session.getIdentity().getUser())) {
-                    identity = new Identity(owner.get(), Optional.empty());
+                    identity = new Identity(owner.get(), Optional.empty(), session.getIdentity().getExtraCredentials());
                     viewAccessControl = new ViewAccessControl(accessControl);
                 }
                 else {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/Identity.java
@@ -56,6 +56,11 @@ public class Identity
         this(user, principal, emptyMap(), emptyMap(), emptyMap(), Optional.empty(), Optional.empty());
     }
 
+    public Identity(String user, Optional<Principal> principal, Map<String, String> extraCredentials)
+    {
+        this(user, principal, emptyMap(), extraCredentials, emptyMap(), Optional.empty(), Optional.empty());
+    }
+
     public Identity(
             String user,
             Optional<Principal> principal,


### PR DESCRIPTION

## Description
Currently, for view definer mode in Presto, extra credentials such as CAT tokens are not passed. This change ensures that all extra credentials are passed in the view definer mode.

## Motivation and Context

## Impact
User extra credentials such as CAT tokens would be leveraged for presto views definer mode.

## Test Plan
Validated by deploying changes to a cluster. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.



```
== RELEASE NOTES ==

General Changes
* Pass extra credentials such as CAT tokens for definer mode in views.

```
