### PR TITLE
[Verifier] Support reuse of source query output table

### DIFF
--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -276,6 +276,10 @@ Name                                        Description
                                             are emitted to ``stdout``.
 ``control.table-prefix``                    The table prefix to be appended to the control target table.
 ``test.table-prefix``                       The table prefix to be appended to the test target table.
+``control.reuse-table``                     If ``true``, reuse the output table of the control source Insert and CreateTableAsSelect
+                                            query. Otherwise, run the control source query and write to a temporary table.
+``test.reuse-table``                        If ``true``, reuse the output table of the test source Insert and CreateTableAsSelect
+                                            query. Otherwise, run the test source query and write to a temporary table.
 ``test-id``                                 A string to be attached to output events.
 ``max-concurrency``                         Maximum number of concurrent verifications.
 ``suite-repetition``                        How many times a suite is verified.

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
@@ -53,12 +53,11 @@ public class QueryInfo
     private final String bucketChecksumQuery;
     private final String jsonPlan;
     private final String outputTableName;
-
+    private final boolean isReuseTable;
     private final Double cpuTimeSecs;
     private final Double wallTimeSecs;
     private final Long peakTotalMemoryBytes;
     private final Long peakTaskTotalMemoryBytes;
-
     private final String extraStats;
 
     public QueryInfo(
@@ -79,7 +78,8 @@ public class QueryInfo
             Optional<String> bucketChecksumQuery,
             Optional<String> jsonPlan,
             Optional<QueryActionStats> queryActionStats,
-            Optional<String> outputTableName)
+            Optional<String> outputTableName,
+            boolean isReuseTable)
     {
         Optional<QueryStats> stats = queryActionStats.flatMap(QueryActionStats::getQueryStats);
         this.catalog = requireNonNull(catalog, "catalog is null");
@@ -105,6 +105,7 @@ public class QueryInfo
         this.peakTaskTotalMemoryBytes = stats.map(QueryStats::getPeakTaskTotalMemoryBytes).orElse(null);
         this.extraStats = queryActionStats.flatMap(QueryActionStats::getExtraStats).orElse(null);
         this.outputTableName = outputTableName.orElse(null);
+        this.isReuseTable = isReuseTable;
     }
 
     private static double millisToSeconds(long millis)
@@ -221,6 +222,12 @@ public class QueryInfo
     }
 
     @EventField
+    public boolean getIsReuseTable()
+    {
+        return isReuseTable;
+    }
+
+    @EventField
     public Double getCpuTimeSecs()
     {
         return cpuTimeSecs;
@@ -279,6 +286,7 @@ public class QueryInfo
         private Optional<String> jsonPlan = Optional.empty();
         private Optional<QueryActionStats> queryActionStats = Optional.empty();
         private Optional<String> outputTableName = Optional.empty();
+        private boolean isReuseTable;
 
         private Builder(
                 String catalog,
@@ -376,6 +384,12 @@ public class QueryInfo
             return this;
         }
 
+        public Builder setIsReuseTable(boolean isReuseTable)
+        {
+            this.isReuseTable = isReuseTable;
+            return this;
+        }
+
         public QueryInfo build()
         {
             return new QueryInfo(
@@ -396,7 +410,8 @@ public class QueryInfo
                     bucketChecksumQuery,
                     jsonPlan,
                     queryActionStats,
-                    outputTableName);
+                    outputTableName,
+                    isReuseTable);
         }
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/VerifierQueryEvent.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/VerifierQueryEvent.java
@@ -39,6 +39,7 @@ public class VerifierQueryEvent
         FAILED,
         FAILED_RESOLVED,
         SKIPPED,
+        RESUBMITTED,
     }
 
     private final String suite;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateTableVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateTableVerification.java
@@ -67,7 +67,7 @@ public class CreateTableVerification
     @Override
     protected QueryObjectBundle getQueryRewrite(ClusterType clusterType)
     {
-        return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), clusterType);
+        return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), getSourceQuery().getQueryConfiguration(clusterType), clusterType);
     }
 
     @Override

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateViewVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateViewVerification.java
@@ -67,7 +67,7 @@ public class CreateViewVerification
     @Override
     protected QueryObjectBundle getQueryRewrite(ClusterType clusterType)
     {
-        return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), clusterType);
+        return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), getSourceQuery().getQueryConfiguration(clusterType), clusterType);
     }
 
     @Override

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataMatchResult.java
@@ -97,6 +97,12 @@ public class DataMatchResult
         return matchType == ROW_COUNT_MISMATCH || matchType == COLUMN_MISMATCH;
     }
 
