### PR TITLE
Update com.jayway.jsonpath:json-path from 2.6.0 to 2.9.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dep.hudi.version>0.14.0</dep.hudi.version>
         <dep.testcontainers.version>1.18.3</dep.testcontainers.version>
         <dep.docker-java.version>3.3.0</dep.docker-java.version>
-        <dep.jayway.version>2.6.0</dep.jayway.version>
+        <dep.jayway.version>2.9.0</dep.jayway.version>
         <dep.ratis.version>2.2.0</dep.ratis.version>
         <!--
           America/Bahia_Banderas has:


### PR DESCRIPTION

## Description
There are several required fixes between 2.6.0 to  2.9.0.

There is a fix for for CVE-2023-51074.

Refer https://github.com/json-path/JsonPath/releases/tag/json-path-2.9.0

## Motivation and Context
Keeping up to date with latest packages important from security perspective as well as the functional changes mentioned above

## Impact
None

## Test Plan
All UTs are running fine

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Update dependency json-path
* Upgrade json-path from 2.6.0 to 2.9.0.
```


