### PR TITLE
[native] Change to use the new named spillWrites stat

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -600,7 +600,7 @@ void PeriodicTaskManager::updateSpillStatsTask() {
   REPORT_IF_NOT_ZERO(
       kCounterSpillSerializationTimeUs,
       deltaSpillStats.spillSerializationTimeUs);
-  REPORT_IF_NOT_ZERO(kCounterSpillDiskWrites, deltaSpillStats.spillDiskWrites);
+  REPORT_IF_NOT_ZERO(kCounterSpillWrites, deltaSpillStats.spillWrites);
   REPORT_IF_NOT_ZERO(
       kCounterSpillFlushTimeUs, deltaSpillStats.spillFlushTimeUs);
   REPORT_IF_NOT_ZERO(

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -198,7 +198,7 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(kCounterSpillSortTimeUs, facebook::velox::StatType::SUM);
   DEFINE_METRIC(
       kCounterSpillSerializationTimeUs, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpillDiskWrites, facebook::velox::StatType::SUM);
+  DEFINE_METRIC(kCounterSpillWrites, facebook::velox::StatType::SUM);
   DEFINE_METRIC(kCounterSpillFlushTimeUs, facebook::velox::StatType::SUM);
   DEFINE_METRIC(kCounterSpillWriteTimeUs, facebook::velox::StatType::SUM);
   DEFINE_METRIC(kCounterSpillMemoryBytes, facebook::velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -192,8 +192,8 @@ constexpr folly::StringPiece kCounterSpillSortTimeUs{
 constexpr folly::StringPiece kCounterSpillSerializationTimeUs{
     "presto_cpp.spill_serialization_time_us"};
 /// The number of disk writes to spill rows.
-constexpr folly::StringPiece kCounterSpillDiskWrites{
-    "presto_cpp.spill_disk_write_count"};
+constexpr folly::StringPiece kCounterSpillWrites{
+    "presto_cpp.spill_write_count"};
 /// The time spent on copy out serialized rows for disk write. If compression
 /// is enabled, this includes the compression time.
 constexpr folly::StringPiece kCounterSpillFlushTimeUs{


### PR DESCRIPTION

```
== NO RELEASE NOTE ==
```