+    @Override
+    public boolean isMismatchPossiblyCausedByReuseOutdatedTable()
+    {
+        return matchType == SCHEMA_MISMATCH || matchType == ROW_COUNT_MISMATCH || matchType == COLUMN_MISMATCH;
+    }
+
     public MatchType getMatchType()
     {
         return matchType;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -85,15 +85,17 @@ public class DataVerification
     @Override
     protected QueryObjectBundle getQueryRewrite(ClusterType clusterType)
     {
-        return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), clusterType);
+        return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), getSourceQuery().getQueryConfiguration(clusterType), clusterType,
+                getVerificationContext().getResubmissionCount() == 0);
     }
 
     @Override
     protected void updateQueryInfoWithQueryBundle(QueryInfo.Builder queryInfo, Optional<QueryObjectBundle> queryBundle)
     {
         super.updateQueryInfoWithQueryBundle(queryInfo, queryBundle);
-        queryInfo.setQuery(queryBundle.map(bundle -> formatSql(bundle.getQuery(), bundle.getRewrittenFunctionCalls())));
-        queryInfo.setOutputTableName(queryBundle.map(QueryObjectBundle::getObjectName).map(QualifiedName::toString));
+        queryInfo.setQuery(queryBundle.map(bundle -> formatSql(bundle.getQuery(), bundle.getRewrittenFunctionCalls())))
+                .setOutputTableName(queryBundle.map(QueryObjectBundle::getObjectName).map(QualifiedName::toString))
+                .setIsReuseTable(queryBundle.map(QueryObjectBundle::isReuseTable).orElse(false));
     }
 
     @Override
@@ -174,7 +176,7 @@ public class DataVerification
             checkState(control.isPresent(), "control is missing");
             return failureResolverManager.resolveResultMismatch((DataMatchResult) matchResult.get(), control.get());
         }
-        if (throwable.isPresent() && controlQueryContext.getState() == QueryState.SUCCEEDED) {
+        if (throwable.isPresent() && ImmutableList.of(QueryState.SUCCEEDED, QueryState.REUSE).contains(controlQueryContext.getState())) {
             checkState(controlQueryContext.getMainQueryStats().isPresent(), "controlQueryStats is missing");
             return failureResolverManager.resolveException(controlQueryContext.getMainQueryStats().get(), throwable.get(), test);
         }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlMatchResult.java
@@ -71,6 +71,12 @@ public class DdlMatchResult
     }
 
     @Override
