### PR TITLE
[native] Add missing task runtime stats 

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -408,10 +408,17 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
   prestoTaskStats.lastEndTime =
       util::toISOTimestamp(taskStats.executionEndTimeMs);
   prestoTaskStats.endTime = util::toISOTimestamp(taskStats.executionEndTimeMs);
+
+  const uint64_t currentTimeMs = velox::getCurrentTimeMs();
+  const uint64_t sinceLastPeriodMs = currentTimeMs - lastTaskStatsUpdateMs;
+
   if (taskStats.executionEndTimeMs > taskStats.executionStartTimeMs) {
     prestoTaskStats.elapsedTimeInNanos =
         (taskStats.executionEndTimeMs - taskStats.executionStartTimeMs) *
         1'000'000;
+  } else {
+    prestoTaskStats.elapsedTimeInNanos =
+        (currentTimeMs - taskStats.executionStartTimeMs) * 1'000'000;
   }
 
   const auto stats = task->pool()->stats();
@@ -427,9 +434,6 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
   if (lastTaskStatsUpdateMs == 0) {
     lastTaskStatsUpdateMs = taskStats.executionStartTimeMs;
   }
-
-  const uint64_t currentTimeMs = velox::getCurrentTimeMs();
-  const uint64_t sinceLastPeriodMs = currentTimeMs - lastTaskStatsUpdateMs;
 
   const int64_t currentBytes = stats.currentBytes;
 

--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -478,11 +478,11 @@ protocol::TaskInfo PrestoTask::updateInfoLocked() {
         {"memoryReclaimWallNanos", fromMillis(taskStats.memoryReclaimMs)});
   }
 
+  taskRuntimeStats["createTime"].addValue(taskStats.executionStartTimeMs);
   if (taskStats.endTimeMs >= taskStats.executionEndTimeMs) {
     taskRuntimeStats.insert(
         {"outputConsumedDelayInNanos",
          fromMillis(taskStats.endTimeMs - taskStats.executionEndTimeMs)});
-    taskRuntimeStats["createTime"].addValue(taskStats.executionStartTimeMs);
     taskRuntimeStats["endTime"].addValue(taskStats.endTimeMs);
   }
 


### PR DESCRIPTION
* Some operator runtime stats were missing from task runtime stats. These include numSplits, inputBatches, outputBatches and numMemoryAllocations .
* createTime task runtime stat was reported only after task has finished.
* elapsedTimeInNanos stat was reported only after task has finished.

```
== NO RELEASE NOTE ==
```

