### PR TITLE
[Iceberg]Support year/month/day/hour transforms both on legacy and non-legacy TimestampType column

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -16,6 +16,8 @@ package com.facebook.presto.iceberg;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.DateType;
@@ -46,8 +48,11 @@ import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.LocationProvider;
-import org.apache.iceberg.transforms.Transform;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -72,6 +77,8 @@ import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class IcebergPageSink
         implements ConnectorPageSink
@@ -124,7 +131,9 @@ public class IcebergPageSink
         this.session = requireNonNull(session, "session is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.maxOpenWriters = maxOpenWriters;
-        this.pagePartitioner = new PagePartitioner(pageIndexerFactory, toPartitionColumns(inputColumns, partitionSpec));
+        this.pagePartitioner = new PagePartitioner(pageIndexerFactory,
+                toPartitionColumns(inputColumns, partitionSpec),
+                session);
     }
 
     @Override
@@ -281,13 +290,14 @@ public class IcebergPageSink
         }
 
         // create missing writers
+        Page transformedPage = pagePartitioner.getTransformedPage();
         for (int position = 0; position < page.getPositionCount(); position++) {
             int writerIndex = writerIndexes[position];
             if (writers.get(writerIndex) != null) {
                 continue;
             }
 
-            Optional<PartitionData> partitionData = getPartitionData(pagePartitioner.getColumns(), page, position);
+            Optional<PartitionData> partitionData = getPartitionData(pagePartitioner.getColumns(), transformedPage, position);
             WriteContext writer = createWriter(partitionData);
 
             writers.set(writerIndex, writer);
@@ -315,7 +325,7 @@ public class IcebergPageSink
         return new WriteContext(writer, outputPath, partitionData);
     }
 
-    private Optional<PartitionData> getPartitionData(List<PartitionColumn> columns, Page page, int position)
+    private Optional<PartitionData> getPartitionData(List<PartitionColumn> columns, Page transformedPage, int position)
     {
         if (columns.isEmpty()) {
             return Optional.empty();
@@ -324,19 +334,11 @@ public class IcebergPageSink
         Object[] values = new Object[columns.size()];
         for (int i = 0; i < columns.size(); i++) {
             PartitionColumn column = columns.get(i);
-            Block block = page.getBlock(column.getSourceChannel());
-            Type type = column.getSourceType();
-            org.apache.iceberg.types.Type icebergType = outputSchema.findType(column.getField().sourceId());
-            Object value = getIcebergValue(block, position, type);
-            values[i] = applyTransform(column.getField().transform(), icebergType, value);
+            Block block = transformedPage.getBlock(i);
+            Type type = column.getResultType();
+            values[i] = getIcebergValue(block, position, type);
         }
         return Optional.of(new PartitionData(values));
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Object applyTransform(Transform<?, ?> transform, org.apache.iceberg.types.Type icebergType, Object value)
-    {
-        return ((Transform<Object, Object>) transform).bind(icebergType).apply(value);
     }
 
     public static Object getIcebergValue(Block block, int position, Type type)
@@ -377,6 +379,23 @@ public class IcebergPageSink
             return MILLISECONDS.toMicros(time);
         }
         throw new UnsupportedOperationException("Type not supported as partition column: " + type.getDisplayName());
+    }
+
+    private static Object adjustTimestampForPartitionTransform(SqlFunctionProperties functionProperties, Type type, Object value)
+    {
+        if (type instanceof TimestampType && functionProperties.isLegacyTimestamp()) {
+            long timestampValue = (long) value;
+            TimestampType timestampType = (TimestampType) type;
+            Instant instant = Instant.ofEpochSecond(timestampType.getPrecision().toSeconds(timestampValue),
+                    timestampType.getPrecision().toNanos(timestampValue % timestampType.getPrecision().convert(1, SECONDS)));
+            LocalDateTime localDateTime = instant
+                    .atZone(ZoneId.of(functionProperties.getTimeZoneKey().getId()))
+                    .toLocalDateTime();
+
+            return timestampType.getPrecision().convert(localDateTime.toEpochSecond(ZoneOffset.UTC), SECONDS) +
+                    timestampType.getPrecision().convert(localDateTime.getNano(), NANOSECONDS);
+        }
+        return value;
     }
 
     private static List<PartitionColumn> toPartitionColumns(List<IcebergColumnHandle> handles, PartitionSpec partitionSpec)
