### PR TITLE
Add Metastore cache

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaModule.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaModule.java
@@ -40,6 +40,8 @@ import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.InMemoryMetastoreCache;
+import com.facebook.presto.hive.metastore.MetastoreCache;
 import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -104,6 +106,7 @@ public class DeltaModule
         binder.bind(MetastoreCacheStats.class).to(HiveMetastoreCacheStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(MetastoreCacheStats.class).as(generatedNameOf(MetastoreCacheStats.class, connectorId));
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(MetastoreCache.class).to(InMemoryMetastoreCache.class).in(Scopes.SINGLETON);
         binder.bind(HdfsConfiguration.class).annotatedWith(ForMetastoreHdfsEnvironment.class).to(HiveCachingHdfsConfiguration.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(HiveGcsConfig.class);

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -18,61 +18,27 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.ForCachingHiveMetastore;
 import com.facebook.presto.hive.HiveTableHandle;
 import com.facebook.presto.hive.HiveType;
-import com.facebook.presto.hive.MetastoreClientConfig;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.SetMultimap;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
-import static com.facebook.presto.hive.HiveErrorCode.HIVE_CORRUPTED_PARTITION_CACHE;
-import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURING_QUERY;
 import static com.facebook.presto.hive.metastore.CachingHiveMetastore.MetastoreCacheScope.ALL;
-import static com.facebook.presto.hive.metastore.HivePartitionName.hivePartitionName;
-import static com.facebook.presto.hive.metastore.HiveTableName.hiveTableName;
 import static com.facebook.presto.hive.metastore.NoopMetastoreCacheStats.NOOP_METASTORE_CACHE_STATS;
-import static com.facebook.presto.hive.metastore.PartitionFilter.partitionFilter;
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.throwIfInstanceOf;
-import static com.google.common.base.Throwables.throwIfUnchecked;
-import static com.google.common.cache.CacheLoader.asyncReloading;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
-import static com.google.common.collect.Iterables.transform;
-import static com.google.common.collect.Streams.stream;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Hive Metastore Cache
@@ -87,284 +53,51 @@ public class CachingHiveMetastore
     }
 
     protected final ExtendedHiveMetastore delegate;
-
-    private final LoadingCache<KeyAndContext<String>, Optional<Database>> databaseCache;
-    private final LoadingCache<KeyAndContext<String>, List<String>> databaseNamesCache;
-    private final LoadingCache<KeyAndContext<HiveTableHandle>, Optional<Table>> tableCache;
-    private final LoadingCache<KeyAndContext<String>, Optional<List<String>>> tableNamesCache;
-    private final LoadingCache<KeyAndContext<HiveTableName>, PartitionStatistics> tableStatisticsCache;
-    private final LoadingCache<KeyAndContext<HiveTableName>, List<TableConstraint<String>>> tableConstraintsCache;
-    private final LoadingCache<KeyAndContext<HivePartitionName>, PartitionStatistics> partitionStatisticsCache;
-    private final LoadingCache<KeyAndContext<String>, Optional<List<String>>> viewNamesCache;
-    private final LoadingCache<KeyAndContext<HivePartitionName>, Optional<Partition>> partitionCache;
-    private final LoadingCache<KeyAndContext<PartitionFilter>, List<String>> partitionFilterCache;
-    private final LoadingCache<KeyAndContext<HiveTableName>, Optional<List<String>>> partitionNamesCache;
-    private final LoadingCache<KeyAndContext<UserTableKey>, Set<HivePrivilegeInfo>> tablePrivilegesCache;
-    private final LoadingCache<KeyAndContext<String>, Set<String>> rolesCache;
-    private final LoadingCache<KeyAndContext<PrestoPrincipal>, Set<RoleGrant>> roleGrantsCache;
-    private final MetastoreCacheStats metastoreCacheStats;
-
-    private final boolean metastoreImpersonationEnabled;
-    private final boolean partitionVersioningEnabled;
-    private final double partitionCacheValidationPercentage;
-    private final int partitionCacheColumnCountLimit;
+    protected final MetastoreCache metastoreCache;
 
     @Inject
     public CachingHiveMetastore(
             @ForCachingHiveMetastore ExtendedHiveMetastore delegate,
-            @ForCachingHiveMetastore ExecutorService executor,
-            MetastoreCacheStats metastoreCacheStats,
-            MetastoreClientConfig metastoreClientConfig)
+            MetastoreCache metastoreCache)
     {
-        this(
-                delegate,
-                executor,
-                metastoreClientConfig.isMetastoreImpersonationEnabled(),
-                metastoreClientConfig.getMetastoreCacheTtl(),
-                metastoreClientConfig.getMetastoreRefreshInterval(),
-                metastoreClientConfig.getMetastoreCacheMaximumSize(),
-                metastoreClientConfig.isPartitionVersioningEnabled(),
-                metastoreClientConfig.getMetastoreCacheScope(),
-                metastoreClientConfig.getPartitionCacheValidationPercentage(),
-                metastoreClientConfig.getPartitionCacheColumnCountLimit(),
-                metastoreCacheStats);
-    }
-
-    public CachingHiveMetastore(
-            ExtendedHiveMetastore delegate,
-            ExecutorService executor,
-            boolean metastoreImpersonationEnabled,
-            Duration cacheTtl,
-            Duration refreshInterval,
-            long maximumSize,
-            boolean partitionVersioningEnabled,
-            MetastoreCacheScope metastoreCacheScope,
-            double partitionCacheValidationPercentage,
-            int partitionCacheColumnCountLimit,
-            MetastoreCacheStats metastoreCacheStats)
-    {
-        this(
-                delegate,
-                executor,
-                metastoreImpersonationEnabled,
-                OptionalLong.of(cacheTtl.toMillis()),
-                refreshInterval.toMillis() >= cacheTtl.toMillis() ? OptionalLong.empty() : OptionalLong.of(refreshInterval.toMillis()),
-                maximumSize,
-                partitionVersioningEnabled,
-                metastoreCacheScope,
-                partitionCacheValidationPercentage,
-                partitionCacheColumnCountLimit,
-                metastoreCacheStats);
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.metastoreCache = requireNonNull(metastoreCache, "metastoreCache is null");
     }
 
     public static CachingHiveMetastore memoizeMetastore(ExtendedHiveMetastore delegate, boolean isMetastoreImpersonationEnabled, long maximumSize, int partitionCacheMaxColumnCount)
     {
         return new CachingHiveMetastore(
                 delegate,
-                newDirectExecutorService(),
-                isMetastoreImpersonationEnabled,
-                OptionalLong.empty(),
-                OptionalLong.empty(),
-                maximumSize,
-                false,
-                ALL,
-                0.0,
-                partitionCacheMaxColumnCount,
-                NOOP_METASTORE_CACHE_STATS);
-    }
-
-    private CachingHiveMetastore(
-            ExtendedHiveMetastore delegate,
-            ExecutorService executor,
-            boolean metastoreImpersonationEnabled,
-            OptionalLong expiresAfterWriteMillis,
-            OptionalLong refreshMills,
-            long maximumSize,
-            boolean partitionVersioningEnabled,
-            MetastoreCacheScope metastoreCacheScope,
-            double partitionCacheValidationPercentage,
-            int partitionCacheColumnCountLimit,
-            MetastoreCacheStats metastoreCacheStats)
-    {
-        this.delegate = requireNonNull(delegate, "delegate is null");
-        requireNonNull(executor, "executor is null");
-        this.metastoreImpersonationEnabled = metastoreImpersonationEnabled;
-        this.partitionVersioningEnabled = partitionVersioningEnabled;
-        this.partitionCacheValidationPercentage = partitionCacheValidationPercentage;
-        this.partitionCacheColumnCountLimit = partitionCacheColumnCountLimit;
-        this.metastoreCacheStats = metastoreCacheStats;
-
-        OptionalLong cacheExpiresAfterWriteMillis;
-        OptionalLong cacheRefreshMills;
-        long cacheMaxSize;
-
-        OptionalLong partitionCacheExpiresAfterWriteMillis;
-        OptionalLong partitionCacheRefreshMills;
-        long partitionCacheMaxSize;
-
-        switch (metastoreCacheScope) {
-            case PARTITION:
-                partitionCacheExpiresAfterWriteMillis = expiresAfterWriteMillis;
-                partitionCacheRefreshMills = refreshMills;
-                partitionCacheMaxSize = maximumSize;
-                cacheExpiresAfterWriteMillis = OptionalLong.of(0);
-                cacheRefreshMills = OptionalLong.of(0);
-                cacheMaxSize = 0;
-                break;
-
-            case ALL:
-                partitionCacheExpiresAfterWriteMillis = expiresAfterWriteMillis;
-                partitionCacheRefreshMills = refreshMills;
-                partitionCacheMaxSize = maximumSize;
-                cacheExpiresAfterWriteMillis = expiresAfterWriteMillis;
-                cacheRefreshMills = refreshMills;
-                cacheMaxSize = maximumSize;
-                break;
-
-            default:
-                throw new IllegalArgumentException("Unknown metastore-cache-scope: " + metastoreCacheScope);
-        }
-
-        databaseNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadAllDatabases), executor));
-
-        databaseCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadDatabase), executor));
-
-        tableNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadAllTables), executor));
-
-        tableStatisticsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(new CacheLoader<KeyAndContext<HiveTableName>, PartitionStatistics>()
-                {
-                    @Override
-                    public PartitionStatistics load(KeyAndContext<HiveTableName> key)
-                    {
-                        return loadTableColumnStatistics(key);
-                    }
-                }, executor));
-
-        partitionStatisticsCache = newCacheBuilder(partitionCacheExpiresAfterWriteMillis, partitionCacheRefreshMills, partitionCacheMaxSize)
-                .build(asyncReloading(new CacheLoader<KeyAndContext<HivePartitionName>, PartitionStatistics>()
-                {
-                    @Override
-                    public PartitionStatistics load(KeyAndContext<HivePartitionName> key)
-                    {
-                        return loadPartitionColumnStatistics(key);
-                    }
-
-                    @Override
-                    public Map<KeyAndContext<HivePartitionName>, PartitionStatistics> loadAll(Iterable<? extends KeyAndContext<HivePartitionName>> keys)
-                    {
-                        return loadPartitionColumnStatistics(keys);
-                    }
-                }, executor));
-
-        tableCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadTable), executor));
-        metastoreCacheStats.setTableCache(tableCache);
-
-        tableConstraintsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadTableConstraints), executor));
-
-        viewNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadAllViews), executor));
-
-        partitionNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadPartitionNames), executor));
-
-        partitionFilterCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadPartitionNamesByFilter), executor));
-        metastoreCacheStats.setPartitionNamesCache(partitionFilterCache);
-
-        partitionCache = newCacheBuilder(partitionCacheExpiresAfterWriteMillis, partitionCacheRefreshMills, partitionCacheMaxSize)
-                .build(asyncReloading(new CacheLoader<KeyAndContext<HivePartitionName>, Optional<Partition>>()
-                {
-                    @Override
-                    public Optional<Partition> load(KeyAndContext<HivePartitionName> partitionName)
-                    {
-                        return loadPartitionByName(partitionName);
-                    }
-
-                    @Override
-                    public Map<KeyAndContext<HivePartitionName>, Optional<Partition>> loadAll(Iterable<? extends KeyAndContext<HivePartitionName>> partitionNames)
-                    {
-                        return loadPartitionsByNames(partitionNames);
-                    }
-                }, executor));
-        metastoreCacheStats.setPartitionCache(partitionCache);
-
-        tablePrivilegesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadTablePrivileges), executor));
-
-        rolesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadAllRoles), executor));
-
-        roleGrantsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
-                .build(asyncReloading(CacheLoader.from(this::loadRoleGrants), executor));
+                new InMemoryMetastoreCache(
+                        delegate,
+                        newDirectExecutorService(),
+                        isMetastoreImpersonationEnabled,
+                        OptionalLong.empty(),
+                        OptionalLong.empty(),
+                        maximumSize,
+                        false,
+                        ALL,
+                        0.0,
+                        partitionCacheMaxColumnCount,
+                        NOOP_METASTORE_CACHE_STATS));
     }
 
     @Managed
     public void flushCache()
     {
-        databaseNamesCache.invalidateAll();
-        tableNamesCache.invalidateAll();
-        viewNamesCache.invalidateAll();
-        partitionNamesCache.invalidateAll();
-        databaseCache.invalidateAll();
-        tableCache.invalidateAll();
-        tableConstraintsCache.invalidateAll();
-        partitionCache.invalidateAll();
-        partitionFilterCache.invalidateAll();
-        tablePrivilegesCache.invalidateAll();
-        tableStatisticsCache.invalidateAll();
-        partitionStatisticsCache.invalidateAll();
-        rolesCache.invalidateAll();
-    }
-
-    private static <K, V> V get(LoadingCache<K, V> cache, K key)
-    {
-        try {
-            return cache.getUnchecked(key);
-        }
-        catch (UncheckedExecutionException e) {
-            throwIfInstanceOf(e.getCause(), PrestoException.class);
-            throw e;
-        }
-    }
-
-    private static <K, V> Map<K, V> getAll(LoadingCache<K, V> cache, Iterable<K> keys)
-    {
-        try {
-            return cache.getAll(keys);
-        }
-        catch (ExecutionException | UncheckedExecutionException e) {
-            throwIfInstanceOf(e.getCause(), PrestoException.class);
-            throwIfUnchecked(e);
-            throw new UncheckedExecutionException(e);
-        }
+        metastoreCache.invalidateAll();
     }
 
     @Override
     public Optional<Database> getDatabase(MetastoreContext metastoreContext, String databaseName)
     {
-        return get(databaseCache, getCachingKey(metastoreContext, databaseName));
-    }
-
-    private Optional<Database> loadDatabase(KeyAndContext<String> databaseName)
-    {
-        return delegate.getDatabase(databaseName.getContext(), databaseName.getKey());
+        return metastoreCache.getDatabase(metastoreContext, databaseName);
     }
 
     @Override
     public List<String> getAllDatabases(MetastoreContext metastoreContext)
     {
-        return get(databaseNamesCache, getCachingKey(metastoreContext, ""));
-    }
-
-    private List<String> loadAllDatabases(KeyAndContext<String> key)
-    {
-        return delegate.getAllDatabases(key.getContext());
+        return metastoreCache.getAllDatabases(metastoreContext);
     }
 
     @Override
