### PR TITLE
[native] Remove logging of "Calling getResult() on a aborted task".

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -810,7 +810,6 @@ folly::Future<std::unique_ptr<Result>> TaskManager::getResults(
 
     // If the task is aborted or failed, then return an error.
     if (prestoTask->info.taskStatus.state == protocol::TaskState::ABORTED) {
-      LOG(WARNING) << "Calling getResult() on a aborted task: " << taskId;
       promiseHolder->promise.setValue(createEmptyResult(token));
       return std::move(future).via(httpSrvCpuExecutor_);
     }


### PR DESCRIPTION
Remove logging of "Calling getResult() on a aborted task".
Over the years we haven't really used this message at all.

Example of one log file almost entirely comprised of these messages:
```
[15:00:11 root@tsp_pnb/presto/pnb3_verifier_t10_4.worker/0 ~]$ cat ../logs/stderr.20240111_015033.78 | grep "Calling getResult() on a aborted task" >> /tmp/aaa
[15:00:46 root@tsp_pnb/presto/pnb3_verifier_t10_4.worker/0 ~]$ wc -l ../logs/stderr.20240111_015033.78
835303 ../logs/stderr.20240111_015033.78
[15:01:14 root@tsp_pnb/presto/pnb3_verifier_t10_4.worker/0 ~]$ wc -l /tmp/aaa
835276 /tmp/aaa
```



```
== NO RELEASE NOTE ==
```

