### PR TITLE
[documentation] revision of redis-hbo-provider.rst

### DIFF
--- a/presto-docs/src/main/sphinx/plugin/redis-hbo-provider.rst
+++ b/presto-docs/src/main/sphinx/plugin/redis-hbo-provider.rst
@@ -2,14 +2,16 @@
 Redis HBO Provider
 =======================
 
-Redis HBO Provider allows loading a custom configured Redis Client for storing/retrieving Historical Stats. The Redis client is stateful and is based on
-`Lettuce <https://github.com/lettuce-io/lettuce-core>`_ . Both RedisClient and RedisClusterClient are supported, RedisClusterAsyncCommandsFactory is meant to be extended by the user for custom configurations
+Redis HBO Provider supports loading a custom configured Redis Client for storing and retrieving historical stats for Historical Based Optimization (HBO). The Redis client is stateful and is based on
+`Lettuce <https://github.com/lettuce-io/lettuce-core>`_. Both RedisClient and RedisClusterClient are supported, RedisClusterAsyncCommandsFactory is meant to be extended by the user for custom configurations.
 
 
 Configuration
 -------------
 
-Create ``etc/catalog/redis-provider.properties`` to mount the Redis HBO Provider Plugin, replacing the properties as appropriate:
+Create ``etc/catalog/redis-provider.properties`` to mount the Redis HBO Provider Plugin. 
+
+Edit the configuration properties as appropriate:
 
 Configuration properties
 ------------------------
@@ -30,74 +32,77 @@ Property Name                                Description
 ``hbo.redis-provider.cluster-mode-enabled``  Boolean property whether cluster mode is enabled
 ============================================ =====================================================================
 
-Optimizer Configuration for Historical Based Optimization:
+Coordinator Configuration for Historical Based Optimization:
 ------------------------
 
-These properties must be configured on the coordinator in ``etc/config.properties`` for tracking and using historical statistics in planning
+These properties must be configured on the Presto coordinator in ``etc/config.properties`` for tracking and using historical statistics in planning:
 
-================================================= =====================================================================
-Property Name                                     Description
-================================================= =====================================================================
-``optimizer.use-history-based-plan-statistics``   Boolean property to enable the use of historical plan statistics (default is false)
-``optimizer.track-history-based-plan-statistics`` Boolean property to enable tracking of historical plan statistics (default is false)
-``optimizer.history-canonical-plan-node-limit``   Integer use history based optimizations only when number of nodes in canonical plan is within this limit (default 1000)
-``optimizer.history-based-optimizer-timeout``     Duration end to end timeout for optimizer in plan hashing and gathering Statistics (default is 10sec)
-================================================= =====================================================================
+================================================= ===================================================================== =============
+Property Name                                     Description                                                           Default Value
+================================================= ===================================================================== =============
+``optimizer.use-history-based-plan-statistics``   Boolean property to enable the use of historical plan statistics      false
+``optimizer.track-history-based-plan-statistics`` Boolean property to enable tracking of historical plan statistics     false
+``optimizer.history-canonical-plan-node-limit``   Integer use history based optimizations only when number of nodes     1000
+                                                  in canonical plan is within this limit                                
+``optimizer.history-based-optimizer-timeout``     Duration end to end timeout for optimizer in plan hashing and         10 (seconds)
+                                                  gathering statistics                                                  
+================================================= ===================================================================== =============
 
 Credentials
 -----------
 
-The plugin requires the Redis Server URI property ``hbo.redis-provider.server_uri`` in order to access Redis.
-Based on your custom Redis deployment you may need to add additional credentials.
+The plugin requires the Redis Server URI property ``hbo.redis-provider.server_uri`` to access Redis.
+Based on your custom Redis deployment, you may need to add additional credentials.
 
 Local Test setup
 ------------------------
 
-Set up local Redis Cluster with the guideline of `Redis <https://redis.io/docs/management/scaling/#create-a-redis-cluster>`_.
+1. Set up a local Redis cluster following the Redis documentation to `Create a Redis Cluster <https://redis.io/docs/management/scaling/#create-a-redis-cluster>`_.
 
-Add ``../redis-hbo-provider/pom.xml,\`` to ``plugin.bundles`` of  ``presto-main/etc/config.properties``.
+2. In ``presto-main/etc/config.properties``, add ``../redis-hbo-provider/pom.xml,\`` to ``plugin.bundles``.
 
