### PR TITLE
[native] Export averageOutputBufferWallNanos task-level stat

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -450,6 +450,16 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
 
   std::unordered_map<std::string, RuntimeMetric> taskRuntimeStats;
 
+  if (taskStats.outputBufferStats.has_value()) {
+    const auto& outputBufferStats = taskStats.outputBufferStats.value();
+
+    const auto averageBufferTimeNanos =
+        outputBufferStats.averageBufferTimeMs * 1'000'000;
+    taskRuntimeStats.insert(
+        {"averageOutputBufferWallNanos",
+         RuntimeMetric(averageBufferTimeNanos, RuntimeCounter::Unit::kNanos)});
+  }
+
   if (taskStats.memoryReclaimCount > 0) {
     taskRuntimeStats["memoryReclaimCount"].addValue(
         taskStats.memoryReclaimCount);


### PR DESCRIPTION
This statistic tracks average time a byte of data is waiting in output buffers to be fetched. It helps debug slow exchange.

This was added to Velox in https://github.com/facebookincubator/velox/pull/8534

```
== NO RELEASE NOTE ==
```