@@ -376,13 +109,13 @@ public class CachingHiveMetastore
     @Override
     public Optional<Table> getTable(MetastoreContext metastoreContext, HiveTableHandle hiveTableHandle)
     {
-        return get(tableCache, getCachingKey(metastoreContext, hiveTableHandle));
+        return metastoreCache.getTable(metastoreContext, hiveTableHandle);
     }
 
     @Override
     public List<TableConstraint<String>> getTableConstraints(MetastoreContext metastoreContext, String databaseName, String tableName)
     {
-        return get(tableConstraintsCache, getCachingKey(metastoreContext, hiveTableName(databaseName, tableName)));
+        return metastoreCache.getTableConstraints(metastoreContext, databaseName, tableName);
     }
 
     @Override
@@ -391,71 +124,16 @@ public class CachingHiveMetastore
         return delegate.getSupportedColumnStatistics(metastoreContext, type);
     }
 
-    private Optional<Table> loadTable(KeyAndContext<HiveTableHandle> hiveTableHandle)
-    {
-        return delegate.getTable(hiveTableHandle.getContext(), hiveTableHandle.getKey());
-    }
-
-    private List<TableConstraint<String>> loadTableConstraints(KeyAndContext<HiveTableName> hiveTableName)
-    {
-        return delegate.getTableConstraints(hiveTableName.getContext(), hiveTableName.getKey().getDatabaseName(), hiveTableName.getKey().getTableName());
-    }
-
     @Override
     public PartitionStatistics getTableStatistics(MetastoreContext metastoreContext, String databaseName, String tableName)
     {
-        return get(tableStatisticsCache, getCachingKey(metastoreContext, hiveTableName(databaseName, tableName)));
-    }
-
-    private PartitionStatistics loadTableColumnStatistics(KeyAndContext<HiveTableName> hiveTableName)
-    {
-        return delegate.getTableStatistics(hiveTableName.getContext(), hiveTableName.getKey().getDatabaseName(), hiveTableName.getKey().getTableName());
+        return metastoreCache.getTableStatistics(metastoreContext, databaseName, tableName);
     }
 
     @Override
     public Map<String, PartitionStatistics> getPartitionStatistics(MetastoreContext metastoreContext, String databaseName, String tableName, Set<String> partitionNames)
     {
-        List<KeyAndContext<HivePartitionName>> partitions = partitionNames.stream()
-                .map(partitionName -> getCachingKey(metastoreContext, HivePartitionName.hivePartitionName(databaseName, tableName, partitionName)))
-                .collect(toImmutableList());
-        Map<KeyAndContext<HivePartitionName>, PartitionStatistics> statistics = getAll(partitionStatisticsCache, partitions);
-        return statistics.entrySet()
-                .stream()
-                .collect(toImmutableMap(entry -> entry.getKey().getKey().getPartitionName().get(), Entry::getValue));
-    }
-
-    private PartitionStatistics loadPartitionColumnStatistics(KeyAndContext<HivePartitionName> partition)
-    {
-        String partitionName = partition.getKey().getPartitionName().get();
-        Map<String, PartitionStatistics> partitionStatistics = delegate.getPartitionStatistics(
-                partition.getContext(),
-                partition.getKey().getHiveTableName().getDatabaseName(),
-                partition.getKey().getHiveTableName().getTableName(),
-                ImmutableSet.of(partitionName));
-        if (!partitionStatistics.containsKey(partitionName)) {
-            throw new PrestoException(HIVE_PARTITION_DROPPED_DURING_QUERY, "Statistics result does not contain entry for partition: " + partition.getKey().getPartitionName());
-        }
-        return partitionStatistics.get(partitionName);
-    }
-
-    private Map<KeyAndContext<HivePartitionName>, PartitionStatistics> loadPartitionColumnStatistics(Iterable<? extends KeyAndContext<HivePartitionName>> keys)
-    {
-        SetMultimap<KeyAndContext<HiveTableName>, KeyAndContext<HivePartitionName>> tablePartitions = stream(keys)
-                .collect(toImmutableSetMultimap(nameKey -> getCachingKey(nameKey.getContext(), nameKey.getKey().getHiveTableName()), nameKey -> nameKey));
-        ImmutableMap.Builder<KeyAndContext<HivePartitionName>, PartitionStatistics> result = ImmutableMap.builder();
-        tablePartitions.keySet().forEach(table -> {
-            Set<String> partitionNames = tablePartitions.get(table).stream()
-                    .map(partitionName -> partitionName.getKey().getPartitionName().get())
-                    .collect(toImmutableSet());
-            Map<String, PartitionStatistics> partitionStatistics = delegate.getPartitionStatistics(table.getContext(), table.getKey().getDatabaseName(), table.getKey().getTableName(), partitionNames);
-            for (String partitionName : partitionNames) {
-                if (!partitionStatistics.containsKey(partitionName)) {
-                    throw new PrestoException(HIVE_PARTITION_DROPPED_DURING_QUERY, "Statistics result does not contain entry for partition: " + partitionName);
-                }
-                result.put(getCachingKey(table.getContext(), HivePartitionName.hivePartitionName(table.getKey(), partitionName)), partitionStatistics.get(partitionName));
-            }
-        });
-        return result.build();
+        return metastoreCache.getPartitionStatistics(metastoreContext, databaseName, tableName, partitionNames);
     }
 
     @Override
@@ -465,9 +143,7 @@ public class CachingHiveMetastore
             delegate.updateTableStatistics(metastoreContext, databaseName, tableName, update);
         }
         finally {
-            tableStatisticsCache.asMap().keySet().stream()
-                    .filter(hiveTableNameKey -> hiveTableNameKey.getKey().equals(hiveTableName(databaseName, tableName)))
-                    .forEach(tableStatisticsCache::invalidate);
+            metastoreCache.invalidateTableStatisticsCache(databaseName, tableName);
         }
     }
 
@@ -478,32 +154,20 @@ public class CachingHiveMetastore
             delegate.updatePartitionStatistics(metastoreContext, databaseName, tableName, partitionName, update);
         }
         finally {
-            partitionStatisticsCache.asMap().keySet().stream()
-                    .filter(partitionFilterKey -> partitionFilterKey.getKey().equals(hivePartitionName(databaseName, tableName, partitionName)))
-                    .forEach(partitionStatisticsCache::invalidate);
+            metastoreCache.invalidatePartitionStatisticsCache(databaseName, tableName, partitionName);
         }
     }
 
     @Override
     public Optional<List<String>> getAllTables(MetastoreContext metastoreContext, String databaseName)
     {
-        return get(tableNamesCache, getCachingKey(metastoreContext, databaseName));
-    }
-
-    private Optional<List<String>> loadAllTables(KeyAndContext<String> databaseNameKey)
-    {
-        return delegate.getAllTables(databaseNameKey.getContext(), databaseNameKey.getKey());
+        return metastoreCache.getAllTables(metastoreContext, databaseName);
     }
 
     @Override
     public Optional<List<String>> getAllViews(MetastoreContext metastoreContext, String databaseName)
     {
-        return get(viewNamesCache, getCachingKey(metastoreContext, databaseName));
-    }
-
-    private Optional<List<String>> loadAllViews(KeyAndContext<String> databaseNameKey)
-    {
-        return delegate.getAllViews(databaseNameKey.getContext(), databaseNameKey.getKey());
+        return metastoreCache.getAllViews(metastoreContext, databaseName);
     }
 
     @Override
@@ -513,7 +177,7 @@ public class CachingHiveMetastore
             delegate.createDatabase(metastoreContext, database);
         }
         finally {
-            invalidateDatabase(database.getDatabaseName());
+            metastoreCache.invalidateDatabaseCache(database.getDatabaseName());
         }
     }
 
@@ -524,7 +188,7 @@ public class CachingHiveMetastore
             delegate.dropDatabase(metastoreContext, databaseName);
         }
         finally {
-            invalidateDatabase(databaseName);
+            metastoreCache.invalidateDatabaseCache(databaseName);
         }
     }
 
