### PR TITLE
Fix bugs related to partial aggregation pushdown refactoring

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcAggregatedPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcAggregatedPageSourceFactory.java
@@ -198,12 +198,14 @@ public class OrcAggregatedPageSourceFactory
             return new AggregatedOrcPageSource(physicalColumns, reader.getFooter(), typeManager, functionResolution);
         }
         catch (Exception e) {
+            throw mapToPrestoException(e, path, fileSplit);
+        }
+        finally {
             try {
                 orcDataSource.close();
             }
             catch (IOException ignored) {
             }
-            throw mapToPrestoException(e, path, fileSplit);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetAggregatedPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetAggregatedPageSourceFactory.java
@@ -137,6 +137,9 @@ public class ParquetAggregatedPageSourceFactory
             return new AggregatedParquetPageSource(columns, parquetMetadata, typeManager, functionResolution);
         }
         catch (Exception e) {
+            throw mapToPrestoException(e, path, fileSplit);
+        }
+        finally {
             try {
                 if (dataSource != null) {
                     dataSource.close();
@@ -144,7 +147,6 @@ public class ParquetAggregatedPageSourceFactory
             }
             catch (IOException ignored) {
             }
-            throw mapToPrestoException(e, path, fileSplit);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetAggregatedPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetAggregatedPageSourceFactory.java
@@ -42,9 +42,9 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getReadNullMaskedParquetEncryptedValue;
-import static com.facebook.presto.hive.orc.OrcPageSourceFactoryUtils.mapToPrestoException;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
 import static com.facebook.presto.hive.parquet.ParquetPageSourceFactory.createDecryptor;
+import static com.facebook.presto.hive.parquet.ParquetPageSourceFactoryUtils.mapToPrestoException;
 import static java.util.Objects.requireNonNull;
 
 public class ParquetAggregatedPageSourceFactory

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -103,8 +103,8 @@ import static com.facebook.presto.hive.HiveCommonSessionProperties.isParquetBatc
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isUseParquetColumnNames;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_SCHEMA_MISMATCH;
 import static com.facebook.presto.hive.HiveSessionProperties.columnIndexFilterEnabled;
-import static com.facebook.presto.hive.orc.OrcPageSourceFactoryUtils.mapToPrestoException;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
+import static com.facebook.presto.hive.parquet.ParquetPageSourceFactoryUtils.mapToPrestoException;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.parquet.ParquetTypeUtils.columnPathFromSubfield;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactoryUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactoryUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.hive.HiveFileSplit;
+import com.facebook.presto.parquet.ParquetCorruptionException;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.security.AccessControlException;
+import org.apache.parquet.crypto.HiddenColumnException;
+
+import java.io.FileNotFoundException;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_MISSING_DATA;
+import static com.facebook.presto.spi.StandardErrorCode.PERMISSION_DENIED;
+import static com.google.common.base.Strings.nullToEmpty;
+import static java.lang.String.format;
+
+public class ParquetPageSourceFactoryUtils
+{
+    private ParquetPageSourceFactoryUtils() {}
+
+    public static PrestoException mapToPrestoException(Exception e, Path path, HiveFileSplit fileSplit)
+    {
+        if (e instanceof PrestoException) {
+            throw (PrestoException) e;
+        }
+        if (e instanceof ParquetCorruptionException) {
+            throw new PrestoException(HIVE_BAD_DATA, e);
+        }
+        if (e instanceof AccessControlException) {
+            throw new PrestoException(PERMISSION_DENIED, e.getMessage(), e);
+        }
+        if (nullToEmpty(e.getMessage()).trim().equals("Filesystem closed") ||
+                e instanceof FileNotFoundException) {
+            throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, e);
+        }
+        String message = format("Error opening Hive split %s (offset=%s, length=%s): %s", path, fileSplit.getStart(), fileSplit.getLength(), e.getMessage());
+        if (e.getClass().getSimpleName().equals("BlockMissingException")) {
+            throw new PrestoException(HIVE_MISSING_DATA, message, e);
+        }
+        if (e instanceof HiddenColumnException) {
+            message = format("User does not have access to encryption key for encrypted column = %s. If returning 'null' for encrypted " +
+                    "columns is acceptable to your query, please add 'set session hive.read_null_masked_parquet_encrypted_value_enabled=true' before your query", ((HiddenColumnException) e).getColumn());
+            throw new PrestoException(PERMISSION_DENIED, message, e);
+        }
+        throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, message, e);
+    }
+}


### PR DESCRIPTION
## Description
Fixes bugs from the refactoring of error handling for partial aggregation pushdown https://github.com/prestodb/presto/pull/22011.
1. Accidentally was using the orc error handling for the parquet files because the new utility class with parquet exception mapping didn't get added to the commit.  This switches the error handling back to what it was before
2. Fix a resource leak for aggregated page source factories when no error is encountered.  I think this leak might have been present before the refactoring too.

## Impact
Error messages should now match what they were before https://github.com/prestodb/presto/pull/22011, and there should no longer be a resource leak.
## Test Plan
CI
## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

