### PR TITLE
Fix Thread naming format

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
@@ -93,7 +93,7 @@ public class ColumnCardinalityCache
         Duration expireDuration = config.getCardinalityCacheExpiration();
 
         // Create a bounded executor with a pool size at 4x number of processors
-        this.coreExecutor = newCachedThreadPool(daemonThreadsNamed("cardinality-lookup-%s"));
+        this.coreExecutor = newCachedThreadPool(daemonThreadsNamed("cardinality-lookup-%d"));
         this.executorService = new BoundedExecutor(coreExecutor, 4 * Runtime.getRuntime().availableProcessors());
 
         LOG.debug("Created new cache size %d expiry %s", size, expireDuration);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -94,7 +94,7 @@ public class IndexLookup
         this.cardinalityCache = requireNonNull(cardinalityCache, "cardinalityCache is null");
 
         // Create a bounded executor with a pool size at 4x number of processors
-        this.coreExecutor = newCachedThreadPool(daemonThreadsNamed("cardinality-lookup-%s"));
+        this.coreExecutor = newCachedThreadPool(daemonThreadsNamed("cardinality-lookup-%d"));
         this.executorService = new BoundedExecutor(coreExecutor, 4 * Runtime.getRuntime().availableProcessors());
     }
 

--- a/presto-atop/src/main/java/com/facebook/presto/atop/AtopProcessFactory.java
+++ b/presto-atop/src/main/java/com/facebook/presto/atop/AtopProcessFactory.java
@@ -56,7 +56,7 @@ public class AtopProcessFactory
         this.executablePath = config.getExecutablePath();
         this.timeZone = config.getTimeZoneId();
         this.readTimeout = config.getReadTimeout();
-        this.executor = newFixedThreadPool(config.getConcurrentReadersPerNode(), daemonThreadsNamed("atop-" + connectorId + "executable-reader-%s"));
+        this.executor = newFixedThreadPool(config.getConcurrentReadersPerNode(), daemonThreadsNamed("atop-" + connectorId + "executable-reader-%d"));
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataCache.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataCache.java
@@ -48,7 +48,7 @@ public class JdbcMetadataCache
     public JdbcMetadataCache(JdbcClient jdbcClient, JdbcMetadataConfig config, JdbcMetadataCacheStats stats)
     {
         this(
-                newCachedThreadPool(daemonThreadsNamed("jdbc-metadata-cache" + "-%s")),
+                newCachedThreadPool(daemonThreadsNamed("jdbc-metadata-cache" + "-%d")),
                 jdbcClient,
                 stats,
                 OptionalLong.of(config.getMetadataCacheTtl().toMillis()),

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
@@ -65,7 +65,7 @@ public class TestJdbcMetadata
             throws Exception
     {
         database = new TestingDatabase();
-        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
+        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%d")));
         jdbcMetadataCache = new JdbcMetadataCache(executor, database.getJdbcClient(), new JdbcMetadataCacheStats(), OptionalLong.of(0), OptionalLong.of(0), 100);
         metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false);
         tableHandle = metadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"));

--- a/presto-cache/src/main/java/com/facebook/presto/cache/CachingModule.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CachingModule.java
@@ -59,9 +59,9 @@ public class CachingModule
                     cacheConfig,
                     fileMergeCacheConfig,
                     cacheStats,
-                    newScheduledThreadPool(5, daemonThreadsNamed("hive-cache-flusher-%s")),
-                    newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-remover-%s")),
-                    newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-size-calculator-%s")));
+                    newScheduledThreadPool(5, daemonThreadsNamed("hive-cache-flusher-%d")),
+                    newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-remover-%d")),
+                    newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-size-calculator-%d")));
         }
         return new NoOpCacheManager();
     }

--- a/presto-cache/src/test/java/com/facebook/presto/cache/filemerge/TestFileMergeCacheManager.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/filemerge/TestFileMergeCacheManager.java
@@ -57,9 +57,9 @@ public class TestFileMergeCacheManager
 {
     private static final int DATA_LENGTH = (int) new DataSize(20, KILOBYTE).toBytes();
     private final byte[] data = new byte[DATA_LENGTH];
-    private final ExecutorService flushExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-cache-flusher-%s"));
-    private final ExecutorService removeExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-cache-remover-%s"));
-    private final ScheduledExecutorService cacheSizeCalculator = newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-size-calculator-%s"));
+    private final ExecutorService flushExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-cache-flusher-%d"));
+    private final ExecutorService removeExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-cache-remover-%d"));
+    private final ScheduledExecutorService cacheSizeCalculator = newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-size-calculator-%d"));
 
     private URI cacheDirectory;
     private URI fileDirectory;

--- a/presto-cli/src/main/java/com/facebook/presto/cli/TableNameCompleter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/TableNameCompleter.java
@@ -39,7 +39,7 @@ public class TableNameCompleter
 {
     private static final long RELOAD_TIME_MINUTES = 2;
 
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("completer-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("completer-%d"));
     private final QueryRunner queryRunner;
     private final LoadingCache<String, List<String>> tableCache;
     private final LoadingCache<String, List<String>> functionCache;

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaModule.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaModule.java
@@ -148,6 +148,6 @@ public class DeltaModule
     {
         return newFixedThreadPool(
                 metastoreClientConfig.getMaxMetastoreRefreshThreads(),
-                daemonThreadsNamed("hive-metastore-delta-%s"));
+                daemonThreadsNamed("hive-metastore-delta-%d"));
     }
 }

--- a/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
+++ b/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
@@ -133,7 +133,7 @@ public class S3SelectTestHelper
         }
 
         HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, host, port);
-        executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("hive-%d"));
         HivePartitionManager hivePartitionManager = new HivePartitionManager(FUNCTION_AND_TYPE_MANAGER, config);
 
         S3ConfigurationUpdater s3Config = new PrestoS3ConfigurationUpdater(new HiveS3Config()

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueMetastoreModule.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueMetastoreModule.java
@@ -65,7 +65,7 @@ public class GlueMetastoreModule
             return directExecutor();
         }
         return new BoundedExecutor(
-            newCachedThreadPool(daemonThreadsNamed("hive-glue-%s")),
+            newCachedThreadPool(daemonThreadsNamed("hive-glue-%d")),
             hiveConfig.getGetPartitionThreads());
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -238,7 +238,7 @@ public class HiveClientModule
     @Provides
     public ExecutorService createHiveClientExecutor(HiveConnectorId hiveClientId)
     {
-        return newCachedThreadPool(daemonThreadsNamed("hive-" + hiveClientId + "-%s"));
+        return newCachedThreadPool(daemonThreadsNamed("hive-" + hiveClientId + "-%d"));
     }
 
     @ForCachingHiveMetastore
@@ -248,7 +248,7 @@ public class HiveClientModule
     {
         return newFixedThreadPool(
                 metastoreClientConfig.getMaxMetastoreRefreshThreads(),
-                daemonThreadsNamed("hive-metastore-" + hiveClientId + "-%s"));
+                daemonThreadsNamed("hive-metastore-" + hiveClientId + "-%d"));
     }
 
     @ForUpdatingHiveMetadata
@@ -256,7 +256,7 @@ public class HiveClientModule
     @Provides
     public ExecutorService createUpdatingHiveMetadataExecutor(HiveConnectorId hiveClientId)
     {
-        return newCachedThreadPool(daemonThreadsNamed("hive-metadata-updater-" + hiveClientId + "-%s"));
+        return newCachedThreadPool(daemonThreadsNamed("hive-metadata-updater-" + hiveClientId + "-%d"));
     }
 
     @ForFileRename
@@ -267,7 +267,7 @@ public class HiveClientModule
         return listeningDecorator(
                 new ExecutorServiceAdapter(
                         new BoundedExecutor(
-                                newCachedThreadPool(daemonThreadsNamed("hive-rename-" + hiveClientId + "-%s")),
+                                newCachedThreadPool(daemonThreadsNamed("hive-rename-" + hiveClientId + "-%d")),
                                 hiveClientConfig.getMaxConcurrentFileRenames())));
     }
 
@@ -279,7 +279,7 @@ public class HiveClientModule
         return listeningDecorator(
                 new ExecutorServiceAdapter(
                         new BoundedExecutor(
-                                newCachedThreadPool(daemonThreadsNamed("hive-create-zero-row-file-" + hiveClientId + "-%s")),
+                                newCachedThreadPool(daemonThreadsNamed("hive-create-zero-row-file-" + hiveClientId + "-%d")),
                                 hiveClientConfig.getMaxConcurrentZeroRowFileCreations())));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
@@ -114,7 +114,7 @@ public class HivePageSinkProvider
         this.writerSortBufferSize = requireNonNull(hiveClientConfig.getWriterSortBufferSize(), "writerSortBufferSize is null");
         this.immutablePartitions = hiveClientConfig.isImmutablePartitions();
         this.locationService = requireNonNull(locationService, "locationService is null");
