### PR TITLE
don't not run linux tests just because there is a doc change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,5 @@ workflows:
           # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
           mapping: |
             presto-native-execution/.* run_native_specific_jobs true
-            presto-docs/.* run_linux_tests false
           base-revision: master
           config-path: .circleci/continue_config.yml


### PR DESCRIPTION
## Description
fixes #22120

## Motivation and Context
Better to run the tests on docs changes than not run the changes on non docs changes

## Impact
no public change

## Test Plan
This PR includes a very small change in presto-docs. If linux-presto-e2e-tests runs fully on this PR (nor merely passes) then the bug is fixed. 

![runlinuxtestsistrue](https://github.com/prestodb/presto/assets/1005544/0891b289-c61d-4f20-87a3-f7a7cf6aa75b)


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

