### PR TITLE
Add release notes for 0.286

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    Release-0.286 [2024-02-12] <release/release-0.286>
     Release-0.285.1 [2023-12-30] <release/release-0.285.1>
     Release-0.285 [2023-12-08] <release/release-0.285>
     Release-0.284 [2023-10-11] <release/release-0.284>

--- a/presto-docs/src/main/sphinx/release/release-0.286.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.286.rst
@@ -1,0 +1,84 @@
+=============
+Release 0.286
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a bug for ``min_by`` and ``max_by`` for window functions, where results are incorrect when the function specifies number of elements to keep and the window does not have “unbounded following” in the frame. :pr:`21793`
+* Fix a potential bug in ``EXCEPT`` and ``INTERSECT`` queries by not pruning unreferenced output for intersect and except nodes in the PruneUnreferencedOutputs rule. :pr:`21343`
+* Fix a bug in PullUpExpressionInLambdaRules optimizer where expressions being extracted were of JoniRegexType or LikePatternType. :pr:`21407`
+* Extend PullUpExpressionInLambdaRulesFix optimizers to now extract independent expressions from within conditional expressions. :pr:`21344`
+* Fix an issue with the serialization of the retriable property in QueryError. :pr:`19741`
+* Fix the compilation error of merge function for KHyperLogLog state and add a config property ``limit-khyperloglog-agg-group-number-enabled`` to control whether to limit the number of groups for aggregation functions using KHyperLogLog state. (enabled by default) :pr:`21824`
+* Fix a bug in CTE materialization which was causing incorrect plan generation in some cases. :pr:`21580`
+* Fix :doc:`/plugin/redis-hbo-provider` documentation to include the correct configuration properties and added documentation for coordinator HBO configurations. :pr:`21477`
+* Fix writtenIntermediateBytes metric by ensuring its correct population through temporary table writers. :pr:`21626`
+* Add support for adaptive partial aggregation which disables partial aggregation in cases where it could be inefficient. This feature is configurable by the session property ``adaptive_partial_aggregation`` (disabled by default) :pr:`20979`
+* Improve predicate pushdown through Joins. :pr:`21353`
+* Improve the readability of query plans by formatting numbers with commas for easier interpretation. :pr:`21486`
+* Add additional linear regression functions like REGR_AVGX, REGR_AVGY, REGR_COUNT, REGR_R2, REGR_SXX, REGR_SXY, and REGR_SYY. :pr:`21630`
+* Add UPDATE sql support in Presto. :pr:`21435`
+* Add a session property ``skip_hash_generation_for_join_with_table_scan_input`` to skip hash precomputation for join when the input is table scan, and the hash is on a single big int and is not reused later. The property defaults to not enabled. :pr:`20948`
+* Add a config property ``khyperloglog-agg-group-limit`` to limit the maximum number of groups that ``khyperloglog_agg`` function can have. The query will fail when the limit is exceeded. (The default is 0 which means no limit). :pr:`21510`
+* Add a feature config property ``limit-khyperloglog-agg-group-number-enabled`` to control whether to limit the number of groups for aggregation functions using KHyperLogLog state. :pr:`21824`
+* Add session property ``rewrite_expression_with_constant_expression`` which defaults to enabled. This optimizes queries which have an equivalence check filter or constant assignments. :pr:`19836`
+* Add session property ``rewrite_left_join_array_contains_to_equi_join`` that transforms left joins with an ARRAY CONTAINS condition in the join criteria into an equi join. :pr:`21420`
+* Add an option in the Presto client to disable redirects that fixes advisory `GHSA-xm7x-f3w2-4hjm <https://github.com/prestodb/presto/security/advisories/GHSA-xm7x-f3w2-4hjm>`_. :pr:`21024`
+* Improve prestodb/presto docker image by including ``config.properties`` and ``jvm.config`` files. :pr:`21384`
+* Upgrade ``hadoop-apache2`` to ``2.7.4-12``.  This fixes errors like ``library not found: /nativelib/Linux-aarch64/libhadoop.so`` when running presto on ARM64.  :pr:`21483`
+* Add validation in Presto client to ensure that the host and port of the next URI do not change during query execution in Presto, enhancing security by preventing redirection to untrusted sources. :pr:`21101`
+* Add :doc:`Ecosystem </ecosystem/list>` documentation. :pr:`21698`
+* Add ``cte_hash_partition_count`` session property to specify the number of buckets or writers to be used when using CTE Materialization. :pr:`21625`
+* Add :doc:`/installation/deploy-helm` to Installation documentation. :pr:`21812`
+* Remove redundant sort columns from query plans if a unique constraint can be identified for a prefix of the ordering list. :pr:`21371`
+* Add changelog table ``$changelog`` that allows users  to track when records were added or deleted in snapshots. :pr:`20937`
+* Add `reservoir_sample <../functions/aggregate.html#reservoir_sample>`_ aggregation function which is useful for generating fixed-size samples. :pr:`21296`
+* Remove ``exchange.async-page-transport-enabled`` configuration property as deprecated. :pr:`21772`
+* Pass extra credentials such as CAT tokens for definer mode in views. :pr:`21685`
+* Add function ``map_top_n_keys_by_value`` which returns top ``n`` keys of a map by value. :pr:`21259`
+* Add support for materialization of Common Table Expressions (CTEs) in queries. The underlying connectors must support creating temporary tables, a functionality presently exclusive to the Hive connector. :pr:`20887`
+
+SPI Changes
+___________
+* Add support for connectors to return joins in ``ConnectorPlanOptimizer.optimize``. :pr:`21605`
+
+Hive Changes
+____________
+* Fix parquet dereference pushdown which was not working unless the ``parquet_use_column_names`` session property was set. :pr:`21647`
+* Fix CTE materialization for unsupported Hive bucket types. :pr:`21549`
+* Remove hive config ``hive.s3.use-instance-credentials`` as deprecated. :pr:`21648`
+
+Hudi Changes
+____________
+* Upgrade Hudi version to 0.14.0. :pr:`21012`
+
+Iceberg Changes
+_______________
+* Upgrade Apache Iceberg to 1.4.3.  :pr:`21714`
+* Add Iceberg Filter Pushdown Optimizer Rule for execution with Velox. :pr:`20501`
+* Add ``iceberg.pushdown-filter-enabled`` config property to Iceberg Connector. This config property controls the behaviour of Filter Pushdown in the Iceberg connector. :pr:`20501`
+* Add `register <../connector/iceberg.html#register-table>`_  and `unregister <../connector/iceberg.html#unregister-table>`_ procedures for Iceberg tables. :pr:`21335`
+* Add session property ``iceberg.delete_as_join_rewrite_enabled`` (enabled by default) to apply equality deletes as a join. :pr:`21605`
+* Add support for querying ``"$data_sequence_number"`` which returns the Iceberg data sequence number of the file containing the row. :pr:`21605`
+* Add support for querying ``"$path"`` which returns the file path containing the row. :pr:`21605`
+* Add support for reading v2 row level deletes in Iceberg connector. :pr:`21189`
+* Add support for Day, Month, and Year transform function with partition column for date type in Presto Iceberg connector. :pr:`21303`
+* Add support for Day, Month, and Year transform function with partition column for timestamp type in Presto Iceberg connector. :pr:`21303`
+* Add support for Day, Month, Year, and Hour partition column transform functions when altering a table to add partition columns in Presto Iceberg connector. :pr:`21575`
+* Optimize Table Metadata calls for Iceberg tables. :pr:`21629`
+* Add support for `time travel <../connector/iceberg.html#time-travel-using-version-system-version-and-timestamp-system-time>`_, enabling the retrieval of historical data with the `AS OF` syntax. :pr:`21425`
+* Add support for `time travel <../connector/iceberg.html#time-travel-using-version-system-version-and-timestamp-system-time>`_ ``TIMESTAMP (SYSTEM_TIME)`` syntax includes timestamp-with-time-zone data type. It will return data based on snapshot with matching timestamp or before. :pr:`21425`
+* Add support for `time travel <../connector/iceberg.html#time-travel-using-version-system-version-and-timestamp-system-time>`_ ``VERSION (SYSTEM_VERSION)`` syntax includes snapshot id using bigint data type. :pr:`21425`
+* Add manifest file caching support for Iceberg native catalogs. :pr:`21399`
+* Fix Iceberg memory leak with ``DeleteFile``.  :pr:`21612`
+
+**Credits**
+===========
+
+8dukongjian, AbhijitKulkarni1, Aditi Pandit, Ajay George, Ajay Gupte, Amit Dutta, Anant Aneja, Andrii Rosa, Anil Gupta Somisetty, Antoine Pultier, Arjun Gupta, Avinash Jain, Beinan, Bikramjeet Vig, Changli Liu, Christian Zentgraf, Chunxu Tang, Deepak Majeti, Diana Meehan, Facebook Community Bot, Ge Gao, Jalpreet Singh Nanda (:imjalpreet), Jason Fine, Jialiang Tan, Jimmy Lu, Jonathan Hehir, Junhao Liu, Ke, Kevin Wilfong, Krishna Pai, Linsong Wang, Luis Paolini, Lyublena Antova, Mahadevuni Naveen Kumar, Masha Basmanova, Matthew Peveler, Michael Shang, Nikhil Collooru, Nilay Pochhi, Patrick Stuedi, Paul Meng, Pedro Pedreira, Pramod, Pranjal Shankhdhar, Pratik Joseph Dabre, Reetika Agrawal, Richard Barnes, Rohit Jain, Sagar Sumit, Sergey Pershin, Sergii Druzkin, Shrinidhi Joshi, Steve Burnett, Sudheesh, Tai Le, Tim Meehan, TommyLemon, Vigneshwar Selvaraj, VishnuSanal, Vivek, Yihong Wang, Ying, Zac, Zac Blanco, Zhenxiao Luo, abhiseksaikia, feilong-liu, hainenber, jaystarshot, karteekmurthys, kedia,Akanksha, kiersten-stokes, mohsaka, pratyakshsharma, prithvip, renurajagop, rui-mo, shenhong, wangd, wypb, xiaoxmeng, xumingming


