### PR TITLE
Support binary IDs for Hive partitions

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -45,6 +46,7 @@ public class Partition
     private final boolean sealedPartition;
     private final int createTime;
     private final long lastDataCommitTime;
+    private final Optional<byte[]> rowIdPartitionComponent;
 
     @JsonCreator
     public Partition(
@@ -58,7 +60,8 @@ public class Partition
             @JsonProperty("eligibleToIgnore") boolean eligibleToIgnore,
             @JsonProperty("sealedPartition") boolean sealedPartition,
             @JsonProperty("createTime") int createTime,
-            @JsonProperty("lastDataCommitTime") long lastDataCommitTime)
+            @JsonProperty("lastDataCommitTime") long lastDataCommitTime,
+            @JsonProperty("rowIdPartitionComponent") Optional<byte[]> rowIdPartitionComponent)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -71,6 +74,7 @@ public class Partition
         this.sealedPartition = sealedPartition;
         this.createTime = createTime;
         this.lastDataCommitTime = lastDataCommitTime;
+        this.rowIdPartitionComponent = requireNonNull(rowIdPartitionComponent);
     }
 
     @JsonProperty
@@ -145,6 +149,20 @@ public class Partition
         return lastDataCommitTime;
     }
 
+    /**
+     * A unique identifier for a specific version of a
+     * specific partition in a specific table.
+     */
+    @JsonProperty
+    public Optional<byte[]> getRowIdPartitionComponent()
+    {
+        if (rowIdPartitionComponent.isPresent()) {
+            byte[] copy = Arrays.copyOf(rowIdPartitionComponent.get(), rowIdPartitionComponent.get().length);
+            return Optional.of(copy);
+        }
+        return Optional.empty();
+    }
+
     @Override
     public String toString()
     {
@@ -208,6 +226,7 @@ public class Partition
         private boolean isSealedPartition = true;
         private int createTime;
         private long lastDataCommitTime;
+        private Optional<byte[]> rowIdPartitionComponent = Optional.empty();
 
         private Builder()
         {
@@ -226,6 +245,7 @@ public class Partition
             this.isEligibleToIgnore = partition.isEligibleToIgnore();
             this.createTime = partition.getCreateTime();
             this.lastDataCommitTime = partition.getLastDataCommitTime();
+            this.rowIdPartitionComponent = partition.getRowIdPartitionComponent();
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -299,9 +319,20 @@ public class Partition
             return this;
         }
 
+        /**
+         * Sets a unique identifier for a specific version of a
+         * specific partition in a specific table. This value will normally be
+         * supplied by Metastore, along with other metadata.
+         */
+        public Builder setRowIdPartitionComponent(Optional<byte[]> rowIdPartitionComponent)
+        {
+            this.rowIdPartitionComponent = rowIdPartitionComponent;
+            return this;
+        }
+
         public Partition build()
         {
-            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters, partitionVersion, isEligibleToIgnore, isSealedPartition, createTime, lastDataCommitTime);
+            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters, partitionVersion, isEligibleToIgnore, isSealedPartition, createTime, lastDataCommitTime, rowIdPartitionComponent);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
@@ -56,6 +56,7 @@ public class PartitionMetadata
     private final Map<String, HiveColumnStatistics> columnStatistics;
     private final boolean eligibleToIgnore;
     private final boolean sealedPartition;
+    private final Optional<byte[]> rowIdPartitionComponent;
 
     @JsonCreator
     public PartitionMetadata(
@@ -69,7 +70,8 @@ public class PartitionMetadata
             @JsonProperty("externalLocation") Optional<String> externalLocation,
             @JsonProperty("columnStatistics") Map<String, HiveColumnStatistics> columnStatistics,
             @JsonProperty("eligibleToIgnore") boolean eligibleToIgnore,
-            @JsonProperty("sealedPartition") boolean sealedPartition)
+            @JsonProperty("sealedPartition") boolean sealedPartition,
+            @JsonProperty("rowIdPartitionComponent") Optional<byte[]> rowIdPartitionComponent)
     {
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
@@ -83,6 +85,7 @@ public class PartitionMetadata
         this.columnStatistics = ImmutableMap.copyOf(requireNonNull(columnStatistics, "columnStatistics is null"));
         this.eligibleToIgnore = eligibleToIgnore;
         this.sealedPartition = sealedPartition;
+        this.rowIdPartitionComponent = requireNonNull(rowIdPartitionComponent);
     }
 
     @Deprecated
