### PR TITLE
Use ThreadLocalRandom instead of RandomizationStrategy

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/SfmSketch.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/SfmSketch.java
@@ -330,7 +330,10 @@ public class SfmSketch
      */
     public void mergeWith(SfmSketch other)
     {
-        mergeWith(other, getDefaultRandomizationStrategy());
+        // Using ThreadLocalRandomizationStrategy instead of
+        // SecureRandomizationStrategy since combining sketches
+        // does not need to be cryptographically secure
+        mergeWith(other, new ThreadLocalRandomizationStrategy());
     }
 
     public void mergeWith(SfmSketch other, RandomizationStrategy randomizationStrategy)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/ThreadLocalRandomizationStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/ThreadLocalRandomizationStrategy.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Note: Due to finite-precision implementation details, usage of floating-point functions
+ * as random noise, while cryptographically secure, may leak information from a privacy context.
+ * See "On Significance of the Least Significant Bits For Differential Privacy" by Mironov
+ * and use judiciously.
+ */
+public class ThreadLocalRandomizationStrategy
+        extends RandomizationStrategy
+{
+    public double nextDouble()
+    {
+        return ThreadLocalRandom.current().nextDouble();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/TestSfmSketch.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/TestSfmSketch.java
@@ -28,7 +28,7 @@ public class TestSfmSketch
     @Test
     public void testComputeIndex()
     {
-        for (int indexBitLength : new int[]{6, 12, 18}) {
+        for (int indexBitLength : new int[] {6, 12, 18}) {
             long index = 5L;
             long hash = index << (Long.SIZE - indexBitLength);
             assertEquals(SfmSketch.computeIndex(hash, indexBitLength), index);
@@ -46,7 +46,7 @@ public class TestSfmSketch
     @Test
     public void testNumberOfTrailingZeros()
     {
-        for (int indexBitLength : new int[]{6, 12, 18}) {
+        for (int indexBitLength : new int[] {6, 12, 18}) {
             for (int i = 0; i < Long.SIZE - 1; i++) {
                 long hash = 1L << i;
                 assertEquals(SfmSketch.numberOfTrailingZeros(hash, indexBitLength), Math.min(i, Long.SIZE - indexBitLength));


### PR DESCRIPTION
## Description
- After this change, the SFM sketch will use SecureRandom when adding noise to sketches, but it will use ThreadLocalRandom when combining sketches that have already had noise added to them.

## Motivation and Context
- SFM sketch algorithm [calls](https://proceedings.mlr.press/v202/hehir23a/hehir23a.pdf) for the noise addition to ensure certain privacy-preserving properties, which should be cryptographically secure. The merging of already-random bits, however, does not need to be cryptographically secure.

Because this only affects merges of noisy sketches, this change only affects merge(SfmSketch), and merge_sfm(Array). The other functions are not actually affected.

## Impact
Because this only affects merges of noisy sketches, this change only affects merge(SfmSketch), and merge_sfm(Array).

These other functions are not actually affected:
- cardinality(SfmSketch)
- noisy_approx_distinct_sfm
- noisy_approx_set_sfm
- noisy_empty_approx_set_sfm

## Test Plan
- Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

== RELEASE NOTES ==

```
== NO RELEASE NOTE ==
```

