### PR TITLE
Fix regr functions result to be null when the input data is null

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionAggregation.java
@@ -84,7 +84,8 @@ public class DoubleRegressionAggregation
     public static void regrSxy(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionSxy(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             DOUBLE.writeDouble(out, result);
         }
         else {
@@ -97,7 +98,8 @@ public class DoubleRegressionAggregation
     public static void regrSxx(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionSxx(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             DOUBLE.writeDouble(out, result);
         }
         else {
@@ -110,7 +112,8 @@ public class DoubleRegressionAggregation
     public static void regrSyy(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionSyy(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             DOUBLE.writeDouble(out, result);
         }
         else {
@@ -136,7 +139,7 @@ public class DoubleRegressionAggregation
     public static void regrCount(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionCount(state);
-        if (Double.isFinite(result)) {
+        if (Double.isFinite(result) && result > 0) {
             DOUBLE.writeDouble(out, result);
         }
         else {
@@ -149,7 +152,8 @@ public class DoubleRegressionAggregation
     public static void regrAvgy(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionAvgy(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             DOUBLE.writeDouble(out, result);
         }
         else {
@@ -162,7 +166,8 @@ public class DoubleRegressionAggregation
     public static void regrAvgx(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionAvgx(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             DOUBLE.writeDouble(out, result);
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealRegressionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealRegressionAggregation.java
@@ -84,7 +84,8 @@ public class RealRegressionAggregation
     public static void regrSxy(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionSxy(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             REAL.writeLong(out, floatToRawIntBits((float) result));
         }
         else {
@@ -97,7 +98,8 @@ public class RealRegressionAggregation
     public static void regrSxx(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionSxx(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             REAL.writeLong(out, floatToRawIntBits((float) result));
         }
         else {
@@ -110,7 +112,8 @@ public class RealRegressionAggregation
     public static void regrSyy(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionSyy(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             REAL.writeLong(out, floatToRawIntBits((float) result));
         }
         else {
@@ -136,7 +139,7 @@ public class RealRegressionAggregation
     public static void regrCount(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionCount(state);
-        if (Double.isFinite(result)) {
+        if (Double.isFinite(result) && result > 0) {
             REAL.writeLong(out, floatToRawIntBits((float) result));
         }
         else {
@@ -149,7 +152,8 @@ public class RealRegressionAggregation
     public static void regrAvgy(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionAvgy(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             REAL.writeLong(out, floatToRawIntBits((float) result));
         }
         else {
@@ -162,7 +166,8 @@ public class RealRegressionAggregation
     public static void regrAvgx(@AggregationState RegressionState state, BlockBuilder out)
     {
         double result = getRegressionAvgx(state);
-        if (Double.isFinite(result)) {
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             REAL.writeLong(out, floatToRawIntBits((float) result));
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrAvgxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrAvgxAggregation.java
@@ -29,7 +29,7 @@ public class TestDoubleRegrAvgxAggregation
     public Object getExpectedValue(int start, int length)
     {
         if (length == 0) {
-            return 0.0;
+            return null;
         }
 
         double expected = 0.0;

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrAvgyAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrAvgyAggregation.java
@@ -29,7 +29,7 @@ public class TestDoubleRegrAvgyAggregation
     public Object getExpectedValue(int start, int length)
     {
         if (length == 0) {
-            return 0.0;
+            return null;
         }
 
         double expected = 0.0;

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrCountAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrCountAggregation.java
@@ -30,7 +30,10 @@ public class TestDoubleRegrCountAggregation
     @Override
     public Object getExpectedValue(int start, int length)
     {
-        if (length <= 1) {
+        if (length == 0) {
+            return null;
+        }
+        else if (length == 1) {
             return (double) length;
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrSxxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrSxxAggregation.java
@@ -30,7 +30,10 @@ public class TestDoubleRegrSxxAggregation
     @Override
     public Object getExpectedValue(int start, int length)
     {
-        if (length <= 1) {
+        if (length == 0) {
+            return null;
+        }
+        else if (length == 1) {
             return (double) 0;
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrSxyAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrSxyAggregation.java
@@ -30,7 +30,10 @@ public class TestDoubleRegrSxyAggregation
     @Override
     public Object getExpectedValue(int start, int length)
     {
-        if (length <= 1) {
+        if (length == 0) {
+            return null;
+        }
+        else if (length == 1) {
             return (double) 0;
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrSyyAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrSyyAggregation.java
@@ -30,7 +30,10 @@ public class TestDoubleRegrSyyAggregation
     @Override
     public Object getExpectedValue(int start, int length)
     {
-        if (length <= 1) {
+        if (length == 0) {
+            return null;
+        }
+        else if (length <= 1) {
             return (double) 0;
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrAvgxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrAvgxAggregation.java
@@ -29,7 +29,7 @@ public class TestRealRegrAvgxAggregation
     public Object getExpectedValue(int start, int length)
     {
         if (length == 0) {
-            return 0.0f;
+            return null;
         }
 
         float expected = 0.0f;

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrAvgyAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrAvgyAggregation.java
@@ -29,7 +29,7 @@ public class TestRealRegrAvgyAggregation
     public Object getExpectedValue(int start, int length)
     {
         if (length == 0) {
-            return 0.0f;
+            return null;
         }
 
         float expected = 0.0f;

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrCountAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrCountAggregation.java
@@ -30,7 +30,10 @@ public class TestRealRegrCountAggregation
     @Override
     public Object getExpectedValue(int start, int length)
     {
-        if (length <= 1) {
+        if (length == 0) {
+            return null;
+        }
+        else if (length == 1) {
             return (float) length;
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrSxxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrSxxAggregation.java
@@ -30,7 +30,10 @@ public class TestRealRegrSxxAggregation
     @Override
     public Object getExpectedValue(int start, int length)
     {
-        if (length <= 1) {
+        if (length == 0) {
+            return null;
+        }
+        else if (length == 1) {
             return (float) 0;
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrSxyAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrSxyAggregation.java
@@ -30,7 +30,10 @@ public class TestRealRegrSxyAggregation
     @Override
     public Object getExpectedValue(int start, int length)
     {
-        if (length <= 1) {
+        if (length == 0) {
+            return null;
+        }
+        else if (length == 1) {
             return (float) 0;
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrSyyAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrSyyAggregation.java
@@ -30,7 +30,10 @@ public class TestRealRegrSyyAggregation
     @Override
     public Object getExpectedValue(int start, int length)
     {
-        if (length <= 1) {
+        if (length == 0) {
+            return null;
+        }
+        else if (length <= 1) {
             return (float) 0;
         }
         else {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
The result of the regr_count function should be null when the input data is null, not 0. The same problem exists with regr_avgx, regr_avgy, regr_syy, regr_sxx and regr_sxy.

```
presto> SELECT regr_count(c0, c1)
     -> FROM (
     ->   VALUES 
     ->     (null, null),
     ->     (null, null)
     -> ) AS tmp (c0, c1);
 _col0 
-------
   0.0 
(1 row)

Query 20240307_122037_00003_g2jsb, FINISHED, 1 node
```

fix https://github.com/prestodb/presto/issues/22110


## Release Notes


```
== RELEASE NOTE ==

General Changes
* Fix the regr_count, regr_avgx, regr_avgy, regr_syy, regr_sxx, and regr_sxy functions result to be null when the input data is null, not 0. 
```

