### PR TITLE
Fix min and max for inputs that include NaN values

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -98,6 +98,7 @@ General Aggregate Functions
 .. function:: max(x) -> [same as input]
 
     Returns the maximum value of all input values.
+    When x is a REAL or DOUBLE, returns NaN if all input values are NaN. Ignores NaN values otherwise.
 
 .. function:: max(x, n) -> array<[same as x]>
 
@@ -106,6 +107,7 @@ General Aggregate Functions
 .. function:: min(x) -> [same as input]
 
     Returns the minimum value of all input values.
+    When x is a REAL or DOUBLE, returns NaN if all input values are NaN. Ignores NaN values otherwise.
 
 .. function:: min(x, n) -> array<[same as x]>
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
@@ -278,7 +278,10 @@ public abstract class AbstractMinMaxAggregationFunction
             return;
         }
         try {
-            if ((boolean) methodHandle.invokeExact(value, state.getDouble())) {
+            double currentState = state.getDouble();
+            // If NaN is set as state previously, configure the next state with compared value
+            // to prevent failed comparisons with NaN
+            if (Double.isNaN(currentState) || (boolean) methodHandle.invokeExact(value, currentState)) {
                 state.setDouble(value);
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleMaxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleMaxAggregation.java
@@ -16,15 +16,50 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
 import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import java.util.List;
 
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
 
 public class TestDoubleMaxAggregation
         extends AbstractTestAggregationFunction
 {
+    private static final String FUNCTION_NAME = "max";
+    private JavaAggregationFunctionImplementation maxFunction;
+
+    @BeforeClass
+    public void setup()
+    {
+        FunctionAndTypeManager functionAndTypeManager = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
+        maxFunction = functionAndTypeManager.getJavaAggregateFunctionImplementation(
+                functionAndTypeManager.lookupFunction(TestDoubleMaxAggregation.FUNCTION_NAME, fromTypes(DOUBLE)));
+    }
+
+    @Test
+    public void max()
+    {
+        assertAggregation(maxFunction, 4.0, createDoublesBlock(4.0));
+        assertAggregation(maxFunction, 5.0, createDoublesBlock(2.0, 4.0, 5.0));
+        assertAggregation(maxFunction, 4.0, createDoublesBlock(4.0, NaN, null));
+        assertAggregation(maxFunction, 4.0, createDoublesBlock(NaN, 4.0, null));
+        assertAggregation(maxFunction, POSITIVE_INFINITY, createDoublesBlock(NaN, null, POSITIVE_INFINITY));
+        assertAggregation(maxFunction, POSITIVE_INFINITY, createDoublesBlock(NaN, null, NEGATIVE_INFINITY, POSITIVE_INFINITY));
+        assertAggregation(maxFunction, null, createDoublesBlock((Double) null));
+        assertAggregation(maxFunction, NaN, createDoublesBlock(NaN));
+    }
+
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {


### PR DESCRIPTION
## Description

min and max used to return NaN if the very first value in the input was NaN, but they ignored NaN values otherwise.

After this change min and max return NaN only if all inputs are NaN.

## Motivation and Context
Fixes #21877 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Ensure correct value of `max/min()` not being affected by order of NaNs

## Test Plan
<!---Please fill in how you tested your change-->
- Run `./mvnw clean install` in current PR
- Execute following snippet
```
select max(x) from (values 4.0,nan(),null) T(x);
select max(x) from (values nan(),4,null) T(x);
```
- Results in 
```
presto> select max(x) from (values 4.0,nan(),null) T(x);
 _col0 
-------
   4.0 
(1 row)

Query 20240209_123313_00001_skyr3, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
[Latency: client-side: 172ms, server-side: 143ms] [0 rows, 0B] [0 rows/s, 0B/s]

presto> select max(x) from (values nan(),4,null) T(x);
 _col0 
-------
   4.0 
(1 row)

Query 20240209_123324_00002_skyr3, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
[Latency: client-side: 64ms, server-side: 47ms] [0 rows, 0B] [0 rows/s, 0B/s]

```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fixes issue where NaN value changes final result of aggregation max/min function if given as first item argument.

```

