### PR TITLE
[native] Add 'server/setState' and 'server/announcer' server operations.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
@@ -46,6 +46,11 @@ void PeriodicServiceInventoryManager::stop() {
   eventBaseThread_.stop();
 }
 
+void PeriodicServiceInventoryManager::enableRequest(bool enable) {
+  LOG(INFO) << (enable ? "Enabling " : "Disabling ") << id_;
+  requestEnabled_ = enable;
+}
+
 void PeriodicServiceInventoryManager::sendRequest() {
   // stop() calls EventBase's destructor which executed all pending callbacks;
   // make sure not to do anything if that's the case
@@ -75,6 +80,12 @@ void PeriodicServiceInventoryManager::sendRequest() {
   } catch (const std::exception& ex) {
     LOG(WARNING) << "Error occurred during updating service address: "
                  << ex.what();
+    scheduleNext();
+    return;
+  }
+
+  if (!requestEnabled_) {
+    LOG(INFO) << id_ << " skipped (it is disabled).";
     scheduleNext();
     return;
   }

--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
@@ -33,6 +33,9 @@ class PeriodicServiceInventoryManager {
 
   void stop();
 
+  /// If disabled then won't send any requests, but keeps itself running.
+  void enableRequest(bool enable);
+
  protected:
   // Denotes whether we retry failed requests due to network errors.
   virtual bool retryFailed() {
@@ -69,6 +72,7 @@ class PeriodicServiceInventoryManager {
   folly::SocketAddress serviceAddress_;
   std::shared_ptr<http::HttpClient> client_;
   std::atomic_bool stopped_{true};
+  std::atomic_bool requestEnabled_{true};
   uint64_t failedAttempts_{0};
   uint64_t attempts_{0};
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -113,6 +113,18 @@ bool isCacheTtlEnabled() {
 
 } // namespace
 
+std::string nodeState2String(NodeState nodeState) {
+  switch (nodeState) {
+    case presto::NodeState::kActive:
+      return "active";
+    case presto::NodeState::kInActive:
+      return "inactive";
+    case presto::NodeState::kShuttingDown:
+      return "shutting_down";
+  }
+  return fmt::format("<unknown>:{}>", static_cast<int>(nodeState));
+}
+
 PrestoServer::PrestoServer(const std::string& configDirectoryPath)
     : configDirectoryPath_(configDirectoryPath),
       signalHandler_(std::make_unique<SignalHandler>(this)),
@@ -416,7 +428,7 @@ void PrestoServer::run() {
     }
   }
   prestoServerOperations_ =
-      std::make_unique<PrestoServerOperations>(taskManager_.get());
+      std::make_unique<PrestoServerOperations>(taskManager_.get(), this);
 
   // The endpoint used by operation in production.
   httpServer_->registerGet(
@@ -721,6 +733,12 @@ void PrestoServer::stop() {
       httpServer_->stop();
       PRESTO_SHUTDOWN_LOG(INFO) << "HTTP Server stopped.";
     }
+  }
+}
+
+void PrestoServer::enableAnnouncer(bool enable) {
+  if (announcer_ != nullptr) {
+    announcer_->enableRequest(enable);
   }
 }
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -60,6 +60,8 @@ namespace facebook::presto {
 /// Three states server can be in.
 enum class NodeState : int8_t { kActive, kInActive, kShuttingDown };
 
+std::string nodeState2String(NodeState nodeState);
+
 class Announcer;
 class SignalHandler;
 class TaskManager;
@@ -84,6 +86,10 @@ class PrestoServer {
   void setNodeState(NodeState nodeState) {
     nodeState_ = nodeState;
   }
+
+  /// Enable/disable announcer (process notifying coordinator about this
+  /// worker).
+  void enableAnnouncer(bool enable);
 
  protected:
   /// Hook for derived PrestoServer implementations to add/stop additional

--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
@@ -15,6 +15,7 @@
 #include <velox/common/base/Exceptions.h>
 #include <velox/common/base/VeloxException.h>
 #include <velox/common/process/TraceContext.h>
+#include "presto_cpp/main/PrestoServer.h"
 #include "presto_cpp/main/ServerOperation.h"
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/http/HttpServer.h"
@@ -242,15 +243,73 @@ std::string PrestoServerOperations::taskOperation(
 
 std::string PrestoServerOperations::serverOperation(
     const ServerOperation& op,
-    proxygen::HTTPMessage* /* unused */) {
+    proxygen::HTTPMessage* message) {
   switch (op.action) {
-    case ServerOperation::Action::kTrace: {
-      return velox::process::TraceContext::statusLine();
-    }
+    case ServerOperation::Action::kTrace:
+      return serverOperationTrace();
+    case ServerOperation::Action::kSetState:
+      return serverOperationSetState(message);
+    case ServerOperation::Action::kAnnouncer:
+      return serverOperationAnnouncer(message);
     default:
       break;
   }
   return unsupportedAction(op);
+}
+
+std::string PrestoServerOperations::serverOperationTrace() {
+  return velox::process::TraceContext::statusLine();
+}
+
+std::string PrestoServerOperations::serverOperationSetState(
+    proxygen::HTTPMessage* message) {
+  if (server_) {
+    const auto& stateStr = message->getQueryParam("state");
+    const auto prevState = server_->nodeState();
+    NodeState newNodeState{NodeState::kActive};
+    if (stateStr == "active") {
+      newNodeState = NodeState::kActive;
+    } else if (stateStr == "inactive") {
+      newNodeState = NodeState::kInActive;
+    } else if (stateStr == "shutting_down") {
+      newNodeState = NodeState::kShuttingDown;
+    } else {
+      return fmt::format(
+          "Invalid state '{}'. "
+          "Supported states are: 'active', 'inactive', 'shutting_down'. "
+          "Example: server/setState?state=shutting_down",
+          stateStr);
+    }
+    if (newNodeState != prevState) {
+      LOG(INFO) << "Setting node state to " << nodeState2String(newNodeState);
+      server_->setNodeState(newNodeState);
+    }
+    return fmt::format(
+        "New node state: '{}', previous state: '{}'.",
+        nodeState2String(newNodeState),
+        nodeState2String(prevState));
+  }
+  return "No PrestoServer to change state of (it is nullptr).";
+}
+
+std::string PrestoServerOperations::serverOperationAnnouncer(
+    proxygen::HTTPMessage* message) {
+  if (server_) {
+    const auto& actionStr = message->getQueryParam("action");
+    if (actionStr == "enable") {
+      server_->enableAnnouncer(true);
+      return "Announcer enabled";
+    } else if (actionStr == "disable") {
+      server_->enableAnnouncer(false);
+      return "Announcer disabled";
+    }
+    return fmt::format(
+        "Invalid action '{}'. "
+        "Supported actions are: 'enable', 'disable'. "
+        "Example: server/announcer?action=disable",
+        actionStr);
+  }
+  return "No PrestoServer to change announcer of (it is nullptr).";
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
@@ -23,13 +23,14 @@ class ResponseHandler;
 
 namespace facebook::presto {
 
+class PrestoServer;
 struct ServerOperation;
 
 /// Static class implements Presto Server Operations.
 class PrestoServerOperations {
  public:
-  PrestoServerOperations(TaskManager* const taskManager)
-      : taskManager_(taskManager) {}
+  PrestoServerOperations(TaskManager* taskManager, PrestoServer* server)
+      : taskManager_(taskManager), server_(server) {}
 
   void runOperation(
       proxygen::HTTPMessage* message,
@@ -55,7 +56,15 @@ class PrestoServerOperations {
       const ServerOperation& op,
       proxygen::HTTPMessage* message);
 
+ private:
+  std::string serverOperationTrace();
+
+  std::string serverOperationSetState(proxygen::HTTPMessage* message);
+
+  std::string serverOperationAnnouncer(proxygen::HTTPMessage* message);
+
   TaskManager* const taskManager_;
+  PrestoServer* const server_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/ServerOperation.cpp
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.cpp
@@ -24,7 +24,9 @@ const folly::F14FastMap<std::string, ServerOperation::Action>
         {"getProperty", ServerOperation::Action::kGetProperty},
         {"getDetail", ServerOperation::Action::kGetDetail},
         {"listAll", ServerOperation::Action::kListAll},
-        {"trace", ServerOperation::Action::kTrace}};
+        {"trace", ServerOperation::Action::kTrace},
+        {"setState", ServerOperation::Action::kSetState},
+        {"announcer", ServerOperation::Action::kAnnouncer}};
 
 const folly::F14FastMap<ServerOperation::Action, std::string>
     ServerOperation::kReverseActionLookup{
@@ -34,7 +36,9 @@ const folly::F14FastMap<ServerOperation::Action, std::string>
         {ServerOperation::Action::kGetProperty, "getProperty"},
         {ServerOperation::Action::kGetDetail, "getDetail"},
         {ServerOperation::Action::kListAll, "listAll"},
-        {ServerOperation::Action::kTrace, "trace"}};
+        {ServerOperation::Action::kTrace, "trace"},
+        {ServerOperation::Action::kSetState, "setState"},
+        {ServerOperation::Action::kAnnouncer, "announcer"}};
 
 const folly::F14FastMap<std::string, ServerOperation::Target>
     ServerOperation::kTargetLookup{

--- a/presto-native-execution/presto_cpp/main/ServerOperation.h
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.h
@@ -32,13 +32,26 @@ struct ServerOperation {
 
   /// The action this operation is trying to take
   enum class Action {
+    /// Applicable to kConnector. Clears the connector cache.
     kClearCache,
+    /// Applicable to kConnector. Returns stats of the connector cache.
     kGetCacheStats,
+    /// Applicable to kSystemConfig & kVeloxQueryConfig. Modifies the value of a
+    /// single property.
     kSetProperty,
+    /// Applicable to kSystemConfig & kVeloxQueryConfig. Returns the value of a
+    /// single property.
     kGetProperty,
+    /// Applicable to kTask. Returns detailed info on one Task.
     kGetDetail,
+    /// Applicable to kTask. Returns brief info on all Tasks.
     kListAll,
+    /// Applicable to kServer. Returns data on all TraceContext objets.
     kTrace,
+    /// Applicable to kServer. Change state of the worker node.
+    kSetState,
+    /// Applicable to kServer. Enable/disable Presto Announcer.
+    kAnnouncer,
   };
 
   static const folly::F14FastMap<std::string, Target> kTargetLookup;

--- a/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
@@ -175,7 +175,7 @@ TEST_F(ServerOperationTest, taskEndpoint) {
   EXPECT_EQ(2, taskManager->tasks().size());
 
   // Test body
-  PrestoServerOperations serverOperation(taskManager.get());
+  PrestoServerOperations serverOperation(taskManager.get(), nullptr);
 
   proxygen::HTTPMessage httpMessage;
   auto listAllResponse = serverOperation.taskOperation(
@@ -213,7 +213,7 @@ TEST_F(ServerOperationTest, taskEndpoint) {
 }
 
 TEST_F(ServerOperationTest, systemConfigEndpoint) {
-  PrestoServerOperations serverOperation(nullptr);
+  PrestoServerOperations serverOperation(nullptr, nullptr);
   proxygen::HTTPMessage httpMessage;
   httpMessage.setQueryParam("name", "foo");
   VELOX_ASSERT_THROW(


### PR DESCRIPTION
The new server operations can be used for debugging: isolate a bad worker
from the cluster to unblock the cluster and then debug the worker.

```
== NO RELEASE NOTE ==
```