@@ -430,13 +449,18 @@ public class IcebergPageSink
     {
         private final PageIndexer pageIndexer;
         private final List<PartitionColumn> columns;
+        private final ConnectorSession session;
+        private Page transformedPage;
 
-        public PagePartitioner(PageIndexerFactory pageIndexerFactory, List<PartitionColumn> columns)
+        public PagePartitioner(PageIndexerFactory pageIndexerFactory,
+                               List<PartitionColumn> columns,
+                               ConnectorSession session)
         {
             this.pageIndexer = pageIndexerFactory.createPageIndexer(columns.stream()
                     .map(PartitionColumn::getResultType)
                     .collect(toImmutableList()));
             this.columns = ImmutableList.copyOf(columns);
+            this.session = session;
         }
 
         public int[] partitionPage(Page page)
@@ -444,12 +468,17 @@ public class IcebergPageSink
             Block[] blocks = new Block[columns.size()];
             for (int i = 0; i < columns.size(); i++) {
                 PartitionColumn column = columns.get(i);
-                Block block = page.getBlock(column.getSourceChannel());
+                Block block = adjustBlockIfNecessary(column, page.getBlock(column.getSourceChannel()));
                 blocks[i] = column.getBlockTransform().apply(block);
             }
-            Page transformed = new Page(page.getPositionCount(), blocks);
+            this.transformedPage = new Page(page.getPositionCount(), blocks);
 
-            return pageIndexer.indexPage(transformed);
+            return pageIndexer.indexPage(transformedPage);
+        }
+
+        public Page getTransformedPage()
+        {
+            return this.transformedPage;
         }
 
         public int getMaxIndex()
@@ -460,6 +489,29 @@ public class IcebergPageSink
         public List<PartitionColumn> getColumns()
         {
             return columns;
+        }
+
+        private Block adjustBlockIfNecessary(PartitionColumn column, Block block)
+        {
+            // adjust legacy timestamp value to compatible with Iceberg non-identity transform calculation
+            if (column.sourceType instanceof TimestampType && session.getSqlFunctionProperties().isLegacyTimestamp() && !column.getField().transform().isIdentity()) {
+                TimestampType timestampType = (TimestampType) column.sourceType;
+                BlockBuilder blockBuilder = timestampType.createBlockBuilder(null, block.getPositionCount());
+                for (int t = 0; t < block.getPositionCount(); t++) {
+                    if (block.isNull(t)) {
+                        blockBuilder.appendNull();
+                    }
+                    else {
+                        long adjustedTimestampValue = (long) adjustTimestampForPartitionTransform(
+                                session.getSqlFunctionProperties(),
+                                timestampType,
+                                timestampType.getLong(block, t));
+                        timestampType.writeLong(blockBuilder, adjustedTimestampValue);
+                    }
+                }
+                return blockBuilder.build();
+            }
+            return block;
         }
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.Session.SessionBuilder;
+import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
@@ -25,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.UpdateProperties;
 import org.intellij.lang.annotations.Language;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.nio.file.Path;
@@ -32,6 +35,7 @@ import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.facebook.presto.SystemSessionProperties.LEGACY_TIMESTAMP;
 import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
@@ -1220,84 +1224,110 @@ public class IcebergDistributedSmokeTestBase
         dropTable(session, tableName);
     }
 
