### PR TITLE
Use integer column statistics for byte columns in ORC files

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -778,7 +778,7 @@ public class OrcWriteValidation
                 fieldBuilders = ImmutableList.of();
             }
             else if (TINYINT.equals(type)) {
-                statisticsBuilder = new CountStatisticsBuilder();
+                statisticsBuilder = new IntegerStatisticsBuilder();
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StatisticsBuilders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StatisticsBuilders.java
@@ -38,8 +38,6 @@ public class StatisticsBuilders
             case BOOLEAN:
                 return BooleanStatisticsBuilder::new;
             case BYTE:
-                // TODO: sdruzkin - byte should use IntegerStatisticsBuilder
-                return CountStatisticsBuilder::new;
             case SHORT:
             case INT:
             case LONG:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -25,6 +25,7 @@ import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
+import com.facebook.presto.orc.metadata.statistics.IntegerStatisticsBuilder;
 import com.facebook.presto.orc.stream.ByteOutputStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.orc.stream.StreamDataOutput;
@@ -62,9 +63,7 @@ public class ByteColumnWriter
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
     private long columnStatisticsRetainedSizeInBytes;
-
-    private int nonNullValueCount;
-    private long rawSize;
+    private IntegerStatisticsBuilder statisticsBuilder;
 
     private boolean closed;
 
@@ -82,6 +81,7 @@ public class ByteColumnWriter
         this.dataStream = new ByteOutputStream(columnWriterOptions, dwrfEncryptor);
         this.presentStream = new PresentOutputStream(columnWriterOptions, dwrfEncryptor);
         this.metadataWriter = new CompressedMetadataWriter(metadataWriter, columnWriterOptions, dwrfEncryptor);
+        this.statisticsBuilder = new IntegerStatisticsBuilder();
     }
 
     @Override
@@ -111,13 +111,14 @@ public class ByteColumnWriter
         // record values
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
-                dataStream.writeByte((byte) type.getLong(block, position));
-                nonNullValueCount++;
+                byte value = (byte) type.getLong(block, position);
+                dataStream.writeByte(value);
+                statisticsBuilder.addValue(value);
             }
         }
         // For byte columns, null and values has the same size (1 byte)
         long rawSize = block.getPositionCount() * NULL_SIZE;
-        this.rawSize += rawSize;
+        statisticsBuilder.incrementRawSize(rawSize);
         return rawSize;
     }
 
@@ -125,11 +126,10 @@ public class ByteColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, rawSize, null);
+        ColumnStatistics statistics = statisticsBuilder.buildColumnStatistics();
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
-        nonNullValueCount = 0;
-        rawSize = 0;
+        statisticsBuilder = new IntegerStatisticsBuilder();
         return ImmutableMap.of(column, statistics);
     }
 
@@ -191,7 +191,6 @@ public class ByteColumnWriter
         presentStream.reset();
         rowGroupColumnStatistics.clear();
         columnStatisticsRetainedSizeInBytes = 0;
-        nonNullValueCount = 0;
-        rawSize = 0;
+        statisticsBuilder = new IntegerStatisticsBuilder();
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStatisticsBuilders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStatisticsBuilders.java
@@ -49,7 +49,7 @@ public class TestStatisticsBuilders
     @Test
     public void testCreateStatisticsBuilder()
     {
-        assertTrue(createStatisticsBuilder(TINYINT) instanceof CountStatisticsBuilder);
+        assertTrue(createStatisticsBuilder(TINYINT) instanceof IntegerStatisticsBuilder);
         assertTrue(createStatisticsBuilder(SMALLINT) instanceof IntegerStatisticsBuilder);
         assertTrue(createStatisticsBuilder(INTEGER) instanceof IntegerStatisticsBuilder);
         assertTrue(createStatisticsBuilder(BIGINT) instanceof IntegerStatisticsBuilder);


### PR DESCRIPTION
## Description
Make the byte column writer use integer column statistics instead of generic column
statistics for ORC/DWRF files similar to Velox and BBIO.

## Motivation and Context
Both Velox and BBIO use integer column stats for byte columns, but presto-orc uses
generic column stats. This change closes the difference between presto-orc and Velox 
behavior for byte columns.

## Impact
The column statistic type for byte columns will change from a generic column stats to
integer column stats.

## Test Plan
Existing unit tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