### PR DESCRIPTION
# Missing Release Notes
## AbhijitKulkarni1
- [ ] https://github.com/prestodb/presto/pull/21724 Revert "Upgraded spring boot maven plugin and spring core version to resolve multiple CVE" (Merged by: Timothy Meehan)

## Ajay Gupte
- [ ] https://github.com/prestodb/presto/pull/20991 Add time travel syntax support for iceberg tables (VERSION and TIMESTAMP). (Merged by: Timothy Meehan)

## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/21856 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21813 [native] Register boolean properties properly. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21801 [native] Fix https socket binding. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21789 [native] Remove an unused include. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21788 [native] Add ngrams e2e tests. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21784 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21745 [native] Add config for stats reporting and counters. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21740 [native] Improve worker shutdown logging. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21737 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21711 [native] Rename NodeState enum with proper naming convention (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21728 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21703 [native] Remove unnecessary includes from PrestoServer.cpp (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21686 [native] Reuse sslcontext in secure http connection. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21704 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21693 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21618 Minor fix in Ngrams test. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21561 [native] Add parquet test group for parquet specific tests. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21536 [native] Add e2e tests for any_value aggregate. (Merged by: Amit Dutta)

## Andrii Rosa
- [ ] https://github.com/prestodb/presto/pull/21770 [native pos] Wait for process termination (Merged by: Andrii Rosa)

## Arjun Gupta
- [ ] https://github.com/prestodb/presto/pull/21513 Apply INCREASE_CONTAINER_SIZE execution strategy for user supplied error codes (Merged by: Arjun Gupta)

## Avinash Jain
- [ ] https://github.com/prestodb/presto/pull/21259 Add support for map_keys_by_top_n_values (Merged by: Ajay George)

## Bikramjeet Vig
- [ ] https://github.com/prestodb/presto/pull/21548 [native] Add "numMemoryAllocations" operator runtime metric (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21463 [native] Add system memory check configs (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21478 [native] Enable lazy spill file creation (Merged by: Xiaoxuan)

## Changli Liu
- [ ] https://github.com/prestodb/presto/pull/21594 Correct class and object's name in PhysicalCteOptimizer (Merged by: Timothy Meehan)

## Deepak Majeti
- [ ] https://github.com/prestodb/presto/pull/21620 [native] Advance velox and update memory code (Merged by: Xiaoxuan)

## Jimmy Lu
- [ ] https://github.com/prestodb/presto/pull/21809 [native] Follow up on task watchdog (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21783 [native] Add watchdog to detach the worker if an operator call is stuck for too long (Merged by: Pranjal Shankhdhar)
- [ ] https://github.com/prestodb/presto/pull/21440 [native] Make HTTP client connection pool configurable and disable by default (Merged by: spershin)
- [ ] https://github.com/prestodb/presto/pull/21403 [native] Fix PrestoQueryRunner in case query fails (Merged by: Maria Basmanova)
- [ ] https://github.com/prestodb/presto/pull/21386 [native] Ensure graceful shutdown of exchange source connection pools (Merged by: Xiaoxuan)

## Ke
- [ ] https://github.com/prestodb/presto/pull/21742 [Native] Fix PartitionedOutputNode plan node id (Merged by: Zac)

## Kevin Wilfong
- [ ] https://github.com/prestodb/presto/pull/21481 [Native] Don't propagate errors in getResults (Merged by: Xiaoxuan)

## Mahadevuni Naveen Kumar
- [ ] https://github.com/prestodb/presto/pull/21587 Document update for Parquet Writer Versions V1 and V2 support (Merged by: Timothy Meehan)

## Patrick Stuedi
- [ ] https://github.com/prestodb/presto/pull/21419 [native] Add non-blocking shuffle reader interface (Merged by: Andrii Rosa)

## Pratik Joseph Dabre
- [ ] https://github.com/prestodb/presto/pull/21868 [native] Add e2e tests for from_ieee754_64 Presto scalar function (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/21811 Refactor assertCreateTableAsSelect() and assertExplainAnalyze() functions (Merged by: Deepak Majeti)
- [ ] https://github.com/prestodb/presto/pull/21641 [native] Enable hive.allow-drop-table in NativeQueryRunner (Merged by: Deepak Majeti)

## Reetika Agrawal
- [ ] https://github.com/prestodb/presto/pull/21399 Manifest file caching support for Iceberg Native Catalogs (Merged by: Ying)

## Richard Barnes
- [ ] https://github.com/prestodb/presto/pull/21884 Fix sign shift issue in presto (Merged by: spershin)

## Tim Meehan
- [ ] https://github.com/prestodb/presto/pull/21519 Add more information on how to become a committer (Merged by: Timothy Meehan)

## feilong-liu
- [ ] https://github.com/prestodb/presto/pull/21712 Revert "Refactor `ApproximateMostFrequent` to use type annotations" (Merged by: feilong-liu)

## jaystarshot
- [ ] https://github.com/prestodb/presto/pull/20887 Support persistent CTE's (Merged by: Jay Narale)

## kedia,Akanksha
- [ ] https://github.com/prestodb/presto/pull/21423 Remove unnecessary condition else check (Merged by: Timothy Meehan)

## wypb
- [ ] https://github.com/prestodb/presto/pull/21612 Fix Iceberg memory leak with Delete File. (Merged by: Ying)

## xiaoxmeng
- [ ] https://github.com/prestodb/presto/pull/21794 [native] Add memory reclaim stats to task runtime stats (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21780 [native] Add http request active check when fetch data from output buffer manager (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21697 [native] Fix stats report for cache and spill (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21643 [native]Set cpu driver slicing to 1 second in Prestissimo (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21681 [native] Add output buffer stats in protocol::TaskInfo and advance Velox (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21677 [native] Remove ShuffleReader::hasNext api (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21674 [native]Add to handle empty data case in ShuffleReader::next (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21573 Fix the failed QueryContextManagerTests (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21570 Fix HttpTestSuite tests (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21559 [native]Advance velox and update memory part (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/21539 [native] Update prestissimo to help velox memory manager refactor (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/21485 [native]Advance velox and update metric code (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21451 [native]Add hook to stop additional periodic tasks (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21437 [native]Advance velox version and code update (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21433 [native]Add hook to stop additional periodic task (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/21417 [native]Add server memory pushback configs (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/21414 [native]Advance velox version (Merged by: Aditi Pandit)

# Extracted Release Notes
- #19741 (Author: Matthew Peveler): Fix serialized name for retriable QueryError property
  - Fix serialized name for retriable QueryError property.
- #19836 (Author: feilong-liu): Rewrite expressions in query plans when variables are constant.
  - Add an optimization to optimize queries which has equivalence check filter or constant assignments. Controlled by session property `rewrite_expression_with_constant_expression` and default to enabled.
- #20501 (Author: Jalpreet Singh Nanda (:imjalpreet)): Add Iceberg Filter Pushdown Optimizer Rule for execution with Velox
  - Add ``iceberg.pushdown-filter-enabled`` config property to Iceberg Connector. This config property will control the behaviour of Filter Pushdown in the iceberg connector.
  - Add Iceberg Filter Pushdown Optimizer Rule for execution with Velox.
- #20937 (Author: Zac Blanco): [Iceberg] Add changelog table
  - A new changelog table has been added to the Iceberg connector.
- #20948 (Author: feilong-liu): Skip pre hash computation for join when input is table scan
  - Add a session property to skip hash precomputation for join when the input is table scan, and the hash is on a single big int and is not reused later. It's controlled by session property `skip_hash_generation_for_join_with_table_scan_input` and default to not enabled.
