### PR TITLE
[native] Replace 'FOLLY_FALLTHROUGH' by '[[fallthrough]]'.

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -425,9 +425,9 @@ std::shared_ptr<const ConstantTypedExpr> VeloxExprConverter::toVeloxExpr(
   const auto type = typeParser_->parse(pexpr->type);
   switch (type->kind()) {
     case TypeKind::ROW:
-      FOLLY_FALLTHROUGH;
+      [[fallthrough]];
     case TypeKind::ARRAY:
-      FOLLY_FALLTHROUGH;
+      [[fallthrough]];
     case TypeKind::MAP: {
       auto valueVector =
           protocol::readBlock(type, pexpr->valueBlock.data, pool_);


### PR DESCRIPTION
## Description
FOLLY_FALLTHROUGH can fail build on the system where it is not defined.
Also, Velox using [[fallthrough]] only.


```
== NO RELEASE NOTE ==
```

