### PR TITLE
[Iceberg]Support non-identity partition predicate for thoroughly push down

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -381,7 +381,7 @@ public class IcebergPageSink
         throw new UnsupportedOperationException("Type not supported as partition column: " + type.getDisplayName());
     }
 
-    private static Object adjustTimestampForPartitionTransform(SqlFunctionProperties functionProperties, Type type, Object value)
+    public static Object adjustTimestampForPartitionTransform(SqlFunctionProperties functionProperties, Type type, Object value)
     {
         if (type instanceof TimestampType && functionProperties.isLegacyTimestamp()) {
             long timestampValue = (long) value;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
@@ -24,6 +24,8 @@ import io.airlift.slice.Slices;
 import org.apache.iceberg.PartitionField;
 import org.joda.time.DateTimeField;
 
+import javax.annotation.Nullable;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.function.Function;
@@ -41,6 +43,7 @@ import static com.facebook.presto.common.type.Decimals.isShortDecimal;
 import static com.facebook.presto.common.type.Decimals.readBigDecimal;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static io.airlift.slice.SliceUtf8.offsetOfCodePoint;
@@ -70,41 +73,55 @@ public final class PartitionTransforms
         String transform = field.transform().toString();
         switch (transform) {
             case "identity":
-                return new ColumnTransform(type, Function.identity());
+                return new ColumnTransform(transform, type, Function.identity(), ValueTransform.identity(type));
             case "year":
                 if (type.equals(DATE)) {
                     LongUnaryOperator transformYear = value -> epochYear(DAYS.toMillis(value));
-                    return new ColumnTransform(INTEGER, block -> transformBlock(DATE, block, transformYear));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(DATE, block, transformYear),
+                            ValueTransform.from(DATE, transformYear));
                 }
                 if (type.equals(TIMESTAMP)) {
                     LongUnaryOperator transformYear = value -> epochYear(value);
-                    return new ColumnTransform(INTEGER, block -> transformBlock(TIMESTAMP, block, transformYear));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP, block, transformYear),
+                            ValueTransform.from(TIMESTAMP, transformYear));
                 }
                 throw new UnsupportedOperationException("Unsupported type for 'year': " + field);
             case "month":
                 if (type.equals(DATE)) {
                     LongUnaryOperator transformMonth = value -> epochMonth(DAYS.toMillis(value));
-                    return new ColumnTransform(INTEGER, block -> transformBlock(DATE, block, transformMonth));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(DATE, block, transformMonth),
+                            ValueTransform.from(DATE, transformMonth));
                 }
                 if (type.equals(TIMESTAMP)) {
                     LongUnaryOperator transformMonth = value -> epochMonth(value);
-                    return new ColumnTransform(INTEGER, block -> transformBlock(TIMESTAMP, block, transformMonth));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP, block, transformMonth),
+                            ValueTransform.from(TIMESTAMP, transformMonth));
                 }
                 throw new UnsupportedOperationException("Unsupported type for 'month': " + field);
             case "day":
                 if (type.equals(DATE)) {
                     LongUnaryOperator transformDay = value -> epochDay(DAYS.toMillis(value));
-                    return new ColumnTransform(INTEGER, block -> transformBlock(DATE, block, transformDay));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(DATE, block, transformDay),
+                            ValueTransform.from(DATE, transformDay));
                 }
                 if (type.equals(TIMESTAMP)) {
                     LongUnaryOperator transformDay = value -> epochDay(value);
-                    return new ColumnTransform(INTEGER, block -> transformBlock(TIMESTAMP, block, transformDay));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP, block, transformDay),
+                            ValueTransform.from(TIMESTAMP, transformDay));
                 }
                 throw new UnsupportedOperationException("Unsupported type for 'day': " + field);
             case "hour":
                 if (type.equals(TIMESTAMP)) {
                     LongUnaryOperator transformHour = value -> epochHour(value);
-                    return new ColumnTransform(INTEGER, block -> transformBlock(TIMESTAMP, block, transformHour));
+                    return new ColumnTransform(transform, INTEGER,
+                            block -> transformBlock(TIMESTAMP, block, transformHour),
+                            ValueTransform.from(TIMESTAMP, transformHour));
                 }
                 throw new UnsupportedOperationException("Unsupported type for 'hour': " + field);
         }