+    public boolean isMismatchPossiblyCausedByReuseOutdatedTable()
+    {
+        return false;
+    }
+
+    @Override
     public String getReport()
     {
         StringBuilder message = new StringBuilder()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
@@ -131,7 +131,7 @@ public class DeterminismAnalyzer
         Map<QueryBundle, DeterminismAnalysisRun.Builder> queryRuns = new HashMap<>();
         try {
             for (int i = 0; i < maxAnalysisRuns; i++) {
-                QueryObjectBundle queryBundle = queryRewriter.rewriteQuery(sourceQuery.getQuery(CONTROL), CONTROL);
+                QueryObjectBundle queryBundle = queryRewriter.rewriteQuery(sourceQuery.getQuery(CONTROL), sourceQuery.getQueryConfiguration(CONTROL), CONTROL, false);
                 DeterminismAnalysisRun.Builder run = determinismAnalysisDetails.addRun().setTableName(queryBundle.getObjectName().toString());
                 queryRuns.put(queryBundle, run);
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainMatchResult.java
@@ -58,6 +58,12 @@ public class ExplainMatchResult
     }
 
     @Override
+    public boolean isMismatchPossiblyCausedByReuseOutdatedTable()
+    {
+        return false;
+    }
+
+    @Override
     public String getReport()
     {
         return matchType.name();

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
@@ -23,5 +23,7 @@ public interface MatchResult
 
     boolean isMismatchPossiblyCausedByNonDeterminism();
 
+    boolean isMismatchPossiblyCausedByReuseOutdatedTable();
+
     String getReport();
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryObjectBundle.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryObjectBundle.java
@@ -25,6 +25,7 @@ public class QueryObjectBundle
         extends QueryBundle
 {
     private final QualifiedName objectName;
+    private final boolean reuseTable;
     private final Optional<String> rewrittenFunctionCalls;
 
     public QueryObjectBundle(
@@ -33,11 +34,13 @@ public class QueryObjectBundle
             Statement query,
             List<Statement> teardownQueries,
             ClusterType cluster,
-            Optional<String> rewrittenFunctionCalls)
+            Optional<String> rewrittenFunctionCalls,
+            boolean reuseTable)
     {
         super(setupQueries, query, teardownQueries, cluster);
         this.objectName = requireNonNull(objectName, "objectName is null");
         this.rewrittenFunctionCalls = requireNonNull(rewrittenFunctionCalls, "rewrittenFunctionCalls is null");
+        this.reuseTable = reuseTable;
     }
 
     public QualifiedName getObjectName()
@@ -48,5 +51,10 @@ public class QueryObjectBundle
     public Optional<String> getRewrittenFunctionCalls()
     {
         return rewrittenFunctionCalls;
+    }
+
+    public boolean isReuseTable()
+    {
+        return reuseTable;
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryState.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryState.java
@@ -16,6 +16,7 @@ package com.facebook.presto.verifier.framework;
 public enum QueryState
 {
     SUCCEEDED,
+    REUSE,
     FAILED,
     TIMED_OUT,
     FAILED_TO_SETUP,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/SourceQuery.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/SourceQuery.java
@@ -18,6 +18,7 @@ import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
 import static com.facebook.presto.verifier.framework.ClusterType.TEST;
@@ -31,6 +32,8 @@ public class SourceQuery
     private final String name;
     private final String controlQuery;
     private final String testQuery;
+    private final Optional<String> controlQueryId;
+    private final Optional<String> testQueryId;
     private final QueryConfiguration controlConfiguration;
     private final QueryConfiguration testConfiguration;
 
@@ -40,6 +43,8 @@ public class SourceQuery
             @ColumnName("name") String name,
             @ColumnName("controlQuery") String controlQuery,
             @ColumnName("testQuery") String testQuery,
+            @ColumnName("controlQueryId") Optional<String> controlQueryId,
+            @ColumnName("testQueryId") Optional<String> testQueryId,
             @Nested("control") QueryConfiguration controlConfiguration,
             @Nested("test") QueryConfiguration testConfiguration)
     {
@@ -47,6 +52,8 @@ public class SourceQuery
         this.name = requireNonNull(name, "name is null");
         this.controlQuery = clean(controlQuery);
         this.testQuery = clean(testQuery);
+        this.controlQueryId = requireNonNull(controlQueryId, "controlQueryId is null");
+        this.testQueryId = requireNonNull(testQueryId, "testQueryId is null");
         this.controlConfiguration = requireNonNull(controlConfiguration, "controlConfiguration is null");
         this.testConfiguration = requireNonNull(testConfiguration, "testConfiguration is null");
     }
@@ -65,6 +72,18 @@ public class SourceQuery
     {
         checkArgument(clusterType == CONTROL || clusterType == TEST, "Invalid ClusterType: %s", clusterType);
         return clusterType == CONTROL ? controlQuery : testQuery;
+    }
+
+    public Optional<String> getQueryId(ClusterType clusterType)
+    {
+        checkArgument(clusterType == CONTROL || clusterType == TEST, "Invalid ClusterType: %s", clusterType);
+        return clusterType == CONTROL ? controlQueryId : testQueryId;
+    }
+
+    public QueryConfiguration getQueryConfiguration(ClusterType clusterType)
+    {
+        checkArgument(clusterType == CONTROL || clusterType == TEST, "Invalid ClusterType: %s", clusterType);
+        return clusterType == CONTROL ? controlConfiguration : testConfiguration;
     }
 
     public QueryConfiguration getControlConfiguration()
@@ -102,6 +121,8 @@ public class SourceQuery
                 Objects.equals(name, o.name) &&
                 Objects.equals(controlQuery, o.controlQuery) &&
                 Objects.equals(testQuery, o.testQuery) &&
+                Objects.equals(controlQueryId, o.controlQueryId) &&
+                Objects.equals(testQueryId, o.testQueryId) &&
                 Objects.equals(controlConfiguration, o.controlConfiguration) &&
                 Objects.equals(testConfiguration, o.testConfiguration);
     }
@@ -109,7 +130,7 @@ public class SourceQuery
     @Override
     public int hashCode()
     {
-        return Objects.hash(suite, name, controlQuery, testQuery, controlConfiguration, testConfiguration);
+        return Objects.hash(suite, name, controlQuery, testQuery, controlQueryId, testQueryId, controlConfiguration, testConfiguration);
     }
 
     @Override
@@ -120,6 +141,8 @@ public class SourceQuery
                 .add("name", name)
                 .add("controlQuery", controlQuery)
                 .add("testQuery", testQuery)
+                .add("controlQueryId", controlQueryId)
+                .add("testQueryId", testQueryId)
                 .add("controlConfiguration", controlConfiguration)
                 .add("testConfiguration", testConfiguration)
                 .toString();

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/PrestoExceptionClassifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/PrestoExceptionClassifier.java
@@ -47,7 +47,9 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURING_QUERY;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_OFFLINE;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_READ_ONLY;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TABLE_DROPPED_DURING_QUERY;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_TABLE_READ_ONLY;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TOO_MANY_OPEN_PARTITIONS;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
@@ -70,7 +72,6 @@ import static com.facebook.presto.spi.StandardErrorCode.SYNTAX_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
 import static com.facebook.presto.verifier.framework.QueryStage.CONTROL_SETUP;
 import static com.facebook.presto.verifier.framework.QueryStage.DESCRIBE;
-import static com.facebook.presto.verifier.framework.QueryStage.TEST_MAIN;
 import static com.facebook.presto.verifier.framework.QueryStage.TEST_SETUP;
 import static com.google.common.base.Functions.identity;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -148,10 +149,12 @@ public class PrestoExceptionClassifier
                 .addResubmittedError(HIVE_TABLE_DROPPED_DURING_QUERY)
                 .addResubmittedError(CLUSTER_OUT_OF_MEMORY)
                 .addResubmittedError(ADMINISTRATIVELY_PREEMPTED)
+                .addResubmittedError(HIVE_TABLE_READ_ONLY)
+                .addResubmittedError(HIVE_PARTITION_READ_ONLY)
+                .addResubmittedError(HIVE_PARTITION_OFFLINE)
                 // Conditional Resubmitted Errors
                 .addResubmittedError(SYNTAX_ERROR, Optional.of(CONTROL_SETUP), Optional.of(TABLE_ALREADY_EXISTS_PATTERN))
-                .addResubmittedError(SYNTAX_ERROR, Optional.of(TEST_SETUP), Optional.of(TABLE_ALREADY_EXISTS_PATTERN))
-                .addResubmittedError(HIVE_PARTITION_OFFLINE, Optional.of(TEST_MAIN), Optional.empty());
+                .addResubmittedError(SYNTAX_ERROR, Optional.of(TEST_SETUP), Optional.of(TABLE_ALREADY_EXISTS_PATTERN));
     }
 
     public QueryException createException(QueryStage queryStage, QueryActionStats queryActionStats, SQLException cause)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/QueryActionStats.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/QueryActionStats.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.prestoaction;
 
+import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.jdbc.QueryStats;
 
 import java.util.Optional;
@@ -25,6 +26,12 @@ public class QueryActionStats
 
     private final Optional<QueryStats> queryStats;
     private final Optional<String> extraStats;
+
+    public static QueryActionStats queryIdStats(String queryId)
+    {
+        return new QueryActionStats(Optional.of(new QueryStats(queryId, QueryState.FINISHED.toString(), false, false, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                Optional.empty())), Optional.empty());
+    }
 
     public QueryActionStats(Optional<QueryStats> queryStats, Optional<String> extraStats)
     {

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriteConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriteConfig.java
@@ -31,6 +31,21 @@ public class QueryRewriteConfig
     private QualifiedName tablePrefix = QualifiedName.of("tmp_verifier");
     private Map<String, Object> tableProperties = ImmutableMap.of();
 
+    private boolean reuseTable;
+
+    public boolean isReuseTable()
+    {
+        return reuseTable;
+    }
+
+    @ConfigDescription("If true, reuse the output table of the source query. Otherwise, run the query and write to a temporary shadow table.")
+    @Config("reuse-table")
+    public QueryRewriteConfig setReuseTable(boolean reuseTable)
+    {
+        this.reuseTable = reuseTable;
+        return this;
+    }
+
     @NotNull
     public QualifiedName getTablePrefix()
     {

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
@@ -52,6 +52,8 @@ public class VerificationQueryRewriterFactory
     private final QualifiedName testTablePrefix;
     private final List<Property> controlTableProperties;
     private final List<Property> testTableProperties;
+    private final boolean controlReuseTable;
+    private final boolean testReuseTable;
 
     private final Multimap<String, FunctionCallSubstitute> functionSubstitutes;
 
@@ -69,6 +71,8 @@ public class VerificationQueryRewriterFactory
         this.testTablePrefix = requireNonNull(testConfig.getTablePrefix(), "testTablePrefix is null");
         this.controlTableProperties = constructProperties(controlConfig.getTableProperties());
         this.testTableProperties = constructProperties(testConfig.getTableProperties());
+        this.controlReuseTable = controlConfig.isReuseTable();
+        this.testReuseTable = testConfig.isReuseTable();
         this.functionSubstitutes = verifierConfig.getFunctionSubstitutes();
     }
 
@@ -81,6 +85,7 @@ public class VerificationQueryRewriterFactory
                 prestoAction,
                 ImmutableMap.of(CONTROL, controlTablePrefix, TEST, testTablePrefix),
                 ImmutableMap.of(CONTROL, controlTableProperties, TEST, testTableProperties),
+                ImmutableMap.of(CONTROL, controlReuseTable, TEST, testReuseTable),
                 functionSubstitutes);
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/PrestoQuerySourceQuerySupplier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/PrestoQuerySourceQuerySupplier.java
@@ -41,20 +41,26 @@ public class PrestoQuerySourceQuerySupplier
                     resultSet.getString("name"),
                     resultSet.getString("control_query"),
                     resultSet.getString("test_query"),
+                    Optional.ofNullable(resultSet.getString("control_query_id")),
+                    Optional.ofNullable(resultSet.getString("test_query_id")),
                     new QueryConfiguration(
                             resultSet.getString("control_catalog"),
                             resultSet.getString("control_schema"),
                             Optional.ofNullable(resultSet.getString("control_username")),
                             Optional.ofNullable(resultSet.getString("control_password")),
                             Optional.ofNullable(resultSet.getString("control_session_properties"))
-                                    .map(StringToStringMapColumnMapper.CODEC::fromJson)),
+                                    .map(StringToStringMapColumnMapper.CODEC::fromJson),
+                            Optional.ofNullable(resultSet.getString("control_client_tags"))
+                                    .map(StringListColumnMapper.CODEC::fromJson)),
                     new QueryConfiguration(
                             resultSet.getString("test_catalog"),
                             resultSet.getString("test_schema"),
                             Optional.ofNullable(resultSet.getString("test_username")),
                             Optional.ofNullable(resultSet.getString("test_password")),
                             Optional.ofNullable(resultSet.getString("test_session_properties"))
-                                    .map(StringToStringMapColumnMapper.CODEC::fromJson))));
+                                    .map(StringToStringMapColumnMapper.CODEC::fromJson),
+                            Optional.ofNullable(resultSet.getString("test_client_tags"))
+                                    .map(StringListColumnMapper.CODEC::fromJson))));
 
     private final PrestoAction helperAction;
     private final SqlParser sqlParser;
