### PR TITLE
Simplify RowNumber and TopNRowNumber node with empty input

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyPlanWithEmptyInput.java
@@ -33,10 +33,12 @@ import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.OffsetNode;
+import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UnnestNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.google.common.collect.ImmutableList;
@@ -279,6 +281,18 @@ public class SimplifyPlanWithEmptyInput
 
         @Override
         public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
+        {
+            return convertToEmptyNodeIfInputEmpty(node, context);
+        }
+
+        @Override
+        public PlanNode visitRowNumber(RowNumberNode node, RewriteContext<Void> context)
+        {
+            return convertToEmptyNodeIfInputEmpty(node, context);
+        }
+
+        @Override
+        public PlanNode visitTopNRowNumber(TopNRowNumberNode node, RewriteContext<Void> context)
         {
             return convertToEmptyNodeIfInputEmpty(node, context);
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSimplifyPlanWithEmptyInput.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSimplifyPlanWithEmptyInput.java
@@ -226,4 +226,24 @@ public class TestSimplifyPlanWithEmptyInput
                         ImmutableList.of("custkey", "name", "acctbal", "sum"),
                         values("sum", "custkey", "name", "acctbal")));
     }
+
+    @Test
+    public void testRowNumberWithEmptyInput()
+    {
+        assertPlan("select orderkey, row_number() over (partition by orderpriority), orderpriority from (select orderkey, orderpriority from orders where false)",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("orderkey", "rownumber", "orderpriority"),
+                        values(ImmutableList.of("orderkey", "orderpriority", "rownumber"), ImmutableList.of())));
+    }
+
+    @Test
+    public void testTopNRowNumberWithEmptyInput()
+    {
+        assertPlan("select * from (select orderkey, row_number() over (partition by orderpriority order by orderkey) row_number, orderpriority from (select orderkey, orderpriority from orders where false)) where row_number < 2",
+                enableOptimization(),
+                output(
+                        ImmutableList.of("orderkey", "row_number", "orderpriority"),
+                        values(ImmutableList.of("orderkey", "orderpriority", "row_number"), ImmutableList.of())));
+    }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6675,6 +6675,8 @@ public abstract class AbstractTestQueries
         assertQuery(enableOptimization, "WITH emptyorders as (select * from orders where false) SELECT p.name, l.orderkey, l.partkey, l.quantity, RANK() OVER (PARTITION BY p.name ORDER BY l.quantity DESC) AS rank_quantity " +
                 "FROM lineitem l JOIN emptyorders o ON l.orderkey = o.orderkey JOIN part p ON l.partkey = p.partkey WHERE o.orderdate BETWEEN DATE '1995-03-01' AND DATE '1995-03-31' " +
                 "AND l.shipdate BETWEEN DATE '1995-03-01' AND DATE '1995-03-31' AND p.size = 15 ORDER BY p.name, rank_quantity LIMIT 100");
+        assertQuery(enableOptimization, "select orderkey, row_number() over (partition by orderpriority), orderpriority from (select orderkey, orderpriority from orders where false)");
+        assertQuery(enableOptimization, "select * from (select orderkey, row_number() over (partition by orderpriority order by orderkey) row_number, orderpriority from (select orderkey, orderpriority from orders where false)) where row_number < 2");
 
         emptyJoinQueries(enableOptimization);
     }


### PR DESCRIPTION
## Description
We have an optimizer `SimplifyPlanWithEmptyInput` which simplify query plans with empty values input. However, it does not cover RowNumber and TopNRowNumber node. In this PR, I include them so that it will also be optimized.

## Motivation and Context
Simplify query plan with RowNumber and TopNRowNumber with empty input.

## Impact
Improve performance.

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add optimization for query plans which contains RowNumber and TopNRowNumber nodes with empty input
```