@@ -113,27 +130,41 @@ public final class PartitionTransforms
         if (matcher.matches()) {
             int count = parseInt(matcher.group(1));
             if (type.equals(INTEGER)) {
-                return new ColumnTransform(INTEGER, block -> bucketInteger(block, count));
+                return new ColumnTransform(transform, INTEGER,
+                        block -> bucketInteger(block, count),
+                        (block, position) -> bucketValueInteger(block, position, count));
             }
             if (type.equals(BIGINT)) {
-                return new ColumnTransform(INTEGER, block -> bucketBigint(block, count));
+                return new ColumnTransform(transform, INTEGER,
+                        block -> bucketBigint(block, count),
+                        (block, position) -> bucketValueBigint(block, position, count));
             }
             if (isShortDecimal(type)) {
                 DecimalType decimal = (DecimalType) type;
-                return new ColumnTransform(INTEGER, block -> bucketShortDecimal(decimal, block, count));
+                return new ColumnTransform(transform, INTEGER,
+                        block -> bucketShortDecimal(decimal, block, count),
+                        (block, position) -> bucketValueShortDecimal(decimal, block, position, count));
             }
             if (isLongDecimal(type)) {
                 DecimalType decimal = (DecimalType) type;
-                return new ColumnTransform(INTEGER, block -> bucketLongDecimal(decimal, block, count));
+                return new ColumnTransform(transform, INTEGER,
+                        block -> bucketLongDecimal(decimal, block, count),
+                        (block, position) -> bucketValueLongDecimal(decimal, block, position, count));
             }
             if (type.equals(DATE)) {
-                return new ColumnTransform(INTEGER, block -> bucketDate(block, count));
+                return new ColumnTransform(transform, INTEGER,
+                        block -> bucketDate(block, count),
+                        (block, position) -> bucketValueDate(block, position, count));
             }
             if (type instanceof VarcharType) {
-                return new ColumnTransform(INTEGER, block -> bucketVarchar(block, count));
+                return new ColumnTransform(transform, INTEGER,
+                        block -> bucketVarchar(block, count),
+                        (block, position) -> bucketValueVarchar(block, position, count));
             }
             if (type.equals(VARBINARY)) {
-                return new ColumnTransform(INTEGER, block -> bucketVarbinary(block, count));
+                return new ColumnTransform(transform, INTEGER,
+                        block -> bucketVarbinary(block, count),
+                        (block, position) -> bucketValueVarbinary(block, position, count));
             }
             throw new UnsupportedOperationException("Unsupported type for 'bucket': " + field);
         }
@@ -142,24 +173,68 @@ public final class PartitionTransforms
         if (matcher.matches()) {
             int width = parseInt(matcher.group(1));
             if (type.equals(INTEGER)) {
-                return new ColumnTransform(INTEGER, block -> truncateInteger(block, width));
+                return new ColumnTransform(transform, INTEGER,
+                        block -> truncateInteger(block, width),
+                        (block, position) -> {
+                            if (block.isNull(position)) {
+                                return null;
+                            }
+                            return truncateInteger(block, position, width);
+                        });
             }
             if (type.equals(BIGINT)) {
-                return new ColumnTransform(BIGINT, block -> truncateBigint(block, width));
+                return new ColumnTransform(transform, BIGINT,
+                        block -> truncateBigint(block, width),
+                        (block, position) -> {
+                            if (block.isNull(position)) {
+                                return null;
+                            }
+                            return truncateBigint(block, position, width);
+                        });
             }
             if (isShortDecimal(type)) {
                 DecimalType decimal = (DecimalType) type;
-                return new ColumnTransform(type, block -> truncateShortDecimal(decimal, block, width));
+                BigInteger unscaledWidth = BigInteger.valueOf(width);
+                return new ColumnTransform(transform, type,
+                        block -> truncateShortDecimal(decimal, block, unscaledWidth),
+                        (block, position) -> {
+                            if (block.isNull(position)) {
+                                return null;
+                            }
+                            return truncateShortDecimal(decimal, block, position, unscaledWidth);
+                        });
             }
             if (isLongDecimal(type)) {
                 DecimalType decimal = (DecimalType) type;
-                return new ColumnTransform(type, block -> truncateLongDecimal(decimal, block, width));
+                BigInteger unscaledWidth = BigInteger.valueOf(width);
+                return new ColumnTransform(transform, type,
+                        block -> truncateLongDecimal(decimal, block, unscaledWidth),
+                        (block, position) -> {
+                            if (block.isNull(position)) {
+                                return null;
+                            }
+                            return truncateLongDecimal(decimal, block, position, unscaledWidth);
+                        });
             }
             if (type instanceof VarcharType) {
-                return new ColumnTransform(VARCHAR, block -> truncateVarchar(block, width));
+                return new ColumnTransform(transform, VARCHAR,
+                        block -> truncateVarchar(block, width),
+                        (block, position) -> {
+                            if (block.isNull(position)) {
+                                return null;
+                            }
+                            return truncateVarchar(VARCHAR.getSlice(block, position), width);
+                        });
             }
             if (type.equals(VARBINARY)) {
-                return new ColumnTransform(VARBINARY, block -> truncateVarbinary(block, width));
+                return new ColumnTransform(transform, VARBINARY,
+                        block -> truncateVarbinary(block, width),
+                        (block, position) -> {
+                            if (block.isNull(position)) {
+                                return null;
+                            }
+                            return truncateVarbinary(VARBINARY.getSlice(block, position), width);
+                        });
             }
             throw new UnsupportedOperationException("Unsupported type for 'truncate': " + field);
         }
