### PR TITLE
Push down thoroughly predicates that could be enforced by Iceberg table

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
@@ -15,6 +15,8 @@ package com.facebook.presto.iceberg.optimizer;
 
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.hive.SubfieldExtractor;
 import com.facebook.presto.iceberg.IcebergAbstractMetadata;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
@@ -26,6 +28,7 @@ import com.facebook.presto.spi.ConnectorPlanRewriter;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -34,34 +37,47 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.expressions.LogicalRowExpressions.FALSE_CONSTANT;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
 import static com.facebook.presto.iceberg.IcebergUtil.getIcebergTable;
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 public class IcebergPlanOptimizer
         implements ConnectorPlanOptimizer
 {
     private final RowExpressionService rowExpressionService;
     private final StandardFunctionResolution functionResolution;
+    private final FunctionMetadataManager functionMetadataManager;
     private final IcebergTransactionManager transactionManager;
 
     IcebergPlanOptimizer(StandardFunctionResolution functionResolution,
                          RowExpressionService rowExpressionService,
+                         FunctionMetadataManager functionMetadataManager,
                          IcebergTransactionManager transactionManager)
     {
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
+        this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
     }
 
@@ -71,7 +87,7 @@ public class IcebergPlanOptimizer
         if (isPushdownFilterEnabled(session)) {
             return maxSubplan;
         }
-        return rewriteWith(new FilterPushdownRewriter(functionResolution, rowExpressionService,
+        return rewriteWith(new FilterPushdownRewriter(functionResolution, rowExpressionService, functionMetadataManager,
                 transactionManager, idAllocator, session), maxSubplan);
     }
 
@@ -81,18 +97,21 @@ public class IcebergPlanOptimizer
         private final ConnectorSession session;
         private final RowExpressionService rowExpressionService;
         private final StandardFunctionResolution functionResolution;
+        private final FunctionMetadataManager functionMetadataManager;
         private final PlanNodeIdAllocator idAllocator;
         private final IcebergTransactionManager transactionManager;
 
         public FilterPushdownRewriter(
                 StandardFunctionResolution functionResolution,
                 RowExpressionService rowExpressionService,
+                FunctionMetadataManager functionMetadataManager,
                 IcebergTransactionManager transactionManager,
                 PlanNodeIdAllocator idAllocator,
                 ConnectorSession session)
         {
             this.functionResolution = functionResolution;
             this.rowExpressionService = rowExpressionService;
+            this.functionMetadataManager = functionMetadataManager;
             this.transactionManager = transactionManager;
             this.idAllocator = idAllocator;
             this.session = session;
@@ -109,8 +128,10 @@ public class IcebergPlanOptimizer
 
             Map<String, IcebergColumnHandle> nameToColumnHandlesMapping = tableScan.getAssignments().entrySet().stream()
                     .collect(Collectors.toMap(e -> e.getKey().getName(), e -> (IcebergColumnHandle) e.getValue()));
+            Map<IcebergColumnHandle, String> columnHandleToNameMapping = ImmutableBiMap.copyOf(nameToColumnHandlesMapping).inverse();
 
             RowExpression filterPredicate = filter.getPredicate();
+            checkArgument(!filterPredicate.equals(FALSE_CONSTANT), "Filter expression 'FALSE' should not be left to handle here");
 
             //TODO we should optimize the filter expression
             DomainTranslator.ExtractionResult<Subfield> decomposedFilter = rowExpressionService.getDomainTranslator()
@@ -120,20 +141,61 @@ public class IcebergPlanOptimizer
             TupleDomain<IcebergColumnHandle> entireColumnDomain = decomposedFilter.getTupleDomain()
                     .transform(subfield -> subfield.getPath().isEmpty() ? subfield.getRootName() : null)
                     .transform(nameToColumnHandlesMapping::get);
-            boolean hasSubfieldsInNestedStructures = decomposedFilter.getTupleDomain().getDomains()
-                    .map(map -> map.keySet().stream().anyMatch(subfield -> !subfield.getPath().isEmpty()))
-                    .orElse(false);
+
+            TableHandle handle = tableScan.getTable();
+            IcebergTableHandle tableHandle = (IcebergTableHandle) handle.getConnectorHandle();
+            IcebergAbstractMetadata metadata = (IcebergAbstractMetadata) transactionManager.get(handle.getTransaction());
+            Table icebergTable = getIcebergTable(metadata, session, tableHandle.getSchemaTableName());
+
+            // Get predicate expression on subfield
+            SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session);
+            Map<String, Type> columnTypes = nameToColumnHandlesMapping.entrySet().stream()
+                    .collect(toImmutableMap(entry -> entry.getKey(), entry -> entry.getValue().getType()));
+            TupleDomain<RowExpression> subfieldTupleDomain = decomposedFilter.getTupleDomain()
+                    .transform(subfield -> subfield.getPath().isEmpty() ? null : subfield)
+                    .transform(subfield -> subfieldExtractor.toRowExpression(subfield, columnTypes.get(subfield.getRootName())));
+            RowExpression subfieldPredicate = rowExpressionService.getDomainTranslator().toPredicate(subfieldTupleDomain);
+
+            // Get predicate tuple domain on identity partition columns, which could be enforced by iceberg table itself
+            Set<IcebergColumnHandle> identityPartitionColumns = getIdentityPartitionColumnHandles(icebergTable,
+                    nameToColumnHandlesMapping.values().stream().collect(Collectors.toList()));
+            TupleDomain<ColumnHandle> identityPartitionColumnPredicate = TupleDomain.withColumnDomains(
+                    Maps.filterKeys(
+                            entireColumnDomain.transform(icebergColumnHandle -> (ColumnHandle) icebergColumnHandle)
+                                    .getDomains().get(),
+                            Predicates.in(identityPartitionColumns)));
+
+            // Get predicate expression non-identity entire columns
+            TupleDomain<RowExpression> nonPartitionColumnPredicate = TupleDomain.withColumnDomains(
+                    Maps.filterKeys(
+                            entireColumnDomain.transform(icebergColumnHandle -> (ColumnHandle) icebergColumnHandle)
+                                    .getDomains().get(),
+                            Predicates.not(Predicates.in(identityPartitionColumns))))
+                    .transform(columnHandle -> new Subfield(columnHandleToNameMapping.get(columnHandle), ImmutableList.of()))
+                    .transform(subfield -> subfieldExtractor.toRowExpression(subfield, columnTypes.get(subfield.getRootName())));
+            RowExpression nonPartitionColumn = rowExpressionService.getDomainTranslator().toPredicate(nonPartitionColumnPredicate);
+
+            // Combine all the rest predicate expressions except predicate on identity partition columns
+            LogicalRowExpressions logicalRowExpressions = new LogicalRowExpressions(
+                    rowExpressionService.getDeterminismEvaluator(),
+                    functionResolution,
+                    functionMetadataManager);
+            RowExpression remainingFilterExpression = logicalRowExpressions.combineConjuncts(
+                    ImmutableList.of(
+                            decomposedFilter.getRemainingExpression(),
+                            subfieldPredicate,
+                            nonPartitionColumn));
 
             // Simplify call is required because iceberg does not support a large value list for IN predicate
             TupleDomain<IcebergColumnHandle> simplifiedColumnDomain = entireColumnDomain.simplify();
+            boolean predicateNotChangedBySimplification = simplifiedColumnDomain.equals(entireColumnDomain);
 
-            TableHandle handle = tableScan.getTable();
             IcebergTableHandle oldTableHandle = (IcebergTableHandle) handle.getConnectorHandle();
             IcebergTableHandle newTableHandle = new IcebergTableHandle(
                     oldTableHandle.getSchemaName(),
                     oldTableHandle.getIcebergTableName(),
                     oldTableHandle.isSnapshotSpecified(),
-                    simplifiedColumnDomain,
+                    simplifiedColumnDomain.intersect(oldTableHandle.getPredicate()),
                     oldTableHandle.getTableSchemaJson(),
                     oldTableHandle.getPartitionSpecId(),
                     oldTableHandle.getEqualityFieldIds());
@@ -143,48 +205,41 @@ public class IcebergPlanOptimizer
                     new TableHandle(handle.getConnectorId(), newTableHandle, handle.getTransaction(), handle.getLayout()),
                     tableScan.getOutputVariables(),
                     tableScan.getAssignments(),
-                    tableScan.getCurrentConstraint(),
-                    TupleDomain.all());
+                    simplifiedColumnDomain.transform(ColumnHandle.class::cast)
+                            .intersect(tableScan.getCurrentConstraint()),
+                    predicateNotChangedBySimplification ?
+                            identityPartitionColumnPredicate.intersect(tableScan.getEnforcedConstraint()) :
+                            tableScan.getEnforcedConstraint());
 
