### PR TITLE
Track bytes read even when its a FragmentResultCache hit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheConfig.java
@@ -40,6 +40,8 @@ public class FileFragmentResultCacheConfig
     private DataSize maxSinglePagesSize = new DataSize(500, MEGABYTE);
     private DataSize maxCacheSize = new DataSize(100, GIGABYTE);
 
+    private boolean inputDataStatsEnabled;
+
     public boolean isCachingEnabled()
     {
         return cachingEnabled;
@@ -146,6 +148,19 @@ public class FileFragmentResultCacheConfig
     public FileFragmentResultCacheConfig setMaxCacheSize(DataSize maxCacheSize)
     {
         this.maxCacheSize = maxCacheSize;
+        return this;
+    }
+
+    public boolean isInputDataStatsEnabled()
+    {
+        return inputDataStatsEnabled;
+    }
+
+    @Config("fragment-result-cache.input-data-stats-enabled")
+    @ConfigDescription("Enable tracking of the input data size for fragment cache")
+    public FileFragmentResultCacheConfig setInputDataStatsEnabled(boolean inputDataStatsEnabled)
+    {
+        this.inputDataStatsEnabled = inputDataStatsEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/FragmentCacheResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FragmentCacheResult.java
@@ -14,26 +14,30 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.common.Page;
-import com.facebook.presto.metadata.Split;
 
-import java.util.List;
+import java.util.Iterator;
 import java.util.Optional;
-import java.util.concurrent.Future;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.util.Objects.requireNonNull;
 
-public class NoOpFragmentResultCacheManager
-        implements FragmentResultCacheManager
+public class FragmentCacheResult
 {
-    @Override
-    public Future<?> put(String serializedPlan, Split split, List<Page> result, long inputDataSize)
+    Optional<Iterator<Page>> pages;
+    long inputDataSize;
+
+    public FragmentCacheResult(Optional<Iterator<Page>> pages, long inputDataSize)
     {
-        return immediateFuture(null);
+        this.pages = requireNonNull(pages, "pages is null");
+        this.inputDataSize = inputDataSize;
     }
 
-    @Override
-    public FragmentCacheResult get(String serializedPlan, Split split)
+    public Optional<Iterator<Page>> getPages()
     {
-        return new FragmentCacheResult(Optional.empty(), 0);
+        return pages;
+    }
+
+    public long getInputDataSize()
+    {
+        return inputDataSize;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/FragmentResultCacheManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FragmentResultCacheManager.java
@@ -16,14 +16,12 @@ package com.facebook.presto.operator;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.metadata.Split;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.Future;
 
 public interface FragmentResultCacheManager
 {
-    Future<?> put(String serializedPlan, Split split, List<Page> result);
+    Future<?> put(String serializedPlan, Split split, List<Page> result, long inputDataSize);
 
-    Optional<Iterator<Page>> get(String serializedPlan, Split split);
+    FragmentCacheResult get(String serializedPlan, Split split);
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -55,7 +55,6 @@ import org.testng.annotations.Test;
 
 import java.io.Closeable;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -672,23 +671,23 @@ public class TestDriver
     private static class TestingFragmentResultCacheManager
             implements FragmentResultCacheManager
     {
-        private final Map<CacheKey, List<Page>> cache = new HashMap<>();
+        private final Map<CacheKey, FragmentCacheResult> cache = new HashMap<>();
 
         @Override
-        public Future<?> put(String plan, Split split, List<Page> result)
+        public Future<?> put(String plan, Split split, List<Page> result, long inputDataSize)
         {
-            cache.put(new CacheKey(plan, split.getSplitIdentifier()), result);
+            cache.put(new CacheKey(plan, split.getSplitIdentifier()), new FragmentCacheResult(Optional.of(result.stream().iterator()), inputDataSize));
             return immediateFuture(null);
         }
 
         @Override
-        public Optional<Iterator<Page>> get(String plan, Split split)
+        public FragmentCacheResult get(String plan, Split split)
         {
             CacheKey key = new CacheKey(plan, split.getSplitIdentifier());
             if (cache.containsKey(key)) {
-                return Optional.of(cache.get(key).iterator());
+                return cache.get(key);
             }
-            return Optional.empty();
+            return new FragmentCacheResult(Optional.empty(), 0);
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheConfig.java
@@ -41,7 +41,8 @@ public class TestFileFragmentResultCacheConfig
                 .setCacheTtl(new Duration(2, DAYS))
                 .setMaxInFlightSize(new DataSize(1, GIGABYTE))
                 .setMaxSinglePagesSize(new DataSize(500, MEGABYTE))
-                .setMaxCacheSize(new DataSize(100, GIGABYTE)));
+                .setMaxCacheSize(new DataSize(100, GIGABYTE))
+                .setInputDataStatsEnabled(false));
     }
 
     @Test
@@ -57,6 +58,7 @@ public class TestFileFragmentResultCacheConfig
                 .put("fragment-result-cache.max-in-flight-size", "2GB")
                 .put("fragment-result-cache.max-single-pages-size", "200MB")
                 .put("fragment-result-cache.max-cache-size", "200GB")
+                .put("fragment-result-cache.input-data-stats-enabled", "true")
                 .build();
 
         FileFragmentResultCacheConfig expected = new FileFragmentResultCacheConfig()
@@ -67,7 +69,8 @@ public class TestFileFragmentResultCacheConfig
                 .setCacheTtl(new Duration(1, DAYS))
                 .setMaxInFlightSize(new DataSize(2, GIGABYTE))
                 .setMaxSinglePagesSize(new DataSize(200, MEGABYTE))
-                .setMaxCacheSize(new DataSize(200, GIGABYTE));
+                .setMaxCacheSize(new DataSize(200, GIGABYTE))
+                .setInputDataStatsEnabled(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
Track bytes read even when its a FragmentResultCache hit

## Motivation and Context
Currently, the input bytes, positions read for a query are reported
as 0 when there is a 100% fragment result cache hit. But for some
usecases its helpful to report the input data size even when its
a fragment result cache hit.
This PR adds support to track the input data size for every fragment
we cache.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for tracking of the input data size even when there is a fragment result cache hit. This can be enabled by setting the config ```fragment-result-cache.input-data-stats-enabled=true```.

```