-    @Test
-    public void testTimestampPartitionedByYear()
+    @DataProvider(name = "timezones")
+    public Object[][] timezones()
     {
-        Session session = Session.builder(getSession())
-                .setTimeZoneKey(UTC_KEY)
-                .build();
+        return new Object[][] {
+                {"UTC", true},
+                {"America/Los_Angeles", true},
+                {"Asia/Shanghai", true},
+                {"None", false}};
+    }
+
+    @Test(dataProvider = "timezones")
+    public void testTimestampPartitionedByYear(String zoneId, boolean legacyTimestamp)
+    {
+        Session session = sessionForTimezone(zoneId, legacyTimestamp);
         String tableName = "test_timestamp_partitioned_by_year";
 
-        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['year(c2)'])");
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 00:00:00.000')", 1);
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1980-01-01 12:10:31.315'), (4, timestamp '1990-01-01 12:10:31.315')", 2);
+        try {
+            assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['year(c2)'])");
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 00:00:00.000')", 1);
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1980-01-01 12:10:31.315'), (4, timestamp '1990-01-01 12:10:31.315')", 2);
 
-        assertQuery(session, "SELECT c2_year, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_year",
-                "VALUES (10, 1, 1), (20, 1, 1), (52, 1, 1), (53, 1, 1)");
-        assertQuery(session, "SELECT * FROM " + tableName + " WHERE year(c2) = 2023", "VALUES (2, '2023-11-02 12:10:31.315')");
-
-        dropTable(session, tableName);
+            assertQuery(session, "SELECT c2_year, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_year",
+                    "VALUES (10, 1, 1), (20, 1, 1), (52, 1, 1), (53, 1, 1)");
+            assertQuery(session, "SELECT * FROM " + tableName + " WHERE year(c2) = 2023", "VALUES (2, '2023-11-02 12:10:31.315')");
+        }
+        finally {
+            dropTable(session, tableName);
+        }
     }
 
-    @Test
-    public void testTimestampPartitionedByMonth()
+    @Test(dataProvider = "timezones")
+    public void testTimestampPartitionedByMonth(String zoneId, boolean legacyTimestamp)
     {
-        Session session = Session.builder(getSession())
-                .setTimeZoneKey(UTC_KEY)
-                .build();
+        Session session = sessionForTimezone(zoneId, legacyTimestamp);
         String tableName = "test_timestamp_partitioned_by_month";
 
-        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['month(c2)'])");
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 00:00:00.000')", 1);
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1970-02-02 12:10:31.315'), (4, timestamp '1971-01-02 12:10:31.315')", 2);
+        try {
+            assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['month(c2)'])");
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 00:00:00.000')", 1);
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1970-02-02 12:10:31.315'), (4, timestamp '1971-01-02 12:10:31.315')", 2);
 
-        assertQuery(session, "SELECT c2_month, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_month",
-                "VALUES (1, 1, 1), (12, 1, 1), (633, 1, 1), (646, 1, 1)");
-        assertQuery(session, "SELECT * FROM " + tableName + " WHERE month(c2) = 11", "VALUES (2, '2023-11-02 12:10:31.315')");
-
-        dropTable(session, tableName);
+            assertQuery(session, "SELECT c2_month, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_month",
+                    "VALUES (1, 1, 1), (12, 1, 1), (633, 1, 1), (646, 1, 1)");
+            assertQuery(session, "SELECT * FROM " + tableName + " WHERE month(c2) = 11", "VALUES (2, '2023-11-02 12:10:31.315')");
+        }
+        finally {
+            dropTable(session, tableName);
+        }
     }
 
-    @Test
-    public void testTimestampPartitionedByDay()
+    @Test(dataProvider = "timezones")
+    public void testTimestampPartitionedByDay(String zoneId, boolean legacyTimestamp)
     {
-        Session session = Session.builder(getSession())
-                .setTimeZoneKey(UTC_KEY)
-                .build();
+        Session session = sessionForTimezone(zoneId, legacyTimestamp);
         String tableName = "test_timestamp_partitioned_by_day";
 
-        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['day(c2)'])");
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 00:00:00.000')", 1);
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1970-01-05 00:00:00.000'), (4, timestamp '1971-01-10 12:10:31.315')", 2);
+        try {
+            assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['day(c2)'])");
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 00:00:00.000')", 1);
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1970-01-05 00:00:00.000'), (4, timestamp '1971-01-10 12:10:31.315')", 2);
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (5, TIMESTAMP '1969-12-30 18:47:33.345')," +
+                    " (6, TIMESTAMP '1969-12-31 00:00:00.000')," +
+                    " (7, TIMESTAMP '1969-12-31 05:06:07.234')", 3);
 
