### PR TITLE
[native] Fix 'Number of sorting keys must be greater than zero'

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -171,7 +171,7 @@ class VeloxQueryPlanConverterBase {
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId);
 
-  std::shared_ptr<const velox::core::TopNRowNumberNode> toVeloxQueryPlan(
+  std::shared_ptr<const velox::core::PlanNode> toVeloxQueryPlan(
       const std::shared_ptr<const protocol::TopNRowNumberNode>& node,
       const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
       const protocol::TaskId& taskId);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
@@ -196,5 +196,8 @@ public abstract class AbstractTestNativeWindowQueries
         assertQuery("SELECT row_number() OVER (PARTITION BY orderdate ORDER BY orderdate) FROM orders");
         assertQuery("SELECT min(orderkey) OVER (PARTITION BY orderdate ORDER BY orderdate, totalprice) FROM orders");
         assertQuery("SELECT * FROM (SELECT row_number() over(partition by orderstatus order by orderkey, orderstatus) rn, * from orders) WHERE rn = 1");
+
+        assertQuery("WITH t AS (SELECT linenumber, row_number() over (partition by linenumber order by linenumber) as rn FROM lineitem) " +
+                "SELECT * FROM t WHERE rn = 1");
     }
 }


### PR DESCRIPTION
A query with row_number() window function using same partitioning and sorting
keys and a limit on row number values used to fail with 

```
Caused by: java.lang.RuntimeException: sortingKeys_.size() > 0 (0 vs. 0) Number of sorting keys must be greater than zero
```

This happened because Prestissimo dropped sorting keys from Presto's
TopNRowNumberNode and tried to create TopNRowNumberNode in Velox with no
sorting keys. The fix is to use Velox's RowNumberNode when all sorting keys are
present as partitioning keys.