### PR TITLE
Add limit to merge function for KHyperLogLog

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -269,6 +269,7 @@ import com.facebook.presto.type.VarcharParametricType;
 import com.facebook.presto.type.khyperloglog.KHyperLogLogAggregationFunction;
 import com.facebook.presto.type.khyperloglog.KHyperLogLogFunctions;
 import com.facebook.presto.type.khyperloglog.KHyperLogLogOperators;
+import com.facebook.presto.type.khyperloglog.KHyperLogLogWithLimitAggregationFunction;
 import com.facebook.presto.type.khyperloglog.MergeKHyperLogLogAggregationFunction;
 import com.facebook.presto.type.khyperloglog.MergeKHyperLogLogWithLimitAggregationFunction;
 import com.facebook.presto.type.setdigest.BuildSetDigestAggregation;
@@ -944,7 +945,6 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregate(BuildSetDigestAggregation.class)
                 .scalars(SetDigestFunctions.class)
                 .scalars(SetDigestOperators.class)
-                .function(new KHyperLogLogAggregationFunction(featuresConfig.getKHyperLogLogAggregationGroupNumberLimit()))
                 .scalars(KHyperLogLogFunctions.class)
                 .scalars(KHyperLogLogOperators.class)
                 .scalars(WilsonInterval.class)
@@ -1013,9 +1013,11 @@ public class BuiltInTypeAndFunctionNamespaceManager
 
         if (featuresConfig.getLimitNumberOfGroupsForKHyperLogLogAggregations()) {
             builder.function(new MergeKHyperLogLogWithLimitAggregationFunction(featuresConfig.getKHyperLogLogAggregationGroupNumberLimit()));
+            builder.function(new KHyperLogLogWithLimitAggregationFunction(featuresConfig.getKHyperLogLogAggregationGroupNumberLimit()));
         }
         else {
             builder.aggregates(MergeKHyperLogLogAggregationFunction.class);
+            builder.aggregates(KHyperLogLogAggregationFunction.class);
         }
 
         return builder.getFunctions();

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -270,6 +270,7 @@ import com.facebook.presto.type.khyperloglog.KHyperLogLogAggregationFunction;
 import com.facebook.presto.type.khyperloglog.KHyperLogLogFunctions;
 import com.facebook.presto.type.khyperloglog.KHyperLogLogOperators;
 import com.facebook.presto.type.khyperloglog.MergeKHyperLogLogAggregationFunction;
+import com.facebook.presto.type.khyperloglog.MergeKHyperLogLogWithLimitAggregationFunction;
 import com.facebook.presto.type.setdigest.BuildSetDigestAggregation;
 import com.facebook.presto.type.setdigest.MergeSetDigestAggregation;
 import com.facebook.presto.type.setdigest.SetDigestFunctions;
@@ -943,7 +944,6 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregate(BuildSetDigestAggregation.class)
                 .scalars(SetDigestFunctions.class)
                 .scalars(SetDigestOperators.class)
-                .aggregates(MergeKHyperLogLogAggregationFunction.class)
                 .function(new KHyperLogLogAggregationFunction(featuresConfig.getKHyperLogLogAggregationGroupNumberLimit()))
                 .scalars(KHyperLogLogFunctions.class)
                 .scalars(KHyperLogLogOperators.class)
@@ -1009,6 +1009,13 @@ public class BuiltInTypeAndFunctionNamespaceManager
             builder.aggregates(ApproximateRealPercentileAggregations.class);
             builder.aggregates(ApproximateRealPercentileArrayAggregations.class);
             builder.function(new MultimapAggregationFunction(featuresConfig.getMultimapAggGroupImplementation()));
