### PR TITLE
Add flag to remove redundant progress logs in CIs

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     name: "Label and notify"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          show-progress: false
       - uses: sourcegraph/codenotify@v0.6.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,9 @@ jobs:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -39,7 +39,9 @@ jobs:
       group: ${{ github.workflow }}-hive-tests-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8
@@ -88,7 +90,9 @@ jobs:
       group: ${{ github.workflow }}-hive-dockerized-tests-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -37,7 +37,9 @@ jobs:
       group: ${{ github.workflow }}-kudu-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -23,7 +23,9 @@ jobs:
           df -h
           sudo apt-get clean
           df -h
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -43,7 +43,9 @@ jobs:
           sudo apt-get clean
           rm -rf /opt/hostedtoolcache
           df -h
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -43,7 +43,9 @@ jobs:
           sudo apt-get clean
           rm -rf /opt/hostedtoolcache
           df -h
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8
@@ -91,7 +93,9 @@ jobs:
           sudo apt-get clean
           rm -rf /opt/hostedtoolcache
           df -h
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -39,7 +39,9 @@ jobs:
       group: ${{ github.workflow }}-singlestore-dockerized-tests-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Remove unnecessary pre-installed toolchains for free disk spaces
         run: |
           echo "=== BEFORE ==="

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -38,7 +38,9 @@ jobs:
       group: ${{ github.workflow }}-spark-integration-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -38,7 +38,9 @@ jobs:
       group: ${{ github.workflow }}-test-other-modules-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         with:
           java-version: 8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,8 +71,10 @@ jobs:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: needs.changes.outputs.codechange == 'true'
+        with:
+          show-progress: false
       - uses: actions/setup-java@v1
         if: needs.changes.outputs.codechange == 'true'
         with:

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -34,6 +34,8 @@ jobs:
       group: ${{ github.workflow }}-web-ui-checks-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Web UI Checks
         run: presto-main/bin/check_webui.sh


### PR DESCRIPTION
## Description
Resolves #22164.
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

