### PR TITLE
Add date_diff function that work on unix timestamps

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -168,6 +168,12 @@ Unit              Description
 
     Returns ``timestamp2 - timestamp1`` expressed in terms of ``unit``.
 
+.. function:: date_diff(unit, unixtime1, unixtime2) -> bigint
+
+    Returns ``unixtime2 - unixtime1`` expressed in terms of ``unit``.
+
+    Unsupported units for this function are  ``millisecond``, ``month``, ``quarter``, and ``year``.
+
 Duration Function
 -----------------
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -202,6 +202,7 @@ import com.facebook.presto.operator.scalar.WilsonInterval;
 import com.facebook.presto.operator.scalar.WordStemFunction;
 import com.facebook.presto.operator.scalar.queryplan.JsonPrestoQueryPlanFunctions;
 import com.facebook.presto.operator.scalar.sql.ArraySqlFunctions;
+import com.facebook.presto.operator.scalar.sql.DateSqlFunction;
 import com.facebook.presto.operator.scalar.sql.MapNormalizeFunction;
 import com.facebook.presto.operator.scalar.sql.MapSqlFunctions;
 import com.facebook.presto.operator.scalar.sql.SimpleSamplingPercent;
@@ -966,6 +967,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .sqlInvokedScalars(MapSqlFunctions.class)
                 .sqlInvokedScalars(SimpleSamplingPercent.class)
                 .sqlInvokedScalars(StringSqlFunctions.class)
