### PR TITLE
Increase wait time in quick stats test

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
@@ -387,7 +387,7 @@ public class TestQuickStatsProvider
             assertEquals(quickStats.get("p6"), empty());
 
             // Subsequent queries for the same partitions will fetch the cached stats though
-            Thread.sleep(20); // Sleep to allow futures to complete
+            Thread.sleep(250); // Sleep to allow futures to complete
 
             quickStats = quickStatsProvider.getQuickStats(session, metastoreMock,
                     new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, ImmutableList.of("p5", "p6"));


### PR DESCRIPTION
To allow sufficient time for background build of
quick stats to finish

This should fix test failures see in CI - https://github.com/prestodb/presto/actions/runs/8056340779/job/22007021834?pr=21969

```
== NO RELEASE NOTE ==
```

