### PR TITLE
Revert "Refactor `ApproximateMostFrequent` to use type annotations"

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -88,7 +88,6 @@ import com.facebook.presto.operator.aggregation.RealSumAggregation;
 import com.facebook.presto.operator.aggregation.ReduceAggregationFunction;
 import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
-import com.facebook.presto.operator.aggregation.approxmostfrequent.ApproximateMostFrequent;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggregationFunction;
 import com.facebook.presto.operator.aggregation.arrayagg.SetAggregationFunction;
 import com.facebook.presto.operator.aggregation.arrayagg.SetUnionFunction;
@@ -354,6 +353,7 @@ import static com.facebook.presto.operator.aggregation.RealAverageAggregation.RE
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG;
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG_WITH_WEIGHT;
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG_WITH_WEIGHT_AND_COMPRESSION;
+import static com.facebook.presto.operator.aggregation.approxmostfrequent.ApproximateMostFrequent.APPROXIMATE_MOST_FREQUENT;
 import static com.facebook.presto.operator.aggregation.minmaxby.AlternativeMaxByAggregationFunction.ALTERNATIVE_MAX_BY;
 import static com.facebook.presto.operator.aggregation.minmaxby.AlternativeMinByAggregationFunction.ALTERNATIVE_MIN_BY;
 import static com.facebook.presto.operator.aggregation.minmaxby.MaxByAggregationFunction.MAX_BY;
@@ -937,7 +937,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .functions(ARRAY_TRANSFORM_FUNCTION, ARRAY_REDUCE_FUNCTION)
                 .functions(MAP_TRANSFORM_KEY_FUNCTION, MAP_TRANSFORM_VALUE_FUNCTION)
                 .function(TRY_CAST)
