### PR TITLE
Remove duplicate code for getting Iceberg table of various catalogTypes

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergFilterPushdown.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergFilterPushdown.java
@@ -16,14 +16,10 @@ package com.facebook.presto.iceberg.optimizer;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.TypeManager;
-import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HivePartition;
-import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.rule.BaseSubfieldExtractionRewriter;
 import com.facebook.presto.iceberg.IcebergAbstractMetadata;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
-import com.facebook.presto.iceberg.IcebergHiveMetadata;
-import com.facebook.presto.iceberg.IcebergResourceFactory;
 import com.facebook.presto.iceberg.IcebergTableHandle;
 import com.facebook.presto.iceberg.IcebergTableLayoutHandle;
 import com.facebook.presto.iceberg.IcebergTransactionManager;
@@ -56,8 +52,7 @@ import java.util.Set;
 import static com.facebook.presto.hive.rule.FilterPushdownUtils.getDomainPredicate;
 import static com.facebook.presto.hive.rule.FilterPushdownUtils.getPredicateColumnNames;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
-import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
-import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
+import static com.facebook.presto.iceberg.IcebergUtil.getIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitionKeyColumnHandles;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitions;
 import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
@@ -74,8 +69,6 @@ public class IcebergFilterPushdown
     private final RowExpressionService rowExpressionService;
     private final StandardFunctionResolution functionResolution;
     private final FunctionMetadataManager functionMetadataManager;
-    private final IcebergResourceFactory resourceFactory;
-    private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
     private final IcebergTransactionManager icebergTransactionManager;
 
@@ -84,16 +77,12 @@ public class IcebergFilterPushdown
             StandardFunctionResolution functionResolution,
             FunctionMetadataManager functionMetadataManager,
             IcebergTransactionManager transactionManager,
-            IcebergResourceFactory resourceFactory,
-            HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager)
     {
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         this.icebergTransactionManager = requireNonNull(transactionManager, "transactionManager is null");
-        this.resourceFactory = requireNonNull(resourceFactory, "resourceFactory is null");
-        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
@@ -110,16 +99,12 @@ public class IcebergFilterPushdown
                 functionResolution,
                 functionMetadataManager,
                 icebergTransactionManager,
-                resourceFactory,
-                hdfsEnvironment,
                 typeManager), maxSubplan);
     }
 
     public static class SubfieldExtractionRewriter
             extends BaseSubfieldExtractionRewriter
     {
-        private final IcebergResourceFactory resourceFactory;
-        private final HdfsEnvironment hdfsEnvironment;
         private final TypeManager typeManager;
 
         public SubfieldExtractionRewriter(
@@ -129,14 +114,10 @@ public class IcebergFilterPushdown
                 StandardFunctionResolution functionResolution,
                 FunctionMetadataManager functionMetadataManager,
                 IcebergTransactionManager icebergTransactionManager,
-                IcebergResourceFactory resourceFactory,
-                HdfsEnvironment hdfsEnvironment,
                 TypeManager typeManager)
         {
             super(session, idAllocator, rowExpressionService, functionResolution, functionMetadataManager, tableHandle -> getConnectorMetadata(icebergTransactionManager, tableHandle));
 
-            this.resourceFactory = requireNonNull(resourceFactory, "resourceFactory is null");
-            this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
             this.typeManager = requireNonNull(typeManager, "typeManager is null");
         }
 
@@ -155,15 +136,7 @@ public class IcebergFilterPushdown
             checkArgument(metadata instanceof IcebergAbstractMetadata, "metadata must be IcebergAbstractMetadata");
             checkArgument(tableHandle instanceof IcebergTableHandle, "tableHandle must be IcebergTableHandle");
 
-            Table icebergTable;
-            if (metadata instanceof IcebergHiveMetadata) {
-                ExtendedHiveMetastore metastore = ((IcebergHiveMetadata) metadata).getMetastore();
-                icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, session, ((IcebergTableHandle) tableHandle).getSchemaTableName());
-            }
-            else {
-                icebergTable = getNativeIcebergTable(resourceFactory, session, ((IcebergTableHandle) tableHandle).getSchemaTableName());
-            }
-
+            Table icebergTable = getIcebergTable(metadata, session, ((IcebergTableHandle) tableHandle).getSchemaTableName());
             TupleDomain<ColumnHandle> unenforcedConstraint = TupleDomain.withColumnDomains(Maps.filterKeys(constraint.getSummary().getDomains().get(), not(Predicates.in(getPartitionKeyColumnHandles(icebergTable, typeManager)))));
 
             TupleDomain<Subfield> domainPredicate = getDomainPredicate(decomposedFilter, unenforcedConstraint);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
@@ -14,8 +14,6 @@
 package com.facebook.presto.iceberg.optimizer;
 
 import com.facebook.presto.common.type.TypeManager;
-import com.facebook.presto.hive.HdfsEnvironment;
-import com.facebook.presto.iceberg.IcebergResourceFactory;
 import com.facebook.presto.iceberg.IcebergTransactionManager;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
@@ -40,20 +38,16 @@ public class IcebergPlanOptimizerProvider
             RowExpressionService rowExpressionService,
             StandardFunctionResolution functionResolution,
             FunctionMetadataManager functionMetadataManager,
-            IcebergResourceFactory resourceFactory,
-            HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager)
     {
         requireNonNull(transactionManager, "transactionManager is null");
         requireNonNull(rowExpressionService, "rowExpressionService is null");
         requireNonNull(functionResolution, "functionResolution is null");
         requireNonNull(functionMetadataManager, "functionMetadataManager is null");
-        requireNonNull(resourceFactory, "resourceFactory is null");
-        requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         requireNonNull(typeManager, "typeManager is null");
         this.planOptimizers = ImmutableSet.of(
                 new IcebergPlanOptimizer(functionResolution, rowExpressionService, transactionManager),
-                new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, resourceFactory, hdfsEnvironment, typeManager),
+                new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, typeManager),
                 new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager));
     }
 


### PR DESCRIPTION
## Description

We can use utility method IcebergUtil.getIcebergTable to remove duplicate code for getting Iceberg table of different catalogTypes in `IcebergFilterPushdown`.

## Test Plan

 - Make sure the fix do not effect existing test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

