### PR TITLE
[native] Disable aggregation pushdown for Hive Connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -29,6 +29,7 @@ import com.facebook.presto.hive.s3.HiveS3Module;
 import com.facebook.presto.hive.security.HiveSecurityModule;
 import com.facebook.presto.hive.security.SystemTableAwareAccessControl;
 import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
@@ -134,6 +135,7 @@ public class HiveConnectorFactory
                         binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
                         binder.bind(FilterStatsCalculatorService.class).toInstance(context.getFilterStatsCalculatorService());
                         binder.bind(BlockEncodingSerde.class).toInstance(context.getBlockEncodingSerde());
+                        binder.bind(ConnectorSystemConfig.class).toInstance(context.getConnectorSystemConfig());
                     });
 
             Injector injector = app

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePlanOptimizerProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePlanOptimizerProvider.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.HivePartitionManager;
 import com.facebook.presto.hive.HiveTransactionManager;
 import com.facebook.presto.hive.TransactionalMetadata;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
@@ -43,7 +44,8 @@ public class HivePlanOptimizerProvider
             HivePartitionManager partitionManager,
             FunctionMetadataManager functionMetadataManager,
             TypeManager typeManager,
-            Supplier<TransactionalMetadata> metadataFactory)
+            Supplier<TransactionalMetadata> metadataFactory,
+            ConnectorSystemConfig connectorSystemConfig)
     {
         requireNonNull(transactionManager, "transactionManager is null");
         requireNonNull(rowExpressionService, "rowExpressionService is null");
@@ -51,11 +53,15 @@ public class HivePlanOptimizerProvider
         requireNonNull(partitionManager, "partitionManager is null");
         requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         requireNonNull(typeManager, "typeManager is null");
-        this.planOptimizers = ImmutableSet.of(
-                new HiveFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, partitionManager),
-                new HiveAddRequestedColumnsToLayout(),
-                new HiveParquetDereferencePushDown(transactionManager, rowExpressionService),
-                new HivePartialAggregationPushdown(functionMetadataManager, functionResolution, metadataFactory));
+        ImmutableSet.Builder<ConnectorPlanOptimizer> planOptimizerBuilder = ImmutableSet.<ConnectorPlanOptimizer>builder()
+                .add(new HiveFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, partitionManager))
+                .add(new HiveAddRequestedColumnsToLayout())
+                .add(new HiveParquetDereferencePushDown(transactionManager, rowExpressionService));
+        if (!connectorSystemConfig.isNativeExecution()) {
+            planOptimizerBuilder.add(new HivePartialAggregationPushdown(functionMetadataManager, functionResolution, metadataFactory));
+        }
+
+        this.planOptimizers = planOptimizerBuilder.build();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePlanOptimizerProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePlanOptimizerProvider.java
@@ -58,7 +58,7 @@ public class HivePlanOptimizerProvider
                 .add(new HiveAddRequestedColumnsToLayout())
                 .add(new HiveParquetDereferencePushDown(transactionManager, rowExpressionService));
         if (!connectorSystemConfig.isNativeExecution()) {
-            planOptimizerBuilder.add(new HivePartialAggregationPushdown(functionMetadataManager, functionResolution, metadataFactory));
+            planOptimizerBuilder.add(new HivePartialAggregationPushdown(functionResolution, metadataFactory));
         }
 
         this.planOptimizers = planOptimizerBuilder.build();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -1320,7 +1320,6 @@ public class TestHiveLogicalPlanner
                 ImmutableMap.of("x", toSubfields("x.a", "x.b")));
 
         // Join