-            if (TRUE_CONSTANT.equals(filterPredicate)) {
+            if (TRUE_CONSTANT.equals(remainingFilterExpression) && predicateNotChangedBySimplification) {
                 return newTableScan;
             }
-
-            if (TRUE_CONSTANT.equals(decomposedFilter.getRemainingExpression()) && !hasSubfieldsInNestedStructures && simplifiedColumnDomain.equals(entireColumnDomain)) {
-                Set<Integer> predicateColumnIds = simplifiedColumnDomain.getDomains().get().keySet().stream()
-                        .map(IcebergColumnHandle::getId)
-                        .collect(toImmutableSet());
-
-                IcebergTableHandle tableHandle = (IcebergTableHandle) handle.getConnectorHandle();
-                IcebergAbstractMetadata metadata = (IcebergAbstractMetadata) transactionManager.get(handle.getTransaction());
-                Table icebergTable = getIcebergTable(metadata, session, tableHandle.getSchemaTableName());
-
-                // check iceberg table's every partition specs, to make sure the filterPredicate could be enforced
-                boolean canEnforced = true;
-                for (PartitionSpec spec : icebergTable.specs().values()) {
-                    // Currently we do not support delete when any partition columns in predicate is not transform by identity()
-                    Set<Integer> partitionColumnSourceIds = spec.fields().stream()
-                            .filter(field -> field.transform().isIdentity())
-                            .map(PartitionField::sourceId).collect(Collectors.toSet());
-
-                    if (!partitionColumnSourceIds.containsAll(predicateColumnIds)) {
-                        canEnforced = false;
-                        break;
-                    }
-                }
-
-                if (canEnforced) {
-                    return new TableScanNode(
-                            newTableScan.getSourceLocation(),
-                            newTableScan.getId(),
-                            newTableScan.getTable(),
-                            newTableScan.getOutputVariables(),
-                            newTableScan.getAssignments(),
-                            newTableScan.getCurrentConstraint(),
-                            simplifiedColumnDomain.transform(icebergColumnHandle -> (ColumnHandle) icebergColumnHandle));
-                }
+            else if (predicateNotChangedBySimplification) {
+                return new FilterNode(filter.getSourceLocation(), idAllocator.getNextId(), newTableScan, remainingFilterExpression);
             }
-            return new FilterNode(filter.getSourceLocation(), idAllocator.getNextId(), newTableScan, filterPredicate);
+            else {
+                return new FilterNode(filter.getSourceLocation(), idAllocator.getNextId(), newTableScan, filterPredicate);
+            }
         }
+    }
+
+    private static Set<IcebergColumnHandle> getIdentityPartitionColumnHandles(Table table,
+                                                                              List<IcebergColumnHandle> allColumns)
+    {
+        Map<Integer, IcebergColumnHandle> idToColumnsMap = allColumns.stream()
+                .filter(icebergColumnHandle -> icebergColumnHandle.getColumnType() != SYNTHESIZED)
+                .collect(Collectors.toMap(IcebergColumnHandle::getId, identity()));
+
+        // In the case of partition evolution, we must check every partition specs of the table to figure out
+        //  whether the predicate on identity partition columns could be enforced by iceberg table itself
+        return table.specs().values().stream()
+                .map(partitionSpec -> partitionSpec.fields().stream()
+                        .filter(field -> field.transform().isIdentity())
+                        .map(PartitionField::sourceId)
+                        .filter(idToColumnsMap::containsKey)
+                        .map(idToColumnsMap::get)
+                        .collect(Collectors.toSet()))
+                .reduce((columnHandleSet1, columnHandleSet2) -> columnHandleSet1.stream().filter(columnHandleSet2::contains).collect(toImmutableSet()))
+                .orElse(ImmutableSet.of());
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
@@ -47,7 +47,7 @@ public class IcebergPlanOptimizerProvider
         requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         requireNonNull(typeManager, "typeManager is null");
         this.planOptimizers = ImmutableSet.of(
-                new IcebergPlanOptimizer(functionResolution, rowExpressionService, transactionManager),
+                new IcebergPlanOptimizer(functionResolution, rowExpressionService, functionMetadataManager, transactionManager),
                 new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, typeManager),
                 new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager));
         this.logicalPlanOptimizers = ImmutableSet.<ConnectorPlanOptimizer>builder()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