@@ -96,7 +99,8 @@ public class PartitionMetadata
             Optional<String> externalLocation,
             Map<String, HiveColumnStatistics> columnStatistics,
             boolean eligibleToIgnore,
-            boolean sealedPartition)
+            boolean sealedPartition,
+            Optional<byte[]> rowIdPartitionComponent)
     {
         this(
                 columns,
@@ -108,7 +112,8 @@ public class PartitionMetadata
                 externalLocation,
                 columnStatistics,
                 eligibleToIgnore,
-                sealedPartition);
+                sealedPartition,
+                rowIdPartitionComponent);
     }
 
     public PartitionMetadata(Table table, PartitionWithStatistics partitionWithStatistics)
@@ -134,6 +139,7 @@ public class PartitionMetadata
         columnStatistics = ImmutableMap.copyOf(statistics.getColumnStatistics());
         eligibleToIgnore = partition.isEligibleToIgnore();
         sealedPartition = partition.isSealedPartition();
+        this.rowIdPartitionComponent = partition.getRowIdPartitionComponent();
     }
 
     @JsonProperty
@@ -205,12 +211,12 @@ public class PartitionMetadata
 
     public PartitionMetadata withParameters(Map<String, String> parameters)
     {
-        return new PartitionMetadata(columns, parameters, storageFormat, bucketProperty, storageParameters, serdeParameters, externalLocation, columnStatistics, eligibleToIgnore, sealedPartition);
+        return new PartitionMetadata(columns, parameters, storageFormat, bucketProperty, storageParameters, serdeParameters, externalLocation, columnStatistics, eligibleToIgnore, sealedPartition, rowIdPartitionComponent);
     }
 
     public PartitionMetadata withColumnStatistics(Map<String, HiveColumnStatistics> columnStatistics)
     {
-        return new PartitionMetadata(columns, parameters, storageFormat, bucketProperty, storageParameters, serdeParameters, externalLocation, columnStatistics, eligibleToIgnore, sealedPartition);
+        return new PartitionMetadata(columns, parameters, storageFormat, bucketProperty, storageParameters, serdeParameters, externalLocation, columnStatistics, eligibleToIgnore, sealedPartition, rowIdPartitionComponent);
     }
 
     public Partition toPartition(String databaseName, String tableName, List<String> values, String location)
@@ -232,6 +238,7 @@ public class PartitionMetadata
                 eligibleToIgnore,
                 sealedPartition,
                 0,
-                0);
+                0,
+                rowIdPartitionComponent);
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
@@ -116,7 +116,8 @@ public class TestRecordingHiveMetastore
             false,
             true,
             0,
-            0);
+            0,
+            Optional.of(new byte[0]));
     private static final PartitionStatistics PARTITION_STATISTICS = new PartitionStatistics(
             new HiveBasicStatistics(10, 11, 10000, 10001),
             ImmutableMap.of("column", new HiveColumnStatistics(

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/file/TestPartitionMetadata.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/file/TestPartitionMetadata.java
@@ -113,7 +113,8 @@ public class TestPartitionMetadata
                 Optional.empty(),
                 ImmutableMap.of(),
                 false,
-                false);
+                false,
+                Optional.of(new byte[0]));
     }
 
     private static Column column(String name)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
@@ -27,21 +27,24 @@ public class HivePartitionMetadata
     private final HivePartition hivePartition;
     private final TableToPartitionMapping tableToPartitionMapping;
     private final Optional<EncryptionInformation> encryptionInformation;
-    // This is a set of columns whose domain could be removed from table layout because all of the value in the partition will satisfy.
+    // This is a set of columns whose domain could be removed from table layout because all values in the partition will satisfy.
     private final Set<ColumnHandle> redundantColumnDomains;
