### PR TITLE
[native] Re-use sslcontext in secure http connection.

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -81,14 +81,12 @@ Announcer::Announcer(
     const std::string& nodeLocation,
     const std::vector<std::string>& connectorIds,
     const uint64_t maxFrequencyMs,
-    const std::string& clientCertAndKeyPath,
-    const std::string& ciphers)
+    folly::SSLContextPtr sslContext)
     : PeriodicServiceInventoryManager(
           address,
           port,
           coordinatorDiscoverer,
-          clientCertAndKeyPath,
-          ciphers,
+          std::move(sslContext),
           "Announcement",
           maxFrequencyMs),
       announcementBody_(announcementBody(

--- a/presto-native-execution/presto_cpp/main/Announcer.h
+++ b/presto-native-execution/presto_cpp/main/Announcer.h
@@ -33,8 +33,7 @@ class Announcer : public PeriodicServiceInventoryManager {
       const std::string& nodeLocation,
       const std::vector<std::string>& connectorIds,
       const uint64_t maxFrequencyMs_,
-      const std::string& clientCertAndKeyPath = "",
-      const std::string& ciphers = "");
+      folly::SSLContextPtr sslContext);
 
   ~Announcer() = default;
 

--- a/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.cpp
@@ -19,16 +19,14 @@ PeriodicHeartbeatManager::PeriodicHeartbeatManager(
     const std::string& address,
     int port,
     const std::shared_ptr<CoordinatorDiscoverer>& coordinatorDiscoverer,
-    const std::string& clientCertAndKeyPath,
-    const std::string& ciphers,
+    folly::SSLContextPtr sslContext,
     std::function<protocol::NodeStatus()> nodeStatusFetcher,
     uint64_t frequencyMs)
     : PeriodicServiceInventoryManager(
           address,
           port,
           coordinatorDiscoverer,
-          clientCertAndKeyPath,
-          ciphers,
+          std::move(sslContext),
           "Heartbeat",
           frequencyMs),
       nodeStatusFetcher_(std::move(nodeStatusFetcher)) {}

--- a/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.h
@@ -24,8 +24,7 @@ class PeriodicHeartbeatManager : public PeriodicServiceInventoryManager {
       const std::string& address,
       int port,
       const std::shared_ptr<CoordinatorDiscoverer>& coordinatorDiscoverer,
-      const std::string& clientCertAndKeyPath,
-      const std::string& ciphers,
+      folly::SSLContextPtr sslContext,
       std::function<protocol::NodeStatus()> nodeStatusFetcher,
       uint64_t frequencyMs);
 

--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
@@ -20,15 +20,13 @@ PeriodicServiceInventoryManager::PeriodicServiceInventoryManager(
     std::string address,
     int port,
     std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer,
-    std::string clientCertAndKeyPath,
-    std::string ciphers,
+    folly::SSLContextPtr sslContext,
     std::string id,
     uint64_t frequencyMs)
     : address_(std::move(address)),
       port_(port),
       coordinatorDiscoverer_(std::move(coordinatorDiscoverer)),
-      clientCertAndKeyPath_(std::move(clientCertAndKeyPath)),
-      ciphers_(std::move(ciphers)),
+      sslContext_(std::move(sslContext)),
       id_(std::move(id)),
       frequencyMs_(frequencyMs),
       pool_(velox::memory::deprecatedAddDefaultLeafMemoryPool(id_)),
@@ -72,8 +70,7 @@ void PeriodicServiceInventoryManager::sendRequest() {
           std::chrono::milliseconds(10'000),
           std::chrono::milliseconds(0),
           pool_,
-          clientCertAndKeyPath_,
-          ciphers_);
+          sslContext_);
     }
   } catch (const std::exception& ex) {
     LOG(WARNING) << "Error occurred during updating service address: "

--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
@@ -25,8 +25,7 @@ class PeriodicServiceInventoryManager {
       std::string address,
       int port,
       std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer,
-      std::string clientCertAndKeyPath,
-      std::string ciphers,
+      folly::SSLContextPtr sslContext,
       std::string id,
       uint64_t frequencyMs);
 
@@ -58,8 +57,7 @@ class PeriodicServiceInventoryManager {
   const std::string address_;
   const int port_;
   const std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer_;
-  const std::string clientCertAndKeyPath_;
-  const std::string ciphers_;
+  const folly::SSLContextPtr sslContext_;
   const std::string id_;
   const uint64_t frequencyMs_;
   const std::shared_ptr<velox::memory::MemoryPool> pool_;

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -108,8 +108,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
       folly::CPUThreadPoolExecutor* driverExecutor,
       folly::EventBase* ioEventBase,
       proxygen::SessionPool* sessionPool,
-      const std::string& clientCertAndKeyPath_ = "",
-      const std::string& ciphers_ = "");
+      folly::SSLContextPtr sslContext);
 
   /// Returns 'true' is there is no request in progress, this source is not at
   /// end and most recent request hasn't failed. Transitions into
