### PR TITLE
[native] Add http request active check when fetch data from output buffer manager

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <memory>
+#include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/main/types/PrestoTaskId.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/exec/Task.h"
@@ -59,10 +60,25 @@ struct Result {
 
 struct ResultRequest {
   PromiseHolderWeakPtr<std::unique_ptr<Result>> promise;
+  std::weak_ptr<http::CallbackRequestHandlerState> state;
   protocol::TaskId taskId;
   int64_t bufferId;
   int64_t token;
   protocol::DataSize maxSize;
+
+  ResultRequest(
+      PromiseHolderWeakPtr<std::unique_ptr<Result>> _promise,
+      std::weak_ptr<http::CallbackRequestHandlerState> _state,
+      protocol::TaskId _taskId,
+      int64_t _bufferId,
+      int64_t _token,
+      protocol::DataSize _maxSize)
+      : promise(std::move(_promise)),
+        state(std::move(_state)),
+        taskId(_taskId),
+        bufferId(_bufferId),
+        token(_token),
+        maxSize(_maxSize) {}
 };
 
 struct PrestoTask {

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
@@ -35,6 +35,11 @@ void verifyQueryCtxCache(
 } // namespace
 
 class QueryContextCacheTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     FLAGS_velox_memory_leak_check_enabled = true;
   }


### PR DESCRIPTION
Add http request active check when fetch data from output buffer manager
in Velox. The active check is based on whether the http callstate has been destroyed
or the associated request has expired. This is to avoid arbitrary output buffer
to load data into a destination buffer which has set notify but the associated client
request has expired. This helps to accelerate the shuffle for query with scale writer
which uses arbitrary output buffer.

Unit test is added to verify this behavior.
