### PR TITLE
[native pos] Improve communication loss detection

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -162,7 +162,7 @@ public class PrestoNativeQueryRunnerUtils
                 ImmutableList.of(),
                 ImmutableList.of(),
                 ImmutableMap.<String, String>builder()
-                        .put("http-server.http.port", "8080")
+                        .put("http-server.http.port", "8081")
                         .put("experimental.internal-communication.thrift-transport-enabled", String.valueOf(useThrift))
                         .putAll(getNativeWorkerSystemProperties())
                         .build(),

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -391,7 +391,7 @@ public class PrestoSparkModule
         binder.bind(Executor.class).toInstance(executor);
         binder.bind(ExecutorService.class).toInstance(executor);
         // Set the initial thread pool size to 1 (instead of 0) to avoid the thread pool hogging CPU due to JDK8 bug: https://bugs.openjdk.org/browse/JDK-8129861
-        binder.bind(ScheduledExecutorService.class).toInstance(newScheduledThreadPool(1, daemonThreadsNamed("presto-spark-scheduled-executor-%s")));
+        binder.bind(ScheduledExecutorService.class).toInstance(newScheduledThreadPool(5, daemonThreadsNamed("presto-spark-scheduled-executor-%s")));
 
         // task executor
         binder.bind(EmbedVersion.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/http/PrestoSparkHttpTaskClient.java
@@ -357,7 +357,6 @@ public class PrestoSparkHttpTaskClient
         @Override
         public BaseResponse<byte[]> handle(Request request, Response response)
         {
-
             return new BytesResponse(
                     response.getStatusCode(),
                     response.getStatusMessage(),

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcess.java
@@ -23,6 +23,7 @@ import io.airlift.units.Duration;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static java.util.Objects.requireNonNull;
@@ -40,6 +41,7 @@ public class DetachedNativeExecutionProcess
     public DetachedNativeExecutionProcess(
             Session session,
             HttpClient httpClient,
+            ExecutorService executorService,
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             Duration maxErrorDuration,
@@ -48,6 +50,7 @@ public class DetachedNativeExecutionProcess
     {
         super(session,
                 httpClient,
+                executorService,
                 errorRetryScheduledExecutor,
                 serverInfoCodec,
                 maxErrorDuration,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcessFactory.java
@@ -36,6 +36,7 @@ public class DetachedNativeExecutionProcessFactory
         extends NativeExecutionProcessFactory
 {
     private final HttpClient httpClient;
+    private final ExecutorService coreExecutor;
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final JsonCodec<ServerInfo> serverInfoCodec;
     private final WorkerProperty<?, ?, ?, ?> workerProperty;
@@ -50,6 +51,7 @@ public class DetachedNativeExecutionProcessFactory
     {
         super(httpClient, coreExecutor, errorRetryScheduledExecutor, serverInfoCodec, workerProperty);
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.coreExecutor = requireNonNull(coreExecutor, "ecoreExecutor is null");
         this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
         this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
         this.workerProperty = requireNonNull(workerProperty, "workerProperty is null");
@@ -68,6 +70,7 @@ public class DetachedNativeExecutionProcessFactory
             return new DetachedNativeExecutionProcess(
                     session,
                     httpClient,
+                    coreExecutor,
                     errorRetryScheduledExecutor,
                     serverInfoCodec,
                     maxErrorDuration,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskInfoFetcher.java
@@ -15,26 +15,18 @@ package com.facebook.presto.spark.execution.nativeprocess;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.execution.TaskInfo;
-import com.facebook.presto.server.RequestErrorTracker;
-import com.facebook.presto.server.smile.BaseResponse;
 import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
-import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
 
 import javax.annotation.concurrent.GuardedBy;
 
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.facebook.presto.spi.StandardErrorCode.NATIVE_EXECUTION_TASK_ERROR;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -46,16 +38,12 @@ import static java.util.Objects.requireNonNull;
 public class HttpNativeExecutionTaskInfoFetcher
 {
     private static final Logger log = Logger.get(HttpNativeExecutionTaskInfoFetcher.class);
-    private static final String TASK_ERROR_MESSAGE = "TaskInfoFetcher encountered too many errors talking to native process.";
 
     private final PrestoSparkHttpTaskClient workerClient;
     private final ScheduledExecutorService updateScheduledExecutor;
     private final AtomicReference<TaskInfo> taskInfo = new AtomicReference<>();
-    private final Executor executor;
     private final Duration infoFetchInterval;
-    private final RequestErrorTracker errorTracker;
-    private final AtomicReference<RuntimeException> lastException = new AtomicReference<>();
-    private final Duration maxErrorDuration;
+    private final AtomicReference<Throwable> lastException = new AtomicReference<>();
     private final Object taskFinished;
 
     @GuardedBy("this")
@@ -63,26 +51,13 @@ public class HttpNativeExecutionTaskInfoFetcher
 
     public HttpNativeExecutionTaskInfoFetcher(
             ScheduledExecutorService updateScheduledExecutor,
-            ScheduledExecutorService errorRetryScheduledExecutor,
             PrestoSparkHttpTaskClient workerClient,
-            Executor executor,
             Duration infoFetchInterval,
-            Duration maxErrorDuration,
             Object taskFinished)
     {
         this.workerClient = requireNonNull(workerClient, "workerClient is null");
         this.updateScheduledExecutor = requireNonNull(updateScheduledExecutor, "updateScheduledExecutor is null");
-        this.executor = requireNonNull(executor, "executor is null");
         this.infoFetchInterval = requireNonNull(infoFetchInterval, "infoFetchInterval is null");
-        this.maxErrorDuration = requireNonNull(maxErrorDuration, "maxErrorDuration is null");
-        this.errorTracker = new RequestErrorTracker(
-                "NativeExecution",
-                workerClient.getLocation(),
-                NATIVE_EXECUTION_TASK_ERROR,
-                TASK_ERROR_MESSAGE,
-                maxErrorDuration,
-                requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null"),
-                "getting taskInfo from native process");
         this.taskFinished = requireNonNull(taskFinished, "taskFinished is null");
     }
 
@@ -103,53 +78,31 @@ public class HttpNativeExecutionTaskInfoFetcher
     void doGetTaskInfo()
     {
         try {
-            BaseResponse<TaskInfo> response = workerClient.getTaskInfo().get();
-            onSuccess(response);
+            TaskInfo result = workerClient.getTaskInfo();
+            onSuccess(result);
         }
         catch (Throwable t) {
             onFailure(t);
         }
     }
 
-    private void onSuccess(BaseResponse<TaskInfo> result)
+    private void onSuccess(TaskInfo result)
     {
-        log.debug("TaskInfoCallback success %s", result.getValue().getTaskId());
-        taskInfo.set(result.getValue());
-
-        errorTracker.requestSucceeded();
-
-        if (result.getValue().getTaskStatus().getState().isDone()) {
+        log.debug("TaskInfoCallback success %s", result.getTaskId());
+        taskInfo.set(result);
+        if (result.getTaskStatus().getState().isDone()) {
             synchronized (taskFinished) {
                 taskFinished.notifyAll();
             }
         }
     }
 
-    private void onFailure(Throwable t)
+    private void onFailure(Throwable failure)
     {
-        // record failure
-        try {
-            errorTracker.requestFailed(t);
-        }
-        catch (PrestoException e) {
-            // Entering here means that we are unable
-            // to get any task info from the CPP process
-            // likely because process has crashed
-            stop();
-            lastException.set(e);
-            synchronized (taskFinished) {
-                taskFinished.notifyAll();
-            }
-            return;
-        }
-        ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
-        try {
-            // synchronously wait on throttling
-            errorRateLimit.get(maxErrorDuration.toMillis(), TimeUnit.MILLISECONDS);
-        }
-        catch (InterruptedException | ExecutionException | TimeoutException e) {
-            // throttling error is not fatal, just log the error.
-            log.debug(e.getMessage());
+        stop();
+        lastException.set(failure);
+        synchronized (taskFinished) {
+            taskFinished.notifyAll();
         }
     }
 
@@ -157,13 +110,15 @@ public class HttpNativeExecutionTaskInfoFetcher
             throws RuntimeException
     {
         if (scheduledFuture != null && scheduledFuture.isCancelled() && lastException.get() != null) {
-            throw lastException.get();
+            Throwable failure = lastException.get();
+            throwIfUnchecked(failure);
+            throw new RuntimeException(failure);
         }
         TaskInfo info = taskInfo.get();
         return info == null ? Optional.empty() : Optional.of(info);
     }
 
-    public AtomicReference<RuntimeException> getLastException()
+    public AtomicReference<Throwable> getLastException()
     {
         return lastException;
     }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskResultFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskResultFetcher.java
@@ -172,7 +172,7 @@ public class HttpNativeExecutionTaskResultFetcher
         }
         token = nextToken;
         if (pagesResponse.isClientComplete()) {
-            workerClient.abortResults();
+            workerClient.abortResultsAsync();
             scheduledFuture.cancel(false);
         }
         if (!pages.isEmpty()) {
@@ -184,7 +184,7 @@ public class HttpNativeExecutionTaskResultFetcher
 
     private void onFailure(Throwable t)
     {
-        workerClient.abortResults();
+        workerClient.abortResultsAsync();
         stop(false);
         lastException.set(t);
         synchronized (taskHasResult) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskResultFetcher.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/HttpNativeExecutionTaskResultFetcher.java
@@ -15,32 +15,28 @@ package com.facebook.presto.spark.execution.nativeprocess;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.operator.PageBufferClient;
-import com.facebook.presto.server.RequestErrorTracker;
 import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.page.SerializedPage;
-import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static com.facebook.presto.spi.StandardErrorCode.NATIVE_EXECUTION_TASK_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.SERIALIZED_PAGE_CHECKSUM_ERROR;
 import static com.facebook.presto.spi.page.PagesSerdeUtil.isChecksumValid;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -61,17 +57,13 @@ public class HttpNativeExecutionTaskResultFetcher
     private static final Duration POLL_TIMEOUT = new Duration(100, TimeUnit.MILLISECONDS);
     private static final DataSize MAX_RESPONSE_SIZE = new DataSize(32, DataSize.Unit.MEGABYTE);
     private static final DataSize MAX_BUFFER_SIZE = new DataSize(128, DataSize.Unit.MEGABYTE);
-    private static final String TASK_ERROR_MESSAGE = "TaskResultsFetcher encountered too many errors talking to native process.";
 
-    private final Executor executor;
     private final ScheduledExecutorService scheduler;
     private final PrestoSparkHttpTaskClient workerClient;
     private final LinkedBlockingDeque<SerializedPage> pageBuffer = new LinkedBlockingDeque<>();
     private final AtomicLong bufferMemoryBytes;
     private final Object taskHasResult;
-    private final Duration maxErrorDuration;
-    private final RequestErrorTracker errorTracker;
-    private final AtomicReference<RuntimeException> lastException = new AtomicReference<>();
+    private final AtomicReference<Throwable> lastException = new AtomicReference<>();
 
     private ScheduledFuture<?> scheduledFuture;
 
@@ -79,26 +71,13 @@ public class HttpNativeExecutionTaskResultFetcher
 
     public HttpNativeExecutionTaskResultFetcher(
             ScheduledExecutorService scheduler,
-            ScheduledExecutorService errorRetryScheduledExecutor,
             PrestoSparkHttpTaskClient workerClient,
-            Executor executor,
-            Duration maxErrorDuration,
             Object taskHasResult)
     {
-        this.executor = requireNonNull(executor, "executor is null");
         this.scheduler = requireNonNull(scheduler, "scheduler is null");
         this.workerClient = requireNonNull(workerClient, "workerClient is null");
         this.bufferMemoryBytes = new AtomicLong();
         this.taskHasResult = requireNonNull(taskHasResult, "taskHasResult is null");
-        this.maxErrorDuration = requireNonNull(maxErrorDuration, "maxErrorDuration is null");
-        this.errorTracker = new RequestErrorTracker(
-                "NativeExecution",
-                workerClient.getLocation(),
-                NATIVE_EXECUTION_TASK_ERROR,
-                TASK_ERROR_MESSAGE,
-                maxErrorDuration,
-                requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null"),
-                "getting results from native process");
     }
 
     public void start()
@@ -129,10 +108,7 @@ public class HttpNativeExecutionTaskResultFetcher
     public Optional<SerializedPage> pollPage()
             throws InterruptedException
     {
-        if (scheduledFuture != null && scheduledFuture.isCancelled() && lastException.get() != null) {
-            throw lastException.get();
-        }
-
+        throwIfFailed();
         SerializedPage page = pageBuffer.poll((long) POLL_TIMEOUT.getValue(), POLL_TIMEOUT.getUnit());
         if (page != null) {
             bufferMemoryBytes.addAndGet(-page.getSizeInBytes());
@@ -143,11 +119,17 @@ public class HttpNativeExecutionTaskResultFetcher
 
     public boolean hasPage()
     {
-        if (scheduledFuture != null && scheduledFuture.isCancelled() && lastException.get() != null) {
-            throw lastException.get();
-        }
-
+        throwIfFailed();
         return !pageBuffer.isEmpty();
+    }
+
+    private void throwIfFailed()
+    {
+        if (scheduledFuture != null && scheduledFuture.isCancelled() && lastException.get() != null) {
+            Throwable failure = lastException.get();
+            throwIfUnchecked(failure);
+            throw new RuntimeException(failure);
+        }
     }
 
     private void doGetResults()
@@ -157,7 +139,7 @@ public class HttpNativeExecutionTaskResultFetcher
         }
 
         try {
-            PageBufferClient.PagesResponse pagesResponse = workerClient.getResults(token, MAX_RESPONSE_SIZE).get();
+            PageBufferClient.PagesResponse pagesResponse = getFutureValue(workerClient.getResults(token, MAX_RESPONSE_SIZE));
             onSuccess(pagesResponse);
         }
         catch (Throwable t) {
@@ -167,8 +149,6 @@ public class HttpNativeExecutionTaskResultFetcher
 
     private void onSuccess(PageBufferClient.PagesResponse pagesResponse)
     {
-        errorTracker.requestSucceeded();
-
         List<SerializedPage> pages = pagesResponse.getPages();
         long bytes = 0;
         long positionCount = 0;
@@ -204,29 +184,11 @@ public class HttpNativeExecutionTaskResultFetcher
 
     private void onFailure(Throwable t)
     {
-        // record failure
-        try {
-            errorTracker.requestFailed(t);
-        }
-        catch (PrestoException e) {
-            // Entering here means that we are unable to get any results from the CPP process
-            // likely because process has crashed.
-            workerClient.abortResults();
-            stop(false);
-            lastException.set(e);
-            synchronized (taskHasResult) {
-                taskHasResult.notifyAll();
-            }
-            return;
-        }
-        ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
-        try {
-            // synchronously wait on throttling
-            errorRateLimit.get(maxErrorDuration.toMillis(), TimeUnit.MILLISECONDS);
-        }
-        catch (InterruptedException | ExecutionException | TimeoutException e) {
-            // throttling error is not fatal, just log the error.
-            log.debug(e.getMessage());
+        workerClient.abortResults();
+        stop(false);
+        lastException.set(t);
+        synchronized (taskHasResult) {
+            taskHasResult.notifyAll();
         }
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcessFactory.java
@@ -76,6 +76,7 @@ public class NativeExecutionProcessFactory
             return new NativeExecutionProcess(
                     session,
                     httpClient,
+                    coreExecutor,
                     errorRetryScheduledExecutor,
                     serverInfoCodec,
                     maxErrorDuration,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
@@ -74,8 +74,7 @@ public class NativeExecutionTask
             TableWriteInfo tableWriteInfo,
             Optional<String> shuffleWriteInfo,
             Optional<String> broadcastBasePath,
-            ScheduledExecutorService updateScheduledExecutor,
-            ScheduledExecutorService errorRetryScheduledExecutor,
+            ScheduledExecutorService scheduledExecutorService,
             TaskManagerConfig taskManagerConfig)
     {
         this.session = requireNonNull(session, "session is null");
@@ -87,16 +86,15 @@ public class NativeExecutionTask
         this.workerClient = requireNonNull(workerClient, "workerClient is null");
         this.outputBuffers = createInitialEmptyOutputBuffers(planFragment.getPartitioningScheme().getPartitioning().getHandle()).withNoMoreBufferIds();
         requireNonNull(taskManagerConfig, "taskManagerConfig is null");
-        requireNonNull(updateScheduledExecutor, "updateScheduledExecutor is null");
-        requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
+        requireNonNull(scheduledExecutorService, "scheduledExecutorService is null");
         this.taskInfoFetcher = new HttpNativeExecutionTaskInfoFetcher(
-                updateScheduledExecutor,
+                scheduledExecutorService,
                 this.workerClient,
                 taskManagerConfig.getInfoUpdateInterval(),
                 taskFinishedOrHasResult);
         if (!shuffleWriteInfo.isPresent()) {
             this.taskResultFetcher = Optional.of(new HttpNativeExecutionTaskResultFetcher(
-                    updateScheduledExecutor,
+                    scheduledExecutorService,
                     this.workerClient,
                     taskFinishedOrHasResult));
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTask.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
 import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTaskInfoFetcher;
 import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTaskResultFetcher;
 import com.facebook.presto.spi.page.SerializedPage;
-import com.facebook.presto.spi.security.TokenAuthenticator;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.Duration;
@@ -78,7 +77,6 @@ public class NativeExecutionTask
     // Results will be fetched only if not written to shuffle.
     private final Optional<HttpNativeExecutionTaskResultFetcher> taskResultFetcher;
     private final Object taskFinishedOrHasResult = new Object();
-    private Optional<TokenAuthenticator> tokenAuthenticator;
 
     public NativeExecutionTask(
             Session session,
@@ -119,10 +117,7 @@ public class NativeExecutionTask
         if (!shuffleWriteInfo.isPresent()) {
             this.taskResultFetcher = Optional.of(new HttpNativeExecutionTaskResultFetcher(
                     updateScheduledExecutor,
-                    errorRetryScheduledExecutor,
                     this.workerClient,
-                    this.executor,
-                    remoteTaskMaxErrorDuration,
                     taskFinishedOrHasResult));
         }
         else {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTaskFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTaskFactory.java
@@ -107,11 +107,9 @@ public class NativeExecutionTaskFactory
                 tableWriteInfo,
                 shuffleWriteInfo,
                 broadcastBasePath,
-                executor,
                 updateScheduledExecutor,
                 errorRetryScheduledExecutor,
-                taskManagerConfig,
-                queryManagerConfig);
+                taskManagerConfig);
     }
 
     @PreDestroy

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTaskFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTaskFactory.java
@@ -96,8 +96,7 @@ public class NativeExecutionTaskFactory
                 taskInfoCodec,
                 planFragmentCodec,
                 taskUpdateRequestCodec,
-                taskManagerConfig.getInfoRefreshMaxWait(),
-                session.getIdentity().getExtraAuthenticators());
+                taskManagerConfig.getInfoRefreshMaxWait());
         return new NativeExecutionTask(
                 session,
                 workerClient,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTaskFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/NativeExecutionTaskFactory.java
@@ -96,7 +96,9 @@ public class NativeExecutionTaskFactory
                 taskInfoCodec,
                 planFragmentCodec,
                 taskUpdateRequestCodec,
-                taskManagerConfig.getInfoRefreshMaxWait());
+                taskManagerConfig.getInfoRefreshMaxWait(),
+                errorRetryScheduledExecutor,
+                queryManagerConfig.getRemoteTaskMaxErrorDuration());
         return new NativeExecutionTask(
                 session,
                 workerClient,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
@@ -94,6 +94,7 @@ public class TestNativeExecutionProcess
                 new NativeExecutionVeloxConfig());
         NativeExecutionProcessFactory factory = new NativeExecutionProcessFactory(
                 new TestPrestoSparkHttpClient.TestingHttpClient(
+                        errorScheduler,
                         new TestPrestoSparkHttpClient.TestingResponseManager(taskId.toString(), new TestPrestoSparkHttpClient.FailureRetryResponseManager(5))),
                 newSingleThreadExecutor(),
                 errorScheduler,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -76,7 +76,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -173,8 +172,7 @@ public class TestPrestoSparkHttpClient
                 TASK_INFO_JSON_CODEC,
                 PLAN_FRAGMENT_JSON_CODEC,
                 TASK_UPDATE_REQUEST_JSON_CODEC,
-                new Duration(1, TimeUnit.SECONDS),
-                new HashMap<>());
+                new Duration(1, TimeUnit.SECONDS));
     }
 
     HttpNativeExecutionTaskResultFetcher createResultFetcher(PrestoSparkHttpTaskClient workerClient)
@@ -585,7 +583,8 @@ public class TestPrestoSparkHttpClient
     }
 
     @Test
-    public void testResultFetcherTransportErrorFail() throws InterruptedException
+    public void testResultFetcherTransportErrorFail()
+            throws InterruptedException
     {
         TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -22,7 +22,6 @@ import com.facebook.airlift.http.client.Response;
 import com.facebook.airlift.http.client.ResponseHandler;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.client.ServerInfo;
-import com.facebook.presto.common.ErrorCode;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
@@ -46,7 +45,6 @@ import com.facebook.presto.spark.execution.property.NativeExecutionVeloxConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
 import com.facebook.presto.spark.execution.task.NativeExecutionTask;
 import com.facebook.presto.spark.execution.task.NativeExecutionTaskFactory;
-import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.PrestoTransportException;
 import com.facebook.presto.spi.page.PageCodecMarker;
@@ -92,7 +90,6 @@ import static com.facebook.presto.client.PrestoHeaders.PRESTO_BUFFER_COMPLETE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_NEXT_TOKEN;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_TOKEN;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_TASK_INSTANCE_ID;
-import static com.facebook.presto.common.ErrorType.USER_ERROR;
 import static com.facebook.presto.execution.TaskTestUtils.createPlanFragment;
 import static com.facebook.presto.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
@@ -604,7 +601,7 @@ public class TestPrestoSparkHttpClient
     private static class PrestoExceptionResponseManager
             extends TestingResponseManager.TestingResultResponseManager
     {
-        private int requestCount = 0;
+        private int requestCount;
 
         @Override
         public Response createResultResponse(String taskId)
@@ -1282,7 +1279,7 @@ public class TestPrestoSparkHttpClient
             public Response createTaskInfoResponse(HttpStatus httpStatus, String taskId)
                     throws PrestoException
             {
-                throw new RuntimeException( "Server refused connection");
+                throw new RuntimeException("Server refused connection");
             }
         }
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -191,6 +191,7 @@ public class TestPrestoSparkHttpClient
                 TASK_UPDATE_REQUEST_JSON_CODEC,
                 new Duration(1, TimeUnit.SECONDS),
                 scheduledExecutorService,
+                scheduledExecutorService,
                 new Duration(1, TimeUnit.SECONDS));
     }
 
@@ -848,7 +849,6 @@ public class TestPrestoSparkHttpClient
                     new TestingHttpClient(
                             scheduledExecutorService,
                             new TestingResponseManager(taskId.toString(), new TimeoutResponseManager(0, 10, 0))),
-                    scheduledExecutorService,
                     scheduledExecutorService,
                     scheduledExecutorService,
                     TASK_INFO_JSON_CODEC,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
@@ -58,6 +58,7 @@ public class TestHttpNativeExecutionTaskInfoFetcher
                 // very low tolerance for error for unit testing
                 new Duration(1, TimeUnit.MILLISECONDS),
                 updateScheduledExecutor,
+                updateScheduledExecutor,
                 new Duration(1, TimeUnit.SECONDS));
 
         Object taskFinishedOrLostSignal = new Object();

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spark.execution.http.BatchTaskUpdateRequest;
 import com.facebook.presto.spark.execution.http.PrestoSparkHttpTaskClient;
 import com.facebook.presto.spark.execution.http.TestPrestoSparkHttpClient;
 import com.facebook.presto.sql.planner.PlanFragment;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
@@ -56,8 +55,8 @@ public class TestHttpNativeExecutionTaskInfoFetcher
                 TASK_INFO_JSON_CODEC,
                 PLAN_FRAGMENT_JSON_CODEC,
                 TASK_UPDATE_REQUEST_JSON_CODEC,
-                new Duration(1, TimeUnit.MILLISECONDS), // very low tolerance for error for unit testing
-                ImmutableMap.of());
+                // very low tolerance for error for unit testing
+                new Duration(1, TimeUnit.MILLISECONDS));
 
         Object taskFinishedOrLostSignal = new Object();
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
@@ -47,16 +47,20 @@ public class TestHttpNativeExecutionTaskInfoFetcher
     public void testNativeExecutionTaskFailsWhenProcessCrashes()
     {
         PrestoSparkHttpTaskClient workerClient = new PrestoSparkHttpTaskClient(
-                new TestPrestoSparkHttpClient.TestingHttpClient(new TestPrestoSparkHttpClient.TestingResponseManager(
-                        TEST_TASK_ID.toString(),
-                        new TestPrestoSparkHttpClient.TestingResponseManager.CrashingTaskInfoResponseManager(1))),
+                new TestPrestoSparkHttpClient.TestingHttpClient(
+                        updateScheduledExecutor,
+                        new TestPrestoSparkHttpClient.TestingResponseManager(
+                                TEST_TASK_ID.toString(),
+                                new TestPrestoSparkHttpClient.TestingResponseManager.CrashingTaskInfoResponseManager(1))),
                 TEST_TASK_ID,
                 BASE_URI,
                 TASK_INFO_JSON_CODEC,
                 PLAN_FRAGMENT_JSON_CODEC,
                 TASK_UPDATE_REQUEST_JSON_CODEC,
                 // very low tolerance for error for unit testing
-                new Duration(1, TimeUnit.MILLISECONDS));
+                new Duration(1, TimeUnit.MILLISECONDS),
+                updateScheduledExecutor,
+                new Duration(1, TimeUnit.SECONDS));
 
         Object taskFinishedOrLostSignal = new Object();
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/nativeprocess/TestHttpNativeExecutionTaskInfoFetcher.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -40,7 +39,6 @@ public class TestHttpNativeExecutionTaskInfoFetcher
     private static final JsonCodec<TaskInfo> TASK_INFO_JSON_CODEC = JsonCodec.jsonCodec(TaskInfo.class);
     private static final JsonCodec<PlanFragment> PLAN_FRAGMENT_JSON_CODEC = JsonCodec.jsonCodec(PlanFragment.class);
     private static final JsonCodec<BatchTaskUpdateRequest> TASK_UPDATE_REQUEST_JSON_CODEC = JsonCodec.jsonCodec(BatchTaskUpdateRequest.class);
-    private static final ScheduledExecutorService errorScheduler = newScheduledThreadPool(4);
     private static final ScheduledExecutorService updateScheduledExecutor = newScheduledThreadPool(4);
 
     @Test
@@ -51,7 +49,7 @@ public class TestHttpNativeExecutionTaskInfoFetcher
                         updateScheduledExecutor,
                         new TestPrestoSparkHttpClient.TestingResponseManager(
                                 TEST_TASK_ID.toString(),
-                                new TestPrestoSparkHttpClient.TestingResponseManager.CrashingTaskInfoResponseManager(1))),
+                                new TestPrestoSparkHttpClient.TestingResponseManager.CrashingTaskInfoResponseManager())),
                 TEST_TASK_ID,
                 BASE_URI,
                 TASK_INFO_JSON_CODEC,
@@ -66,21 +64,9 @@ public class TestHttpNativeExecutionTaskInfoFetcher
 
         HttpNativeExecutionTaskInfoFetcher taskInfoFetcher = new HttpNativeExecutionTaskInfoFetcher(
                 updateScheduledExecutor,
-                errorScheduler,
                 workerClient,
-                directExecutor(),
-                new Duration(1, TimeUnit.SECONDS),
                 new Duration(1, TimeUnit.SECONDS),
                 taskFinishedOrLostSignal);
-
-        // first attempt will result in task info
-        taskInfoFetcher.doGetTaskInfo();
-
-        // subsequent attempts will result in failed to fetch task info
-        // we call enough number of times to trigger error tracker
-        taskInfoFetcher.doGetTaskInfo();
-        taskInfoFetcher.doGetTaskInfo();
-        taskInfoFetcher.doGetTaskInfo();
 
         // set up a listener for the notification
         AtomicBoolean notifyCalled = new AtomicBoolean(false);


### PR DESCRIPTION
## Description

Improve error retries to only retry communication related failures. Improve communication failure detection.

## Motivation and Context

When a server responds with an invalid response it usually indicates an implementation problem which should not be retried. 

This PR mimics Presto logic for retries for Prestissimo on Spark

## Test Plan

Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