-        this.writeVerificationExecutor = listeningDecorator(newFixedThreadPool(hiveClientConfig.getWriteValidationThreads(), daemonThreadsNamed("hive-write-validation-%s")));
+        this.writeVerificationExecutor = listeningDecorator(newFixedThreadPool(hiveClientConfig.getWriteValidationThreads(), daemonThreadsNamed("hive-write-validation-%d")));
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
         this.partitionUpdateSmileCodec = requireNonNull(partitionUpdateSmileCodec, "partitionUpdateSmileCodec is null");
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -137,7 +137,7 @@ public class HivePartitionManager
         this.domainCompactionThreshold = domainCompactionThreshold;
         this.partitionFilteringFromMetastoreEnabled = partitionFilteringFromMetastoreEnabled;
         ExecutorService threadPoolExecutor = new ThreadPoolExecutor(0, maxParallelParsingConcurrency,
-                60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), daemonThreadsNamed("partition-value-parser-%s"));
+                60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), daemonThreadsNamed("partition-value-parser-%d"));
         this.executorService = listeningDecorator(threadPoolExecutor);
         this.executorServiceMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) threadPoolExecutor);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/ParquetQuickStatsBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/ParquetQuickStatsBuilder.java
@@ -104,7 +104,7 @@ public class ParquetQuickStatsBuilder
         this.stats = stats;
         this.hdfsEnvironment = hdfsEnvironment;
         this.footerFetchTimeoutMillis = hiveClientConfig.getParquetQuickStatsFileMetadataFetchTimeout().roundTo(MILLISECONDS);
-        ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("parquet-quick-stats-bg-fetch-%s"));
+        ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("parquet-quick-stats-bg-fetch-%d"));
         this.footerFetchExecutor = new BoundedExecutor(coreExecutor, hiveClientConfig.getMaxConcurrentParquetQuickStatsCalls());
         this.footerFetchExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) coreExecutor);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/QuickStatsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/QuickStatsProvider.java
@@ -114,7 +114,7 @@ public class QuickStatsProvider
         this.reaperExpiryMillis = hiveClientConfig.getQuickStatsReaperExpiry().toMillis();
         this.nameNodeStats = nameNodeStats;
         this.statsBuilderStrategies = statsBuilderStrategies;
-        ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("quick-stats-bg-fetch-%s"));
+        ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("quick-stats-bg-fetch-%d"));
         this.backgroundFetchExecutor = new BoundedExecutor(coreExecutor, hiveClientConfig.getMaxConcurrentQuickStatsCalls());
         this.backgroundFetchExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) coreExecutor);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -777,7 +777,7 @@ public abstract class AbstractTestHiveClient
     @BeforeClass
     public void setupClass()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("hive-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -152,7 +152,7 @@ public abstract class AbstractTestHiveFileSystem
     @BeforeClass
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("hive-%d"));
     }
 
     @AfterClass(alwaysRun = true)
@@ -184,7 +184,7 @@ public abstract class AbstractTestHiveFileSystem
         }
 
         HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, host, port);
-        ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
+        ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("hive-%d"));
         HivePartitionManager hivePartitionManager = new HivePartitionManager(FUNCTION_AND_TYPE_MANAGER, config);
 
         HdfsConfiguration hdfsConfiguration = hdfsConfigurationProvider.apply(config, metastoreClientConfig);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -103,7 +103,7 @@ public class TestBackgroundHiveSplitLoader
     private static final Path RETURNED_PATH = new Path(SAMPLE_PATH);
     private static final Path FILTERED_PATH = new Path(SAMPLE_PATH_FILTERED);
 
-    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-%d"));
 
     private static final Domain RETURNED_PATH_DOMAIN = Domain.singleValue(VARCHAR, utf8Slice(RETURNED_PATH.toString()));
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
@@ -123,7 +123,7 @@ public class TestHiveCommitHandleOutput
     {
         TestingExtendedHiveMetastore metastore = new TestingExtendedHiveMetastore();
         HiveClientConfig hiveClientConfig = new HiveClientConfig().setPartitionStatisticsBasedOptimizationEnabled(true);
-        ListeningExecutorService listeningExecutor = MoreExecutors.listeningDecorator(newFixedThreadPool(10, daemonThreadsNamed("test-hive-commit-handle-%s")));
+        ListeningExecutorService listeningExecutor = MoreExecutors.listeningDecorator(newFixedThreadPool(10, daemonThreadsNamed("test-hive-commit-handle-%d")));
         ConnectorSession connectorSession = new TestingConnectorSession(
                 new HiveSessionProperties(
                         new HiveClientConfig().setPartitionStatisticsBasedOptimizationEnabled(true),
@@ -154,7 +154,7 @@ public class TestHiveCommitHandleOutput
     {
         TestingExtendedHiveMetastore metastore = new TestingExtendedHiveMetastore();
         HiveClientConfig hiveClientConfig = new HiveClientConfig().setPartitionStatisticsBasedOptimizationEnabled(true);
-        ListeningExecutorService listeningExecutor = MoreExecutors.listeningDecorator(newFixedThreadPool(10, daemonThreadsNamed("test-hive-commit-handle-%s")));
+        ListeningExecutorService listeningExecutor = MoreExecutors.listeningDecorator(newFixedThreadPool(10, daemonThreadsNamed("test-hive-commit-handle-%d")));
         HiveMetadata hiveMeta = getHiveMetadata(metastore, hiveClientConfig, listeningExecutor);
         ConnectorSession connectorSession = new TestingConnectorSession(
                 new HiveSessionProperties(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -107,7 +107,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
     {
         baseDirectory = new File(Files.createTempDir(), "metastore");
         metastore = new BridgingHiveMetastore(new InMemoryHiveMetastore(baseDirectory), new HivePartitionMutator());
-        executor = newCachedThreadPool(daemonThreadsNamed("hive-encryption-test-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("hive-encryption-test-%d"));
         transactionManager = new HiveTransactionManager();
         metadataFactory = new HiveMetadataFactory(
                 metastore,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -160,7 +160,7 @@ public class TestHiveSplitManager
     @BeforeClass
     public void setUp()
     {
-        executor = MoreExecutors.listeningDecorator(newFixedThreadPool(10, daemonThreadsNamed("test-hive-split-manager-%s")));
+        executor = MoreExecutors.listeningDecorator(newFixedThreadPool(10, daemonThreadsNamed("test-hive-split-manager-%d")));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableConstraints.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableConstraints.java
@@ -61,7 +61,7 @@ public class TestHiveTableConstraints
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
         mockClient = new MockHiveMetastoreClient();
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
-        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
+        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%d")));
         PartitionMutator hivePartitionMutator = new HivePartitionMutator();
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, metastoreClientConfig), ImmutableSet.of(), config);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
@@ -381,8 +381,8 @@ public class TestOrcBatchPageSourceMemoryTracking
         private final List<HiveColumnHandle> columns;
         private final List<Type> types;
         private final List<HivePartitionKey> partitionKeys;
-        private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
         public TestPreparer(String tempFilePath)
                 throws Exception

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
@@ -80,7 +80,7 @@ public class TestingSemiTransactionalHiveMetastore
         HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, HOST, PORT);
         ColumnConverterProvider columnConverterProvider = HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER;
         ExtendedHiveMetastore delegate = new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig, hdfsEnvironment), new HivePartitionMutator());
-        ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
+        ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("hive-%d"));
         ListeningExecutorService renameExecutor = listeningDecorator(executor);
 
         return new TestingSemiTransactionalHiveMetastore(hdfsEnvironment, delegate, renameExecutor, false, false, true, columnConverterProvider);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
@@ -79,7 +79,7 @@ public class TestCachingHiveMetastore
     {
         mockClient = new MockHiveMetastoreClient();
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
-        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
+        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%d")));
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
         ThriftHiveMetastore thriftHiveMetastore = new ThriftHiveMetastore(mockHiveCluster, metastoreClientConfig, HDFS_ENVIRONMENT);
         PartitionMutator hivePartitionMutator = new HivePartitionMutator();
@@ -220,7 +220,7 @@ public class TestCachingHiveMetastore
     {
         MockHiveMetastoreClient mockClient = new MockHiveMetastoreClient();
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
-        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("partition-versioning-test-%s")));
+        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("partition-versioning-test-%d")));
         MockHiveMetastore mockHiveMetastore = new MockHiveMetastore(mockHiveCluster);
         PartitionMutator mockPartitionMutator = new MockPartitionMutator(identity());
         CachingHiveMetastore partitionCachingEnabledmetastore = new CachingHiveMetastore(
@@ -269,7 +269,7 @@ public class TestCachingHiveMetastore
     {
         MockHiveMetastoreClient mockClient = new MockHiveMetastoreClient();
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
-        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("partition-versioning-test-%s")));
+        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("partition-versioning-test-%d")));
         MockHiveMetastore mockHiveMetastore = new MockHiveMetastore(mockHiveCluster);
         ColumnConverter hiveColumnConverter = new HiveColumnConverter();
         CachingHiveMetastore partitionCachingEnabledmetastore = new CachingHiveMetastore(
@@ -305,7 +305,7 @@ public class TestCachingHiveMetastore
     {
         MockHiveMetastoreClient mockClient = new MockHiveMetastoreClient();
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
-        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("partition-versioning-test-%s")));
+        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("partition-versioning-test-%d")));
         MockHiveMetastore mockHiveMetastore = new MockHiveMetastore(mockHiveCluster);
         PartitionMutator mockPartitionMutator = new MockPartitionMutator(identity());
         ColumnConverter hiveColumnConverter = new HiveColumnConverter();
