### PR TITLE
Read dataDirectory from system/env variables

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -92,7 +92,6 @@
                     <artifactId>animal-sniffer-annotations</artifactId>
                 </exclusion>
             </exclusions>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -534,6 +533,13 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -38,7 +38,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.tpch.TpchTable;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -51,6 +50,7 @@ import java.util.function.BiFunction;
 
 import static com.facebook.airlift.log.Level.ERROR;
 import static com.facebook.airlift.log.Level.WARN;
+import static com.facebook.presto.hive.HiveTestUtils.getDataDirectoryPath;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -282,38 +282,17 @@ public final class IcebergQueryRunner
             throws Exception
     {
         setupLogging();
-        Optional<Path> dataDirectory = Optional.empty();
+        Optional<Path> dataDirectory;
         if (args.length > 0) {
             if (args.length != 1) {
                 log.error("usage: IcebergQueryRunner [dataDirectory]\n");
                 log.error("       [dataDirectory] is a local directory under which you want the iceberg_data directory to be created.]\n");
                 System.exit(1);
             }
-
-            File dataDirectoryFile = new File(args[0]);
-            if (dataDirectoryFile.exists()) {
-                if (!dataDirectoryFile.isDirectory()) {
-                    log.error("Error: " + dataDirectoryFile.getAbsolutePath() + " is not a directory.");
-                    System.exit(1);
-                }
-                else if (!dataDirectoryFile.canRead() || !dataDirectoryFile.canWrite()) {
-                    log.error("Error: " + dataDirectoryFile.getAbsolutePath() + " is not readable/writable.");
-                    System.exit(1);
-                }
-            }
-            else {
-                // For user supplied path like [path_exists_but_is_not_readable_or_writable]/[paths_do_not_exist], the hadoop file system won't
-                // be able to create directory for it. e.g. "/aaa/bbb" is not creatable because path "/" is not writable.
-                while (!dataDirectoryFile.exists()) {
-                    dataDirectoryFile = dataDirectoryFile.getParentFile();
-                }
-                if (!dataDirectoryFile.canRead() || !dataDirectoryFile.canWrite()) {
-                    log.error("Error: The ancestor directory " + dataDirectoryFile.getAbsolutePath() + " is not readable/writable.");
-                    System.exit(1);
-                }
-            }
-
-            dataDirectory = Optional.of(dataDirectoryFile.toPath());
+            dataDirectory = getDataDirectoryPath(Optional.of(args[0]));
+        }
+        else {
+            dataDirectory = getDataDirectoryPath(Optional.empty());
         }
 
         Map<String, String> properties = ImmutableMap.of("http-server.http.port", "8080");


### PR DESCRIPTION
Refactor IcebergQueryRunner and HiveQueryRunner to read the data directory from system variables rather than program arguments. This is done to ensure these runners are in sync with HiveExternalWorkerQueryRunner.

## Impact
No impact

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

