### PR TITLE
Splitting a flaky test and disabling part of it

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeWindowQueries.java
@@ -191,13 +191,18 @@ public abstract class AbstractTestNativeWindowQueries
     }
 
     @Test
-    public void testOverlappingPartitionAndSortingKeys()
+    public void testOverlappingPartitionAndSortingKeys1()
     {
         assertQuery("SELECT row_number() OVER (PARTITION BY orderdate ORDER BY orderdate) FROM orders");
         assertQuery("SELECT min(orderkey) OVER (PARTITION BY orderdate ORDER BY orderdate, totalprice) FROM orders");
         assertQuery("SELECT * FROM (SELECT row_number() over(partition by orderstatus order by orderkey, orderstatus) rn, * from orders) WHERE rn = 1");
+    }
 
+    //Disabling flaky test
+    @Test(enabled = false)
+    public void testOverlappingPartitionAndSortingKeys2()
+    {
         assertQuery("WITH t AS (SELECT linenumber, row_number() over (partition by linenumber order by linenumber) as rn FROM lineitem) " +
-                "SELECT * FROM t WHERE rn = 1");
+                        "SELECT * FROM t WHERE rn = 1");
     }
 }


### PR DESCRIPTION
## Description
Disabling flaky test AbstractTestNativeWindowQueries.testOverlappingPartitionAndSortingKeys by splitting the part which is flaky.

## Motivation and Context
https://github.com/prestodb/presto/issues/22129

## Impact
builds will be more reliable

## Test Plan
unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

```
== NO RELEASE NOTE ==
```