@@ -337,7 +337,7 @@ public class TestCachingHiveMetastore
     {
         MockHiveMetastoreClient mockClient = new MockHiveMetastoreClient();
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
-        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("partition-versioning-test-%s")));
+        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("partition-versioning-test-%d")));
         MockHiveMetastore mockHiveMetastore = new MockHiveMetastore(mockHiveCluster);
         PartitionMutator mockPartitionMutator = new MockPartitionMutator(identity());
         CachingHiveMetastore partitionCachingEnabledMetastore = new CachingHiveMetastore(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
@@ -151,7 +151,7 @@ public class TestHiveClientGlueMetastore
     @BeforeClass
     public void setUp()
     {
-        executorService = newCachedThreadPool(daemonThreadsNamed("hive-glue-%s"));
+        executorService = newCachedThreadPool(daemonThreadsNamed("hive-glue-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/util/TestAsyncQueue.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/util/TestAsyncQueue.java
@@ -43,7 +43,7 @@ public class TestAsyncQueue
     @BeforeClass
     public void setUpClass()
     {
-        executor = Executors.newFixedThreadPool(8, Threads.daemonThreadsNamed("test-async-queue-%s"));
+        executor = Executors.newFixedThreadPool(8, Threads.daemonThreadsNamed("test-async-queue-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiModule.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiModule.java
@@ -136,7 +136,7 @@ public class HudiModule
     {
         return newFixedThreadPool(
                 metastoreClientConfig.getMaxMetastoreRefreshThreads(),
-                daemonThreadsNamed("hive-metastore-hudi-%s"));
+                daemonThreadsNamed("hive-metastore-hudi-%d"));
     }
 
     @ForHudiSplitAsyncQueue
@@ -144,7 +144,7 @@ public class HudiModule
     @Provides
     public ExecutorService createHudiSplitManagerExecutor()
     {
-        return newCachedThreadPool(daemonThreadsNamed("hudi-split-manager-%s"));
+        return newCachedThreadPool(daemonThreadsNamed("hudi-split-manager-%d"));
     }
 
     @ForHudiSplitSource
@@ -154,7 +154,7 @@ public class HudiModule
     {
         return newScheduledThreadPool(
                 hudiConfig.getSplitLoaderParallelism(),
-                daemonThreadsNamed("hudi-split-loader-%s"));
+                daemonThreadsNamed("hudi-split-loader-%d"));
     }
 
     @ForHudiBackgroundSplitLoader
@@ -164,7 +164,7 @@ public class HudiModule
     {
         return newFixedThreadPool(
                 hudiConfig.getSplitGeneratorParallelism(),
-                daemonThreadsNamed("hudi-split-generator-%s"));
+                daemonThreadsNamed("hudi-split-generator-%d"));
     }
 
     @Singleton

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -167,7 +167,7 @@ public class IcebergCommonModule
     {
         return newFixedThreadPool(
                 metastoreClientConfig.getMaxMetastoreRefreshThreads(),
-                daemonThreadsNamed("hive-metastore-iceberg-%s"));
+                daemonThreadsNamed("hive-metastore-iceberg-%d"));
     }
 
     @Singleton

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcWarnings.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcWarnings.java
@@ -130,7 +130,7 @@ public class TestJdbcWarnings
     public void testLongRunningStatement()
             throws SQLException, InterruptedException
     {
-        ExecutorService queryExecutor = newSingleThreadExecutor(daemonThreadsNamed("test-%s"));
+        ExecutorService queryExecutor = newSingleThreadExecutor(daemonThreadsNamed("test-%d"));
         QueryCreationFuture queryCreationFuture = new QueryCreationFuture();
         queryExecutor.submit(() -> {
             try {
@@ -164,7 +164,7 @@ public class TestJdbcWarnings
     public void testLongRunningQuery()
             throws SQLException, InterruptedException
     {
-        ExecutorService queryExecutor = newSingleThreadExecutor(daemonThreadsNamed("test-%s"));
+        ExecutorService queryExecutor = newSingleThreadExecutor(daemonThreadsNamed("test-%d"));
         QueryCreationFuture queryCreationFuture = new QueryCreationFuture();
         queryExecutor.submit(() -> {
             try {

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -133,7 +133,7 @@ public class TestPrestoDriver
         sessionPropertyManager.addConnectorSessionProperties(bogusTestingCatalog.getConnectorId(), TEST_CATALOG_PROPERTIES);
         waitForNodeRefresh(server);
         setupTestTables();
-        executorService = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+        executorService = newCachedThreadPool(daemonThreadsNamed("test-%d"));
     }
 
     static void waitForNodeRefresh(TestingPrestoServer server)

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxPeriodicSampler.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxPeriodicSampler.java
@@ -37,7 +37,7 @@ public class JmxPeriodicSampler
 
     private final JmxHistoricalData jmxHistoricalData;
     private final JmxRecordSetProvider jmxRecordSetProvider;
-    private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("jmx-history-%s"));
+    private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("jmx-history-%d"));
     private final long period;
     private final List<JmxTableHandle> tableHandles;
     private long lastDumpTimestamp;

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchExecutor.java
@@ -49,12 +49,12 @@ public class DispatchExecutor
     @Inject
     public DispatchExecutor(QueryManagerConfig config)
     {
-        ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("dispatcher-query-%s"));
+        ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("dispatcher-query-%d"));
         closer.register(coreExecutor::shutdownNow);
         executor = listeningDecorator(coreExecutor);
         boundedExecutor = new BoundedExecutor(coreExecutor, config.getQuerySubmissionMaxThreads());
 
-        ScheduledExecutorService coreScheduledExecutor = newScheduledThreadPool(config.getQueryManagerExecutorPoolSize(), daemonThreadsNamed("dispatch-executor-%s"));
+        ScheduledExecutorService coreScheduledExecutor = newScheduledThreadPool(config.getQueryManagerExecutorPoolSize(), daemonThreadsNamed("dispatch-executor-%d"));
         closer.register(coreScheduledExecutor::shutdownNow);
         scheduledExecutor = listeningDecorator(coreScheduledExecutor);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/ClusterSizeMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ClusterSizeMonitor.java
@@ -113,7 +113,7 @@ public class ClusterSizeMonitor
         this.coordinatorMaxWait = requireNonNull(coordinatorMaxWait, "coordinatorMaxWait is null");
         checkArgument(resourceManagerMinCountActive >= 0, "resourceManagerMinCountActive is negative");
         this.resourceManagerMinCountActive = resourceManagerMinCountActive;
-        this.executor = newSingleThreadScheduledExecutor(threadsNamed("node-monitor-%s"));
+        this.executor = newSingleThreadScheduledExecutor(threadsNamed("node-monitor-%d"));
     }
 
     @PostConstruct

--- a/presto-main/src/main/java/com/facebook/presto/execution/PartialResultQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PartialResultQueryManager.java
@@ -41,7 +41,7 @@ public class PartialResultQueryManager
     private void startExecutor()
     {
         // Start the executor if not already started
-        if (executor.compareAndSet(null, newSingleThreadScheduledExecutor(threadsNamed("partial-result-query-manager-%s")))) {
+        if (executor.compareAndSet(null, newSingleThreadScheduledExecutor(threadsNamed("partial-result-query-manager-%d")))) {
             executor.get().scheduleWithFixedDelay(this::checkAndCancelTasks, 1, 1, TimeUnit.SECONDS);
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -117,7 +117,7 @@ public class SqlQueryManager
         this.maxQueryOutputPositions = queryManagerConfig.getQueryMaxOutputPositions();
         this.maxQueryOutputSize = queryManagerConfig.getQueryMaxOutputSize();
 
-        this.queryManagementExecutor = Executors.newScheduledThreadPool(queryManagerConfig.getQueryManagerExecutorPoolSize(), threadsNamed("query-management-%s"));
+        this.queryManagementExecutor = Executors.newScheduledThreadPool(queryManagerConfig.getQueryManagerExecutorPoolSize(), threadsNamed("query-management-%d"));
         this.queryManagementExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) queryManagementExecutor);
 
         this.queryTracker = new QueryTracker<>(queryManagerConfig, queryManagementExecutor, clusterQueryTrackerService);

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -155,11 +155,11 @@ public class SqlTaskManager
 
         DataSize maxBufferSize = config.getSinkMaxBufferSize();
 
-        taskNotificationExecutor = newFixedThreadPool(config.getTaskNotificationThreads(), threadsNamed("task-notification-%s"));
+        taskNotificationExecutor = newFixedThreadPool(config.getTaskNotificationThreads(), threadsNamed("task-notification-%d"));
         taskNotificationExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) taskNotificationExecutor);
 
         this.taskManagementExecutor = requireNonNull(taskManagementExecutor, "taskManagementExecutor cannot be null").getExecutor();
-        this.driverYieldExecutor = newScheduledThreadPool(config.getTaskYieldThreads(), threadsNamed("task-yield-%s"));
+        this.driverYieldExecutor = newScheduledThreadPool(config.getTaskYieldThreads(), threadsNamed("task-yield-%d"));
 
         SqlTaskExecutionFactory sqlTaskExecutionFactory = new SqlTaskExecutionFactory(
                 taskNotificationExecutor,

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagementExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagementExecutor.java
@@ -36,7 +36,7 @@ public final class TaskManagementExecutor
 
     public TaskManagementExecutor()
     {
-        taskManagementExecutor = newScheduledThreadPool(5, threadsNamed("task-management-%s"));
+        taskManagementExecutor = newScheduledThreadPool(5, threadsNamed("task-management-%d"));
         taskManagementExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) taskManagementExecutor);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBufferFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBufferFactory.java
@@ -46,7 +46,7 @@ public class SpoolingOutputBufferFactory
 
     private final Closer closer = Closer.create();
 
-    private final ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("spooling-outputbuffer-%s"));
+    private final ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("spooling-outputbuffer-%d"));
 
     @Inject
     public SpoolingOutputBufferFactory(FeaturesConfig featuresConfig, TempStorageManager tempStorageManager, FinalizerService finalizerService)

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
@@ -267,7 +267,7 @@ public class TaskExecutor
         checkArgument(interruptSplitInterval.getValue(SECONDS) >= 1.0, "interruptSplitInterval must be at least 1 second");
 
         // we manage thread pool size directly, so create an unlimited pool
-        this.executor = newCachedThreadPool(threadsNamed("task-processor-%s"));
+        this.executor = newCachedThreadPool(threadsNamed("task-processor-%d"));
         this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) executor);
         this.runnerThreads = runnerThreads;
         this.embedVersion = requireNonNull(embedVersion, "embedVersion is null");

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NetworkLocationCache.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NetworkLocationCache.java
@@ -39,7 +39,7 @@ public class NetworkLocationCache
 
     private static final Logger log = Logger.get(NetworkLocationCache.class);
 
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("network-location-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("network-location-%d"));
     private final NetworkTopology networkTopology;
     private final LoadingCache<HostAddress, NetworkLocation> cache;
     private final Cache<HostAddress, Boolean> negativeCache;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -147,8 +147,8 @@ public final class DiscoveryNodeManager
         this.expectedNodeVersion = requireNonNull(expectedNodeVersion, "expectedNodeVersion is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.driftClient = requireNonNull(driftClient, "driftClient is null");
-        this.nodeStateUpdateExecutor = newSingleThreadScheduledExecutor(threadsNamed("node-state-poller-%s"));
-        this.nodeStateEventExecutor = newCachedThreadPool(threadsNamed("node-state-events-%s"));
+        this.nodeStateUpdateExecutor = newSingleThreadScheduledExecutor(threadsNamed("node-state-poller-%d"));
+        this.nodeStateEventExecutor = newCachedThreadPool(threadsNamed("node-state-events-%d"));
         this.httpsRequired = internalCommunicationConfig.isHttpsRequired();
 
         this.currentNode = findCurrentNode(

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
@@ -98,7 +98,7 @@ public class ExchangeClientFactory
 
         this.scheduler = requireNonNull(scheduler, "scheduler is null");
 
-        this.pageBufferClientCallbackExecutor = newFixedThreadPool(pageBufferClientMaxCallbackThreads, daemonThreadsNamed("page-buffer-client-callback-%s"));
+        this.pageBufferClientCallbackExecutor = newFixedThreadPool(pageBufferClientMaxCallbackThreads, daemonThreadsNamed("page-buffer-client-callback-%d"));
         this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) pageBufferClientCallbackExecutor);
 
         this.responseSizeExponentialMovingAverageDecayingAlpha = responseSizeExponentialMovingAverageDecayingAlpha;

--- a/presto-main/src/main/java/com/facebook/presto/server/CatalogServerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CatalogServerModule.java
@@ -83,7 +83,7 @@ public class CatalogServerModule
     @ForTransactionManager
     public static ExecutorService createTransactionFinishingExecutor()
     {
-        return newCachedThreadPool(daemonThreadsNamed("transaction-finishing-%s"));
+        return newCachedThreadPool(daemonThreadsNamed("transaction-finishing-%d"));
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -255,7 +255,7 @@ public class CoordinatorModule
 
         // query execution
         binder.bind(ExecutorService.class).annotatedWith(ForQueryExecution.class)
-                .toInstance(newCachedThreadPool(threadsNamed("query-execution-%s")));
+                .toInstance(newCachedThreadPool(threadsNamed("query-execution-%d")));
         binder.bind(QueryExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(QueryExecutionMBean.class).as(generatedNameOf(QueryExecution.class));
 
@@ -314,7 +314,7 @@ public class CoordinatorModule
     @ForStatementResource
     public static ExecutorService createStatementResponseCoreExecutor()
     {
-        return newCachedThreadPool(daemonThreadsNamed("statement-response-%s"));
+        return newCachedThreadPool(daemonThreadsNamed("statement-response-%d"));
     }
 
     @Provides
@@ -330,7 +330,7 @@ public class CoordinatorModule
     @ForStatementResource
     public static ScheduledExecutorService createStatementTimeoutExecutor(TaskManagerConfig config)
     {
-        return newScheduledThreadPool(config.getHttpTimeoutThreads(), daemonThreadsNamed("statement-timeout-%s"));
+        return newScheduledThreadPool(config.getHttpTimeoutThreads(), daemonThreadsNamed("statement-timeout-%d"));
     }
 
     @Provides
@@ -346,7 +346,7 @@ public class CoordinatorModule
     @ForTransactionManager
     public static ExecutorService createTransactionFinishingExecutor()
     {
-        return newCachedThreadPool(daemonThreadsNamed("transaction-finishing-%s"));
+        return newCachedThreadPool(daemonThreadsNamed("transaction-finishing-%d"));
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
@@ -48,8 +48,8 @@ public class GracefulShutdownHandler
     private static final Logger log = Logger.get(GracefulShutdownHandler.class);
     private static final Duration LIFECYCLE_STOP_TIMEOUT = new Duration(30, SECONDS);
 
-    private final ScheduledExecutorService shutdownHandler = newSingleThreadScheduledExecutor(threadsNamed("shutdown-handler-%s"));
-    private final ExecutorService lifeCycleStopper = newSingleThreadExecutor(threadsNamed("lifecycle-stopper-%s"));
+    private final ScheduledExecutorService shutdownHandler = newSingleThreadScheduledExecutor(threadsNamed("shutdown-handler-%d"));
+    private final ExecutorService lifeCycleStopper = newSingleThreadExecutor(threadsNamed("lifecycle-stopper-%d"));
     private final LifeCycleManager lifeCycleManager;
     private final QueryManager queryManager;
     private final TaskManager sqlTaskManager;

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -311,7 +311,7 @@ public class ServerMainModule
 
         // Metadata Extractor
         binder.bind(ExecutorService.class).annotatedWith(ForMetadataExtractor.class)
-                .toInstance(newCachedThreadPool(threadsNamed("metadata-extractor-%s")));
+                .toInstance(newCachedThreadPool(threadsNamed("metadata-extractor-%d")));
         binder.bind(MetadataExtractorMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(MetadataExtractorMBean.class).as(generatedNameOf(MetadataExtractor.class));
 
@@ -465,7 +465,7 @@ public class ServerMainModule
                                 60,
                                 SECONDS,
                                 new LinkedBlockingQueue<>(),
-                                daemonThreadsNamed("resource-manager-executor-%s"));
+                                daemonThreadsNamed("resource-manager-executor-%d"));
                         return listeningDecorator(executor);
                     }
                 },
@@ -786,7 +786,7 @@ public class ServerMainModule
     @ForExchange
     public static ScheduledExecutorService createExchangeExecutor(ExchangeClientConfig config)
     {
-        return newScheduledThreadPool(config.getClientThreads(), daemonThreadsNamed("exchange-client-%s"));
+        return newScheduledThreadPool(config.getClientThreads(), daemonThreadsNamed("exchange-client-%d"));
     }
 
     @Provides
@@ -794,7 +794,7 @@ public class ServerMainModule
     @ForAsyncRpc
     public static ExecutorService createAsyncHttpResponseCoreExecutor()
     {
-        return newCachedThreadPool(daemonThreadsNamed("async-http-response-%s"));
+        return newCachedThreadPool(daemonThreadsNamed("async-http-response-%d"));
     }
 
     @Provides
@@ -822,8 +822,8 @@ public class ServerMainModule
                     config,
                     blockEncodingSerde,
                     fragmentCacheStats,
-                    newFixedThreadPool(5, daemonThreadsNamed("fragment-result-cache-writer-%s")),
-                    newFixedThreadPool(1, daemonThreadsNamed("fragment-result-cache-remover-%s")));
+                    newFixedThreadPool(5, daemonThreadsNamed("fragment-result-cache-writer-%d")),
+                    newFixedThreadPool(1, daemonThreadsNamed("fragment-result-cache-remover-%d")));
         }
         return new NoOpFragmentResultCacheManager();
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -135,7 +135,7 @@ public class HttpRemoteTaskFactory
         this.handleResolver = handleResolver;
         this.connectorTypeSerdeManager = connectorTypeSerdeManager;
 
