### PR TITLE
Fix min_by/max_by for window function evaluation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedKeyValueHeap.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedKeyValueHeap.java
@@ -74,6 +74,11 @@ public class TypedKeyValueHeap
         return positionCount == 0;
     }
 
+    public Type getKeyType()
+    {
+        return keyType;
+    }
+
     public void serialize(BlockBuilder out)
     {
         BlockBuilder blockBuilder = out.beginBlockEntry();
@@ -111,9 +116,23 @@ public class TypedKeyValueHeap
         }
     }
 
+    public void popAll(BlockBuilder valueResultBlockBuilder, BlockBuilder keyResultBlockBuilder)
+    {
+        while (positionCount > 0) {
+            pop(valueResultBlockBuilder, keyResultBlockBuilder);
+        }
+    }
+
     public void pop(BlockBuilder resultBlockBuilder)
     {
         valueType.appendTo(valueBlockBuilder, heapIndex[0], resultBlockBuilder);
+        remove();
+    }
+
+    public void pop(BlockBuilder valueResultBlockBuilder, BlockBuilder keyResultBlockBuilder)
+    {
+        valueType.appendTo(valueBlockBuilder, heapIndex[0], valueResultBlockBuilder);
+        keyType.appendTo(keyBlockBuilder, heapIndex[0], keyResultBlockBuilder);
         remove();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/minmaxby/AbstractMinMaxByNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/minmaxby/AbstractMinMaxByNAggregationFunction.java
@@ -140,16 +140,17 @@ public abstract class AbstractMinMaxByNAggregationFunction
         }
 
         Type elementType = outputType.getElementType();
+        Type keyType = heap.getKeyType();
 
         BlockBuilder arrayBlockBuilder = out.beginBlockEntry();
-        BlockBuilder reversedBlockBuilder = elementType.createBlockBuilder(null, heap.getCapacity());
-        long startSize = heap.getEstimatedSize();
-        heap.popAll(reversedBlockBuilder);
-        state.addMemoryUsage(heap.getEstimatedSize() - startSize);
+        BlockBuilder reversedValueBlockBuilder = elementType.createBlockBuilder(null, heap.getCapacity());
+        BlockBuilder reversedKeyBlockBuilder = keyType.createBlockBuilder(null, heap.getCapacity());
+        heap.popAll(reversedValueBlockBuilder, reversedKeyBlockBuilder);
 
-        for (int i = reversedBlockBuilder.getPositionCount() - 1; i >= 0; i--) {
-            elementType.appendTo(reversedBlockBuilder, i, arrayBlockBuilder);
+        for (int i = reversedValueBlockBuilder.getPositionCount() - 1; i >= 0; i--) {
+            elementType.appendTo(reversedValueBlockBuilder, i, arrayBlockBuilder);
         }
+        heap.addAll(reversedKeyBlockBuilder, reversedValueBlockBuilder);
         out.closeEntry();
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1817,6 +1817,21 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testMinMaxByN()
+    {
+        assertQuery("SELECT MIN_BY(c0, c0, c1) OVER ( PARTITION BY c2 ORDER BY c3 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW ) FROM " +
+                "( VALUES (1, 10, FALSE, 0), (2, 10, FALSE, 1) ) AS t(c0, c1, c2, c3)", "values array[1], array[1, 2]");
+        assertQuery("SELECT MIN_BY(c0, c3, c1) OVER ( PARTITION BY c2 ORDER BY c3 ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW ) FROM " +
+                "( VALUES (1, 10, FALSE, 2), (2, 10, FALSE, 1) ) AS t(c0, c1, c2, c3)", "values array[2], array[2, 1]");
+        assertQuery("select max_by(k1, k2, 2) over (partition by k3 order by k4) from (values (1, 'a', 1, 3), (2, 'b', 1, 2), (5, 'd', 2, 1), (8, 'c', 2, 0)) " +
+                "t(k1, k2, k3, k4)", "values array[8], array[5, 8], array[2], array[2, 1]");
+        assertQuery("select max_by(k1, k2, 2) over (partition by k3 order by k4) from (values (1, 'a', 1, 3), (2, 'b', 1, 2), (5, 'd', 2, 1), (8, 'c', 2, 0), (7, 'e', 1, 8), " +
+                "(9, 'f', 2, 10), (0, 'g', 1, 9)) t(k1, k2, k3, k4)", "values array[8], array[5, 8], array[9, 5], array[2], array[2, 1], array[7, 2], array[0, 7]");
+        assertQuery("select min_by(k1, k2, 2) over (partition by k3 order by k4) from (values (1, 'a', 1, 3), (2, 'b', 1, 2), (5, 'd', 2, 1), (8, 'c', 2, 0), (7, 'e', 1, 8), " +
+                "(9, 'f', 2, 10), (0, 'g', 1, 9)) t(k1, k2, k3, k4)", "values array[2], array[1, 2], array[1, 2], array[1, 2], array[8], array[8, 5], array[8, 5]");
+    }
+
+    @Test
     public void testRowNumberFilterAndLimit()
     {
         MaterializedResult actual = computeActual("" +


### PR DESCRIPTION
## Description
Fix issue https://github.com/prestodb/presto/issues/21653

## Motivation and Context
As described in https://github.com/prestodb/presto/issues/21653, the min_by/max_by are not returning the expected result, due to the optimization in window function expression. A similar bug in min/max function was fixed in https://github.com/prestodb/presto/pull/18615

## Impact
Fix the correctness issue for max_by/min_by in window function. 
The queries with the following pattern will be impacted:
- The max_by/min_by function should take three arguments, i.e. have the n argument like max_by(x, y, n). This is because the max_by(x, y) function has a [different implementation](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/aggregation/minmaxby/AbstractMinMaxBy.java) than the max_by(x, y, n) function
- The max_by/min_by function should not have “unbounded following” in the frame definition. This is because the optimization in the window function evaluation only works when the end of frame changes for different rows in the same partition.

Notice that this change will also slightly degrade the performance of this aggregation function. The fix is to restore the accumulation state after outputting the result, which is not needed if not used in window function. However, to mitigate this, we need to know whether it's used in window function in the implementation, which makes the code complex and not worth the benefit.

## Test Plan
Tested with the query in the issue.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix a bug for min_by/max_by for window function, where results are incorrect when the function specifies number of elements to keep and the window does not have “unbounded following” in the frame.
```


