### PR TITLE
[native] Revisit stuck operator detection.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
@@ -46,6 +46,10 @@ void PeriodicServiceInventoryManager::stop() {
   eventBaseThread_.stop();
 }
 
+void PeriodicServiceInventoryManager::setDetails(const std::string& details) {
+  *details_.wlock() = details;
+}
+
 void PeriodicServiceInventoryManager::enableRequest(bool enable) {
   if (requestEnabled_.exchange(enable) != enable) {
     LOG(INFO) << id_ << " has been " << (enable ? "enabled" : "disabled");
@@ -108,7 +112,8 @@ void PeriodicServiceInventoryManager::sendRequest() {
           LOG(ERROR) << id_ << " failed: " << response->error();
         } else {
           failedAttempts_ = 0;
-          LOG(INFO) << id_ << " succeeded: HTTP " << message->getStatusCode();
+          LOG(INFO) << id_ << " succeeded: HTTP " << message->getStatusCode()
+                    << ". " << *details_.rlock();
         }
       })
       .thenError(

--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
@@ -33,6 +33,9 @@ class PeriodicServiceInventoryManager {
 
   void stop();
 
+  /// Set extra text to log during 'request succeeded' events.
+  void setDetails(const std::string& details);
+
   /// If disabled then won't send any requests, but keeps itself running.
   void enableRequest(bool enable);
 
@@ -62,6 +65,7 @@ class PeriodicServiceInventoryManager {
   const std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer_;
   const folly::SSLContextPtr sslContext_;
   const std::string id_;
+  folly::Synchronized<std::string> details_;
   const uint64_t frequencyMs_;
   const std::shared_ptr<velox::memory::MemoryPool> pool_;
   /// jitter value for backoff delay time in case of failure

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -135,6 +135,7 @@ class PeriodicTaskManager {
   void addWatchdogTask();
 
   void detachWorker();
+  void maybeAttachWorker();
 
   folly::CPUThreadPoolExecutor* const driverCPUExecutor_;
   folly::IOThreadPoolExecutor* const httpExecutor_;


### PR DESCRIPTION
## Description

We have recently added the functionality to take worker offline when we detect long running operators (stuck ones or super slow). Such situation can lead to all Driver threads being blocked and already scheduled queried not progressing and new ones getting queued on the workers and on the coordinator. As the result the cluster becomes inoperational.

We observed this with just one or two workers in such condition can bring down the whole cluster.
The solution was to set the worker state to 'shutting_down' - this will signal to the coordinator to not schedule any more tasks on it, while allowing the already running tasks to complete (if they can).

The current implementation has few issues:
1. From the log it is not clear which operator got stuck.
2. When announcement is succeeded (we do and log every 30 seconds), it is not clear what state the worker is in.
3. Operator might not be truly stuck, but rather slow running, so it can eventually complete. Need to bring the worker back to the active mode.
4. Trace Context output is abrupt and confusing in the log - need to give engineer a hint what they are looking at.

So, here we change the following:
1. For each stuck operator we log the operator type, node id and the method name.
2. We add the node/worker state to the Announcement succeeded message.
3. We attach worker back when no stuck operators are detected.
4. Code changed a bit (to use folly::synchronized) to ensure we change the shuttingDown flag and the state safely.
5. Prefix the TraceContext logging with the 'title' to better understand what it is.
6. If the server does not have CoordinatorDiscoverer (and Announcer) we don't spin the WatchDog thread up. That situation is applied to the Spark on Velox.

```
============== Before:

0207 09:36:55.019454   576 PeriodicTaskManager.cpp:680] Stuck operator: tid=48549 taskId=20240207_085357_24936_99p2y.2.0.128.0 opId=2
E0207 09:36:55.019484   576 PeriodicTaskManager.cpp:693] Driver::run=1 entered 34989390 avg ms 3 max ms 769847 continuous for 31736365

W0207 09:36:55.419687   558 PeriodicTaskManager.cpp:697] Changing node status to SHUTTING_DOWN due to detected stuck drivers

I0207 12:13:40.209054   491 PeriodicServiceInventoryManager.cpp:115] Announcement succeeded: HTTP 202


============== After:

E0207 12:14:35.888252   558 PeriodicTaskManager.cpp:680] Stuck operator: tid=1040 taskId=20240207_201049_00000_2j8r9.3.0.0.0 opCall=TableScan.1::getOutput duration= 1m 20s
W0207 12:14:35.888353   558 PeriodicTaskManager.cpp:696] TraceContext::status:
Driver::run: numThreads=15 numEnters=88441 avgMs=1 maxMs=120834 continued=83672

W0207 12:14:35.888398   558 PeriodicTaskManager.cpp:699] Will detach worker due to detected stuck operators
W0207 12:14:35.888403   558 PrestoServer.cpp:763] Changing node status to SHUTTING_DOWN.

W0207 12:15:35.888581   558 PeriodicTaskManager.cpp:707] Will attach worker due to the absence of stuck operators
W0207 12:15:35.888610   558 PrestoServer.cpp:771] Changing node status to ACTIVE.

I0207 12:13:40.209054   491 PeriodicServiceInventoryManager.cpp:115] Announcement succeeded: HTTP 202. State: active.
I0207 12:14:45.136858   491 PeriodicServiceInventoryManager.cpp:115] Announcement succeeded: HTTP 202. State: shutting_down.
```

As a test I ran a query in a cluster of 60 workers with 0.1% of chance for every TableScan::getOutput() to sleep for 2 minutes, while having 1 minute threshold to detect a stuck operator.
A query (normally running in under 20 seconds) took 51 minutes to complete with the number of active workers fluctuating during the run. After the query completion all workers returned to the active state. Logs show expected output.

```
== NO RELEASE NOTE ==
```

