### PR TITLE
[Iceberg]Fix identity and truncate transform on DecimalType column

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types.DecimalType;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -168,7 +169,7 @@ public class PartitionData
                     throw new UncheckedIOException("Failed during JSON conversion of " + partitionValue, e);
                 }
             case DECIMAL:
-                return partitionValue.decimalValue();
+                return partitionValue.decimalValue().setScale(((DecimalType) type).scale());
         }
         throw new UnsupportedOperationException("Type not supported as partition column: " + type);
     }


### PR DESCRIPTION
## Description

When we create partitions on DecimalType columns(using identity or truncate transform) in Iceberg, we will meet various problems  because of the inappropriate handling for decimal data.

This PR fix the problems appears when using decimal as a partition column.

## Test Plan

 - Test identity transform on column of `ShortDecimalType` type
 - Test truncate transform on column of `ShortDecimalType` type
 - Test identity transform on column of `LongDecimalType` type
 - Test truncate transform on column of `LongDecimalType` type


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Changes
* Fix identity and truncate transforms on DecimalType columns
```
