### PR TITLE
Optimize repeat function by creating runlength block

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.type.DecimalParseResult;
 import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.common.type.SqlDecimal;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.SqlScalarFunction;
@@ -89,6 +90,11 @@ public abstract class AbstractTestFunctions
     {
         closeAllRuntimeException(functionAssertions);
         functionAssertions = null;
+    }
+
+    public FunctionAndTypeManager getFunctionAndTypeManager()
+    {
+        return functionAssertions.getFunctionAndTypeManager();
     }
 
     protected void assertFunction(String projection, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRepeatFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRepeatFunction.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.DriverYieldSignal;
+import com.facebook.presto.operator.project.PageProcessor;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.gen.PageFunctionCompiler;
+import com.google.common.collect.ImmutableList;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.runner.options.WarmupMode;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkRepeatFunction
+{
+    private static final int POSITIONS = 1000;
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkRepeatFunction().benchmark(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .warmupMode(WarmupMode.INDI)
+                .include(".*" + BenchmarkRepeatFunction.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS)
+    public List<Optional<Page>> benchmark(BenchmarkData data)
+    {
+        return ImmutableList.copyOf(
+                data.getPageProcessor().process(
+                        SESSION.getSqlFunctionProperties(),
+                        new DriverYieldSignal(),
+                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                        data.getPage()));
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private String name = "repeat";
+
+        @Param({"10", "100", "1000"})
+        private int repeatArgument = 100;
+
+        private Page page;
+        private PageProcessor pageProcessor;
+
+        @Setup
+        public void setup()
+        {
+            MetadataManager metadata = createTestMetadataManager();
+            ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
+
+            Type inputType = INTEGER;
+            ConstantExpression inputValue = new ConstantExpression((long) 2, inputType);
+            ConstantExpression repeatNum = new ConstantExpression((long) repeatArgument, INTEGER);
+
+            ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
+
+            FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().lookupFunction(name, fromTypes(inputType, INTEGER));
+            projectionsBuilder.add(new CallExpression(
+                    name,
+                    functionHandle,
+                    new ArrayType(inputType),
+                    ImmutableList.of(inputValue, repeatNum)));
+
+            ImmutableList<RowExpression> projections = projectionsBuilder.build();
+            pageProcessor = compiler.compilePageProcessor(SESSION.getSqlFunctionProperties(), Optional.empty(), projections).get();
+            page = new Page(10000);
+        }
+
+        public PageProcessor getPageProcessor()
+        {
+            return pageProcessor;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7463,4 +7463,11 @@ public abstract class AbstractTestQueries
                 "select cardinality(khyperloglog_agg(v1, v2)), uniqueness_distribution(khyperloglog_agg(v1, v2)) from (values (1, 1, 2, 3), (1, 1, 4, 0), (1, 2, 90, 20), (1, 2, 87, 1), (2, 1, 11, 30), (2, 1, 11, 11), " +
                         "(2, 2, 9, 1), (2, 2, 87, 2)) t(k1, k2, v1, v2)");
     }
+
+    @Test
+    public void testRepeat()
+    {
+        assertQuery("select repeat(k1, k2), repeat(k1, 5), repeat(3, k2) from (values (3, 2), (5, 4), (2, 4))t(k1, k2)",
+                "values (array[3, 3], array[3,3,3,3,3], array[3, 3]), (array[5, 5, 5, 5], array[5, 5, 5, 5, 5], array[3, 3, 3, 3]), (array[2, 2, 2, 2], array[2, 2, 2, 2, 2], array[3, 3, 3, 3])");
+    }
 }


### PR DESCRIPTION
## Description
Currently repeat function implementation is to write the result block multiple times. However this is not efficient, since the result block is a repeat of the same value multiple times, we can create a RunLengthBlock which is more efficient, both in memory and construction cost.

## Motivation and Context
To improve performance of repeat function.
Also the result block created by repeat function will have small memory size, and it will be evaluated during query compilation (otherwise it will be skipped as the result block is too big https://github.com/prestodb/presto/blob/6998a7362764a73186a13a713a651ec71314c5f7/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java#L776)


## Impact
Improve performance for repeat function. repeat(1, 1000) shows 35% performance improvement.

Current:
```
Benchmark                          (repeatArgument)  Mode  Cnt      Score       Error  Units
BenchmarkRepeatFunction.benchmark              1000  avgt   20  60774.020 ± 14228.873  ns/op
```

After optimization
```
Benchmark                          (repeatArgument)  Mode  Cnt      Score      Error  Units
BenchmarkRepeatFunction.benchmark              1000  avgt   20  39639.608 ± 8549.023  ns/op
```

## Test Plan
Add unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve repeat function to create RunLengthEncodedBlock to improve performance
```