@@ -67,7 +73,7 @@ public class PrestoQuerySourceQuerySupplier
             PrestoQuerySourceQueryConfig config)
     {
         this.helperAction = helperActionFactory.create(
-                new QueryConfiguration(config.getCatalog(), config.getSchema(), config.getUsername(), config.getPassword(), Optional.empty()),
+                new QueryConfiguration(config.getCatalog(), config.getSchema(), config.getUsername(), config.getPassword(), Optional.empty(), Optional.empty()),
                 VerificationContext.create("", ""));
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.query = requireNonNull(config.getQuery(), "query is null");

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/StringListColumnMapper.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/StringListColumnMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import com.facebook.airlift.json.JsonCodec;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+
+public class StringListColumnMapper
+        implements ColumnMapper<List<String>>
+{
+    public static final JsonCodec<List<String>> CODEC = listJsonCodec(String.class);
+
+    @Override
+    public List<String> map(ResultSet resultSet, int columnNumber, StatementContext ctx)
+            throws SQLException
+    {
+        String columnValue = resultSet.getString(columnNumber);
+        return columnValue == null ? null : CODEC.fromJson(columnValue);
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/VerifierDao.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/VerifierDao.java
@@ -25,6 +25,7 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import java.util.List;
 
 @RegisterColumnMapper(StringToStringMapColumnMapper.class)
+@RegisterColumnMapper(StringListColumnMapper.class)
 public interface VerifierDao
 {
     @SqlUpdate("CREATE TABLE <table_name> (\n" +
@@ -34,32 +35,40 @@ public interface VerifierDao
             "  control_catalog varchar(256) NOT NULL,\n" +
             "  control_schema varchar(256) NOT NULL,\n" +
             "  control_query text NOT NULL,\n" +
+            "  control_query_id mediumtext DEFAULT NULL,\n" +
             "  control_username varchar(256) DEFAULT NULL,\n" +
             "  control_password varchar(256) DEFAULT NULL,\n" +
             "  control_session_properties text DEFAULT NULL,\n" +
+            "  control_client_tags text DEFAULT NULL,\n" +
             "  test_catalog varchar(256) NOT NULL,\n" +
             "  test_schema varchar(256) NOT NULL,\n" +
             "  test_query text NOT NULL,\n" +
+            "  test_query_id mediumtext DEFAULT NULL,\n" +
             "  test_username varchar(256) DEFAULT NULL,\n" +
             "  test_password varchar(256) DEFAULT NULL,\n" +
-            "  test_session_properties text DEFAULT NULL)")
+            "  test_session_properties text DEFAULT NULL,\n" +
+            "  test_client_tags text DEFAULT NULL)")
     void createVerifierQueriesTable(@Define("table_name") String tableName);
 
     @SqlQuery("SELECT\n" +
             "  suite,\n" +
             "  name,\n" +
             "  control_query,\n" +
+            "  name control_query_id,\n" +
             "  control_catalog,\n" +
             "  control_schema,\n" +
             "  control_username,\n" +
             "  control_password,\n" +
             "  control_session_properties,\n" +
+            "  control_client_tags,\n" +
             "  test_query,\n" +
+            "  test_query_id,\n" +
             "  test_catalog,\n" +
             "  test_schema,\n" +
             "  test_username,\n" +
             "  test_password,\n" +
-            "  test_session_properties\n" +
+            "  test_session_properties,\n" +
+            "  test_client_tags\n" +
             "FROM\n" +
             "  <table_name>\n" +
             "WHERE\n" +

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
@@ -71,7 +71,8 @@ public class VerifierTestUtil
                     ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build()),
             ImmutableList.of(),
             CONTROL,
-            Optional.empty());
+            Optional.empty(),
+            false);
 
     private static final MySqlOptions MY_SQL_OPTIONS = MySqlOptions.builder()
             .setCommandTimeout(new Duration(90, SECONDS))

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
@@ -66,7 +66,7 @@ public class TestDeterminismAnalyzer
 
     private static DeterminismAnalyzer createDeterminismAnalyzer(String mutableCatalogPattern)
     {
-        QueryConfiguration configuration = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty());
+        QueryConfiguration configuration = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty());
         VerificationContext verificationContext = VerificationContext.create(SUITE, NAME);
         VerifierConfig verifierConfig = new VerifierConfig().setTestId("test-id");
         RetryConfig retryConfig = new RetryConfig();
