### PR TITLE
Update Logging Properties Documentation

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -891,3 +891,69 @@ CTE Materialization Properties
     The name of the catalog to be used for Common Table Expressions (CTE) and which provides custom partitioning for Common Table Expression (CTE) materialization.
     This setting specifies which catalog should be used for CTE materialization and for determining how to partition the materialization of CTEs in queries.
     This can also be specified on a per-query basis using the ``cte_partitioning_provider_catalog`` session property.
+
+
+Logging Properties
+------------------
+
+``log.max-history``
+^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``integer``
+    * **Default value:** ``30``
+
+    The ``log.max-history`` property controls the number of archive log periods that the application retains.
+    In Presto, one log period corresponds to one day. For instance, if ``log.max-history`` is set to 30, the system will keep logs for the
+    past 30 days.
+
+``log.max-size``
+^^^^^^^^^^^^^^^^
+
+    * **Type:** ``data size``
+    * **Default value:** ``100MB``
+
+    The maximum file size for the general application log file.
+
+``http-server.log.enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``boolean``
+    * **Default value:** ``true``
+
+    Flag to enable or disable logging for the HTTP server.
+
+``http-server.log.compression.enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``boolean``
+    * **Default value:** ``true``
+
+    Flag to enable or disable compression of the log files of the HTTP server.
+
+``http-server.log.path``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``string``
+    * **Default value:** ``var/log/http-request.log``
+
+    The path to the log file used by the HTTP server. The path is relative to
+    the data directory, configured by the launcher script as detailed in
+    :ref:`running_presto`.
+
+``http-server.log.max-history``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``integer``
+    * **Default value:** ``15``
+
+    The ``http-server.log.max-history`` property controls the number of archive log periods that the HTTP server retains.
+    In Presto, one log period corresponds to one day. For instance, if ``http-server.log.max-history`` is set to 15, the
+    system will keep logs for the past 15 days.
+
+``http-server.log.max-size``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``data size``
+    * **Default value:** ``100MB``
+
+    The maximum file size for the log file of the HTTP server.


### PR DESCRIPTION
## Description
In PrestoDB version 0.207, the Airlift library is used for logging. Airlift employs a FlushingFileAppender along with a TimeBasedRollingPolicy and SizeAndTimeBasedFNATP triggering policy for managing server.log and http-server.log. These components are part of the Logback library(v1.2.3).

The FlushingFileAppender is responsible for writing log messages to a file and ensuring that the log file is regularly flushed to disk.

The TimeBasedRollingPolicy allows for log file rotation based on time. It can be configured with a specific file name pattern and maximum history.

The SizeAndTimeBasedFNATP triggering policy supplements this by adding a file size limit to the rotation criteria.

These configurations can be set manually. However, if not explicitly set, default values are used.

## Motivation and Context
How logs are rotated and compressed for server and http-server.log(https://github.com/prestodb/presto/issues/21744)

## Impact
no impact just documentation

## Test Plan
local setup tested.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

