### PR TITLE
use single threaded tests to reduce flakiness

### DIFF
--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestClickHouseDistributedQueries.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestClickHouseDistributedQueries.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestClickHouseDistributedQueries
             extends AbstractTestDistributedQueries
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -34,6 +34,7 @@ import static java.util.stream.Collectors.joining;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestHiveDistributedQueries
         extends AbstractTestDistributedQueries
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithExchangeMaterialization.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithExchangeMaterialization.java
@@ -32,6 +32,7 @@ import static io.airlift.tpch.TpchTable.getTables;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
+@Test(singleThreaded = true)
 public class TestHiveDistributedQueriesWithExchangeMaterialization
         extends AbstractTestDistributedQueries
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithOptimizedRepartitioning.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithOptimizedRepartitioning.java
@@ -16,11 +16,13 @@ package com.facebook.presto.hive;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import java.util.Optional;
 
 import static io.airlift.tpch.TpchTable.getTables;
 
+@Test(singleThreaded = true)
 public class TestHiveDistributedQueriesWithOptimizedRepartitioning
         extends AbstractTestDistributedQueries
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithThriftRpc.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithThriftRpc.java
@@ -16,11 +16,13 @@ package com.facebook.presto.hive;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import java.util.Optional;
 
 import static io.airlift.tpch.TpchTable.getTables;
 
+@Test(singleThreaded = true)
 public class TestHiveDistributedQueriesWithThriftRpc
         extends AbstractTestDistributedQueries
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownDistributedQueries.java
@@ -26,6 +26,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.tpch.TpchTable.getTables;
 import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestHivePushdownDistributedQueries
         extends AbstractTestDistributedQueries
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetDistributedQueries.java
@@ -30,6 +30,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.tpch.TpchTable.getTables;
 import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestParquetDistributedQueries
         extends AbstractTestDistributedQueries
 {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -112,6 +112,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class IcebergDistributedTestBase
         extends AbstractTestDistributedQueries
 {

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -33,7 +33,7 @@ import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-@Test
+@Test(singleThreaded = true)
 public class TestMySqlDistributedQueries
         extends AbstractTestDistributedQueries
 {

--- a/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreDistributedQueries.java
+++ b/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreDistributedQueries.java
@@ -29,7 +29,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 import static org.testng.Assert.assertTrue;
 
-@Test
+@Test(singleThreaded = true)
 public class TestSingleStoreDistributedQueries
         extends AbstractTestDistributedQueries
 {


### PR DESCRIPTION
## Description
Mark more classes `Test(singleThreaded=true)`
fixes #22113

## Motivation and Context
Tests are continuing to flake with a runtime exception that suggests this. It seems annotating the superclass is insufficient. 

## Impact
none

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