@@ -88,9 +88,10 @@ public class TestDeterminismAnalyzer
                 typeManager,
                 prestoAction,
                 ImmutableMap.of(CONTROL, QualifiedName.of("tmp_verifier_c"), TEST, QualifiedName.of("tmp_verifier_t")),
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                ImmutableMap.of(CONTROL, false, TEST, false));
         ChecksumValidator checksumValidator = createChecksumValidator(verifierConfig);
-        SourceQuery sourceQuery = new SourceQuery("test", "", "", "", configuration, configuration);
+        SourceQuery sourceQuery = new SourceQuery("test", "", "", "", Optional.empty(), Optional.empty(), configuration, configuration);
 
         return new DeterminismAnalyzer(
                 sourceQuery,

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -115,12 +115,14 @@ public class TestVerificationManager
     private static final String NAME = "test-query";
     private static final QualifiedName TABLE_PREFIX = QualifiedName.of("tmp_verifier");
     private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON));
-    private static final QueryConfiguration QUERY_CONFIGURATION = new QueryConfiguration("test", "di", Optional.of("user"), Optional.empty(), Optional.empty());
+    private static final QueryConfiguration QUERY_CONFIGURATION = new QueryConfiguration("test", "di", Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty());
     private static final SourceQuery SOURCE_QUERY = new SourceQuery(
             SUITE,
             NAME,
             "SELECT 1",
             "SELECT 2",
+            Optional.of("control_query_id"),
+            Optional.of("test_query_id"),
             QUERY_CONFIGURATION,
             QUERY_CONFIGURATION);
     private static final VerifierConfig VERIFIER_CONFIG = new VerifierConfig().setTestId("test");
