### PR TITLE
feat(presto-docs): build PDF for Presto's doc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,10 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - name: Install LaTeX dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra latexmk tex-gyre texlive-xetex fonts-freefont-otf xindy
       - name: Cache local Maven repository
         id: cache-maven
         uses: actions/cache@v2

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Maven Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install -B -V -T C1 -DskipTests -Dmaven.javadoc.skip=true -P ci -pl '!presto-test-coverage,!:presto-server'
+          ./mvnw install -B -V -T C1 -DskipTests -Dmaven.javadoc.skip=true -P ci -pl '!presto-test-coverage,!:presto-server,!:presto-docs'
       - name: Clean Maven Output
         run: ./mvnw clean -pl '!:presto-server,!:presto-cli,!presto-test-coverage'

--- a/presto-docs/README.md
+++ b/presto-docs/README.md
@@ -14,6 +14,20 @@ To install venv:
 python3 -m pip install --user virtualenv
 ```
 
+Optionally, the PDF version of `presto-docs` requires LaTeX tooling.
+
+For MacOS,
+```
+brew install --cask mactex
+```
+
+For Ubuntu,
+```
+sudo apt-get update
+sudo apt-get install -y texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra latexmk tex-gyre texlive-xetex fonts-freefont-otf xindy
+```
+
+
 ## Building manually
 The default build uses Apache Maven to download dependencies and generate the HTML. You can run it as follows:
 ```
@@ -25,6 +39,12 @@ Or, to build the documentation more quickly:
 cd presto-docs
 ./build
 ```
+To build PDF version of the documentation
+```
+cd presto-docs
+./build --with-pdf
+```
+
 ## Viewing the documentation
 When the build is complete, you'll find the output HTML files in the `target/html/` folder.
 

--- a/presto-docs/build
+++ b/presto-docs/build
@@ -8,6 +8,10 @@ python3 -m venv presto-docs-venv
 source presto-docs-venv/bin/activate
 pip install -r requirements.txt
 
-make clean html
+if [[ "$1" == "--with-pdf" ]]; then
+  make clean html latexpdf
+else
+  make clean html
+fi
 
 deactivate

--- a/presto-docs/requirements.txt
+++ b/presto-docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==5.3.0
+sphinx==7.2.6
 sphinx-material==0.0.35
 sphinx-copybutton==0.5.0

--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -76,6 +76,9 @@ master_doc = 'index'
 
 project = u'Presto'
 
+# Set Author blank to avoid default value of 'unknown'
+author = ''
+
 version = get_version()
 release = version
 
@@ -87,6 +90,9 @@ rst_epilog = """
 .. |presto_server_release| replace:: ``presto-server-{release}``
 .. |presto_router_release| replace:: ``presto-router-{release}``
 """.replace('{release}', release)
+
+# 'xelatex' natively supports Unicode
+latex_engine = 'xelatex'
 
 # -- Options for HTML output ---------------------------------------------------
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add workflow to build PDF for `presto-docs`

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
Implements #21805 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
There will be PDF version of currently available [Presto doc](https://prestodb.io/docs/0.285.1/)

## Test Plan
<!---Please fill in how you tested your change-->
Install LaTeX tooling locally and run `./build` in `presto-docs`

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```

== NO RELEASE NOTE ==

