### PR TITLE
Fix variable width encoding description in serialized-page.rst

### DIFF
--- a/presto-docs/src/main/sphinx/develop/serialized-page.rst
+++ b/presto-docs/src/main/sphinx/develop/serialized-page.rst
@@ -152,7 +152,7 @@ Let’s again take the example from the Null Flags section and say that we
 have a string column with 10 rows with nulls in zero-based rows 1, 4, 6, 7, 9.
 The non-null rows will have values: 0 - Denali, 2 - Reinier, 3 - Whitney,
 5 - Bona, 8 - Bear. We’ll have 4 bytes storing the number of rows: 10, followed
-by 40 bytes of offsets, followed by 3 bytes of null flags, followed by 1 bytes
+by 40 bytes of offsets, followed by 3 bytes of null flags, followed by 4 bytes
 storing total size of all strings: 28, followed by the concatenated string values.
 Notice that we have offsets for all rows, not just the non-null rows.
 


### PR DESCRIPTION
The bullet points under "VARIABLE_WIDTH Encoding" list "total number of bytes in all values" as 4 bytes, but in the descriptive paragraph below it says 1 byte.  I checked the code and the correct value is 4 bytes.

I updated the text, but the image is wrong as well, I don't know how to regenerate it.