+    private final Optional<byte[]> rowIdPartitionComponent;
 
     HivePartitionMetadata(
             HivePartition hivePartition,
             Optional<Partition> partition,
             TableToPartitionMapping tableToPartitionMapping,
             Optional<EncryptionInformation> encryptionInformation,
-            Set<ColumnHandle> redundantColumnDomains)
+            Set<ColumnHandle> redundantColumnDomains,
+            Optional<byte[]> rowIdPartitionComponent)
     {
         this.partition = requireNonNull(partition, "partition is null");
         this.hivePartition = requireNonNull(hivePartition, "hivePartition is null");
         this.tableToPartitionMapping = requireNonNull(tableToPartitionMapping, "tableToPartitionMapping is null");
         this.encryptionInformation = requireNonNull(encryptionInformation, "encryptionInformation is null");
         this.redundantColumnDomains = requireNonNull(redundantColumnDomains, "redundantColumnDomains is null");
+        this.rowIdPartitionComponent = requireNonNull(rowIdPartitionComponent, "rowIdPartitionComponent is null");
     }
 
     public HivePartition getHivePartition()
@@ -70,5 +73,10 @@ public class HivePartitionMetadata
     public Set<ColumnHandle> getRedundantColumnDomains()
     {
         return redundantColumnDomains;
+    }
+
+    public Optional<byte[]> getRowIdPartitionComponent()
+    {
+        return this.rowIdPartitionComponent;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -59,6 +59,7 @@ public class HiveSplit
     private final Optional<EncryptionInformation> encryptionInformation;
     private final Set<ColumnHandle> redundantColumnDomains;
     private final SplitWeight splitWeight;
+    private final Optional<byte[]> rowIdPartitionComponent;
 
     @JsonCreator
     public HiveSplit(
@@ -79,7 +80,8 @@ public class HiveSplit
             @JsonProperty("cacheQuota") CacheQuotaRequirement cacheQuotaRequirement,
             @JsonProperty("encryptionMetadata") Optional<EncryptionInformation> encryptionInformation,
             @JsonProperty("redundantColumnDomains") Set<ColumnHandle> redundantColumnDomains,
-            @JsonProperty("splitWeight") SplitWeight splitWeight)
+            @JsonProperty("splitWeight") SplitWeight splitWeight,
+            @JsonProperty("rowIdPartitionComponent") Optional<byte[]> rowIdPartitionComponent)
     {
         requireNonNull(fileSplit, "fileSplit is null");
         requireNonNull(database, "database is null");
@@ -96,6 +98,7 @@ public class HiveSplit
         requireNonNull(cacheQuotaRequirement, "cacheQuotaRequirement is null");
         requireNonNull(encryptionInformation, "encryptionMetadata is null");
         requireNonNull(redundantColumnDomains, "redundantColumnDomains is null");
+        requireNonNull(rowIdPartitionComponent, "rowIdPartitionComponent is null");
 
         this.fileSplit = fileSplit;
         this.database = database;
@@ -115,6 +118,7 @@ public class HiveSplit
         this.encryptionInformation = encryptionInformation;
         this.redundantColumnDomains = ImmutableSet.copyOf(redundantColumnDomains);
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
+        this.rowIdPartitionComponent = rowIdPartitionComponent;
     }
 
     @JsonProperty
@@ -234,6 +238,12 @@ public class HiveSplit
     public SplitWeight getSplitWeight()
     {
         return splitWeight;
+    }
+
+    @JsonProperty
+    public Optional<byte[]> getRowIdPartitionComponent()
+    {
+        return rowIdPartitionComponent;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -457,7 +457,8 @@ public class HiveSplitManager
                         Optional.empty(),
                         TableToPartitionMapping.empty(),
                         encryptionInformationProvider.getReadEncryptionInformation(session, table, allRequestedColumns),
-                        ImmutableSet.of()));
+                        ImmutableSet.of(),
+                        Optional.empty()));
             }
         }
 