@@ -197,7 +199,7 @@ public class TestVerificationManager
 
     private static SourceQuery createSourceQuery(String name, String controlQuery, String testQuery)
     {
-        return new SourceQuery(SUITE, name, controlQuery, testQuery, QUERY_CONFIGURATION, QUERY_CONFIGURATION);
+        return new SourceQuery(SUITE, name, controlQuery, testQuery, Optional.empty(), Optional.empty(), QUERY_CONFIGURATION, QUERY_CONFIGURATION);
     }
 
     private static void assertSkippedEvent(VerifierQueryEvent event, String name, SkippedReason skippedReason)
@@ -216,7 +218,9 @@ public class TestVerificationManager
                 new VerificationFactory(
                         SQL_PARSER,
                         (sourceQuery, verificationContext) -> new QueryActions(prestoAction, prestoAction, prestoAction),
-                        presto -> new QueryRewriter(SQL_PARSER, createTypeManager(), presto, ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX), ImmutableMap.of()),
+                        presto -> new QueryRewriter(SQL_PARSER, createTypeManager(), presto, ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX),
+                                ImmutableMap.of(),
+                                ImmutableMap.of(CONTROL, false, TEST, false)),
                         new FailureResolverManagerFactory(ImmutableSet.of(), ImmutableSet.of()),
                         createChecksumValidator(verifierConfig),
                         PrestoExceptionClassifier.defaultBuilder().build(),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestJdbcPrestoAction.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestJdbcPrestoAction.java
