### PR TITLE
Support timestamp type in mysql jdbc connector

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -82,6 +82,30 @@ public final class TimestampType
         return Objects.hash(getClass(), precision);
     }
 
+    /**
+     * Gets the timestamp's number of total seconds.
+     * The epoch second count is a simple incrementing count of seconds where second 0 is 1970-01-01T00:00:00Z.
+     *
+     * Returns:
+     * the total seconds in timestamp
+     */
+    public long getEpochSecond(long timestamp)
+    {
+        return this.precision.toSeconds(timestamp);
+    }
+
+    /**
+     * Gets the timestamp's nanosecond portion.
+     *
+     * Returns:
+     * this timestamp's fractional seconds component
+     */
+    public int getNanos(long timestamp)
+    {
+        long unitsPerSecond = precision.convert(1, TimeUnit.SECONDS);
+        return (int) precision.toNanos(timestamp % unitsPerSecond);
+    }
+
     private static String getType(TimeUnit precision)
     {
         if (precision == MICROSECONDS) {

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.mysql;
 
+import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
@@ -44,7 +45,6 @@ import java.util.Properties;
 
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
@@ -164,8 +164,9 @@ public class MySqlClient
         if (TIME_WITH_TIME_ZONE.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
             throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
         }
-        if (TIMESTAMP.equals(type)) {
-            return "datetime";
+        if (type instanceof TimestampType) {
+            // In order to preserve microsecond information for TIMESTAMP_MICROSECONDS
+            return "datetime(6)";
         }
         if (VARBINARY.equals(type)) {
             return "mediumblob";

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -169,6 +169,29 @@ public class TestMySqlIntegrationSmokeTest
     }
 
     @Test
+    public void testMysqlTimestamp()
+    {
+        // Do not support timestamp with time zone in mysql connector
+        assertQueryFails("CREATE TABLE test_timestamp (x timestamp with time zone)", "Unsupported column type: timestamp with time zone");
+
+        assertUpdate("CREATE TABLE test_timestamp (x timestamp)");
+        assertUpdate("INSERT INTO test_timestamp VALUES (timestamp '1970-01-01 00:00:00')", 1);
+        assertUpdate("INSERT INTO test_timestamp VALUES (timestamp '2017-05-01 10:12:34')", 1);
+        assertUpdate("INSERT INTO test_timestamp VALUES (timestamp '2018-06-02 11:13:45.123')", 1);
+        assertQuery("SELECT * FROM test_timestamp", "VALUES CAST('1970-01-01 00:00:00' AS TIMESTAMP)," +
+                " CAST('2017-05-01 10:12:34' AS TIMESTAMP)," +
+                " CAST('2018-06-02 11:13:45.123' AS TIMESTAMP)");
+
+        assertUpdate("CREATE TABLE test_timestamp2 (x timestamp)");
+        assertUpdate("INSERT INTO test_timestamp2 SELECT * from test_timestamp", 3);
+        assertQuery("SELECT * FROM test_timestamp2", "VALUES CAST('1970-01-01 00:00:00' AS TIMESTAMP)," +
+                " CAST('2017-05-01 10:12:34' AS TIMESTAMP)," +
+                " CAST('2018-06-02 11:13:45.123' AS TIMESTAMP)");
+        assertUpdate("DROP TABLE test_timestamp");
+        assertUpdate("DROP TABLE test_timestamp2");
+    }
+
+    @Test
     public void testCharTrailingSpace()
             throws Exception
     {


### PR DESCRIPTION
## Description

Fix issue #21731. Support column type: timestamp in mysql connector.


## Test Plan

 - Newly added test case in TestMySqlIntegrationSmokeTest.testMysqlTimestamp()

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Mysql Changes
* Support timestamp column type
```
