### PR TITLE
Implement ALTER TABLE SET PROPERTIES in ClickHouse

### DIFF
--- a/presto-clickhouse/pom.xml
+++ b/presto-clickhouse/pom.xml
@@ -245,7 +245,7 @@
                             <!-- these tests take a very long time so only run them in the CI server -->
                             <excludes>
                                 <exclude>**/TestClickHouseIntegrationSmokeTest.java</exclude>
-                                <include>**/TestClickHouseDistributedQueries.java</include>
+                                <exclude>**/TestClickHouseDistributedQueries.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseMetadata.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseMetadata.java
@@ -254,6 +254,13 @@ public class ClickHouseMetadata
     }
 
     @Override
+    public void setTableProperties(ConnectorSession session, ConnectorTableHandle table, Map<String, Object> properties)
+    {
+        ClickHouseTableHandle tableHandle = (ClickHouseTableHandle) table;
+        clickHouseClient.setTableProperties(ClickHouseIdentity.from(session), tableHandle, properties);
+    }
+
+    @Override
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
     {
         ClickHouseTableHandle handle = (ClickHouseTableHandle) tableHandle;


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/9401/commits/cf368de373b796c4c343748b3873795cc59c4658

Co-authored-by: ebyhr

## Description
Implement ALTER TABLE SET PROPERTIES support in presto-clickhouse connector

## Motivation and Context
Makes the connector feature rich and more user friendly.

## Impact
Users will be able to set/reset the table properties for a clickhouse table via presto-clickhouse connector.

## Test Plan
Manual and unit tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Clickhouse Changes
* Add support for setting table properties via presto-clickhouse connector
```

