### PR TITLE
[native] Update build to support new dependency versions

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -60,7 +60,8 @@ commands:
 executors:
   build:
     docker:
-      - image: prestocpp/prestocpp-avx-centos:root-20230613
+      # These images are managed by the Presto Release team.
+      - image: public.ecr.aws/oss-presto/prestocpp:root-20240129
     resource_class: 2xlarge
     environment:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"

--- a/presto-native-execution/presto_cpp/main/PrestoMain.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoMain.cpp
@@ -22,7 +22,7 @@
 DEFINE_string(etc_dir, ".", "etc directory for presto configuration");
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init init{&argc, &argv};
 
   google::InstallFailureSignalHandler();
   PRESTO_STARTUP_LOG(INFO) << "Entering main()";

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
@@ -22,7 +22,7 @@ using namespace facebook::velox::memory;
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, true);
+  folly::Init init{&argc, &argv};
   return RUN_ALL_TESTS();
 }
 

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -15,7 +15,7 @@
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, true);
+  folly::Init init{&argc, &argv};
   return RUN_ALL_TESTS();
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -1177,6 +1177,6 @@ TEST_F(UnsafeRowShuffleTest, shuffleInterfaceRegistration) {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init init{&argc, &argv};
   return RUN_ALL_TESTS();
 }

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -41,7 +41,6 @@ target_link_libraries(
   velox_aggregates
   velox_hive_partition_function
   ${RE2}
-  Folly::folly
   gmock
   gtest
   gtest_main)

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -42,7 +42,7 @@ using namespace testing;
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, true);
+  folly::Init init{&argc, &argv};
   FLAGS_velox_memory_leak_check_enabled = true;
   return RUN_ALL_TESTS();
 }

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -1035,7 +1035,8 @@ core::SortOrder toVeloxSortOrder(const protocol::SortOrder& sortOrder) {
     case protocol::SortOrder::DESC_NULLS_LAST:
       return core::SortOrder(false, false);
     default:
-      VELOX_UNSUPPORTED("Unsupported sort order: {}.", sortOrder);
+      VELOX_UNSUPPORTED(
+          "Unsupported sort order: {}.", fmt::underlying(sortOrder));
   }
 }
 
@@ -1144,7 +1145,8 @@ core::WindowNode::WindowType toVeloxWindowType(
     case protocol::WindowType::ROWS:
       return core::WindowNode::WindowType::kRows;
     default:
-      VELOX_UNSUPPORTED("Unsupported window type: {}", windowType);
+      VELOX_UNSUPPORTED(
+          "Unsupported window type: {}", fmt::underlying(windowType));
   }
 }
 
@@ -1161,7 +1163,8 @@ core::WindowNode::BoundType toVeloxBoundType(protocol::BoundType boundType) {
     case protocol::BoundType::UNBOUNDED_FOLLOWING:
       return core::WindowNode::BoundType::kUnboundedFollowing;
     default:
-      VELOX_UNSUPPORTED("Unsupported window bound type: {}", boundType);
+      VELOX_UNSUPPORTED(
+          "Unsupported window bound type: {}", fmt::underlying(boundType));
   }
 }
 

--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -45,15 +45,6 @@ fi
 export COMPILER_FLAGS=$(echo -n $(get_cxx_flags $CPU_TARGET))
 
 (
-  wget --max-redirect 3 https://download.libsodium.org/libsodium/releases/LATEST.tar.gz &&
-  tar -xzvf LATEST.tar.gz &&
-  cd libsodium-stable &&
-  ./configure &&
-  make "-j$(nproc)" &&
-  make install
-)
-
-(
   wget http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz &&
   tar xvfz gperf-3.1.tar.gz &&
   cd gperf-3.1 &&
@@ -63,26 +54,6 @@ export COMPILER_FLAGS=$(echo -n $(get_cxx_flags $CPU_TARGET))
   ln -s /usr/local/gperf/3_1/bin/gperf /usr/local/bin/
 )
 