@@ -535,17 +199,9 @@ public class CachingHiveMetastore
             delegate.renameDatabase(metastoreContext, databaseName, newDatabaseName);
         }
         finally {
-            invalidateDatabase(databaseName);
-            invalidateDatabase(newDatabaseName);
+            metastoreCache.invalidateDatabaseCache(databaseName);
+            metastoreCache.invalidateDatabaseCache(newDatabaseName);
         }
-    }
-
-    protected void invalidateDatabase(String databaseName)
-    {
-        databaseCache.asMap().keySet().stream()
-                .filter(databaseKey -> databaseKey.getKey().equals(databaseName))
-                .forEach(databaseCache::invalidate);
-        databaseNamesCache.invalidateAll();
     }
 
     @Override
@@ -555,7 +211,7 @@ public class CachingHiveMetastore
             return delegate.createTable(metastoreContext, table, principalPrivileges, constraints);
         }
         finally {
-            invalidateTable(table.getDatabaseName(), table.getTableName());
+            metastoreCache.invalidateTableCache(table.getDatabaseName(), table.getTableName());
         }
     }
 
@@ -566,7 +222,7 @@ public class CachingHiveMetastore
             delegate.dropTable(metastoreContext, databaseName, tableName, deleteData);
         }
         finally {
-            invalidateTable(databaseName, tableName);
+            metastoreCache.invalidateTableCache(databaseName, tableName);
         }
     }
 
@@ -577,7 +233,7 @@ public class CachingHiveMetastore
             delegate.dropTableFromMetastore(metastoreContext, databaseName, tableName);
         }
         finally {
-            invalidateTable(databaseName, tableName);
+            metastoreCache.invalidateTableCache(databaseName, tableName);
         }
     }
 
@@ -588,8 +244,8 @@ public class CachingHiveMetastore
             return delegate.replaceTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges);
         }
         finally {
-            invalidateTable(databaseName, tableName);
-            invalidateTable(newTable.getDatabaseName(), newTable.getTableName());
+            metastoreCache.invalidateTableCache(databaseName, tableName);
+            metastoreCache.invalidateTableCache(newTable.getDatabaseName(), newTable.getTableName());
         }
     }
 
@@ -600,8 +256,8 @@ public class CachingHiveMetastore
             return delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
         }
         finally {
-            invalidateTable(databaseName, tableName);
-            invalidateTable(newDatabaseName, newTableName);
+            metastoreCache.invalidateTableCache(databaseName, tableName);
+            metastoreCache.invalidateTableCache(newDatabaseName, newTableName);
         }
     }
 
@@ -612,7 +268,7 @@ public class CachingHiveMetastore
             return delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
         }
         finally {
-            invalidateTable(databaseName, tableName);
+            metastoreCache.invalidateTableCache(databaseName, tableName);
         }
     }
 
@@ -623,7 +279,7 @@ public class CachingHiveMetastore
             return delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
         }
         finally {
-            invalidateTable(databaseName, tableName);
+            metastoreCache.invalidateTableCache(databaseName, tableName);
         }
     }
 
@@ -634,68 +290,20 @@ public class CachingHiveMetastore
             return delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
         }
         finally {
-            invalidateTable(databaseName, tableName);
+            metastoreCache.invalidateTableCache(databaseName, tableName);
         }
-    }
-
-    private static boolean isSameTable(HiveTableHandle hiveTableHandle, HiveTableName hiveTableName)
-    {
-        return hiveTableHandle.getSchemaName().equals(hiveTableName.getDatabaseName()) &&
-                hiveTableHandle.getTableName().equals(hiveTableName.getTableName());
-    }
-
-    protected void invalidateTable(String databaseName, String tableName)
-    {
-        HiveTableName hiveTableName = hiveTableName(databaseName, tableName);
-
-        tableCache.asMap().keySet().stream()
-                .filter(hiveTableHandle -> isSameTable(hiveTableHandle.getKey(), hiveTableName))
-                .forEach(tableCache::invalidate);
-
-        tableConstraintsCache.asMap().keySet().stream()
-                .filter(hiveTableNameKey -> hiveTableNameKey.getKey().equals(hiveTableName))
-                .forEach(tableConstraintsCache::invalidate);
-
-        tableNamesCache.asMap().keySet().stream()
-                .filter(tableNameKey -> tableNameKey.getKey().equals(databaseName))
-                .forEach(tableNamesCache::invalidate);
-
-        viewNamesCache.asMap().keySet().stream()
-                .filter(viewNameKey -> viewNameKey.getKey().equals(databaseName))
-                .forEach(viewNamesCache::invalidate);
-
-        tablePrivilegesCache.asMap().keySet().stream()
-                .filter(userTableKey -> userTableKey.getKey().matches(databaseName, tableName))
-                .forEach(tablePrivilegesCache::invalidate);
-
-        tableStatisticsCache.asMap().keySet().stream()
-                .filter(hiveTableNameKey -> hiveTableNameKey.getKey().equals(hiveTableName))
-                .forEach(tableStatisticsCache::invalidate);
-
-        invalidatePartitionCache(databaseName, tableName);
     }
 
     @Override
     public Optional<Partition> getPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionValues)
     {
-        KeyAndContext<HivePartitionName> key = getCachingKey(metastoreContext, hivePartitionName(databaseName, tableName, partitionValues));
-        Optional<Partition> result = get(partitionCache, key);
-        if (isPartitionCacheValidationEnabled()) {
-            validatePartitionCache(key, result);
-        }
-        invalidatePartitionsWithHighColumnCount(result, key);
-        return result;
+        return metastoreCache.getPartition(metastoreContext, databaseName, tableName, partitionValues);
     }
 
     @Override
     public Optional<List<String>> getPartitionNames(MetastoreContext metastoreContext, String databaseName, String tableName)
     {
-        return get(partitionNamesCache, getCachingKey(metastoreContext, hiveTableName(databaseName, tableName)));
-    }
-
-    private Optional<List<String>> loadPartitionNames(KeyAndContext<HiveTableName> hiveTableNameKey)
-    {
-        return delegate.getPartitionNames(hiveTableNameKey.getContext(), hiveTableNameKey.getKey().getDatabaseName(), hiveTableNameKey.getKey().getTableName());
+        return metastoreCache.getPartitionNames(metastoreContext, databaseName, tableName);
     }
 
     @Override
@@ -705,13 +313,7 @@ public class CachingHiveMetastore
             String tableName,
             Map<Column, Domain> partitionPredicates)
     {
-        if (partitionVersioningEnabled) {
-            List<PartitionNameWithVersion> partitionNamesWithVersion = getPartitionNamesWithVersionByFilter(metastoreContext, databaseName, tableName, partitionPredicates);
-            List<String> result = partitionNamesWithVersion.stream().map(PartitionNameWithVersion::getPartitionName).collect(toImmutableList());
-            invalidateStalePartitions(partitionNamesWithVersion, databaseName, tableName, metastoreContext);
-            return result;
-        }
-        return get(partitionFilterCache, getCachingKey(metastoreContext, partitionFilter(databaseName, tableName, partitionPredicates)));
+        return metastoreCache.getPartitionNamesByFilter(metastoreContext, databaseName, tableName, partitionPredicates);
     }
 
     @Override
@@ -724,136 +326,10 @@ public class CachingHiveMetastore
         return delegate.getPartitionNamesWithVersionByFilter(metastoreContext, databaseName, tableName, partitionPredicates);
     }
 
-    private void invalidateStalePartitions(
-            List<PartitionNameWithVersion> partitionNamesWithVersion,
-            String databaseName,
-            String tableName,
-            MetastoreContext metastoreContext)
-    {
-        for (PartitionNameWithVersion partitionNameWithVersion : partitionNamesWithVersion) {
-            HivePartitionName hivePartitionName = hivePartitionName(databaseName, tableName, partitionNameWithVersion.getPartitionName());
-            KeyAndContext<HivePartitionName> partitionNameKey = getCachingKey(metastoreContext, hivePartitionName);
-            Optional<Partition> partition = partitionCache.getIfPresent(partitionNameKey);
-            if (partition == null || !partition.isPresent()) {
-                partitionCache.invalidate(partitionNameKey);
-                partitionStatisticsCache.invalidate(partitionNameKey);
-            }
-            else {
-                Optional<Long> partitionVersion = partition.get().getPartitionVersion();
-                if (!partitionVersion.isPresent() || !partitionVersion.equals(partitionNameWithVersion.getPartitionVersion())) {
-                    partitionCache.invalidate(partitionNameKey);
-                    partitionStatisticsCache.invalidate(partitionNameKey);
-                }
-            }
-        }
-    }
-
-    private void invalidatePartitionsWithHighColumnCount(Optional<Partition> partition, KeyAndContext<HivePartitionName> partitionCacheKey)
-    {
-        // Do NOT cache partitions with # of columns > partitionCacheColumnLimit
-        if (partition.isPresent() && partition.get().getColumns().size() > partitionCacheColumnCountLimit) {
-            partitionCache.invalidate(partitionCacheKey);
-            metastoreCacheStats.incrementPartitionsWithColumnCountGreaterThanThreshold();
-        }
-    }
-
-    private boolean isPartitionCacheValidationEnabled()
-    {
-        return partitionCacheValidationPercentage > 0 &&
-                ThreadLocalRandom.current().nextDouble(100) < partitionCacheValidationPercentage;
-    }
-
-    private void validatePartitionCache(KeyAndContext<HivePartitionName> partitionName, Optional<Partition> partitionFromCache)
-    {
-        Optional<Partition> partitionFromMetastore = loadPartitionByName(partitionName);
-        if (!partitionFromCache.equals(partitionFromMetastore)) {
-            String errorMessage = format("Partition returned from cache is different from partition from Metastore.%nPartition name = %s.%nPartition from cache = %s%n Partition from Metastore = %s",
-                    partitionName,
-                    partitionFromCache,
-                    partitionFromMetastore);
-            throw new PrestoException(HIVE_CORRUPTED_PARTITION_CACHE, errorMessage);
-        }
-    }
-
-    private void validatePartitionCache(Map<KeyAndContext<HivePartitionName>, Optional<Partition>> actualResult)
-    {
-        Map<KeyAndContext<HivePartitionName>, Optional<Partition>> expectedResult = loadPartitionsByNames(actualResult.keySet());
-
-        for (Entry<KeyAndContext<HivePartitionName>, Optional<Partition>> entry : expectedResult.entrySet()) {
-            HivePartitionName partitionName = entry.getKey().getKey();
-            Optional<Partition> partitionFromCache = actualResult.get(entry.getKey());
-            Optional<Partition> partitionFromMetastore = entry.getValue();
-
-            if (!partitionFromCache.equals(partitionFromMetastore)) {
-                String errorMessage = format("Partition returned from cache is different from partition from Metastore.%nPartition name = %s.%nPartition from cache = %s%n Partition from Metastore = %s",
-                        partitionName,
-                        partitionFromCache,
-                        partitionFromMetastore);
-                throw new PrestoException(HIVE_CORRUPTED_PARTITION_CACHE, errorMessage);
-            }
-        }
-    }
-
-    private List<String> loadPartitionNamesByFilter(KeyAndContext<PartitionFilter> partitionFilterKey)
-    {
-        return delegate.getPartitionNamesByFilter(
-                partitionFilterKey.getContext(),
-                partitionFilterKey.getKey().getHiveTableName().getDatabaseName(),
-                partitionFilterKey.getKey().getHiveTableName().getTableName(),
-                partitionFilterKey.getKey().getPartitionPredicates());
-    }
-
     @Override
     public Map<String, Optional<Partition>> getPartitionsByNames(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionNames)
     {
-        Iterable<KeyAndContext<HivePartitionName>> names = transform(partitionNames, name -> getCachingKey(metastoreContext, HivePartitionName.hivePartitionName(databaseName, tableName, name)));
-
-        Map<KeyAndContext<HivePartitionName>, Optional<Partition>> all = getAll(partitionCache, names);
-        if (isPartitionCacheValidationEnabled()) {
-            validatePartitionCache(all);
-        }
-        ImmutableMap.Builder<String, Optional<Partition>> partitionsByName = ImmutableMap.builder();
-        for (Entry<KeyAndContext<HivePartitionName>, Optional<Partition>> entry : all.entrySet()) {
-            Optional<Partition> value = entry.getValue();
-            invalidatePartitionsWithHighColumnCount(value, entry.getKey());
-            partitionsByName.put(entry.getKey().getKey().getPartitionName().get(), value);
-        }
-        return partitionsByName.build();
-    }
-
-    private Optional<Partition> loadPartitionByName(KeyAndContext<HivePartitionName> partitionName)
-    {
-        return delegate.getPartition(
-                partitionName.getContext(),
-                partitionName.getKey().getHiveTableName().getDatabaseName(),
-                partitionName.getKey().getHiveTableName().getTableName(),
-                partitionName.getKey().getPartitionValues());
-    }
-
-    private Map<KeyAndContext<HivePartitionName>, Optional<Partition>> loadPartitionsByNames(Iterable<? extends KeyAndContext<HivePartitionName>> partitionNamesKey)
-    {
-        requireNonNull(partitionNamesKey, "partitionNames is null");
-        checkArgument(!Iterables.isEmpty(partitionNamesKey), "partitionNames is empty");
-
-        KeyAndContext<HivePartitionName> firstPartitionKey = Iterables.get(partitionNamesKey, 0);
-
-        HiveTableName hiveTableName = firstPartitionKey.getKey().getHiveTableName();
-        String databaseName = hiveTableName.getDatabaseName();
-        String tableName = hiveTableName.getTableName();
-
-        List<String> partitionsToFetch = new ArrayList<>();
-        for (KeyAndContext<HivePartitionName> partitionNameKey : partitionNamesKey) {
-            checkArgument(partitionNameKey.getKey().getHiveTableName().equals(hiveTableName), "Expected table name %s but got %s", hiveTableName, partitionNameKey.getKey().getHiveTableName());
-            checkArgument(partitionNameKey.getContext().equals(firstPartitionKey.getContext()), "Expected context %s but got %s", firstPartitionKey.getContext(), partitionNameKey.getContext());
-            partitionsToFetch.add(partitionNameKey.getKey().getPartitionName().get());
-        }
-
-        ImmutableMap.Builder<KeyAndContext<HivePartitionName>, Optional<Partition>> partitions = ImmutableMap.builder();
-        Map<String, Optional<Partition>> partitionsByNames = delegate.getPartitionsByNames(firstPartitionKey.getContext(), databaseName, tableName, partitionsToFetch);
-        for (Entry<String, Optional<Partition>> entry : partitionsByNames.entrySet()) {
-            partitions.put(getCachingKey(firstPartitionKey.getContext(), HivePartitionName.hivePartitionName(hiveTableName, entry.getKey())), entry.getValue());
-        }
-        return partitions.build();
+        return metastoreCache.getPartitionsByNames(metastoreContext, databaseName, tableName, partitionNames);
     }
 
     @Override
