### PR TITLE
Add release notes for 0.285.1

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    Release-0.285.1 [2023-12-30] <release/release-0.285.1>
     Release-0.285 [2023-12-08] <release/release-0.285>
     Release-0.284 [2023-10-11] <release/release-0.284>
     Release-0.283 [2023-08-08] <release/release-0.283>

--- a/presto-docs/src/main/sphinx/release/release-0.285.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.285.1.rst
@@ -1,0 +1,7 @@
+===============
+Release 0.285.1
+===============
+
+General Changes
+_______________
+* Fix bug for LIKE pattern with multiple-byte characters. (:pr:`21578`)

--- a/presto-docs/src/main/sphinx/release/release-0.285.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.285.rst
@@ -2,6 +2,10 @@
 Release 0.285
 =============
 
+.. warning::
+
+   There is a bug for LIKE pattern with multiple-byte characters. (:pr:`21578`)
+
 **Details**
 ===========
 


### PR DESCRIPTION
## Description
0.285.1 is a patch release of a bug fixed in https://github.com/prestodb/presto/pull/21578.

```
== NO RELEASE NOTE ==
```

