### PR TITLE
[native] Add support for optional velox.properties file

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -152,8 +152,9 @@ void PrestoServer::run() {
         fmt::format("{}/config.properties", configDirectoryPath_));
     nodeConfig->initialize(
         fmt::format("{}/node.properties", configDirectoryPath_));
+    // velox.properties is optional.
     baseVeloxQueryConfig->initialize(
-        fmt::format("{}/velox.properties", configDirectoryPath_));
+        fmt::format("{}/velox.properties", configDirectoryPath_), true);
 
     if (systemConfig->enableRuntimeMetricsCollection()) {
       enableRuntimeMetricReporting();

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -47,9 +47,14 @@ std::string bool2String(bool value) {
 ConfigBase::ConfigBase()
     : config_(std::make_unique<velox::core::MemConfig>()) {}
 
-void ConfigBase::initialize(const std::string& filePath) {
-  // See if we want to create a mutable config.
-  auto values = util::readConfig(fs::path(filePath));
+void ConfigBase::initialize(const std::string& filePath, bool optionalConfig) {
+  auto path = fs::path(filePath);
+  std::unordered_map<std::string, std::string> values;
+  if (!optionalConfig || fs::exists(path)) {
+    // See if we want to create a mutable config.
+    values = util::readConfig(path);
+  }
+
   filePath_ = filePath;
   checkRegisteredProperties(values);
   updateLoadedValues(values);

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -29,7 +29,8 @@ class ConfigBase {
   /// Reads configuration properties from the specified file. Must be called
   /// before calling any of the getters below.
   /// @param filePath Path to configuration file.
-  void initialize(const std::string& filePath);
+  /// @param optionalConfig Specify if the configuration file is optional.
+  void initialize(const std::string& filePath, bool optionalConfig = false);
 
   /// Allows individual config to manipulate just-loaded-from-file key-value map
   /// before it is used to initialize the config.


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Velox config has no required fields and therefore velox.properties should be optional.
From a Presto user perspective, existing config files (config.properties, node.properties)
for Java should work for Prestissimo as well.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Make Prestissimo config aligned to Presto Java

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
velox.properties is now optional.

## Test Plan
<!---Please fill in how you tested your change-->
Tested locally.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== NO RELEASE NOTE ==
```