@@ -56,7 +56,7 @@ public class TestJdbcPrestoAction
     private static final String SUITE = "test-suite";
     private static final String NAME = "test-query";
     private static final QueryStage QUERY_STAGE = CONTROL_MAIN;
-    private static final QueryConfiguration CONFIGURATION = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty());
+    private static final QueryConfiguration CONFIGURATION = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty());
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
     private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DECIMAL).build();
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
@@ -68,6 +68,7 @@ public class TestIgnoredFunctionsMismatchResolver
                 sqlParser.createStatement(query, PARSING_OPTIONS),
                 ImmutableList.of(),
                 CONTROL,
-                Optional.empty());
+                Optional.empty(),
+                false);
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestTooManyOpenPartitionsFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestTooManyOpenPartitionsFailureResolver.java
@@ -88,7 +88,8 @@ public class TestTooManyOpenPartitionsFailureResolver
                     ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build()),
             ImmutableList.of(),
             TEST,
-            Optional.empty());
+            Optional.empty(),
+            false);
     private static final QueryException HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION = new PrestoQueryException(
             new RuntimeException(),
             false,

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriteConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriteConfig.java
@@ -30,7 +30,8 @@ public class TestQueryRewriteConfig
     {
         assertRecordedDefaults(recordDefaults(QueryRewriteConfig.class)
                 .setTablePrefix("tmp_verifier")
-                .setTableProperties(null));
+                .setTableProperties(null)
+                .setReuseTable(false));
     }
 
     @Test
