### PR TITLE
Refactor base lakehouse connector classes in presto-hive-common

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/BaseHiveColumnHandle.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/BaseHiveColumnHandle.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.spi.ColumnHandle;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -39,12 +38,11 @@ public class BaseHiveColumnHandle
     private final ColumnType columnType;
     private final List<Subfield> requiredSubfields;
 
-    @JsonCreator
     public BaseHiveColumnHandle(
-            @JsonProperty("name") String name,
-            @JsonProperty("comment") Optional<String> comment,
-            @JsonProperty("columnType") ColumnType columnType,
-            @JsonProperty("requiredSubfields") List<Subfield> requiredSubfields)
+            String name,
+            Optional<String> comment,
+            ColumnType columnType,
+            List<Subfield> requiredSubfields)
     {
         this.name = requireNonNull(name, "name is null");
         this.comment = requireNonNull(comment, "comment is null");

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/BaseHiveTableHandle.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/BaseHiveTableHandle.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.SchemaTableName;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static java.util.Objects.requireNonNull;
@@ -26,10 +25,7 @@ public class BaseHiveTableHandle
     private final String schemaName;
     private final String tableName;
 
-    @JsonCreator
-    public BaseHiveTableHandle(
-            @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName)
+    public BaseHiveTableHandle(String schemaName, String tableName)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/BaseHiveTableLayoutHandle.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/BaseHiveTableLayoutHandle.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.relation.RowExpression;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -39,23 +38,6 @@ public class BaseHiveTableLayoutHandle
 
     // coordinator-only properties
     private final Optional<List<HivePartition>> partitions;
-
-    @JsonCreator
-    public BaseHiveTableLayoutHandle(
-            @JsonProperty("partitionColumns") List<BaseHiveColumnHandle> partitionColumns,
-            @JsonProperty("domainPredicate") TupleDomain<Subfield> domainPredicate,
-            @JsonProperty("remainingPredicate") RowExpression remainingPredicate,
-            @JsonProperty("pushdownFilterEnabled") boolean pushdownFilterEnabled,
-            @JsonProperty("partitionColumnPredicate") TupleDomain<ColumnHandle> partitionColumnPredicate)
-    {
-        this(
-                partitionColumns,
-                domainPredicate,
-                remainingPredicate,
-                pushdownFilterEnabled,
-                partitionColumnPredicate,
-                Optional.empty());
-    }
 
     public BaseHiveTableLayoutHandle(
             List<BaseHiveColumnHandle> partitionColumns,


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
As we no longer need to serialise the BaseHiveTableLayoutHandle, BaseHiveColumnHandle, BaseHiveTableHandle objects, this commit removes the JSON constructors from the mentioned classes

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No user impact

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

