### PR TITLE
[native] Add installation of python and pip

### DIFF
--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -19,7 +19,7 @@ set -eufx -o pipefail
 # Run the velox setup script first.
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-ubuntu.sh"
 export FB_OS_VERSION=v2022.11.14.00
-sudo apt install -y gperf uuid-dev libsodium-dev
+sudo apt install -y gperf uuid-dev libsodium-dev python3 python3-pip
 
 function install_six {
   pip3 install six


### PR DESCRIPTION
## Description
The Velox script does not install python and
it may not be installed by default.
However it is needed to install "six" using pip3.

Therefore, making sure it is installed to ensure
successful completion of the script.

## Motivation and Context
Make it easier for users to run the script without interruption.

## Impact
Impact for first time users or when redoing setup on a new environment.

## Test Plan
N/A

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