+        }
+
+        if (featuresConfig.getLimitNumberOfGroupsForKHyperLogLogAggregations()) {
+            builder.function(new MergeKHyperLogLogWithLimitAggregationFunction(featuresConfig.getKHyperLogLogAggregationGroupNumberLimit()));
+        }
+        else {
+            builder.aggregates(MergeKHyperLogLogAggregationFunction.class);
         }
 
         return builder.getFunctions();

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -297,6 +297,7 @@ public class FeaturesConfig
     private boolean removeRedundantCastToVarcharInJoin = true;
     private boolean skipHashGenerationForJoinWithTableScanInput;
     private long kHyperLogLogAggregationGroupNumberLimit;
+    private boolean limitNumberOfGroupsForKHyperLogLogAggregations = true;
     private boolean generateDomainFilters;
 
     public enum PartitioningPrecisionStrategy
@@ -2971,6 +2972,19 @@ public class FeaturesConfig
     public FeaturesConfig setKHyperLogLogAggregationGroupNumberLimit(long kHyperLogLogAggregationGroupNumberLimit)
     {
         this.kHyperLogLogAggregationGroupNumberLimit = kHyperLogLogAggregationGroupNumberLimit;
+        return this;
+    }
+
+    public boolean getLimitNumberOfGroupsForKHyperLogLogAggregations()
+    {
+        return limitNumberOfGroupsForKHyperLogLogAggregations;
+    }
+
+    @Config("limit-khyperloglog-agg-group-number-enabled")
+    @ConfigDescription("Enable limiting number of groups for khyperloglog_agg and merge of KHyperLogLog states")
+    public FeaturesConfig setLimitNumberOfGroupsForKHyperLogLogAggregations(boolean limitNumberOfGroupsForKHyperLogLogAggregations)
+    {
+        this.limitNumberOfGroupsForKHyperLogLogAggregations = limitNumberOfGroupsForKHyperLogLogAggregations;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogAggregationFunction.java
@@ -11,141 +11,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.facebook.presto.type.khyperloglog;
 
-import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.common.block.BlockBuilder;
-import com.facebook.presto.common.type.Type;
-import com.facebook.presto.metadata.BoundVariables;
-import com.facebook.presto.metadata.FunctionAndTypeManager;
-import com.facebook.presto.metadata.SqlAggregationFunction;
-import com.facebook.presto.operator.aggregation.AccumulatorCompiler;
-import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
-import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.function.AccumulatorState;
-import com.facebook.presto.spi.function.AccumulatorStateSerializer;
-import com.facebook.presto.spi.function.aggregation.Accumulator;
-import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
-import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
-import com.google.common.collect.ImmutableList;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.LiteralParameters;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
 import io.airlift.slice.Slice;
 import io.airlift.slice.XxHash64;
 
-import java.lang.invoke.MethodHandle;
-import java.util.List;
-
-import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
-import static com.facebook.presto.spi.function.Signature.typeVariable;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
-import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
-import static com.facebook.presto.type.khyperloglog.KHyperLogLogType.K_HYPER_LOG_LOG;
-import static com.facebook.presto.util.Reflection.methodHandle;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
+@AggregationFunction("khyperloglog_agg")
 public final class KHyperLogLogAggregationFunction
-        extends SqlAggregationFunction
 {
-    private static final String NAME = "khyperloglog_agg";
     private static final KHyperLogLogStateSerializer SERIALIZER = new KHyperLogLogStateSerializer();
-    private static final MethodHandle LONG_LONG_INPUT_FUNCTION = methodHandle(KHyperLogLogAggregationFunction.class, "input", KHyperLogLogState.class, long.class, long.class);
-    private static final MethodHandle SLICE_LONG_INPUT_FUNCTION = methodHandle(KHyperLogLogAggregationFunction.class, "input", KHyperLogLogState.class, Slice.class, long.class);
-    private static final MethodHandle DOUBLE_LONG_INPUT_FUNCTION = methodHandle(KHyperLogLogAggregationFunction.class, "input", KHyperLogLogState.class, double.class, long.class);
-    private static final MethodHandle LONG_SLICE_INPUT_FUNCTION = methodHandle(KHyperLogLogAggregationFunction.class, "input", KHyperLogLogState.class, long.class, Slice.class);
-    private static final MethodHandle SLICE_SLICE_INPUT_FUNCTION = methodHandle(KHyperLogLogAggregationFunction.class, "input", KHyperLogLogState.class, Slice.class, Slice.class);
-    private static final MethodHandle DOUBLE_SLICE_INPUT_FUNCTION = methodHandle(KHyperLogLogAggregationFunction.class, "input", KHyperLogLogState.class, double.class, Slice.class);
-    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(KHyperLogLogAggregationFunction.class, "output", KHyperLogLogState.class, BlockBuilder.class);
-    private static final MethodHandle COMBINE_FUNCTION = methodHandle(KHyperLogLogAggregationFunction.class, "combine", KHyperLogLogState.class, KHyperLogLogState.class);
-    private final long groupLimit;
 
-    public KHyperLogLogAggregationFunction(long groupLimit)
-    {
-        super(NAME, ImmutableList.of(typeVariable("E"), typeVariable("T")), ImmutableList.of(), K_HYPER_LOG_LOG.getTypeSignature(), ImmutableList.of(parseTypeSignature("E"), parseTypeSignature("T")));
-        this.groupLimit = groupLimit;
-    }
+    private KHyperLogLogAggregationFunction() {}
 
-    public static String getFunctionName()
-    {
-        return NAME;
-    }
-
-    @Override
-    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
-    {
-        Type firstInputType = boundVariables.getTypeVariable("E");
-        Type secondInputType = boundVariables.getTypeVariable("T");
-        return generateAggregation(firstInputType, secondInputType);
-    }
-
-    private BuiltInAggregationFunctionImplementation generateAggregation(Type firstInputType, Type secondInputType)
-    {
-        DynamicClassLoader classLoader = new DynamicClassLoader(KHyperLogLogAggregationFunction.class.getClassLoader());
-        List<Type> inputTypes = ImmutableList.of(firstInputType, secondInputType);
-        Class<? extends AccumulatorState> stateInterface = KHyperLogLogState.class;
-        AccumulatorStateSerializer<?> stateSerializer = new KHyperLogLogStateSerializer();
-        MethodHandle inputFunction = getMethodHandle(firstInputType, secondInputType);
-
-        AggregationMetadata metadata = new AggregationMetadata(
-                generateAggregationName(NAME, K_HYPER_LOG_LOG.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
-                ImmutableList.of(new AggregationMetadata.ParameterMetadata(STATE), new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, firstInputType), new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, secondInputType)),
-                inputFunction,
-                COMBINE_FUNCTION,
-                OUTPUT_FUNCTION,
-                ImmutableList.of(new AggregationMetadata.AccumulatorStateDescriptor(
-                        stateInterface,
-                        stateSerializer,
-                        new KHyperLogLogStateFactory(groupLimit))),
-                K_HYPER_LOG_LOG);
-
-        Type intermediateType = stateSerializer.getSerializedType();
-
-        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
-                Accumulator.class,
-                metadata,
-                classLoader);
-        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
-                GroupedAccumulator.class,
-                metadata,
-                classLoader);
-        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), K_HYPER_LOG_LOG,
-                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
-    }
-
-    private static MethodHandle getMethodHandle(Type firstInputType, Type secondInputType)
-    {
-        MethodHandle inputFunction;
-        if (firstInputType.getJavaType() == long.class && secondInputType.getJavaType() == long.class) {
-            inputFunction = LONG_LONG_INPUT_FUNCTION;
-        }
-        else if (firstInputType.getJavaType() == Slice.class && secondInputType.getJavaType() == long.class) {
-            inputFunction = SLICE_LONG_INPUT_FUNCTION;
-        }
-        else if (firstInputType.getJavaType() == double.class && secondInputType.getJavaType() == long.class) {
-            inputFunction = DOUBLE_LONG_INPUT_FUNCTION;
-        }
-        else if (firstInputType.getJavaType() == long.class && secondInputType.getJavaType() == Slice.class) {
-            inputFunction = LONG_SLICE_INPUT_FUNCTION;
-        }
-        else if (firstInputType.getJavaType() == Slice.class && secondInputType.getJavaType() == Slice.class) {
-            inputFunction = SLICE_SLICE_INPUT_FUNCTION;
-        }
-        else if (firstInputType.getJavaType() == double.class && secondInputType.getJavaType() == Slice.class) {
-            inputFunction = DOUBLE_SLICE_INPUT_FUNCTION;
-        }
-        else {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "input types for khyperloglog_agg are not supported");
-        }
-        return inputFunction;
-    }
-
-    @Override
-    public String getDescription()
-    {
-        return "Returns the KHyperLogLog sketch that represents the relationship between columns x and y. The MinHash structure summarizes x and the HyperLogLog sketches represent y values linked to x values.";
-    }
-
-    public static void input(KHyperLogLogState state, long value, long uii)
+    @InputFunction
+    public static void input(@AggregationState KHyperLogLogState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.BIGINT) long uii)
     {
         if (state.getKHLL() == null) {
             state.setKHLL(new KHyperLogLog());
@@ -153,7 +42,9 @@ public final class KHyperLogLogAggregationFunction
         state.getKHLL().add(value, uii);
     }
 
-    public static void input(KHyperLogLogState state, Slice value, long uii)
+    @InputFunction
+    @LiteralParameters("x")
+    public static void input(@AggregationState KHyperLogLogState state, @SqlType("varchar(x)") Slice value, @SqlType(StandardTypes.BIGINT) long uii)
     {
         if (state.getKHLL() == null) {
             state.setKHLL(new KHyperLogLog());
@@ -161,27 +52,35 @@ public final class KHyperLogLogAggregationFunction
         state.getKHLL().add(value, uii);
     }
 
-    public static void input(KHyperLogLogState state, double value, long uii)
+    @InputFunction
+    public static void input(@AggregationState KHyperLogLogState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long uii)
     {
         input(state, Double.doubleToLongBits(value), uii);
     }
 
-    public static void input(KHyperLogLogState state, long value, Slice uii)
+    @InputFunction
+    @LiteralParameters("x")
+    public static void input(@AggregationState KHyperLogLogState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType("varchar(x)") Slice uii)
     {
         input(state, value, XxHash64.hash(uii));
     }
 
-    public static void input(KHyperLogLogState state, Slice value, Slice uii)
+    @InputFunction
+    @LiteralParameters({"x", "y"})
+    public static void input(@AggregationState KHyperLogLogState state, @SqlType("varchar(x)") Slice value, @SqlType("varchar(y)") Slice uii)
     {
         input(state, value, XxHash64.hash(uii));
     }
 
-    public static void input(KHyperLogLogState state, double value, Slice uii)
+    @InputFunction
+    @LiteralParameters("x")
+    public static void input(@AggregationState KHyperLogLogState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType("varchar(x)") Slice uii)
     {
         input(state, Double.doubleToLongBits(value), XxHash64.hash(uii));
     }
 
-    public static void combine(KHyperLogLogState state, KHyperLogLogState otherState)
+    @CombineFunction
+    public static void combine(@AggregationState KHyperLogLogState state, @AggregationState KHyperLogLogState otherState)
     {
         if (state.getKHLL() == null) {
             KHyperLogLog copy = new KHyperLogLog();
@@ -193,7 +92,8 @@ public final class KHyperLogLogAggregationFunction
         }
     }
 
-    public static void output(KHyperLogLogState state, BlockBuilder out)
+    @OutputFunction(KHyperLogLogType.NAME)
+    public static void output(@AggregationState KHyperLogLogState state, BlockBuilder out)
     {
         SERIALIZER.serialize(state, out);
     }

--- a/presto-main/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogStateFactory.java
@@ -31,6 +31,10 @@ public class KHyperLogLogStateFactory
 
     private final long groupLimit;
 
+    public KHyperLogLogStateFactory()
+    {
+        this.groupLimit = 0;
+    }
     public KHyperLogLogStateFactory(long groupLimit)
     {
         this.groupLimit = groupLimit;

--- a/presto-main/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogWithLimitAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogWithLimitAggregationFunction.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type.khyperloglog;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.AccumulatorCompiler;
+import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.function.aggregation.Accumulator;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
+import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.function.Signature.typeVariable;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.type.khyperloglog.KHyperLogLogType.K_HYPER_LOG_LOG;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public final class KHyperLogLogWithLimitAggregationFunction
+        extends SqlAggregationFunction
+{
+    private static final String NAME = "khyperloglog_agg";
+    private static final KHyperLogLogStateSerializer SERIALIZER = new KHyperLogLogStateSerializer();
+    private static final MethodHandle LONG_LONG_INPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "input", KHyperLogLogState.class, long.class, long.class);
+    private static final MethodHandle SLICE_LONG_INPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "input", KHyperLogLogState.class, Slice.class, long.class);
+    private static final MethodHandle DOUBLE_LONG_INPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "input", KHyperLogLogState.class, double.class, long.class);
+    private static final MethodHandle LONG_SLICE_INPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "input", KHyperLogLogState.class, long.class, Slice.class);
+    private static final MethodHandle SLICE_SLICE_INPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "input", KHyperLogLogState.class, Slice.class, Slice.class);
+    private static final MethodHandle DOUBLE_SLICE_INPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "input", KHyperLogLogState.class, double.class, Slice.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "output", KHyperLogLogState.class, BlockBuilder.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(KHyperLogLogWithLimitAggregationFunction.class, "combine", KHyperLogLogState.class, KHyperLogLogState.class);
+    private final long groupLimit;
+
+    public KHyperLogLogWithLimitAggregationFunction(long groupLimit)
+    {
+        super(NAME, ImmutableList.of(typeVariable("E"), typeVariable("T")), ImmutableList.of(), K_HYPER_LOG_LOG.getTypeSignature(), ImmutableList.of(parseTypeSignature("E"), parseTypeSignature("T")));
+        this.groupLimit = groupLimit;
+    }
+
+    public static String getFunctionName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        Type firstInputType = boundVariables.getTypeVariable("E");
+        Type secondInputType = boundVariables.getTypeVariable("T");
+        return generateAggregation(firstInputType, secondInputType);
+    }
+
+    private BuiltInAggregationFunctionImplementation generateAggregation(Type firstInputType, Type secondInputType)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(KHyperLogLogWithLimitAggregationFunction.class.getClassLoader());
+        List<Type> inputTypes = ImmutableList.of(firstInputType, secondInputType);
+        Class<? extends AccumulatorState> stateInterface = KHyperLogLogState.class;
+        AccumulatorStateSerializer<?> stateSerializer = new KHyperLogLogStateSerializer();
+        MethodHandle inputFunction = getMethodHandle(firstInputType, secondInputType);
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, K_HYPER_LOG_LOG.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                ImmutableList.of(new AggregationMetadata.ParameterMetadata(STATE), new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, firstInputType), new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, secondInputType)),
+                inputFunction,
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                ImmutableList.of(new AggregationMetadata.AccumulatorStateDescriptor(
+                        stateInterface,
+                        stateSerializer,
+                        new KHyperLogLogStateFactory(groupLimit))),
+                K_HYPER_LOG_LOG);
+
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                Accumulator.class,
+                metadata,
+                classLoader);
+        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                GroupedAccumulator.class,
+                metadata,
+                classLoader);
+        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), K_HYPER_LOG_LOG,
+                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+    }
+
+    private static MethodHandle getMethodHandle(Type firstInputType, Type secondInputType)
+    {
+        MethodHandle inputFunction;
+        if (firstInputType.getJavaType() == long.class && secondInputType.getJavaType() == long.class) {
+            inputFunction = LONG_LONG_INPUT_FUNCTION;
+        }
+        else if (firstInputType.getJavaType() == Slice.class && secondInputType.getJavaType() == long.class) {
+            inputFunction = SLICE_LONG_INPUT_FUNCTION;
+        }
+        else if (firstInputType.getJavaType() == double.class && secondInputType.getJavaType() == long.class) {
+            inputFunction = DOUBLE_LONG_INPUT_FUNCTION;
+        }
+        else if (firstInputType.getJavaType() == long.class && secondInputType.getJavaType() == Slice.class) {
+            inputFunction = LONG_SLICE_INPUT_FUNCTION;
+        }
+        else if (firstInputType.getJavaType() == Slice.class && secondInputType.getJavaType() == Slice.class) {
+            inputFunction = SLICE_SLICE_INPUT_FUNCTION;
+        }
+        else if (firstInputType.getJavaType() == double.class && secondInputType.getJavaType() == Slice.class) {
+            inputFunction = DOUBLE_SLICE_INPUT_FUNCTION;
+        }
+        else {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "input types for khyperloglog_agg are not supported");
+        }
+        return inputFunction;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Returns the KHyperLogLog sketch that represents the relationship between columns x and y. The MinHash structure summarizes x and the HyperLogLog sketches represent y values linked to x values.";
+    }
+
+    public static void input(KHyperLogLogState state, long value, long uii)
+    {
+        if (state.getKHLL() == null) {
+            state.setKHLL(new KHyperLogLog());
+        }
+        state.getKHLL().add(value, uii);
+    }
+
+    public static void input(KHyperLogLogState state, Slice value, long uii)
+    {
+        if (state.getKHLL() == null) {
+            state.setKHLL(new KHyperLogLog());
+        }
+        state.getKHLL().add(value, uii);
+    }
+
+    public static void input(KHyperLogLogState state, double value, long uii)
+    {
+        input(state, Double.doubleToLongBits(value), uii);
+    }
+
+    public static void input(KHyperLogLogState state, long value, Slice uii)
+    {
+        input(state, value, XxHash64.hash(uii));
+    }
+
+    public static void input(KHyperLogLogState state, Slice value, Slice uii)
+    {
+        input(state, value, XxHash64.hash(uii));
+    }
+
+    public static void input(KHyperLogLogState state, double value, Slice uii)
+    {
+        input(state, Double.doubleToLongBits(value), XxHash64.hash(uii));
+    }
+
+    public static void combine(KHyperLogLogState state, KHyperLogLogState otherState)
+    {
+        if (state.getKHLL() == null) {
+            KHyperLogLog copy = new KHyperLogLog();
+            copy.mergeWith(otherState.getKHLL());
+            state.setKHLL(copy);
+        }
+        else {
+            state.getKHLL().mergeWith(otherState.getKHLL());
+        }
+    }
+
+    public static void output(KHyperLogLogState state, BlockBuilder out)
+    {
+        SERIALIZER.serialize(state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/khyperloglog/MergeKHyperLogLogWithLimitAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/khyperloglog/MergeKHyperLogLogWithLimitAggregationFunction.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.type.khyperloglog;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.AccumulatorCompiler;
+import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.aggregation.Accumulator;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
+import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.type.khyperloglog.KHyperLogLogType.K_HYPER_LOG_LOG;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public final class MergeKHyperLogLogWithLimitAggregationFunction
+        extends SqlAggregationFunction
+{
+    private static final String NAME = "merge";
+
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(MergeKHyperLogLogWithLimitAggregationFunction.class, "input", KHyperLogLogState.class, Slice.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(MergeKHyperLogLogWithLimitAggregationFunction.class, "output", KHyperLogLogState.class, BlockBuilder.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(MergeKHyperLogLogWithLimitAggregationFunction.class, "combine", KHyperLogLogState.class, KHyperLogLogState.class);
+
+    private final long groupLimit;
+
+    public MergeKHyperLogLogWithLimitAggregationFunction(long groupLimit)
+    {
+        super(NAME, ImmutableList.of(), ImmutableList.of(), K_HYPER_LOG_LOG.getTypeSignature(), ImmutableList.of(K_HYPER_LOG_LOG.getTypeSignature()));
+        this.groupLimit = groupLimit;
+    }
+
+    public static void input(@AggregationState KHyperLogLogState state, @SqlType(KHyperLogLogType.NAME) Slice value)
+    {
+        KHyperLogLog instance = KHyperLogLog.newInstance(value);
+        merge(state, instance);
+    }
+
+    public static void combine(@AggregationState KHyperLogLogState state, @AggregationState KHyperLogLogState otherState)
+    {
+        merge(state, otherState.getKHLL());
+    }
+
+    private static void merge(@AggregationState KHyperLogLogState state, KHyperLogLog instance)
+    {
+        if (state.getKHLL() == null) {
+            state.setKHLL(instance);
+        }
+        else {
+            state.getKHLL().mergeWith(instance);
+        }
+    }
+
+    public static void output(@AggregationState KHyperLogLogState state, BlockBuilder out)
+    {
+        if (state.getKHLL() == null) {
+            out.appendNull();
+        }
+        else {
+            K_HYPER_LOG_LOG.writeSlice(out, state.getKHLL().serialize());
+        }
+    }
+
+    @Override
+    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(MergeKHyperLogLogWithLimitAggregationFunction.class.getClassLoader());
+        List<Type> inputTypes = ImmutableList.of(K_HYPER_LOG_LOG);
+        Class<? extends AccumulatorState> stateInterface = KHyperLogLogState.class;
+        AccumulatorStateSerializer<?> stateSerializer = new KHyperLogLogStateSerializer();
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, K_HYPER_LOG_LOG.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                ImmutableList.of(new AggregationMetadata.ParameterMetadata(STATE), new AggregationMetadata.ParameterMetadata(INPUT_CHANNEL, K_HYPER_LOG_LOG)),
+                INPUT_FUNCTION,
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                ImmutableList.of(new AggregationMetadata.AccumulatorStateDescriptor(
+                        stateInterface,
+                        stateSerializer,
+                        new KHyperLogLogStateFactory(groupLimit))),
+                K_HYPER_LOG_LOG);
+
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                Accumulator.class,
+                metadata,
+                classLoader);
+        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                GroupedAccumulator.class,
+                metadata,
+                classLoader);
+        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), K_HYPER_LOG_LOG,
+                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Merge KHyperLogLog sketches";
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -260,6 +260,7 @@ public class TestFeaturesConfig
                 .setSkipHashGenerationForJoinWithTableScanInput(false)
                 .setCteMaterializationStrategy(CteMaterializationStrategy.NONE)
                 .setKHyperLogLogAggregationGroupNumberLimit(0)
+                .setLimitNumberOfGroupsForKHyperLogLogAggregations(true)
                 .setGenerateDomainFilters(false)
                 .setRewriteExpressionWithConstantVariable(true));
     }
