### PR TITLE
Fix CanonicalPlanGenerate to canonicalize without plan ID

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TableScanNode;
@@ -107,7 +108,10 @@ import static java.util.stream.Collectors.toCollection;
 public class CanonicalPlanGenerator
         extends InternalPlanVisitor<Optional<PlanNode>, CanonicalPlanGenerator.Context>
 {
-    private final PlanNodeIdAllocator planNodeidAllocator = new PlanNodeIdAllocator();
+    private static final String CANONICAL_STRING = "CANONICAL";
+
+    // Not using a new override to objectMapper because PlanNodeId has a JsonValue annotation which cannot be directly overriden in a serializer
+    private final PlanNodeIdAllocator planNodeidAllocator;
     private final VariableAllocator variableAllocator = new VariableAllocator();
     // TODO: DEFAULT strategy has a very different canonicalizaiton implementation, refactor it into a separate class.
     private final PlanCanonicalizationStrategy strategy;
@@ -119,6 +123,26 @@ public class CanonicalPlanGenerator
         this.strategy = requireNonNull(strategy, "strategy is null");
         this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
         this.session = requireNonNull(session, "session is null");
+        this.planNodeidAllocator = createPlanNodeIdAllocator(strategy);
+    }
+
+    private PlanNodeIdAllocator createPlanNodeIdAllocator(PlanCanonicalizationStrategy strategy)
+    {
+        //ToDO: For HBO we always want planNodeId to be canonicalized but currently fragment result caching is using the same class with default strategy
+        // refactor the default strategy to a different class
+        if (strategy.equals(DEFAULT)) {
+            return new PlanNodeIdAllocator();
+        }
+        else {
+            return new PlanNodeIdAllocator()
+            {
+                @Override
+                public PlanNodeId getNextId()
+                {
+                    return new PlanNodeId(CANONICAL_STRING);
+                }
+            };
+        }
     }
 
     public static Optional<CanonicalPlanFragment> generateCanonicalPlanFragment(PlanNode root, PartitioningScheme partitioningScheme, ObjectMapper objectMapper, Session session)


### PR DESCRIPTION
## Description
Fixes first part of #21449. Would need to canonicalize repeated variables for part2


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix plan canonicalization by canonicalizing plan node ids.