- #20979 (Author: prithvip): Add support for adaptive partial aggregation
  - Improve efficiency of partial aggregation step. This can be enabled by setting the ``adaptive_partial_aggregation`` session property to true.
- #21012 (Author: Sagar Sumit): Upgrade Hudi version to 0.14.0
  - Upgrade Hudi version to 0.14.0.
- #21024 (Author: Diana Meehan): Add client option to disable redirects
  - Add client option to disable redirects.
- #21101 (Author: Diana Meehan): Add validation that checks next URI host and port does not change during query execution
  - Add validation to check that next URI host and port does not change during query execution.
- #21189 (Author: wypb): Add support for reading v2 row level deletes in Iceberg connector
  - Add support for reading v2 row level deletes in Iceberg connector.
- #21296 (Author: Zac Blanco): Add reservoir_sample aggregation function
  - A reservoir_sample aggregation function is now available.
- #21303 (Author: Ajay Gupte): Partition Column transform support for Year, Month, Day & Hour
  - Day, Month & Year partition column transform functions are supported for date type in Presto Iceberg connector.
  - Day, Month, Year & Hour partition column transform functions are supported for timestamp type in Presto Iceberg connector.
- #21335 (Author: kiersten-stokes): Add Iceberg table register and unregister procedures
  - Add register and unregister procedures for Iceberg tables.
- #21343 (Author: feilong-liu): Fix prune output rules for intersect and except nodes
  - Fix a potential bug in except and intersect queries. Do not prune unreferenced output in intersect and except nodes.
- #21344 (Author: feilong-liu): Extend pull lambda out for conditional expression
  - Fix lambda expression pull out optimizer so that it will be able to extract independent expressions from conditional expression.
- #21353 (Author: Anant Aneja): Infer domain filters during predicate pushdown
  - Improve predicate pushdown through Joins.
- #21371 (Author: Anant Aneja): Remove redundant sort columns
  - Remove redundant sort columns from Plan nodes if a unique constraint can be identified for a prefix of the ordering list.
- #21384 (Author: Yihong Wang): Add simple settings to prestodb/presto image
  - Add simple configurations to prestodb/presto docker image and make the image easier to use, including ``config.properties`` and ``jvm.config``.
- #21407 (Author: feilong-liu): Fix pull up lambda expression optimizer for regex_like and like function
  - Fix bug of pull lambda out optimizers when expressions pulled out are of type JoniRegexType or LikePatternType.
- #21420 (Author: feilong-liu): Add optimization to rewrite left join with array contains to equi-join
  - Add an optimization to rewrite left join with array contains in join condition to equi join, the optimization is controlled by session property `rewrite_left_join_array_contains_to_equi_join `.
- #21425 (Author: Ajay Gupte): Iceberg connector support for time travel VERSION and TIMESTAMP.
  - Support time travel `AS OF` syntax for Iceberg tables to return historical data.
  - Time travel VERSION (SYSTEM_VERSION) syntax will include snapshot id using bigint data type.
  - Time travel TIMESTAMP (SYSTEM_TIME) syntax will include timestamp-with-time-zone data type. It will return data based on snapshot with matching timestamp or before.
  - Examples :.
  - SELECT * FROM tab1 FOR VERSION AS OF 8772871542276440693;.
  - SELECT * FROM tab1 FOR SYSTEM_VERSION AS OF 8772871542276440693;.
  - SELECT * FROM tab1 FOR TIMESTAMP AS OF TIMESTAMP '2023-10-17 13:29:46.822 America/Los_Angeles';.
  - SELECT * FROM tab1 FOR SYSTEM_TIME AS OF TIMESTAMP '2023-10-17 13:29:46.822 America/Los_Angeles';.
- #21435 (Author: Reetika Agrawal): Add UPDATE sql support in Presto Engine
  - Add UPDATE sql support in Presto Engine.
- #21477 (Author: jaystarshot): Fix redis-hbo-provider docs and add coordinator hbo configuration
  - Fixed redis-provider-plugin docs which previously contained an incorrect file name for property loading, and included the HBO configurations for the coordinator.
- #21483 (Author: Jalpreet Singh Nanda (:imjalpreet)): Upgrade hadoop-apache2 to 2.7.4-12
  - Add support for running on Linux and M1/M2 macOS aarch64 (ARM64).
- #21486 (Author: feilong-liu): Add comma for number in printed query plan
  - Improve the readability of query plan by making the number printed in query plan to be comma separated.
- #21510 (Author: feilong-liu): Add option to add limit to number of groups for khyperloglog_agg function
  - Add an feature config property `khyperloglog-agg-group-limit` to set the maximum number of groups `khyperloglog_agg` can have. It will fail the query when the limit is exceeded. The default is 0 which means no limit.
- #21549 (Author: jaystarshot): Fix CTE Materialization unsupported hive bucket types
  - Fixed CTE Materialization for unsupported hive bucket types.
- #21575 (Author: wangd): Support year/month/day/hour transform when add partition column in Iceberg
  - Day, Month, Year & Hour partition column transform functions are supported when altering table to add columns in Presto Iceberg connector.
- #21580 (Author: jaystarshot): Use Proper query scope in CTE Materialization
  - Fixed a bug in cte materialization which was causing incorrect plan generation in some cases.
- #21605 (Author: Jason Fine): Iceberg: Support applying equality deletes as a join
  - Add support for querying ``"$path"`` which returns the file path containing the row.
  - Add support for querying ``"$data_sequence_number"`` which returns the Iceberg data sequence number of the file containing the row.
  - Add support for applying equality deletes as a join. This can be enabled with the session property ``iceberg.delete_as_join_pushdown_enabled``.
  - Add support for connectors to return joins  in ``ConnectorPlanOptimizer.optimize``.
- #21625 (Author: jaystarshot): Separate CTE materialization session Properties from exchange Materialization
  - Added CTE hash partition count session property.
- #21626 (Author: jaystarshot): Fix writtenIntermediateBytes metric to capture correct intermediate w…
  - Fixed writtenIntermediateBytes metric by ensuring its correct population through temporary table writers.
- #21629 (Author: Reetika Agrawal): Optimize Table Metadata calls for Iceberg tables
  - Optimize Table Metadata calls for Iceberg tables.
- #21630 (Author: 8dukongjian): Add additional linear regression functions
  - Add REGR_AVGX, REGR_AVGY, REGR_COUNT, REGR_R2, REGR_SXX, REGR_SXY, and REGR_SYY.
- #21647 (Author: xumingming): Fix Parquet dereference pushdown
  - Fix parquet dereference pushdown, which fails when parquet_use_column_names is not enabled before.
- #21648 (Author: Jalpreet Singh Nanda (:imjalpreet)): Deprecate hive config `hive.s3.use-instance-credentials`
  - Deprecate hive config ``hive.s3.use-instance-credentials``. This config will be removed in the upcoming release (:issue:`21633`).
- #21685 (Author: Rohit Jain): Pass cat token for view definer mode
  - Pass extra credentials such as CAT tokens for definer mode in views.
- #21698 (Author: TommyLemon): Add Ecosystem and ORM to docs
  - Added 1 folder(ecosystem) and 1 file in sphinx.
  - Added 1 line in sphinx/index.rst.
- #21714 (Author: Sudheesh): Upgrade Iceberg Version
  - Upgrade Apache Iceberg to 1.4.3.
- #21772 (Author: Andrii Rosa): Drop legacy results api
  - Deprecate exchange.async-page-transport-enabled configuration property.
- #21793 (Author: feilong-liu): Fix min_by/max_by for window function evaluation
  - Fix a bug for min_by/max_by for window function, where results are incorrect when the function specifies number of elements to keep and the window does not have “unbounded following” in the frame.
- #21812 (Author: Steve Burnett): add Helm Charts to Installation docs
  - Added Helm Charts to Installation documentation.
- #21824 (Author: feilong-liu): Add limit to merge function for KHyperLogLog
  - Fix the compilation error of merge function for KHyperLogLog state.
  - Add an feature config property `limit-khyperloglog-agg-group-number-enabled` to control whether to limit the number of groups for aggregation functions using KHyperLogLog state.