@@ -172,9 +247,19 @@ public final class PartitionTransforms
         return bucketBlock(block, count, position -> bucketHash(INTEGER.getLong(block, position)));
     }
 
+    private static int bucketValueInteger(Block block, int position, int count)
+    {
+        return bucketValue(block, count, position, pos -> bucketHash(INTEGER.getLong(block, pos)));
+    }
+
     private static Block bucketBigint(Block block, int count)
     {
         return bucketBlock(block, count, position -> bucketHash(BIGINT.getLong(block, position)));
+    }
+
+    private static int bucketValueBigint(Block block, int position, int count)
+    {
+        return bucketValue(block, count, position, pos -> bucketHash(BIGINT.getLong(block, pos)));
     }
 
     private static Block bucketShortDecimal(DecimalType decimal, Block block, int count)
@@ -182,6 +267,15 @@ public final class PartitionTransforms
         return bucketBlock(block, count, position -> {
             // TODO: write optimized implementation
             BigDecimal value = readBigDecimal(decimal, block, position);
+            return bucketHash(Slices.wrappedBuffer(value.unscaledValue().toByteArray()));
+        });
+    }
+
+    private static int bucketValueShortDecimal(DecimalType decimal, Block block, int position, int count)
+    {
+        return bucketValue(block, count, position, pos -> {
+            // TODO: write optimized implementation
+            BigDecimal value = readBigDecimal(decimal, block, pos);
             return bucketHash(Slices.wrappedBuffer(value.unscaledValue().toByteArray()));
         });
     }
@@ -195,9 +289,23 @@ public final class PartitionTransforms
         });
     }
 
+    private static int bucketValueLongDecimal(DecimalType decimal, Block block, int position, int count)
+    {
+        return bucketValue(block, count, position, pos -> {
+            // TODO: write optimized implementation
+            BigDecimal value = readBigDecimal(decimal, block, pos);
+            return bucketHash(Slices.wrappedBuffer(value.unscaledValue().toByteArray()));
+        });
+    }
+
     private static Block bucketDate(Block block, int count)
     {
         return bucketBlock(block, count, position -> bucketHash(DATE.getLong(block, position)));
+    }
+
+    private static int bucketValueDate(Block block, int position, int count)
+    {
+        return bucketValue(block, position, count, pos -> bucketHash(DATE.getLong(block, pos)));
     }
 
     private static Block bucketVarchar(Block block, int count)
@@ -205,9 +313,19 @@ public final class PartitionTransforms
         return bucketBlock(block, count, position -> bucketHash(VARCHAR.getSlice(block, position)));
     }
 
+    private static int bucketValueVarchar(Block block, int position, int count)
+    {
+        return bucketValue(block, position, count, pos -> bucketHash(VARCHAR.getSlice(block, pos)));
+    }
+
     private static Block bucketVarbinary(Block block, int count)
     {
         return bucketBlock(block, count, position -> bucketHash(VARCHAR.getSlice(block, position)));
+    }
+
+    private static int bucketValueVarbinary(Block block, int position, int count)
+    {
+        return bucketValue(block, position, count, pos -> bucketHash(VARCHAR.getSlice(block, pos)));
     }
 
     private static Block bucketBlock(Block block, int count, IntUnaryOperator hasher)
@@ -223,6 +341,16 @@ public final class PartitionTransforms
             INTEGER.writeLong(builder, bucket);
         }
         return builder.build();
+    }
+
+    private static Integer bucketValue(Block block, int position, int count, IntUnaryOperator hasher)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+        int hash = hasher.applyAsInt(position);
+        int bucket = (hash & Integer.MAX_VALUE) % count;
+        return bucket;
     }
 
     private static int bucketHash(long value)
@@ -243,11 +371,15 @@ public final class PartitionTransforms
                 builder.appendNull();
                 continue;
             }
-            long value = INTEGER.getLong(block, position);
-            value -= ((value % width) + width) % width;
-            INTEGER.writeLong(builder, value);
+            INTEGER.writeLong(builder, truncateInteger(block, position, width));
         }
         return builder.build();
+    }
+
+    private static long truncateInteger(Block block, int position, int width)
+    {
+        long value = INTEGER.getLong(block, position);
+        return value - ((value % width) + width) % width;
     }
 
     private static Block truncateBigint(Block block, int width)
@@ -258,45 +390,57 @@ public final class PartitionTransforms
                 builder.appendNull();
                 continue;
             }
-            long value = BIGINT.getLong(block, position);
-            value -= ((value % width) + width) % width;
-            BIGINT.writeLong(builder, value);
+            BIGINT.writeLong(builder, truncateBigint(block, position, width));
         }
         return builder.build();
     }
 
