### PR TITLE
Add Heuristic CTE Materialization Strategy

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -31,7 +31,6 @@ import com.facebook.presto.resourcemanager.ClusterQueryTrackerService;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
-import com.facebook.presto.spi.eventlistener.CTEInformation;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.version.EmbedVersion;
@@ -65,6 +64,7 @@ import static com.facebook.presto.SystemSessionProperties.getQueryMaxOutputPosit
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxOutputSize;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxScanRawInputBytes;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxWrittenIntermediateBytesLimit;
+import static com.facebook.presto.SystemSessionProperties.isCteMaterializationApplicable;
 import static com.facebook.presto.execution.QueryLimit.Source.QUERY;
 import static com.facebook.presto.execution.QueryLimit.Source.RESOURCE_GROUP;
 import static com.facebook.presto.execution.QueryLimit.Source.SYSTEM;
@@ -438,8 +438,7 @@ public class SqlQueryManager
     private void enforceWrittenIntermediateBytesLimit()
     {
         for (QueryExecution query : queryTracker.getAllQueries()) {
-            if (query.getSession().getCteInformationCollector()
-                    .getCTEInformationList().stream().noneMatch(CTEInformation::isMaterialized)) {
+            if (!isCteMaterializationApplicable(query.getSession())) {
                 // No Ctes Materialized
                 continue;
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/CTEInformationCollector.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/CTEInformationCollector.java
@@ -23,10 +23,16 @@ public class CTEInformationCollector
 {
     private final HashMap<String, CTEInformation> cteInformationMap = new HashMap<>();
 
+    // In this case cteName will be cteId
     public void addCTEReference(String cteName, boolean isView, boolean isMaterialized)
     {
-        cteInformationMap.putIfAbsent(cteName, new CTEInformation(cteName, 0, isView, isMaterialized));
-        cteInformationMap.get(cteName).incrementReferences();
+        addCTEReference(cteName, cteName, isView, isMaterialized);
+    }
+
+    public void addCTEReference(String cteName, String cteId, boolean isView, boolean isMaterialized)
+    {
+        cteInformationMap.putIfAbsent(cteId, new CTEInformation(cteName, cteId, 0, isView, isMaterialized));
+        cteInformationMap.get(cteId).incrementReferences();
     }
 
     public List<CTEInformation> getCTEInformationList()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -93,9 +93,9 @@ public class FeaturesConfig
     private DataSize maxRevocableMemoryPerTask = new DataSize(500, MEGABYTE);
     private JoinReorderingStrategy joinReorderingStrategy = JoinReorderingStrategy.AUTOMATIC;
     private PartialMergePushdownStrategy partialMergePushdownStrategy = PartialMergePushdownStrategy.NONE;
-
     private CteMaterializationStrategy cteMaterializationStrategy = CteMaterializationStrategy.NONE;
     private boolean cteFilterAndProjectionPushdownEnabled;
+    private int cteHeuristicReplicationThreshold = 4;
     private int maxReorderedJoins = 9;
     private boolean useHistoryBasedPlanStatistics;
     private boolean trackHistoryBasedPlanStatistics;
@@ -364,7 +364,9 @@ public class FeaturesConfig
     public enum CteMaterializationStrategy
     {
         ALL, // Materialize all CTES
-        NONE // Materialize no ctes
+        NONE, // Materialize no CTES
+        HEURISTIC, // Materialize CTES occuring  >= CTE_HEURISTIC_REPLICATION_THRESHOLD
+        HEURISTIC_COMPLEX_QUERIES_ONLY // Materialize CTES occuring >= CTE_HEURISTIC_REPLICATION_THRESHOLD and having a join or an aggregate
     }
 
     public enum TaskSpillingStrategy
@@ -597,7 +599,7 @@ public class FeaturesConfig
     }
 
     @Config("cte-materialization-strategy")
-    @ConfigDescription("Set strategy used to determine whether to materialize CTEs (ALL, NONE)")
+    @ConfigDescription("Set strategy used to determine whether to materialize ctes (ALL, NONE, HEURISTIC, HEURISTIC_COMPLEX_QUERIES_ONLY)")
     public FeaturesConfig setCteMaterializationStrategy(CteMaterializationStrategy cteMaterializationStrategy)
     {
         this.cteMaterializationStrategy = cteMaterializationStrategy;
@@ -614,6 +616,19 @@ public class FeaturesConfig
     public FeaturesConfig setCteFilterAndProjectionPushdownEnabled(boolean cteFilterAndProjectionPushdownEnabled)
     {
         this.cteFilterAndProjectionPushdownEnabled = cteFilterAndProjectionPushdownEnabled;
+        return this;
+    }
+
+    public int getCteHeuristicReplicationThreshold()
+    {
+        return cteHeuristicReplicationThreshold;
+    }
+
+    @Config("cte-heuristic-replication-threshold")
+    @ConfigDescription("Used with CTE Materialization Strategy = Heuristic. CTES are only materialized if they are used greater than or equal to this number")
+    public FeaturesConfig setCteHeuristicReplicationThreshold(int cteHeuristicReplicationThreshold)
+    {
+        this.cteHeuristicReplicationThreshold = cteHeuristicReplicationThreshold;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.eventlistener.CTEInformation;
 import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.CteProducerNode;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -47,10 +46,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.getCteFilterAndProjectionPushdownEnabled;
-import static com.facebook.presto.SystemSessionProperties.getCteMaterializationStrategy;
+import static com.facebook.presto.SystemSessionProperties.isCteMaterializationApplicable;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
-import static com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrategy.ALL;
 import static com.facebook.presto.sql.planner.PlannerUtils.isConstant;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.google.common.base.Preconditions.checkState;
@@ -102,12 +100,10 @@ public class CteProjectionAndPredicatePushDown
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
         requireNonNull(warningCollector, "warningCollector is null");
-        if (!getCteMaterializationStrategy(session).equals(ALL)
-                || session.getCteInformationCollector().getCTEInformationList().stream().noneMatch(CTEInformation::isMaterialized)
+        if (!isCteMaterializationApplicable(session)
                 || !getCteFilterAndProjectionPushdownEnabled(session)) {
             return PlanOptimizerResult.optimizerResult(plan, false);
         }
-
         CteContext cteContext = new CteContext();
         plan.accept(new CtePredicateAndProjectionExtractor(session, idAllocator, variableAllocator), cteContext);
 
@@ -135,7 +131,7 @@ public class CteProjectionAndPredicatePushDown
         @Override
         public Void visitCteProducer(CteProducerNode node, CteContext context)
         {
-            String cteName = node.getCteName();
+            String cteName = node.getCteId();
             List<VariableReferenceExpression> columns = node.getOutputVariables();
             context.addCteProducerInfo(cteName, columns);
 
@@ -150,7 +146,7 @@ public class CteProjectionAndPredicatePushDown
                 return super.visitFilter(node, context);
             }
 
-            String cteName = ((CteConsumerNode) childNode).getCteName();
+            String cteName = ((CteConsumerNode) childNode).getCteId();
             List<VariableReferenceExpression> producerColumns = context.getCteProducerColumns(cteName);
             RowExpression predicate = node.getPredicate();
             Map<VariableReferenceExpression, VariableReferenceExpression> varMap = constructConsumerToProducerVarMap((CteConsumerNode) childNode, context);
@@ -182,7 +178,7 @@ public class CteProjectionAndPredicatePushDown
                 predicate = constant(true, BOOLEAN);
             }
 
-            context.addCteConsumerInfo(cteConsumerNode.getCteName(), usedColumns, ImmutableList.of(predicate));
+            context.addCteConsumerInfo(cteConsumerNode.getCteId(), usedColumns, ImmutableList.of(predicate));
             return null;
         }
 
@@ -190,7 +186,7 @@ public class CteProjectionAndPredicatePushDown
         public Void visitCteConsumer(CteConsumerNode node, CteContext context)
         {
             // if we reach this point, it means that the CTE consumer had no filter or projection on top of it and we must take all columns and rows
-            String cteName = node.getCteName();
+            String cteName = node.getCteId();
             // TODO: support pushing of projections in the cte consumer (similar to table scan projection push down)
             // for now, take the original columns of the CTE producer
             List<VariableReferenceExpression> producerColumns = context.getCteProducerColumns(cteName);
@@ -262,7 +258,7 @@ public class CteProjectionAndPredicatePushDown
         private Map<VariableReferenceExpression, VariableReferenceExpression> constructConsumerToProducerVarMap(CteConsumerNode cteConsumerNode, CteContext context)
         {
             List<VariableReferenceExpression> consumerColumns = cteConsumerNode.getOutputVariables();
-            List<VariableReferenceExpression> producerColumns = context.getCteProducerColumns(cteConsumerNode.getCteName());
+            List<VariableReferenceExpression> producerColumns = context.getCteProducerColumns(cteConsumerNode.getCteId());
             Map<VariableReferenceExpression, VariableReferenceExpression> varMap = constructVarMap(consumerColumns, producerColumns);
             return varMap;
         }
@@ -304,7 +300,7 @@ public class CteProjectionAndPredicatePushDown
         @Override
         public PlanNode visitCteProducer(CteProducerNode node, RewriteContext<CteContext> context)
         {
-            String cteName = node.getCteName();
+            String cteName = node.getCteId();
             List<VariableReferenceExpression> usedColumns = context.get().getCteRequiredColumns(cteName);
             List<RowExpression> predicates = context.get().getPredicates(cteName);
 
@@ -341,9 +337,9 @@ public class CteProjectionAndPredicatePushDown
         public PlanNode visitCteConsumer(CteConsumerNode node, RewriteContext<CteContext> context)
         {
             // project out consumer columns
-            List<VariableReferenceExpression> allProducerColumns = context.get().getCteProducerColumns(node.getCteName());
-            List<VariableReferenceExpression> requiredProducerColumns = context.get().getCteRequiredColumns(node.getCteName());
-            checkState(requiredProducerColumns != null, "Required columns for producer " + node.getCteName() + " not found");
+            List<VariableReferenceExpression> allProducerColumns = context.get().getCteProducerColumns(node.getCteId());
+            List<VariableReferenceExpression> requiredProducerColumns = context.get().getCteRequiredColumns(node.getCteId());
+            checkState(requiredProducerColumns != null, "Required columns for producer " + node.getCteId() + " not found");
             Map<VariableReferenceExpression, VariableReferenceExpression> varMap = constructVarMap(allProducerColumns, node.getOutputVariables());
 
             Set<VariableReferenceExpression> requiredProducerColumnsSet = new HashSet<>(requiredProducerColumns);
@@ -356,7 +352,7 @@ public class CteProjectionAndPredicatePushDown
                             newConsumerColumns.add(pair.getValue());
                         }
                     });
-            return new CteConsumerNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), newConsumerColumns, node.getCteName(), node.getOriginalSource());
+            return new CteConsumerNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), newConsumerColumns, node.getCteId(), node.getOriginalSource());
         }
 
         public boolean isPlanRewritten()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -519,7 +519,7 @@ public class PruneUnreferencedOutputs
         {
             Set<VariableReferenceExpression> expectedInputs = ImmutableSet.copyOf(node.getOutputVariables());
             PlanNode source = context.rewrite(node.getSource(), expectedInputs);
-            return new CteProducerNode(node.getSourceLocation(), node.getId(), source, node.getCteName(), node.getRowCountVariable(), node.getOutputVariables());
+            return new CteProducerNode(node.getSourceLocation(), node.getId(), source, node.getCteId(), node.getRowCountVariable(), node.getOutputVariables());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -166,14 +166,14 @@ public class UnaliasSymbolReferences
         public PlanNode visitCteReference(CteReferenceNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getSource());
-            return new CteReferenceNode(node.getSourceLocation(), node.getId(), source, node.getCteName());
+            return new CteReferenceNode(node.getSourceLocation(), node.getId(), source, node.getCteId());
         }
 
         public PlanNode visitCteProducer(CteProducerNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getSource());
             List<VariableReferenceExpression> canonical = Lists.transform(node.getOutputVariables(), this::canonicalize);