# All Commits
- d2bc02d44b71071eff2927b6ebdc196d77f2143d [native] Add e2e tests for from_ieee754_64 Presto scalar function (Pratik Joseph Dabre)
- 82518cb6d6b9324ac6a796eabd4a1674cc655791 Fix sign shift issue in presto (Richard Barnes)
- 20e7712a81284e378a7b25c26641423a5529b34f Refactor assertCreateTableAsSelect() and assertExplainAnalyze() functions (Pratik Joseph Dabre)
- b60d6974b9fe388ef43dbae1eda69764f248183b Add Ecosystem and ORM to docs (TommyLemon)
- 0651498795afbfd96695b9a1ee7cda2403e02019 [native] Advance Velox version. (Sergey Pershin)
- 344f188fbcf0d3bcbdab100d5422c2dc9d24ed14 Implement projection and predicate pushdown for CTEs. (Lyublena Antova)
- f6aa4bf27e3da8b989d246fe811a9e48d443711b Add data directory param to IcebergQueryRunner (pratyakshsharma)
- 4ed9b52bf53fc610d5c40bb2cd1decfe9445ab49 Revert "Preserve case for RowType's field name and JSON content when ``CAST``" (Ajay George)
- 6eba1f7330de2879ca2f4012c8bbd9b1f7a5f727 [native] Add e2e tests for aggregate window functions (Pramod)
- 24f1c141e909dc84fce5c305bcf862f93c2cf83d [native] Remove python package 'six' install from setup scripts (Deepak Majeti)
- 1bd7843cd321023d04c6cba734b136b6c552ea96 [native] Remove RE2 dependency from centos setup script (Deepak Majeti)
- 6588babe1fe0599e5ff83718a164bc243aaa8641 Add a wrapper for the ChangelogOperation enum from Iceberg Library (Jalpreet Singh Nanda (:imjalpreet))
- 4bedf67d4c019ababf84d004cd6a25bc3d7a0d17 Add a wrapper for the FileContent enum from Iceberg Library (Jalpreet Singh Nanda (:imjalpreet))
- f974c6a8ec5e20f9d049fba0a0bf5c13e2591675 Add a wrapper for the FileFormat enum from Iceberg Library (Jalpreet Singh Nanda (:imjalpreet))
- 762a82f661c8a1bb300863490b0df4c478a7507b [native] Advance velox. (Amit Dutta)
- efd604aa7dd00fb7faa7f0b8d1474777abc3828b Add spill related session property for native engine (Ke)
- 1c14dfff7a8a9638d342133488eec9f25f76b98d [native] Remove libuuid dependency from Centos and Ubuntu setup scripts (Deepak Majeti)
- 6426275c4226ae794c711dd05f50c882c1443e04 [native] Remove libsodium dependency from MacOS and Ubuntu setup scripts (Deepak Majeti)
- 0c30fd638305f3c8c956e005c0cff67cf015472b [native] Fix FB_OS_VERSION in Centos Ubuntu setup scripts (Deepak Majeti)
- 908699b250a954f54973957d35019d55d621583a Push down thoroughly predicates that could be enforced by Iceberg table (wangd)
- 4cce0ae640341eb826f4d8873e5100230c49a363 [native] Export averageOutputBufferWallNanos task-level stat (Masha Basmanova)
- f5f930c6d14cafe235fe3187fc568edbbdd28471 [native] Modify protocol::JoinNodeType to protocol::JoinType (Jalpreet Singh Nanda (:imjalpreet))
- c2803ca0a60797c04a17664a4b1e92040534a6e3 [native] Update presto protocol (Jalpreet Singh Nanda (:imjalpreet))
- eb8a766cf68730d88f21f3910f563a8031617951 Make runtime stats available for DirectoryLister (abhiseksaikia)
- f37e83aea566fd6da4bdbef8849803edaf03d941 Fix error `java.lang.OutOfMemoryError: Compressed class space` (Pramod)
- e87373c34d1689c3ee9456d376b377442090a5cf Make group number limit for khyperloglog_agg feature config controlled (feilong-liu)
- e12deb66cbe75d7a10f5812601dfcee868f5f6a3 Add limit to merge function for KHyperLogLog (feilong-liu)
- 20738bcfb0d3afbc35984fc20c369f3ecbb237bf [native] Follow up on task watchdog (Jimmy Lu)
- 6af66f1f71ddaaba329f9b3e98155c8d4cbc8169 [native] Update to latest Velox. (Krishna Pai)
- 5508a4203c05c4b44407c9d0d4f43a6cf10fe6d6 [native] Update build to support new dependency versions (Krishna Pai)
- c61f42471906abc75ab72cb604bd4b8ae485a370 Fix unsupported type hive bucketing for cte materialization (jaystarshot)
- 89f95d9395e256400a7a830a1fa18b5c4c17bf0d Fix writtenIntermediateBytes metric to capture correct intermediate write metrics (jaystarshot)
- 1fea5468adf96e6e4c8044ee6e18faee318e8af5 [native] Use 'max_output_buffer_size' instead of 'max_arbitrary_buffer_size' (Sergey Pershin)
- 2e0d73c3cd818d16422b8d707c48f3b4e05f9480 Refactor ApproximateMostFrequent function to use type annotations (Zac Blanco)
- d3c93d58bfbd5358121107d29219d5b176cf744a [native] Remove PrestoQueryRunner and tests (Deepak Majeti)
- f4cb2cab946cd6682b7ee6537028555d40d088b8 Update types.rst (renurajagop)
- a5723dede54cc811266a37c15cb4881f1b0bb612 minor edits to CONTRIBUTING.md (Steve Burnett)
- 288abe727eafd470de03966000ceaf3d6c6b8f82 Fix min_by/max_by for window function evaluation (feilong-liu)
- b5cb9b2d61bcdaa5c022bce918a92400f399ddfb add Helm Charts to Deploy docs (Steve Burnett)
- 5dfa33d9836aaa287ae09036975b6cb6a5ba6ba3 [native] Register boolean properties properly. (Amit Dutta)
- 2e3cb6ea0bf7e45bd4277a48e3255669adb30984 Add raw and storage size to DWRF column statistics (Sergii Druzkin)
- e6b024fa798cf794d4a21c7192e6bd7a6500091b [Native] Fix PartitionedOutputNode plan node id (Ke)
- cd4b994538b1473d3ac4ef58b3deebb5bb687f36 Use softlink for jmx_prometheus_javaagent jar file in building docker image (Linsong Wang)
- 25cd944e43564901aae9b2e2e92e6e376c5dd009 [native pos] Increase scheduled executor pool size (Andrii Rosa)
- c1055fd9e1e12ad78aa23a67a0a3a7ae46787108 [native pos] Use core executor to run callback (Andrii Rosa)
- c246fa5486038f13b4a6bd2618b4f4d972a72e30 [native pos] Improve communication loss condition (Andrii Rosa)
- 0dd6d0126ae59dbeb765ecbc176a3dfb2f12ef65 [native pos] Consolidate and improve NativeExecutionTask retries (Andrii Rosa)
- 501e0576a93552a6c0be87abc396a51c7d8faecb [native pos] Move getResults retry logic to PrestoSparkHttpTaskClient (Andrii Rosa)
- ccdf486f39411e1ce1107e39882f94548e6a53ec [native pos] Cleanup PrestoSparkHttpTaskClient (Andrii Rosa)
- 0ddb2c1e4b3ceb6e8e72af486b6f21195a8fa518 [native] Add watchdog to detach the worker if an operator call is stuck for too long (Jimmy Lu)
- db88c9b50868e3cd9d86dc6469bb678859e5874f [native] Upload worker log as artifacts in CircleCI (Jimmy Lu)
- 17476679fbede3bf8254f2bb8da0cd19c286b1f7 Remove partitions from JSON constructor of BaseHiveTableLayoutHandle (Jalpreet Singh Nanda (:imjalpreet))
- eecf1b995ce7618e47ea9057e1f9b60761523199 Optimize Table Metadata calls for Iceberg tables (Reetika Agrawal)
- e315265fc4b1d958e815bbd35221654f0697e7b3 [native] Fix https socket binding. (Amit Dutta)
- 5cbb00d027cb92c2b3e8dfed59956a513c8acc24 [native] Return error on erroneous server operation calls (Sergey Pershin)
- 5f43cfa3ece48d9d37e8e28b2192b1f0216574cb [native] Add 'server/setState' and 'server/announcer' server operations. (Sergey Pershin)
- 86d180669b98077837cd4fa9d75d5daf254113f8 [native pos] Bind native execution process to specific interface (Andrii Rosa)
- 1a9009c86dca1bd21d607c3e47369a340e1d9b50 [native] Add memory reclaim stats to task runtime stats (xiaoxmeng)
- 7290ab8848485df21cf01b8e7c958bbc36bb0775 Remove blocking implementation of /v1/task/<id>/results (Andrii Rosa)
- 02786de77ba3e5a9cabd32e82dd412cff4053265 Expose getResults metrics in AsyncPageTransportServlet (Andrii Rosa)
- edff7d5a2dc261321a0a469c4ca0a16ced2487d1 [native] Change to use the new named spillWrites stat (Jialiang Tan)
- d62a06f2baa7280cbbeca5fcbdddf80e9c2b0856 [native] Add http request active check when fetch data from output buffer manager (xiaoxmeng)
- 2aa0615c591c65df2797c0949b1376faec9c02fe Advance velox version (xiaoxmeng)
- b569c6aee5e9343e7588e0a2823a1a6175677b64 [native] Remove an unused include. (Amit Dutta)
- 91e397d0ca0eeb97a3f20b85a40833c03d615a17 [native] Add ngrams e2e tests. (Amit Dutta)
- 9b2d379c35b8ebb25348603f571fba8f5005d807 [native] Use folly::dynamic as propagation media for printing (Jialiang Tan)
- da4fafbbe6b38725ba3f24e2cb0f443cdd1f3e43 [native] Advance velox. (Amit Dutta)
- 4b458d41b8988f02c09bf9ff85e5d7bacf093b98 Iceberg: Support applying equality deletes as a join (Jason Fine)
- 2f129d76010e3abcb8793030a80d2185767605f7 Iceberg: Support metadata columns (Jason Fine)
- eb94b3f4b83dae444519c618b42b4c853d4380b0 Allow connector optimizers to create joins (Jason Fine)
- 0907cd8374b674783e6ab4415eca096dcbae8737 [native pos] Wait for process termination (Andrii Rosa)
- 3f1c6b6e145d8009d4b603e3277e76be99280ad1 Fix memory accounting for Theta Sketch Aggregation (Zac Blanco)
- 3f2ed80ca1a9f464804ad6ae2cfabff3cfd5c77c [native] Refactor server operation endpoint (Jialiang Tan)
- 6b8b56ede30b6e52ca9b3090a7ee4a9ca099d46d Disable running CircleCI tests for docs-only PRs (hainenber)
- 41d290e2c9bb807b7daedb9e365b8854c835a5e4 Add tests for rewrite constant optimizer (feilong-liu)
- 2da20b453cc630efa7661b026824500d73a827fd Add rules to simplify sort/topn node with constant input (feilong-liu)
- 2b0782324e182cb941bbfbdf5db90b2dc6fa787e Add rule to extract constant variables from projection and filter (feilong-liu)
- 7f17913450239fa07b57d194b7b0c27681c41a89 Add documentation for cte-materailization-strategy (jaystarshot)
- 0ca8cce0aef71ed139e60a9e222e603247b3851c Separate CTE Materialization Properties (jaystarshot)
- 5a91680a1ac4f25e580996aaf94c3451c266878a [native] Add config for stats reporting and counters. (Amit Dutta)
- ba78cabac7025691e7d2b52bd4a62d592b05bcd6 Add shuffledBytes and shuffledRows to QueryCompletedEvent (Ke)
- f5700b948194afe7ade9da4a9b9589c7c500202a Add TableWriterMergeNode in presto UI (Ke)
- 00faa91bab5a1e4b7be36baecca1aeda0e33a1a3 fix typo in release/release-0.255.rst (Steve Burnett)
- a0b0a7d1bd5df3dc9cc724ca32771dc80ba52db1 [native] Add non-blocking shuffle reader interface (Patrick Stuedi)
- a12f21f6c60ebb29daee9ee770c0de7d88882363 Revert "Upgraded spring boot maven plugin and spring core version to resolve multiple CVE" (AbhijitKulkarni1)
- 8f26a662d88838e3f5fb4d77e2936328a3a0b116 [native] Improve worker shutdown logging. (Amit Dutta)
- 3ae41a5108e047e0b469482f5c6214b5aa2ce667 [native] Advance velox. (Amit Dutta)
- f4f434a243a3d126738f697415bd39b391232fa5 [native] Rename NodeState enum with proper naming convention (Amit Dutta)
- a6f8091a00b0eda8ff7efab55c780f76f7da35de [native] Disable partial agg over system table scan (Andrii Rosa)
- b1dacd39cd2156f2a6a6f8d95a00576676d4d307 Reformat AbstractTestNativeGeneralQueries (Andrii Rosa)
- c2a8f8e287d5984ccf29d618e50af5d872e057f5 Refactor to use Optional ifPresent instead of isPresent and get (Ajay George)
- 52ee594a1bab76f7a2950c6250c4fdcbc0f9c092 [native] Fix exchange source close race condition (Jialiang Tan)
- a2cbd2dc92c17ec11938a02438db9b736fc3f91e [native] Advance velox. (Amit Dutta)
- 1a4e0eb2b39894b295c5d75d396294b5b1d1ef08 [native] Enable hive.allow-drop-table in NativeQueryRunner (Pratik Joseph Dabre)
- 496e98ca25fb243ab25731d188c2fd56eba3b3e9 Add WarningCollector to MetastoreContext (Nikhil Collooru)
- d11d79ffee23715ea5464f9b11baaf67195774e3 Remove duplicate code for getting Iceberg table of various catalogTypes (wangd)
- f75f9db63bc83348cc66a330ff9eb4d80ef642cd Convert BaseHiveColumnHandle interface into a class (Jalpreet Singh Nanda (:imjalpreet))
- f75610e68199b8c0d3434347f2df456fb1b1ccc3 Introduce BaseHiveTableHandle (Jalpreet Singh Nanda (:imjalpreet))
- 38df84dd5d396f7fa93e77def3281afec66196e8 Move partitionColumns to BaseHiveTableLayoutHandle (Jalpreet Singh Nanda (:imjalpreet))
- a497c3811a13f93d858c793506132099d654c03e Rename TableType to IcebergTableType in Iceberg Connector (Jalpreet Singh Nanda (:imjalpreet))
- 501f890fba3e2c54ff7eed0a9e8401fadba180fc Annotate all parameters of DeleteFile constructor with @JsonProperty (Jalpreet Singh Nanda (:imjalpreet))
- 28588596a6b1cd0649391fcfcc5957aeed071819 Upgrade Iceberg Version (Sudheesh)
- 5949bdfdc25050017bfab51377472d704992937e [native pos] Make `max_spill_bytes` configurable in presto-on-spark (Shrinidhi Joshi)
- 68bfa6cb2bfc7b11db375315701413d497d5d698 Fix memory accounting in SfmSketchStateFactory (Jonathan Hehir)
- a7f5b430dd6027a7cbfa23d66d24c4d13064002b [Native] update presto to velox session property mapping (Ke)
- 5326f30b031ecf72edf371f49a59fa36374c1dc1 Add spill related session property for native engine (Ke)
- 87c1fec26a141bcd451da99c7b444a62ba62f68f [native] Remove mmap arena exposure from Prestissimo (Jialiang Tan)
- 0c76a0ddeed99a8f494e360c89ce92b3e0372b8a Revert "Refactor `ApproximateMostFrequent` to use type annotations" (feilong-liu)
- 34f858f65f974d0887d86369aa2d3518701c9704 [native] Remove unnecessary includes from PrestoServer.cpp (Amit Dutta)
- d99aedff03d8b7ef891799d88e4c3f120ffc6da4 Clean up tables registered in test cases to avoid impacting others (wangd)
- 2fbf4d3a820ff11182b0a9d18cfb4ea8ef9ea9ac [native] Re-use sslcontext in secure http connection. (Amit Dutta)
- 18fd15aa318ebb9f9f6f731b046fb4695216be1b [native] Make memory reclaim timeout configurable (Andrii Rosa)
- 83c6e364c5908ebf49890b93fcc9ee921a598bd0 [native] Fix stats report for cache and spill (xiaoxmeng)
- 34d31c342d2e504444b12d62ee9cd318f7e28fe3 Add available raptorx caching details in Iceberg Connector (Reetika Agrawal)
- 71d20fecae8cf53ce60eedaa7f80fc64ca375770 MapUnionSum should writeLong when value is RealType (Junhao Liu)
- 211eebab667fd6d2af2dbcdec4c76b1e1bcf35e3 [native] Advance velox. (Amit Dutta)
- 02e492c7dd869eed9cbb07bef106d4c17a97c8ab Optimize the Split page (Yihong Wang)
- b582c31e1cd2262543f6316014699e0abd39b708 Bump Sphinx version to fix build (Tim Meehan)
- 725f39d79fdc70a91ed5668b95e0bfd555578464 [native] Remove logging of "Calling getResult() on a aborted task". (Sergey Pershin)
- 01b3f14e72b4a7880cfcb89a7f2fcc358b4762d6 [native] Advance velox. (Amit Dutta)
- e909effbb1397249f8cd59fd72d41c328e26603c [native]Set cpu driver slicing to 1 second in Prestissimo (xiaoxmeng)
- ed06263a4e748f6bb38d11fc0847f3e9b3b3d888 Fix Parquet dereference pushdown (xumingming)
- d0b658e483a63914177a5e643b5e60dc6c649b4d Add additional linear regression functions (8dukongjian)
- 6b9f680f997e72c227906faa96676c755c4003eb Pass cat token for view definer mode (Rohit Jain)
- e01dc5256a9cd05dbd8b4249a3ff21a46bbd44f9 [native] Add output buffer stats in protocol::TaskInfo and advance Velox (xiaoxmeng)
- b078b8ce5931b0e5f7ade3f27a112dbb9f8a650d [native] Remove ShuffleReader::hasNext api (xiaoxmeng)
- 2b97cf18cfad8bda265a83e42847aa6ebb6c2d23 Update web page title (Yihong Wang)
- 0fd71abdb87dca2f6f7c9ad18eae57ff3c8b7a3b [native] Remove deprecated config kCastToIntByTruncate (rui-mo)
- 859f32c40fc3e1ea9b8f1fa95e0d3deb5ecd52e4 [native]Add to handle empty data case in ShuffleReader::next (xiaoxmeng)
- 885f5cf25883e697f693cec5d97ede509cb356ca Add presto server version to SessionConfigurationContext (Nikhil Collooru)
- 3d6bba23d56bc1004cacf5401714730a29289a9e fix formatting in kurtosis entry of aggregate function (Steve Burnett)
- ffd79917edfba5592db040faa030fab332e7b7bc [native pos] Store query id in native process env vars (Andrii Rosa)
- 23ad9e5da7f36602b9f060eb74f0c275482f6c3d [native pos] Include process crash information in error message (Andrii Rosa)
- d4d569e167916077b0d0910db03f732e6d0a6b21 [native pos] Do not include executable path twice (Andrii Rosa)
- 06ed4156dccd6cd60ddf6d575b6a8abdd6323574 [native pos] Ensure NativeExecutionProcess does not create more than 1 process (Andrii Rosa)
- 700df7aa60689e2d0ccd7963ac85893905e9ae8c [native pos] Drop unused fields (Andrii Rosa)
- 75a6e4fc8239b18bbe6efb4897872c8fd6d18f32 [native pos] Extend error message when native process does not respond (Andrii Rosa)
- 76a1fd56efa875884fbf4a3223d4a67d0c3982de [native] Allow termination with core on allocation failure (Andrii Rosa)
- 91954e1693130bd913a1bb9eb432875e221886c7 [native] Remove unused code (Deepak Majeti)
- 3cc627d5867099097b7fd54fa7f3d49b6a28fd6c [native] Update Presto protocol (Deepak Majeti)
- 49b74826d4346d40417e1135a6563f0f5947931e [native] Remove unused config node.memory_gb (Deepak Majeti)
- 5a5044bf8246c10b2bf6fbe87c16ae9c3869c153 Add client option to disable redirects (Diana Meehan)
- 1d9647598fd00be1dc6a53fc90a28a09a171b741 Deprecate hive config `hive.s3.use-instance-credentials` (Jalpreet Singh Nanda (:imjalpreet))
- 9ca2ea67c0a25fb3e20799c76a38cfbad4f8d663 Provide non-identity column predicate as well when scanning for splits (wangd)
- bed052afeef85c728d0c99237be1047f60e24839 Move build information to consolidated CONTRIBUTING guide (Tim Meehan)
- b5a403b6e0caf2d433b00b63ebd23b62ecf4dd35 Fix Iceberg memory leak with Delete File. (wypb)
- 55113a37aecfee8fc018a9d8764d223cf800d696 Remove redundant sort columns (Anant Aneja)
- 3e8de3a913c49d2a63a73ff5009d279b5d6a72a3 Infer domain filters for better source pruning (Anant Aneja)
- 6b39307bf506c9334d7e70b8bd21ffbd0d6137f6 Fix default value of `hive.s3.use-instance-credentials` in hive docs (Jalpreet Singh Nanda (:imjalpreet))
- 5e2323deca06e81b6ea491221c828d9ca77dec1f Fix filtering by unmatched value with Iceberg filter pushdown enabled (wangd)
- d5a31b3ebb22254f000dca40e420a857bfdc5e15 Preserve case for RowType's field name and JSON content when ``CAST`` (wangd)
- 0d09809ed42534b0ac5a801d7dd25bbef3a3092a Move iceberg session properties to hive common module (Reetika Agrawal)
- 5a70da7c9d0d15714cc2170c187c048bb9c0d4a9 Fix scopes of CTE References when initializing (jaystarshot)
- cb582bce0fd18f51d8862a8b2f53a134780f41aa Fix pull up lambda expression optimizer for reggex and like pattern (feilong-liu)
- 67b6e5cbba6eade283a39655f368b8be246e0d82 Refactor Consistent Hashing logic to make it simpler (Ajay George)
- 9bcc64de995551d54606ef0e8a1b873788c676e9 Fix filtering by subfield of RowType in Iceberg table (wangd)
- ec51f52cd4bfe12ccdb8d680a66cab1d13656cc5 Add SQL Client page (Yihong Wang)
- 328cc32ce15ecac965a64e08968fc1c9b72ed8f9 Add Iceberg table register and unregister procedures (kiersten-stokes)
- 7573c1f501f59a180fbd3d2e7fb1cb343171a7cb Reorder IndexJoin and AddNotNullFiltersToJoinNode optimizations to avoid index join optimization (Lyublena Antova)
- 003e9b915a51f3140f958b1f48d2c1af618d6477 [native] Advance velox and update memory code (xiaoxmeng)
- d6193da7f69db7f2b48454ba853d9a3aa7afdf00 Minor fix in Ngrams test. (Amit Dutta)
- 6222e07c35c12196801af256a9345a3ebbb3eb5b [native] Enable cache TTL and export stats (Ge Gao)
- 85947b2d9b70d107fd760b7cfdbf621f9fa596f8 Add better check argument message for duration nanos (Ajay George)
- 55d3f059cf028d7b6b0da64e1d0be519e678b7a0 Refactor NodeScheduler to use addAll instead of iterate and add (Ajay George)
- 0f896337377927b16441f7027d886315c927d357 Add validation to check that next URI host and port does not change during query execution (dianatatar)
- a735bcb09afe73b27aa4c5328670e6d3bee0cd01 Update Iceberg Document for SELECT Sql Support (Reetika Agrawal)
- 8ac5ef7985b689d295ff5f64aefc60fa9da9790a Refactor ApproximateMostFrequent to use type annotations (Nilay Pochhi)
- d35e4f3cc4f093296fdb5e49cfc146240a4a915d Introduce new parameter dataColumns in IcebergTableLayoutHandle (Jalpreet Singh Nanda (:imjalpreet))
- b6dd22309e36204e0583c65c6b19f6ff3d9d5bed Prune Iceberg table partitions when filter pushdown is enabled (Jalpreet Singh Nanda (:imjalpreet))
- 67aeac0162aff19119b8e71b5b8d31ee4174b09f Correct class and object's name in PhysicalCteOptimizer (Changli Liu)
- 689da4f5f5aa5064c69d6952d8e7fe3943ef8b5f Document update for Parquet Writer Versions V1 and V2 support (Mahadevuni Naveen Kumar)
- 180b0a98a8256cc58bddb22376f4268891a388a0 Support multi-arch docker image (Yihong Wang)
- 3da6e5a7817354264bb18c3a215a10aded8e05da [native] Fix master on TaskManagerTest (Jialiang Tan)
- 8aebd3434b8253cc821b06621df7d5c21f61f3be Fix serialized name for retriable QueryError property (Matthew Peveler)
- 08e2e00557353c2aa6c093afc067eda756deac01 Include s3 configuration even when hadoop config resources are provided (Reetika Agrawal)
- 0c04592546bb5b54ab79907789185fa767f18de7 Include GCS configuration for Iceberg Native Catalog (Reetika Agrawal)
- 3d35ac45abe643c9106e06d2563278196392ff24 Add Manifest file caching support for Iceberg Native Catalogs (Reetika Agrawal)
- 18523367a9729f70e5ddfbbbc550eda1af1a64f0 Change catalog cache key in Iceberg connector (Reetika Agrawal)
- a562c596a72b75bd5e46a70f23030d2e8ddb6dca [native] Advance Velox version (Ge Gao)
- 27855fb80d95543bbf817a3fc25461ff072c806f Allow connector derived from Hive to specialize filter pushdown (Paul Meng)
- db203c4257dcec7e43eed81c69955a9fa9bf1a08 Improve CONTRIBUTING.md (VishnuSanal)
- d3ac849d4f3f383f70e345e0f0ee0faef3c15a99 [native]Advance velox and remove legacy memory apis (xiaoxmeng)
- f60635ecd1fd8fb9059dcde3f5da1e873082813d Support year/month/day/hour transform when add partition column in Iceberg (wangd)
- d59b973b60eb5604901ab395ba4f9750eff0dd03 [native] Report TableWrite stats using Java operator name (Masha Basmanova)
- f7dc5383829ac1cbcece474297d144be7fe6ff19 Fix bug for LIKE pattern with multiple-byte characters (wangd)
- 0bf05493f0edb1574cb78f4b87da942fdcd5749d Fix the failed QueryContextManagerTests (xiaoxmeng)
- 8b37cecacaee2219cfeeb95b3f3b1aedcb58922f Partition Column transform support for year(), month(), day() and hour() functions. (Ajay Gupte)
- 1e6dc1d14712bfde7cc9f5178a308d0d9ef896ce Preserve original page objects when region remains unchanged (kedia,Akanksha)
- 2e140a627eec830177ea93509e49f85b2965bf05 Fix HttpTestSuite tests (xiaoxmeng)
- 038ff56f969d5169f9a2510dcd47e3728946f573 [native] Combines system config and session config (Jialiang Tan)
- b2127c4bd27c1ab08199d3f7da77251af3357184 [native]Advance velox and update memory part (xiaoxmeng)
- 8fb73fc9b58e2780c59d61b4f1834457056af8df [native] Add spill file create config to system config (Jialiang Tan)
- b113d6e0d17aaa64e7e3ce0d56337e569fc987c6 Add option to add limit to number of groups for khyperloglog_agg function (feilong-liu)
- ebe3bdc042c7c4917429f18d30eb2621e754cd5a Decorrelate subqueries with Limit or TopN (Naveen Kumar Mahadevuni)
- f1301809b453b938a0e490900832476e8b41f1f7 Enhance web UX dev experience (Yihong Wang)
- 9902f7e35296c2d7983fcff6e90c456ae2542dac Update the Apache Commons IO version (kedia,Akanksha)
- 7cd24d1869dfd4cb8c103899d6be7d0dbf497e4d Improve checks readibility (kedia,Akanksha)
- 1525e041a986daf8442c3f41c67a707cd8176131 [native] Add parquet test group for parquet specific tests. (Amit Dutta)
- 0de87a699923b17abe87f2e4f37773ad527c1691 [native] Add spill_file_create_config native prefix removal (Jialiang Tan)
- deebd62b1778c4fc946bd461d83da7b105c08551 [native] Add "numMemoryAllocations" operator runtime metric (Bikramjeet Vig)
- a852d7b7c7e94f19e929ba7da9b5233acf077edc [native] Translate 'sink.max-buffer-size' and 'driver.max-page-partitioning-buffer-size'. (Sergey Pershin)
- e7a29fceb19d9038d9f7e5c79589102451d758cb [Native] Add approx_distinct e2e tests for decimal type (karteekmurthys)
- 2e4ed63db0b9a124d597f072b7f7689baf27caa8 Add BlockBuilderUtil class to support null map keys for OrcReader (Vigneshwar Selvaraj)
- 63be8b4264ebb029e5f55f9825fa33278e43923d Upgraded spring boot maven plugin and spring core version to resolve multiple CVE (Anil Gupta Somisetty)
- 93d7a57793b41af4c4b501309dd2bc12524d7b3f Check arguments in StageExecutionId, TaskId, StageId,TableWriteInfo (kedia,Akanksha)
- 87688fb9d0cfc8a0a1dde37d1ee2167327b1f8d8 Add optimization to rewrite left join with array contains to equi-join (feilong-liu)
- 02cda05d5bf2d9d8fe27f2a67a657427e69c38b1 [Native] Advance velox (karteekmurthys)
- da58f9f55cce521498c5387224bd3f980eb42e22 [native]Update velox code for memory manager refactor (xiaoxmeng)
- 3d24f0b7fdaf195c184845a5e97bda625a6f73fd Upgrade Hudi version to 0.14.0 (Sagar Sumit)
- 513d3a005ee5d7b231548abff0a3b2e30a7a8d60 Add more information on how to become a committer (Timothy Meehan)
- 4c3dc98f7715c672688b39e99884dd6a575f5c38 Fix bug for udt in TestJdbcResultSet (wangd)
- 70f961c5e56e89731847f2702bac316c575722f3 [native] Add e2e tests for any_value aggregate. (Amit Dutta)
- 872eca121837e8bc28b232d668733b8a5975b404 Support udt when forcing values from Jackson to have expected type (wangd)
- fae3a7d8645ce4f1a32676b859de6b95c860e448 Fix bug in tracking partial aggregation stats when the query is a group-by on the partitioning key (Lyublena Antova)
- 3d75905e5c95f34c8b00344a1621604eddf08d49 Fix notNullColumnVariables when mapping symbol for TableWriterNode (wangd)
- 77dfcc805ec1ce06d0cc95ebf3f10d7b7838aad8 CTE Materialization scheduling changes (jaystarshot)
- d121d92484856665157f36a74151be3ce3a3f474 CTE Materialization Planner Changes (jaystarshot)
- 133c60ed9fdea9626c72613da21ed81ab73ecca8 Add CTE Materialization session property and ast changes (jaystarshot)
- 333ae21a2ed258705d78da687a78c3fdcfaad306 Handle case of table with no supported columns (kedia,Akanksha)
- 8584c85f4bb42660de8071b5a319dcfb1e70c5b0 Add spill write buffer size to session property list (Jialiang Tan)
- 029e2c9ddc3b087dd9a2e45d85ee218bf5483d73 Relax methods visibility for Meta's internal classes' access (Paul Meng)
- 5e943182c845093405c86aa1a03212dd06d2cf89 update Google Tag Manager (Steve Burnett)
- 3b8e8cc4d276bdcec085415344b822cecfaf9856 [Iceberg] Add changelog table (Zac Blanco)
- 3ae56663206067bc7db147b9d09e381693f66a62 Fix a build break with older version of testng (Michael Shang)
- 7a68af2783a31d87a9aa48572cc384569108811e Adding documentation for Handle case of table with no supported columns (kedia,Akanksha)
- ccded7dc32145cde62da76b4c948c5b69a14c95b Update deploy-docker.rst (Antoine Pultier)
- e65015229f9b29dc7fe8e06b8198019c998abbb9 Apply INCREASE_CONTAINER_SIZE execution strategy for user supplied error codes (Arjun Gupta)
- 26b4bc9db249f71735f0605d6fec25a96ede46d6 [native] Enable unit tests in CI (Deepak Majeti)
- 1475da92aa1329ea4a3328e087d9ca822c73903b [native pos] Fix sendUpdateRequest retry logic (Andrii Rosa)
- 0a25eafd22d87ad596720fa38c0859ef8cfa3dd4 Enhancing readme for first time users (Christian Zentgraf)
- eede270ef1e6f7d01e1196621b0622103a172016 Add reservoir_sample aggregation function (Zac Blanco)
- d9fc66d73c0f3aadb6df1116420251ff7cc4f688 Skip hash generation for join when input is table scan (feilong-liu)
- e718f7a0a6855d47a75b88984482755c3319a7b1 [native] Use Velox::TypeParser instead of Antlr and remove Antlr (Deepak Majeti)
- 27646452761918d8a20ffc56650264a520b76052 Fix getting type signature for UDT from uppercase type string (wangd)
- 24aec09bf8e2fa135d1f474495c279448cd9e6ed fix docker pull command in deploy-docker.rst (Steve Burnett)
- 3d4db808eeb9ca55296223206e29f8948dca7696 Add comma for number in printed query plan (feilong-liu)
- 6baf8202b1949a248524368a19960cd76869349d [native] Remove redundant duckdb dependency for presto_expressions_test (Deepak Majeti)
- 2d6a65b610e0fabf64654cae2b4e1a5c21553fc4 [native] Fix PartitionAndSerialize with constant keys (Masha Basmanova)
- 7898a8610947fddd918e9329f3749cb9f02ce4c8 [native] Advance Velox (Masha Basmanova)
- 072216f7831f479e1a30c4d02c935975de575723 [native] Add periodic malloc memory checking configs (Bikramjeet Vig)
- 06196d3fa01884205d0b57495a54a5f38fe4fb4f [native] Enable lazy spill file creation (Bikramjeet Vig)
- 2b592dc3b3500bd35f28f8ae876fa729b302f804 Upgrade Alluxio to 307 (Beinan)
- 32f213b2e4071980e62d5770b2b66d911ade7917 Support TimeType for Iceberg with parquet format (wangd)
- dadc0d312a19fc132160380c893d68b6a0912caf [Native] Don't pass in nullptr for connector config (Ke)
- e501b0983f45b60ccf820bd6bf0e6f6c462c57c7 [native-pos] Throw fatal exception native process cannot find port (Shrinidhi Joshi)
- ab71e549a5a1c9701188f6074b2b88745fcc69e8 Deprecate Nessie BASIC authentication type (Reetika Agrawal)
- d2e4e2f4beefcef324ba517f60b0ab4a06b49de2 [Native] Don't propagate errors in getResults (Kevin Wilfong)
- b435c2992dfe4167b875613754a5189a0a09ba07 [native]Advance velox and update metric code (xiaoxmeng)
- 67dd54624133e04a640c48fd93264d4970fc1181 Add docs for Prestodb to postgresql type mapping in postgresql connector (kedia,Akanksha)
- 9e752cb13a11c7958ccc52176d901cd24794b75d fix indentation format on develop/presto-native.rst (Steve Burnett)
- 0dfc35efc4cc5bac27ea31aaf31f90a87eb4525b Fix redis-hbo-provider docs and add coordinator hbo configuration (jaystarshot)
- 5b1e67b627908b7d158c87e7bf2141db0d29ea8a Upgrade hadoop-apache2 to 2.7.4-12 (Jalpreet Singh Nanda (:imjalpreet))
- 61c7980077cbbf77512ad9922189860803fb2c54 Add support for reading v2 row level deletes in Iceberg connector (wypb)
- c361c45459b6ca332b7d9a02de07de2f1ca06c7f Update hive-apache to 3.0.0-10 (wypb)
- 76ae3edcf27b05ad297b701e292dc490e27f226c Add UPDATE sql support in Presto Engine (Reetika Agrawal)
- d865192180f2b763633c2e080005e72b1218124e Add Iceberg Filter Pushdown Optimizer Rule for execution with Velox (Jalpreet Singh Nanda (:imjalpreet))
- 128320e59e2ca7c4ca6cd64699228ab853578c81 Modify IcebergTableLayoutHandle and IcebergColumnHandle to implement Filter Pushdown (Jalpreet Singh Nanda (:imjalpreet))
- 660ec3eb2a00fd2699141b3649fa4f024df32e9f Add iceberg.pushdown-filter-enabled config property (Jalpreet Singh Nanda (:imjalpreet))
- 415582b67639bab2e4d7b62672327b6ad1dbbaaa Refactor HiveMetadata and Introduce MetadataUtils in presto-hive-common (Jalpreet Singh Nanda (:imjalpreet))
- ec6829e2f25db621cf491b44839798ae40705596 Refactor Hive Filter Pushdown and Introduce BaseSubfieldExtractionRewriter (Jalpreet Singh Nanda (:imjalpreet))
- 85d72dc22c3adf8ba8344e5087437b314d33a652 Move HivePartialAggregationPushdown to com.facebook.presto.hive.rule package (Jalpreet Singh Nanda (:imjalpreet))
- d56656c60efc55b2a24e1bb85236a26656e0b2b6 Introduce BaseHiveColumnHandle (Jalpreet Singh Nanda (:imjalpreet))
- e1b706192affcb3b9d5f1f9dca45ce79b9381521 Introduce BaseHiveTableLayoutHandle (Jalpreet Singh Nanda (:imjalpreet))
- be52332a655e5098bcc2dd39b62dcd25adae0975 [native] Advance Velox (Andrii Rosa)
- 8c9104d037c0345f72fcbc0a198593dbb7eb026b [native] Move 4 num threads config params to HW multiplier. (Sergey Pershin)
- 4c4712a8a00fc513ee591345ec92ee16aab052f6 Use non-blocking SecureRandom in noisy aggregators (Jonathan Hehir)
- a3946f5a65dad02593264e36ca6c34dead76256d Remove unnecessary condition else check (kedia,Akanksha)
- 381d51ce702533eaee1fd46150f688eafcd0e944 Add a flag to disable tracking of partial histories (Lyublena Antova)
- e2e22b350d0d570ef0f43912ef3a6f45eb0ae7a4 update overview/use-cases.rst (Steve Burnett)
- 2b7d54a2efdd9061cfc38441bd27a672bf29dd12 Add the dot before the launcher script to execute it (Luis Paolini)
- 8d55103255db4ee7e1fcec71b2ebe4a4ea8b5029 Add support for map_keys_by_top_n_values (Avinash Jain)
- 048672d5861a9a7b2e3e786a9b3afd1683ec3bde Remove ahanaio/prestodb-sandbox reference (Luis Paolini)
- 327ca59dc201783e73d90204a0724706b05f81a8 [native]Add hook to stop additional periodic tasks (xiaoxmeng)
- 91e00f5c1e89476c02cabffa582c8d1ba065ccea Add noisy_approx_distinct_sfm and related functions (Jonathan Hehir)
- e69795f5f01898a461d2c31a5ef8e1cd60e03f7e Fix build failure due to merge conflict in Iceberg connector (Vivek)
- af06669b664328d8c26a06e9e48eb4cd26414602 Iceberg connector support for time travel VERSION and TIMESTAMP. (Ajay Gupte)
- d892a1ff4f703b0c84e454f52de436717351366e Add ConnectorTableVersion class in SPI. (Ajay Gupte)
- 925499ac3b317acab538497e2e5b60d56cad17ed Add the resource group page (Yihong Wang)
- 1539cda252562ee8f20f93e728298909cf72e3fc [native] Remove 'http_exec_threads' from configProperties in PrestoNativeQueryRunnerUtils. (Sergey Pershin)
- b715341d02a2fcbcebca2884d90faca55af11c11 [native]Advance velox version and code update (xiaoxmeng)
- 259e4204bd8c8eda70e204f695314db419c4c1ea [native] Change HTTP executor num threads config param to HW multiplier. (Sergey Pershin)
- 345ce612d7337c851305668629b89987c988d8ae [native] Make HTTP client connection pool configurable and disable by default (Jimmy Lu)
- 588660e1174c4a3e7dca9abe49b1ef00cb9c416a Add support for adaptive partial aggregation (prithvip)
- a67b145a165d2f0c9852e7fbf7cff03d8cdfa1d2 Remove unused methods and variables from Iceberg connector (Reetika Agrawal)
- 3c33fccf7131a8b9f0db14b2e642186d8773f0e1 [native] Support converting Presto plan with VARBINARY constant expression to velox plan (wypb)
- 542beb8d89fa86feb15008611f8900f0f316ef5f [native] Remove unnecessary flags from fuzzer test (Pedro Pedreira)
- 63afba6388c17450bbb42d6b38f179f954c7856c [native] Add E2E tests for Presto system.runtime table queries (mohsaka)
- fe61466a2846b99d5710971e727d7c76a67b5238 [native]Add hook to stop additional periodic task (xiaoxmeng)
- 24818fc96213a7f4cdc37a659fd99caa7457852b [native] Fix promise_ race in PrestoExchangeSource. (Sergey Pershin)
- 798a61d2ed1ea7d04be4c73020858e9815ddb193 minor edits to iceberg.rst (Steve Burnett)
- 9932f8c6d3b833f1171036114e795164011a8afc Refactor set union function (Tai Le)
- 83959568e893fdb1a2d7abd0e514a0386f91376b Refactor set aggregate function (Tai Le)
- d86205ca988a4921894791cb7f5ffb904e09e2e1 [native]Add server memory pushback configs (xiaoxmeng)
- 86108d8fec7589f5aedb8e5a5081e92cff25d79c [native]Advance velox version (xiaoxmeng)
- 1f62a7378774298186d5104d59aa20ed10227b28 [native pos] Ensure BroadcastFileReader#next is called outside the lock (Andrii Rosa)
- 8242a40e7132946cc2de1645bef5dfdaadcc6a71 Add time travel syntax support for VERSION/SYSTEM_VERSION and TIMESTAMP/SYSTEM_TIME. (Ajay Gupte)
- e8e079805426434bb546fd08365f827a4bde67ca Refactor ResumableTask to rename TaskStatus (Ajay George)
- 03f171082bfb5166184900d601795d3a41bf33f1 Fix Hive Partition exception message to add schema and table name (Ajay George)
- 1fa07f4303aae44d709e2b8b375e31a3946b2342 Extend pull lambda out for conditional expression (feilong-liu)
- 7a64e22feb6899fbb398b136b68482ad5db019e3 Refactor Hive Split classes for readability (Ajay George)
- 6470fd5af22e27979d34c18326f1eb4be86e2af5 add alias any_value for arbitrary (shenhong)
- 1c6eea38fa2053041b3a737bd9236ee7cec99bae Updated the snappy version to 1.1.10.4 (kedia,Akanksha)
- 374bec5f3ec78f2a32c5c3203aaceec1e3fc7ff2 Fix prune output rules for intersect and except nodes (feilong-liu)
- 6bcf33022da0ed9b0f2a94c589713cf5362d1988 [native] Fix PrestoQueryRunner in case query fails (Jimmy Lu)
- c1f7fc792512924dc9269bb6946eedd2aa066ec9 [native] Enable IN predicate with non-constant in-list (Masha Basmanova)
- 49112360d2f3edacb946c7d173fa0c56862a2b9c [native] Advance Velox (Masha Basmanova)
- a768596b4350cf60737e6c40a0ab91b979b25dec Add simple settings to prestodb/presto image (Yihong Wang)
- 471282d6429fa0b8dde2ed50b0a9c96bfa987d26 [native] Ensure graceful shutdown of exchange sources (Jimmy Lu)