### PR TITLE
[native] Fix bug in creation of HashNode(kLeftSemiProject).

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJoinQueries.java
@@ -72,8 +72,11 @@ public abstract class AbstractTestNativeJoinQueries
     {
         assertQuery(joinTypeSession, "SELECT * FROM orders WHERE orderdate IN (SELECT shipdate FROM lineitem) or orderdate IN (SELECT commitdate FROM lineitem)");
         assertQuery(joinTypeSession, "SELECT * FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
-        assertQuery(joinTypeSession, "SELECT * FROM lineitem " +
-                "WHERE linenumber = 3 OR orderkey IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
+        assertQuery(joinTypeSession, "SELECT * FROM lineitem WHERE linenumber = 3 OR orderkey IN (SELECT orderkey FROM orders WHERE (orderkey + custkey) % 2 = 0)");
+        assertQuery(joinTypeSession, "WITH\n" +
+                "users AS (SELECT orderkey FROM orders ),\n" +
+                "left_table AS (SELECT * FROM ( VALUES (0, NULL), (283755559, NULL), (NULL, NULL) ) AS left_table (userid, sid_cast))\n" +
+                "SELECT userid FROM left_table WHERE (sid_cast IS NOT NULL) OR (NOT (userid IN (SELECT * FROM users)))");
     }
 
     @Test(dataProvider = "joinTypeProvider")

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
 
 public abstract class AbstractTestNativeWindowQueries
@@ -36,6 +37,7 @@ public abstract class AbstractTestNativeWindowQueries
     {
         QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
         createOrders(queryRunner);
+        createLineitem(queryRunner);
     }
 
     private static final List<String> OVER_CLAUSES_WITH_ORDER_BY = Arrays.asList(
@@ -197,7 +199,6 @@ public abstract class AbstractTestNativeWindowQueries
         assertQuery("SELECT min(orderkey) OVER (PARTITION BY orderdate ORDER BY orderdate, totalprice) FROM orders");
         assertQuery("SELECT * FROM (SELECT row_number() over(partition by orderstatus order by orderkey, orderstatus) rn, * from orders) WHERE rn = 1");
 
-        assertQuery("WITH t AS (SELECT linenumber, row_number() over (partition by linenumber order by linenumber) as rn FROM lineitem) " +
-                "SELECT * FROM t WHERE rn = 1");
+        assertQuery("WITH t AS (SELECT linenumber, row_number() over (partition by linenumber order by linenumber) as rn FROM lineitem) SELECT * FROM t WHERE rn = 1");
     }
 }


### PR DESCRIPTION
## Description
In Presto Native we create HashNode(kLeftSemiProject) with nullAware=false from toVeloxQueryPlan(FilterNode). 'nullAware' dictates how we treat nulls in the left keys.

This causes some queries in Presto Native to return more rows than Presto. Because Presto does not have any member in class SemiJoinNode that indicates how it processes nulls and is always 'null aware'.

Interesting, that toVeloxQueryPlan(SemiJoinNode) code path creates HashNode(kLeftSemiProject) with nullAware=true, which is correct.

To fix the issue we route the creation of HashNode(kLeftSemiProject) in toVeloxQueryPlan(FilterNode) through toVeloxQueryPlan(SemiJoinNode), thus having only one place where we create HashNode(kLeftSemiProject) with nullAware=true.

## Test Plan
Added the previously failing query to the integration test.

```
== NO RELEASE NOTE ==
```