-            return new CteProducerNode(node.getSourceLocation(), node.getId(), source, node.getCteName(), node.getRowCountVariable(), canonical);
+            return new CteProducerNode(node.getSourceLocation(), node.getId(), source, node.getCteId(), node.getRowCountVariable(), canonical);
         }
 
         public PlanNode visitCteConsumer(CteConsumerNode node, RewriteContext<Void> context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -850,7 +850,7 @@ public class PlanPrinter
         {
             NodeRepresentation nodeOutput;
             nodeOutput = addNode(node, "CteConsumer");
-            nodeOutput.appendDetailsLine("CTE_NAME: %s", node.getCteName());
+            nodeOutput.appendDetailsLine("CTE_NAME: %s", node.getCteId());
             return processChildren(node, context);
         }
 
@@ -859,7 +859,7 @@ public class PlanPrinter
         {
             NodeRepresentation nodeOutput;
             nodeOutput = addNode(node, "CteProducer");
-            nodeOutput.appendDetailsLine("CTE_NAME: %s", node.getCteName());
+            nodeOutput.appendDetailsLine("CTE_NAME: %s", node.getCteId());
             return processChildren(node, context);
         }
 
@@ -1407,7 +1407,7 @@ public class PlanPrinter
         Collections.reverse(cteProducers);
         return format("executionOrder = %s",
                 cteProducers.stream()
-                        .map(CteProducerNode::getCteName)
+                        .map(CteProducerNode::getCteId)
                         .collect(Collectors.joining(" -> ", "{", "}")));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -266,7 +266,8 @@ public class TestFeaturesConfig
                 .setGenerateDomainFilters(false)
                 .setRewriteExpressionWithConstantVariable(true)
                 .setDefaultWriterReplicationCoefficient(3.0)
-                .setDefaultViewSecurityMode(DEFINER));
+                .setDefaultViewSecurityMode(DEFINER)
+                .setCteHeuristicReplicationThreshold(4));
     }
 
     @Test
