### PR TITLE
[Native] Replace deprecated node.ip with node.internal-address in NativeQueryRunner classes

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -387,7 +387,7 @@ public class PrestoNativeQueryRunnerUtils
                         Files.write(tempDirectoryPath.resolve("config.properties"), configProperties.getBytes());
                         Files.write(tempDirectoryPath.resolve("node.properties"),
                                 format("node.id=%s%n" +
-                                        "node.ip=127.0.0.1%n" +
+                                        "node.internal-address=127.0.0.1%n" +
                                         "node.environment=testing%n" +
                                         "node.location=test-location", UUID.randomUUID()).getBytes());
 


### PR DESCRIPTION
## Test Plan
All native e2e tests

```
== NO RELEASE NOTE ==
```