-        this.coreExecutor = newCachedThreadPool(daemonThreadsNamed("remote-task-callback-%s"));
+        this.coreExecutor = newCachedThreadPool(daemonThreadsNamed("remote-task-callback-%d"));
         this.executor = new BoundedExecutor(coreExecutor, config.getRemoteTaskMaxCallbackThreads());
         this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) coreExecutor);
         this.stats = requireNonNull(stats, "stats is null");
@@ -180,8 +180,8 @@ public class HttpRemoteTaskFactory
         this.metadataManager = metadataManager;
         this.queryManager = queryManager;
 
-        this.updateScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("task-info-update-scheduler-%s"));
-        this.errorScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("remote-task-error-delay-%s"));
+        this.updateScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("task-info-update-scheduler-%d"));
+        this.errorScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("remote-task-error-delay-%d"));
         this.taskUpdateRequestSize = new DecayCounter(ExponentialDecay.oneMinute());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpillerFactory.java
@@ -74,7 +74,7 @@ public class FileSingleStreamSpillerFactory
         this(
                 listeningDecorator(newFixedThreadPool(
                         requireNonNull(featuresConfig, "featuresConfig is null").getSpillerThreads(),
-                        daemonThreadsNamed("binary-spiller-%s"))),
+                        daemonThreadsNamed("binary-spiller-%d"))),
                 blockEncodingSerde,
                 spillerStats,
                 requireNonNull(featuresConfig, "featuresConfig is null").getSpillerSpillPaths(),

