### PR TITLE
Add buffered bytes metadata to task results

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -46,6 +46,7 @@ public final class PrestoHeaders
     public static final String PRESTO_CURRENT_STATE = "X-Presto-Current-State";
     public static final String PRESTO_MAX_WAIT = "X-Presto-Max-Wait";
     public static final String PRESTO_MAX_SIZE = "X-Presto-Max-Size";
+    public static final String PRESTO_BUFFER_REMAINING_BYTES = "X-Presto-Buffer-Remaining-Bytes";
     public static final String PRESTO_TASK_INSTANCE_ID = "X-Presto-Task-Instance-Id";
     public static final String PRESTO_PAGE_TOKEN = "X-Presto-Page-Sequence-Id";
     public static final String PRESTO_PAGE_NEXT_TOKEN = "X-Presto-Page-End-Sequence-Id";

--- a/presto-docs/src/main/sphinx/develop/worker-protocol.rst
+++ b/presto-docs/src/main/sphinx/develop/worker-protocol.rst
@@ -61,6 +61,10 @@ upstream worker.
   the receipt of the results and allows the worker to delete them.
 * A ``DELETE`` on ``{taskId}/results/{bufferId}`` deletes all results from the
   specified output buffer in case of an error.
+* Optionally, a ``HEAD`` request can be made to ``{taskId}/results/{bufferId}``
+  to retrieve any non-data page sequence related headers.  Use this to check if
+  the buffer is finished, or to see how much data is buffered without fetching
+  the data.
 
 Coordinator and workers fetch results in chunks. They specify the maximum size
 in bytes for the chunk using ``X-Presto-Max-Size`` HTTP header. Each chunk is
@@ -73,6 +77,10 @@ response includes:
   request the next chunk as ``X-Presto-Page-End-Sequence-Id`` HTTP header,
 * An indication that there are no more results as ``X-Presto-Buffer-Complete``
   HTTP header with the value of "true".
+* The remaining buffered bytes in the output buffer as ``X-Presto-Buffer-Remaining-Bytes``
+  HTTP header.  This should return a comma separated list of the size in bytes of
+  the pages that can be returned in the next request.  This can be used as a hint
+  to upstream tasks to optimize data exchange.
 
 The body of the response contains a list of pages in :doc:`SerializedPage wire format <serialized-page>`.
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.execution.buffer.BufferInfo;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.LazyOutputBuffer;
 import com.facebook.presto.execution.buffer.OutputBuffer;
@@ -492,6 +493,14 @@ public class SqlTask
         checkArgument(maxSize.toBytes() > 0, "maxSize must be at least 1 byte");
 
         return outputBuffer.get(bufferId, startingSequenceId, maxSize);
+    }
+
+    public Optional<BufferInfo> getTaskBufferInfo(OutputBufferId bufferId)
+    {
+        requireNonNull(bufferId, "bufferId is null");
+        return outputBuffer.getInfo().getBuffers().stream()
+                .filter(bufferInfo -> bufferInfo.getBufferId().equals(bufferId))
+                .findFirst();
     }
 
     public void acknowledgeTaskResults(OutputBufferId bufferId, long sequenceId)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -23,6 +23,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.event.SplitMonitor;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.execution.buffer.BufferInfo;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
@@ -450,6 +451,14 @@ public class SqlTaskManager
         requireNonNull(maxSize, "maxSize is null");
 
         return tasks.getUnchecked(taskId).getTaskResults(bufferId, startingSequenceId, maxSize);
+    }
+
+    @Override
+    public Optional<BufferInfo> getTaskBufferInfo(TaskId taskId, OutputBufferId bufferId)
+    {
+        requireNonNull(taskId, "taskId is null");
+        requireNonNull(bufferId, "bufferId is null");
+        return tasks.getUnchecked(taskId).getTaskBufferInfo(bufferId);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.execution.buffer.BufferInfo;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
@@ -116,6 +117,13 @@ public interface TaskManager
      * eventually exist are queried.
      */
     ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize);
