### PR TITLE
[native] Propagate task.max-partial-aggregation-memory to Velox.

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -148,6 +148,7 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kDiscoveryUri),
           NUM_PROP(kMaxDriversPerTask, 16),
           NUM_PROP(kConcurrentLifespansPerTask, 1),
+          STR_PROP(kTaskMaxPartialAggregationMemory, "16MB"),
           NUM_PROP(kHttpServerNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kHttpServerNumCpuThreadsHwMultiplier, 1.0),
           NONE_PROP(kHttpServerHttpsPort),
@@ -765,6 +766,9 @@ void BaseVeloxQueryConfig::updateLoadedValues(
       {QueryConfig::kMaxPartitionedOutputBufferSize,
        systemConfig->capacityPropertyAsBytesString(
            SystemConfig::kDriverMaxPagePartitioningBufferSize)},
+      {QueryConfig::kMaxPartialAggregationMemory,
+       systemConfig->capacityPropertyAsBytesString(
+           SystemConfig::kTaskMaxPartialAggregationMemory)},
   };
 
   std::stringstream updated;

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -180,6 +180,8 @@ class SystemConfig : public ConfigBase {
       "task.max-drivers-per-task"};
   static constexpr std::string_view kConcurrentLifespansPerTask{
       "task.concurrent-lifespans-per-task"};
+  static constexpr std::string_view kTaskMaxPartialAggregationMemory{
+      "task.max-partial-aggregation-memory"};
 
   /// Floating point number used in calculating how many threads we would use
   /// for HTTP IO executor: hw_concurrency x multiplier. 1.0 is default.


### PR DESCRIPTION
Propagate 'task.max-partial-aggregation-memory' config property to Velox's 'max_partial_aggregation_memory' query property.

```
== NO RELEASE NOTE ==
```

