### PR TITLE
Fix bug in Quick Stats in-progress tracker

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
@@ -253,7 +253,7 @@ public class TestQuickStatsProvider
             // Build a session where an inline quick stats build will occur for the 1st query that initiates the build,
             // but subsequent queries will NOT wait
 
-            ConnectorSession session = getSession("300ms", "0ms");
+            ConnectorSession session = getSession("600ms", "0ms");
             // Execute two concurrent calls for the same partitions; wait for them to complete
             CompletableFuture<Map<String, PartitionStatistics>> future1 = supplyAsync(() -> quickStatsProvider.getQuickStats(session, metastoreMock,
                     new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitions), commonPool());


### PR DESCRIPTION
Because a background fetch future can complete immediately, a cleanup call made by `fetchFuture.whenComplete` to remove the in-progress build was resulting in a deadlock because it was occurring within the `computeIfAbsent` block
(this behavior is disallowed by ConcurrentHashMap)

See [this](https://stackoverflow.com/questions/46034531/how-to-prevent-completablefuturewhencomplete-execution-in-context-thread) SO thread for a discussion on a similar problem

Fixes https://github.com/prestodb/presto/issues/22084

## Test Plan
Invoked each test 1000 times using `invocationCount` manually


```
== NO RELEASE NOTE ==
```