-        Session session = getQueryRunner().getDefaultSession();
         assertPlan("SELECT l.orderkey, x.a, mod(x.d.d1, 2) FROM lineitem l, test_pushdown_struct_subfields a WHERE l.linenumber = a.id",
                 anyTree(
                         node(JoinNode.class,
@@ -1854,7 +1853,7 @@ public class TestHiveLogicalPlanner
 
             Map<Optional<String>, ExpectedValueProvider<FunctionCall>> aggregations = ImmutableMap.of(Optional.of("count"),
                     PlanMatchPattern.functionCall("count", false, ImmutableList.of(anySymbol())));
-            List<String> groupByKey = ImmutableList.of("count_star");
+
             assertPlan(partialAggregatePushdownEnabled(),
                     "select count(*) from orders_partitioned_parquet",
                     anyTree(aggregation(globalAggregation(), aggregations, ImmutableMap.of(), Optional.empty(), AggregationNode.Step.FINAL,
@@ -1890,13 +1889,6 @@ public class TestHiveLogicalPlanner
                     anyTree(PlanMatchPattern.tableScan("orders_partitioned_parquet")),
                     plan -> assertNoAggregatedColumns(plan, "orders_partitioned_parquet"));
 
-            aggregations = ImmutableMap.of(
-                    Optional.of("count_1"),
-                    PlanMatchPattern.functionCall("count", false, ImmutableList.of(anySymbol())),
-                    Optional.of("arbitrary"),
-                    PlanMatchPattern.functionCall("arbitrary", false, ImmutableList.of(anySymbol())),
-                    Optional.of("min"),
-                    PlanMatchPattern.functionCall("max", false, ImmutableList.of(anySymbol())));
             assertPlan(partialAggregatePushdownEnabled(),
                     "select count(orderkey), arbitrary(orderpriority), min(ds) from orders_partitioned_parquet",
                     anyTree(PlanMatchPattern.tableScan("orders_partitioned_parquet")),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveNativeLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveNativeLogicalPlanner.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
+import static com.facebook.presto.hive.HiveSessionProperties.PARTIAL_AGGREGATION_PUSHDOWN_ENABLED;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestHiveNativeLogicalPlanner
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS),
+                ImmutableMap.of("native-execution-enabled", "true"),
+                Optional.empty());
+    }
+
+    @Test
+    public void testPartialAggregatePushdownDisabled()
+    {
+        assertPlan(partialAggregatePushdownEnabled(),
+                "select count(orderkey), max(orderpriority) from orders",
+                anyTree(PlanMatchPattern.tableScan("orders")),
+                plan -> assertNoAggregatedColumns(plan, "orders"));
+    }
+
+    private Session partialAggregatePushdownEnabled()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(HIVE_CATALOG, PARTIAL_AGGREGATION_PUSHDOWN_ENABLED, "true")
+                .build();
+    }
+
+    private void assertNoAggregatedColumns(Plan plan, String tableName)
+    {
+        TableScanNode tableScan = searchFrom(plan.getRoot())
+                .where(node -> isTableScanNode(node, tableName))
+                .findOnlyElement();
+
+        for (ColumnHandle columnHandle : tableScan.getAssignments().values()) {
+            assertTrue(columnHandle instanceof HiveColumnHandle);
+            HiveColumnHandle hiveColumnHandle = (HiveColumnHandle) columnHandle;
+            assertFalse(hiveColumnHandle.getColumnType() == HiveColumnHandle.ColumnType.AGGREGATED);
+            assertFalse(hiveColumnHandle.getPartialAggregation().isPresent());
+        }
+    }
+
+    private static boolean isTableScanNode(PlanNode node, String tableName)
+    {
+        return node instanceof TableScanNode && ((HiveTableHandle) ((TableScanNode) node).getTable().getConnectorHandle()).getTableName().equals(tableName);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorContextInstance.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorContextInstance.java
@@ -15,6 +15,7 @@ package com.facebook.presto.connector;
 
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
@@ -38,6 +39,7 @@ public class ConnectorContextInstance
     private final RowExpressionService rowExpressionService;
     private final FilterStatsCalculatorService filterStatsCalculatorService;
     private final BlockEncodingSerde blockEncodingSerde;
+    private final ConnectorSystemConfig connectorSystemConfig;
 
     public ConnectorContextInstance(
             NodeManager nodeManager,
@@ -48,7 +50,8 @@ public class ConnectorContextInstance
             PageIndexerFactory pageIndexerFactory,
             RowExpressionService rowExpressionService,
             FilterStatsCalculatorService filterStatsCalculatorService,
-            BlockEncodingSerde blockEncodingSerde)
+            BlockEncodingSerde blockEncodingSerde,
+            ConnectorSystemConfig connectorSystemConfig)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -59,6 +62,7 @@ public class ConnectorContextInstance
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
+        this.connectorSystemConfig = requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
     }
 
     @Override
@@ -113,5 +117,11 @@ public class ConnectorContextInstance
     public BlockEncodingSerde getBlockEncodingSerde()
     {
         return blockEncodingSerde;
+    }
+
+    @Override
+    public ConnectorSystemConfig getConnectorSystemConfig()
+    {
+        return connectorSystemConfig;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -475,7 +475,8 @@ public class LocalQueryRunner
                 new RowExpressionPredicateCompiler(metadata),
                 new RowExpressionDeterminismEvaluator(metadata.getFunctionAndTypeManager()),
                 new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer),
-                blockEncodingManager);
+                blockEncodingManager,
+                featuresConfig);
 
         GlobalSystemConnectorFactory globalSystemConnectorFactory = new GlobalSystemConnectorFactory(ImmutableSet.of(
                 new NodeSystemTable(nodeManager),

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
@@ -30,6 +30,7 @@ import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
@@ -152,5 +153,11 @@ public class TestingConnectorContext
     public BlockEncodingSerde getBlockEncodingSerde()
     {
         return blockEncodingSerde;
+    }
+
+    @Override
+    public ConnectorSystemConfig getConnectorSystemConfig()
+    {
+        return () -> false;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSystemConfig.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSystemConfig.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+public interface ConnectorSystemConfig
+{
+    boolean isNativeExecution();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorContext.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.connector;
 
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
@@ -66,6 +67,11 @@ public interface ConnectorContext
     }
 
     default BlockEncodingSerde getBlockEncodingSerde()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default ConnectorSystemConfig getConnectorSystemConfig()
     {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Native execution doesn't need (or support) explicit aggregation pushdown. The same optimization is implemented by integrating LazyVectors with aggregation functions.

Fixes #22047

```
== NO RELEASE NOTE ==
```

