### PR TITLE
[native] Call renamed createIterativeSerializer in Velox's VectorSerde

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/BroadcastFactory.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastFactory.cpp
@@ -130,7 +130,8 @@ void BroadcastFileWriter::write(const RowVectorPtr& rowVector) {
   const IndexRange allRows{0, numRows};
 
   auto arena = std::make_unique<StreamArena>(pool_);
-  auto serializer = serde_->createSerializer(inputType_, numRows, arena.get());
+  auto serializer =
+      serde_->createIterativeSerializer(inputType_, numRows, arena.get());
 
   serializer->append(rowVector, folly::Range(&allRows, 1));
   maxSerializedSize_ += serializer->maxSerializedSize();


### PR DESCRIPTION
The function createSerializer was renamed to createIterativeSerializer in VectorSerde.  Updating the call site in Presto to call the new function.

See https://github.com/facebookincubator/velox/pull/8605