### PR TITLE
Refactor ConnectorMetadata to deprecate multi-layouts returning method

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -230,12 +230,8 @@ public class InformationSchemaMetadata
     }
 
     @Override
-    public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+    public ConnectorTableLayoutResult getTableLayoutForConstraint(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
     {
-        if (constraint.getSummary().isNone()) {
-            return ImmutableList.of();
-        }
-
         InformationSchemaTableHandle handle = checkTableHandle(table);
 
         Set<QualifiedTablePrefix> prefixes = calculatePrefixesWithSchemaName(session, constraint.getSummary(), constraint.predicate());
@@ -252,7 +248,7 @@ public class InformationSchemaMetadata
         }
 
         ConnectorTableLayout layout = new ConnectorTableLayout(new InformationSchemaTableLayoutHandle(handle, prefixes));
-        return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
+        return new ConnectorTableLayoutResult(layout, constraint.getSummary());
     }
 
     private boolean isTablesEnumeratingTable(SchemaTableName schemaTableName)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -364,14 +364,10 @@ public class MetadataManager
         CatalogMetadata catalogMetadata = getCatalogMetadata(session, connectorId);
         ConnectorMetadata metadata = catalogMetadata.getMetadataFor(connectorId);
         ConnectorSession connectorSession = session.toConnectorSession(connectorId);
-        List<ConnectorTableLayoutResult> layouts = metadata.getTableLayouts(connectorSession, connectorTable, constraint, desiredColumns);
+        ConnectorTableLayoutResult layout = metadata.getTableLayoutForConstraint(connectorSession, connectorTable, constraint, desiredColumns);
         session.getRuntimeStats().addMetricValue(GET_LAYOUT_TIME_NANOS, NANO, System.nanoTime() - startTime);
 
-        if (layouts.size() != 1) {
-            throw new PrestoException(NOT_SUPPORTED, "Connector returned multiple layouts for table " + table);
-        }
-
-        return new TableLayoutResult(fromConnectorLayout(connectorId, table.getConnectorHandle(), table.getTransaction(), layouts.get(0).getTableLayout()), layouts.get(0).getUnenforcedConstraint());
+        return new TableLayoutResult(fromConnectorLayout(connectorId, table.getConnectorHandle(), table.getTransaction(), layout.getTableLayout()), layout.getUnenforcedConstraint());
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/connector/MockConnectorFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/connector/MockConnectorFactory.java
@@ -205,7 +205,7 @@ public class MockConnectorFactory
             @Override
             public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
             {
-                return ImmutableList.of();
+                throw new UnsupportedOperationException();
             }
 
             @Override

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestInformationSchemaMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestInformationSchemaMetadata.java
@@ -43,7 +43,6 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -105,14 +104,13 @@ public class TestInformationSchemaMetadata
         Constraint<ColumnHandle> constraint = new Constraint<>(TupleDomain.withColumnDomains(domains.build()));
 
         InformationSchemaMetadata informationSchemaMetadata = new InformationSchemaMetadata("test_catalog", metadata);
-        List<ConnectorTableLayoutResult> layoutResults = informationSchemaMetadata.getTableLayouts(
+        ConnectorTableLayoutResult layoutResult = informationSchemaMetadata.getTableLayoutForConstraint(
                 createNewSession(transactionId),
                 new InformationSchemaTableHandle("test_catalog", "information_schema", "views"),
                 constraint,
                 Optional.empty());
 
-        assertEquals(layoutResults.size(), 1);
-        ConnectorTableLayoutHandle handle = layoutResults.get(0).getTableLayout().getHandle();
+        ConnectorTableLayoutHandle handle = layoutResult.getTableLayout().getHandle();
         assertTrue(handle instanceof InformationSchemaTableLayoutHandle);
         InformationSchemaTableLayoutHandle tableHandle = (InformationSchemaTableLayoutHandle) handle;
         assertEquals(tableHandle.getPrefixes(), ImmutableSet.of(new QualifiedTablePrefix("test_catalog", "test_schema", "test_view")));
@@ -143,14 +141,13 @@ public class TestInformationSchemaMetadata
                 });
 
         InformationSchemaMetadata informationSchemaMetadata = new InformationSchemaMetadata("test_catalog", metadata);