@@ -477,6 +478,7 @@ public class TestFeaturesConfig
                 .put("optimizer.rewrite-expression-with-constant-variable", "false")
                 .put("optimizer.default-writer-replication-coefficient", "5.0")
                 .put("default-view-security-mode", INVOKER.name())
+                .put("cte-heuristic-replication-threshold", "2")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -684,7 +686,8 @@ public class TestFeaturesConfig
                 .setGenerateDomainFilters(true)
                 .setRewriteExpressionWithConstantVariable(false)
                 .setDefaultWriterReplicationCoefficient(5.0)
-                .setDefaultViewSecurityMode(INVOKER);
+                .setDefaultViewSecurityMode(INVOKER)
+                .setCteHeuristicReplicationThreshold(2);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CteConsumerMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CteConsumerMatcher.java
@@ -46,7 +46,7 @@ final class CteConsumerMatcher
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         CteConsumerNode otherNode = (CteConsumerNode) node;
-        if (!expectedCteName.equalsIgnoreCase(otherNode.getCteName())) {
+        if (!expectedCteName.equalsIgnoreCase(otherNode.getCteId())) {
             return NO_MATCH;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CteProducerMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CteProducerMatcher.java
@@ -28,10 +28,10 @@ import static java.util.Objects.requireNonNull;
 final class CteProducerMatcher
         implements Matcher
 {
-    private final String expectedCteName;
-    public CteProducerMatcher(String cteName)
+    private final String expectedCteId;
+    public CteProducerMatcher(String cteId)
     {
-        this.expectedCteName = requireNonNull(cteName, "expectedCteName is null");
+        this.expectedCteId = requireNonNull(cteId, "expectedCteName is null");
     }
 
     @Override
@@ -45,7 +45,7 @@ final class CteProducerMatcher
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         CteProducerNode otherNode = (CteProducerNode) node;
-        if (!expectedCteName.equalsIgnoreCase(otherNode.getCteName())) {
+        if (!expectedCteId.equalsIgnoreCase(otherNode.getCteId())) {
             return NO_MATCH;
         }
         return match();
@@ -56,7 +56,7 @@ final class CteProducerMatcher
     {
         return toStringHelper(this)
                 .omitNullValues()
-                .add("expectedCteName", expectedCteName)
+                .add("expectedCteName", expectedCteId)
                 .toString();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLogicalCteOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLogicalCteOptimizer.java
@@ -14,14 +14,24 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.CteConsumerNode;
+import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.CteReferenceNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.SequenceNode;
 import com.facebook.presto.sql.Optimizer;
+import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.assertions.PlanAssert;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.function.Consumer;
 
+import static com.facebook.presto.SystemSessionProperties.CTE_HEURISTIC_REPLICATION_THRESHOLD;
 import static com.facebook.presto.SystemSessionProperties.CTE_MATERIALIZATION_STRATEGY;
 import static com.facebook.presto.sql.planner.SqlPlannerContext.CteInfo.delimiter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
@@ -32,10 +42,13 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.latera
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sequence;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static org.testng.Assert.assertFalse;
 
 public class TestLogicalCteOptimizer
         extends BasePlanTest
 {
+    private static final List<Class<? extends PlanNode>> CTE_PLAN_NODES = ImmutableList.of(CteReferenceNode.class, CteConsumerNode.class, CteProducerNode.class, SequenceNode.class);
+
     @Test
     public void testConvertSimpleCte()
     {
@@ -274,6 +287,147 @@ public class TestLogicalCteOptimizer
                 anyTree(values("text_column", "number_column")));
     }
 
+    @Test
+    public void testHeuristicComplexCteMaterialization()
+    {
+        assertUnitPlan(
+                Session.builder(this.getQueryRunner().getDefaultSession())
+                        .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "HEURISTIC_COMPLEX_QUERIES_ONLY")
+                        .setSystemProperty(CTE_HEURISTIC_REPLICATION_THRESHOLD, "4")
+                        .build(),
+                "WITH temp AS (" +
+                        "    SELECT orderkey FROM ORDERS GROUP BY orderkey" +
+                        ")" +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp",
+                anyTree(
+                        sequence(
+                                cteProducer(addQueryScopeDelimiter("temp", 0), anyTree(tableScan("orders"))),
+                                anyTree(cteConsumer(addQueryScopeDelimiter("temp", 0))))));
+    }
+
+    @Test
+    public void testHeuristicComplexCteMaterializationForInnerCtes()
+    {
+        assertUnitPlan(
+                Session.builder(this.getQueryRunner().getDefaultSession())
+                        .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "HEURISTIC_COMPLEX_QUERIES_ONLY")
+                        .setSystemProperty(CTE_HEURISTIC_REPLICATION_THRESHOLD, "4")
+                        .build(),
+                "WITH temp AS (" +
+                        "With inner_temp AS(  " +
+                        "  SELECT orderkey FROM ORDERS GROUP BY orderkey)" +
+                        "SELECT * FROM inner_temp" +
+                        ")" +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp",
+                anyTree(
+                        sequence(
+                                cteProducer(addQueryScopeDelimiter("inner_temp", 0), anyTree(tableScan("orders"))),
+                                anyTree(cteConsumer(addQueryScopeDelimiter("inner_temp", 0))))));
+    }
+
+    @Test
+    public void testNoHeuristicComplexCteMaterializationWithoutComplexNodes()
+    {
+        assertUnitPlanWithValidator(
+                Session.builder(this.getQueryRunner().getDefaultSession())
+                        .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "HEURISTIC_COMPLEX_QUERIES_ONLY")
+                        .setSystemProperty(CTE_HEURISTIC_REPLICATION_THRESHOLD, "4")
+                        .build(),
+                "WITH temp AS (" +
+                        "    SELECT orderkey FROM ORDERS" +
+                        ")" +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp",
+                anyTree(tableScan("orders")),
+                plan ->
+                        assertFalse(PlanNodeSearcher.searchFrom(plan.getRoot())
+                                .where(planNode -> CTE_PLAN_NODES.stream().anyMatch(clazz -> clazz.isInstance(planNode)))
+                                .matches()));
+    }
+
+    @Test
+    public void testNoHeuristicComplexCteMaterializationWithoutDataNodes()
+    {
+        assertUnitPlanWithValidator(
+                Session.builder(this.getQueryRunner().getDefaultSession())
+                        .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "HEURISTIC_COMPLEX_QUERIES_ONLY")
+                        .setSystemProperty(CTE_HEURISTIC_REPLICATION_THRESHOLD, "0")
+                        .build(),
+                "WITH temp AS (" +
+                        "    SELECT colB FROM (VALUES (1), (2)) AS TempTable(colB)" +
+                        ")" +
+                        "SELECT * FROM temp ",
+                anyTree(values("colB")),
+                plan ->
+                        assertFalse(PlanNodeSearcher.searchFrom(plan.getRoot())
+                                .where(planNode -> CTE_PLAN_NODES.stream().anyMatch(clazz -> clazz.isInstance(planNode)))
+                                .matches()));
+    }
+
+    @Test
+    public void testHeuristicCteMaterialization()
+    {
+        assertUnitPlan(
+                Session.builder(this.getQueryRunner().getDefaultSession())
+                        .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "HEURISTIC")
+                        .setSystemProperty(CTE_HEURISTIC_REPLICATION_THRESHOLD, "4")
+                        .build(),
+                "WITH temp AS (" +
+                        "    SELECT orderkey FROM ORDERS" +
+                        ")" +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp",
+                anyTree(
+                        sequence(
+                                cteProducer(addQueryScopeDelimiter("temp", 0), anyTree(tableScan("orders"))),
+                                anyTree(cteConsumer(addQueryScopeDelimiter("temp", 0))))));
+    }
+
+    @Test
+    public void testNoHeuristicCteMaterializationWithLesserReferences()
+    {
+        assertUnitPlanWithValidator(
+                Session.builder(this.getQueryRunner().getDefaultSession())
+                        .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "HEURISTIC")
+                        .setSystemProperty(CTE_HEURISTIC_REPLICATION_THRESHOLD, "4")
+                        .build(),
+                "WITH temp AS (" +
+                        "    SELECT orderkey FROM ORDERS" +
+                        ")" +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp " +
+                        "UNION " +
+                        "SELECT * FROM temp ",
+                anyTree(tableScan("orders")),
+                plan ->
+                        assertFalse(PlanNodeSearcher.searchFrom(plan.getRoot())
+                                .where(planNode -> CTE_PLAN_NODES.stream().anyMatch(clazz -> clazz.isInstance(planNode)))
+                                .matches()));
+    }
+
     public static String addQueryScopeDelimiter(String cteName, int scope)
     {
         return String.valueOf(scope) + delimiter + cteName;
@@ -281,9 +435,31 @@ public class TestLogicalCteOptimizer
 
     private void assertUnitPlan(String sql, PlanMatchPattern pattern)
     {
+        assertUnitPlan(getSession(), sql, pattern);
+    }
+
+    private void assertUnitPlan(Session session, String sql, PlanMatchPattern pattern)
+    {
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new LogicalCteOptimizer(getQueryRunner().getMetadata()));
-        assertPlan(sql, getSession(), Optimizer.PlanStage.OPTIMIZED, pattern, optimizers);
+        assertPlan(sql, session, Optimizer.PlanStage.OPTIMIZED, pattern, optimizers);
+    }
+
+    private void assertUnitPlanWithValidator(Session session, String sql, PlanMatchPattern pattern, Consumer<Plan> planValidator)
+    {
+        List<PlanOptimizer> optimizers = ImmutableList.of(
+                new LogicalCteOptimizer(getQueryRunner().getMetadata()));
+        getQueryRunner().inTransaction(session, transactionSession -> {
+            Plan actualPlan = getQueryRunner().createPlan(
+                    transactionSession,
+                    sql,
+                    optimizers,
+                    Optimizer.PlanStage.OPTIMIZED,
+                    WarningCollector.NOOP);
+            PlanAssert.assertPlan(transactionSession, getQueryRunner().getMetadata(), getQueryRunner().getStatsCalculator(), actualPlan, pattern);
+            planValidator.accept(actualPlan);
+            return null;
+        });
     }
 
     private Session getSession()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/CTEInformation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/CTEInformation.java
