### PR TITLE
Bump Sphinx version to fix build

### DIFF
--- a/presto-docs/requirements.txt
+++ b/presto-docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==4.4.0
+sphinx==5.3.0
 sphinx-material==0.0.35
 sphinx-copybutton==0.5.0


### PR DESCRIPTION
## Description
4.4.0 is no longer supported, bump to next version.

```
Running Sphinx v4.4.0

Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```

## Motivation and Context
Fix the build

## Impact
Fix the build

## Test Plan
Locally generated docs to ensure continuity.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