-                .aggregate(ApproximateMostFrequent.class)
+                .function(APPROXIMATE_MOST_FREQUENT)
                 .function(K_DISTINCT)
                 .aggregate(MergeSetDigestAggregation.class)
                 .aggregate(BuildSetDigestAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequent.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequent.java
@@ -13,25 +13,45 @@
  */
 package com.facebook.presto.operator.aggregation.approxmostfrequent;
 
+import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.NamedTypeSignature;
+import com.facebook.presto.common.type.RowFieldName;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.operator.aggregation.NullablePosition;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.AccumulatorCompiler;
+import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
 import com.facebook.presto.operator.aggregation.approxmostfrequent.stream.StreamSummary;
-import com.facebook.presto.spi.function.AggregationFunction;
-import com.facebook.presto.spi.function.AggregationState;
-import com.facebook.presto.spi.function.BlockIndex;
-import com.facebook.presto.spi.function.BlockPosition;
-import com.facebook.presto.spi.function.CombineFunction;
-import com.facebook.presto.spi.function.Description;
-import com.facebook.presto.spi.function.InputFunction;
-import com.facebook.presto.spi.function.OutputFunction;
-import com.facebook.presto.spi.function.SqlType;
-import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.function.aggregation.Accumulator;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
+import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.ROW;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.function.Signature.comparableTypeParameter;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Math.toIntExact;
 
 /**
@@ -46,36 +66,110 @@ import static java.lang.Math.toIntExact;
  * by Ahmed Metwally, Divyakant Agrawal, and Amr El Abbadi
  * </p>
  */
-@AggregationFunction(value = "approx_most_frequent", isCalledOnNullInput = true)
-@Description("Computes the top frequent elements approximately")
 public final class ApproximateMostFrequent
+        extends SqlAggregationFunction
 {
-    private ApproximateMostFrequent()
-    {}
+    public static final ApproximateMostFrequent APPROXIMATE_MOST_FREQUENT = new ApproximateMostFrequent();
+    public static final String NAME = "approx_most_frequent";
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(ApproximateMostFrequent.class, "output", ApproximateMostFrequentState.class, BlockBuilder.class);
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(ApproximateMostFrequent.class, "input", Type.class, ApproximateMostFrequentState.class, long.class, Block.class, int.class, long.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(ApproximateMostFrequent.class, "combine", ApproximateMostFrequentState.class, ApproximateMostFrequentState.class);
+    private static final String MAX_BUCKETS = "max_buckets";
+    private static final String CAPACITY = "capacity";
+    private static final String KEYS = "keys";
+    private static final String VALUES = "values";
 
-    @InputFunction
-    @TypeParameter("T")
-    public static void input(
-            @TypeParameter("T") Type type,
-            @AggregationState ApproximateMostFrequentState state,
-            @SqlType(BIGINT) long buckets,
-            @BlockPosition @SqlType("T") @NullablePosition Block valueBlock,
-            @BlockIndex int valueIndex,
-            @SqlType(BIGINT) long capacity)
+    protected ApproximateMostFrequent()
+    {
+        super(NAME,
+                ImmutableList.of(comparableTypeParameter("K")),
+                ImmutableList.of(),
+                parseTypeSignature("map(K,bigint)"),
+                ImmutableList.of(parseTypeSignature(BIGINT), parseTypeSignature("K"), parseTypeSignature(BIGINT)));
+    }
+
+    @Override
+    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        Type keyType = boundVariables.getTypeVariable("K");
+        checkArgument(keyType.isComparable(), "keyType must be comparable");
+        Type serializedType = functionAndTypeManager.getParameterizedType(ROW, ImmutableList.of(
+                buildTypeSignatureParameter(MAX_BUCKETS, BigintType.BIGINT),
+                buildTypeSignatureParameter(CAPACITY, BigintType.BIGINT),
+                buildTypeSignatureParameter(KEYS, new ArrayType(keyType)),
+                buildTypeSignatureParameter(VALUES, new ArrayType(BigintType.BIGINT))));
+        Type outputType = functionAndTypeManager.getParameterizedType(MAP, ImmutableList.of(
+                TypeSignatureParameter.of(keyType.getTypeSignature()),
+                TypeSignatureParameter.of(BigintType.BIGINT.getTypeSignature())));
+
+        DynamicClassLoader classLoader = new DynamicClassLoader(ApproximateMostFrequent.class.getClassLoader());
+        List<Type> inputTypes = ImmutableList.of(keyType);
+        ApproximateMostFrequentStateSerializer stateSerializer = new ApproximateMostFrequentStateSerializer(keyType, serializedType);
+        MethodHandle inputFunction = INPUT_FUNCTION.bindTo(keyType);
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                createInputParameterMetadata(keyType),
+                inputFunction,
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                ImmutableList.of(new AggregationMetadata.AccumulatorStateDescriptor(
+                        ApproximateMostFrequentState.class,
+                        stateSerializer,
+                        new ApproximateMostFrequentStateFactory())),
+                outputType);
+
+        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                Accumulator.class,
+                metadata,
+                classLoader);
+        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                GroupedAccumulator.class,
+                metadata,
+                classLoader);
+        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(serializedType), outputType,
+                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+    }
+
+    private TypeSignatureParameter buildTypeSignatureParameter(String fieldName, Type type)
+    {
+        return TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(fieldName, false)), type.getTypeSignature()));
+    }
+
+    private static List<AggregationMetadata.ParameterMetadata> createInputParameterMetadata(Type keyType)
+    {
+        return ImmutableList.of(new AggregationMetadata.ParameterMetadata(STATE),
+                new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, BigintType.BIGINT),
+                new AggregationMetadata.ParameterMetadata(BLOCK_INPUT_CHANNEL, keyType),
+                new AggregationMetadata.ParameterMetadata(BLOCK_INDEX),
+                new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, BigintType.BIGINT));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Computes the top frequent elements approximately";
+    }
+
+    public static void input(Type type,
+            ApproximateMostFrequentState state,
+            long buckets,
+            Block valueBlock,
+            int valueIndex, long capacity)
     {
         StreamSummary streamSummary = state.getStateSummary();
         if (streamSummary == null) {
             checkCondition(buckets > 1, INVALID_FUNCTION_ARGUMENT, "approx_most_frequent bucket count must be greater than one, input bucket count: %s", buckets);
-            streamSummary = new StreamSummary(type, toIntExact(buckets), toIntExact(capacity));
+            streamSummary = new StreamSummary(
+                    type,
+                    toIntExact(buckets),
+                    toIntExact(capacity));
             state.setStateSummary(streamSummary);
         }
         streamSummary.add(valueBlock, valueIndex, 1L);
     }
 
-    @CombineFunction
-    public static void combine(
-            @AggregationState ApproximateMostFrequentState state,
-            @AggregationState ApproximateMostFrequentState otherState)
+    public static void combine(ApproximateMostFrequentState state, ApproximateMostFrequentState otherState)
     {
         StreamSummary streamSummary = state.getStateSummary();
         if (streamSummary == null) {
@@ -86,8 +180,7 @@ public final class ApproximateMostFrequent
         }
     }
 