@@ -39,10 +40,12 @@ public class TestQueryRewriteConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("table-prefix", "local.tmp")
                 .put("table-properties", "{\"retention\":21}")
+                .put("reuse-table", "true")
                 .build();
         QueryRewriteConfig expected = new QueryRewriteConfig()
                 .setTablePrefix("local.tmp")
-                .setTableProperties("{\"retention\":21}");
+                .setTableProperties("{\"retention\":21}")
+                .setReuseTable(true);
 
         assertFullMapping(properties, expected);
         assertEquals(expected.getTableProperties(), ImmutableMap.of("retention", 21));

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestPrestoQuerySourceQuerySupplier.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestPrestoQuerySourceQuerySupplier.java
@@ -59,25 +59,30 @@ public class TestPrestoQuerySourceQuerySupplier
             "    'schema' control_schema,\n" +
             "    'user' control_username,\n" +
             "    '{\"a\": \"b\"}' control_session_properties,\n" +
+            "    '[\"x\"]' control_client_tags,\n" +
+            "    query_id control_query_id,\n" +
             "    NULL control_password,\n" +
             "    query test_query,\n" +
             "    'catalog' test_catalog,\n" +
             "    'schema' test_schema,\n" +
             "    'user' test_username,\n" +
             "    NULL test_password,\n" +
-            "    '{\"c\": \"d\"}' test_session_properties\n" +
+            "    '{\"c\": \"d\"}' test_session_properties,\n" +
+            "    '[\"y\"]' test_client_tags,\n" +
+            "    query_id test_query_id\n" +
             "FROM (\n" +
             "    VALUES\n" +
-            "        ('Q1', 'SELECT 1'),\n" +
-            "        ('Q2', 'INSERT INTO test_table SELECT 1')\n" +
-            ") queries(name, query)";
+            "        ('Q1', 'SELECT 1', 'T1'),\n" +
+            "        ('Q2', 'INSERT INTO test_table SELECT 1', 'T2')\n" +
+            ") queries(name, query, query_id)";
     private static final QueryConfiguration CONTROL_CONFIGURATION = new QueryConfiguration(
-            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("a", "b")));
+            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("a", "b")), Optional.of(ImmutableList.of("x")));
     private static final QueryConfiguration TEST_CONFIGURATION = new QueryConfiguration(
-            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("c", "d")));
+            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("c", "d")), Optional.of(ImmutableList.of("y")));
     private static final List<SourceQuery> SOURCE_QUERIES = ImmutableList.of(
-            new SourceQuery("test", "Q1", "SELECT 1", "SELECT 1", CONTROL_CONFIGURATION, TEST_CONFIGURATION),
-            new SourceQuery("test", "Q2", "INSERT INTO test_table SELECT 1", "INSERT INTO test_table SELECT 1", CONTROL_CONFIGURATION, TEST_CONFIGURATION));
+            new SourceQuery("test", "Q1", "SELECT 1", "SELECT 1", Optional.of("T1"), Optional.of("T1"), CONTROL_CONFIGURATION, TEST_CONFIGURATION),
+            new SourceQuery("test", "Q2", "INSERT INTO test_table SELECT 1", "INSERT INTO test_table SELECT 1", Optional.of("T2"), Optional.of("T2"), CONTROL_CONFIGURATION,
+                    TEST_CONFIGURATION));
 
     private static StandaloneQueryRunner queryRunner;
     private static Injector injector;


### PR DESCRIPTION
Add support to Presto Verifier to reuse the output tables of the source query for control and test. Add configs --control-reuse-table and --test-reuse-table to turn the feature on and off. If reuse-table is turned on, skip the execution of main query as well as the setup and teardown queries. Compute checksums on the output table of main query directly.

```
== NO RELEASE NOTE ==
```

