### PR TITLE
[native] Remove mmap arena exposure from Prestissimo

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -612,8 +612,6 @@ void PrestoServer::initializeVeloxMemory() {
   options.allocatorCapacity = memoryGb << 30;
   if (systemConfig->useMmapAllocator()) {
     options.useMmapAllocator = true;
-    options.useMmapArena = systemConfig->useMmapArena();
-    options.mmapArenaCapacityRatio = systemConfig->mmapArenaCapacityRatio();
   }
   options.checkUsageLeak = systemConfig->enableMemoryLeakCheck();
   options.trackDefaultUsage =

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -175,8 +175,6 @@ SystemConfig::SystemConfig() {
           STR_PROP(kAsyncCacheSsdPath, "/mnt/flash/async_cache."),
           STR_PROP(kAsyncCacheSsdDisableFileCow, "false"),
           STR_PROP(kEnableSerializedPageChecksum, "true"),
-          STR_PROP(kUseMmapArena, "false"),
-          NUM_PROP(kMmapArenaCapacityRatio, 10),
           STR_PROP(kUseMmapAllocator, "true"),
           STR_PROP(kMemoryArbitratorKind, ""),
           NUM_PROP(kQueryMemoryGb, 38),
@@ -429,14 +427,6 @@ bool SystemConfig::enableVeloxTaskLogging() const {
 
 bool SystemConfig::enableVeloxExprSetLogging() const {
   return optionalProperty<bool>(kEnableVeloxExprSetLogging).value();
-}
-
-bool SystemConfig::useMmapArena() const {
-  return optionalProperty<bool>(kUseMmapArena).value();
-}
-
-int32_t SystemConfig::mmapArenaCapacityRatio() const {
-  return optionalProperty<int32_t>(kMmapArenaCapacityRatio).value();
 }
 
 bool SystemConfig::useMmapAllocator() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -293,10 +293,6 @@ class SystemConfig : public ConfigBase {
   /// cache entries.
   static constexpr std::string_view kCacheVeloxTtlCheckInterval{
       "cache.velox.ttl-check-interval"};
-
-  static constexpr std::string_view kUseMmapArena{"use-mmap-arena"};
-  static constexpr std::string_view kMmapArenaCapacityRatio{
-      "mmap-arena-capacity-ratio"};
   static constexpr std::string_view kUseMmapAllocator{"use-mmap-allocator"};
 
   /// Specifies the memory arbitrator kind. If it is empty, then there is no
@@ -569,10 +565,6 @@ class SystemConfig : public ConfigBase {
   bool enableVeloxTaskLogging() const;
 
   bool enableVeloxExprSetLogging() const;
-
-  bool useMmapArena() const;
-
-  int32_t mmapArenaCapacityRatio() const;
 
   bool useMmapAllocator() const;
 


### PR DESCRIPTION
mmap arena is never used and will not be a good use case for Prestissimo. Removing the exposure of mmap arena configs to reduce confusion.
```
== NO RELEASE NOTE ==
```