@@ -141,7 +140,8 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
       velox::memory::MemoryPool* memoryPool,
       folly::CPUThreadPoolExecutor* cpuExecutor,
       folly::IOThreadPoolExecutor* ioExecutor,
-      ConnectionPools* connectionPools);
+      ConnectionPools* connectionPools,
+      folly::SSLContextPtr sslContext);
 
   /// Completes the future returned by 'request()' if it hasn't completed
   /// already.
@@ -247,8 +247,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   const std::string basePath_;
   const std::string host_;
   const uint16_t port_;
-  const std::string clientCertAndKeyPath_;
-  const std::string ciphers_;
+  const folly::SSLContextPtr sslContext_;
   const bool immediateBufferTransfer_;
 
   folly::CPUThreadPoolExecutor* const driverExecutor_;

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -16,6 +16,7 @@
 #include <folly/SocketAddress.h>
 #include <folly/Synchronized.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/io/async/SSLContext.h>
 #include <proxygen/httpserver/RequestHandlerFactory.h>
 #include <velox/exec/Task.h>
 #include <velox/expression/Expr.h>
@@ -219,6 +220,7 @@ class PrestoServer {
   std::string nodeId_;
   std::string address_;
   std::string nodeLocation_;
+  folly::SSLContextPtr sslContext_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -188,10 +188,15 @@ class SystemConfig : public ConfigBase {
       "http-server.https.port"};
   static constexpr std::string_view kHttpServerHttpsEnabled{
       "http-server.https.enabled"};
+  // List of comma separated ciphers the client can use.
+  ///
+  /// NOTE: the client needs to have at least one cipher shared with server
+  // to communicate.
   static constexpr std::string_view kHttpsSupportedCiphers{
       "https-supported-ciphers"};
   static constexpr std::string_view kHttpsCertPath{"https-cert-path"};
   static constexpr std::string_view kHttpsKeyPath{"https-key-path"};
+  // Path to a .PEM file with certificate and key concatenated together.
   static constexpr std::string_view kHttpsClientCertAndKeyPath{
       "https-client-cert-key-path"};
 

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -120,8 +120,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
       std::chrono::milliseconds transactionTimeout,
       std::chrono::milliseconds connectTimeout,
       std::shared_ptr<velox::memory::MemoryPool> pool,
-      const std::string& clientCertAndKeyPath = "",
-      const std::string& ciphers = "",
+      folly::SSLContextPtr sslContext,
       std::function<void(int)>&& reportOnBodyStatsFunc = nullptr);
 
   ~HttpClient();
@@ -142,13 +141,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
   const proxygen::WheelTimerInstance transactionTimer_;
   const std::chrono::milliseconds connectTimeout_;
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
-  // clientCertAndKeyPath_ Points to a file (usually with pem extension) which
-  // contains certificate and key concatenated together
-  const std::string clientCertAndKeyPath_;
-  // List of ciphers (comma separated) client can use. Note that, to communicate
-  // successfully with server, client needs to have at least one cipher common
-  // with server's cipher list
-  const std::string ciphers_;
+  const folly::SSLContextPtr sslContext_;
   const std::function<void(int)> reportOnBodyStatsFunc_;
   const uint64_t maxResponseAllocBytes_;
   proxygen::SessionPool* sessionPool_;

--- a/presto-native-execution/presto_cpp/main/tests/PrestoQueryRunner.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoQueryRunner.cpp
@@ -469,7 +469,8 @@ std::vector<RowVectorPtr> PrestoQueryRunner::execute(const std::string& sql) {
       coordinatorUri_,
       std::chrono::milliseconds(10'000),
       std::chrono::milliseconds(20'000),
-      pool_);
+      pool_,
+      nullptr);
 
   auto response = ServerResponse(startQuery(sql, *client));
   response.throwIfFailed();

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -169,7 +169,8 @@ class TaskManagerTest : public testing::Test {
               pool,
               cpuExecutor.get(),
               ioExecutor.get(),
-              connectionPools.get());
+              connectionPools.get(),
+              nullptr);
         });
     if (!isRegisteredVectorSerde()) {
       serializer::presto::PrestoVectorSerde::registerVectorSerde();


### PR DESCRIPTION
 While creating a https connection, a file containing certificate and key is passed to Presto server (similar to config properties). Current code always read client [certificate and key](https://github.com/prestodb/presto/blob/master/presto-native-execution/presto_cpp/main/http/HttpClient.cpp#L327-L331) from file. This is a very hot path as every http request goes through this. This is simply not required as client certificate and key files are immutable (like config properties) and should be just read at once during startup. Here we cache the SSL context and pass through exchange and announcement for http requests, thus re-using the context instead of creating it from disk in (skipping two synchronous I/O) in every request. This is simply more performant. Apart from these, we also observed crashes while reading this file due to disk corruption or any unusual activity on disk. Bypassing the IO in the hot path completely eliminate such source of crash.