@@ -26,10 +26,12 @@ public class CTEInformation
     private int numberOfReferences;
     private final boolean isView;
     private final boolean isMaterialized;
+    private final String cteId;
 
     @JsonCreator
     public CTEInformation(
             @JsonProperty("cteName") String cteName,
+            @JsonProperty("cteId") String cteId,
             @JsonProperty("numberOfReferences") int numberOfReferences,
             @JsonProperty("isView") boolean isView,
             @JsonProperty("isMaterialized") boolean isMaterialized)
@@ -38,6 +40,7 @@ public class CTEInformation
         this.numberOfReferences = numberOfReferences;
         this.isView = isView;
         this.isMaterialized = isMaterialized;
+        this.cteId = cteId;
     }
 
     @JsonProperty
@@ -56,6 +59,12 @@ public class CTEInformation
     public int getNumberOfReferences()
     {
         return numberOfReferences;
+    }
+
+    @JsonProperty
+    public String getCteId()
+    {
+        return cteId;
     }
 
     @JsonProperty

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteConsumerNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteConsumerNode.java
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
 public final class CteConsumerNode
         extends PlanNode
 {
-    private final String cteName;
+    private final String cteId;
     private final List<VariableReferenceExpression> originalOutputVariables;
     private final PlanNode originalSource;
 
@@ -39,10 +39,10 @@ public final class CteConsumerNode
             Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("outputvars") List<VariableReferenceExpression> originalOutputVariables,
-            @JsonProperty("cteName") String cteName,
+            @JsonProperty("cteId") String cteId,
             @JsonProperty("originalSource") PlanNode originalSource)
     {
-        this(sourceLocation, id, Optional.empty(), originalOutputVariables, cteName, originalSource);
+        this(sourceLocation, id, Optional.empty(), originalOutputVariables, cteId, originalSource);
     }
 
     public CteConsumerNode(
@@ -50,11 +50,11 @@ public final class CteConsumerNode
             PlanNodeId id,
             Optional<PlanNode> statsEquivalentPlanNode,
             List<VariableReferenceExpression> originalOutputVariables,
-            String cteName,
+            String cteId,
             PlanNode originalSource)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
