### PR TITLE
[codemod][lowrisk] Remove extra semi colon from github/presto-trunk/presto-native-execution/presto_cpp/main/PrestoServer.h

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -88,9 +88,9 @@ class PrestoServer {
  protected:
   /// Hook for derived PrestoServer implementations to add/stop additional
   /// periodic tasks.
-  virtual void addAdditionalPeriodicTasks(){};
+  virtual void addAdditionalPeriodicTasks(){}
 
-  virtual void stopAdditionalPeriodicTasks(){};
+  virtual void stopAdditionalPeriodicTasks(){}
 
   virtual void initializeCoordinatorDiscoverer();
 


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D52969187