-        assertQuery(session, "SELECT c2_day, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_day",
-                "VALUES ('1970-01-05', 1, 1), ('1971-01-10', 1, 1), ('2022-10-01', 1, 1), ('2023-11-02', 1, 1)");
-        assertQuery(session, "SELECT * FROM " + tableName + " WHERE day(c2) = 2", "VALUES (2, '2023-11-02 12:10:31.315')");
+            assertQuery(session, "SELECT c2_day, row_count, file_count, c2.min, c2.max FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_day",
+                    "VALUES ('1970-01-05', 1, 1, timestamp '1970-01-05 00:00:00.000', timestamp '1970-01-05 00:00:00.000'), " +
+                            "('1971-01-10', 1, 1, timestamp '1971-01-10 12:10:31.315', timestamp '1971-01-10 12:10:31.315'), " +
+                            "('2022-10-01', 1, 1, timestamp '2022-10-01 00:00:00.000', timestamp '2022-10-01 00:00:00.000'), " +
+                            "('1969-12-30', 1, 1, timestamp '1969-12-30 18:47:33.345', timestamp '1969-12-30 18:47:33.345'), " +
+                            "('1969-12-31', 2, 1, timestamp '1969-12-31 00:00:00.000', timestamp '1969-12-31 05:06:07.234'), " +
+                            "('2023-11-02', 1, 1, timestamp '2023-11-02 12:10:31.315', timestamp '2023-11-02 12:10:31.315')");
+            assertQuery(session, "SELECT * FROM " + tableName + " WHERE day(c2) = 2", "VALUES (2, '2023-11-02 12:10:31.315')");
 
-        dropTable(session, tableName);
+            assertQuery(session,
+                    "SELECT * FROM " + tableName + " WHERE c2 = TIMESTAMP '1969-12-31 05:06:07.234'",
+                    "VALUES (7, TIMESTAMP '1969-12-31 05:06:07.234')");
+        }
+        finally {
+            dropTable(session, tableName);
+        }
     }
 
-    @Test
-    public void testTimestampPartitionedByHour()
+    @Test(dataProvider = "timezones")
+    public void testTimestampPartitionedByHour(String zoneId, boolean legacyTimestamp)
     {
-        Session session = Session.builder(getSession())
-                .setTimeZoneKey(UTC_KEY)
-                .build();
+        Session session = sessionForTimezone(zoneId, legacyTimestamp);
         String tableName = "test_timestamp_partitioned_by_hour";
 
-        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['hour(c2)'])");
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 10:00:00.000')", 1);
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
-        assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1970-01-01 10:10:31.315'), (4, timestamp '1970-01-02 10:10:31.315')", 2);
+        try {
+            assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 timestamp) WITH(partitioning = ARRAY['hour(c2)'])");
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (1, timestamp '2022-10-01 10:00:00.000')", 1);
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (2, timestamp '2023-11-02 12:10:31.315')", 1);
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES (3, timestamp '1970-01-01 10:10:31.315'), (4, timestamp '1970-01-02 10:10:31.315')", 2);
 
-        assertQuery(session, "SELECT c2_hour, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_hour",
-                "VALUES (10, 1, 1), (34, 1, 1), (462394, 1, 1), (471924, 1, 1)");
-        assertQuery(session, "SELECT * FROM " + tableName + " WHERE hour(c2) = 12", "VALUES (2, '2023-11-02 12:10:31.315')");
-
-        dropTable(session, tableName);
+            assertQuery(session, "SELECT c2_hour, row_count, file_count FROM " + "\"" + tableName + "$partitions\" ORDER BY c2_hour",
+                    "VALUES (10, 1, 1), (34, 1, 1), (462394, 1, 1), (471924, 1, 1)");
+            assertQuery(session, "SELECT * FROM " + tableName + " WHERE hour(c2) = 12", "VALUES (2, '2023-11-02 12:10:31.315')");
+        }
+        finally {
+            dropTable(session, tableName);
+        }
     }
 
     @Test
