### PR TITLE
[docs] fix formatting of code examples in array and map functions doc

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -135,7 +135,7 @@ Array Functions
 .. function:: array_sort(x) -> array
 
     Sorts and returns the array ``x``. The elements of ``x`` must be orderable.
-    Null elements will be placed at the end of the returned array.
+    Null elements will be placed at the end of the returned array.::
 
 .. function:: array_sort(array(T), function(T,T,int)) -> array(T)
 
@@ -170,7 +170,7 @@ Array Functions
 .. function:: array_sort_desc(x) -> array
 
     Returns the ``array`` sorted in the descending order. Elements of the ``array`` must be orderable.
-    Null elements will be placed at the end of the returned array.
+    Null elements will be placed at the end of the returned array.::
 
         SELECT array_sort_desc(ARRAY [100, 1, 10, 50]); -- [100, 50, 10, 1]
         SELECT array_sort_desc(ARRAY [null, 100, null, 1, 10, 50]); -- [100, 50, 10, 1, null, null]
@@ -187,7 +187,8 @@ Array Functions
 .. function:: array_top_n(array(T), int) -> array(T)
 
     Returns an array of top n elements from a given ``array``, according to its natural descending order.
-    If n is smaller than the size of the given ``array``, the returned list will be the same size as the input instead of n.
+    If n is smaller than the size of the given ``array``, the returned list will be the same size as the input instead of n.::
+
         SELECT array_top_n(ARRAY [1, 100, 2, 5, 3], 3); -- [100, 5, 3]
         SELECT array_top_n(ARRAY [1, 100], 5); -- [100, 1]
         SELECT array_top_n(ARRAY ['a', 'zzz', 'zz', 'b', 'g', 'f'], 3); -- ['zzz', 'zz', 'g']

--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -108,7 +108,7 @@ Map Functions
     Returns top ``n`` keys in the map ``x`` by sorting its keys in descending order.
     ``n`` must be a non-negative integer.
 
-    For bottom ``n`` keys, use the function with lambda operator to perform custom sorting
+    For bottom ``n`` keys, use the function with lambda operator to perform custom sorting ::
 
         SELECT map_top_n_keys(map(ARRAY['a', 'b', 'c'], ARRAY[3, 2, 1]), 2) --- ['c', 'b']
 
@@ -124,14 +124,14 @@ Map Functions
 .. function:: map_keys_by_top_n_values(x(K,V), n) -> array(K)
 
     Returns top ``n`` keys in the map ``x`` by sorting its values in descending order. If two or more keys have equal values, the higher key takes precedence.
-    ``n`` must be a non-negative integer.
+    ``n`` must be a non-negative integer.::
 
         SELECT map_top_n_keys_by_value(map(ARRAY['a', 'b', 'c'], ARRAY[2, 1, 3]), 2) --- ['c', 'a']
 
 .. function:: map_top_n(x(K,V), n) -> map(K, V)
 
     Truncates map items. Keeps only the top N elements by value.
-    ``n`` must be a non-negative integer
+    ``n`` must be a non-negative integer.::
 
         SELECT map_top_n(map(ARRAY['a', 'b', 'c'], ARRAY[2, 3, 1]), 2) --- {'b' -> 3, 'a' -> 2}
 
@@ -148,7 +148,7 @@ Map Functions
 
     Returns top n values in the map ``x``.
     ``n`` must be a positive integer
-    For bottom ``n`` values, use the function with lambda operator to perform custom sorting
+    For bottom ``n`` values, use the function with lambda operator to perform custom sorting.::
 
         SELECT map_top_n_values(map(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]), 2) --- [3, 2]
 


### PR DESCRIPTION
## Description
Edited https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/functions/array.rst and https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/functions/map.rst to fix formatting of code examples. 

## Motivation and Context
Fixes [Issue 19329](https://github.com/prestodb/presto/issues/19329).

## Impact
Documentation.

## Test Plan
Local build of docs, edited and built until all code examples were correctly formatted. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