-(
-  git clone https://github.com/facebook/folly &&
-  cd folly &&
-  git checkout $FB_OS_VERSION &&
-  cmake_install -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -DFOLLY_HAVE_INT128_T=ON
-)
-
-(
-  git clone https://github.com/facebookincubator/fizz &&
-  cd fizz &&
-  git checkout $FB_OS_VERSION &&
-  cmake_install -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON fizz
-)
-
-(
-  git clone https://github.com/facebook/wangle &&
-  cd wangle &&
-  git checkout $FB_OS_VERSION &&
-  cmake_install -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON wangle
-)
 
 (
   git clone https://github.com/facebook/proxygen &&
@@ -98,11 +69,5 @@ export COMPILER_FLAGS=$(echo -n $(get_cxx_flags $CPU_TARGET))
   cmake_install -DBUILD_SHARED_LIBS=ON
 )
 
-(
-  git clone https://github.com/facebook/fbthrift &&
-  cd fbthrift &&
-  git checkout $FB_OS_VERSION &&
-  cmake_install -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON
-)
 
 dnf clean all

--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -17,7 +17,8 @@ set -eufx -o pipefail
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-macos.sh"
 
 MACOS_DEPS="${MACOS_DEPS} bison gperf libsodium"
-export FB_OS_VERSION=v2022.11.14.00
+export FB_OS_VERSION=v2023.12.04.00
+
 
 function install_six {
   pip3 install six
@@ -25,43 +26,15 @@ function install_six {
 
 export PATH=$(brew --prefix bison)/bin:$PATH
 
-function install_folly {
-  github_checkout facebook/folly "${FB_OS_VERSION}"
-  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
-   cmake_install -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
-}
-
-function install_fizz {
-  github_checkout facebookincubator/fizz "${FB_OS_VERSION}"
-  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
-    cmake_install -DBUILD_TESTS=OFF -S fizz
-}
-
-function install_wangle {
-  github_checkout facebook/wangle "${FB_OS_VERSION}"
-  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
-    cmake_install -DBUILD_TESTS=OFF -S wangle
-}
-
-function install_fbthrift {
-  github_checkout facebook/fbthrift "${FB_OS_VERSION}"
-  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
-    cmake_install -DBUILD_TESTS=OFF
-}
 
 function install_proxygen {
   github_checkout facebook/proxygen "${FB_OS_VERSION}"
-  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
-    cmake_install -DBUILD_TESTS=OFF
+  cmake_install -DBUILD_TESTS=OFF
 }
 
 function install_presto_deps {
   install_velox_deps
-  run_and_time install_folly
   run_and_time install_six
-  run_and_time install_fizz
-  run_and_time install_wangle
-  run_and_time install_fbthrift
   run_and_time install_proxygen
 }
 

--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -25,21 +25,6 @@ function install_six {
   pip3 install six
 }
 
-function install_fizz {
-  github_checkout facebookincubator/fizz "${FB_OS_VERSION}"
-  cmake_install -DBUILD_TESTS=OFF -S fizz
-}
-
-function install_wangle {
-  github_checkout facebook/wangle "${FB_OS_VERSION}"
-  cmake_install -DBUILD_TESTS=OFF -S wangle
-}
-
-function install_fbthrift {
-  github_checkout facebook/fbthrift "${FB_OS_VERSION}"
-  cmake_install -DBUILD_TESTS=OFF
-}
-
 function install_proxygen {
   github_checkout facebook/proxygen "${FB_OS_VERSION}"
   cmake_install -DBUILD_TESTS=OFF
@@ -48,9 +33,6 @@ function install_proxygen {
 function install_presto_deps {
   install_velox_deps
   run_and_time install_six
-  run_and_time install_fizz
-  run_and_time install_wangle
-  run_and_time install_fbthrift
   run_and_time install_proxygen
 }
 


### PR DESCRIPTION
## Description
FMT is updated to 10.1.1.
Folly, Fizz, Wangle, FBThrift are updated to v2023.12.04.00.
New dependency mvfst v2023.12.04.00 added.
The specific requirement of OpenSSL@1.1 is now removed.

Users will have to reinstall the dependencies

## Motivation and Context
This change should allow you to build Prestissimo with versions of fmt above 9.  Velox updated its dependency to fmt 10. Users who update to fmt 10 will not be able to build presto_native. This change fixes presto_native so that it can build with fmt 9 and above.


## Impact
Users who are on fmt 8 will need to update their systems by running `./scripts/setup-<os>.sh`.

## Test Plan
Tested locally


```
== NO RELEASE NOTE ==
```

Resolves https://github.com/prestodb/presto/issues/21792
