### PR TITLE
[docs] document Prestissimo reduce_agg behavior

### DIFF
--- a/presto-docs/src/main/sphinx/prestissimo.rst
+++ b/presto-docs/src/main/sphinx/prestissimo.rst
@@ -21,3 +21,4 @@ Prestissimo's codebase is located at `presto-native-execution
     :maxdepth: 1
 
     prestissimo/prestissimo-features
+    prestissimo/prestissimo-limitations

--- a/presto-docs/src/main/sphinx/prestissimo/prestissimo-limitations.rst
+++ b/presto-docs/src/main/sphinx/prestissimo/prestissimo-limitations.rst
@@ -1,0 +1,19 @@
+=======================
+Prestissimo Limitations
+=======================
+
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+Functions
+=========
+
+reduce_agg
+----------
+
+In Prestissimo, ``reduce_agg`` is not permitted to return ``null`` in either the 
+``inputFunction`` or the ``combineFunction``. In Presto Java, this is permitted 
+but undefined behavior. For more information about ``reduce_agg`` in Presto, 
+see `reduce_agg <../functions/aggregate.html#reduce_agg>`_. 


### PR DESCRIPTION
## Description
Adds documentation of the behavior of reduce_agg in Prestissimo as requested in [Issue 21179](https://github.com/prestodb/presto/issues/21179). 

To contain this and future related content, this PR adds a new page "Prestissimo Limitations" to the Prestissimo Developer Guide documentation - parallel to the existing page "Prestissimo Features".
(The Prestissimo Developer Guide documentation was restructured in [PR 21953](https://github.com/prestodb/presto/pull/21953).)

My thanks to @tdcmeehan for providing the draft explanation of the behavior of reduce_agg in Prestissimo.

## Motivation and Context
Fixes [Issue 21179](https://github.com/prestodb/presto/issues/21179). 

## Impact
Documentation.

## Test Plan
Screenshots of the local build of documentation:

1) Prestissimo Developer Guide index page, showing new Limitations page link in left navbar and also in the page (center, bottom). 
<img width="1183" alt="Screenshot 2024-02-21 at 10 56 44 AM" src="https://github.com/prestodb/presto/assets/7013443/6186c400-1b31-40d9-9ab6-a14d0508a564">

2) Limitations page, showing the reduce_agg description in context. 
<img width="1197" alt="Screenshot 2024-02-21 at 10 58 11 AM" src="https://github.com/prestodb/presto/assets/7013443/e78b6a4b-02fe-44c0-9000-76cec15b0feb">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

