### PR TITLE
Re-enable TaskManagerTest.aggregationSpill

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -1107,7 +1107,7 @@ TEST_F(TaskManagerTest, timeoutOutOfOrderRequests) {
           .getVia(eventBase));
 }
 
-TEST_F(TaskManagerTest, DISABLED_aggregationSpill) {
+TEST_F(TaskManagerTest, aggregationSpill) {
   // NOTE: we need to write more than one batches to each file (source split) to
   // trigger spill.
   const int numBatchesPerFile = 5;
@@ -1132,15 +1132,16 @@ TEST_F(TaskManagerTest, DISABLED_aggregationSpill) {
     std::shared_ptr<exec::test::TempDirectoryPath> spillDirectory;
     std::map<std::string, std::string> queryConfigs;
 
+    int32_t spillPct{0};
     if (doSpill) {
       spillDirectory = TaskManagerTest::setupSpillPath();
       taskManager_->setBaseSpillDirectory(spillDirectory->path);
-      // TODO(jtan6): use TestScopedSpillInjection after velox PR lands and
-      // re-enable the test.
+      spillPct = 100;
       queryConfigs.emplace(core::QueryConfig::kSpillEnabled, "true");
       queryConfigs.emplace(core::QueryConfig::kAggregationSpillEnabled, "true");
     }
 
+    TestScopedSpillInjection scopedSpillInjection(spillPct);
     testCountAggregation(
         fmt::format("aggregationSpill:{}", queryId++),
         filePaths,


### PR DESCRIPTION
The test was disabled for preparing to deprecate spill pct. Now the spill pct is deprecated, we should bring this test back
```
== NO RELEASE NOTE ==
```

