### PR TITLE
[native] Support reading Iceberg V2 tables with Position deletes

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(
   velox_functions_lib
   velox_functions_prestosql
   velox_hive_connector
+  velox_hive_iceberg_splitreader
   velox_hive_partition_function
   velox_presto_serializer
   velox_serialization

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxSplit.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxSplit.cpp
@@ -14,6 +14,8 @@
 #include "presto_cpp/main/types/PrestoToVeloxSplit.h"
 #include <optional>
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/tpch/TpchConnectorSplit.h"
 #include "velox/exec/Exchange.h"
 
@@ -52,6 +54,16 @@ dwio::common::FileFormat toVeloxFileFormat(
     return dwio::common::FileFormat::PARQUET;
   }
   VELOX_UNSUPPORTED("Unsupported file format: {}", fmt::underlying(format));
+}
+
+velox::connector::hive::iceberg::FileContent toVeloxFileContent(
+    const presto::protocol::FileContent content) {
+  if (content == protocol::FileContent::DATA) {
+    return velox::connector::hive::iceberg::FileContent::kData;
+  } else if (content == protocol::FileContent::POSITION_DELETES) {
+    return velox::connector::hive::iceberg::FileContent::kPositionalDeletes;
+  }
+  VELOX_UNSUPPORTED("Unsupported file content: {}", fmt::underlying(content));
 }
 
 } // anonymous namespace
@@ -114,14 +126,43 @@ velox::exec::Split toVeloxSplit(
               : std::optional<std::string>{*entry.second.value});
     }
 
+    std::unordered_map<std::string, std::string> customSplitInfo;
+    customSplitInfo["table_format"] = "hive-iceberg";
+
+    std::vector<velox::connector::hive::iceberg::IcebergDeleteFile> deletes;
+    deletes.reserve(icebergSplit->deletes.size());
+    for (const auto& deleteFile : icebergSplit->deletes) {
+      std::unordered_map<int32_t, std::string> lowerBounds(
+          deleteFile.lowerBounds.begin(), deleteFile.lowerBounds.end());
+
+      std::unordered_map<int32_t, std::string> upperBounds(
+          deleteFile.upperBounds.begin(), deleteFile.upperBounds.end());
+
+      velox::connector::hive::iceberg::IcebergDeleteFile icebergDeleteFile(
+          toVeloxFileContent(deleteFile.content),
+          deleteFile.path,
+          toVeloxFileFormat(deleteFile.format),
+          deleteFile.recordCount,
+          deleteFile.fileSizeInBytes,
+          std::vector(deleteFile.equalityFieldIds),
+          lowerBounds,
+          upperBounds);
+
+      deletes.emplace_back(icebergDeleteFile);
+    }
+
     return velox::exec::Split(
-        std::make_shared<connector::hive::HiveConnectorSplit>(
+        std::make_shared<connector::hive::iceberg::HiveIcebergSplit>(
             scheduledSplit.split.connectorId,
             icebergSplit->path,
             toVeloxFileFormat(icebergSplit->fileFormat),
             icebergSplit->start,
             icebergSplit->length,
-            partitionKeys),
+            partitionKeys,
+            std::nullopt,
+            customSplitInfo,
+            nullptr,
+            deletes),
         splitGroupId);
   }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This PR adds support for reading Iceberg V2 tables with Position Deletes. An unsupported exception will be thrown if the table contains Equality Deletes

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
https://github.com/facebookincubator/velox/pull/7847

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
With this change, users will be able to read a subset of Iceberg V2 Tables, i.e. tables with position deletes. 

## Test Plan
<!---Please fill in how you tested your change-->
Tested manually by creating Iceberg V2 tables with multiple Position Deletes.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add support to read Iceberg V2 tables with Position Deletes 

```