@@ -522,8 +522,11 @@ public final class RowExpressionVerifier
             SpecialFormExpression actualLogicalBinary = (SpecialFormExpression) actual;
             if ((expected.getOperator() == OR && actualLogicalBinary.getForm() == SpecialFormExpression.Form.OR) ||
                     (expected.getOperator() == AND && actualLogicalBinary.getForm() == SpecialFormExpression.Form.AND)) {
-                return process(expected.getLeft(), actualLogicalBinary.getArguments().get(0)) &&
-                        process(expected.getRight(), actualLogicalBinary.getArguments().get(1));
+                // `Logical AND` and `Logical OR` both satisfy the commutative property
+                return process(expected.getLeft(), actualLogicalBinary.getArguments().get(0)) ?
+                        process(expected.getRight(), actualLogicalBinary.getArguments().get(1)) :
+                        process(expected.getLeft(), actualLogicalBinary.getArguments().get(1)) &&
+                                process(expected.getRight(), actualLogicalBinary.getArguments().get(0));
             }
         }
         return false;


### PR DESCRIPTION
## Description

For Iceberg table, as the filter predicates on identity partition columns could be enforced, such predicates could be removed from the filter node above the table, or the filter node could be wholly dropped if no predicate left after the enforced pushdown. The PR implements this feature.


## Test Plan

 - Test filter node being removed when only existing predicates on identity partition columns
 - Test filter predicates partially pushing down when existing predicates on identity partition columns as well as other columns
 - Test no pushing down when predicate simplification causing its semantic changes
 - Test filter pushing down in the case of partition evolution
 - Make sure the new feature do not effect existing test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