+                .sqlInvokedScalars(DateSqlFunction.class)
                 .scalar(DynamicFilterPlaceholderFunction.class)
                 .scalars(EnumCasts.class)
                 .scalars(LongEnumOperators.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -495,7 +495,11 @@ public final class DateTimeFunctions
     @ScalarFunction("date_diff")
     @LiteralParameters("x")
     @SqlType(StandardTypes.BIGINT)
-    public static long diffDate(SqlFunctionProperties properties, @SqlType("varchar(x)") Slice unit, @SqlType(StandardTypes.DATE) long date1, @SqlType(StandardTypes.DATE) long date2)
+    public static long diffDate(
+            SqlFunctionProperties properties,
+            @SqlType("varchar(x)") Slice unit,
+            @SqlType(StandardTypes.DATE) long date1,
+            @SqlType(StandardTypes.DATE) long date2)
     {
         return getDateField(UTC_CHRONOLOGY, unit).getDifferenceAsLong(DAYS.toMillis(date2), DAYS.toMillis(date1));
     }
@@ -504,7 +508,11 @@ public final class DateTimeFunctions
     @ScalarFunction("date_diff")
     @LiteralParameters("x")
     @SqlType(StandardTypes.BIGINT)
-    public static long diffTime(SqlFunctionProperties properties, @SqlType("varchar(x)") Slice unit, @SqlType(StandardTypes.TIME) long time1, @SqlType(StandardTypes.TIME) long time2)
+    public static long diffTime(
+            SqlFunctionProperties properties,
+            @SqlType("varchar(x)") Slice unit,
+            @SqlType(StandardTypes.TIME) long time1,
+            @SqlType(StandardTypes.TIME) long time2)
     {
         if (properties.isLegacyTimestamp()) {
             // Session zone could have policy change on/around 1970-01-01, so we cannot use UTC

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/DateSqlFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/DateSqlFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlParameters;
+import com.facebook.presto.spi.function.SqlType;
+
+public class DateSqlFunction
+{
+    private DateSqlFunction() {}
+
+    @SqlInvokedScalarFunction(value = "date_diff", deterministic = true, calledOnNullInput = false)
+    @Description("Difference of the given dates in the given unit")
+    @SqlParameters({@SqlParameter(name = "unit", type = "varchar"), @SqlParameter(name = "unixtime1", type = "bigint"), @SqlParameter(name = "unixtime2", type = "bigint")})
+    @SqlType("bigint")
+    public static String diffUnixtime()
+    {
+        return "RETURN IF(unit NOT IN ('millisecond', 'month', 'quarter', 'year'), " +
+                "CASE WHEN unit = 'week' THEN (unixtime2 - unixtime1) / 604800 " +
+                "WHEN unit = 'day' THEN (unixtime2 - unixtime1) / 86400 " +
+                "WHEN unit = 'hour' THEN (unixtime2 - unixtime1) / 3600 " +
+                "WHEN unit = 'minute' THEN (unixtime2 - unixtime1) / 60 " +
+                "WHEN unit = 'second' THEN unixtime2 - unixtime1 END, " +
+                "fail(7, 'Invalid unix time parameters'))";
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -100,6 +100,7 @@ public abstract class TestDateTimeFunctionsBase
     protected static final DateTime DATE = new DateTime(2001, 8, 22, 0, 0, 0, 0, DateTimeZone.UTC);
     protected static final String DATE_LITERAL = "DATE '2001-08-22'";
     protected static final String DATE_ISO8601_STRING = "2001-08-22";
+    protected static final long DATE_UNIXTIME = 998438400;
 
     protected static final LocalTime TIME = LocalTime.of(3, 4, 5, 321_000_000);
     protected static final String TIME_LITERAL = "TIME '03:04:05.321'";
@@ -741,6 +742,33 @@ public abstract class TestDateTimeFunctionsBase
         assertFunction("date_diff('second', " + weirdBaseDateTimeLiteral + ", " + WEIRD_TIME_LITERAL + ")", BIGINT, secondsBetween(weirdBaseDateTime, WEIRD_TIME));
         assertFunction("date_diff('minute', " + weirdBaseDateTimeLiteral + ", " + WEIRD_TIME_LITERAL + ")", BIGINT, minutesBetween(weirdBaseDateTime, WEIRD_TIME));
         assertFunction("date_diff('hour', " + weirdBaseDateTimeLiteral + ", " + WEIRD_TIME_LITERAL + ")", BIGINT, hoursBetween(weirdBaseDateTime, WEIRD_TIME));
+    }
+
+    @Test
+    public void testDateDiffFromUnixtime()
+    {
+        DateTime baseDateTime = new DateTime(1975, 4, 30, 11, 30, 0, 0, DateTimeZone.UTC);
+        long baseDateTimeUnixtime = 168089400;
+
+        assertFunction("date_diff('second', " + baseDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) secondsBetween(baseDateTime, DATE).getSeconds());
+        assertFunction("date_diff('minute', " + baseDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) minutesBetween(baseDateTime, DATE).getMinutes());
+        assertFunction("date_diff('hour', " + baseDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) hoursBetween(baseDateTime, DATE).getHours());
+        assertFunction("date_diff('day', " + baseDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) daysBetween(baseDateTime, DATE).getDays());
+        assertFunction("date_diff('week', " + baseDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) weeksBetween(baseDateTime, DATE).getWeeks());
+
+        DateTime boundaryDateTime = new DateTime(1945, 1, 1, 1, 1, 1, 0, DateTimeZone.UTC);
+        long boundaryDateTimeUnixtime = -788914739;
+
+        assertFunction("date_diff('second', " + boundaryDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) secondsBetween(boundaryDateTime, DATE).getSeconds());
+        assertFunction("date_diff('minute', " + boundaryDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) minutesBetween(boundaryDateTime, DATE).getMinutes());
+        assertFunction("date_diff('hour', " + boundaryDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) hoursBetween(boundaryDateTime, DATE).getHours());
+        assertFunction("date_diff('day', " + boundaryDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) daysBetween(boundaryDateTime, DATE).getDays());
+        assertFunction("date_diff('week', " + boundaryDateTimeUnixtime + ", " + DATE_UNIXTIME + ")", BIGINT, (long) weeksBetween(boundaryDateTime, DATE).getWeeks());
+
+        assertInvalidFunction("date_diff('millisecond', -788914739, 168089400)", StandardErrorCode.INVALID_FUNCTION_ARGUMENT, "Invalid unix time parameters");
+        assertInvalidFunction("date_diff('month', -788914739, 168089400)", StandardErrorCode.INVALID_FUNCTION_ARGUMENT, "Invalid unix time parameters");
+        assertInvalidFunction("date_diff('quarter', -788914739, 168089400)", StandardErrorCode.INVALID_FUNCTION_ARGUMENT, "Invalid unix time parameters");
+        assertInvalidFunction("date_diff('year', -788914739, 168089400)", StandardErrorCode.INVALID_FUNCTION_ARGUMENT, "Invalid unix time parameters");
     }
 
     @Test


### PR DESCRIPTION
## Description
Resolves #22157 
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Unit tests added.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
General Changes
* Add function :func:`date_diff(unit, unixtime1, unixtime2) → bigint`
```