-    @OutputFunction("map(T,bigint)")
-    public static void output(@AggregationState ApproximateMostFrequentState state, BlockBuilder out)
+    public static void output(ApproximateMostFrequentState state, BlockBuilder out)
     {
         if (state.getStateSummary() == null) {
             out.appendNull();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequentStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequentStateSerializer.java
@@ -15,32 +15,20 @@ package com.facebook.presto.operator.aggregation.approxmostfrequent;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
-import com.facebook.presto.common.type.ArrayType;
-import com.facebook.presto.common.type.BigintType;
-import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.operator.aggregation.approxmostfrequent.stream.StreamSummary;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
-import com.facebook.presto.spi.function.TypeParameter;
-import com.google.common.collect.ImmutableList;
 
 public class ApproximateMostFrequentStateSerializer
         implements AccumulatorStateSerializer<ApproximateMostFrequentState>
 {
     private final Type type;
     private final Type serializedType;
-    private static final String MAX_BUCKETS = "max_buckets";
-    private static final String CAPACITY = "capacity";
-    private static final String KEYS = "keys";
-    private static final String VALUES = "values";
 
-    public ApproximateMostFrequentStateSerializer(@TypeParameter("T") Type type)
+    public ApproximateMostFrequentStateSerializer(Type type, Type serializedType)
     {
         this.type = type;
-        this.serializedType = RowType.from(ImmutableList.of(RowType.field(MAX_BUCKETS, BigintType.BIGINT),
-                RowType.field(CAPACITY, BigintType.BIGINT),
-                RowType.field(KEYS, new ArrayType(type)),
-                RowType.field(VALUES, new ArrayType(BigintType.BIGINT))));
+        this.serializedType = serializedType;
     }
 
     @Override


### PR DESCRIPTION
Reverts prestodb/presto#21418

The refactor code fails for NULL input, for example:
```
presto:tpch> select k, approx_most_frequent(2, v, 10) from (values (1, null), (2, 3)) t(k, v) group by k;

Query 20240117_041732_00044_a7kid, FAILED, 1 node
http://localhost:8080/ui/query.html?20240117_041732_00044_a7kid
Splits: 9 total, 8 done (88.89%)
CPU Time: 0.1s total,     0 rows/s,     0B/s, 35% active
Per Node: 0.1 parallelism,     0 rows/s,     0B/s
Parallelism: 0.1
Peak User Memory: 0B
Peak Total Memory: 0B
Peak Task Total Memory: 0B
S0-driverCountPerTask: sum=9 count=1 min=9 max=9
S0-taskBlockedTimeNanos: sum=0:01 count=1 min=0:01 max=0:01
S0-taskElapsedTimeNanos: sum=0:01 count=1 min=0:01 max=0:01
S0-taskQueuedTimeNanos: sum=257ms count=1 min=257ms max=257ms
S0-taskScheduledTimeNanos: sum=301ms count=1 min=301ms max=301ms
fragmentPlanTimeNanos: sum=11ms count=1 min=11ms max=11ms
getCanonicalInfoTimeNanos: sum=0ms count=1 min=0ms max=0ms
logicalPlannerTimeNanos: sum=31ms count=1 min=31ms max=31ms
optimizerTimeNanos: sum=171ms count=1 min=171ms max=171ms
[Latency: client-side: 0:01, server-side: 0:01] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20240117_041732_00044_a7kid failed: Map keys must not be null
java.lang.IllegalArgumentException: Map keys must not be null
	at com.facebook.presto.common.block.MapBlockBuilder.appendStructureInternal(MapBlockBuilder.java:458)
	at com.facebook.presto.common.block.AbstractMapBlock.writePositionTo(AbstractMapBlock.java:329)
	at com.facebook.presto.common.type.MapType.appendTo(MapType.java:237)
	at com.facebook.presto.operator.project.MergingPageOutput.buffer(MergingPageOutput.java:246)
	at com.facebook.presto.operator.project.MergingPageOutput.process(MergingPageOutput.java:234)
	at com.facebook.presto.operator.project.MergingPageOutput.getOutput(MergingPageOutput.java:139)
	at com.facebook.presto.operator.FilterAndProjectOperator.getOutput(FilterAndProjectOperator.java:105)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:436)
	at com.facebook.presto.operator.Driver.lambda$processFor$10(Driver.java:319)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:740)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:312)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1079)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:165)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:621)
	at com.facebook.presto.$gen.Presto_null__testversion____20240117_041622_3.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

After revert, it succeeds:
```
presto:tpch> select k, approx_most_frequent(2, v, 10) from (values (1, null), (2, 3)) t(k, v) group by k;
 k | _col1 
---+-------
 1 | NULL  
 2 | {3=1} 
(2 rows)
```