### PR TITLE
[native] Add memory reclaim stats to task runtime stats

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -440,9 +440,22 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
 
   std::unordered_map<std::string, RuntimeMetric> taskRuntimeStats;
 
+  if (taskStats.memoryReclaimCount > 0) {
+    taskRuntimeStats["memoryReclaimCount"].addValue(
+        taskStats.memoryReclaimCount);
+    taskRuntimeStats.insert(
+        {"memoryReclaimWallNanos",
+         RuntimeMetric(
+             taskStats.memoryReclaimMs * 1'000'000,
+             RuntimeCounter::Unit::kNanos)});
+  }
+
   if (taskStats.endTimeMs >= taskStats.executionEndTimeMs) {
-    taskRuntimeStats["outputConsumedDelayInNanos"].addValue(
-        (taskStats.endTimeMs - taskStats.executionEndTimeMs) * 1'000'000);
+    taskRuntimeStats.insert(
+        {"outputConsumedDelayInNanos",
+         RuntimeMetric(
+             (taskStats.endTimeMs - taskStats.executionEndTimeMs) * 1'000'000,
+             RuntimeCounter::Unit::kNanos)});
     taskRuntimeStats["createTime"].addValue(taskStats.executionStartTimeMs);
     taskRuntimeStats["endTime"].addValue(taskStats.endTimeMs);
   }


### PR DESCRIPTION
Add task runtime stats to collect memory reclaim stats during a task execution.
This helps to debug how much time spent on task memory reclaim of a slow query
execution. If the memory reclaim is triggered by the task itself, then the time will
also be counted in task cpu execution time. If not, it is counted in the task's scheduled
time but not execution time as the task will be stopped before memory reclamation.