### PR TITLE
Remove logback core depenency as it's not been used anywhere

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
         <dep.tempto.version>1.53</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
-        <dep.logback.version>1.2.3</dep.logback.version>
         <dep.parquet.version>1.13.1</dep.parquet.version>
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>


### PR DESCRIPTION
## Description
Remove logback core depenency as its not been used anywhere

## Motivation and Context
i see vulnerabilities as well:
Direct vulnerabilities:
[CVE-2023-6378](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-6378)
[CVE-2021-42550](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42550)

using mvn dependency:tree -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true 

 +- com.facebook.airlift:log:jar:0.207:compile
[INFO] +- com.facebook.airlift:log-manager:jar:0.207:compile
[INFO] |  +- org.slf4j:slf4j-jdk14:jar:1.7.25:runtime
[INFO] |  |  \- org.slf4j:slf4j-api:jar:1.7.25:runtime
[INFO] |  +- org.slf4j:log4j-over-slf4j:jar:1.7.25:runtime
[INFO] |  +- org.slf4j:jcl-over-slf4j:jar:1.7.25:runtime
**[INFO] |  \- ch.qos.logback:logback-core:jar:1.2.3:compile**
[INFO] +- com.facebook.airlift:http-server:jar:0.207:compile
[INFO] |  +- com.facebook.airlift:http-utils:jar:0.207:compile
[INFO] |  +- com.facebook.airlift:security:jar:0.207:compile
[INFO] |  +- com.facebook.airlift:stats:jar:0.207:compile
[INFO] |  |  +- org.hdrhistogram:HdrHistogram:jar:2.1.9:compile
[INFO] |  |  +- io.airlift:slice:jar:0.34:compile

presto directly is not using the dependency of logback-core

## Impact
no impact 

## Test Plan
Ran test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTE ==
Security Changes
* Remove logback 1.2.3
```