-        this.cteName = requireNonNull(cteName, "cteName must not be null");
+        this.cteId = requireNonNull(cteId, "cteName must not be null");
         this.originalOutputVariables = requireNonNull(originalOutputVariables, "originalOutputVariables must not be null");
         this.originalSource = originalSource;
     }
@@ -77,14 +77,14 @@ public final class CteConsumerNode
     {
         // this function expects a new instance
         checkArgument(newChildren.size() == 0, "expected newChildren to contain 0 node");
-        return new CteConsumerNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), originalOutputVariables, cteName, originalSource);
+        return new CteConsumerNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), originalOutputVariables, cteId, originalSource);
     }
 
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
         return new CteConsumerNode(getSourceLocation(), getId(),
-                statsEquivalentPlanNode, originalOutputVariables, cteName, originalSource);
+                statsEquivalentPlanNode, originalOutputVariables, cteId, originalSource);
     }
 
     public PlanNode getOriginalSource()
@@ -99,9 +99,9 @@ public final class CteConsumerNode
     }
 
     @JsonProperty
-    public String getCteName()
+    public String getCteId()
     {
-        return cteName;
+        return cteId;
     }
 
     private static void checkArgument(boolean condition, String message)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteProducerNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteProducerNode.java
@@ -31,7 +31,7 @@ public final class CteProducerNode
         extends PlanNode
 {
     private final PlanNode source;
-    private final String cteName;
+    private final String cteId;
     private final VariableReferenceExpression rowCountVariable;
     private final List<VariableReferenceExpression> originalOutputVariables;
 
@@ -40,11 +40,11 @@ public final class CteProducerNode
             Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("cteName") String cteName,
+            @JsonProperty("cteId") String cteId,
             @JsonProperty("rowCountVariable") VariableReferenceExpression rowCountVariable,
             @JsonProperty("originalOutputVariables") List<VariableReferenceExpression> originalOutputVariables)
     {
-        this(sourceLocation, id, Optional.empty(), source, cteName, rowCountVariable, originalOutputVariables);
+        this(sourceLocation, id, Optional.empty(), source, cteId, rowCountVariable, originalOutputVariables);
     }
 
     public CteProducerNode(
@@ -52,13 +52,13 @@ public final class CteProducerNode
             PlanNodeId id,
             Optional<PlanNode> statsEquivalentPlanNode,
             PlanNode source,
-            String cteName,
+            String cteId,
             VariableReferenceExpression rowCountVariable,
             List<VariableReferenceExpression> originalOutputVariables)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
         // Inside your method or constructor
