### PR TITLE
[Native] Fix error `java.lang.OutOfMemoryError: Compressed class space`

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -64,8 +64,8 @@ executors:
       - image: public.ecr.aws/oss-presto/prestocpp:root-20240129
     resource_class: 2xlarge
     environment:
-      MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
-      MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError -XX:CompressedClassSpaceSize=3g"
+      MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError -XX:CompressedClassSpaceSize=3g"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
       MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
   check:


### PR DESCRIPTION
## Description

The following error was seen when adding presto native e2e tests for window aggregate functions in  https://github.com/prestodb/presto/pull/20625 :
```
[ERROR] java.lang.OutOfMemoryError: Compressed class space
[ERROR] Terminating due to java.lang.OutOfMemoryError: Compressed class space
```

This error is fixed by increasing the compressed class space size to 3gb in the CircleCI config for `linux-presto-e2e-tests`.

## Test Plan

The CircleCI job `linux-presto-e2e-tests` was verified to be passing with this fix: https://app.circleci.com/pipelines/github/prestodb/presto/11583/workflows/b23f1755-3811-49fd-844e-748dc2212080/jobs/43847 .


```
== NO RELEASE NOTE ==
```