### PR TITLE
[native] Add position delete tests with native iceberg connector

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeIcebergPositionDeleteQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeIcebergPositionDeleteQueries.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNationWithFormat;
+import static org.testng.Assert.assertEquals;
+
+public abstract class AbstractTestNativeIcebergPositionDeleteQueries
+        extends AbstractTestQueryFramework
+{
+    private final String storageFormat = "PARQUET";
+
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+
+        createNationWithFormat(queryRunner, storageFormat);
+    }
+
+    @Test
+    public void testIcebergReadPositionDeletesOnNonPartitionedTable()
+    {
+        QueryRunner javaIcebergQueryRunner = (QueryRunner) getExpectedQueryRunner();
+
+        try {
+            javaIcebergQueryRunner.execute("CREATE TABLE iceberg_native_position_delete_test AS SELECT * FROM nation");
+
+            // ASSERT number of rows in the table before delete is executed
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test", 25);
+
+            // Verify that a row with nationkey = 10 exists in the table
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test where nationkey = 10", 1);
+
+            // DELETE a ROW and create a position delete file
+            javaIcebergQueryRunner.execute("DELETE FROM iceberg_native_position_delete_test where nationkey = 10");
+
+            // ASSERT number of rows in the table after delete is executed
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test", 24);
+
+            // Verify that the row with nationkey = 10 does not exist after the delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test where nationkey = 10", 0);
+
+            // Verify that a row with nationkey = 20 exists in the table
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test where nationkey = 20", 1);
+
+            // DELETE another ROW to create a second delete file
+            javaIcebergQueryRunner.execute("DELETE FROM iceberg_native_position_delete_test where nationkey = 20");
+
+            // ASSERT number of rows in the table after second delete operation
+            // This also tests iceberg read with Multiple Delete Files
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test", 23);
+
+            // Verify that a row with nationkey = 20 does not exist after the delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test where nationkey = 20", 0);
+
+            // Verify that a row with nationkey = 100 does not exist in the table
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test where nationkey = 100", 0);
+
+            // DELETE a row which does not exist
+            javaIcebergQueryRunner.execute("DELETE FROM iceberg_native_position_delete_test where nationkey = 100");
+
+            // ASSERT number of rows in the table after third delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test", 23);
+
+            // DELETE all rows in the table
+            javaIcebergQueryRunner.execute("DELETE FROM iceberg_native_position_delete_test where nationkey >= 0");
+
+            // ASSERT number of rows in the table after fourth delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test", 0);
+
+            // INSERT few NULL column values
+            javaIcebergQueryRunner.execute("INSERT INTO iceberg_native_position_delete_test" +
+                    " VALUES" +
+                    "(NULL, 'INDIA', 1, 'NULL Value Row')," +
+                    "(NULL, 'USA', 2, 'NULL Value Row')," +
+                    "(NULL, 'UK', 3, 'NULL Value Row')," +
+                    "(25, 'AUSTRALIA', 1, 'Non-NULL Value Row')");
+
+            // ASSERT number of rows in the table
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test", 4);
+
+            // DELETE a row with non-null value in a table with NULL values
+            javaIcebergQueryRunner.execute("DELETE FROM iceberg_native_position_delete_test where nationkey = 25");
+
+            // ASSERT number of rows in the table after delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test", 3);
+
+            // DELETE all rows with nationkey = NULL in the table
+            javaIcebergQueryRunner.execute("DELETE FROM iceberg_native_position_delete_test where nationkey is NULL");
+
+            // ASSERT number of rows in the table after delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_native_position_delete_test", 0);
+        }
+        finally {
+            javaIcebergQueryRunner.execute("DROP TABLE IF EXISTS iceberg_native_position_delete_test");
+        }
+    }
+
+    @Test
+    public void testIcebergReadPositionDeletesOnPartitionedTable()
+    {
+        QueryRunner javaIcebergQueryRunner = (QueryRunner) getExpectedQueryRunner();
+
+        try {
+            // CREATE A PARTITIONED ICEBERG v2 TABLE
+            javaIcebergQueryRunner.execute(
+                    "CREATE TABLE iceberg_partitioned_native_position_delete_test(" +
+                            "nationkey BIGINT, " +
+                            "name VARCHAR, " +
+                            "comment VARCHAR, " +
+                            "regionkey VARCHAR)" +
+                            " WITH (partitioning = ARRAY['regionkey'])");
+            javaIcebergQueryRunner.execute(
+                    "INSERT INTO iceberg_partitioned_native_position_delete_test " +
+                            "SELECT " +
+                            "nationkey, " +
+                            "name, " +
+                            "comment, " +
+                            "cast(regionkey as VARCHAR) " +
+                            "FROM nation");
+
+            // ASSERT number of rows in the table before delete is executed
+            assertQueryResultCount("SELECT * FROM iceberg_partitioned_native_position_delete_test", 25);
+
+            // Verify that a row with nationkey = 10 exists in the table
+            assertQueryResultCount("SELECT * FROM iceberg_partitioned_native_position_delete_test where nationkey = 10", 1);
+
+            // DELETE on a non-partition column
+            javaIcebergQueryRunner.execute("DELETE FROM iceberg_partitioned_native_position_delete_test where nationkey = 10");
+
+            // ASSERT number of rows in the table after delete is executed
+            assertQueryResultCount("SELECT * FROM iceberg_partitioned_native_position_delete_test", 24);
+
+            // Verify that the row with nationkey = 10 does not exist after the delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_partitioned_native_position_delete_test where nationkey = 10", 0);
+
+            // Verify the count of rows with regionkey = 0 before a delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_partitioned_native_position_delete_test where regionkey = '0'", 5);
+
+            // DELETE on a partition column
+            javaIcebergQueryRunner.execute("DELETE FROM iceberg_partitioned_native_position_delete_test where regionkey = '0'");
+
+            // ASSERT number of rows in the table after delete is executed
+            assertQueryResultCount("SELECT * FROM iceberg_partitioned_native_position_delete_test", 19);
+
+            // Verify the count of rows with regionkey = 0 after the delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_partitioned_native_position_delete_test where regionkey = '0'", 0);
+
+            // INSERT a new row with partition column value as NULL
+            javaIcebergQueryRunner.execute("INSERT INTO iceberg_partitioned_native_position_delete_test" +
+                    " VALUES" +
+                    "(25, 'INDIA', 'NULL Value Row', NULL)," +
+                    "(26, 'USA', 'NULL Value Row', NULL)," +
+                    "(27, 'UK', 'NULL Value Row', NULL)," +
+                    "(28, 'AUSTRALIA', 'Non-NULL Value Row', '5')");
+
+            // ASSERT number of rows in the table
+            assertQueryResultCount("SELECT * FROM iceberg_partitioned_native_position_delete_test", 23);
+
+            // DELETE on a partition column with NULL value
+            javaIcebergQueryRunner.execute("DELETE FROM iceberg_partitioned_native_position_delete_test where regionkey is NULL");
+
+            // ASSERT number of rows in the table after the delete operation
+            assertQueryResultCount("SELECT * FROM iceberg_partitioned_native_position_delete_test", 20);
+        }
+        finally {
+            javaIcebergQueryRunner.execute("DROP TABLE IF EXISTS iceberg_partitioned_native_position_delete_test");
+        }
+    }
+
+    private void assertQueryResultCount(String sql, int expectedResultCount)
+    {
+        assertEquals(getQueryRunner().execute(sql).getRowCount(), expectedResultCount);
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -32,6 +32,12 @@ public class NativeQueryRunnerUtils
                 "hive.orc-compression-codec", "ZSTD");
     }
 