-    private static Block truncateShortDecimal(DecimalType type, Block block, int width)
+    private static long truncateBigint(Block block, int position, int width)
     {
-        BigInteger unscaledWidth = BigInteger.valueOf(width);
+        long value = BIGINT.getLong(block, position);
+        return value - ((value % width) + width) % width;
+    }
+
+    private static Block truncateShortDecimal(DecimalType type, Block block, BigInteger unscaledWidth)
+    {
         BlockBuilder builder = type.createBlockBuilder(null, block.getPositionCount());
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (block.isNull(position)) {
                 builder.appendNull();
                 continue;
             }
-            // TODO: write optimized implementation
-            BigDecimal value = readBigDecimal(type, block, position);
-            value = truncateDecimal(value, unscaledWidth);
-            type.writeLong(builder, encodeShortScaledValue(value, type.getScale()));
+            type.writeLong(builder, truncateShortDecimal(type, block, position, unscaledWidth));
         }
         return builder.build();
     }
 
-    private static Block truncateLongDecimal(DecimalType type, Block block, int width)
+    private static long truncateShortDecimal(DecimalType type, Block block, int position, BigInteger unscaledWidth)
     {
-        BigInteger unscaledWidth = BigInteger.valueOf(width);
+        // TODO: write optimized implementation
+        BigDecimal value = readBigDecimal(type, block, position);
+        value = truncateDecimal(value, unscaledWidth);
+        return encodeShortScaledValue(value, type.getScale());
+    }
+
+    private static Block truncateLongDecimal(DecimalType type, Block block, BigInteger unscaledWidth)
+    {
         BlockBuilder builder = type.createBlockBuilder(null, block.getPositionCount());
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (block.isNull(position)) {
                 builder.appendNull();
                 continue;
             }
-            // TODO: write optimized implementation
-            BigDecimal value = readBigDecimal(type, block, position);
-            value = truncateDecimal(value, unscaledWidth);
-            type.writeSlice(builder, encodeScaledValue(value, type.getScale()));
+            type.writeSlice(builder, truncateLongDecimal(type, block, position, unscaledWidth));
         }
         return builder.build();
+    }
+
+    private static Slice truncateLongDecimal(DecimalType type, Block block, int position, BigInteger unscaledWidth)
+    {
+        // TODO: write optimized implementation
+        BigDecimal value = readBigDecimal(type, block, position);
+        value = truncateDecimal(value, unscaledWidth);
+        return encodeScaledValue(value, type.getScale());
     }
 
     private static BigDecimal truncateDecimal(BigDecimal value, BigInteger unscaledWidth)
@@ -346,12 +490,17 @@ public final class PartitionTransforms
                 continue;
             }
             Slice value = VARBINARY.getSlice(block, position);
-            if (value.length() > max) {
-                value = value.slice(0, max);
-            }
-            VARBINARY.writeSlice(builder, value);
+            VARBINARY.writeSlice(builder, truncateVarbinary(value, max));
         }
         return builder.build();
+    }
+
+    private static Slice truncateVarbinary(Slice value, int max)
+    {
+        if (value.length() > max) {
+            value = value.slice(0, max);
+        }
+        return value;
     }
 
     static long epochYear(long epochMilli)