@@ -586,7 +587,8 @@ public class HiveSplitManager
                                 Optional.of(partition),
                                 tableToPartitionMapping,
                                 encryptionInformation,
-                                partitionSplitInfo.get(hivePartition.getPartitionId()).getRedundantColumnDomains()));
+                                partitionSplitInfo.get(hivePartition.getPartitionId()).getRedundantColumnDomains(),
+                                Optional.empty()));
             }
             if (unreadablePartitionsSkipped > 0) {
                 StringBuilder warningMessage = new StringBuilder(format("Table '%s' has %s out of %s partitions unreadable: ", tableName, unreadablePartitionsSkipped, partitionBatch.size()));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
@@ -46,6 +46,7 @@ public class HiveSplitPartitionInfo
     private final TableToPartitionMapping tableToPartitionMapping;
     private final Optional<HiveSplit.BucketConversion> bucketConversion;
     private final Set<ColumnHandle> redundantColumnDomains;
+    private final Optional<byte[]> rowIdPartitionComponent;
 
     // keep track of how many InternalHiveSplits reference this PartitionInfo.
     private final AtomicInteger references = new AtomicInteger(0);
@@ -58,7 +59,8 @@ public class HiveSplitPartitionInfo
             int partitionDataColumnCount,
             TableToPartitionMapping tableToPartitionMapping,
             Optional<HiveSplit.BucketConversion> bucketConversion,
-            Set<ColumnHandle> redundantColumnDomains)
+            Set<ColumnHandle> redundantColumnDomains,
+            Optional<byte[]> rowIdPartitionComponent)
     {
         requireNonNull(storage, "storage is null");
         requireNonNull(path, "path is null");
@@ -67,6 +69,7 @@ public class HiveSplitPartitionInfo
         requireNonNull(tableToPartitionMapping, "tableToPartitionMapping is null");
         requireNonNull(bucketConversion, "bucketConversion is null");
         requireNonNull(redundantColumnDomains, "redundantColumnDomains is null");
+        requireNonNull(rowIdPartitionComponent, "rowIdPartitionComponent is null");
 
         this.storage = storage;
         this.path = ensurePathHasTrailingSlash(path);
@@ -76,6 +79,7 @@ public class HiveSplitPartitionInfo
         this.tableToPartitionMapping = tableToPartitionMapping;
         this.bucketConversion = bucketConversion;
         this.redundantColumnDomains = redundantColumnDomains;
+        this.rowIdPartitionComponent = rowIdPartitionComponent;
     }
 
     // Hadoop path strips trailing slashes from the path string,
@@ -110,6 +114,11 @@ public class HiveSplitPartitionInfo
     public String getPartitionName()
     {
         return partitionName;
+    }
+
+    public Optional<byte[]> getRowIdPartitionComponent()
+    {
+        return rowIdPartitionComponent;
     }
 
     public int getPartitionDataColumnCount()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -537,7 +537,8 @@ class HiveSplitSource
                         cacheQuotaRequirement,
                         internalSplit.getEncryptionInformation(),
                         internalSplit.getPartitionInfo().getRedundantColumnDomains(),
-                        splitWeightProvider.weightForSplitSizeInBytes(splitBytes)));
+                        splitWeightProvider.weightForSplitSizeInBytes(splitBytes),
+                        internalSplit.getPartitionInfo().getRowIdPartitionComponent()));
 
                 internalSplit.increaseStart(splitBytes);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -178,7 +178,8 @@ public class ManifestPartitionLoader
                         partitionDataColumnCount,
                         partition.getTableToPartitionMapping(),
                         Optional.empty(),
-                        partition.getRedundantColumnDomains()),
+                        partition.getRedundantColumnDomains(),
+                        partition.getRowIdPartitionComponent()),
                 schedulerUsesHostAddresses,
                 partition.getEncryptionInformation());
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -243,7 +243,8 @@ public class StoragePartitionLoader
                         partitionDataColumnCount,
                         partition.getTableToPartitionMapping(),
                         bucketConversion,