@@ -467,6 +468,7 @@ public class TestFeaturesConfig
                 .put("optimizer.handle-complex-equi-joins", "true")
                 .put("optimizer.skip-hash-generation-for-join-with-table-scan-input", "true")
                 .put("khyperloglog-agg-group-limit", "1000")
+                .put("limit-khyperloglog-agg-group-number-enabled", "false")
                 .put("optimizer.generate-domain-filters", "true")
                 .put("optimizer.rewrite-expression-with-constant-variable", "false")
                 .build();
@@ -672,6 +674,7 @@ public class TestFeaturesConfig
                 .setSkipHashGenerationForJoinWithTableScanInput(true)
                 .setCteMaterializationStrategy(CteMaterializationStrategy.ALL)
                 .setKHyperLogLogAggregationGroupNumberLimit(1000)
+                .setLimitNumberOfGroupsForKHyperLogLogAggregations(false)
                 .setGenerateDomainFilters(true)
                 .setRewriteExpressionWithConstantVariable(false);
         assertFullMapping(properties, expected);

--- a/presto-main/src/test/java/com/facebook/presto/type/khyperloglog/TestKHyperLogLogAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/khyperloglog/TestKHyperLogLogAggregationFunction.java
@@ -41,7 +41,7 @@ import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 public class TestKHyperLogLogAggregationFunction
 {
     private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
-    private static final String NAME = KHyperLogLogAggregationFunction.getFunctionName();
+    private static final String NAME = KHyperLogLogWithLimitAggregationFunction.getFunctionName();
 
     @Test
     public void testSimpleKHyperLogLog()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7419,4 +7419,18 @@ public abstract class AbstractTestQueries
         sql = "select orderkey, price, count(*) from (select orderkey, extendedprice as price from lineitem where orderkey=5 union all select orderkey, totalprice as price from orders) group by orderkey, price";
         assertQuery(enableOptimization, sql);
     }
