### PR TITLE
Use softlink for jmx_prometheus_javaagent jar file in building docker…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM quay.io/centos/centos:stream8
 ARG PRESTO_VERSION
 ARG PRESTO_PKG=presto-server-$PRESTO_VERSION.tar.gz
 ARG PRESTO_CLI_JAR=presto-cli-$PRESTO_VERSION-executable.jar
+ARG JMX_PROMETHEUS_JAVAAGENT_VERSION=0.20.0
 
 ENV PRESTO_HOME="/opt/presto-server"
 
@@ -26,8 +27,8 @@ RUN dnf install -y java-11-openjdk less procps python3 \
     && mkdir -p $PRESTO_HOME/etc/catalog \
     && mkdir -p /var/lib/presto/data \
         && mkdir -p /usr/lib/presto/utils \
-        # Download jmx prometheus exporter \
-        && curl -o /usr/lib/presto/utils/jmx_prometheus_javaagent-0.20.0.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.20.0/jmx_prometheus_javaagent-0.20.0.jar
+        && curl -o /usr/lib/presto/utils/jmx_prometheus_javaagent-$JMX_PROMETHEUS_JAVAAGENT_VERSION.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/$JMX_PROMETHEUS_JAVAAGENT_VERSION/jmx_prometheus_javaagent-$JMX_PROMETHEUS_JAVAAGENT_VERSION.jar \
+        && ln -s /usr/lib/presto/utils/jmx_prometheus_javaagent-$JMX_PROMETHEUS_JAVAAGENT_VERSION.jar /usr/lib/presto/utils/jmx_prometheus_javaagent.jar
 
 COPY etc/config.properties.example $PRESTO_HOME/etc/config.properties
 COPY etc/jvm.config.example $PRESTO_HOME/etc/jvm.config


### PR DESCRIPTION
## Description
Create a soft link jmx_prometheus_javaagent.jar to jmx_prometheus_javaagent-0.20.0.jar file.

## Motivation and Context
When we enable JMX Prometheus exporter, we need to add the following into jvm.config
`-javaagent:/usr/lib/presto/utils/jmx_prometheus_javaagent-0.20.0.jar=9404:/opt/presto-server/etc/jmx-exporter-config.yaml`
The version number (0.20.0, in the current code base) forces us to update the version in our deployment scripts, whenever it is updated in Presto, causing the deployment scripts not backward compatible.

## Impact
No public API or user-facing feature impact.

## Test Plan
Have built and deployed a cluster with updates.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== NO RELEASE NOTE ==
```