### PR TITLE
use different view name for each test

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -121,7 +121,8 @@ public abstract class AbstractTestingPrestoClient<T>
 
             if (error.getFailureInfo() != null) {
                 RuntimeException remoteException = error.getFailureInfo().toException();
-                throw new RuntimeException(Optional.ofNullable(remoteException.getMessage()).orElseGet(remoteException::toString), remoteException);
+                String message = Optional.ofNullable(remoteException.getMessage()).orElseGet(remoteException::toString);
+                throw new RuntimeException(message, remoteException);
             }
             throw new RuntimeException("Query failed: " + error.getMessage());
 


### PR DESCRIPTION
## Description
Randomize view names in test

## Motivation and Context
On https://github.com/prestodb/presto/pull/22036 this test failed with the message java.lang.RuntimeException: View already exists: 'tpch.test_view_access' which points to a race condition in the test where one view is not deleted before the next test method attempts to create it again.

## Impact
none

## Test Plan
CI

## Contributor checklist

- [X ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- X[ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

