### PR TITLE
[native] Prepare for deprecating testSpillPct

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -725,7 +725,6 @@ BaseVeloxQueryConfig::BaseVeloxQueryConfig() {
           NUM_PROP(
               QueryConfig::kOrderBySpillMemoryThreshold,
               c.orderBySpillMemoryThreshold()),
-          NUM_PROP(QueryConfig::kTestingSpillPct, c.testingSpillPct()),
           NUM_PROP(QueryConfig::kMaxSpillLevel, c.maxSpillLevel()),
           NUM_PROP(QueryConfig::kMaxSpillFileSize, c.maxSpillFileSize()),
           NUM_PROP(QueryConfig::kMinSpillRunSize, c.minSpillRunSize()),

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -1107,7 +1107,7 @@ TEST_F(TaskManagerTest, timeoutOutOfOrderRequests) {
           .getVia(eventBase));
 }
 
-TEST_F(TaskManagerTest, aggregationSpill) {
+TEST_F(TaskManagerTest, DISABLED_aggregationSpill) {
   // NOTE: we need to write more than one batches to each file (source split) to
   // trigger spill.
   const int numBatchesPerFile = 5;
@@ -1135,7 +1135,8 @@ TEST_F(TaskManagerTest, aggregationSpill) {
     if (doSpill) {
       spillDirectory = TaskManagerTest::setupSpillPath();
       taskManager_->setBaseSpillDirectory(spillDirectory->path);
-      queryConfigs.emplace(core::QueryConfig::kTestingSpillPct, "100");
+      // TODO(jtan6): use TestScopedSpillInjection after velox PR lands and
+      // re-enable the test.
       queryConfigs.emplace(core::QueryConfig::kSpillEnabled, "true");
       queryConfigs.emplace(core::QueryConfig::kAggregationSpillEnabled, "true");
     }


### PR DESCRIPTION
testSpillPct config will be deprecated in Velox. This PR prepares presto native to be compatible with the change Velox is going to make. Follow up deprecation PR will be created after Velox deprecation PR lands
```
== NO RELEASE NOTE ==
```