-        this.cteName = requireNonNull(cteName, "cteName must not be null");
+        this.cteId = requireNonNull(cteId, "cteName must not be null");
         this.source = requireNonNull(source, "source must not be null");
         this.rowCountVariable = requireNonNull(rowCountVariable, "rowCountVariable must not be null");
         this.originalOutputVariables = requireNonNull(originalOutputVariables, "originalOutputVariables must not be null");
@@ -87,13 +87,13 @@ public final class CteProducerNode
     {
         checkArgument(newChildren.size() == 1, "expected newChildren to contain 1 node");
         return new CteProducerNode(newChildren.get(0).getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0),
-                cteName, rowCountVariable, originalOutputVariables);
+                cteId, rowCountVariable, originalOutputVariables);
     }
 
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new CteProducerNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, cteName, rowCountVariable, originalOutputVariables);
+        return new CteProducerNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, cteId, rowCountVariable, originalOutputVariables);
     }
 
     @Override
@@ -103,9 +103,9 @@ public final class CteProducerNode
     }
 
     @JsonProperty
-    public String getCteName()
+    public String getCteId()
     {
-        return cteName;
+        return cteId;
     }
 
     public VariableReferenceExpression getRowCountVariable()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteReferenceNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteReferenceNode.java
@@ -31,16 +31,16 @@ public final class CteReferenceNode
         extends PlanNode
 {
     private final PlanNode source;
-    private final String cteName;
+    private final String cteId;
 
     @JsonCreator
     public CteReferenceNode(
             Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("cteName") String cteName)
+            @JsonProperty("cteName") String cteId)
     {
-        this(sourceLocation, id, Optional.empty(), source, cteName);
+        this(sourceLocation, id, Optional.empty(), source, cteId);
     }
 
     public CteReferenceNode(
@@ -48,10 +48,10 @@ public final class CteReferenceNode
             PlanNodeId id,
             Optional<PlanNode> statsEquivalentPlanNode,
             PlanNode source,
-            String cteName)
+            String cteId)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
-        this.cteName = requireNonNull(cteName, "cteName must not be null");
+        this.cteId = requireNonNull(cteId, "cteName must not be null");
         this.source = requireNonNull(source, "source must not be null");
     }
 