+
+    @Test
+    public void testMergeKHyperLogLog()
+    {
+        assertQueryWithSameQueryRunner("select k1, cardinality(merge(khll)), uniqueness_distribution(merge(khll)) from (select k1, k2, khyperloglog_agg(v1, v2) khll from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), " +
+                        "(2, 1, 11, 30), (2, 1, 11, 11), (2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2) group by k1, k2) group by k1",
+                "select k1, cardinality(khyperloglog_agg(v1, v2)), uniqueness_distribution(khyperloglog_agg(v1, v2)) from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), (2, 1, 11, 30), (2, 1, 11, 11), " +
+                        "(2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2) group by k1");
+
+        assertQueryWithSameQueryRunner("select cardinality(merge(khll)), uniqueness_distribution(merge(khll)) from (select k1, k2, khyperloglog_agg(v1, v2) khll from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), " +
+                        "(2, 1, 11, 30), (2, 1, 11, 11), (2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2) group by k1, k2)",
+                "select cardinality(khyperloglog_agg(v1, v2)), uniqueness_distribution(khyperloglog_agg(v1, v2)) from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), (2, 1, 11, 30), (2, 1, 11, 11), " +
+                        "(2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2)");
+    }
 }


### PR DESCRIPTION
## Description

After https://github.com/prestodb/presto/pull/21510, the constructor for `KHyperLogLogStateFactory` takes a long integer as input for group limit. However, the merge function for KHyperLogLog still uses the parametric aggregation style, which makes the new constructor not valid, hence throw compile error. It can be solved with two ways: 1) simply add a default constructor without any input parameter. However, it will make the merge function facing the same memory issue we solved for khyperloglog_agg 2) make the merge function to not use parametric aggregation style

In this PR, I apply both approaches, i.e. add a default constructor without any input parameter for `KHyperLogLogStateFactory` so that the current function will not fail compilation. I also add another version of implementation for the `merge` function of khyperloglog which can take group limit. Which version to use is controlled by feature config, so that it can be rolled out smoothly.

Since I implement two versions for merge khyperloglog, I also chose to improve the change in https://github.com/prestodb/presto/pull/21510 so that it also has two versions, and gated by the same config.

## Motivation and Context
Similar to https://github.com/prestodb/presto/pull/21510
In addition to the memory issue, the merge function for KHyperLogLog currently does not compile, it will fix the problem too.

## Impact
Refer to https://github.com/prestodb/presto/pull/21510.

## Test Plan
Add e2e test, also run verifier locally

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix the compilation error of merge function for KHyperLogLog state
* Add an feature config property `limit-khyperloglog-agg-group-number-enabled` to control whether to limit the number of groups for aggregation functions using KHyperLogLog state
```


