### PR TITLE
Added support for DeleteNode GraphvizPrinter which was throwing UnsupportedOperationException previously

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -42,6 +42,7 @@ import com.facebook.presto.sql.planner.optimizations.JoinNodeUtils;
 import com.facebook.presto.sql.planner.plan.AbstractJoinNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
@@ -127,6 +128,7 @@ public final class GraphvizPrinter
         UNNEST,
         ANALYZE_FINISH,
         EXPLAIN_ANALYZE,
+        DELETE
     }
 
     private static final Map<NodeType, String> NODE_COLORS = immutableEnumMap(ImmutableMap.<NodeType, String>builder()
@@ -156,6 +158,7 @@ public final class GraphvizPrinter
             .put(NodeType.SAMPLE, "goldenrod4")
             .put(NodeType.ANALYZE_FINISH, "plum")
             .put(NodeType.EXPLAIN_ANALYZE, "cadetblue1")
+            .put(NodeType.DELETE, "darkgrey")
             .build());
 
     static {
@@ -327,6 +330,13 @@ public final class GraphvizPrinter
         {
             printNode(node, format("MetadataDeleteNode[%s]", Joiner.on(", ").join(node.getOutputVariables())), NODE_COLORS.get(NodeType.METADATA_DELETE));
             return null;
+        }
+
+        @Override
+        public Void visitDelete(DeleteNode node, Void context)
+        {
+            printNode(node, format("DeleteNode[%s]", Joiner.on(", ").join(node.getOutputVariables())), NODE_COLORS.get(NodeType.DELETE));
+            return node.getSource().accept(this, context);
         }
 
         @Override


### PR DESCRIPTION
## Description
Added support for DeleteNode GraphvizPrinter which was throwing UnsupportedOperationException previously.

## Motivation and Context
While performing DELETE operation, the result of the DELETE event fails to print in the console. It happens because the GraphViz printer implementation in Presto doesn't implement the default method of visitDelete with DeleteNode type.

Related issues
https://github.com/prestodb/presto/issues/21903
https://github.com/prestodb/presto/issues/21916

## Impact
Graceful query printing for delete operations which uses DeleteNode implementation with BeginDelete and FinishDelete method implementations.

## Test Plan

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Added support for DeleteNode GraphvizPrinter

```