@@ -864,7 +340,7 @@ public class CachingHiveMetastore
         }
         finally {
             // todo do we need to invalidate all partitions?
-            invalidatePartitionCache(databaseName, tableName);
+            metastoreCache.invalidatePartitionCache(databaseName, tableName);
         }
     }
 
@@ -875,7 +351,7 @@ public class CachingHiveMetastore
             delegate.dropPartition(metastoreContext, databaseName, tableName, parts, deleteData);
         }
         finally {
-            invalidatePartitionCache(databaseName, tableName);
+            metastoreCache.invalidatePartitionCache(databaseName, tableName);
         }
     }
 
@@ -886,7 +362,7 @@ public class CachingHiveMetastore
             return delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
         }
         finally {
-            invalidatePartitionCache(databaseName, tableName);
+            metastoreCache.invalidatePartitionCache(databaseName, tableName);
         }
     }
 
@@ -897,7 +373,7 @@ public class CachingHiveMetastore
             delegate.createRole(metastoreContext, role, grantor);
         }
         finally {
-            rolesCache.invalidateAll();
+            metastoreCache.invalidateRolesCache();
         }
     }
 
@@ -908,20 +384,15 @@ public class CachingHiveMetastore
             delegate.dropRole(metastoreContext, role);
         }
         finally {
-            rolesCache.invalidateAll();
-            roleGrantsCache.invalidateAll();
+            metastoreCache.invalidateRolesCache();
+            metastoreCache.invalidateRoleGrantsCache();
         }
     }
 
     @Override
     public Set<String> listRoles(MetastoreContext metastoreContext)
     {
-        return get(rolesCache, getCachingKey(metastoreContext, ""));
-    }
-
-    private Set<String> loadAllRoles(KeyAndContext<String> rolesKey)
-    {
-        return delegate.listRoles(rolesKey.getContext());
+        return metastoreCache.listRoles(metastoreContext);
     }
 
     @Override
@@ -931,7 +402,7 @@ public class CachingHiveMetastore
             delegate.grantRoles(metastoreContext, roles, grantees, withAdminOption, grantor);
         }
         finally {
-            roleGrantsCache.invalidateAll();
+            metastoreCache.invalidateRoleGrantsCache();
         }
     }
 
@@ -942,44 +413,14 @@ public class CachingHiveMetastore
             delegate.revokeRoles(metastoreContext, roles, grantees, adminOptionFor, grantor);
         }
         finally {
-            roleGrantsCache.invalidateAll();
+            metastoreCache.invalidateRoleGrantsCache();
         }
     }
 
     @Override
     public Set<RoleGrant> listRoleGrants(MetastoreContext metastoreContext, PrestoPrincipal principal)
     {
-        return get(roleGrantsCache, getCachingKey(metastoreContext, principal));
-    }
-
-    private Set<RoleGrant> loadRoleGrants(KeyAndContext<PrestoPrincipal> principalKey)
-    {
-        return delegate.listRoleGrants(principalKey.getContext(), principalKey.getKey());
-    }
-
-    private void invalidatePartitionCache(String databaseName, String tableName)
-    {
-        HiveTableName hiveTableName = hiveTableName(databaseName, tableName);
-        partitionNamesCache.asMap().keySet().stream()
-                .filter(hiveTableNameKey -> hiveTableNameKey.getKey().equals(hiveTableName))
-                .forEach(partitionNamesCache::invalidate);
-        partitionCache.asMap().keySet().stream()
-                .filter(partitionNameKey -> partitionNameKey.getKey().getHiveTableName().equals(hiveTableName))
-                .forEach(partitionCache::invalidate);
-        partitionFilterCache.asMap().keySet().stream()
-                .filter(partitionFilterKey -> partitionFilterKey.getKey().getHiveTableName().equals(hiveTableName))
-                .forEach(partitionFilterCache::invalidate);
-        partitionStatisticsCache.asMap().keySet().stream()
-                .filter(partitionFilterKey -> partitionFilterKey.getKey().getHiveTableName().equals(hiveTableName))
-                .forEach(partitionStatisticsCache::invalidate);
-    }
-
-    private void invalidateTablePrivilegesCache(PrestoPrincipal grantee, String databaseName, String tableName)
-    {
-        UserTableKey userTableKey = new UserTableKey(grantee, databaseName, tableName);
-        tablePrivilegesCache.asMap().keySet().stream()
-                .filter(tablePrivilegesCacheKey -> tablePrivilegesCacheKey.getKey().equals(userTableKey))
-                .forEach(tablePrivilegesCache::invalidate);
+        return metastoreCache.listRoleGrants(metastoreContext, principal);
     }
 
     @Override
@@ -989,7 +430,7 @@ public class CachingHiveMetastore
             delegate.grantTablePrivileges(metastoreContext, databaseName, tableName, grantee, privileges);
         }
         finally {
-            invalidateTablePrivilegesCache(grantee, databaseName, tableName);
+            metastoreCache.invalidateTablePrivilegesCache(grantee, databaseName, tableName);
         }
     }
 
@@ -1000,14 +441,14 @@ public class CachingHiveMetastore
             delegate.revokeTablePrivileges(metastoreContext, databaseName, tableName, grantee, privileges);
         }
         finally {
-            invalidateTablePrivilegesCache(grantee, databaseName, tableName);
+            metastoreCache.invalidateTablePrivilegesCache(grantee, databaseName, tableName);
         }
     }
 
     @Override
     public Set<HivePrivilegeInfo> listTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal principal)
     {
-        return get(tablePrivilegesCache, getCachingKey(metastoreContext, new UserTableKey(principal, databaseName, tableName)));
+        return metastoreCache.listTablePrivileges(metastoreContext, databaseName, tableName, principal);
     }
 
     @Override
@@ -1023,7 +464,7 @@ public class CachingHiveMetastore
             return delegate.dropConstraint(metastoreContext, databaseName, tableName, constraintName);
         }
         finally {
-            invalidateTable(databaseName, tableName);
+            metastoreCache.invalidateTableCache(databaseName, tableName);
         }
     }
 