--- a/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpillerFactory.java
@@ -58,7 +58,7 @@ public class TempStorageSingleStreamSpillerFactory
                 tempStorageManager,
                 listeningDecorator(newFixedThreadPool(
                         requireNonNull(featuresConfig, "featuresConfig is null").getSpillerThreads(),
-                        daemonThreadsNamed("binary-spiller-%s"))),
+                        daemonThreadsNamed("binary-spiller-%d"))),
                 blockEncodingSerde,
                 spillerStats,
                 requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").isSpillCompressionEnabled(),

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -340,7 +340,7 @@ public class LocalQueryRunner
     private final PlanChecker distributedPlanChecker;
     private final PlanChecker singleNodePlanChecker;
 
-    private static ExecutorService metadataExtractorExecutor = newCachedThreadPool(threadsNamed("query-execution-%s"));
+    private static ExecutorService metadataExtractorExecutor = newCachedThreadPool(threadsNamed("query-execution-%d"));
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -371,8 +371,8 @@ public class LocalQueryRunner
 
         this.nodeSpillConfig = requireNonNull(nodeSpillConfig, "nodeSpillConfig is null");
         this.alwaysRevokeMemory = alwaysRevokeMemory;
-        this.notificationExecutor = newCachedThreadPool(daemonThreadsNamed("local-query-runner-executor-%s"));
-        this.yieldExecutor = newScheduledThreadPool(2, daemonThreadsNamed("local-query-runner-scheduler-%s"));
+        this.notificationExecutor = newCachedThreadPool(daemonThreadsNamed("local-query-runner-executor-%d"));
+        this.yieldExecutor = newScheduledThreadPool(2, daemonThreadsNamed("local-query-runner-scheduler-%d"));
         this.finalizerService = new FinalizerService();
         finalizerService.start();
         this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");

