### PR TITLE
[native] Rolling back commit 6eba1f7330de2879ca2f4012c8bbd9b1f7a5f727

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
@@ -28,7 +28,7 @@ public abstract class AbstractTestNativeWindowQueries
         extends AbstractTestQueryFramework
 {
     protected enum FunctionType {
-        RANK, VALUE, AGGREGATE,
+        RANK, VALUE,
     }
 
     @Override
@@ -74,7 +74,7 @@ public abstract class AbstractTestNativeWindowQueries
         ImmutableList.Builder<String> queries = ImmutableList.builder();
         List<String> overClauses = new ArrayList<>(OVER_CLAUSES_WITH_ORDER_BY);
         List<String> frameClauses = FRAME_CLAUSES;
-        if (functionType != FunctionType.RANK) {
+        if (functionType == FunctionType.VALUE) {
             overClauses.addAll(OVER_CLAUSES_WITHOUT_ORDER_BY);
         }
         List<String> windowClauseList = new ArrayList<>();
@@ -113,12 +113,6 @@ public abstract class AbstractTestNativeWindowQueries
         for (String query : queries) {
             assertQuery(query);
         }
-    }
-
-    protected void testWindowAggregate(String functionName)
-    {
-        testWindowFunction(functionName + "(orderkey)", FunctionType.AGGREGATE);
-        testWindowFunction(functionName + "(totalprice)", FunctionType.AGGREGATE);
     }
 
     @Test
@@ -202,35 +196,5 @@ public abstract class AbstractTestNativeWindowQueries
         assertQuery("SELECT row_number() OVER (PARTITION BY orderdate ORDER BY orderdate) FROM orders");
         assertQuery("SELECT min(orderkey) OVER (PARTITION BY orderdate ORDER BY orderdate, totalprice) FROM orders");
         assertQuery("SELECT * FROM (SELECT row_number() over(partition by orderstatus order by orderkey, orderstatus) rn, * from orders) WHERE rn = 1");
-    }
-
-    @Test
-    public void testSum()
-    {
-        testWindowAggregate("sum");
-    }
-
-    @Test
-    public void testAvg()
-    {
-        testWindowAggregate("avg");
-    }
-
-    @Test
-    public void testCount()
-    {
-        testWindowAggregate("count");
-    }
-
-    @Test
-    public void testMin()
-    {
-        testWindowAggregate("min");
-    }
-
-    @Test
-    public void testMax()
-    {
-        testWindowAggregate("max");
     }
 }


### PR DESCRIPTION
Rollback of https://github.com/prestodb/presto/commit/6eba1f7330de2879ca2f4012c8bbd9b1f7a5f727

The commit being rolled back (reverted) has added several window function e2e tests.
It caused "linux-presto-e2e-tests" and "linux-spark-e2e-tests" to use a lot of memory and
trigger a flurry of Major GC.
As the result "linux-spark-e2e-tests" is timing out after 5 hrs or running most of the time
and "linux-presto-e2e-tests" is failing with weird AbstractSurefireMojo error.

More details in the issue: https://github.com/prestodb/presto/issues/21923

We are reverting to unblock the repo and the re-introduction of the tests need to be done very carefully.

```
== NO RELEASE NOTE ==
```