### PR TITLE
[native] Do not add extra LocalExchange for native queries with join spill enabled

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -72,6 +72,7 @@ import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
 import static com.facebook.presto.SystemSessionProperties.isDistributedSortEnabled;
 import static com.facebook.presto.SystemSessionProperties.isEnforceFixedDistributionForOutputOperator;
 import static com.facebook.presto.SystemSessionProperties.isJoinSpillingEnabled;
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.SystemSessionProperties.isQuickDistinctLimitEnabled;
 import static com.facebook.presto.SystemSessionProperties.isSegmentedAggregationEnabled;
 import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
@@ -762,7 +763,7 @@ public class AddLocalExchanges
         public PlanWithProperties visitJoin(JoinNode node, StreamPreferredProperties parentPreferences)
         {
             PlanWithProperties probe;
-            if (isSpillEnabled(session) && isJoinSpillingEnabled(session)) {
+            if (isSpillEnabled(session) && isJoinSpillingEnabled(session) && !isNativeExecutionEnabled(session)) {
                 probe = planAndEnforce(
                         node.getLeft(),
                         fixedParallelism(),


### PR DESCRIPTION
Unlike Java workers, native workers do not have any special requirements on the plan share when join spill is enabled. At the same, it is confusing that query plan changes based on whether join spilling is enabled or not.

For reference, here is a commit that added extra LocalExchange for Java workers: https://github.com/prestodb/presto/commit/ba98c10770a9b40687aae64c3612bdb2101d5603#diff-0d1dbdeb9958c20dabf2907e354679fdc10db52c4010f0e5d7fe38cbaa4872ee

```
== NO RELEASE NOTE ==
```