@@ -1034,115 +475,19 @@ public class CachingHiveMetastore
             return delegate.addConstraint(metastoreContext, databaseName, tableName, tableConstraint);
         }
         finally {
-            invalidateTable(databaseName, tableName);
+            metastoreCache.invalidateTableCache(databaseName, tableName);
         }
     }
 
     @Override
     public Optional<Long> lock(MetastoreContext metastoreContext, String databaseName, String tableName)
     {
-        tableCache.invalidate(getCachingKey(metastoreContext, new HiveTableHandle(databaseName, tableName)));
-        return delegate.lock(metastoreContext, databaseName, tableName);
+        return metastoreCache.lock(metastoreContext, databaseName, tableName);
     }
 
     @Override
     public void unlock(MetastoreContext metastoreContext, long lockId)
     {
         delegate.unlock(metastoreContext, lockId);
-    }
-
-    public Set<HivePrivilegeInfo> loadTablePrivileges(KeyAndContext<UserTableKey> loadTablePrivilegesKey)
-    {
-        return delegate.listTablePrivileges(loadTablePrivilegesKey.getContext(), loadTablePrivilegesKey.getKey().getDatabase(), loadTablePrivilegesKey.getKey().getTable(), loadTablePrivilegesKey.getKey().getPrincipal());
-    }
-
-    private static class KeyAndContext<T>
-    {
-        private final MetastoreContext context;
-        private final T key;
-
-        public KeyAndContext(MetastoreContext context, T key)
-        {
-            this.context = requireNonNull(context, "context is null");
-            this.key = requireNonNull(key, "key is null");
-        }
-
-        public MetastoreContext getContext()
-        {
-            return context;
-        }
-
-        public T getKey()
-        {
-            return key;
-        }
-
-        // QueryId changes for every query. For caching to be effective across multiple queries, we should NOT include queryId,
-        // other fields of MetastoreContext in equals() and hashCode() methods below.
-        // But we should include username because we want the cache to be effective at per-user level when impersonation is enabled.
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            KeyAndContext<?> other = (KeyAndContext<?>) o;
-            if (context.isImpersonationEnabled()) {
-                return Objects.equals(context.getUsername(), other.context.getUsername()) &&
-                        Objects.equals(key, other.key);
-            }
-            return Objects.equals(key, other.key);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            if (context.isImpersonationEnabled()) {
-                return Objects.hash(context.getUsername(), key);
-            }
-            return Objects.hash(key);
-        }
-
-        @Override
-        public String toString()
-        {
-            return toStringHelper(this)
-                    .add("context", context)
-                    .add("key", key)
-                    .toString();
-        }
-    }
-
-    private <T> KeyAndContext<T> getCachingKey(MetastoreContext context, T key)
-    {
-        if (metastoreImpersonationEnabled) {
-            context = new MetastoreContext(
-                    context.getUsername(),
-                    context.getQueryId(),
-                    context.getClientInfo(),
-                    context.getSource(),
-                    true,
-                    context.getMetastoreHeaders(),
-                    context.isUserDefinedTypeEncodingEnabled(),
-                    context.getColumnConverterProvider(),
-                    context.getWarningCollector(),
-                    context.getRuntimeStats());
-        }
-        return new KeyAndContext<>(context, key);
-    }
-
-    private static CacheBuilder<Object, Object> newCacheBuilder(OptionalLong expiresAfterWriteMillis, OptionalLong refreshMillis, long maximumSize)
-    {
-        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
-        if (expiresAfterWriteMillis.isPresent()) {
-            cacheBuilder = cacheBuilder.expireAfterWrite(expiresAfterWriteMillis.getAsLong(), MILLISECONDS);
-        }
-        if (refreshMillis.isPresent() && (!expiresAfterWriteMillis.isPresent() || expiresAfterWriteMillis.getAsLong() > refreshMillis.getAsLong())) {
-            cacheBuilder = cacheBuilder.refreshAfterWrite(refreshMillis.getAsLong(), MILLISECONDS);
-        }
-        return cacheBuilder.maximumSize(maximumSize).recordStats();
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryMetastoreCache.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryMetastoreCache.java
@@ -1,0 +1,880 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.hive.ForCachingHiveMetastore;
+import com.facebook.presto.hive.HiveTableHandle;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.constraints.TableConstraint;
+import com.facebook.presto.spi.security.PrestoPrincipal;
+import com.facebook.presto.spi.security.RoleGrant;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.SetMultimap;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_CORRUPTED_PARTITION_CACHE;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURING_QUERY;
+import static com.facebook.presto.hive.metastore.HivePartitionName.hivePartitionName;
+import static com.facebook.presto.hive.metastore.HiveTableName.hiveTableName;
+import static com.facebook.presto.hive.metastore.PartitionFilter.partitionFilter;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.cache.CacheLoader.asyncReloading;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Streams.stream;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Provides an in-memory caching layer for the Hive Metastore, utilizing a {@link LoadingCache} mechanism.
+ * This implementation aims to reduce the number of direct calls to the underlying metastore by caching
+ * frequently accessed data such as database, table, and partition information. The cache
+ * is automatically populated on cache misses and can be configured for eviction and refresh policies
+ * to ensure data consistency.
+ */
+public class InMemoryMetastoreCache
+        implements MetastoreCache
+{
+    //Guava LoadingCache instances
+    private final LoadingCache<KeyAndContext<String>, Optional<Database>> databaseCache;
+    private final LoadingCache<KeyAndContext<String>, List<String>> databaseNamesCache;
+    private final LoadingCache<KeyAndContext<HiveTableHandle>, Optional<Table>> tableCache;
+    private final LoadingCache<KeyAndContext<String>, Optional<List<String>>> tableNamesCache;
+    private final LoadingCache<KeyAndContext<HiveTableName>, PartitionStatistics> tableStatisticsCache;
+    private final LoadingCache<KeyAndContext<HiveTableName>, List<TableConstraint<String>>> tableConstraintsCache;
+    private final LoadingCache<KeyAndContext<HivePartitionName>, PartitionStatistics> partitionStatisticsCache;
+    private final LoadingCache<KeyAndContext<String>, Optional<List<String>>> viewNamesCache;
+    private final LoadingCache<KeyAndContext<HivePartitionName>, Optional<Partition>> partitionCache;
+    private final LoadingCache<KeyAndContext<PartitionFilter>, List<String>> partitionFilterCache;
+    private final LoadingCache<KeyAndContext<HiveTableName>, Optional<List<String>>> partitionNamesCache;
+    private final LoadingCache<KeyAndContext<UserTableKey>, Set<HivePrivilegeInfo>> tablePrivilegesCache;
+    private final LoadingCache<KeyAndContext<String>, Set<String>> rolesCache;
+    private final LoadingCache<KeyAndContext<PrestoPrincipal>, Set<RoleGrant>> roleGrantsCache;
+
+    private final boolean metastoreImpersonationEnabled;
+    private final boolean partitionVersioningEnabled;
+    private final double partitionCacheValidationPercentage;
+    private final int partitionCacheColumnCountLimit;
+
+    private final ExtendedHiveMetastore delegate;
+    private final MetastoreCacheStats metastoreCacheStats;
+
+    @Inject
+    public InMemoryMetastoreCache(
+            @ForCachingHiveMetastore ExtendedHiveMetastore delegate,
+            @ForCachingHiveMetastore ExecutorService executor,
+            MetastoreCacheStats metastoreCacheStats,
+            MetastoreClientConfig metastoreClientConfig)
+    {
+        this(
+                delegate,
+                executor,
+                requireNonNull(metastoreClientConfig, "metastoreClientConfig is null").isMetastoreImpersonationEnabled(),
+                OptionalLong.of(metastoreClientConfig.getMetastoreCacheTtl().toMillis()),
+                metastoreClientConfig.getMetastoreRefreshInterval().toMillis() >= metastoreClientConfig.getMetastoreCacheTtl().toMillis() ? OptionalLong.empty() : OptionalLong.of(metastoreClientConfig.getMetastoreRefreshInterval().toMillis()),
+                metastoreClientConfig.getMetastoreCacheMaximumSize(),
+                metastoreClientConfig.isPartitionVersioningEnabled(),
+                metastoreClientConfig.getMetastoreCacheScope(),
+                metastoreClientConfig.getPartitionCacheValidationPercentage(),
+                metastoreClientConfig.getPartitionCacheColumnCountLimit(),
+                requireNonNull(metastoreCacheStats, "metastoreCacheStats is null"));
+    }
+
+    public InMemoryMetastoreCache(
+            ExtendedHiveMetastore delegate,
+            ExecutorService executor,
+            boolean metastoreImpersonationEnabled,
+            OptionalLong expiresAfterWriteMillis,
+            OptionalLong refreshMills,
+            long maximumSize,
+            boolean partitionVersioningEnabled,
+            CachingHiveMetastore.MetastoreCacheScope metastoreCacheScope,
+            double partitionCacheValidationPercentage,
+            int partitionCacheColumnCountLimit,
+            MetastoreCacheStats metastoreCacheStats)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        requireNonNull(executor, "executor is null");
+        this.metastoreImpersonationEnabled = metastoreImpersonationEnabled;
+        this.partitionVersioningEnabled = partitionVersioningEnabled;
+        this.partitionCacheValidationPercentage = partitionCacheValidationPercentage;
+        this.partitionCacheColumnCountLimit = partitionCacheColumnCountLimit;
+        this.metastoreCacheStats = metastoreCacheStats;
+
+        OptionalLong cacheExpiresAfterWriteMillis;
+        OptionalLong cacheRefreshMills;
+        long cacheMaxSize;
+
+        OptionalLong partitionCacheExpiresAfterWriteMillis;
+        OptionalLong partitionCacheRefreshMills;
+        long partitionCacheMaxSize;
+
+        switch (metastoreCacheScope) {
+            case PARTITION:
+                partitionCacheExpiresAfterWriteMillis = expiresAfterWriteMillis;
+                partitionCacheRefreshMills = refreshMills;
+                partitionCacheMaxSize = maximumSize;
+                cacheExpiresAfterWriteMillis = OptionalLong.of(0);
+                cacheRefreshMills = OptionalLong.of(0);
+                cacheMaxSize = 0;
+                break;
+
+            case ALL:
+                partitionCacheExpiresAfterWriteMillis = expiresAfterWriteMillis;
+                partitionCacheRefreshMills = refreshMills;
+                partitionCacheMaxSize = maximumSize;
+                cacheExpiresAfterWriteMillis = expiresAfterWriteMillis;
+                cacheRefreshMills = refreshMills;
+                cacheMaxSize = maximumSize;
+                break;
+
+            default:
+                throw new IllegalArgumentException("Unknown metastore-cache-scope: " + metastoreCacheScope);
+        }
+
+        databaseNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadAllDatabases), executor));
+
+        databaseCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadDatabase), executor));
+
+        tableNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadAllTables), executor));
+
+        tableStatisticsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(new CacheLoader<KeyAndContext<HiveTableName>, PartitionStatistics>()
+                {
+                    @Override
+                    public PartitionStatistics load(KeyAndContext<HiveTableName> key)
+                    {
+                        return loadTableColumnStatistics(key);
+                    }
+                }, executor));
+
+        partitionStatisticsCache = newCacheBuilder(partitionCacheExpiresAfterWriteMillis, partitionCacheRefreshMills, partitionCacheMaxSize)
+                .build(asyncReloading(new CacheLoader<KeyAndContext<HivePartitionName>, PartitionStatistics>()
+                {
+                    @Override
+                    public PartitionStatistics load(KeyAndContext<HivePartitionName> key)
+                    {
+                        return loadPartitionColumnStatistics(key);
+                    }
+
+                    @Override
+                    public Map<KeyAndContext<HivePartitionName>, PartitionStatistics> loadAll(Iterable<? extends KeyAndContext<HivePartitionName>> keys)
+                    {
+                        return loadPartitionColumnStatistics(keys);
+                    }
+                }, executor));
+
+        tableCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadTable), executor));
+        metastoreCacheStats.setTableCache(tableCache);
+
+        tableConstraintsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadTableConstraints), executor));
+
+        viewNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadAllViews), executor));
+
+        partitionNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadPartitionNames), executor));
+
+        partitionFilterCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadPartitionNamesByFilter), executor));
+        metastoreCacheStats.setPartitionNamesCache(partitionFilterCache);
+
+        partitionCache = newCacheBuilder(partitionCacheExpiresAfterWriteMillis, partitionCacheRefreshMills, partitionCacheMaxSize)
+                .build(asyncReloading(new CacheLoader<KeyAndContext<HivePartitionName>, Optional<Partition>>()
+                {
+                    @Override
+                    public Optional<Partition> load(KeyAndContext<HivePartitionName> partitionName)
+                    {
+                        return loadPartitionByName(partitionName);
+                    }
+
+                    @Override
+                    public Map<KeyAndContext<HivePartitionName>, Optional<Partition>> loadAll(Iterable<? extends KeyAndContext<HivePartitionName>> partitionNames)
+                    {
+                        return loadPartitionsByNames(partitionNames);
+                    }
+                }, executor));
+        metastoreCacheStats.setPartitionCache(partitionCache);
+
+        tablePrivilegesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadTablePrivileges), executor));
+
+        rolesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadAllRoles), executor));
+
+        roleGrantsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
+                .build(asyncReloading(CacheLoader.from(this::loadRoleGrants), executor));
+    }
+
+    @Override
+    public Optional<Database> getDatabase(
+            MetastoreContext metastoreContext,
+            String databaseName)
+    {
+        return get(databaseCache, getCachingKey(metastoreContext, databaseName));
+    }
+
+    @Override
+    public List<String> getAllDatabases(MetastoreContext metastoreContext)
+    {
+        return get(databaseNamesCache, getCachingKey(metastoreContext, ""));
+    }
+
+    @Override
+    public Optional<Table> getTable(
+            MetastoreContext metastoreContext,
+            HiveTableHandle hiveTableHandle)
+    {
+        return get(tableCache, getCachingKey(metastoreContext, hiveTableHandle));
+    }
+
+    @Override
+    public Optional<List<String>> getAllTables(
+            MetastoreContext metastoreContext,
+            String databaseName)
+    {
+        return get(tableNamesCache, getCachingKey(metastoreContext, databaseName));
+    }
+
+    @Override
+    public PartitionStatistics getTableStatistics(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName)
+    {
+        return get(tableStatisticsCache, getCachingKey(metastoreContext, hiveTableName(databaseName, tableName)));
+    }
+
+    @Override
+    public List<TableConstraint<String>> getTableConstraints(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName)
+    {
+        return get(tableConstraintsCache, getCachingKey(metastoreContext, hiveTableName(databaseName, tableName)));
+    }
+
+    @Override
+    public Map<String, PartitionStatistics> getPartitionStatistics(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            Set<String> partitionNames)
+    {
+        List<KeyAndContext<HivePartitionName>> partitions = partitionNames.stream()
+                .map(partitionName -> getCachingKey(metastoreContext, HivePartitionName.hivePartitionName(databaseName, tableName, partitionName)))
+                .collect(toImmutableList());
+        Map<KeyAndContext<HivePartitionName>, PartitionStatistics> statistics = getAll(partitionStatisticsCache, partitions);
+        return statistics.entrySet()
+                .stream()
+                .collect(toImmutableMap(entry -> entry.getKey().getKey().getPartitionName().get(), Map.Entry::getValue));
+    }
+
+    @Override
+    public Optional<List<String>> getAllViews(
+            MetastoreContext metastoreContext,
+            String databaseName)
+    {
+        return get(viewNamesCache, getCachingKey(metastoreContext, databaseName));
+    }
+
+    @Override
+    public Map<String, Optional<Partition>> getPartitionsByNames(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<String> partitionNames)
+    {
+        Iterable<KeyAndContext<HivePartitionName>> names = transform(partitionNames, name -> getCachingKey(metastoreContext, HivePartitionName.hivePartitionName(databaseName, tableName, name)));
+
+        Map<KeyAndContext<HivePartitionName>, Optional<Partition>> all = getAll(partitionCache, names);
+        if (isPartitionCacheValidationEnabled()) {
+            validatePartitionCache(all);
+        }
+        ImmutableMap.Builder<String, Optional<Partition>> partitionsByName = ImmutableMap.builder();
+        for (Map.Entry<KeyAndContext<HivePartitionName>, Optional<Partition>> entry : all.entrySet()) {
+            Optional<Partition> value = entry.getValue();
+            invalidatePartitionsWithHighColumnCount(value, entry.getKey());
+            partitionsByName.put(entry.getKey().getKey().getPartitionName().get(), value);
+        }
+        return partitionsByName.build();
+    }
+
+    @Override
+    public Optional<Partition> getPartition(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<String> partitionValues)
+    {
+        KeyAndContext<HivePartitionName> key = getCachingKey(metastoreContext, hivePartitionName(databaseName, tableName, partitionValues));
+        Optional<Partition> result = get(partitionCache, key);
+        if (isPartitionCacheValidationEnabled()) {
+            validatePartitionCache(key, result);
+        }
+        invalidatePartitionsWithHighColumnCount(result, key);
+        return result;
+    }
+
+    @Override
+    public List<String> getPartitionNamesByFilter(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        if (partitionVersioningEnabled) {
+            List<PartitionNameWithVersion> partitionNamesWithVersion = getPartitionNamesWithVersionByFilter(metastoreContext, databaseName, tableName, partitionPredicates);
+            List<String> result = partitionNamesWithVersion.stream().map(PartitionNameWithVersion::getPartitionName).collect(toImmutableList());
+            invalidateStalePartitions(partitionNamesWithVersion, databaseName, tableName, metastoreContext);
+            return result;
+        }
+        return get(partitionFilterCache, getCachingKey(metastoreContext, partitionFilter(databaseName, tableName, partitionPredicates)));
+    }
+
+    @Override
+    public Optional<List<String>> getPartitionNames(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName)
+    {
+        return get(partitionNamesCache, getCachingKey(metastoreContext, hiveTableName(databaseName, tableName)));
+    }
+
+    @Override
+    public Set<HivePrivilegeInfo> listTablePrivileges(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            PrestoPrincipal principal)
+    {
+        return get(tablePrivilegesCache, getCachingKey(metastoreContext, new UserTableKey(principal, databaseName, tableName)));
+    }
+
+    @Override
+    public Set<String> listRoles(MetastoreContext metastoreContext)
+    {
+        return get(rolesCache, getCachingKey(metastoreContext, ""));
+    }
+
+    @Override
+    public Set<RoleGrant> listRoleGrants(
+            MetastoreContext metastoreContext,
+            PrestoPrincipal principal)
+    {
+        return get(roleGrantsCache, getCachingKey(metastoreContext, principal));
+    }
+
+    @Override
+    public Optional<Long> lock(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName)
+    {
+        tableCache.invalidate(getCachingKey(metastoreContext, new HiveTableHandle(databaseName, tableName)));
+        return delegate.lock(metastoreContext, databaseName, tableName);
+    }
+
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        return delegate.getPartitionNamesWithVersionByFilter(metastoreContext, databaseName, tableName, partitionPredicates);
+    }
+
+    @Override
+    public void invalidateAll()
+    {
+        databaseNamesCache.invalidateAll();
+        tableNamesCache.invalidateAll();
+        viewNamesCache.invalidateAll();
+        partitionNamesCache.invalidateAll();
+        databaseCache.invalidateAll();
+        tableCache.invalidateAll();
+        tableConstraintsCache.invalidateAll();
+        partitionCache.invalidateAll();
+        partitionFilterCache.invalidateAll();
+        tablePrivilegesCache.invalidateAll();
+        tableStatisticsCache.invalidateAll();
+        partitionStatisticsCache.invalidateAll();
+        rolesCache.invalidateAll();
+    }
+
+    @Override
+    public void invalidateTableStatisticsCache(
+            String databaseName,
+            String tableName)
+    {
+        tableStatisticsCache.asMap().keySet().stream()
+                .filter(hiveTableNameKey -> hiveTableNameKey.getKey().equals(hiveTableName(databaseName, tableName)))
+                .forEach(tableStatisticsCache::invalidate);
+    }
+
+    @Override
+    public void invalidatePartitionStatisticsCache(
+            String databaseName,
+            String tableName,
+            String partitionName)
+    {
+        partitionStatisticsCache.asMap().keySet().stream()
+                .filter(partitionFilterKey -> partitionFilterKey.getKey().equals(hivePartitionName(databaseName, tableName, partitionName)))
+                .forEach(partitionStatisticsCache::invalidate);
+    }
+
+    @Override
+    public void invalidateDatabaseCache(String databaseName)
+    {
+        databaseCache.asMap().keySet().stream()
+                .filter(databaseKey -> databaseKey.getKey().equals(databaseName))
+                .forEach(databaseCache::invalidate);
+        databaseNamesCache.invalidateAll();
+    }
+
+    @Override
+    public void invalidatePartitionCache(
+            String databaseName,
+            String tableName)
+    {
+        HiveTableName hiveTableName = hiveTableName(databaseName, tableName);
+        partitionNamesCache.asMap().keySet().stream()
+                .filter(hiveTableNameKey -> hiveTableNameKey.getKey().equals(hiveTableName))
+                .forEach(partitionNamesCache::invalidate);
+        partitionCache.asMap().keySet().stream()
+                .filter(partitionNameKey -> partitionNameKey.getKey().getHiveTableName().equals(hiveTableName))
+                .forEach(partitionCache::invalidate);
+        partitionFilterCache.asMap().keySet().stream()
+                .filter(partitionFilterKey -> partitionFilterKey.getKey().getHiveTableName().equals(hiveTableName))
+                .forEach(partitionFilterCache::invalidate);
+        partitionStatisticsCache.asMap().keySet().stream()
+                .filter(partitionFilterKey -> partitionFilterKey.getKey().getHiveTableName().equals(hiveTableName))
+                .forEach(partitionStatisticsCache::invalidate);
+    }
+
+    @Override
+    public void invalidateTablePrivilegesCache(
+            PrestoPrincipal grantee,
+            String databaseName,
+            String tableName)
+    {
+        UserTableKey userTableKey = new UserTableKey(grantee, databaseName, tableName);
+        tablePrivilegesCache.asMap().keySet().stream()
+                .filter(tablePrivilegesCacheKey -> tablePrivilegesCacheKey.getKey().equals(userTableKey))
+                .forEach(tablePrivilegesCache::invalidate);
+    }
+
+    @Override
+    public void invalidateTableCache(
+            String databaseName,
+            String tableName)
+    {
+        HiveTableName hiveTableName = hiveTableName(databaseName, tableName);
+
+        tableCache.asMap().keySet().stream()
+                .filter(hiveTableHandle -> isSameTable(hiveTableHandle.getKey(), hiveTableName))
+                .forEach(tableCache::invalidate);
+
+        tableConstraintsCache.asMap().keySet().stream()
+                .filter(hiveTableNameKey -> hiveTableNameKey.getKey().equals(hiveTableName))
+                .forEach(tableConstraintsCache::invalidate);
+
+        tableNamesCache.asMap().keySet().stream()
+                .filter(tableNameKey -> tableNameKey.getKey().equals(databaseName))
+                .forEach(tableNamesCache::invalidate);
+
+        viewNamesCache.asMap().keySet().stream()
+                .filter(viewNameKey -> viewNameKey.getKey().equals(databaseName))
+                .forEach(viewNamesCache::invalidate);
+
+        tablePrivilegesCache.asMap().keySet().stream()
+                .filter(userTableKey -> userTableKey.getKey().matches(databaseName, tableName))
+                .forEach(tablePrivilegesCache::invalidate);
+
+        tableStatisticsCache.asMap().keySet().stream()
+                .filter(hiveTableNameKey -> hiveTableNameKey.getKey().equals(hiveTableName))
+                .forEach(tableStatisticsCache::invalidate);
+
+        invalidatePartitionCache(databaseName, tableName);
+    }
+
+    @Override
+    public void invalidateRolesCache()
+    {
+        rolesCache.invalidateAll();
+    }
+
+    @Override
+    public void invalidateRoleGrantsCache()
+    {
+        roleGrantsCache.invalidateAll();
+    }
+
+    private static class KeyAndContext<T>
+    {
+        private final MetastoreContext context;
+        private final T key;
+
+        public KeyAndContext(MetastoreContext context, T key)
+        {
+            this.context = requireNonNull(context, "context is null");
+            this.key = requireNonNull(key, "key is null");
+        }
+
+        public MetastoreContext getContext()
+        {
+            return context;
+        }
+
+        public T getKey()
+        {
+            return key;
+        }
+
+        // QueryId changes for every query. For caching to be effective across multiple queries, we should NOT include queryId,
+        // other fields of MetastoreContext in equals() and hashCode() methods below.
+        // But we should include username because we want the cache to be effective at per-user level when impersonation is enabled.
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            KeyAndContext<?> other = (KeyAndContext<?>) o;
+            if (context.isImpersonationEnabled()) {
+                return Objects.equals(context.getUsername(), other.context.getUsername()) &&
+                        Objects.equals(key, other.key);
+            }
+            return Objects.equals(key, other.key);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            if (context.isImpersonationEnabled()) {
+                return Objects.hash(context.getUsername(), key);
+            }
+            return Objects.hash(key);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("context", context)
+                    .add("key", key)
+                    .toString();
+        }
+    }
+
+    private <T> KeyAndContext<T> getCachingKey(MetastoreContext context, T key)
+    {
+        if (metastoreImpersonationEnabled) {
+            context = new MetastoreContext(
+                    context.getUsername(),
+                    context.getQueryId(),
+                    context.getClientInfo(),
+                    context.getSource(),
+                    true,
+                    context.getMetastoreHeaders(),
+                    context.isUserDefinedTypeEncodingEnabled(),
+                    context.getColumnConverterProvider(),
+                    context.getWarningCollector(),
+                    context.getRuntimeStats());
+        }
+        return new KeyAndContext<>(context, key);
+    }
+
+    private static CacheBuilder<Object, Object> newCacheBuilder(
+            OptionalLong expiresAfterWriteMillis,
+            OptionalLong refreshMillis,
+            long maximumSize)
+    {
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (expiresAfterWriteMillis.isPresent()) {
+            cacheBuilder = cacheBuilder.expireAfterWrite(expiresAfterWriteMillis.getAsLong(), MILLISECONDS);
+        }
+        if (refreshMillis.isPresent() && (!expiresAfterWriteMillis.isPresent() || expiresAfterWriteMillis.getAsLong() > refreshMillis.getAsLong())) {
+            cacheBuilder = cacheBuilder.refreshAfterWrite(refreshMillis.getAsLong(), MILLISECONDS);
+        }
+        return cacheBuilder.maximumSize(maximumSize).recordStats();
+    }
+
+    private static <K, V> V get(LoadingCache<K, V> cache, K key)
+    {
+        try {
+            return cache.getUnchecked(key);
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
+        }
+    }
+
+    private static <K, V> Map<K, V> getAll(LoadingCache<K, V> cache, Iterable<K> keys)
+    {
+        try {
+            return cache.getAll(keys);
+        }
+        catch (ExecutionException | UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throwIfUnchecked(e);
+            throw new UncheckedExecutionException(e);
+        }
+    }
+
+    private List<String> loadAllDatabases(KeyAndContext<String> key)
+    {
+        return delegate.getAllDatabases(key.getContext());
+    }
+
+    private Optional<Database> loadDatabase(KeyAndContext<String> databaseName)
+    {
+        return delegate.getDatabase(databaseName.getContext(), databaseName.getKey());
+    }
+
+    private Optional<List<String>> loadAllTables(KeyAndContext<String> databaseNameKey)
+    {
+        return delegate.getAllTables(databaseNameKey.getContext(), databaseNameKey.getKey());
+    }
+
+    private PartitionStatistics loadTableColumnStatistics(KeyAndContext<HiveTableName> hiveTableName)
+    {
+        return delegate.getTableStatistics(hiveTableName.getContext(), hiveTableName.getKey().getDatabaseName(), hiveTableName.getKey().getTableName());
+    }
+
+    private PartitionStatistics loadPartitionColumnStatistics(KeyAndContext<HivePartitionName> partition)
+    {
+        String partitionName = partition.getKey().getPartitionName().get();
+        Map<String, PartitionStatistics> partitionStatistics = delegate.getPartitionStatistics(
+                partition.getContext(),
+                partition.getKey().getHiveTableName().getDatabaseName(),
+                partition.getKey().getHiveTableName().getTableName(),
+                ImmutableSet.of(partitionName));
+        if (!partitionStatistics.containsKey(partitionName)) {
+            throw new PrestoException(HIVE_PARTITION_DROPPED_DURING_QUERY, "Statistics result does not contain entry for partition: " + partition.getKey().getPartitionName());
+        }
+        return partitionStatistics.get(partitionName);
+    }
+
+    private Map<KeyAndContext<HivePartitionName>, PartitionStatistics> loadPartitionColumnStatistics(Iterable<? extends KeyAndContext<HivePartitionName>> keys)
+    {
+        SetMultimap<KeyAndContext<HiveTableName>, KeyAndContext<HivePartitionName>> tablePartitions = stream(keys)
+                .collect(toImmutableSetMultimap(nameKey -> getCachingKey(nameKey.getContext(), nameKey.getKey().getHiveTableName()), nameKey -> nameKey));
+        ImmutableMap.Builder<KeyAndContext<HivePartitionName>, PartitionStatistics> result = ImmutableMap.builder();
+        tablePartitions.keySet().forEach(table -> {
+            Set<String> partitionNames = tablePartitions.get(table).stream()
+                    .map(partitionName -> partitionName.getKey().getPartitionName().get())
+                    .collect(toImmutableSet());
+            Map<String, PartitionStatistics> partitionStatistics = delegate.getPartitionStatistics(table.getContext(), table.getKey().getDatabaseName(), table.getKey().getTableName(), partitionNames);
+            for (String partitionName : partitionNames) {
+                if (!partitionStatistics.containsKey(partitionName)) {
+                    throw new PrestoException(HIVE_PARTITION_DROPPED_DURING_QUERY, "Statistics result does not contain entry for partition: " + partitionName);
+                }
+                result.put(getCachingKey(table.getContext(), HivePartitionName.hivePartitionName(table.getKey(), partitionName)), partitionStatistics.get(partitionName));
+            }
+        });
+        return result.build();
+    }
+
+    private Optional<Table> loadTable(KeyAndContext<HiveTableHandle> hiveTableHandle)
+    {
+        return delegate.getTable(hiveTableHandle.getContext(), hiveTableHandle.getKey());
+    }
+
+    private List<TableConstraint<String>> loadTableConstraints(KeyAndContext<HiveTableName> hiveTableName)
+    {
+        return delegate.getTableConstraints(hiveTableName.getContext(), hiveTableName.getKey().getDatabaseName(), hiveTableName.getKey().getTableName());
+    }
+
+    private Optional<List<String>> loadAllViews(KeyAndContext<String> databaseNameKey)
+    {
+        return delegate.getAllViews(databaseNameKey.getContext(), databaseNameKey.getKey());
+    }
+
+    private Optional<List<String>> loadPartitionNames(KeyAndContext<HiveTableName> hiveTableNameKey)
+    {
+        return delegate.getPartitionNames(hiveTableNameKey.getContext(), hiveTableNameKey.getKey().getDatabaseName(), hiveTableNameKey.getKey().getTableName());
+    }
+
+    private List<String> loadPartitionNamesByFilter(KeyAndContext<PartitionFilter> partitionFilterKey)
+    {
+        return delegate.getPartitionNamesByFilter(
+                partitionFilterKey.getContext(),
+                partitionFilterKey.getKey().getHiveTableName().getDatabaseName(),
+                partitionFilterKey.getKey().getHiveTableName().getTableName(),
+                partitionFilterKey.getKey().getPartitionPredicates());
+    }
+
+    private Optional<Partition> loadPartitionByName(KeyAndContext<HivePartitionName> partitionName)
+    {
+        return delegate.getPartition(
+                partitionName.getContext(),
+                partitionName.getKey().getHiveTableName().getDatabaseName(),
+                partitionName.getKey().getHiveTableName().getTableName(),
+                partitionName.getKey().getPartitionValues());
+    }
+
+    private Map<KeyAndContext<HivePartitionName>, Optional<Partition>> loadPartitionsByNames(Iterable<? extends KeyAndContext<HivePartitionName>> partitionNamesKey)
+    {
+        requireNonNull(partitionNamesKey, "partitionNames is null");
+        checkArgument(!Iterables.isEmpty(partitionNamesKey), "partitionNames is empty");
+
+        KeyAndContext<HivePartitionName> firstPartitionKey = Iterables.get(partitionNamesKey, 0);
+
+        HiveTableName hiveTableName = firstPartitionKey.getKey().getHiveTableName();
+        String databaseName = hiveTableName.getDatabaseName();
+        String tableName = hiveTableName.getTableName();
+
+        List<String> partitionsToFetch = new ArrayList<>();
+        for (KeyAndContext<HivePartitionName> partitionNameKey : partitionNamesKey) {
+            checkArgument(partitionNameKey.getKey().getHiveTableName().equals(hiveTableName), "Expected table name %s but got %s", hiveTableName, partitionNameKey.getKey().getHiveTableName());
+            checkArgument(partitionNameKey.getContext().equals(firstPartitionKey.getContext()), "Expected context %s but got %s", firstPartitionKey.getContext(), partitionNameKey.getContext());
+            partitionsToFetch.add(partitionNameKey.getKey().getPartitionName().get());
+        }
+
+        ImmutableMap.Builder<KeyAndContext<HivePartitionName>, Optional<Partition>> partitions = ImmutableMap.builder();
+        Map<String, Optional<Partition>> partitionsByNames = delegate.getPartitionsByNames(firstPartitionKey.getContext(), databaseName, tableName, partitionsToFetch);
+        for (Map.Entry<String, Optional<Partition>> entry : partitionsByNames.entrySet()) {
+            partitions.put(getCachingKey(firstPartitionKey.getContext(), HivePartitionName.hivePartitionName(hiveTableName, entry.getKey())), entry.getValue());
+        }
+        return partitions.build();
+    }
+
+    public Set<HivePrivilegeInfo> loadTablePrivileges(KeyAndContext<UserTableKey> loadTablePrivilegesKey)
+    {
+        return delegate.listTablePrivileges(loadTablePrivilegesKey.getContext(), loadTablePrivilegesKey.getKey().getDatabase(), loadTablePrivilegesKey.getKey().getTable(), loadTablePrivilegesKey.getKey().getPrincipal());
+    }
+
+    private Set<String> loadAllRoles(KeyAndContext<String> rolesKey)
+    {
+        return delegate.listRoles(rolesKey.getContext());
+    }
+
+    private Set<RoleGrant> loadRoleGrants(KeyAndContext<PrestoPrincipal> principalKey)
+    {
+        return delegate.listRoleGrants(principalKey.getContext(), principalKey.getKey());
+    }
+
+    private boolean isPartitionCacheValidationEnabled()
+    {
+        return partitionCacheValidationPercentage > 0 &&
+                ThreadLocalRandom.current().nextDouble(100) < partitionCacheValidationPercentage;
+    }
+
+    private void invalidatePartitionsWithHighColumnCount(Optional<Partition> partition, KeyAndContext<HivePartitionName> partitionCacheKey)
+    {
+        // Do NOT cache partitions with # of columns > partitionCacheColumnLimit
+        if (partition.isPresent() && partition.get().getColumns().size() > partitionCacheColumnCountLimit) {
+            partitionCache.invalidate(partitionCacheKey);
+            metastoreCacheStats.incrementPartitionsWithColumnCountGreaterThanThreshold();
+        }
+    }
+
+    private void validatePartitionCache(KeyAndContext<HivePartitionName> partitionName, Optional<Partition> partitionFromCache)
+    {
+        Optional<Partition> partitionFromMetastore = loadPartitionByName(partitionName);
+        if (!partitionFromCache.equals(partitionFromMetastore)) {
+            String errorMessage = format("Partition returned from cache is different from partition from Metastore.%nPartition name = %s.%nPartition from cache = %s%n Partition from Metastore = %s",
+                    partitionName,
+                    partitionFromCache,
+                    partitionFromMetastore);
+            throw new PrestoException(HIVE_CORRUPTED_PARTITION_CACHE, errorMessage);
+        }
+    }
+
+    private void validatePartitionCache(Map<KeyAndContext<HivePartitionName>, Optional<Partition>> actualResult)
+    {
+        Map<KeyAndContext<HivePartitionName>, Optional<Partition>> expectedResult = loadPartitionsByNames(actualResult.keySet());
+
+        for (Map.Entry<KeyAndContext<HivePartitionName>, Optional<Partition>> entry : expectedResult.entrySet()) {
+            HivePartitionName partitionName = entry.getKey().getKey();
+            Optional<Partition> partitionFromCache = actualResult.get(entry.getKey());
+            Optional<Partition> partitionFromMetastore = entry.getValue();
+
+            if (!partitionFromCache.equals(partitionFromMetastore)) {
+                String errorMessage = format("Partition returned from cache is different from partition from Metastore.%nPartition name = %s.%nPartition from cache = %s%n Partition from Metastore = %s",
+                        partitionName,
+                        partitionFromCache,
+                        partitionFromMetastore);
+                throw new PrestoException(HIVE_CORRUPTED_PARTITION_CACHE, errorMessage);
+            }
+        }
+    }
+
+    private void invalidateStalePartitions(
+            List<PartitionNameWithVersion> partitionNamesWithVersion,
+            String databaseName,
+            String tableName,
+            MetastoreContext metastoreContext)
+    {
+        for (PartitionNameWithVersion partitionNameWithVersion : partitionNamesWithVersion) {
+            HivePartitionName hivePartitionName = hivePartitionName(databaseName, tableName, partitionNameWithVersion.getPartitionName());
+            KeyAndContext<HivePartitionName> partitionNameKey = getCachingKey(metastoreContext, hivePartitionName);
+            Optional<Partition> partition = partitionCache.getIfPresent(partitionNameKey);
+            if (partition == null || !partition.isPresent()) {
+                partitionCache.invalidate(partitionNameKey);
+                partitionStatisticsCache.invalidate(partitionNameKey);
+            }
+            else {
+                Optional<Long> partitionVersion = partition.get().getPartitionVersion();
+                if (!partitionVersion.isPresent() || !partitionVersion.equals(partitionNameWithVersion.getPartitionVersion())) {
+                    partitionCache.invalidate(partitionNameKey);
+                    partitionStatisticsCache.invalidate(partitionNameKey);
+                }
+            }
+        }
+    }
+
+    private static boolean isSameTable(HiveTableHandle hiveTableHandle, HiveTableName hiveTableName)
+    {
+        return hiveTableHandle.getSchemaName().equals(hiveTableName.getDatabaseName()) &&
+                hiveTableHandle.getTableName().equals(hiveTableName.getTableName());
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreCache.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreCache.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.hive.HiveTableHandle;
+import com.facebook.presto.spi.constraints.TableConstraint;
+import com.facebook.presto.spi.security.PrestoPrincipal;
+import com.facebook.presto.spi.security.RoleGrant;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Defines the contract for a metastore cache that supports operations for caching metastore data and invalidating it when necessary.
+ * This interface is designed to be implemented by various caching strategies, including but not limited to in-memory caching and distributed caching systems.
+ * The primary goal of implementing this interface is to enhance the performance of metastore operations by reducing the need for repetitive
+ * and potentially expensive data retrieval operations.
+ */
+public interface MetastoreCache
+{
+    Optional<Database> getDatabase(
+            MetastoreContext metastoreContext,
+            String databaseName);
+
+    List<String> getAllDatabases(MetastoreContext metastoreContext);
+
+    Optional<Table> getTable(
+            MetastoreContext metastoreContext,
+            HiveTableHandle hiveTableHandle);
+
+    Optional<List<String>> getAllTables(
+            MetastoreContext metastoreContext,
+            String databaseName);
+
+    PartitionStatistics getTableStatistics(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName);
+
+    List<TableConstraint<String>> getTableConstraints(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName);
+
+    Map<String, PartitionStatistics> getPartitionStatistics(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            Set<String> partitionNames);
+
+    Optional<List<String>> getAllViews(
+            MetastoreContext metastoreContext,
+            String databaseName);
+
+    Map<String, Optional<Partition>> getPartitionsByNames(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<String> partitionNames);
+
+    Optional<Partition> getPartition(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<String> partitionValues);
+
+    List<String> getPartitionNamesByFilter(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates);
+
+    Optional<List<String>> getPartitionNames(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName);
+
+    Set<HivePrivilegeInfo> listTablePrivileges(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            PrestoPrincipal principal);
+
+    Set<String> listRoles(MetastoreContext metastoreContext);
+
+    Set<RoleGrant> listRoleGrants(
+            MetastoreContext metastoreContext,
+            PrestoPrincipal principal);
+
+    Optional<Long> lock(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName);
+
+    void invalidateAll();
+
+    void invalidateTableStatisticsCache(
+            String databaseName,
+            String tableName);
+
+    void invalidatePartitionStatisticsCache(
+            String databaseName,
+            String tableName,
+            String partitionName);
+
+    void invalidateDatabaseCache(String databaseName);
+
+    void invalidatePartitionCache(
+            String databaseName,
+            String tableName);
+
+    void invalidateTablePrivilegesCache(
+            PrestoPrincipal grantee,
+            String databaseName,
+            String tableName);
+
+    void invalidateTableCache(
+            String databaseName,
+            String tableName);
+
+    void invalidateRolesCache();
+
+    void invalidateRoleGrantsCache();
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileMetastoreModule.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileMetastoreModule.java
@@ -16,6 +16,8 @@ package com.facebook.presto.hive.metastore.file;
 import com.facebook.presto.hive.ForCachingHiveMetastore;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.InMemoryMetastoreCache;
+import com.facebook.presto.hive.metastore.MetastoreCache;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -41,6 +43,7 @@ public class FileMetastoreModule
         configBinder(binder).bindConfig(FileHiveMetastoreConfig.class);
         binder.bind(ExtendedHiveMetastore.class).annotatedWith(ForCachingHiveMetastore.class).to(FileHiveMetastore.class).in(Scopes.SINGLETON);
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(MetastoreCache.class).to(InMemoryMetastoreCache.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ExtendedHiveMetastore.class)
                 .as(generatedNameOf(CachingHiveMetastore.class, connectorId));
     }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueMetastoreModule.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueMetastoreModule.java
@@ -17,6 +17,8 @@ import com.facebook.airlift.concurrent.BoundedExecutor;
 import com.facebook.presto.hive.ForCachingHiveMetastore;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.InMemoryMetastoreCache;
+import com.facebook.presto.hive.metastore.MetastoreCache;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -50,6 +52,7 @@ public class GlueMetastoreModule
         binder.bind(GlueHiveMetastore.class).in(Scopes.SINGLETON);
         binder.bind(ExtendedHiveMetastore.class).annotatedWith(ForCachingHiveMetastore.class).to(GlueHiveMetastore.class).in(Scopes.SINGLETON);
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(MetastoreCache.class).to(InMemoryMetastoreCache.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ExtendedHiveMetastore.class)
                 .as(generatedNameOf(CachingHiveMetastore.class, connectorId));
         newExporter(binder).export(GlueHiveMetastore.class)

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -19,6 +19,8 @@ import com.facebook.presto.hive.ForRecordingHiveMetastore;
 import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.InMemoryMetastoreCache;
+import com.facebook.presto.hive.metastore.MetastoreCache;
 import com.facebook.presto.hive.metastore.RecordingHiveMetastore;
 import com.facebook.presto.spi.ConnectorId;
 import com.google.inject.Binder;
@@ -70,6 +72,7 @@ public class ThriftMetastoreModule
         }
 
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(MetastoreCache.class).to(InMemoryMetastoreCache.class).in(Scopes.SINGLETON);
         newExporter(binder).export(HiveMetastore.class)
                 .as(generatedNameOf(ThriftHiveMetastore.class, connectorId));
         newExporter(binder).export(ExtendedHiveMetastore.class)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -25,6 +25,7 @@ import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.InMemoryMetastoreCache;
 import com.facebook.presto.hive.metastore.MetastoreContext;
 import com.facebook.presto.hive.metastore.MetastoreOperationResult;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
