### PR TITLE
[native] Fix setup-centos.sh to include Velox dependencies

### DIFF
--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -23,17 +23,6 @@ export CXX=/opt/rh/gcc-toolset-9/root/bin/g++
 dnf install -y maven java python3-devel clang-tools-extra jq perl-XML-XPath
 python3 -m pip install regex pyyaml chevron black
 
-function install_gperf {
-  wget_and_untar http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz gperf
-  (
-   cd gperf &&
-   ./configure --prefix=/usr/local/gperf/3_1 &&
-   make "-j$(nproc)" &&
-   make install &&
-   ln -s /usr/local/gperf/3_1/bin/gperf /usr/local/bin/
-  )
-}
-
 function install_proxygen {
   github_checkout facebook/proxygen "${FB_OS_VERSION}"
   cmake_install -DBUILD_TESTS=OFF
@@ -42,7 +31,6 @@ function install_proxygen {
 function install_presto_deps {
   install_velox_deps
   run_and_time install_proxygen
-  run_and_time install_gperf
 }
 
 if [[ $# -ne 0 ]]; then

--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -16,9 +16,7 @@ set -eufx -o pipefail
 # Run the velox setup script first.
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-macos.sh"
 
-MACOS_DEPS="${MACOS_DEPS} bison"
 export FB_OS_VERSION=v2023.12.04.00
-
 export PATH=$(brew --prefix bison)/bin:$PATH
 
 function install_proxygen {

--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -16,7 +16,7 @@ set -eufx -o pipefail
 # Run the velox setup script first.
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-macos.sh"
 
-MACOS_DEPS="${MACOS_DEPS} bison gperf"
+MACOS_DEPS="${MACOS_DEPS} bison"
 export FB_OS_VERSION=v2023.12.04.00
 
 export PATH=$(brew --prefix bison)/bin:$PATH

--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -19,7 +19,6 @@ set -eufx -o pipefail
 # Run the velox setup script first.
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-ubuntu.sh"
 export FB_OS_VERSION=v2023.12.04.00
-sudo apt install -y gperf
 
 function install_proxygen {
   github_checkout facebook/proxygen "${FB_OS_VERSION}"


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Improve Centos setup script to install velox dependencies.
Remove bison from macos setup script.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