-                        partition.getRedundantColumnDomains()),
+                        partition.getRedundantColumnDomains(),
+                        partition.getRowIdPartitionComponent()),
                 schedulerUsesHostAddresses,
                 partition.getEncryptionInformation());
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -109,8 +109,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, Optional.empty()),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, Optional.empty())));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -129,8 +129,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                 table,
                 Optional.of(ImmutableSet.of()),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, Optional.empty()),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, Optional.empty())));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -161,8 +161,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, Optional.empty()),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0, Optional.empty())));
 
         Map<String, byte[]> expectedFieldToKeyData = ImmutableMap.of("col_bigint", "key2".getBytes(), "col_struct.a", "key2".getBytes(), "col_struct.b.b2", "key1".getBytes());
         assertTrue(encryptionInformation.isPresent());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -235,7 +235,8 @@ public class TestBackgroundHiveSplitLoader
                                 Optional.of(orcPartition()),
                                 TableToPartitionMapping.empty(),
                                 Optional.empty(),
-                                ImmutableSet.of()));
+                                ImmutableSet.of(),
+                                Optional.empty()));
 
         BackgroundHiveSplitLoader backgroundHiveSplitLoader = backgroundHiveSplitLoader(
                 SESSION,
@@ -271,7 +272,8 @@ public class TestBackgroundHiveSplitLoader
                 false,
                 true,
                 0,
-                0);
+                0,
+                Optional.empty());
     }
 
     @Test
@@ -544,7 +546,8 @@ public class TestBackgroundHiveSplitLoader
                                 Optional.empty(),
                                 TableToPartitionMapping.empty(),
                                 Optional.empty(),
-                                ImmutableSet.of()));
+                                ImmutableSet.of(),
+                                Optional.empty()));
     }
 
     private static BackgroundHiveSplitLoader backgroundHiveSplitLoader(List<LocatedFileStatus> files, DirectoryLister directoryLister, String fileStatusCacheTables)
@@ -612,7 +615,8 @@ public class TestBackgroundHiveSplitLoader
                                 Optional.empty(),
                                 TableToPartitionMapping.empty(),
                                 Optional.empty(),
-                                ImmutableSet.of());
+                                ImmutableSet.of(),
+                                Optional.empty());
                     case 1:
                         throw new RuntimeException("OFFLINE");
                     default:

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
@@ -160,7 +160,8 @@ public class TestDynamicPruning
                 NO_CACHE_REQUIREMENT,
                 Optional.empty(),
                 ImmutableSet.of(),
-                SplitWeight.standard());
+                SplitWeight.standard(),
+                Optional.empty());
 
         HiveTableHandle hiveTableHandle = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME);
         HiveTableLayoutHandle tableLayoutHandle = new HiveTableLayoutHandle.Builder()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -268,7 +268,8 @@ public class TestHivePageSink
                 NO_CACHE_REQUIREMENT,
                 Optional.empty(),
                 ImmutableSet.of(),
-                SplitWeight.standard());
+                SplitWeight.standard(),
+                Optional.empty());
 
         HiveTableLayoutHandle layoutHandle = new HiveTableLayoutHandle.Builder()
                 .setSchemaTableName(new SchemaTableName(SCHEMA_NAME, TABLE_NAME))

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
@@ -161,7 +161,8 @@ public class TestHivePageSourceProvider
                 NO_CACHE_REQUIREMENT,
                 Optional.empty(),
                 ImmutableSet.of(),
-                SplitWeight.standard());
+                SplitWeight.standard(),
+                Optional.empty());
 
         CacheQuota cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
         CacheQuota expectedCacheQuota = new CacheQuota(".", Optional.empty());
@@ -191,7 +192,8 @@ public class TestHivePageSourceProvider
                 new CacheQuotaRequirement(PARTITION, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE))),
                 Optional.empty(),
                 ImmutableSet.of(),
-                SplitWeight.standard());
+                SplitWeight.standard(),
+                Optional.empty());
 
         cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
         expectedCacheQuota = new CacheQuota(SCHEMA_NAME + "." + TABLE_NAME + "." + PARTITION_NAME, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE)));
