### PR TITLE
Add dataDirectory param to IcebergQueryRunner

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHadoopCatalog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHadoopCatalog.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
@@ -55,7 +56,8 @@ public class BenchmarkIcebergHadoopCatalog
                     PARQUET,
                     false,
                     true,
-                    OptionalInt.of(1));
+                    OptionalInt.of(1),
+                    Optional.empty());
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHiveCatalog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHiveCatalog.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
@@ -54,7 +55,8 @@ public class BenchmarkIcebergHiveCatalog
                     PARQUET,
                     false,
                     true,
-                    OptionalInt.of(1));
+                    OptionalInt.of(1),
+                    Optional.empty());
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -24,8 +24,10 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
 import org.apache.iceberg.FileFormat;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.airlift.log.Level.WARN;
@@ -45,16 +47,16 @@ public final class IcebergQueryRunner
 
     private IcebergQueryRunner() {}
 
-    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties)
+    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, Optional<Path> dataDirectory)
             throws Exception
     {
-        return createIcebergQueryRunner(extraProperties, ImmutableMap.of());
+        return createIcebergQueryRunner(extraProperties, ImmutableMap.of(), dataDirectory);
     }
 
     public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, CatalogType catalogType)
             throws Exception
     {
-        return createIcebergQueryRunner(extraProperties, ImmutableMap.of("iceberg.catalog.type", catalogType.name()));
+        return createIcebergQueryRunner(extraProperties, ImmutableMap.of("iceberg.catalog.type", catalogType.name()), Optional.empty());
     }
 
     public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, CatalogType catalogType, Map<String, String> extraConnectorProperties)
@@ -65,30 +67,38 @@ public final class IcebergQueryRunner
                 ImmutableMap.<String, String>builder()
                         .putAll(extraConnectorProperties)
                         .put("iceberg.catalog.type", catalogType.name())
-                        .build());
+                        .build(),
+                Optional.empty());
     }
 
     public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, Map<String, String> extraConnectorProperties)
             throws Exception
     {
+        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, Optional.empty());
+    }
+
+    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, Map<String, String> extraConnectorProperties, Optional<Path> dataDirectory)
+            throws Exception
+    {
         FileFormat defaultFormat = new IcebergConfig().getFileFormat();
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, defaultFormat, true);
+        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, defaultFormat, true, dataDirectory);
     }
 
     public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, Map<String, String> extraConnectorProperties, FileFormat format)
             throws Exception
     {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, true);
+        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, true, Optional.empty());
     }
 
     public static DistributedQueryRunner createIcebergQueryRunner(
             Map<String, String> extraProperties,
             Map<String, String> extraConnectorProperties,
             FileFormat format,
-            boolean createTpchTables)
+            boolean createTpchTables,
+            Optional<Path> dataDirectory)
             throws Exception
     {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, false, OptionalInt.empty());
+        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, false, OptionalInt.empty(), dataDirectory);
     }
 
     public static DistributedQueryRunner createIcebergQueryRunner(
@@ -97,7 +107,8 @@ public final class IcebergQueryRunner
             FileFormat format,
             boolean createTpchTables,
             boolean addJmxPlugin,
-            OptionalInt nodeCount)
+            OptionalInt nodeCount,
+            Optional<Path> dataDirectory)
             throws Exception
     {
         Logging logger = Logging.initialize();
@@ -108,7 +119,8 @@ public final class IcebergQueryRunner
                 .build();
 
         DistributedQueryRunner.Builder queryRunnerBuilder = DistributedQueryRunner.builder(session)
-                .setExtraProperties(extraProperties);
+                .setExtraProperties(extraProperties)
+                .setDataDirectory(dataDirectory);
 
         nodeCount.ifPresent(queryRunnerBuilder::setNodeCount);
 
@@ -117,14 +129,14 @@ public final class IcebergQueryRunner
         queryRunner.installPlugin(new TpchPlugin());
         queryRunner.createCatalog("tpch", "tpch");
 
-        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory();
+        Path icebergDataDirectory = queryRunner.getCoordinator().getDataDirectory();
 
         queryRunner.installPlugin(new IcebergPlugin());
 
         String catalogType = extraConnectorProperties.getOrDefault("iceberg.catalog.type", HIVE.name());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
                 .put("iceberg.file-format", format.name())
-                .putAll(getConnectorProperties(CatalogType.valueOf(catalogType), dataDirectory))
+                .putAll(getConnectorProperties(CatalogType.valueOf(catalogType), icebergDataDirectory))
                 .putAll(extraConnectorProperties)
                 .build();
 
@@ -164,10 +176,44 @@ public final class IcebergQueryRunner
             throws Exception
     {
         Logging.initialize();
+        Optional<Path> dataDirectory = Optional.empty();
+        if (args.length > 0) {
+            if (args.length != 1) {
+                log.error("usage: IcebergQueryRunner [dataDirectory]\n");
+                log.error("       [dataDirectory] is a local directory under which you want the iceberg_data directory to be created.]\n");
+                System.exit(1);
+            }
+
+            File dataDirectoryFile = new File(args[0]);
+            if (dataDirectoryFile.exists()) {
+                if (!dataDirectoryFile.isDirectory()) {
+                    log.error("Error: " + dataDirectoryFile.getAbsolutePath() + " is not a directory.");
+                    System.exit(1);
+                }
+                else if (!dataDirectoryFile.canRead() || !dataDirectoryFile.canWrite()) {
+                    log.error("Error: " + dataDirectoryFile.getAbsolutePath() + " is not readable/writable.");
+                    System.exit(1);
+                }
+            }
+            else {
+                // For user supplied path like [path_exists_but_is_not_readable_or_writable]/[paths_do_not_exist], the hadoop file system won't
+                // be able to create directory for it. e.g. "/aaa/bbb" is not creatable because path "/" is not writable.
+                while (!dataDirectoryFile.exists()) {
+                    dataDirectoryFile = dataDirectoryFile.getParentFile();
+                }
+                if (!dataDirectoryFile.canRead() || !dataDirectoryFile.canWrite()) {
+                    log.error("Error: The ancestor directory " + dataDirectoryFile.getAbsolutePath() + " is not readable/writable.");
+                    System.exit(1);
+                }
+            }
+
+            dataDirectory = Optional.of(dataDirectoryFile.toPath());
+        }
+
         Map<String, String> properties = ImmutableMap.of("http-server.http.port", "8080");
         DistributedQueryRunner queryRunner = null;
         try {
-            queryRunner = createIcebergQueryRunner(properties);
+            queryRunner = createIcebergQueryRunner(properties, dataDirectory);
         }
         catch (Throwable t) {
             log.error(t);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergParquetMetadataCaching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergParquetMetadataCaching.java
@@ -21,6 +21,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
@@ -44,7 +45,8 @@ public class TestIcebergParquetMetadataCaching
                 PARQUET,
                 false,
                 true,
-                OptionalInt.of(2));
+                OptionalInt.of(2),
+                Optional.empty());
     }
 
     @BeforeClass

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
@@ -52,7 +53,7 @@ public class TestIcebergSplitManager
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(ImmutableMap.of());
+        return createIcebergQueryRunner(ImmutableMap.of(), Optional.empty());
     }
 
     @Test


### PR DESCRIPTION
## Description
Add support for custom data directory parameter for IcebergQueryRunner where the data and metadata can be persisted between query runner runs.

## Motivation and Context
This allows IcebergQueryRunner to read and write the data and metadata from an Optional path. On subsequent runs using the same path, IcebergQueryRunner can reuse the data already created.

## Impact
None

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

