### PR TITLE
Remove erroneous resource group documentation

### DIFF
--- a/presto-docs/src/main/sphinx/admin/resource-groups-example1.sql
+++ b/presto-docs/src/main/sphinx/admin/resource-groups-example1.sql
@@ -36,9 +36,6 @@ CREATE TABLE IF NOT EXISTS resource_groups (
 INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, jmx_export)
 VALUES ('global', '80%', 100, 1000, true);
 
-INSERT INTO resource_groups (name, soft_memory_limit, hard_concurrency_limit, max_queued, jmx_export, parent_id)
-VALUES ('user', '50%', 50, 500, false, LAST_INSERT_ID());
-
 CREATE TABLE IF NOT EXISTS selectors (
                                          id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                                          resource_group_id BIGINT NOT NULL,

--- a/presto-docs/src/main/sphinx/admin/resource-groups.rst
+++ b/presto-docs/src/main/sphinx/admin/resource-groups.rst
@@ -248,8 +248,6 @@ Here are the key components of selector rules in PrestoDB:
 
 * ``user`` (optional): This is a regular expression that matches the user who is submitting the query.
 
-* ``userGroup`` (optional): Regex to match against every user group the user belongs to.
-
 * ``source`` (optional): This matches the source of the query, which is typically the
   application submitting the query.
 
@@ -321,30 +319,29 @@ There are four selectors, that define which queries run in which resource group:
 
 * The first selector matches queries from ``bob`` and places them in the admin group.
 
-* The second selector matches queries from ``admin`` user group and places them in the admin group.
-
-* The third selector matches all data definition (DDL) queries from a source name that includes ``pipeline``
+* The second selector matches all data definition (DDL) queries from a source name that includes ``pipeline``
   and places them in the ``global.data_definition`` group. This could help reduce queue times for this
   class of queries, since they are expected to be fast.
 
-* The fourth selector matches queries from a source name that includes ``pipeline``, and places them in a
+* The third selector matches queries from a source name that includes ``pipeline``, and places them in a
   dynamically-created per-user pipeline group under the ``global.pipeline`` group.
 
-* The fifth selector matches queries that come from BI tools which have a source matching the regular
-  expression ``jdbc#(?<toolname>.*)`` and have client provided tags that are a superset of ``hipri``.
-  These are placed in a dynamically-created sub-group under the ``global.adhoc`` group.
-  The dynamic sub-groups are created based on the values of named variables ``toolname`` and ``user``.
-  The values are derived from the source regular expression and the query user respectively.
-  Consider a query with a source ``jdbc#powerfulbi``, user ``kayla``, and client tags ``hipri`` and ``fast``.
-  This query is routed to the ``global.adhoc.bi-powerfulbi.kayla`` resource group.
+* The fourth selector matches queries that come from BI tools which have a source matching the regular
+  expression ``jdbc#(?<toolname>.*)``, and have client provided tags that are a superset of ``hi-pri``.
+  These are placed in a dynamically-created sub-group under the ``global.pipeline.tools`` group. The dynamic
+  sub-group is created based on the named variable ``toolname``, which is extracted from the
+  regular expression for source.
+
+  Consider a query with a source ``jdbc#powerfulbi``, user ``kayla``, and
+  client tags ``hipri`` and ``fast``. This query is routed to the ``global.pipeline.bi-powerfulbi.kayla``
+  resource group.
 
 * The last selector is a catch-all, which places all queries that have not yet been matched into a per-user
   adhoc group.
 
 Together, these selectors implement the following policy:
 
-* The user ``bob`` and any user belonging to user group ``admin``
-  is an admin and can run up to 50 concurrent queries.
+* The user ``bob`` is an admin and can run up to 50 concurrent queries.
   Queries will be run based on user-provided priority.
 
 For the remaining users:

--- a/presto-docs/src/main/sphinx/admin/resources-groups-example.json
+++ b/presto-docs/src/main/sphinx/admin/resources-groups-example.json
@@ -89,10 +89,6 @@
       "group": "admin"
     },
     {
-      "userGroup": "admin",
-      "group": "admin"
-    },
-    {
       "source": ".*pipeline.*",
       "queryType": "DATA_DEFINITION",
       "group": "global.data_definition"


### PR DESCRIPTION
Documentation added in #21057 doesn't accurately reflect the state of resource group management in Presto 

## Description
Documentation added in #21057 doesn't accurately reflect the state of resource group management in Presto 

## Motivation and Context
According to https://github.com/prestodb/presto/pull/21057, Resource manager selector rules support a userGroup component.

However, Presto 0.285 doesn't actually support this selector:

https://github.com/prestodb/presto/blob/0.285.1/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/SelectorRecord.java doesn't contain a member that represents this component.
https://github.com/prestodb/presto/blob/0.285.1/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/SelectorSpec.java doesn't have one either

Presto version used: 0.285
Storage (HDFS/S3/GCS..): n/a
Data source and connector used: n/a
Deployment (Cloud or On-prem): on-prem
[Pastebin](https://pastebin.com/) link to the complete debug logs: n/a

## Impact
Documentation added in #21057 doesn't accurately reflect the state of resource group management in Presto

## Test Plan
Install presto 0.285 and configure the file resource group manager as shown on https://prestodb.io/docs/0.285/admin/resource-groups.html
Run a query as a user that is in the "admin" user group, but isn't "bob"
The query should run in the "admin" resource group, but runs in an ad-hoc "global.adhoc.other.${USER}" resource group

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

