### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from github/presto-trunk/presto-native-execution/presto_cpp/main/TaskResource.cpp

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -233,14 +233,14 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
               try {
                 taskInfo =
                     createOrUpdateFunc(taskId, updateJson, startProcessCpuTime);
-              } catch (const velox::VeloxException& e) {
+              } catch (const velox::VeloxException&) {
                 // Creating an empty task, putting errors inside so that next
                 // status fetch from coordinator will catch the error and well
                 // categorize it.
                 try {
                   taskInfo = taskManager_.createOrUpdateErrorTask(
                       taskId, std::current_exception(), startProcessCpuTime);
-                } catch (const velox::VeloxUserError& e) {
+                } catch (const velox::VeloxUserError&) {
                   throw;
                 }
               }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D52957791