+
+    /**
+     * Gets the {@link BufferInfo} associated with the specified task and buffer id.
+     *
+     * @return absent if the buffer is not present, otherwise the buffer info
+     */
+    Optional<BufferInfo> getTaskBufferInfo(TaskId taskId, OutputBufferId bufferId);
 
     /**
      * Acknowledges previously received results.

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BufferResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BufferResult.java
@@ -28,13 +28,19 @@ public class BufferResult
 {
     public static BufferResult emptyResults(String taskInstanceId, long token, boolean bufferComplete)
     {
-        return new BufferResult(taskInstanceId, token, token, bufferComplete, ImmutableList.of());
+        return emptyResults(taskInstanceId, token, 0, bufferComplete);
+    }
+
+    public static BufferResult emptyResults(String taskInstanceId, long token, long bufferedBytes, boolean bufferComplete)
+    {
+        return new BufferResult(taskInstanceId, token, token, bufferComplete, bufferedBytes, ImmutableList.of());
     }
 
     private final String taskInstanceId;
     private final long token;
     private final long nextToken;
     private final boolean bufferComplete;
+    private final long bufferedBytes;
     private final List<SerializedPage> serializedPages;
 
     public BufferResult(
@@ -42,6 +48,7 @@ public class BufferResult
             long token,
             long nextToken,
             boolean bufferComplete,
+            long bufferedBytes,
             List<SerializedPage> serializedPages)
     {
         checkArgument(!isNullOrEmpty(taskInstanceId), "taskInstanceId is null");
@@ -50,6 +57,7 @@ public class BufferResult
         this.token = token;
         this.nextToken = nextToken;
         this.bufferComplete = bufferComplete;
+        this.bufferedBytes = bufferedBytes;
         this.serializedPages = ImmutableList.copyOf(requireNonNull(serializedPages, "serializedPages is null"));
     }
 
@@ -71,6 +79,11 @@ public class BufferResult
     public boolean isBufferComplete()
     {
         return bufferComplete;
+    }
+
+    public long getBufferedBytes()
+    {
+        return bufferedBytes;
     }
 
     public List<SerializedPage> getSerializedPages()

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBuffer.java
@@ -365,7 +365,7 @@ public class SpoolingOutputBuffer
 
         ListenableFuture<BufferResult> resultFuture = transform(memoryPages, input -> {
             long newSequenceId = startSequenceId + input.size();
-            return new BufferResult(taskInstanceId, startSequenceId, newSequenceId, false, input);
+            return new BufferResult(taskInstanceId, startSequenceId, newSequenceId, false, 0, input);
         }, executor);
 
         return catchingAsync(resultFuture, Exception.class, e -> {

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/ThriftBufferResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/ThriftBufferResult.java
@@ -36,6 +36,7 @@ public class ThriftBufferResult
     private final long token;
     private final long nextToken;
     private final boolean bufferComplete;
+    private final long bufferedBytes;
     private final List<ThriftSerializedPage> thriftSerializedPages;
 
     public static ThriftBufferResult fromBufferResult(BufferResult bufferResult)
@@ -50,6 +51,7 @@ public class ThriftBufferResult
                 bufferResult.getToken(),
                 bufferResult.getNextToken(),
                 bufferResult.isBufferComplete(),
+                bufferResult.getBufferedBytes(),
                 thriftSerializedPages);
     }
 
@@ -62,6 +64,7 @@ public class ThriftBufferResult
             long token,
             long nextToken,
             boolean bufferComplete,
+            long bufferedBytes,
             List<ThriftSerializedPage> thriftSerializedPages)
     {
         checkArgument(!isNullOrEmpty(taskInstanceId), "taskInstanceId is null");
@@ -70,6 +73,7 @@ public class ThriftBufferResult
         this.token = token;
         this.nextToken = nextToken;
         this.bufferComplete = bufferComplete;
+        this.bufferedBytes = bufferedBytes;
         this.thriftSerializedPages = ImmutableList.copyOf(requireNonNull(thriftSerializedPages, "thriftSerializedPages is null"));
     }
 
@@ -101,6 +105,12 @@ public class ThriftBufferResult
     public List<ThriftSerializedPage> getThriftSerializedPages()
     {
         return thriftSerializedPages;
+    }
+
+    @ThriftField(6)
+    public long getBufferedBytes()
+    {
+        return bufferedBytes;
     }
 
     public List<SerializedPage> getSerializedPages()
@@ -141,6 +151,7 @@ public class ThriftBufferResult
                 .add("nextToken", nextToken)
                 .add("taskInstanceId", taskInstanceId)
                 .add("bufferComplete", bufferComplete)
+                .add("bufferedBytes", bufferedBytes)
                 .add("thriftSerializedPages", thriftSerializedPages)
                 .toString();
     }
@@ -148,6 +159,6 @@ public class ThriftBufferResult
     @VisibleForTesting
     public BufferResult toBufferResult()
     {
-        return new BufferResult(taskInstanceId, token, nextToken, bufferComplete, getSerializedPages());
+        return new BufferResult(taskInstanceId, token, nextToken, bufferComplete, bufferedBytes, getSerializedPages());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/AsyncPageTransportServlet.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/AsyncPageTransportServlet.java
@@ -18,8 +18,10 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.TimeStat;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskManager;
+import com.facebook.presto.execution.buffer.BufferInfo;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import com.facebook.presto.execution.buffer.PageBufferInfo;
 import com.facebook.presto.operator.ExchangeClientConfig;
 import com.facebook.presto.spi.page.SerializedPage;
 import com.google.common.annotations.VisibleForTesting;
@@ -48,6 +50,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import static com.facebook.airlift.concurrent.MoreFutures.addTimeout;
 import static com.facebook.presto.PrestoMediaTypes.PRESTO_PAGES;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_BUFFER_COMPLETE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_BUFFER_REMAINING_BYTES;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_MAX_SIZE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_NEXT_TOKEN;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_TOKEN;
@@ -197,7 +200,14 @@ public class AsyncPageTransportServlet
         ListenableFuture<BufferResult> bufferResultFuture = taskManager.getTaskResults(taskId, bufferId, token, maxSize);
         bufferResultFuture = addTimeout(
                 bufferResultFuture,
-                () -> BufferResult.emptyResults(taskManager.getTaskInstanceId(taskId), token, false),
+                () -> BufferResult.emptyResults(
+                        taskManager.getTaskInstanceId(taskId),
+                        token,
+                        taskManager.getTaskBufferInfo(taskId, bufferId)
+                                .map(BufferInfo::getPageBufferInfo)
+                                .map(PageBufferInfo::getBufferedBytes)
+                                .orElse(0L),
+                        false),
                 waitTime,
                 timeoutExecutor);
 
@@ -214,6 +224,7 @@ public class AsyncPageTransportServlet
                         response.setHeader(PRESTO_PAGE_TOKEN, String.valueOf(bufferResult.getToken()));
                         response.setHeader(PRESTO_PAGE_NEXT_TOKEN, String.valueOf(bufferResult.getNextToken()));
                         response.setHeader(PRESTO_BUFFER_COMPLETE, String.valueOf(bufferResult.isBufferComplete()));
+                        response.setHeader(PRESTO_BUFFER_REMAINING_BYTES, String.valueOf(bufferResult.getBufferedBytes()));
 
                         List<SerializedPage> serializedPages = bufferResult.getSerializedPages();
                         if (serializedPages.isEmpty()) {

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
@@ -39,6 +39,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -62,6 +63,8 @@ import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICA
 import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_FB_COMPACT;
 import static com.facebook.airlift.http.server.AsyncResponseHandler.bindAsyncResponse;
 import static com.facebook.presto.PrestoMediaTypes.APPLICATION_JACKSON_SMILE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_BUFFER_COMPLETE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_BUFFER_REMAINING_BYTES;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CURRENT_STATE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_MAX_WAIT;
 import static com.facebook.presto.server.TaskResourceUtils.convertToThriftTaskInfo;
@@ -286,6 +289,33 @@ public class TaskResource
         requireNonNull(bufferId, "bufferId is null");
 
         taskManager.acknowledgeTaskResults(taskId, bufferId, token);
+    }
+
+    @HEAD
+    @Path("{taskId}/results/{bufferId}")
+    public Response taskResultsHeaders(
+            @PathParam("taskId") TaskId taskId,
+            @PathParam("bufferId") OutputBufferId bufferId)
+    {
+        requireNonNull(taskId, "taskId is null");
+        requireNonNull(bufferId, "bufferId is null");
+
+        return taskManager.getTaskBufferInfo(taskId, bufferId)
+                .map(bufferInfo -> Response.ok()
+                        .header(PRESTO_BUFFER_REMAINING_BYTES, bufferInfo.getPageBufferInfo().getBufferedBytes())
+                        .header(PRESTO_BUFFER_COMPLETE, bufferInfo.isFinished())
+                        .build())
+                .orElse(Response.status(Response.Status.NOT_FOUND).build());
+    }
+
+    @HEAD
+    @Path("{taskId}/results/{bufferId}/{token}")
+    public Response taskResultsHeaders(
+            @PathParam("taskId") TaskId taskId,
+            @PathParam("bufferId") OutputBufferId bufferId,
+            @PathParam("token") final long unused)
+    {
+        return taskResultsHeaders(taskId, bufferId);
     }
 
     @DELETE

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.stats.CounterStat;
 import com.facebook.airlift.stats.TestingGcMonitor;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.execution.TestSqlTaskManager.MockExchangeClientSupplier;
+import com.facebook.presto.execution.buffer.BufferInfo;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.BufferState;
 import com.facebook.presto.execution.buffer.OutputBuffers;
@@ -29,6 +30,7 @@ import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
+import com.facebook.presto.spi.page.SerializedPage;
 import com.facebook.presto.spiller.SpillSpaceTracker;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
@@ -161,9 +163,21 @@ public class TestSqlTask
         assertEquals(results.isBufferComplete(), false);
         assertEquals(results.getSerializedPages().size(), 1);
         assertEquals(results.getSerializedPages().get(0).getPositionCount(), 1);
+        // Task results clear out all buffered data once ack is sent
+        long pagesRetanedSizeInBytes = results.getSerializedPages().stream().mapToLong(SerializedPage::getRetainedSizeInBytes).sum();
+        assertEquals(results.getBufferedBytes(), 0);
+        Optional<BufferInfo> taskBufferInfo = sqlTask.getTaskBufferInfo(OUT);
+        assertTrue(taskBufferInfo.isPresent());
+        // Buffer still remains as acknowledgement has not been received
+        assertEquals(taskBufferInfo.get().getPageBufferInfo().getBufferedBytes(), pagesRetanedSizeInBytes);
 
         for (boolean moreResults = true; moreResults; moreResults = !results.isBufferComplete()) {
             results = sqlTask.getTaskResults(OUT, results.getToken() + results.getSerializedPages().size(), new DataSize(1, MEGABYTE)).get();
+            pagesRetanedSizeInBytes = results.getSerializedPages().stream().mapToLong(SerializedPage::getRetainedSizeInBytes).sum();
+            assertEquals(results.getBufferedBytes(), pagesRetanedSizeInBytes);
+            taskBufferInfo = sqlTask.getTaskBufferInfo(OUT);
+            assertTrue(taskBufferInfo.isPresent());
+            assertEquals(taskBufferInfo.get().getPageBufferInfo().getBufferedBytes(), pagesRetanedSizeInBytes);
         }
         assertEquals(results.getSerializedPages().size(), 0);
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/BufferTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/BufferTestUtils.java
@@ -80,6 +80,7 @@ public final class BufferTestUtils
                 token,
                 token + pages.size(),
                 false,
+                0,
                 pages.stream()
                         .map(PAGES_SERDE::serialize)
                         .collect(Collectors.toList()));

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestClientBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestClientBuffer.java
@@ -179,6 +179,30 @@ public class TestClientBuffer
     }
 
     @Test
+    public void testBufferResults()
+    {
+        ClientBuffer buffer = new ClientBuffer(TASK_INSTANCE_ID, BUFFER_ID, NOOP_RELEASE_LISTENER);
+
+        long totalSizeOfPagesInBytes = 0;
+        for (int i = 0; i < 3; i++) {
+            Page page = createPage(i);
+            SerializedPageReference pageReference = new SerializedPageReference(PAGES_SERDE.serialize(page), 1, Lifespan.taskWide());
+            totalSizeOfPagesInBytes = totalSizeOfPagesInBytes + pageReference.getSerializedPage().getRetainedSizeInBytes();
+            addPage(buffer, page);
+        }
+        // Everything buffered
+        assertBufferInfo(buffer, 3, 0, totalSizeOfPagesInBytes);
+
+        BufferResult bufferResult = getBufferResult(buffer, 0, sizeOfPages(1), NO_WAIT);
+        long remainingBytes = totalSizeOfPagesInBytes - bufferResult.getBufferedBytes();
+        assertEquals(bufferResult.getBufferedBytes(), sizeOfPages(1).toBytes());
+        assertBufferInfo(buffer, 3, 0, totalSizeOfPagesInBytes);
+
+        buffer.acknowledgePages(bufferResult.getNextToken());
+        assertBufferInfo(buffer, 2, 1, remainingBytes);
+    }
+
+    @Test
     public void testDuplicateRequests()
     {
         ClientBuffer buffer = new ClientBuffer(TASK_INSTANCE_ID, BUFFER_ID, NOOP_RELEASE_LISTENER);
@@ -392,14 +416,41 @@ public class TestClientBuffer
     private static void addPage(ClientBuffer buffer, Page page, PagesReleasedListener onPagesReleased)
     {
         SerializedPageReference serializedPageReference = new SerializedPageReference(PAGES_SERDE.serialize(page), 1, Lifespan.taskWide());
-        buffer.enqueuePages(ImmutableList.of(serializedPageReference));
-        dereferencePages(ImmutableList.of(serializedPageReference), onPagesReleased);
+        addPage(buffer, serializedPageReference, onPagesReleased);
+    }
+
+    private static void addPage(ClientBuffer buffer, SerializedPageReference page, PagesReleasedListener onPagesReleased)
+    {
+        buffer.enqueuePages(ImmutableList.of(page));
+        dereferencePages(ImmutableList.of(page), onPagesReleased);
     }
 
     private static void assertBufferInfo(
             ClientBuffer buffer,
             int bufferedPages,
             int pagesSent)
+    {
+        assertEquals(
+                buffer.getInfo(),
+                new BufferInfo(
+                        BUFFER_ID,
+                        false,
+                        bufferedPages,
+                        pagesSent,
+                        new PageBufferInfo(
+                                BUFFER_ID.getId(),
+                                bufferedPages,
+                                sizeOfPages(bufferedPages).toBytes(),
+                                bufferedPages + pagesSent, // every page has one row
+                                bufferedPages + pagesSent)));
+        assertFalse(buffer.isDestroyed());
+    }
+
+    private static void assertBufferInfo(
+            ClientBuffer buffer,
+            int bufferedPages,
+            int pagesSent,
+            long bufferedBytes)
     {
         assertEquals(
                 buffer.getInfo(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestThriftBufferResult.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestThriftBufferResult.java
@@ -36,7 +36,7 @@ public class TestThriftBufferResult
     @Test
     public void testThriftBufferResult()
     {
-        BufferResult bufferResult = new BufferResult("task-instance-id", 0, 0, false, ImmutableList.of());
+        BufferResult bufferResult = new BufferResult("task-instance-id", 0, 0, false, 0, ImmutableList.of());
         ThriftBufferResult thriftBufferResult = fromBufferResult(bufferResult);
         BufferResult newBufferResult = thriftBufferResult.toBufferResult();
         assertEquals(bufferResult, newBufferResult);

--- a/presto-main/src/test/java/com/facebook/presto/operator/MockExchangeRequestProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/MockExchangeRequestProcessor.java
@@ -220,7 +220,7 @@ public class MockExchangeRequestProcessor
             // update sequence id
             long nextToken = token.get() + responsePages.size();
 
-            BufferResult bufferResult = new BufferResult(TASK_INSTANCE_ID, token.get(), nextToken, false, responsePages);
+            BufferResult bufferResult = new BufferResult(TASK_INSTANCE_ID, token.get(), nextToken, false, 0, responsePages);
             token.set(nextToken);
 
             return bufferResult;

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
@@ -34,6 +34,7 @@ import com.facebook.presto.execution.TaskManager;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.TaskState;
 import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.execution.buffer.BufferInfo;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
@@ -212,6 +213,12 @@ public class TestThriftServerInfoIntegration
 
                 @Override
                 public ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Optional<BufferInfo> getTaskBufferInfo(TaskId taskId, OutputBufferId bufferId)
                 {
                     throw new UnsupportedOperationException();
                 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
@@ -33,6 +33,7 @@ import com.facebook.presto.execution.TaskManager;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.TaskState;
 import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.execution.buffer.BufferInfo;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
@@ -243,6 +244,12 @@ public class TestThriftTaskIntegration
                 public ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
                 {
                     return Futures.immediateFuture(emptyResults("test", 1, true));
+                }
+
+                @Override
+                public Optional<BufferInfo> getTaskBufferInfo(TaskId taskId, OutputBufferId bufferId)
+                {
+                    throw new UnsupportedOperationException();
                 }
 
                 @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkTaskManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkTaskManager.java
@@ -21,6 +21,7 @@ import com.facebook.presto.execution.TaskManager;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.TaskState;
 import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.execution.buffer.BufferInfo;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
@@ -98,6 +99,12 @@ public class PrestoSparkTaskManager
 
     @Override
     public ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBuffers.OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<BufferInfo> getTaskBufferInfo(TaskId taskId, OutputBuffers.OutputBufferId bufferId)
     {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
## Description
 
Add remaining buffered bytes to task results endpoints.  Add a new HEAD request to task results to allow for a lightweight way to retrieve header-only information.

## Motivation and Context
See #21926 for context and motivation.

## Impact
This will allow the design in #21926 to be more RESTful and reduce the need for special-case flags.

## Test Plan
Unit test coverage.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

