### PR TITLE
Fix memory accounting in SfmSketchStateFactory

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/SfmSketchStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/SfmSketchStateFactory.java
@@ -89,7 +89,7 @@ public class SfmSketchStateFactory
             requireNonNull(value, "value is null");
             retainedBytes -= getSketch().getRetainedSizeInBytes();
             getSketch().mergeWith(value);
-            retainedBytes += value.getRetainedSizeInBytes();
+            retainedBytes += getSketch().getRetainedSizeInBytes();
         }
 
         @Override


### PR DESCRIPTION
## Description

When merging SFM sketches in a grouped state, the existing memory accounting was using the wrong sketch size in updates. Since the merged sketch is generally at least as large as the unmerged sketch, this was biasing memory estimates downward until they potentially went negative.

## Motivation and Context

This was causing a bug with the error message `bytes cannot be negative` when trying to allocate the wrong amount of memory in `InMemoryHashAggregationBuilder`.

## Impact

Bug fix only

## Test Plan

Added more thorough unit tests to cover the memory accounting behavior

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

