### PR TITLE
fix typo in release/release-0.255.rst

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.255.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.255.rst
@@ -23,7 +23,7 @@ Druid Connector Changes
 _______________________
 * Add support for querying non-lowercase table names in Druid connector (:pr:`15920`).
 
-Elasticserarch Changes
+Elasticsearch Changes
 ______________________
 * Fix to avoid ``NullPointerException`` when there is an unsupported data type column in the Object field.
 


### PR DESCRIPTION
## Description
Fix typo in release/release-0.255.rst

## Motivation and Context
Noticed typographical error while reviewing Release Notes. 

## Impact
None.

## Test Plan
Performed a local build of the docs from the new branch, verified the page built with typo corrected.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
