### PR TITLE
[native] Allow single zero to be passed as X-Presto-Buffer-Remaining-Bytes

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -265,6 +265,10 @@ void PrestoExchangeSource::processDataResponse(
       protocol::PRESTO_BUFFER_REMAINING_BYTES_HEADER);
   if (!remainingBytesString.empty()) {
     folly::split(',', remainingBytesString, remainingBytes);
+    if (!remainingBytes.empty() && remainingBytes[0] == 0) {
+      VELOX_CHECK_EQ(remainingBytes.size(), 1);
+      remainingBytes.clear();
+    }
   }
 
   int64_t ackSequence =


### PR DESCRIPTION
To be compatible with https://github.com/prestodb/presto/pull/21951