@@ -395,13 +544,25 @@ public final class PartitionTransforms
 
     public static class ColumnTransform
     {
+        private final String transformName;
         private final Type type;
         private final Function<Block, Block> transform;
+        private final ValueTransform valueTransform;
 
-        public ColumnTransform(Type type, Function<Block, Block> transform)
+        public ColumnTransform(String transformName,
+                               Type type,
+                               Function<Block, Block> transform,
+                               ValueTransform valueTransform)
         {
+            this.transformName = requireNonNull(transformName, "transformName is null");
             this.type = requireNonNull(type, "resultType is null");
             this.transform = requireNonNull(transform, "transform is null");
+            this.valueTransform = requireNonNull(valueTransform, "valueTransform is null");
+        }
+
+        public String getTransformName()
+        {
+            return transformName;
         }
 
         public Type getType()
@@ -413,5 +574,31 @@ public final class PartitionTransforms
         {
             return transform;
         }
+
+        public ValueTransform getValueTransform()
+        {
+            return valueTransform;
+        }
+    }
+
+    public interface ValueTransform
+    {
+        static ValueTransform identity(Type type)
+        {
+            return (block, position) -> readNativeValue(type, block, position);
+        }
+
+        static ValueTransform from(Type sourceType, LongUnaryOperator transform)
+        {
+            return (block, position) -> {
+                if (block.isNull(position)) {
+                    return null;
+                }
+                return transform.applyAsLong(sourceType.getLong(block, position));
+            };
+        }
+
+        @Nullable
+        Object apply(Block block, int position);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergUtil.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.DecimalType;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimeType.TIME;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.iceberg.IcebergUtil.DOUBLE_NEGATIVE_INFINITE;
+import static com.facebook.presto.iceberg.IcebergUtil.DOUBLE_NEGATIVE_ZERO;
+import static com.facebook.presto.iceberg.IcebergUtil.DOUBLE_POSITIVE_INFINITE;
+import static com.facebook.presto.iceberg.IcebergUtil.DOUBLE_POSITIVE_ZERO;
+import static com.facebook.presto.iceberg.IcebergUtil.REAL_NEGATIVE_INFINITE;
+import static com.facebook.presto.iceberg.IcebergUtil.REAL_NEGATIVE_ZERO;
+import static com.facebook.presto.iceberg.IcebergUtil.REAL_POSITIVE_INFINITE;
+import static com.facebook.presto.iceberg.IcebergUtil.REAL_POSITIVE_ZERO;
+import static com.facebook.presto.iceberg.IcebergUtil.getAdjacentValue;
+import static java.lang.Double.longBitsToDouble;
+import static java.lang.Float.intBitsToFloat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIcebergUtil
+{
+    @Test
+    public void testPreviousValueForBigint()
+    {
+        long minValue = Long.MIN_VALUE;
+        long maxValue = Long.MAX_VALUE;
+
+        assertThat(getAdjacentValue(BIGINT, minValue, true))
+                .isEqualTo(Optional.empty());
+        assertThat(getAdjacentValue(BIGINT, minValue + 1, true))
+                .isEqualTo(Optional.of(minValue));
+
+        assertThat(getAdjacentValue(BIGINT, 1234L, true))
+                .isEqualTo(Optional.of(1233L));
+
+        assertThat(getAdjacentValue(BIGINT, maxValue - 1, true))
+                .isEqualTo(Optional.of(maxValue - 2));
+        assertThat(getAdjacentValue(BIGINT, maxValue, true))
+                .isEqualTo(Optional.of(maxValue - 1));
+    }
+
+    @Test
+    public void testNextValueForBigint()
+    {
+        long minValue = Long.MIN_VALUE;
+        long maxValue = Long.MAX_VALUE;
+
+        assertThat(getAdjacentValue(BIGINT, minValue, false))
+                .isEqualTo(Optional.of(minValue + 1));
+        assertThat(getAdjacentValue(BIGINT, minValue + 1, false))
+                .isEqualTo(Optional.of(minValue + 2));
+
+        assertThat(getAdjacentValue(BIGINT, 1234L, false))
+                .isEqualTo(Optional.of(1235L));
+
+        assertThat(getAdjacentValue(BIGINT, maxValue - 1, false))
+                .isEqualTo(Optional.of(maxValue));
+        assertThat(getAdjacentValue(BIGINT, maxValue, false))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void testPreviousValueForIntegerAndDate()
+    {
+        long minValue = Integer.MIN_VALUE;
+        long maxValue = Integer.MAX_VALUE;
+
+        assertThat(getAdjacentValue(INTEGER, minValue, true))
+                .isEqualTo(Optional.empty());
+        assertThat(getAdjacentValue(INTEGER, minValue + 1, true))
+                .isEqualTo(Optional.of(minValue));
+        assertThat(getAdjacentValue(DATE, minValue, true))
+                .isEqualTo(Optional.empty());
+        assertThat(getAdjacentValue(DATE, minValue + 1, true))
+                .isEqualTo(Optional.of(minValue));
+
+        assertThat(getAdjacentValue(INTEGER, 1234L, true))
+                .isEqualTo(Optional.of(1233L));
+        assertThat(getAdjacentValue(DATE, 1234L, true))
+                .isEqualTo(Optional.of(1233L));
+
+        assertThat(getAdjacentValue(INTEGER, maxValue - 1, true))
+                .isEqualTo(Optional.of(maxValue - 2));
+        assertThat(getAdjacentValue(INTEGER, maxValue, true))
+                .isEqualTo(Optional.of(maxValue - 1));
+        assertThat(getAdjacentValue(DATE, maxValue - 1, true))
+                .isEqualTo(Optional.of(maxValue - 2));
+        assertThat(getAdjacentValue(DATE, maxValue, true))
+                .isEqualTo(Optional.of(maxValue - 1));
+    }
+
+    @Test
+    public void testNextValueForIntegerAndDate()
+    {
+        long minValue = Integer.MIN_VALUE;
+        long maxValue = Integer.MAX_VALUE;
+
+        assertThat(getAdjacentValue(INTEGER, minValue, false))
+                .isEqualTo(Optional.of(minValue + 1));
+        assertThat(getAdjacentValue(INTEGER, minValue + 1, false))
+                .isEqualTo(Optional.of(minValue + 2));
+        assertThat(getAdjacentValue(DATE, minValue, false))
+                .isEqualTo(Optional.of(minValue + 1));
+        assertThat(getAdjacentValue(DATE, minValue + 1, false))
+                .isEqualTo(Optional.of(minValue + 2));
+
+        assertThat(getAdjacentValue(INTEGER, 1234L, false))
+                .isEqualTo(Optional.of(1235L));
+        assertThat(getAdjacentValue(DATE, 1234L, false))
+                .isEqualTo(Optional.of(1235L));
+
+        assertThat(getAdjacentValue(INTEGER, maxValue - 1, false))
+                .isEqualTo(Optional.of(maxValue));
+        assertThat(getAdjacentValue(INTEGER, maxValue, false))
+                .isEqualTo(Optional.empty());
+        assertThat(getAdjacentValue(DATE, maxValue - 1, false))
+                .isEqualTo(Optional.of(maxValue));
+        assertThat(getAdjacentValue(DATE, maxValue, false))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void testPreviousValueForTimestamp()
+    {
+        long minValue = Long.MIN_VALUE;
+        long maxValue = Long.MAX_VALUE;
+
+        assertThat(getAdjacentValue(TIMESTAMP, minValue, true))
+                .isEqualTo(Optional.empty());
+        assertThat(getAdjacentValue(TIMESTAMP, minValue + 1, true))
+                .isEqualTo(Optional.of(minValue));
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, minValue, true))
+                .isEqualTo(Optional.empty());
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, minValue + 1, true))
+                .isEqualTo(Optional.of(minValue));
+
+        assertThat(getAdjacentValue(TIMESTAMP, 1234L, true))
+                .isEqualTo(Optional.of(1233L));
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, 1234L, true))
+                .isEqualTo(Optional.of(1233L));
+
+        assertThat(getAdjacentValue(TIMESTAMP, maxValue - 1, true))
+                .isEqualTo(Optional.of(maxValue - 2));
+        assertThat(getAdjacentValue(TIMESTAMP, maxValue, true))
+                .isEqualTo(Optional.of(maxValue - 1));
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, maxValue - 1, true))
+                .isEqualTo(Optional.of(maxValue - 2));
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, maxValue, true))
+                .isEqualTo(Optional.of(maxValue - 1));
+    }
+
+    @Test
+    public void testNextValueForTimestamp()
+    {
+        long minValue = Long.MIN_VALUE;
+        long maxValue = Long.MAX_VALUE;
+
+        assertThat(getAdjacentValue(TIMESTAMP, minValue, false))
+                .isEqualTo(Optional.of(minValue + 1));
+        assertThat(getAdjacentValue(TIMESTAMP, minValue + 1, false))
+                .isEqualTo(Optional.of(minValue + 2));
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, minValue, false))
+                .isEqualTo(Optional.of(minValue + 1));
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, minValue + 1, false))
+                .isEqualTo(Optional.of(minValue + 2));
+
+        assertThat(getAdjacentValue(TIMESTAMP, 1234L, false))
+                .isEqualTo(Optional.of(1235L));
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, 1234L, false))
+                .isEqualTo(Optional.of(1235L));
+
+        assertThat(getAdjacentValue(TIMESTAMP, maxValue - 1, false))
+                .isEqualTo(Optional.of(maxValue));
+        assertThat(getAdjacentValue(TIMESTAMP, maxValue, false))
+                .isEqualTo(Optional.empty());
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, maxValue - 1, false))
+                .isEqualTo(Optional.of(maxValue));
+        assertThat(getAdjacentValue(TIMESTAMP_MICROSECONDS, maxValue, false))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void testPreviousValueForSmallInt()
+    {
+        long minValue = Short.MIN_VALUE;
+        long maxValue = Short.MAX_VALUE;
+
+        assertThat(getAdjacentValue(SMALLINT, minValue, true))
+                .isEqualTo(Optional.empty());
+        assertThat(getAdjacentValue(SMALLINT, minValue + 1, true))
+                .isEqualTo(Optional.of(minValue));
+
+        assertThat(getAdjacentValue(SMALLINT, 1234L, true))
+                .isEqualTo(Optional.of(1233L));
+
+        assertThat(getAdjacentValue(SMALLINT, maxValue - 1, true))
+                .isEqualTo(Optional.of(maxValue - 2));
+        assertThat(getAdjacentValue(SMALLINT, maxValue, true))
+                .isEqualTo(Optional.of(maxValue - 1));
+    }
+
+    @Test
+    public void testNextValueForSmallInt()
+    {
+        long minValue = Short.MIN_VALUE;
+        long maxValue = Short.MAX_VALUE;
+
+        assertThat(getAdjacentValue(SMALLINT, minValue, false))
+                .isEqualTo(Optional.of(minValue + 1));
+        assertThat(getAdjacentValue(SMALLINT, minValue + 1, false))
+                .isEqualTo(Optional.of(minValue + 2));
+
+        assertThat(getAdjacentValue(SMALLINT, 1234L, false))
+                .isEqualTo(Optional.of(1235L));
+
+        assertThat(getAdjacentValue(SMALLINT, maxValue - 1, false))
+                .isEqualTo(Optional.of(maxValue));
+        assertThat(getAdjacentValue(SMALLINT, maxValue, false))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void testPreviousValueForTinyInt()
+    {
+        long minValue = Byte.MIN_VALUE;
+        long maxValue = Byte.MAX_VALUE;
+
+        assertThat(getAdjacentValue(TINYINT, minValue, true))
+                .isEqualTo(Optional.empty());
+        assertThat(getAdjacentValue(TINYINT, minValue + 1, true))
+                .isEqualTo(Optional.of(minValue));
+
+        assertThat(getAdjacentValue(TINYINT, 123L, true))
+                .isEqualTo(Optional.of(122L));
+
+        assertThat(getAdjacentValue(TINYINT, maxValue - 1, true))
+                .isEqualTo(Optional.of(maxValue - 2));
+        assertThat(getAdjacentValue(TINYINT, maxValue, true))
+                .isEqualTo(Optional.of(maxValue - 1));
+    }
+
+    @Test
+    public void testNextValueForTinyInt()
+    {
+        long minValue = Byte.MIN_VALUE;
+        long maxValue = Byte.MAX_VALUE;
+
+        assertThat(getAdjacentValue(TINYINT, minValue, false))
+                .isEqualTo(Optional.of(minValue + 1));
+        assertThat(getAdjacentValue(TINYINT, minValue + 1, false))
+                .isEqualTo(Optional.of(minValue + 2));
+
+        assertThat(getAdjacentValue(TINYINT, 123L, false))
+                .isEqualTo(Optional.of(124L));
+
+        assertThat(getAdjacentValue(TINYINT, maxValue - 1, false))
+                .isEqualTo(Optional.of(maxValue));
+        assertThat(getAdjacentValue(TINYINT, maxValue, false))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void testPreviousAndNextValueForDouble()
+    {
+        assertThat(getAdjacentValue(DOUBLE, DOUBLE_NEGATIVE_INFINITE, true))
+                .isEqualTo(Optional.empty());
+        assertThat(longBitsToDouble((long) getAdjacentValue(DOUBLE, getAdjacentValue(DOUBLE, DOUBLE_NEGATIVE_INFINITE, false).get(), true).get()))
+                .isEqualTo(Double.NEGATIVE_INFINITY);
+
+        assertThat(getAdjacentValue(DOUBLE, DOUBLE_POSITIVE_ZERO, true))
+                .isEqualTo(getAdjacentValue(DOUBLE, DOUBLE_NEGATIVE_ZERO, true));
+        assertThat(longBitsToDouble((long) getAdjacentValue(DOUBLE, getAdjacentValue(DOUBLE, DOUBLE_NEGATIVE_ZERO, false).get(), true).get()))
+                .isEqualTo(0.0d);
+        assertThat(getAdjacentValue(DOUBLE, getAdjacentValue(DOUBLE, DOUBLE_NEGATIVE_ZERO, false).get(), true).get())
+                .isEqualTo(DOUBLE_POSITIVE_ZERO);
+        assertThat(longBitsToDouble((long) getAdjacentValue(DOUBLE, getAdjacentValue(DOUBLE, DOUBLE_POSITIVE_ZERO, true).get(), false).get()))
+                .isEqualTo(0.0d);
+        assertThat(getAdjacentValue(DOUBLE, getAdjacentValue(DOUBLE, DOUBLE_POSITIVE_ZERO, true).get(), false).get())
+                .isEqualTo(DOUBLE_POSITIVE_ZERO);
+
+        assertThat(getAdjacentValue(DOUBLE, DOUBLE_POSITIVE_INFINITE, false))
+                .isEqualTo(Optional.empty());
+        assertThat(longBitsToDouble((long) getAdjacentValue(DOUBLE, getAdjacentValue(DOUBLE, DOUBLE_POSITIVE_INFINITE, true).get(), false).get()))
+                .isEqualTo(Double.POSITIVE_INFINITY);
+    }
+
+    @Test
+    public void testPreviousAndNextValueForReal()
+    {
+        assertThat(getAdjacentValue(REAL, REAL_NEGATIVE_INFINITE, true))
+                .isEqualTo(Optional.empty());
+        assertThat(intBitsToFloat((int) getAdjacentValue(REAL, getAdjacentValue(REAL, REAL_NEGATIVE_INFINITE, false).get(), true).get()))
+                .isEqualTo(Float.NEGATIVE_INFINITY);
+
+        assertThat(getAdjacentValue(REAL, REAL_POSITIVE_ZERO, true))
+                .isEqualTo(getAdjacentValue(REAL, REAL_NEGATIVE_ZERO, true));
+        assertThat(intBitsToFloat((int) getAdjacentValue(REAL, getAdjacentValue(REAL, REAL_NEGATIVE_ZERO, false).get(), true).get()))
+                .isEqualTo(0.0f);
+        assertThat(getAdjacentValue(REAL, getAdjacentValue(REAL, REAL_NEGATIVE_ZERO, false).get(), true).get())
+                .isEqualTo(REAL_POSITIVE_ZERO);
+        assertThat(intBitsToFloat((int) getAdjacentValue(REAL, getAdjacentValue(REAL, REAL_POSITIVE_ZERO, true).get(), false).get()))
+                .isEqualTo(0.0f);
+        assertThat(getAdjacentValue(REAL, getAdjacentValue(REAL, REAL_POSITIVE_ZERO, true).get(), false).get())
+                .isEqualTo(REAL_POSITIVE_ZERO);
+
+        assertThat(getAdjacentValue(REAL, REAL_POSITIVE_INFINITE, false))
+                .isEqualTo(Optional.empty());
+        assertThat(intBitsToFloat((int) getAdjacentValue(REAL, getAdjacentValue(REAL, REAL_POSITIVE_INFINITE, true).get(), false).get()))
+                .isEqualTo(Float.POSITIVE_INFINITY);
+    }
+
+    @Test
+    public void testPreviousValueForOtherType()
+    {
+        assertThat(getAdjacentValue(VARCHAR, "anystr", true))
+                .isEmpty();
+        assertThat(getAdjacentValue(BOOLEAN, true, true))
+                .isEmpty();
+        assertThat(getAdjacentValue(TIME, 123L, true))
+                .isEmpty();
+        assertThat(getAdjacentValue(DecimalType.createDecimalType(8, 2), 12345L, true))
+                .isEmpty();
+        assertThat(getAdjacentValue(DecimalType.createDecimalType(20, 2),
+                encodeScaledValue(new BigDecimal(111111111111111123.45)), true))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValueForOtherType()
+    {
+        assertThat(getAdjacentValue(VARCHAR, "anystr", false))
+                .isEmpty();
+        assertThat(getAdjacentValue(BOOLEAN, true, false))
+                .isEmpty();
+        assertThat(getAdjacentValue(TIME, 123L, false))
+                .isEmpty();
+        assertThat(getAdjacentValue(DecimalType.createDecimalType(8, 2), 12345L, false))
+                .isEmpty();
+        assertThat(getAdjacentValue(DecimalType.createDecimalType(20, 2),
+                encodeScaledValue(new BigDecimal(111111111111111123.45)), false))
+                .isEmpty();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
@@ -548,6 +549,11 @@ public final class PlanMatchPattern
     public static PlanMatchPattern filter(String expectedPredicate, PlanMatchPattern source)
     {
         return filter(rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expectedPredicate)), source);
+    }
+
+    public static PlanMatchPattern filterWithDecimal(String expectedPredicate, PlanMatchPattern source)
+    {
+        return filter(rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expectedPredicate, new ParsingOptions(DecimalLiteralTreatment.AS_DECIMAL))), source);
     }
 
     public static PlanMatchPattern filter(Expression expectedPredicate, PlanMatchPattern source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
@@ -59,6 +59,7 @@ import com.facebook.presto.sql.tree.SimpleCaseExpression;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.tree.WhenClause;
 import io.airlift.slice.Slice;
@@ -128,6 +129,12 @@ public final class RowExpressionVerifier
     protected Boolean visitNode(Node node, RowExpression context)
     {
         throw new IllegalStateException(format("Node %s is not supported", node));
+    }
+
+    @Override
+    protected Boolean visitTimestampLiteral(TimestampLiteral node, RowExpression context)
+    {
+        return compareLiteral(node, context);
     }
 
     @Override
@@ -480,6 +487,9 @@ public final class RowExpressionVerifier
         else if (expression instanceof DecimalLiteral) {
             return String.valueOf(((DecimalLiteral) expression).getValue());
         }
+        else if (expression instanceof TimestampLiteral) {
+            return ((TimestampLiteral) expression).getValue();
+        }
         else if (expression instanceof GenericLiteral) {
             return ((GenericLiteral) expression).getValue();
         }
@@ -494,7 +504,7 @@ public final class RowExpressionVerifier
             return getValueFromLiteral(expected).equals(String.valueOf(rowExpressionInterpreter(actual, metadata, session.toConnectorSession()).evaluate()));
         }
         if (actual instanceof ConstantExpression) {
-            return getValueFromLiteral(expected).equals(String.valueOf(LiteralInterpreter.evaluate(TEST_SESSION.toConnectorSession(), (ConstantExpression) actual)));
+            return getValueFromLiteral(expected).equals(String.valueOf(LiteralInterpreter.evaluate(session.toConnectorSession(), (ConstantExpression) actual)));
         }
         return false;
     }


### PR DESCRIPTION
## Description

This PR extends Iceberg capabilities to pushdown thoroughly predicates on partitioning columns. Besides pushdown thoroughly predicates on identity partitioning columns, it also pushdown thoroughly predicates if they align with partitioning boundaries.

It is also helpful for DELETE, as it allows to do metadata-only delete in more cases, where we don't really needing to do a row-level delete.


## Test Plan

 - Added test cases for pushing down predicates on columns of various partition transforms

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

