### PR TITLE
Fix bug during filter pushdown in CTE producers

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.CTE_FILTER_AND_PROJECTION_PUSHDOWN_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.CTE_MATERIALIZATION_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_ENABLED;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -737,6 +738,36 @@ public class TestCteExecution
     }
 
     @Test
+    public void testComplexQuery3()
+    {
+        String testQuery = "WITH  supplier_region AS (" +
+                "   SELECT s.suppkey, s.name AS supplier_name, n.name AS nation_name, r.name AS region_name " +
+                "   FROM SUPPLIER s " +
+                "   JOIN NATION n ON s.nationkey = n.nationkey " +
+                "   JOIN REGION r ON n.regionkey = r.regionkey), " +
+                " supplier_parts AS (" +
+                "   SELECT sr.*, ps.partkey, ps.availqty, ps.supplycost " +
+                "   FROM supplier_region sr " +
+                "   JOIN partsupp ps ON sr.suppkey = ps.suppkey), " +
+                "parts_info AS (" +
+                "   SELECT sp.*, p.name AS part_name, p.type AS part_type, p.size AS part_size " +
+                "   FROM supplier_parts sp " +
+                "   JOIN PART p ON sp.partkey = p.partkey), " +
+                " full_supplier_part_info AS (" +
+                "   SELECT pi.*, n.comment AS nation_comment, r.comment AS region_comment " +
+                "   FROM parts_info pi " +
+                "JOIN REGION r ON pi.region_name = r.name" +
+                "   JOIN NATION n ON pi.nation_name = n.name) " +
+                "SELECT * FROM full_supplier_part_info " +
+                "WHERE part_type LIKE '%BRASS' " +
+                "ORDER BY region_name, supplier_name";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(
+                queryRunner.execute(getMaterializedSession(), testQuery),
+                queryRunner.execute(getSession(), testQuery));
+    }
+
+    @Test
     public void testSimplePersistentCteForCtasQueries()
     {
         QueryRunner queryRunner = getQueryRunner();
@@ -1082,6 +1113,7 @@ public class TestCteExecution
         return Session.builder(super.getSession())
                 .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "true")
                 .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "ALL")
+                .setSystemProperty(CTE_FILTER_AND_PROJECTION_PUSHDOWN_ENABLED, "true")
                 .build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
@@ -318,7 +318,7 @@ public class CteProjectionAndPredicatePushDown
 
             List<VariableReferenceExpression> producerColumns = node.getOutputVariables();
             List<VariableReferenceExpression> newProducerColumns = producerColumns.stream().filter(var -> usedColumnsSet.contains(var)).collect(Collectors.toList());
-            if (newProducerColumns.size() != producerColumns.size()) {
+            if (!newProducerColumns.equals(newChildNode.getOutputVariables())) {
                 newChildNode = PlannerUtils.restrictOutput(newChildNode, idAllocator, newProducerColumns);
             }
 
@@ -331,7 +331,7 @@ public class CteProjectionAndPredicatePushDown
                         newChildNode,
                         cteName,
                         node.getRowCountVariable(),
-                        newChildNode.getOutputVariables());
+                        newProducerColumns);
             }
 
             return node;
@@ -367,7 +367,7 @@ public class CteProjectionAndPredicatePushDown
 
         private PlanNode addFilter(PlanNode node, List<RowExpression> predicates)
         {
-            if (predicates.size() == 0 || predicates.stream().anyMatch(predicate -> isConstant(predicate, BOOLEAN, true))) {
+            if (isConstTrue(predicates)) {
                 return node;
             }
 
@@ -379,6 +379,11 @@ public class CteProjectionAndPredicatePushDown
                 predicate = new SpecialFormExpression(OR, BOOLEAN, predicates);
             }
             return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), node, predicate);
+        }
+
+        private boolean isConstTrue(List<RowExpression> predicates)
+        {
+            return predicates.size() == 0 || predicates.stream().anyMatch(predicate -> isConstant(predicate, BOOLEAN, true));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
@@ -51,7 +51,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 public class TestCteProjectionAndPredicatePushdown
         extends BasePlanTest
-{
+{ 
     @Test
     public void testProjectionPushdown()
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
@@ -75,6 +75,26 @@ public class TestCteProjectionAndPredicatePushdown
     }
 
     @Test
+    public void testComplexQueryFilterPushdown()
+    {
+        String testQuery = "WITH  nation_region AS ( " +
+                "                SELECT n.name, r.comment AS region_comment, n.comment AS nation_comment" +
+                "                FROM region r join nation n on (r.regionkey=n.regionkey)) " +
+                "select * from nation_region where name = 'abc' " +
+                "union all " +
+                "select * from nation_region where name = 'bcd'";
+
+        assertCtePlan(testQuery,
+                anyTree(
+                        sequence(
+                                cteProducer(addQueryScopeDelimiter("nation_region", 0),
+                                        project(// no projection pushdown but a project gets added to make sure columns are ordered the right way
+                                                filter("name = 'abc' or name = 'bcd'",
+                                                        join(tableScan("region"), tableScan("nation", identityMap("name", "comment", "regionkey")))))),
+                                anyTree(cteConsumer(addQueryScopeDelimiter("nation_region", 0))))));
+    }
+
+    @Test
     public void testNoFilterPushdown()
     {
         // one of the CTE consumers is used without a filter: no filter gets pushed to the producer as all rows are needed

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
@@ -51,7 +51,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 public class TestCteProjectionAndPredicatePushdown
         extends BasePlanTest
-{ 
+{
     @Test
     public void testProjectionPushdown()
     {


### PR DESCRIPTION
When pushing down filters in cte producers, in certain cases we destroyed the order of output columns causing correctness issues. With this fix we make sure the order of columns is preserved.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

