### PR TITLE
Fix incorrect result due to different column order in equality delete filter in Iceberg

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/EqualityDeleteFilter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/EqualityDeleteFilter.java
@@ -19,15 +19,12 @@ import com.facebook.presto.iceberg.IcebergColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
-import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.StructLikeSet;
 import org.apache.iceberg.util.StructProjection;
 
 import java.util.List;
-import java.util.Set;
 
 import static com.facebook.presto.iceberg.IcebergUtil.schemaFromHandles;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 public final class EqualityDeleteFilter
@@ -60,15 +57,11 @@ public final class EqualityDeleteFilter
 
     public static DeleteFilter readEqualityDeletes(ConnectorPageSource pageSource, List<IcebergColumnHandle> columns, Schema tableSchema)
     {
-        Set<Integer> ids = columns.stream()
-                .map(IcebergColumnHandle::getId)
-                .collect(toImmutableSet());
-
         Type[] types = columns.stream()
                 .map(IcebergColumnHandle::getType)
                 .toArray(Type[]::new);
 
-        Schema deleteSchema = TypeUtil.select(tableSchema, ids);
+        Schema deleteSchema = schemaFromHandles(columns);
         StructLikeSet deleteSet = StructLikeSet.create(deleteSchema.asStruct());
 
         while (!pageSource.isFinished()) {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -901,6 +901,22 @@ public class IcebergDistributedTestBase
     }
 
     @Test(dataProvider = "equalityDeleteOptions")
+    public void testTableWithEqualityDeleteDifferentColumnOrder(String fileFormat, boolean joinRewriteEnabled)
+            throws Exception
+    {
+        Session session = deleteAsJoinEnabled(joinRewriteEnabled);
+        // Specify equality delete filter with different column order from table definition
+        String tableName = "test_v2_equality_delete_different_order" + randomTableSuffix();
+        assertUpdate(session, "CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
+        Table icebergTable = updateTable(tableName);
+
+        writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L, "name", "ARGENTINA"));
+        assertQuery(session, "SELECT * FROM " + tableName, "SELECT * FROM nation WHERE name != 'ARGENTINA'");
+        // natiokey is before the equality delete column in the table schema, comment is after
+        assertQuery(session, "SELECT nationkey, comment FROM " + tableName, "SELECT nationkey, comment FROM nation WHERE name != 'ARGENTINA'");
+    }
+
+    @Test(dataProvider = "equalityDeleteOptions")
     public void testTableWithPositionDeleteAndEqualityDelete(String fileFormat, boolean joinRewriteEnabled)
             throws Exception
     {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Recently, we found that there were some incorrect results in reading tables with equality delete files through presto. We investigated this problem and found that it was caused by different column order in `EqualityDeleteFilter`.

When we were ready to fix this problem, we found that trino's https://github.com/trinodb/trino/pull/14813 had already solved this problem. We merged this MR into the internal branch and the problem was solved.

Cherry-pick of https://github.com/trinodb/trino/pull/14813.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Changes
* Fix incorrect result due to different column order in equality delete filter in Iceberg
```


CC: @tdcmeehan @yingsu00 