@@ -503,7 +504,7 @@ public abstract class AbstractTestHiveFileSystem
 
         public TestingHiveMetastore(ExtendedHiveMetastore delegate, ExecutorService executor, MetastoreClientConfig metastoreClientConfig, Path basePath, HdfsEnvironment hdfsEnvironment)
         {
-            super(delegate, executor, NOOP_METASTORE_CACHE_STATS, metastoreClientConfig);
+            super(delegate, new InMemoryMetastoreCache(delegate, executor, NOOP_METASTORE_CACHE_STATS, metastoreClientConfig));
             this.basePath = basePath;
             this.hdfsEnvironment = hdfsEnvironment;
         }
@@ -558,7 +559,7 @@ public abstract class AbstractTestHiveFileSystem
                 throw new UncheckedIOException(e);
             }
             finally {
-                invalidateTable(databaseName, tableName);
+                metastoreCache.invalidateTableCache(databaseName, tableName);
             }
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
@@ -21,6 +21,8 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
 import com.facebook.presto.hive.metastore.HiveMetastoreModule;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.InMemoryMetastoreCache;
+import com.facebook.presto.hive.metastore.MetastoreCache;
 import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
 import com.google.inject.Binder;
@@ -49,6 +51,7 @@ public class IcebergHiveModule
     {
         install(new HiveMetastoreModule(this.connectorId, this.metastore));
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(MetastoreCache.class).to(InMemoryMetastoreCache.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(MetastoreClientConfig.class);
         binder.bind(PartitionMutator.class).to(HivePartitionMutator.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
- **Add Metastore cache interface**
- **Add Metastore In Memory cache implementation**

## Description
Add Metastore cache interface
Add Metastore In Memory cache implementation

## Motivation and Context
Provides a way to plug in different caching implementations. Default implementation of Loading Cache backed InMemory cache is provided.

## Test Plan
Unit Tests
Verifier testing.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

