### PR TITLE
Clean up tables registered in test cases to avoid impacting others

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -738,6 +738,12 @@ public class IcebergDistributedSmokeTestBase
         assertUpdate(session, "DROP TABLE " + table);
         assertFalse(getQueryRunner().tableExists(session, table));
     }
+
+    protected void unregisterTable(String schemaName, String newTableName)
+    {
+        assertUpdate("CALL system.unregister_table('" + schemaName + "', '" + newTableName + "')");
+    }
+
     @Test
     public void testCreateNestedPartitionedTable()
     {
@@ -1155,6 +1161,7 @@ public class IcebergDistributedSmokeTestBase
         assertUpdate("CALL system.register_table('" + schemaName + "', '" + newTableName + "', '" + metadataLocation + "')");
         assertQuery("SELECT * FROM " + newTableName, "VALUES (1, 1)");
 
+        unregisterTable(schemaName, newTableName);
         dropTable(getSession(), tableName);
     }
 
@@ -1175,6 +1182,7 @@ public class IcebergDistributedSmokeTestBase
 
         assertQuery("SELECT * FROM " + tableName, "VALUES (1, 1)");
 
+        unregisterTable(schemaName, newTableName);
         dropTable(getSession(), tableName);
     }
 
@@ -1194,6 +1202,7 @@ public class IcebergDistributedSmokeTestBase
         assertUpdate("CALL system.register_table('" + schemaName + "', '" + newTableName + "', '" + metadataLocation + "', '" + metadataFileName + "')");
         assertQuery("SELECT * FROM " + newTableName, "VALUES (1, 1)");
 
+        unregisterTable(schemaName, newTableName);
         dropTable(getSession(), tableName);
     }
 


### PR DESCRIPTION
## Description

In test cases about table registering, we used an existing table `table1`'s metadata file to register another table `table1_new` by calling procedure `system.register_table(...)`. Then, after we dropped table `table1` at bottom of the test, the data files and metadata files of `table1` would all be removed. That would make table `table1_new` corrupt: it still lives in the default schema, but it's metadata file is removed. 

That would impact other test case like `testSelectInformationSchemaColumns()`, it would query `information_schema.columns` about the default schema which currently including table `table1_new `, that would lead to wasting several minutes to retry loading table's metadata file(in hive catalog).

So we should clean up the registered table as well at the bottom of these test cases.

## Impact

Saving several minutes for test case `testSelectInformationSchemaColumns()` in `TestIcebergSmokeHive` 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

