### PR TITLE
Update default spill compression codec for native engine.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -1595,7 +1595,7 @@ public final class SystemSessionProperties
                         NATIVE_SPILL_COMPRESSION_CODEC,
                         "Native Execution only. The compression algorithm type to compress the spilled data.\n " +
                                 "Supported compression codecs are: ZLIB, SNAPPY, LZO, ZSTD, LZ4 and GZIP. NONE means no compression.",
-                        "none",
+                        "snappy",
                         false),
                 longProperty(
                         NATIVE_SPILL_WRITE_BUFFER_SIZE,


### PR DESCRIPTION
We've seen that compressing spill files can substantially reduce query execution wall time for queries that spill a lot of data.

Updating the default codec from none to snappy. Snappy was chosen as it offers a reasonable balance between the CPU cost and compression ratio.


```
== NO RELEASE NOTE ==
```

