### PR TITLE
[native] Remove duplicate find_package calls

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -106,71 +106,18 @@ set(VELOX_BUILD_TEST_UTILS
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(Boost_USE_MULTITHREADED TRUE)
-find_package(
-  Boost
-  1.66.0
-  REQUIRED
-  program_options
-  context
-  filesystem
-  regex
-  thread
-  system
-  date_time
-  atomic)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-
-find_package(gflags COMPONENTS shared)
-
-find_library(GLOG glog)
-
-find_library(FMT fmt)
+set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL ON)
 
 find_library(EVENT event)
-
 find_library(DOUBLE_CONVERSION double-conversion)
-
-find_library(LZ4 lz4)
-find_library(LZO lzo2)
-find_library(ZSTD zstd)
-find_package(ZLIB)
-find_library(SNAPPY snappy)
-
-find_package(folly CONFIG REQUIRED)
-set(FOLLY_WITH_DEPENDENCIES
-    ${FOLLY_LIBRARIES}
-    ${DOUBLE_CONVERSION}
-    Boost::context
-    dl
-    ${EVENT}
-    ${SNAPPY}
-    ${LZ4}
-    ${ZSTD}
-    ${ZLIB_LIBRARIES})
-
-find_package(BZip2 MODULE)
-if(BZIP2_FOUND)
-  list(APPEND FOLLY_WITH_DEPENDENCIES ${BZIP2_LIBRARIES})
-endif()
-include_directories(SYSTEM ${FOLLY_INCLUDE_DIRS})
-
-# Include third party header files
-find_path(OPT_OPENSSL_DIR NAMES opt/openssl@1.1)
-set(OPENSSL_ROOT_DIR "${OPT_OPENSSL_DIR}/opt/openssl@1.1")
-find_package(OpenSSL REQUIRED)
-
-find_package(Sodium REQUIRED)
 find_library(PROXYGEN proxygen)
 find_library(PROXYGEN_HTTP_SERVER proxygenhttpserver)
+find_package(Sodium REQUIRED)
 find_library(FIZZ fizz)
 find_library(WANGLE wangle)
-
-find_library(RE2 re2)
-
-find_package(fizz CONFIG)
-find_package(wangle CONFIG)
-find_package(FBThrift)
+find_package(fizz CONFIG REQUIRED)
+find_package(wangle CONFIG REQUIRED)
+find_package(FBThrift CONFIG REQUIRED)
 include_directories(SYSTEM ${FBTHRIFT_INCLUDE_DIR})
 
 set(PROXYGEN_LIBRARIES ${PROXYGEN_HTTP_SERVER} ${PROXYGEN} ${WANGLE} ${FIZZ})
@@ -188,6 +135,7 @@ include_directories(${CMAKE_BINARY_DIR})
 set(VELOX_GTEST_INCUDE_DIR "velox/third_party/googletest/googletest/include")
 
 add_subdirectory(velox)
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 if(PRESTO_ENABLE_TESTING)
   set(BUILD_TESTING ON) # some third-party dependency could have disabled this.

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -64,10 +64,10 @@ target_link_libraries(
   velox_type_tz
   velox_vector
   velox_window
-  ${RE2}
-  ${FOLLY_WITH_DEPENDENCIES}
-  ${GLOG}
-  ${GFLAGS_LIBRARIES}
+  re2::re2
+  Folly::folly
+  glog::glog
+  gflags::gflags
   pthread)
 
 # Enabling Parquet causes build errors with missing symbols on MacOS. This is
@@ -94,7 +94,7 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
                                             RemoteFunctionRegisterer.cpp)
 
   target_link_libraries(presto_server_remote_function velox_expression
-                        velox_functions_remote ${FOLLY_WITH_DEPENDENCIES})
+                        velox_functions_remote Folly::folly)
   target_link_libraries(presto_server_lib presto_server_remote_function)
 endif()
 

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(
   presto_exception
   velox_exception
   velox_file
-  ${RE2}
+  re2::re2
   gtest
   gtest_main)
 

--- a/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
@@ -29,11 +29,11 @@ target_link_libraries(
   ${LIBSODIUM_LIBRARY}
   ${OPENSSL_SSL_LIBRARY}
   ${OPENSSL_CRYPTO_LIBRARY}
-  ${FOLLY_WITH_DEPENDENCIES}
-  ${GLOG}
-  ${GFLAGS_LIBRARIES}
-  ${FMT}
-  ${RE2})
+  Folly::folly
+  glog::glog
+  gflags::gflags
+  fmt::fmt
+  re2::re2)
 
 set_property(TARGET presto_http PROPERTY JOB_POOL_LINK presto_link_job_pool)
 

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(
   velox_functions_prestosql
   velox_aggregates
   velox_hive_partition_function
-  ${RE2}
+  re2::re2
   gmock
   gtest
   gtest_main)

--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -63,10 +63,10 @@ target_link_libraries(
   velox_type
   velox_type_parser
   Boost::filesystem
-  ${RE2}
-  ${FOLLY_WITH_DEPENDENCIES}
-  ${GLOG}
-  ${GFLAGS_LIBRARIES}
+  re2::re2
+  Folly::folly
+  glog::glog
+  gflags::gflags
   pthread)
 
 set_property(TARGET presto_expressions_test PROPERTY JOB_POOL_LINK

--- a/presto-native-execution/presto_cpp/presto_protocol/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/CMakeLists.txt
@@ -12,7 +12,7 @@
 add_library(presto_protocol OBJECT presto_protocol.cpp Base64Util.cpp
                                    DataSize.cpp Duration.cpp Connectors.cpp)
 
-target_link_libraries(presto_protocol velox_type ${RE2})
+target_link_libraries(presto_protocol velox_type re2::re2)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
@@ -43,9 +43,9 @@ target_link_libraries(
   velox_exception
   velox_vector
   Boost::filesystem
-  ${RE2}
-  ${FOLLY_LIBRARIES}
+  re2::re2
+  Folly::folly
   ${DOUBLE_CONVERSION}
-  ${GLOG}
-  ${GFLAGS_LIBRARIES}
+  glog::glog
+  gflags::gflags
   pthread)


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Velox CMakeLists.txt has these calls and bundles these packages if necessary

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
The calls on the Velox side are upto date.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

