### PR TITLE
[native] Add config for stats reporting and counters.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -143,6 +143,10 @@ void PrestoServer::run() {
     baseVeloxQueryConfig->initialize(
         fmt::format("{}/velox.properties", configDirectoryPath_));
 
+    if (systemConfig->enableRuntimeMetricsCollection()) {
+      enableRuntimeMetricReporting();
+    }
+
     httpPort = systemConfig->httpServerHttpPort();
     if (systemConfig->httpServerHttpsEnabled()) {
       httpsPort = systemConfig->httpServerHttpsPort();
@@ -985,6 +989,12 @@ std::string PrestoServer::getLocalIp() const {
 
 std::string PrestoServer::getBaseSpillDirectory() const {
   return SystemConfig::instance()->spillerSpillPath().value_or("");
+}
+
+void PrestoServer::enableRuntimeMetricReporting() {
+  // This flag must be set to register the counters.
+  facebook::velox::BaseStatsReporter::registered = true;
+  registerStatsCounters();
 }
 
 void PrestoServer::populateMemAndCPUInfo() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -126,8 +126,6 @@ class PrestoServer {
 
   virtual void registerMemoryArbitrators();
 
-  virtual void registerStatsCounters();
-
   /// Invoked after creating global (singleton) config objects (SystemConfig and
   /// NodeConfig) and before loading their properties from the file.
   /// In the implementation any extra config properties can be registered.
@@ -143,6 +141,9 @@ class PrestoServer {
   /// Invoked to get the spill directory.
   virtual std::string getBaseSpillDirectory() const;
 
+  /// Invoked to enable stats reporting and register counters.
+  virtual void enableRuntimeMetricReporting();
+
   /// Invoked to get the list of filters passed to the http server.
   std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
   getHttpServerFilters();
@@ -150,6 +151,8 @@ class PrestoServer {
   void initializeVeloxMemory();
 
   void initializeThreadPools();
+
+  void registerStatsCounters();
 
  protected:
   void addServerPeriodicTasks();

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -215,6 +215,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kCacheVeloxTtlEnabled, false),
           STR_PROP(kCacheVeloxTtlThreshold, "2d"),
           STR_PROP(kCacheVeloxTtlCheckInterval, "1h"),
+          BOOL_PROP(kEnableRuntimeMetricsCollection, false),
       };
 }
 
@@ -589,6 +590,10 @@ std::chrono::duration<double> SystemConfig::cacheVeloxTtlThreshold() const {
 std::chrono::duration<double> SystemConfig::cacheVeloxTtlCheckInterval() const {
   return velox::core::toDuration(
       optionalProperty(kCacheVeloxTtlCheckInterval).value());
+}
+
+bool SystemConfig::enableRuntimeMetricsCollection() const {
+  return optionalProperty<bool>(kEnableRuntimeMetricsCollection).value();
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -300,6 +300,9 @@ class SystemConfig : public ConfigBase {
       "cache.velox.ttl-check-interval"};
   static constexpr std::string_view kUseMmapAllocator{"use-mmap-allocator"};
 
+  static constexpr std::string_view kEnableRuntimeMetricsCollection{
+      "runtime-metrics-collection-enabled"};
+
   /// Specifies the memory arbitrator kind. If it is empty, then there is no
   /// memory arbitration.
   static constexpr std::string_view kMemoryArbitratorKind{
@@ -655,6 +658,8 @@ class SystemConfig : public ConfigBase {
   std::chrono::duration<double> cacheVeloxTtlThreshold() const;
 
   std::chrono::duration<double> cacheVeloxTtlCheckInterval() const;
+
+  bool enableRuntimeMetricsCollection() const;
 };
 
 /// Provides access to node properties defined in node.properties file.


### PR DESCRIPTION
Adding config for stats reporting and counter registration. The code is mostly taken from https://github.com/prestodb/presto/pull/21599. Separated into a PR as this code can allow to deprecate meta internal logic to enable counters, plus simplify https://github.com/prestodb/presto/pull/21599 as well.