+    public static Map<String, String> getNativeWorkerIcebergProperties()
+    {
+        return ImmutableMap.of("iceberg.pushdown-filter-enabled", "true",
+                "iceberg.catalog.type", "HIVE");
+    }
+
     public static Map<String, String> getNativeWorkerSystemProperties()
     {
         return ImmutableMap.<String, String>builder()

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -36,9 +36,9 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 
 import static com.facebook.presto.hive.HiveTestUtils.getProperty;
-import static com.facebook.presto.iceberg.FileFormat.PARQUET;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.getNativeWorkerHiveProperties;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.getNativeWorkerIcebergProperties;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.getNativeWorkerSystemProperties;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -163,9 +163,7 @@ public class PrestoNativeQueryRunnerUtils
             throws Exception
     {
         ImmutableMap.Builder<String, String> icebergPropertiesBuilder = new ImmutableMap.Builder<>();
-        icebergPropertiesBuilder
-                .put("hive.pushdown-filter-enabled", "true")
-                .put("hive.parquet.writer.version", "PARQUET_1_0");
+        icebergPropertiesBuilder.put("hive.parquet.writer.version", "PARQUET_1_0");
 
         Optional<Path> dataDirectory = addStorageFormatToPath ? baseDataDirectory.map(path -> Paths.get(path.toString() + '/' + storageFormat)) : baseDataDirectory;
 
@@ -226,7 +224,7 @@ public class PrestoNativeQueryRunnerUtils
             throws Exception
     {
         ImmutableMap<String, String> icebergProperties = ImmutableMap.<String, String>builder()
-                .putAll(getNativeWorkerHiveProperties(storageFormat))
+                .putAll(getNativeWorkerIcebergProperties())
                 .build();
 
         // Make query runner with external workers for tests
@@ -238,7 +236,7 @@ public class PrestoNativeQueryRunnerUtils
                         .putAll(getNativeWorkerSystemProperties())
                         .build(),
                 icebergProperties,
-                PARQUET,
+                FileFormat.valueOf(storageFormat),
                 false,
                 false,
                 OptionalInt.of(workerCount.orElse(4)),

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergPositionDeleteQueriesUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergPositionDeleteQueriesUsingThrift.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner;
+
+public class TestPrestoNativeIcebergPositionDeleteQueriesUsingThrift
+        extends AbstractTestNativeIcebergPositionDeleteQueries
+{
+    private final String storageFormat = "PARQUET";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createNativeIcebergQueryRunner(true, storageFormat);
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return createJavaIcebergQueryRunner(storageFormat);
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add tests for native iceberg connector for reading iceberg V2 tables with position deletes

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
https://github.com/prestodb/presto/issues/22097

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

