### PR TITLE
Make assertion failures more precise

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -248,19 +248,32 @@ public final class QueryAssertions
             Multiset<?> unexpectedRows = Multisets.difference(actualSet, expectedSet);
             Multiset<?> missingRows = Multisets.difference(expectedSet, actualSet);
             int limit = 100;
-            fail(format(
-                    "%snot equal\n" +
-                            "Actual rows (up to %s of %s extra rows shown, %s rows in total):\n    %s\n" +
-                            "Expected rows (up to %s of %s missing rows shown, %s rows in total):\n    %s\n",
+            String extraRowsMessage = "";
+            if (!unexpectedRows.isEmpty()) {
+                int numShown = Math.min(limit, unexpectedRows.size());
+                extraRowsMessage = format(
+                        "Actual rows (%s of %s extra rows shown, %s rows in total):\n    %s\n",
+                        numShown,
+                        unexpectedRows.size(),
+                        actualSet.size(),
+                        Joiner.on("\n    ").join(Iterables.limit(unexpectedRows, limit)));
+            }
+            String missingRowsMessage = "";
+            if (!missingRows.isEmpty()) {
+                int numShown = Math.min(limit, missingRows.size());
+                missingRowsMessage = format(
+                        "Expected rows (%s of %s missing rows shown, %s rows in total):\n    %s\n",
+                        numShown,
+                        missingRows.size(),
+                        expectedSet.size(),
+                        Joiner.on("\n    ").join(Iterables.limit(missingRows, limit)));
+            }
+            String rowsDiff = format(
+                    "%snot equal\n%s%s",
                     message == null ? "" : (message + "\n"),
-                    limit,
-                    unexpectedRows.size(),
-                    actualSet.size(),
-                    Joiner.on("\n    ").join(Iterables.limit(unexpectedRows, limit)),
-                    limit,
-                    missingRows.size(),
-                    expectedSet.size(),
-                    Joiner.on("\n    ").join(Iterables.limit(missingRows, limit))));
+                    extraRowsMessage,
+                    missingRowsMessage);
+            fail(rowsDiff);
         }
     }
 


### PR DESCRIPTION
## Description

Instead of 

```
[ERROR]   TestPrestoSparkNativeGeneralQueries>AbstractTestNativeGeneralQueries.testUnionAllInsert:1437->AbstractTestQueryFramework.assertQuery:159 For query: 
 SELECT * FROM tmp_presto_52a7847dc5734855a04a8d2d7523c9ba
not equal
Actual rows (up to 100 of 0 extra rows shown, 30000 rows in total):
    
Expected rows (up to 100 of 15000 missing rows shown, 45000 rows in total):
    [53824]
    [53826]
...
```

show

```
[ERROR]   TestPrestoSparkNativeGeneralQueries>AbstractTestNativeGeneralQueries.testUnionAllInsert:1437->AbstractTestQueryFramework.assertQuery:159 For query: 
 SELECT * FROM tmp_presto_52a7847dc5734855a04a8d2d7523c9ba
not equal

Expected rows (100 of 15000 missing rows shown, 45000 rows in total):
    [53824]
    [53826]
...
```
That is, don't show a message for missing rows when no rows are missing. Don't show a message for extra rows when there are no extra rows. 


## Motivation and Context
Wasted time trying to understand this message when encountering flaky tests

## Impact


## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