--- a/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/ConfidenceBasedNodeTtlFetcherManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/ConfidenceBasedNodeTtlFetcherManager.java
@@ -98,7 +98,7 @@ public class ConfidenceBasedNodeTtlFetcherManager
         periodicTtlRefresher = new PeriodicTaskExecutor(
                 ttlFetcher.get().getRefreshInterval().toMillis(),
                 nodeTtlFetcherManagerConfig.getInitialDelayBeforeRefresh().toMillis(),
-                newSingleThreadScheduledExecutor(threadsNamed("refresh-node-ttl-executor-%s")),
+                newSingleThreadScheduledExecutor(threadsNamed("refresh-node-ttl-executor-%d")),
                 this::refreshTtlInfo,
                 ConfidenceBasedNodeTtlFetcherManager::jitterForPeriodicRefresh);
         periodicTtlRefresher.start();

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -160,8 +160,8 @@ public class BenchmarkNodeScheduler
             }
             List<InternalNode> nodes = nodeBuilder.build();
             MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(
-                    newCachedThreadPool(daemonThreadsNamed("remoteTaskExecutor-%s")),
-                    newScheduledThreadPool(2, daemonThreadsNamed("remoteTaskScheduledExecutor-%s")));
+                    newCachedThreadPool(daemonThreadsNamed("remoteTaskExecutor-%d")),
+                    newScheduledThreadPool(2, daemonThreadsNamed("remoteTaskScheduledExecutor-%d")));
             for (int i = 0; i < nodes.size(); i++) {
                 InternalNode node = nodes.get(i);
                 ImmutableList.Builder<Split> initialSplits = ImmutableList.builder();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.fail;
 public class TestCommitTask
 {
     private final MetadataManager metadata = MetadataManager.createTestMetadataManager();
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCreateFunctionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCreateFunctionTask.java
@@ -37,7 +37,7 @@ import static org.testng.Assert.assertEquals;
 public class TestCreateFunctionTask
 {
     private final MetadataManager metadataManager = createTestMetadataManager();
-    private final ExecutorService executorService = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+    private final ExecutorService executorService = newCachedThreadPool(daemonThreadsNamed("test-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
@@ -115,7 +115,7 @@ public class TestCreateMaterializedViewTask
 
         accessControl = new AllowAllAccessControl();
 
-        executorService = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+        executorService = newCachedThreadPool(daemonThreadsNamed("test-%d"));
 
         metadata = new MockMetadata(
                 functionAndTypeManager,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.fail;
 public class TestDeallocateTask
 {
     private final MetadataManager metadata = createTestMetadataManager();
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestDropFunctionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestDropFunctionTask.java
@@ -43,7 +43,7 @@ import static org.testng.Assert.assertTrue;
 public class TestDropFunctionTask
 {
     private final MetadataManager metadataManager = createTestMetadataManager();
-    private final ExecutorService executorService = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+    private final ExecutorService executorService = newCachedThreadPool(daemonThreadsNamed("test-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -115,9 +115,9 @@ public class TestMemoryRevokingScheduler
         taskExecutor.start();
 
         // Must be single threaded
-        singleThreadedExecutor = newSingleThreadExecutor(threadsNamed("task-notification-%s"));
-        singleThreadedScheduledExecutor = newScheduledThreadPool(1, threadsNamed("task-notification-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, threadsNamed("task-notification-%s"));
+        singleThreadedExecutor = newSingleThreadExecutor(threadsNamed("task-notification-%d"));
+        singleThreadedScheduledExecutor = newScheduledThreadPool(1, threadsNamed("task-notification-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, threadsNamed("task-notification-%d"));
 
         LocalExecutionPlanner planner = createTestingPlanner();
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -151,8 +151,8 @@ public class TestNodeScheduler
         // contents of taskMap indicate the node-task map for the current stage
         taskMap = new HashMap<>();
         nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID);
-        remoteTaskExecutor = newCachedThreadPool(daemonThreadsNamed("remoteTaskExecutor-%s"));
-        remoteTaskScheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("remoteTaskScheduledExecutor-%s"));
+        remoteTaskExecutor = newCachedThreadPool(daemonThreadsNamed("remoteTaskExecutor-%d"));
+        remoteTaskScheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("remoteTaskScheduledExecutor-%d"));
 
         finalizerService.start();
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
@@ -51,7 +51,7 @@ import static org.testng.Assert.fail;
 public class TestPrepareTask
 {
     private final MetadataManager metadata = createTestMetadataManager();
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestResetSessionTask.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.assertEquals;
 public class TestResetSessionTask
 {
     private static final String CATALOG_NAME = "catalog";
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%d"));
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
     private final MetadataManager metadata;

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.fail;
 public class TestRollbackTask
 {
     private final MetadataManager metadata = MetadataManager.createTestMetadataManager();
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSetRoleTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSetRoleTask.java
@@ -66,7 +66,7 @@ public class TestSetRoleTask
         metadata = MetadataManager.createTestMetadataManager(transactionManager, new FeaturesConfig());
 
         catalogManager.registerCatalog(createBogusTestingCatalog(CATALOG_NAME));
-        executor = newCachedThreadPool(daemonThreadsNamed("test-set-role-task-executor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-set-role-task-executor-%d"));
         parser = new SqlParser();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSetSessionTask.java
@@ -111,7 +111,7 @@ public class TestSetSessionTask
         return intValue;
     }
 
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -68,8 +68,8 @@ public class TestSqlStageExecution
     @BeforeClass
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @AfterClass

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -90,8 +90,8 @@ public class TestSqlTask
         taskExecutor = new TaskExecutor(8, 16, 3, 4, TASK_FAIR, Ticker.systemTicker());
         taskExecutor.start();
 
-        taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));
-        driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%s"));
+        taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%d"));
+        driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%d"));
 
         LocalExecutionPlanner planner = createTestingPlanner();
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -136,8 +136,8 @@ public class TestSqlTaskExecution
     public void testSimple(PipelineExecutionStrategy executionStrategy)
             throws Exception
     {
-        ScheduledExecutorService taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));
-        ScheduledExecutorService driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%s"));
+        ScheduledExecutorService taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%d"));
+        ScheduledExecutorService driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%d"));
         TaskExecutor taskExecutor = new TaskExecutor(5, 10, 3, 4, TASK_FAIR, Ticker.systemTicker());
         taskExecutor.start();
 
@@ -312,8 +312,8 @@ public class TestSqlTaskExecution
     public void testComplex(PipelineExecutionStrategy executionStrategy)
             throws Exception
     {
-        ScheduledExecutorService taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));
-        ScheduledExecutorService driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%s"));
+        ScheduledExecutorService taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%d"));
+        ScheduledExecutorService driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%d"));
         TaskExecutor taskExecutor = new TaskExecutor(5, 10, 3, 4, TASK_FAIR, Ticker.systemTicker());
         taskExecutor.start();
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
@@ -59,8 +59,8 @@ import static org.testng.Assert.fail;
 public class TestStartTransactionTask
 {
     private final MetadataManager metadata = MetadataManager.createTestMetadataManager();
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%s"));
-    private final ScheduledExecutorService scheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("scheduled-executor-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stage-executor-%d"));
+    private final ScheduledExecutorService scheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("scheduled-executor-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
@@ -37,7 +37,7 @@ public class TestStateMachine
         BREAKFAST, LUNCH, DINNER
     }
 
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -75,7 +75,7 @@ public class TestArbitraryOutputBuffer
     @BeforeClass
     public void setUp()
     {
-        stateNotificationExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-%s"));
+        stateNotificationExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -84,7 +84,7 @@ public class TestBroadcastOutputBuffer
     @BeforeClass
     public void setUp()
     {
-        stateNotificationExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-%s"));
+        stateNotificationExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
@@ -73,7 +73,7 @@ public class TestPartitionedOutputBuffer
     @BeforeClass
     public void setUp()
     {
-        stateNotificationExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-%s"));
+        stateNotificationExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestSpoolingOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestSpoolingOutputBuffer.java
@@ -77,7 +77,7 @@ public class TestSpoolingOutputBuffer
     @BeforeClass
     public void setUp()
     {
-        stateNotificationExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-%s"));
+        stateNotificationExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-%d"));
 
         FeaturesConfig featuresConfig = new FeaturesConfig();
         featuresConfig.setSpoolingOutputBufferThreshold(THRESHOLD);

--- a/presto-main/src/test/java/com/facebook/presto/execution/executor/TaskExecutorSimulator.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/executor/TaskExecutorSimulator.java
@@ -68,7 +68,7 @@ public class TaskExecutorSimulator
         }
     }
 
-    private final ListeningExecutorService submissionExecutor = listeningDecorator(newCachedThreadPool(threadsNamed(getClass().getSimpleName() + "-%s")));
+    private final ListeningExecutorService submissionExecutor = listeningDecorator(newCachedThreadPool(threadsNamed(getClass().getSimpleName() + "-%d")));
     private final ScheduledExecutorService overallStatusPrintExecutor = newSingleThreadScheduledExecutor();
     private final ScheduledExecutorService runningSplitsPrintExecutor = newSingleThreadScheduledExecutor();
     private final ScheduledExecutorService wakeupExecutor = newScheduledThreadPool(32);

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
@@ -81,7 +81,7 @@ public class TestAdaptivePhasedExecutionPolicy
     private static final PlanNodeId TABLE_SCAN_NODE_ID = new PlanNodeId("tableScan");
     private static final ConnectorId CONNECTOR_ID = new ConnectorId("test");
 
-    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("testAdaptivePhasedExecutionPolicy-%s"));
+    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("testAdaptivePhasedExecutionPolicy-%d"));
 
     @AfterClass
     public void tearDownExecutor()

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
@@ -40,8 +40,8 @@ import static org.testng.Assert.assertTrue;
 
 public class TestFixedCountScheduler
 {
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stageExecutor-%s"));
-    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("stageScheduledExecutor-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stageExecutor-%d"));
+    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("stageScheduledExecutor-%d"));
     private final MockRemoteTaskFactory taskFactory;
 
     public TestFixedCountScheduler()

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
@@ -42,8 +42,8 @@ import static org.testng.Assert.assertEquals;
 
 public class TestPartialResultQueryTaskTracker
 {
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stageExecutor-%s"));
-    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("stageScheduledExecutor-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stageExecutor-%d"));
+    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("stageScheduledExecutor-%d"));
     private final PartialResultQueryManager partialResultQueryManager = new PartialResultQueryManager();
     private final WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig(), NORMAL);
     private final MockRemoteTaskFactory taskFactory;

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -107,8 +107,8 @@ public class TestSourcePartitionedScheduler
     private static final ConnectorId CONNECTOR_ID = new ConnectorId("connector_id");
     private static final PlanNodeId TABLE_SCAN_NODE_ID = new PlanNodeId("plan_id");
 
-    private final ExecutorService queryExecutor = newCachedThreadPool(daemonThreadsNamed("stageExecutor-%s"));
-    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("stageScheduledExecutor-%s"));
+    private final ExecutorService queryExecutor = newCachedThreadPool(daemonThreadsNamed("stageExecutor-%d"));
+    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("stageScheduledExecutor-%d"));
     private final LocationFactory locationFactory = new MockLocationFactory();
     private final InMemoryNodeManager nodeManager = new InMemoryNodeManager();
     private final FinalizerService finalizerService = new FinalizerService();

--- a/presto-main/src/test/java/com/facebook/presto/geospatial/TestSpatialJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/geospatial/TestSpatialJoinOperator.java
@@ -124,9 +124,9 @@ public class TestSpatialJoinOperator
                 60L,
                 SECONDS,
                 new SynchronousQueue<>(),
-                daemonThreadsNamed("test-executor-%s"),
+                daemonThreadsNamed("test-executor-%d"),
                 new ThreadPoolExecutor.DiscardPolicy());
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @AfterMethod(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestHighMemoryTaskKiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestHighMemoryTaskKiller.java
@@ -83,8 +83,8 @@ public class TestHighMemoryTaskKiller
         taskExecutor = new TaskExecutor(8, 16, 3, 4, TASK_FAIR, Ticker.systemTicker());
         taskExecutor.start();
 
-        taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%s"));
-        driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%s"));
+        taskNotificationExecutor = newScheduledThreadPool(10, threadsNamed("task-notification-%d"));
+        driverYieldExecutor = newScheduledThreadPool(2, threadsNamed("driver-yield-%d"));
 
         LocalExecutionPlanner planner = createTestingPlanner();
 

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -80,8 +80,8 @@ public class TestMemoryTracking
     @BeforeClass
     public void setUp()
     {
-        notificationExecutor = newCachedThreadPool(daemonThreadsNamed("local-query-runner-executor-%s"));
-        yieldExecutor = newScheduledThreadPool(2, daemonThreadsNamed("local-query-runner-scheduler-%s"));
+        notificationExecutor = newCachedThreadPool(daemonThreadsNamed("local-query-runner-executor-%d"));
+        yieldExecutor = newScheduledThreadPool(2, daemonThreadsNamed("local-query-runner-scheduler-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
@@ -51,7 +51,7 @@ import static org.testng.Assert.assertTrue;
 
 public class TestQueryContext
 {
-    private static final ScheduledExecutorService TEST_EXECUTOR = newScheduledThreadPool(1, threadsNamed("test-executor-%s"));
+    private static final ScheduledExecutorService TEST_EXECUTOR = newScheduledThreadPool(1, threadsNamed("test-executor-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
@@ -76,8 +76,8 @@ public class TestSystemMemoryBlocking
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         TaskContext taskContext = TestingTaskContext.builder(executor, scheduledExecutor, TEST_SESSION)
                 .setQueryMaxMemory(DataSize.valueOf("100MB"))
                 .setMemoryPoolSize(DataSize.valueOf("10B"))

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkDynamicFilterSourceOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkDynamicFilterSourceOperator.java
@@ -78,8 +78,8 @@ public class BenchmarkDynamicFilterSourceOperator
         @Setup
         public void setup()
         {
-            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
             pages = createInputPages(Integer.valueOf(positionsPerPage));
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndSegmentedAggregationOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndSegmentedAggregationOperators.java
@@ -108,8 +108,8 @@ public class BenchmarkHashAndSegmentedAggregationOperators
         @Setup
         public void setup()
         {
-            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
             outputRows = 0;
 
             boolean segmentedAggregation = operatorType.equalsIgnoreCase("segmented");

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndStreamingAggregationOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndStreamingAggregationOperators.java
@@ -108,8 +108,8 @@ public class BenchmarkHashAndStreamingAggregationOperators
         @Setup
         public void setup()
         {
-            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
             int groupsPerPage = ROWS_PER_PAGE / rowsPerGroup;
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -119,8 +119,8 @@ public class BenchmarkHashBuildAndJoinOperators
                 default:
                     throw new UnsupportedOperationException(format("Unknown hashColumns value [%s]", hashColumns));
             }
-            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
             initializeBuildPages();
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkUnnestOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkUnnestOperator.java
@@ -141,8 +141,8 @@ public class BenchmarkUnnestOperator
         @Setup
         public void setup()
         {
-            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
             Metadata metadata = createTestMetadataManager();
 
             ImmutableList.Builder<Type> typesBuilder = ImmutableList.builder();

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkWindowOperator.java
@@ -95,8 +95,8 @@ public class BenchmarkWindowOperator
         @Setup
         public void setup()
         {
-            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
             createOperatorFactoryAndGenerateTestData(numberOfPregroupedColumns);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
@@ -53,8 +53,8 @@ import static org.testng.Assert.assertTrue;
 
 public final class GroupByHashYieldAssertion
 {
-    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-    private static final ScheduledExecutorService SCHEDULED_EXECUTOR = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+    private static final ScheduledExecutorService SCHEDULED_EXECUTOR = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
     private GroupByHashYieldAssertion() {}
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
@@ -83,8 +83,8 @@ public class TestAggregationOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @AfterMethod

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDistinctLimitOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDistinctLimitOperator.java
@@ -59,8 +59,8 @@ public class TestDistinctLimitOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -134,8 +134,8 @@ public class TestDriver
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDynamicFilterSourceOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDynamicFilterSourceOperator.java
@@ -82,8 +82,8 @@ public class TestDynamicFilterSourceOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         pipelineContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -80,9 +80,9 @@ public class TestExchangeClient
     @BeforeClass
     public void setUp()
     {
-        scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
+        scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%d"));
         pageBufferClientCallbackExecutor = Executors.newSingleThreadExecutor();
-        testingHttpClientExecutor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+        testingHttpClientExecutor = newCachedThreadPool(daemonThreadsNamed("test-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
@@ -80,8 +80,8 @@ public class TestExchangeOperator
     @BeforeClass
     public void setUp()
     {
-        scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         pageBufferClientCallbackExecutor = Executors.newSingleThreadExecutor();
         httpClient = new TestingHttpClient(new TestingExchangeHttpClientHandler(taskBuffers), scheduler);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheManager.java
@@ -58,9 +58,9 @@ public class TestFileFragmentResultCacheManager
     private static final Split SPLIT_1 = new Split(new ConnectorId("test"), new ConnectorTransactionHandle() {}, new TestingSplit(1));
     private static final Split SPLIT_2 = new Split(new ConnectorId("test"), new ConnectorTransactionHandle() {}, new TestingSplit(2));
 
-    private final ExecutorService writeExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-cache-flusher-%s"));
-    private final ExecutorService removalExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-cache-remover-%s"));
-    private final ExecutorService multithreadingWriteExecutor = newScheduledThreadPool(10, daemonThreadsNamed("test-cache-multithreading-flusher-%s"));
+    private final ExecutorService writeExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-cache-flusher-%d"));
+    private final ExecutorService removalExecutor = newScheduledThreadPool(5, daemonThreadsNamed("test-cache-remover-%d"));
+    private final ExecutorService multithreadingWriteExecutor = newScheduledThreadPool(10, daemonThreadsNamed("test-cache-multithreading-flusher-%d"));
 
     @AfterClass
     public void close()

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
@@ -65,8 +65,8 @@ public class TestFilterAndProjectOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
@@ -50,8 +50,8 @@ public class TestGroupIdOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -120,8 +120,8 @@ public class TestHashAggregationOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         spillerFactory = new DummySpillerFactory();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperatorInSegmentedAggregationMode.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperatorInSegmentedAggregationMode.java
@@ -87,8 +87,8 @@ public class TestHashAggregationOperatorInSegmentedAggregationMode
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @AfterMethod

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -137,9 +137,9 @@ public class TestHashJoinOperator
                 60L,
                 SECONDS,
                 new SynchronousQueue<>(),
-                daemonThreadsNamed("test-executor-%s"),
+                daemonThreadsNamed("test-executor-%d"),
                 new ThreadPoolExecutor.DiscardPolicy());
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         partitioningProviderManager = new PartitioningProviderManager();
         session = testSessionBuilder().build();
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
@@ -65,8 +65,8 @@ public class TestHashSemiJoinOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestLimitOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestLimitOperator.java
@@ -46,8 +46,8 @@ public class TestLimitOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMarkDistinctOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMarkDistinctOperator.java
@@ -66,8 +66,8 @@ public class TestMarkDistinctOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
@@ -79,7 +79,7 @@ public class TestMergeOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("test-merge-operator-%s"));
+        executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("test-merge-operator-%d"));
         serdeFactory = new TestingPagesSerdeFactory();
 
         taskBuffers = CacheBuilder.newBuilder().build(CacheLoader.from(TestingTaskBuffer::new));

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopBuildOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopBuildOperator.java
@@ -48,8 +48,8 @@ public class TestNestedLoopBuildOperator
     @BeforeClass
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopJoinOperator.java
@@ -55,8 +55,8 @@ public class TestNestedLoopJoinOperator
     @BeforeClass
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
@@ -74,8 +74,8 @@ public class TestOrderByOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         spillerFactory = new DummySpillerFactory();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
@@ -70,7 +70,7 @@ public class TestPageBufferClient
     @BeforeClass
     public void setUp()
     {
-        scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
+        scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%d"));
         pageBufferClientCallbackExecutor = Executors.newSingleThreadExecutor();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPartitionedOutputOperator.java
@@ -68,8 +68,8 @@ public class TestPartitionedOutputOperator
     private static final DataSize PARTITION_MAX_MEMORY = new DataSize(5, MEGABYTE);
     private static final List<Type> TYPES = ImmutableList.of(BIGINT);
     private static final List<Type> REPLICATION_TYPES = ImmutableList.of(BIGINT, BIGINT);
-    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%s"));
-    private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%d"));
+    private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%d"));
 
     private static final Block NULL_BLOCK = new RunLengthEncodedBlock(BIGINT.createBlockBuilder(null, 1).appendNull().build(), POSITIONS_PER_PAGE);
     private static final Block TESTING_BLOCK = createLongSequenceBlock(0, POSITIONS_PER_PAGE);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
@@ -67,8 +67,8 @@ public class TestRowNumberOperator
     @BeforeClass
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -103,8 +103,8 @@ public class TestScanFilterAndProjectOperator
 
     public TestScanFilterAndProjectOperator()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestStreamingAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestStreamingAggregationOperator.java
@@ -66,8 +66,8 @@ public class TestStreamingAggregationOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTableFinishOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTableFinishOperator.java
@@ -85,7 +85,7 @@ public class TestTableFinishOperator
     @BeforeClass
     public void setUp()
     {
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTableWriterOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTableWriterOperator.java
@@ -93,8 +93,8 @@ public class TestTableWriterOperator
     @BeforeClass
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTopNOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTopNOperator.java
@@ -55,8 +55,8 @@ public class TestTopNOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
@@ -67,8 +67,8 @@ public class TestTopNRowNumberOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();
@@ -252,8 +252,8 @@ public class TestTopNRowNumberOperator
     {
         List<Page> input = createSequentialInputPages(1000, ImmutableList.of(BIGINT, DOUBLE, DOUBLE, VARCHAR, DOUBLE), 200, 300, 42);
 
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         driverContext = TestingTaskContext.builder(executor, scheduledExecutor, TEST_SESSION)
                 .setQueryMaxMemory(new DataSize(200, DataSize.Unit.KILOBYTE))
                 .setQueryMaxTotalMemory(new DataSize(200, DataSize.Unit.KILOBYTE))
@@ -289,8 +289,8 @@ public class TestTopNRowNumberOperator
     {
         List<Page> input = createSequentialInputPages(1000, ImmutableList.of(BIGINT, DOUBLE, DOUBLE, VARCHAR, DOUBLE), 200, 300, 42);
 
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         driverContext = TestingTaskContext.builder(executor, scheduledExecutor, TEST_SESSION)
                 .setQueryMaxMemory(new DataSize(200, DataSize.Unit.KILOBYTE))
                 .setQueryMaxTotalMemory(new DataSize(200, DataSize.Unit.KILOBYTE))

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
@@ -100,8 +100,8 @@ public class TestWindowOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         spillerFactory = new DummySpillerFactory();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.fail;
 
 public class TestDictionaryAwarePageProjection
 {
-    private static final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("test-%s"));
+    private static final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("test-%d"));
 
     @DataProvider(name = "forceYield")
     public static Object[][] forceYield()

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
@@ -89,7 +89,7 @@ import static org.testng.Assert.assertTrue;
 
 public class TestPageProcessor
 {
-    private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("test-%s"));
+    private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("test-%d"));
 
     @Test
     public void testProjectNoColumns()

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
@@ -148,8 +148,8 @@ public class BenchmarkPartitionedOutputOperator
         private static final int POSITION_COUNT = 8192;
         private static final DataSize MAX_MEMORY = new DataSize(4, GIGABYTE);
         private static final DataSize MAX_PARTITION_BUFFER_SIZE = new DataSize(256, MEGABYTE);
-        private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%s"));
-        private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
+        private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%d"));
+        private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%d"));
 
         @SuppressWarnings("unused")
         @Param({"true", "false"})

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
@@ -104,8 +104,8 @@ import static org.testng.Assert.assertEquals;
 
 public class TestOptimizedPartitionedOutputOperator
 {
-    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%s"));
-    private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%d"));
+    private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%d"));
     private static final DataSize MAX_MEMORY = new DataSize(1, GIGABYTE);
     private static final PagesSerde PAGES_SERDE = new PagesSerdeFactory(new BlockEncodingManager(), false).createPagesSerde(); //testingPagesSerde();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -160,8 +160,8 @@ import static org.testng.Assert.fail;
 public final class FunctionAssertions
         implements Closeable
 {
-    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-%s"));
-    private static final ScheduledExecutorService SCHEDULED_EXECUTOR = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-%d"));
+    private static final ScheduledExecutorService SCHEDULED_EXECUTOR = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
     private static final SqlParser SQL_PARSER = new SqlParser();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/unnest/TestUnnestOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/unnest/TestUnnestOperator.java
@@ -81,8 +81,8 @@ public class TestUnnestOperator
     private static final int PAGE_COUNT = 10;
     private static final int POSITION_COUNT = 500;
 
-    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%s"));
-    private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%d"));
+    private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%d"));
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
@@ -91,8 +91,8 @@ public class TestUnnestOperator
     @BeforeMethod
     public void setUp()
     {
-        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
@@ -154,7 +154,7 @@ public class TestThriftTaskIntegration
         @ForAsyncRpc
         public static ExecutorService createAsyncHttpResponseCoreExecutor()
         {
-            return newCachedThreadPool(daemonThreadsNamed("async-http-response-%s"));
+            return newCachedThreadPool(daemonThreadsNamed("async-http-response-%d"));
         }
 
         @Provides
@@ -170,7 +170,7 @@ public class TestThriftTaskIntegration
         @ForAsyncRpc
         public static ScheduledExecutorService createAsyncHttpTimeoutExecutor()
         {
-            return newScheduledThreadPool(10, daemonThreadsNamed("async-http-timeout-%s"));
+            return newScheduledThreadPool(10, daemonThreadsNamed("async-http-timeout-%d"));
         }
 
         @Provides

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -162,7 +162,7 @@ public class TestExpressionCompiler
     {
         Logging.initialize();
         if (PARALLEL) {
-            executor = listeningDecorator(newFixedThreadPool(getRuntime().availableProcessors() * 2, daemonThreadsNamed("completer-%s")));
+            executor = listeningDecorator(newFixedThreadPool(getRuntime().availableProcessors() * 2, daemonThreadsNamed("completer-%d")));
         }
         else {
             executor = newDirectExecutorService();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
@@ -83,8 +83,8 @@ import static org.testng.Assert.fail;
 
 public class TestLocalExecutionPlanner
 {
-    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-%s"));
-    private static final ScheduledExecutorService SCHEDULED_EXECUTOR = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-%d"));
+    private static final ScheduledExecutorService SCHEDULED_EXECUTOR = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
 
     private LocalQueryRunner runner;
 

--- a/presto-main/src/test/java/com/facebook/presto/transaction/TestTransactionManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/transaction/TestTransactionManager.java
@@ -58,7 +58,7 @@ public class TestTransactionManager
     private static final ConnectorId CONNECTOR_ID = new ConnectorId(CATALOG_NAME);
     private static final ConnectorId SYSTEM_TABLES_ID = createSystemTablesConnectorId(CONNECTOR_ID);
     private static final ConnectorId INFORMATION_SCHEMA_ID = createInformationSchemaConnectorId(CONNECTOR_ID);
-    private final ExecutorService finishingExecutor = newCachedThreadPool(daemonThreadsNamed("transaction-%s"));
+    private final ExecutorService finishingExecutor = newCachedThreadPool(daemonThreadsNamed("transaction-%d"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()

--- a/presto-main/src/test/java/com/facebook/presto/util/TestThreadNaming.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestThreadNaming.java
@@ -1,0 +1,44 @@
+package com.facebook.presto.util;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ThreadFactory;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static org.testng.Assert.assertEquals;
+
+public class TestThreadNaming
+{
+
+    private ThreadFactory threadFactory;
+    private ThreadFactory daemonThreadFactory;
+
+    @BeforeClass
+    public void setUp()
+    {
+        threadFactory = threadsNamed("test-%d");
+        daemonThreadFactory = daemonThreadsNamed("daemonTest-%d");
+    }
+
+    @Test
+    public void testThreadNaming()
+    {
+        Thread firstThread = threadFactory.newThread(() -> System.out.println(Thread.currentThread().getName()));
+        assertEquals("test-0", firstThread.getName());
+
+        Thread secondThread = threadFactory.newThread(() -> System.out.println(Thread.currentThread().getName()));
+        assertEquals("test-1", secondThread.getName());
+    }
+
+    @Test
+    public void testDaemonThreadNaming()
+    {
+        Thread firstThread = daemonThreadFactory.newThread(() -> System.out.println(Thread.currentThread().getName()));
+        assertEquals("daemonTest-0", firstThread.getName());
+
+        Thread secondThread = daemonThreadFactory.newThread(() -> System.out.println(Thread.currentThread().getName()));
+        assertEquals("daemonTest-1", secondThread.getName());
+    }
+}

--- a/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
@@ -81,7 +81,7 @@ public abstract class AbstractSvmModel
 
         svm_problem problem = toSvmProblem(dataset);
 
-        ExecutorService service = newCachedThreadPool(threadsNamed("libsvm-trainer-" + System.identityHashCode(this) + "-%s"));
+        ExecutorService service = newCachedThreadPool(threadsNamed("libsvm-trainer-" + System.identityHashCode(this) + "-%d"));
         try {
             TimeLimiter limiter = SimpleTimeLimiter.create(service);
             //TODO: this time limit should be configurable

--- a/presto-proxy/src/main/java/com/facebook/presto/proxy/ProxyResource.java
+++ b/presto-proxy/src/main/java/com/facebook/presto/proxy/ProxyResource.java
@@ -94,7 +94,7 @@ public class ProxyResource
     private static final String X509_ATTRIBUTE = "javax.servlet.request.X509Certificate";
     private static final JsonFactory JSON_FACTORY = new JsonFactory().disable(CANONICALIZE_FIELD_NAMES);
 
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("proxy-%s"));
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("proxy-%d"));
     private final HttpClient httpClient;
     private final JsonWebTokenHandler jwtHandler;
     private final URI remoteUri;

--- a/presto-proxy/src/test/java/com/facebook/presto/proxy/TestProxyServer.java
+++ b/presto-proxy/src/test/java/com/facebook/presto/proxy/TestProxyServer.java
@@ -99,7 +99,7 @@ public class TestProxyServer
         lifeCycleManager = injector.getInstance(LifeCycleManager.class);
         httpServerInfo = injector.getInstance(HttpServerInfo.class);
 
-        executorService = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+        executorService = newCachedThreadPool(daemonThreadsNamed("test-%d"));
 
         setupTestTable();
     }

--- a/presto-router/src/main/java/com/facebook/presto/router/cluster/ClusterStatusTracker.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/cluster/ClusterStatusTracker.java
@@ -53,7 +53,7 @@ public class ClusterStatusTracker
     {
         this.clusterManager = requireNonNull(clusterManager, "clusterManager is null");
         this.remoteInfoFactory = requireNonNull(remoteInfoFactory, "remoteInfoFactory is null");
-        this.queryInfoUpdateExecutor = newSingleThreadScheduledExecutor(threadsNamed("query-info-poller-%s"));
+        this.queryInfoUpdateExecutor = newSingleThreadScheduledExecutor(threadsNamed("query-info-poller-%d"));
     }
 
     @PostConstruct

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -382,16 +382,16 @@ public class PrestoSparkModule
 
         // Metadata Extractor
         binder.bind(ExecutorService.class).annotatedWith(ForMetadataExtractor.class)
-                .toInstance(newCachedThreadPool(threadsNamed("metadata-extractor-%s")));
+                .toInstance(newCachedThreadPool(threadsNamed("metadata-extractor-%d")));
         binder.bind(MetadataExtractorMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(MetadataExtractorMBean.class).as(generatedNameOf(MetadataExtractor.class));
 
         // executors
-        ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("presto-spark-executor-%s"));
+        ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("presto-spark-executor-%d"));
         binder.bind(Executor.class).toInstance(executor);
         binder.bind(ExecutorService.class).toInstance(executor);
         // Set the initial thread pool size to 1 (instead of 0) to avoid the thread pool hogging CPU due to JDK8 bug: https://bugs.openjdk.org/browse/JDK-8129861
-        binder.bind(ScheduledExecutorService.class).toInstance(newScheduledThreadPool(5, daemonThreadsNamed("presto-spark-scheduled-executor-%s")));
+        binder.bind(ScheduledExecutorService.class).toInstance(newScheduledThreadPool(5, daemonThreadsNamed("presto-spark-scheduled-executor-%d")));
 
         // task executor
         binder.bind(EmbedVersion.class).in(Scopes.SINGLETON);
@@ -558,8 +558,8 @@ public class PrestoSparkModule
                     config,
                     blockEncodingSerde,
                     fragmentCacheStats,
-                    newFixedThreadPool(5, daemonThreadsNamed("fragment-result-cache-writer-%s")),
-                    newFixedThreadPool(1, daemonThreadsNamed("fragment-result-cache-remover-%s")));
+                    newFixedThreadPool(5, daemonThreadsNamed("fragment-result-cache-writer-%d")),
+                    newFixedThreadPool(1, daemonThreadsNamed("fragment-result-cache-remover-%d")));
         }
         return new NoOpFragmentResultCacheManager();
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/task/TestPrestoSparkTaskExecution.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/task/TestPrestoSparkTaskExecution.java
@@ -79,8 +79,8 @@ public class TestPrestoSparkTaskExecution
     @BeforeMethod
     public void setUp()
     {
-        taskNotificationExecutor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
-        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        taskNotificationExecutor = newCachedThreadPool(daemonThreadsNamed("test-executor-%d"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%d"));
         taskExecutor = new TaskExecutor(8, 16, 3, 4, TASK_FAIR, Ticker.systemTicker());
 
         nativeTestSession = testSessionBuilder()

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
@@ -84,6 +84,6 @@ public class ThriftModule
     @ForMetadataRefresh
     public Executor createMetadataRefreshExecutor(ThriftConnectorConfig config)
     {
-        return newFixedThreadPool(config.getMetadataRefreshThreads(), daemonThreadsNamed("metadata-refresh-%s"));
+        return newFixedThreadPool(config.getMetadataRefreshThreads(), daemonThreadsNamed("metadata-refresh-%d"));
     }
 }

--- a/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
+++ b/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
@@ -72,7 +72,7 @@ public class ThriftTpchService
     protected static final JsonCodec<SplitInfo> SPLIT_INFO_CODEC = jsonCodec(SplitInfo.class);
 
     private final ListeningExecutorService executor = listeningDecorator(
-            newFixedThreadPool(Runtime.getRuntime().availableProcessors(), threadsNamed("thrift-tpch-%s")));
+            newFixedThreadPool(Runtime.getRuntime().availableProcessors(), threadsNamed("thrift-tpch-%d")));
 
     @Override
     public final List<String> listSchemaNames()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
@@ -187,7 +187,7 @@ public class VerifierModule
     @ForTransactionManager
     public static ExecutorService createTransactionFinishingExecutor()
     {
-        return newCachedThreadPool(daemonThreadsNamed("transaction-finishing-%s"));
+        return newCachedThreadPool(daemonThreadsNamed("transaction-finishing-%d"));
     }
 
     @Provides


### PR DESCRIPTION
## Description
Fix Thread Naming format

## Motivation and Context
 ThreadFactoryBuilder.setNameFormat appends a long denoting the current count of threads in the thread factory. So %d is the correct format instead of the current %s.

## Test Plan
unit test com.facebook.presto.util.TestThreadNaming

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