@@ -1523,5 +1553,15 @@ public class IcebergDistributedSmokeTestBase
         assertQueryFails(session, "DELETE FROM " + tableName + " WHERE value = 1", errorMessage);
 
         dropTable(session, tableName);
+    }
+
+    private Session sessionForTimezone(String zoneId, boolean legacyTimestamp)
+    {
+        SessionBuilder sessionBuilder = Session.builder(getSession())
+                .setSystemProperty(LEGACY_TIMESTAMP, String.valueOf(legacyTimestamp));
+        if (legacyTimestamp) {
+            sessionBuilder.setTimeZoneKey(TimeZoneKey.getTimeZoneKey(zoneId));
+        }
+        return sessionBuilder.build();
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1303,6 +1303,10 @@ public class IcebergDistributedSmokeTestBase
             assertQuery(session,
                     "SELECT * FROM " + tableName + " WHERE c2 = TIMESTAMP '1969-12-31 05:06:07.234'",
                     "VALUES (7, TIMESTAMP '1969-12-31 05:06:07.234')");
+
+            assertQuery(session,
+                    "SELECT * FROM " + tableName + " WHERE CAST(c2 as DATE) = DATE '1969-12-31'",
+                    "VALUES (6, TIMESTAMP '1969-12-31 00:00:00.000'), (7, TIMESTAMP '1969-12-31 05:06:07.234')");
         }
         finally {
             dropTable(session, tableName);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -14,10 +14,12 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.Session.SessionBuilder;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.hive.HdfsConfiguration;
 import com.facebook.presto.hive.HdfsConfigurationInitializer;
 import com.facebook.presto.hive.HdfsContext;
@@ -87,6 +89,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.SystemSessionProperties.LEGACY_TIMESTAMP;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
@@ -470,41 +473,56 @@ public class IcebergDistributedTestBase
         assertEquals(actual, expectedParametrizedVarchar);
     }
 
-    @Test
-    public void testPartitionedByTimestampType()
+    @DataProvider(name = "timezones")
+    public Object[][] timezones()
     {
-        // create iceberg table partitioned by column of TimestampType, and insert some data
-        assertQuerySucceeds("create table test_partition_columns(a bigint, b timestamp) with (partitioning = ARRAY['b'])");
-        assertQuerySucceeds("insert into test_partition_columns values(1, timestamp '1984-12-08 00:10:00'), (2, timestamp '2001-01-08 12:01:01')");
+        return new Object[][] {
+                {"UTC", true},
+                {"America/Los_Angeles", true},
+                {"Asia/Shanghai", true},
+                {"None", false}};
+    }
 
