### PR TITLE
Improve iceberg hive statistics documentation

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -45,6 +45,20 @@ as a Hive connector.
     hive.metastore=glue
     iceberg.catalog.type=hive
 
+Additional supported properties for the Hive catalog:
+
+==================================================== ============================================================ =============
+Property Name                                        Description                                                  Default
+==================================================== ============================================================ =============
+``iceberg.hive-statistics-merge-strategy``           The strategy to use when merging statistics from the Hive    ``NONE``
+                                                     metastore into the Iceberg table statistics for the query
+                                                     optimizer. Valid values are ``NONE``, ``USE_NDV``,
+                                                     ``USE_NULLS_FRACTIONS``, and ``USE_NULLS_FRACTION_AND_NDV``.
+                                                     Iceberg statistics will be used except for the statistics
+                                                     specified by this configuration property.
+
+==================================================== ============================================================ =============
+
 Nessie catalog
 ^^^^^^^^^^^^^^
 
@@ -306,7 +320,11 @@ Property Name                                 Description
 ============================================= ======================================================================
 ``iceberg.delete_as_join_rewrite_enabled``    Overrides the behavior of the connector property
                                               ``iceberg.delete-as-join-rewrite-enabled`` in the current session.
+
+``iceberg.hive_statistics_merge_strategy``    See the ``iceberg.hive-statistics-merge-strategy`` description.
+
 ============================================= ======================================================================
+
 
 Caching Support
 ----------------
@@ -1172,7 +1190,7 @@ each Iceberg data type to the corresponding Presto data type, and from each Pres
 The following tables detail the specific type maps between PrestoDB and Iceberg. 
 
 Iceberg to PrestoDB type mapping
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Map of Iceberg types to the relevant PrestoDB types:
 
@@ -1215,7 +1233,7 @@ Map of Iceberg types to the relevant PrestoDB types:
 No other types are supported.
 
 PrestoDB to Iceberg type mapping
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Map of PrestoDB types to the relevant Iceberg types:
 


### PR DESCRIPTION
## Description

- Documented the configuration properties for merging statistics from the hive metastore.
- Added a single integration test to ensure stats are always stored when ANALYZE is run, regardless of whether the iceberg.hive-statistics-merge-strategy is set

## Motivation and Context

Documentation improvements

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

