### PR TITLE
[native] Remove use of deprecated node.ip config with node.internal-address in error message

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1052,7 +1052,7 @@ std::string PrestoServer::getLocalIp() const {
     }
   }
   VELOX_FAIL(
-      "Could not infer Node IP. Please specify node.ip in the node.properties file.");
+      "Could not infer Node IP. Please specify node.internal-address in the node.properties file.");
 }
 
 std::string PrestoServer::getBaseSpillDirectory() const {


### PR DESCRIPTION
## Description
The node.ip node configuration parameter is deprecated. 

## Motivation and Context
The error message should reflect the correct parameter name.

## Impact
Better feedback to users.

## Test Plan
N/A

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

