### PR TITLE
[native] Use folly::dynamic as propagation media for printing

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -154,7 +154,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
     };
   }
 
-  std::string toJsonString() override {
+  folly::dynamic toJson() override {
     folly::dynamic obj = folly::dynamic::object;
     obj["taskId"] = taskId_;
     obj["destination"] = destination_;
@@ -167,7 +167,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
     obj["closed"] = std::to_string(closed_);
     obj["abortResultsIssued"] = std::to_string(abortResultsIssued_);
     obj["atEnd"] = atEnd_;
-    return folly::toPrettyJson(obj);
+    return obj;
   }
 
   int testingFailedAttempts() const {

--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -689,10 +689,10 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
   return str;
 }
 
-std::string PrestoTask::toJsonString() const {
+folly::dynamic PrestoTask::toJson() const {
   std::lock_guard<std::mutex> l(mutex);
   folly::dynamic obj = folly::dynamic::object;
-  obj["task"] = task ? task->toJsonString() : "null";
+  obj["task"] = task ? task->toJson() : "null";
   obj["taskStarted"] = taskStarted;
   obj["lastHeartbeatMs"] = lastHeartbeatMs;
   obj["lastTaskStatsUpdateMs"] = lastTaskStatsUpdateMs;
@@ -700,8 +700,8 @@ std::string PrestoTask::toJsonString() const {
 
   json j;
   to_json(j, info);
-  obj["taskInfo"] = to_string(j);
-  return folly::toPrettyJson(obj);
+  obj["taskInfo"] = folly::parseJson(to_string(j));
+  return obj;
 }
 
 protocol::RuntimeMetric toRuntimeMetric(

--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -137,7 +137,7 @@ struct PrestoTask {
   protocol::TaskInfo updateInfoLocked();
   void updateOutputBufferInfoLocked(const velox::exec::TaskStats& taskStats);
 
-  std::string toJsonString() const;
+  folly::dynamic toJson() const;
 
  private:
   void recordProcessCpuTime();


### PR DESCRIPTION
Using string carrying json content to propagate will create many escapes that at final rendering often is hard to read. Change to folly::dynamic solves the problem
```
== NO RELEASE NOTE ==
```

