### PR TITLE
fix(main/util): fix DeleteNode not having Graphviz visitor

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -42,6 +42,7 @@ import com.facebook.presto.sql.planner.optimizations.JoinNodeUtils;
 import com.facebook.presto.sql.planner.plan.AbstractJoinNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
@@ -114,6 +115,7 @@ public final class GraphvizPrinter
         SINK,
         WINDOW,
         UNION,
+        DELETE,
 
         SEQUENCE,
         SORT,
@@ -156,6 +158,7 @@ public final class GraphvizPrinter
             .put(NodeType.SAMPLE, "goldenrod4")
             .put(NodeType.ANALYZE_FINISH, "plum")
             .put(NodeType.EXPLAIN_ANALYZE, "cadetblue1")
+            .put(NodeType.DELETE, "webmaroon")
             .build());
 
     static {
@@ -680,6 +683,13 @@ public final class GraphvizPrinter
             node.getProbeSource().accept(this, context);
             node.getIndexSource().accept(this, context);
 
+            return null;
+        }
+
+        @Override
+        public Void visitDelete(DeleteNode node, Void context)
+        {
+            printNode(node, format("Delete[%s]", Joiner.on(", ").join(node.getOutputVariables())), NODE_COLORS.get(NodeType.DELETE));
             return null;
         }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2487,6 +2487,23 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testExplainDeleteGraphvizFormat()
+    {
+        String query = "DELETE FROM orders WHERE orderkey = 1";
+        try {
+            getGraphvizExplainPlan("EXPLAIN (FORMAT GRAPHVIZ) ", query, LOGICAL);
+        }
+        catch (UnsupportedOperationException e) {
+            fail("DELETE event should be implemented for Graphviz printing");
+        }
+        catch (Exception e) {
+            if (!e.getMessage().contains("does not support deletes")) {
+                throw e;
+            }
+        }
+    }
+
+    @Test
     public void testLogicalExplain()
     {
         String query = "SELECT * FROM orders";


### PR DESCRIPTION
Add basic support for DeleteNode to GraphvizPrinter, preventing stacktrace produced when print DELETE event

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fixes #21903 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Prevent stacktraces when printing DELETE event in console

## Test Plan
<!---Please fill in how you tested your change-->
N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
*  Fixes exception of DeleteNode not having Graphviz vistor
```

