### PR TITLE
[native] Fix documentation on async data cache

### DIFF
--- a/presto-docs/src/main/sphinx/prestissimo/prestissimo-features.rst
+++ b/presto-docs/src/main/sphinx/prestissimo/prestissimo-features.rst
@@ -152,8 +152,7 @@ disabled if ``connector.num-io-threads-hw-multiplier`` is set to zero.
 * **Default value:** ``true``
 * **Presto on Spark default value:** ``false``
 
-Whether async data cache is enabled.  Setting ``async-data-cache-enabled``
-to ``false`` disables split prefetching in table scan.
+Whether async data cache is enabled.
 
 ``async-cache-ssd-gb``
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -161,8 +160,7 @@ to ``false`` disables split prefetching in table scan.
 * **Type** ``integer``
 * **Default value:** ``0``
 
-Size of the SSD cache when async data cache is enabled.  Must be zero if
-``async-data-cache-enabled`` is ``false``.
+Size of the SSD cache when async data cache is enabled.
 
 ``enable-old-task-cleanup``
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
The documentation incorrectly states that disabling async data cache disables split prefetching in table scan.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

