### PR TITLE
Raise user error for invalid session property

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/SessionPropertyManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SessionPropertyManager.java
@@ -212,8 +212,9 @@ public final class SessionPropertyManager
         if (propertyValue == null) {
             return type.cast(metadata.getDefaultValue());
         }
-        Object objectValue = deserializeSessionProperty(metadata.getSqlType(), propertyValue);
+
         try {
+            Object objectValue = deserializeSessionProperty(metadata.getSqlType(), propertyValue);
             return type.cast(metadata.decode(objectValue));
         }
         catch (PrestoException e) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -1512,6 +1512,17 @@ public abstract class AbstractTestDistributedQueries
         }
     }
 
+    @Test
+    public void testSessionPropertyDecode()
+    {
+        assertQueryFails(
+                Session.builder(getSession())
+                        .setSystemProperty("task_writer_count", "abc" /*number is expected*/)
+                        .build(),
+                "SELECT 1",
+                ".*task_writer_count is invalid.*");
+    }
+
     private void checkCTEInfo(String explain, String name, int frequency, boolean isView)
     {
         String regex = "CTEInfo.*";


### PR DESCRIPTION
## Description

When incorrect session property is specified a USER_ERROR type is expected to be raised

## Motivation and Context

Bug

## Impact

Queries setting invalid session properties fail with INTERNAL_ERROR

## Test Plan

Unit test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