@@ -471,7 +473,8 @@ public class TestHivePageSourceProvider
                 NO_CACHE_REQUIREMENT,
                 Optional.empty(),
                 ImmutableSet.of(),
-                SplitWeight.standard());
+                SplitWeight.standard(),
+                Optional.empty());
     }
 
     static class MockHiveBatchPageSourceFactory

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -89,6 +89,7 @@ public class TestHiveSplit
                 Optional.empty(),
                 customSplitInfo);
 
+        byte[] rowIdPartitionComponent = {(byte) 76, (byte) 58};
         HiveSplit expected = new HiveSplit(
                 fileSplit,
                 "db",
@@ -120,7 +121,8 @@ public class TestHiveSplit
                         "test_algo",
                         "test_provider"))),
                 redundantColumnDomains,
-                SplitWeight.fromProportion(2.0)); // some non-standard value
+                SplitWeight.fromProportion(2.0), // some non-standard value
+                Optional.of(rowIdPartitionComponent));
 
         JsonCodec<HiveSplit> codec = getJsonCodec();
         String json = codec.toJson(expected);
@@ -142,6 +144,7 @@ public class TestHiveSplit
         assertEquals(actual.getCacheQuotaRequirement(), expected.getCacheQuotaRequirement());
         assertEquals(actual.getEncryptionInformation(), expected.getEncryptionInformation());
         assertEquals(actual.getSplitWeight(), expected.getSplitWeight());
+        assertEquals(actual.getRowIdPartitionComponent().get(), expected.getRowIdPartitionComponent().get());
     }
 
     private JsonCodec<HiveSplit> getJsonCodec()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -476,7 +476,8 @@ public class TestHiveSplitManager
                         false,
                         true,
                         0,
-                        0),
+                        0,
+                        Optional.empty()),
                 PARTITION_NAME,
                 partitionStatistics);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -557,7 +557,8 @@ public class TestHiveSplitSource
                             id,
                             TableToPartitionMapping.empty(),
                             Optional.empty(),
-                            ImmutableSet.of()),
+                            ImmutableSet.of(),
+                            Optional.empty()),
                     Optional.empty(),
                     Optional.empty(),
                     ImmutableMap.of());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3select/TestS3SelectPushdown.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3select/TestS3SelectPushdown.java
@@ -75,18 +75,7 @@ public class TestS3SelectPushdown
                 .setLocation("location")
                 .build();
 
-        partition = new Partition(
-                "db",
-                "table",
-                emptyList(),
-                storage,
-                singletonList(column),
-                emptyMap(),
-                Optional.empty(),
-                false,
-                false,
-                1234,
-                4567L);
+        partition = new Partition("db", "table", emptyList(), storage, singletonList(column), emptyMap(), Optional.empty(), false, false, 1234, 4567L, Optional.empty());
 
         table = new Table(
                 "db",
@@ -157,18 +146,7 @@ public class TestS3SelectPushdown
 
         assertFalse(shouldEnablePushdownForTable(session, newTable, "s3://fakeBucket/fakeObject", Optional.empty()));
 
-        Partition newPartition = new Partition(
-                "db",
-                "table",
-                emptyList(),
-                newStorage,
-                singletonList(column),
-                emptyMap(),
-                Optional.empty(),
-                false,
-                false,
-                1234,
-                4567L);
+        Partition newPartition = new Partition("db", "table", emptyList(), newStorage, singletonList(column), emptyMap(), Optional.empty(), false, false, 1234, 4567L, Optional.empty());
         assertFalse(shouldEnablePushdownForTable(session, newTable, "s3://fakeBucket/fakeObject", Optional.of(newPartition)));
     }
 
@@ -210,18 +188,7 @@ public class TestS3SelectPushdown
                 Optional.empty());
         assertFalse(shouldEnablePushdownForTable(session, newTable, "s3://fakeBucket/fakeObject", Optional.empty()));
 
