### PR TITLE
[documentation] update ST_POINT function documentation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -100,7 +100,8 @@ Constructors
 
 .. function:: ST_Point(x, y) -> Point
 
-    Returns a geometry type point object with the given coordinate values.
+    Returns a geometry type point object with the given longitude and latitude coordinate values. 
+    For example, ``ST_Point(-71.0882, 42.3607)``.
 
 .. function:: ST_Polygon(varchar) -> Polygon
 


### PR DESCRIPTION
## Description
Update documentation of the ST_POINT function in [Geospatial Functions](https://prestodb.io/docs/current/functions/geospatial.html) to clarify that the x and y values are longitude and latitude. Added an example copied from the introduction section of the same page.  

## Motivation and Context
Addresses [Issue 21878](https://github.com/prestodb/presto/issues/21878). 

## Impact
Documentation. 

## Test Plan
Local build of my changes. Screenshot: 
<img width="777" alt="Screenshot 2024-02-07 at 1 52 04 PM" src="https://github.com/prestodb/presto/assets/7013443/2008031b-5070-4746-8845-9cbf83b5dc8e">

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```