-        List<ConnectorTableLayoutResult> layoutResults = informationSchemaMetadata.getTableLayouts(
+        ConnectorTableLayoutResult layoutResult = informationSchemaMetadata.getTableLayoutForConstraint(
                 createNewSession(transactionId),
                 new InformationSchemaTableHandle("test_catalog", "information_schema", "views"),
                 constraint,
                 Optional.empty());
 
-        assertEquals(layoutResults.size(), 1);
-        ConnectorTableLayoutHandle handle = layoutResults.get(0).getTableLayout().getHandle();
+        ConnectorTableLayoutHandle handle = layoutResult.getTableLayout().getHandle();
         assertTrue(handle instanceof InformationSchemaTableLayoutHandle);
         InformationSchemaTableLayoutHandle tableHandle = (InformationSchemaTableLayoutHandle) handle;
         assertEquals(tableHandle.getPrefixes(), ImmutableSet.of(new QualifiedTablePrefix("test_catalog", "test_schema", "test_view")));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -117,12 +117,39 @@ public interface ConnectorMetadata
      * Return a list of table layouts that satisfy the given constraint.
      * <p>
      * For each layout, connectors must return an "unenforced constraint" representing the part of the constraint summary that isn't guaranteed by the layout.
+     *
+     * @deprecated replaced by {@link ConnectorMetadata#getTableLayoutForConstraint(ConnectorSession, ConnectorTableHandle, Constraint, Optional)}
      */
-    List<ConnectorTableLayoutResult> getTableLayouts(
+    @Deprecated
+    default List<ConnectorTableLayoutResult> getTableLayouts(
             ConnectorSession session,
             ConnectorTableHandle table,
             Constraint<ColumnHandle> constraint,
-            Optional<Set<ColumnHandle>> desiredColumns);
+            Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        return emptyList();
+    }
+
+    /**
+     * Return a table layout result that satisfy the given constraint.
+     * <p>
+     * Connectors must return an "unenforced constraint" representing the part of the constraint summary that isn't guaranteed by the layout.
+     */
+    default ConnectorTableLayoutResult getTableLayoutForConstraint(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            Constraint<ColumnHandle> constraint,
+            Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        List<ConnectorTableLayoutResult> layouts = getTableLayouts(session, table, constraint, desiredColumns);
+        if (layouts.isEmpty()) {
+            throw new PrestoException(NOT_SUPPORTED, "Connector hasn't implemented either getTableLayoutForConstraint() or getTableLayouts()");
+        }
+        else if (layouts.size() > 1) {
+            throw new PrestoException(NOT_SUPPORTED, "Connector returned multiple layouts for table " + table);
+        }
+        return layouts.get(0);
+    }
 
     ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle);
 
@@ -407,21 +434,13 @@ public interface ConnectorMetadata
      */
     default Optional<ConnectorNewTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        List<ConnectorTableLayout> layouts = getTableLayouts(session, tableHandle, new Constraint<>(TupleDomain.all(), map -> true), Optional.empty())
-                .stream()
-                .map(ConnectorTableLayoutResult::getTableLayout)
-                .filter(layout -> layout.getTablePartitioning().isPresent())
-                .collect(toList());
+        ConnectorTableLayout layout = getTableLayoutForConstraint(session, tableHandle, new Constraint<>(TupleDomain.all(), map -> true), Optional.empty())
+                .getTableLayout();
 
-        if (layouts.isEmpty()) {
+        if (!layout.getTablePartitioning().isPresent()) {
             return Optional.empty();
         }
 
-        if (layouts.size() > 1) {
-            throw new PrestoException(NOT_SUPPORTED, "Tables with multiple layouts can not be written");
-        }
-
-        ConnectorTableLayout layout = layouts.get(0);
         ConnectorPartitioningHandle partitioningHandle = layout.getTablePartitioning().get().getPartitioningHandle();
         Map<ColumnHandle, String> columnNamesByHandle = getColumnHandles(session, tableHandle).entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -87,6 +87,18 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public ConnectorTableLayoutResult getTableLayoutForConstraint(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            Constraint<ColumnHandle> constraint,
+            Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableLayoutForConstraint(session, table, constraint, desiredColumns);
+        }
+    }
+
+    @Override
     public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
## Description

The support for multiple layouts has been removed in PR https://github.com/prestodb/presto/pull/12674, however the SPI method `ConnectorMetadata.getTableLayouts()` still return a `List<ConnectorTableLayoutResult>` which should always contains exactly one element. That's somehow unreasonable, and may lead in some confusion and inconvenience in the reading and subsequent development of the code. This PR try to deprecate this method, and replace it by ``getTableLayoutForConstraint()`` which explicitly return a ``ConnectorTableLayoutResult``.

## Test Plan

 - Make sure this refactor do not effect all existing test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Deprecate SPI method ConnectorMetadata.getTableLayouts(), replace by ConnectorMetadata.getTableLayoutForConstraint()
```