-        Partition newPartition = new Partition(
-                "db",
-                "table",
-                emptyList(),
-                storage,
-                singletonList(column),
-                emptyMap(),
-                Optional.empty(),
-                false,
-                false,
-                1234,
-                4567L);
+        Partition newPartition = new Partition("db", "table", emptyList(), storage, singletonList(column), emptyMap(), Optional.empty(), false, false, 1234, 4567L, Optional.empty());
         assertFalse(shouldEnablePushdownForTable(session, newTable, "s3://fakeBucket/fakeObject", Optional.of(newPartition)));
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestParquetQuickStatsBuilder.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestParquetQuickStatsBuilder.java
@@ -183,25 +183,28 @@ public class TestParquetQuickStatsBuilder
     private void setUp()
     {
         metastoreMock = Mockito.mock(SemiTransactionalHiveMetastore.class);
+        Storage mockStorage = new Storage(
+                fromHiveStorageFormat(PARQUET),
+                "some/path",
+                Optional.empty(),
+                true,
+                ImmutableMap.of(),
+                ImmutableMap.of());
+        Partition mockPartition = new Partition(
+                TEST_SCHEMA,
+                TEST_TABLE,
+                ImmutableList.of(),
+                mockStorage,
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                Optional.empty(),
+                false,
+                true,
+                0,
+                0,
+                Optional.empty());
         when(metastoreMock.getPartition(any(), eq(TEST_SCHEMA), eq(TEST_TABLE), any()))
-                .thenReturn(Optional.of(new Partition(
-                        TEST_SCHEMA,
-                        TEST_TABLE,
-                        ImmutableList.of(),
-                        new Storage(
-                                fromHiveStorageFormat(PARQUET),
-                                "some/path",
-                                Optional.empty(),
-                                true,
-                                ImmutableMap.of(),
-                                ImmutableMap.of()),
-                        ImmutableList.of(),
-                        ImmutableMap.of(),
-                        Optional.empty(),
-                        false,
-                        true,
-                        0,
-                        0)));
+                .thenReturn(Optional.of(mockPartition));
 
         metastoreContext = new MetastoreContext(SESSION.getUser(),
                 SESSION.getQueryId(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
@@ -136,25 +136,28 @@ public class TestQuickStatsProvider
                 DEFAULT_COLUMN_CONVERTER_PROVIDER,
                 SESSION.getWarningCollector(),
                 SESSION.getRuntimeStats());
+        Storage mockStorage = new Storage(
+                fromHiveStorageFormat(PARQUET),
+                "some/path",
+                Optional.empty(),
+                true,
+                ImmutableMap.of(),
+                ImmutableMap.of());
+        Partition mockPartition = new Partition(
+                TEST_SCHEMA,
+                TEST_TABLE,
+                ImmutableList.of(),
+                mockStorage,
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                Optional.empty(),
+                false,
+                true,
+                0,
+                0,
+                Optional.empty());
         when(metastoreMock.getPartition(any(), eq(TEST_SCHEMA), eq(TEST_TABLE), any()))
-                .thenReturn(Optional.of(new Partition(
-                        TEST_SCHEMA,
-                        TEST_TABLE,
-                        ImmutableList.of(),
-                        new Storage(
-                                fromHiveStorageFormat(PARQUET),
-                                "some/path",
-                                Optional.empty(),
-                                true,
-                                ImmutableMap.of(),
-                                ImmutableMap.of()),
-                        ImmutableList.of(),
-                        ImmutableMap.of(),
-                        Optional.empty(),
-                        false,
-                        true,
-                        0,
-                        0)));
+                .thenReturn(Optional.of(mockPartition));
 
         when(metastoreMock.getTable(any(), eq(TEST_SCHEMA), eq(TEST_TABLE)))
                 .thenReturn(Optional.of(new Table(


### PR DESCRIPTION
## Description
Part of the row ID plans for #22078

## Motivation and Context
Adds a place for the partition component of the row ID, should a warehouse choose to supply one.

## Impact
Hive partitions have an id field. 

## Test Plan
./mvnw test -pl :presto-hive-metastore

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

