### PR TITLE
don't spam logs with download messages

### DIFF
--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl presto-kudu
+          ./mvnw install ${MAVEN_FAST_INSTALL} -am --no-transfer-progress -pl presto-kudu
       - name: Kudu Tests
         run: |
           presto-kudu/bin/run_kudu_tests.sh 3 null

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -9,7 +9,7 @@ env:
   MAVEN_OPTS: "-Xmx1024M -XX:+ExitOnOutOfMemoryError"
   MAVEN_INSTALL_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
   MAVEN_FAST_INSTALL: "-B -V --quiet -T C1 -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
-  MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
+  MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --no-transfer-progress  --fail-at-end"
   RETRY: .github/bin/retry
 
 jobs:
@@ -68,7 +68,7 @@ jobs:
       - name: Install SingleStore Module
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl :presto-singlestore
+          ./mvnw install ${MAVEN_FAST_INSTALL} -am  --no-transfer-progress -pl :presto-singlestore
       - name: Run SingleStore Dockerized Tests
         env:
           SINGLESTORE_LICENSE: ${{ secrets.SINGLESTORE_LICENSE }}

--- a/presto-kudu/bin/run_kudu_tests.sh
+++ b/presto-kudu/bin/run_kudu_tests.sh
@@ -59,7 +59,7 @@ start_docker_container
 # run product tests
 pushd ${PROJECT_ROOT}
 set +e
-./mvnw -pl presto-kudu test -P integration \
+./mvnw --no-transfer-progress -pl presto-kudu test -P integration \
   -Dkudu.client.master-addresses=${DOCKER_HOST_IP}:${KUDU_MASTER_RPC_PORT} \
   -Dkudu.schema-emulation.prefix=${TEST_SCHEMA_EMULATION_PREFIX}
 EXIT_CODE=$?


### PR DESCRIPTION
## Description
kudu and singlestore builds

## Motivation and Context
smaller haystack to search through for failures

## Impact
none

## Test Plan
Look at CI logs for this PR and make sure they don't show download messages

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

