### PR TITLE
Make runtime stats available for DirectoryLister

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.google.common.collect.ImmutableMap;
 
@@ -25,18 +26,20 @@ public class HiveDirectoryContext
     private final NestedDirectoryPolicy nestedDirectoryPolicy;
     private final ConnectorIdentity connectorIdentity;
     private final Map<String, String> additionalProperties;
-
+    private final RuntimeStats runtimeStats;
     private boolean cacheable;
 
     public HiveDirectoryContext(
             NestedDirectoryPolicy nestedDirectoryPolicy,
             boolean cacheable,
             ConnectorIdentity connectorIdentity,
-            Map<String, String> additionalProperties)
+            Map<String, String> additionalProperties,
+            RuntimeStats runtimeStats)
     {
         this.nestedDirectoryPolicy = requireNonNull(nestedDirectoryPolicy, "nestedDirectoryPolicy is null");
         this.connectorIdentity = requireNonNull(connectorIdentity, "connectorIdentity is null");
         this.additionalProperties = ImmutableMap.copyOf(requireNonNull(additionalProperties, "additionalProperties is null"));
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
 
         // this can be disabled
         this.cacheable = cacheable;
@@ -65,5 +68,10 @@ public class HiveDirectoryContext
     public Map<String, String> getAdditionalProperties()
     {
         return additionalProperties;
+    }
+
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -191,7 +191,8 @@ public class ManifestPartitionLoader
                 recursiveDirWalkerEnabled ? RECURSE : IGNORED,
                 false,
                 hdfsContext.getIdentity(),
-                buildDirectoryContextProperties(session));
+                buildDirectoryContextProperties(session),
+                session.getRuntimeStats());
 
         Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fileSystem, table, path, partition.getPartition(), namenodeStats, hiveDirectoryContext);
         int fileCount = 0;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -371,7 +371,8 @@ public class StoragePartitionLoader
                 recursiveDirWalkerEnabled ? RECURSE : IGNORED,
                 cacheable,
                 hdfsContext.getIdentity(),
-                buildDirectoryContextProperties(session));
+                buildDirectoryContextProperties(session),
+                session.getRuntimeStats());
         return stream(directoryLister.list(fileSystem, table, path, partition, namenodeStats, hiveDirectoryContext))
                 .map(hiveFileInfo -> splitFactory.createInternalHiveSplit(hiveFileInfo, splittable))
                 .filter(Optional::isPresent)
@@ -402,7 +403,8 @@ public class StoragePartitionLoader
                     FAIL,
                     isUseListDirectoryCache(session),
                     hdfsContext.getIdentity(),
-                    buildDirectoryContextProperties(session))));
+                    buildDirectoryContextProperties(session),
+                    session.getRuntimeStats())));
         }
         catch (HiveFileIterator.NestedDirectoryNotAllowedException e) {
             // Fail here to be on the safe side. This seems to be the same as what Hive does
@@ -550,7 +552,8 @@ public class StoragePartitionLoader
                 recursiveDirWalkerEnabled ? RECURSE : IGNORED,
                 isUseListDirectoryCache(session),
                 hdfsContext.getIdentity(),
-                buildDirectoryContextProperties(session));
+                buildDirectoryContextProperties(session),
+                session.getRuntimeStats());
         return stream(directoryLister.list(fileSystem, table, path, partition, namenodeStats, hiveDirectoryContext))
                 .map(fileInfo -> {
                     int virtualBucketNumber = getVirtualBucketNumber(bucketCount, fileInfo.getPath());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.GroupByHashPageIndexerFactory;
 import com.facebook.presto.cache.CacheConfig;
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
@@ -1203,6 +1204,12 @@ public abstract class AbstractTestHiveClient
             public WarningCollector getWarningCollector()
             {
                 return WarningCollector.NOOP;
+            }
+
+            @Override
+            public RuntimeStats getRuntimeStats()
+            {
+                return session.getRuntimeStats();
             }
         };
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
 import com.facebook.presto.hive.metastore.Storage;
@@ -122,7 +123,8 @@ public class TestHudiDirectoryLister
                     IGNORED,
                     false,
                     new ConnectorIdentity("test", Optional.empty(), Optional.empty()),
-                    ImmutableMap.of()));
+                    ImmutableMap.of(),
+                    new RuntimeStats()));
             assertTrue(fileInfoIterator.hasNext());
             HiveFileInfo fileInfo = fileInfoIterator.next();
             assertEquals(fileInfo.getPath().getName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");
@@ -148,7 +150,8 @@ public class TestHudiDirectoryLister
                     IGNORED,
                     false,
                     new ConnectorIdentity("test", Optional.empty(), Optional.empty()),
-                    ImmutableMap.of()));
+                    ImmutableMap.of(),
+                    new RuntimeStats()));
             assertTrue(fileInfoIterator.hasNext());
             HiveFileInfo fileInfo = fileInfoIterator.next();
             assertEquals(fileInfo.getPath().getName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.metadata.SessionPropertyManager;
@@ -191,5 +192,11 @@ public class FullConnectorSession
     public WarningCollector getWarningCollector()
     {
         return session.getWarningCollector();
+    }
+
+    @Override
+    public RuntimeStats getRuntimeStats()
+    {
+        return session.getRuntimeStats();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.testing;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.execution.QueryIdGenerator;
@@ -204,6 +205,12 @@ public class TestingConnectorSession
     public WarningCollector getWarningCollector()
     {
         return WarningCollector.NOOP;
+    }
+
+    @Override
+    public RuntimeStats getRuntimeStats()
+    {
+        return new RuntimeStats();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.spi.function.SqlFunctionId;
@@ -63,4 +64,6 @@ public interface ConnectorSession
     }
 
     WarningCollector getWarningCollector();
+
+    RuntimeStats getRuntimeStats();
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.spi.function.SqlFunctionId;
@@ -122,6 +123,12 @@ public final class TestingSession
         public WarningCollector getWarningCollector()
         {
             return WarningCollector.NOOP;
+        }
+
+        @Override
+        public RuntimeStats getRuntimeStats()
+        {
+            return new RuntimeStats();
         }
     };
 


### PR DESCRIPTION
## Description
We want to use runtimestats in DirectoryLister implementation to measure different runtime metrics

## Motivation and Context
Goal is to add a metric to measure duration it takes to initialize iterator of HiveFileInfo for one of the implementation of DirectoryLister.

```
== NO RELEASE NOTE ==
```

