### PR TITLE
Update the version of com.jayway.jsonpath:json-path from 2.6.0 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dep.hudi.version>0.14.0</dep.hudi.version>
         <dep.testcontainers.version>1.18.3</dep.testcontainers.version>
         <dep.docker-java.version>3.3.0</dep.docker-java.version>
-        <dep.jayway.version>2.6.0</dep.jayway.version>
+        <dep.jayway.version>2.9.0</dep.jayway.version>
         <dep.ratis.version>2.2.0</dep.ratis.version>
         <!--
           America/Bahia_Banderas has:


### PR DESCRIPTION
## Description
Update the version of com.jayway.jsonpath:json-path from 2.6.0 to 2.9.0

## Motivation and Context
It seems that presto has a number of direct vulnerabilities and vulnerabilities from dependencies. These vulnerabilities are potential security threats and it's important to address them as soon as possible.

 Direct vulnerabilities:
[CVE-2023-51074](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-51074)

Vulnerabilities from dependencies:
[CVE-2023-5072](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-5072)
[CVE-2023-1436](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1436)
[CVE-2023-1370](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1370)
[CVE-2022-45693](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45693)
[CVE-2022-45688](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45688)
[CVE-2022-45685](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45685)
[CVE-2022-42004](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42004)
[CVE-2022-42003](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42003)
[CVE-2022-40150](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40150)
[CVE-2022-40149](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40149)
[CVE-2022-25647](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647)
[CVE-2021-46877](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46877)
[CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518)

## Impact
No impact

## Test Plan
Failures: 
Error:    TestDistributedQueuesDb.testResourceGroupConcurrencyThreshold » ThreadTimeout Method com.facebook.presto.execution.resourceGroups.db.TestDistributedQueuesDb.testResourceGroupConcurrencyThreshold() didn't finish within the time-out 60000
[INFO] 
Error:  Tests run: 3079, Failures: 1, Errors: 0, Skipped: 0

Running Test cases for all modules.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade [com.jayway.jsonpath:json-path](https://github.com/jayway/JsonPath) to 2.9.0.

```