@@ -78,13 +78,13 @@ public final class CteReferenceNode
     {
         requireNonNull(newChildren, "newChildren is null");
         checkArgument(newChildren.size() == 1, "expected newChildren to contain 1 node");
-        return new CteReferenceNode(newChildren.get(0).getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), cteName);
+        return new CteReferenceNode(newChildren.get(0).getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), cteId);
     }
 
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new CteReferenceNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, cteName);
+        return new CteReferenceNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, cteId);
     }
 
     @Override
@@ -93,9 +93,9 @@ public final class CteReferenceNode
         return visitor.visitCteReference(this, context);
     }
 
-    public String getCteName()
+    public String getCteId()
     {
-        return cteName;
+        return cteId;
     }
 
     private static void checkArgument(boolean condition, String message)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/SequenceNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/SequenceNode.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 public class SequenceNode
         extends PlanNode
 {
-    // cteProducers {l1,l2,l3} will be in {l3, l2,l1} order
+    // cteProducers {l1,l2,l3} will be executed in {l3, l2,l1} order
     private final List<PlanNode> cteProducers;
     private final PlanNode primarySource;
 


### PR DESCRIPTION
1. This PR adds support Heuristic CTE materialization.
We have rolled this in one of our production cluster and confirmed that this is stable. 
Our current testing has shown **upto** 50% cpu gain and > 50% less hdfs read for affected queries.
Its heuristic so there may be cases where non-ideal plans are generated.

2. Changed cteName member variable to cteId for cte plan nodes.

3. Also fixed CteInformation to include cteId so that correct references are incremented which crucial for cte materialization.


In heuristic strategy, the relational planner adds cteReferences everywhere and the LogicalCteOptimizer decides which references to implement


Fixes #21637 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add Heuristic CTE Materialization strategy which auto materialized expensive ctes. This is configurable by setting ``cte_materialization_strategy`` to ``HEURISTIC`` or ``HEURISTIC_COMPLEX_QUERIES_ONLY``. (default ``NONE``)