-        // validate return data of TimestampType
-        List<Object> timestampColumnDatas = getQueryRunner().execute("select b from test_partition_columns order by a asc").getOnlyColumn().collect(Collectors.toList());
-        assertEquals(timestampColumnDatas.size(), 2);
-        assertEquals(timestampColumnDatas.get(0), LocalDateTime.parse("1984-12-08 00:10:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-        assertEquals(timestampColumnDatas.get(1), LocalDateTime.parse("2001-01-08 12:01:01", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+    @Test(dataProvider = "timezones")
+    public void testPartitionedByTimestampType(String zoneId, boolean legacyTimestamp)
+    {
+        Session session = sessionForTimezone(zoneId, legacyTimestamp);
 
-        // validate column of TimestampType exists in query filter
-        assertEquals(getQueryRunner().execute("select b from test_partition_columns where b = timestamp '1984-12-08 00:10:00'").getOnlyValue(),
-                LocalDateTime.parse("1984-12-08 00:10:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-        assertEquals(getQueryRunner().execute("select b from test_partition_columns where b = timestamp '2001-01-08 12:01:01'").getOnlyValue(),
-                LocalDateTime.parse("2001-01-08 12:01:01", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        try {
+            // create iceberg table partitioned by column of TimestampType, and insert some data
+            assertQuerySucceeds(session, "create table test_partition_columns(a bigint, b timestamp) with (partitioning = ARRAY['b'])");
+            assertQuerySucceeds(session, "insert into test_partition_columns values(1, timestamp '1984-12-08 00:10:00'), (2, timestamp '2001-01-08 12:01:01')");
 
-        // validate column of TimestampType in system table "partitions"
-        assertEquals(getQueryRunner().execute("select count(*) FROM \"test_partition_columns$partitions\"").getOnlyValue(), 2L);
-        assertEquals(getQueryRunner().execute("select row_count from \"test_partition_columns$partitions\" where b = timestamp '1984-12-08 00:10:00'").getOnlyValue(), 1L);
-        assertEquals(getQueryRunner().execute("select row_count from \"test_partition_columns$partitions\" where b = timestamp '2001-01-08 12:01:01'").getOnlyValue(), 1L);
+            // validate return data of TimestampType
+            List<Object> timestampColumnDatas = getQueryRunner().execute(session, "select b from test_partition_columns order by a asc").getOnlyColumn().collect(Collectors.toList());
+            assertEquals(timestampColumnDatas.size(), 2);
+            assertEquals(timestampColumnDatas.get(0), LocalDateTime.parse("1984-12-08 00:10:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+            assertEquals(timestampColumnDatas.get(1), LocalDateTime.parse("2001-01-08 12:01:01", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
 
-        // validate column of TimestampType exists in delete filter
-        assertUpdate("delete from test_partition_columns WHERE b = timestamp '2001-01-08 12:01:01'", 1);
-        timestampColumnDatas = getQueryRunner().execute("select b from test_partition_columns order by a asc").getOnlyColumn().collect(Collectors.toList());
-        assertEquals(timestampColumnDatas.size(), 1);
-        assertEquals(timestampColumnDatas.get(0), LocalDateTime.parse("1984-12-08 00:10:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-        assertEquals(getQueryRunner().execute("select b FROM test_partition_columns where b = timestamp '1984-12-08 00:10:00'").getOnlyValue(),
-                LocalDateTime.parse("1984-12-08 00:10:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-        assertEquals(getQueryRunner().execute("select count(*) from \"test_partition_columns$partitions\"").getOnlyValue(), 1L);
-        assertEquals(getQueryRunner().execute("select row_count from \"test_partition_columns$partitions\" where b = timestamp '1984-12-08 00:10:00'").getOnlyValue(), 1L);
+            // validate column of TimestampType exists in query filter
+            assertEquals(getQueryRunner().execute(session, "select b from test_partition_columns where b = timestamp '1984-12-08 00:10:00'").getOnlyValue(),
+                    LocalDateTime.parse("1984-12-08 00:10:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+            assertEquals(getQueryRunner().execute(session, "select b from test_partition_columns where b = timestamp '2001-01-08 12:01:01'").getOnlyValue(),
+                    LocalDateTime.parse("2001-01-08 12:01:01", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
 
-        assertQuerySucceeds("drop table test_partition_columns");
+            // validate column of TimestampType in system table "partitions"
+            assertEquals(getQueryRunner().execute(session, "select count(*) FROM \"test_partition_columns$partitions\"").getOnlyValue(), 2L);
+            assertEquals(getQueryRunner().execute(session, "select row_count from \"test_partition_columns$partitions\" where b = timestamp '1984-12-08 00:10:00'").getOnlyValue(), 1L);
+            assertEquals(getQueryRunner().execute(session, "select row_count from \"test_partition_columns$partitions\" where b = timestamp '2001-01-08 12:01:01'").getOnlyValue(), 1L);
+
+            // validate column of TimestampType exists in delete filter
+            assertUpdate(session, "delete from test_partition_columns WHERE b = timestamp '2001-01-08 12:01:01'", 1);
+            timestampColumnDatas = getQueryRunner().execute(session, "select b from test_partition_columns order by a asc").getOnlyColumn().collect(Collectors.toList());
+            assertEquals(timestampColumnDatas.size(), 1);
+            assertEquals(timestampColumnDatas.get(0), LocalDateTime.parse("1984-12-08 00:10:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+            assertEquals(getQueryRunner().execute(session, "select b FROM test_partition_columns where b = timestamp '1984-12-08 00:10:00'").getOnlyValue(),
+                    LocalDateTime.parse("1984-12-08 00:10:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+            assertEquals(getQueryRunner().execute(session, "select count(*) from \"test_partition_columns$partitions\"").getOnlyValue(), 1L);
+            assertEquals(getQueryRunner().execute(session, "select row_count from \"test_partition_columns$partitions\" where b = timestamp '1984-12-08 00:10:00'").getOnlyValue(), 1L);
+        }
+        finally {
+            assertQuerySucceeds(session, "drop table test_partition_columns");
+        }
     }
 
     @Test
@@ -1207,5 +1225,15 @@ public class IcebergDistributedTestBase
         }
 
         throw new PrestoException(NOT_SUPPORTED, "Unsupported Presto Iceberg catalog type " + catalogType);
+    }
+
+    private Session sessionForTimezone(String zoneId, boolean legacyTimestamp)
+    {
+        SessionBuilder sessionBuilder = Session.builder(getSession())
+                .setSystemProperty(LEGACY_TIMESTAMP, String.valueOf(legacyTimestamp));
+        if (legacyTimestamp) {
+            sessionBuilder.setTimeZoneKey(TimeZoneKey.getTimeZoneKey(zoneId));
+        }
+        return sessionBuilder.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
@@ -54,9 +54,12 @@ import static com.facebook.presto.util.DateTimeUtils.printTimestampWithoutTimeZo
 import static com.facebook.presto.util.DateTimeZoneIndex.getChronology;
 import static io.airlift.slice.SliceUtf8.trim;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Math.floorDiv;
 
 public final class TimestampOperators
 {
+    public static final int MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
+    public static final int MILLISECONDS_PER_DAY = MILLISECONDS_PER_HOUR * 24;
     private TimestampOperators()
     {
     }
@@ -134,7 +137,7 @@ public final class TimestampOperators
             long millis = date + chronology.getZone().getOffset(date);
             return TimeUnit.MILLISECONDS.toDays(millis);
         }
-        return TimeUnit.MILLISECONDS.toDays(value);
+        return floorDiv(value, MILLISECONDS_PER_DAY);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestamp.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestamp.java
@@ -13,10 +13,12 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.common.type.SqlDate;
 import org.testng.annotations.Test;
 
 import java.time.LocalDateTime;
 
+import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
 
@@ -80,5 +82,25 @@ public class TestTimestamp
                 "cast('2001-1-22 Asia/Oral' as timestamp)",
                 TIMESTAMP,
                 sqlTimestampOf(LocalDateTime.of(2001, 1, 22, 0, 0, 0)));
+    }
+
+    @Test
+    public void testCastFromTimestampToDate()
+    {
+        assertFunction("cast(timestamp '1970-01-01 00:00:00.000' as date)",
+                DATE,
+                new SqlDate(0));
+
+        assertFunction("cast(timestamp '1970-01-01 05:06:07.234' as date)",
+                DATE,
+                new SqlDate(0));
+
+        assertFunction("cast(TIMESTAMP '1969-12-31 00:00:00.000' as date)",
+                DATE,
+                new SqlDate(-1));
+
+        assertFunction("cast(timestamp '1969-12-31 05:06:07.234' as date)",
+                DATE,
+                new SqlDate(-1));
     }
 }


### PR DESCRIPTION
## Description

When we create partitions on TimestampType columns(using year/month/day/hour transform) in Iceberg, we will meet various problems because of the legacy timestamp logic in presto engine do not match the logic used in Iceberg transform calculation. See issue: #7122 .

This PR fix the problems, and correct the behaviors for both legacy and non-legacy timestamp.

## Test Plan

 - Test year/month/day/hour transform on TimestampType column for various time zones in legacy timestamp mode
 - Test year/month/day/hour transform on TimestampType column in non-legacy timestamp mode

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Changes
* Support year/month/day/hour transforms both on legacy and non-legacy TimestampType column
* Fix the bug that `CAST` from non-legacy timestamp to date rounding to future when the timestamp is prior than `1970-01-01 00:00:00.000`
```

