### PR TITLE
[native] Use 'max_output_buffer_size', not 'max_arbitrary_buffer_size'

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -729,8 +729,7 @@ BaseVeloxQueryConfig::BaseVeloxQueryConfig() {
           BOOL_PROP(
               QueryConfig::kPrestoArrayAggIgnoreNulls,
               c.prestoArrayAggIgnoreNulls()),
-          NUM_PROP(
-              QueryConfig::kMaxArbitraryBufferSize, c.maxArbitraryBufferSize()),
+          NUM_PROP(QueryConfig::kMaxOutputBufferSize, c.maxOutputBufferSize()),
       };
 }
 
@@ -749,7 +748,7 @@ void BaseVeloxQueryConfig::updateLoadedValues(
   const std::unordered_map<std::string, std::string> updatedValues{
       {QueryConfig::kPrestoArrayAggIgnoreNulls,
        bool2String(systemConfig->useLegacyArrayAgg())},
-      {QueryConfig::kMaxArbitraryBufferSize,
+      {QueryConfig::kMaxOutputBufferSize,
        systemConfig->capacityPropertyAsBytesString(
            SystemConfig::kSinkMaxBufferSize)},
       {QueryConfig::kMaxPartitionedOutputBufferSize,

--- a/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
@@ -121,7 +121,7 @@ TEST_F(BaseVeloxQueryConfigTest, fromSystemConfig) {
   cfg->initialize(configFilePath);
 
   ASSERT_EQ("true", GET_VAL(QueryConfig::kPrestoArrayAggIgnoreNulls));
-  ASSERT_EQ("17825792", GET_VAL(QueryConfig::kMaxArbitraryBufferSize));
+  ASSERT_EQ("17825792", GET_VAL(QueryConfig::kMaxOutputBufferSize));
   ASSERT_EQ("6291456", GET_VAL(QueryConfig::kMaxPartitionedOutputBufferSize));
 
 #undef GET_VAL


### PR DESCRIPTION
## Description
'max_arbitrary_buffer_size' is getting deprecated in Velox.

```
== NO RELEASE NOTE ==
```

