### PR TITLE
Remove partitions from JSON constructor of BaseHiveTableLayoutHandle

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/BaseHiveTableLayoutHandle.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/BaseHiveTableLayoutHandle.java
@@ -46,8 +46,24 @@ public class BaseHiveTableLayoutHandle
             @JsonProperty("domainPredicate") TupleDomain<Subfield> domainPredicate,
             @JsonProperty("remainingPredicate") RowExpression remainingPredicate,
             @JsonProperty("pushdownFilterEnabled") boolean pushdownFilterEnabled,
-            @JsonProperty("partitionColumnPredicate") TupleDomain<ColumnHandle> partitionColumnPredicate,
-            @JsonProperty("partitions") Optional<List<HivePartition>> partitions)
+            @JsonProperty("partitionColumnPredicate") TupleDomain<ColumnHandle> partitionColumnPredicate)
+    {
+        this(
+                partitionColumns,
+                domainPredicate,
+                remainingPredicate,
+                pushdownFilterEnabled,
+                partitionColumnPredicate,
+                Optional.empty());
+    }
+
+    public BaseHiveTableLayoutHandle(
+            List<BaseHiveColumnHandle> partitionColumns,
+            TupleDomain<Subfield> domainPredicate,
+            RowExpression remainingPredicate,
+            boolean pushdownFilterEnabled,
+            TupleDomain<ColumnHandle> partitionColumnPredicate,
+            Optional<List<HivePartition>> partitions)
     {
         this.partitionColumns = ImmutableList.copyOf(requireNonNull(partitionColumns, "partitionColumns is null"));
         this.domainPredicate = requireNonNull(domainPredicate, "domainPredicate is null");


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Remove partitions from JSON constructor of BaseHiveTableLayoutHandle

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
partitions are a coordinator-only parameter, therefore can be ignored when serializing

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