-Create the file ``redis-provider.properties`` at the following path: ``presto-main/etc/redis-provider.properties`` with these sample properties
-
-.. code-block:: text
-
-    coordinator=true
-    hbo.redis-provider.enabled=true
-    hbo.redis-provider.total-fetch-timeoutms=5000
-    hbo.redis-provider.total-set-timeoutms=5000
-    hbo.redis-provider.default-ttl-seconds=4320000
-    hbo.redis-provider.cluster-mode-enabled=true
-    hbo.redis-provider.server_uri=redis://localhost:7001/
+3. In ``presto-main/etc/``, create the file ``redis-provider.properties`` with these sample properties:
+   
+   .. code-block:: text
+   
+       coordinator=true
+       hbo.redis-provider.enabled=true
+       hbo.redis-provider.total-fetch-timeoutms=5000
+       hbo.redis-provider.total-set-timeoutms=5000
+       hbo.redis-provider.default-ttl-seconds=4320000
+       hbo.redis-provider.cluster-mode-enabled=true
+       hbo.redis-provider.server_uri=redis://localhost:7001/
 
 Production Setup
 ------------------------
 
-1. You can place the plugin JARs in the production's plugins directory.
+You can place the plugin JARs in the production's ``plugins`` directory.
 
-2. Alternatively, follow this method to ensure that the plugin is loaded during the Presto build.
-Steps to register the plugin in production
+Alternatively, follow this method to ensure that the plugin is loaded during the Presto build.
 
-1. Add the following to register the plugin in <fileSets> in presto-server/src/main/assembly/presto.xml
+1. Add the following to register the plugin in ``<fileSets>`` in ``presto-server/src/main/assembly/presto.xml``:
+   
+   .. code-block:: text
+   
+       <fileSet>
+          <directory>${project.build.directory}/dependency/redis-hbo-provider-${project.version}</directory>
+          <outputDirectory>plugin/redis-hbo-provider</outputDirectory>
+       </fileSet>
 
-.. code-block:: text
+2. In ``redis-hbo-provider/src/main/resources``, create the file ``META-INF.services`` with the Plugin entry class ``com.facebook.presto.statistic.RedisProviderPlugin``.
 
-    <fileSet>
-       <directory>${project.build.directory}/dependency/redis-hbo-provider-${project.version}</directory>
-       <outputDirectory>plugin/redis-hbo-provider</outputDirectory>
-    </fileSet>
+3. Add the dependency on the module in ``presto-server/pom.xml``:
+   
+   .. code-block:: text
+   
+       <dependency>
+           <groupId>com.facebook.presto</groupId>
+           <artifactId>redis-hbo-provider</artifactId>
+           <version>${project.version}</version>
+           <type>zip</type>
+           <scope>provided</scope>
+       </dependency>
 
-2. Add META-INF.services file in ``redis-hbo-provider/src/main/resources`` with the Plugin entry class com.facebook.presto.statistic.RedisProviderPlugin
+4. (Optional) Add your custom Redis client connection login in ``com.facebook.presto.statistic.RedisClusterAsyncCommandsFactory``. 
 
-3. Add dependency on the module in ``presto-server/pom.xml``
-
-.. code-block:: text
-
-    <dependency>
-        <groupId>com.facebook.presto</groupId>
-        <artifactId>redis-hbo-provider</artifactId>
-        <version>${project.version}</version>
-        <type>zip</type>
-        <scope>provided</scope>
-    </dependency>
-
-4. You can add your custom Redis client connection login in ``com.facebook.presto.statistic.RedisClusterAsyncCommandsFactory``, just make sure that the AsyncCommands are provided properly
+   Note: The AsyncCommands must be provided properly.


### PR DESCRIPTION
## Description
Noticed the numbering of the steps in [Production Setup](https://prestodb.io/docs/0.285.1/plugin/redis-hbo-provider.html#production-setup) of [Redis HBO Provider](https://prestodb.io/docs/0.285.1/plugin/redis-hbo-provider.html#production-setup) was out of order and fixed that. Also minor edits of punctuation, formatting, and links. 

## Motivation and Context
Readers might be confused by the step numbering. 

## Impact
Documentation. 

## Test Plan
Built docs locally and reviewed the local build of the page. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
