### PR TITLE
Fix error thrown when trying to execute INSERT INTO statement when white spaces are present in column names in Iceberg connector

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/PrimitiveTypeMapBuilder.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/PrimitiveTypeMapBuilder.java
@@ -27,6 +27,7 @@ import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.MAP;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.iceberg.avro.AvroSchemaUtil.makeCompatibleName;
 
 public class PrimitiveTypeMapBuilder
 {
@@ -42,7 +43,7 @@ public class PrimitiveTypeMapBuilder
     private Map<List<String>, Type> buildTypeMap(List<Type> types, List<String> columnNames)
     {
         for (int i = 0; i < types.size(); i++) {
-            visitType(types.get(i), columnNames.get(i), ImmutableList.of());
+            visitType(types.get(i), makeCompatibleName(columnNames.get(i)), ImmutableList.of());
         }
         return builder.build();
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1388,6 +1388,18 @@ public class IcebergDistributedSmokeTestBase
     }
 
     @Test
+    public void testColumnNameWithSpace()
+    {
+        Session session = getSession();
+        String tableName = "test_column_name_with_space";
+        String columnName = "column a";
+        assertUpdate(format("CREATE TABLE %s (\"%s\" int)", tableName, columnName));
+        assertUpdate(format("INSERT INTO %s VALUES (123), (456)", tableName), 2);
+        assertQuery(format("SELECT \"%s\" FROM %s", columnName, tableName), "VALUES (123), (456)");
+        dropTable(session, tableName);
+    }
+
+    @Test
     public void testDeleteUnPartitionedTable()
     {
         Session session = getSession();


### PR DESCRIPTION
Added fix for `presto type is null` error thrown when trying to execute INSERT INTO statement when white spaces are present in column names in Iceberg connector.

## Description
Added fix to resolve the `presto type is null` error occurring during the execution of an INSERT INTO statement when there are white spaces in column names within the Iceberg connector.

## Motivation and Context
This change is essential to address a specific issue related to the Iceberg connector. The problem revolves around the occurrence of the` presto type is null` error when attempting to execute an INSERT INTO statement in cases where column names contain white spaces within the Iceberg connector.

## Impact
In Iceberg connector, user will be able to insert into tables with columns having white spaces in its name. 
Fixes the issue https://github.com/prestodb/presto/issues/21829.

## Test Plan
Tested the fix by creating a table in Iceberg having column with white spaces in its name. 
Tried inserting values into the table using the INSERT INTO statement. Successfully executed the query.


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fixes: Fix error encountered when attempting to execute an INSERT INTO statement, in cases where column names contain white spaces.

```

