### PR TITLE
Add Void Type ProfileNano Helper Function 

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
@@ -137,4 +137,11 @@ public class RuntimeStats
         addMetricValueIgnoreZero(tag, NANO, System.nanoTime() - startTime);
         return result;
     }
+
+    public void profileNanosVoid(String tag, Runnable runnable)
+    {
+        long startTime = System.nanoTime();
+        runnable.run();
+        addMetricValueIgnoreZero(tag, NANO, System.nanoTime() - startTime);
+    }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/TestRuntimeStats.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestRuntimeStats.java
@@ -29,7 +29,9 @@ public class TestRuntimeStats
     private static final String TEST_METRIC_NAME_3 = "test3";
     private static final String TEST_METRIC_NAME_NANO_1 = "test_nano_1";
     private static final String TEST_METRIC_NAME_NANO_2 = "test_nano_2";
+    private static final String TEST_METRIC_NAME_NANO_3 = "test_nano_3";
     private static final String TEST_METRIC_NAME_BYTE = "test_byte";
+    private static final long ONE_SECOND_IN_NANOS = 1_000_000_000L;
 
     private void assertRuntimeMetricEquals(RuntimeMetric m1, RuntimeMetric m2)
     {
@@ -233,5 +235,24 @@ public class TestRuntimeStats
     {
         RuntimeStats stats = new RuntimeStats();
         stats.getMetrics().put(TEST_METRIC_NAME_1, new RuntimeMetric(TEST_METRIC_NAME_1, NONE));
+    }
+
+    @Test
+    public void testProfileNano()
+    {
+        RuntimeStats stats = new RuntimeStats();
+        int status = stats.profileNanos(TEST_METRIC_NAME_NANO_3, () -> 1);
+
+        assert stats.getMetric(TEST_METRIC_NAME_NANO_3).getSum() < ONE_SECOND_IN_NANOS;
+        assertEquals(status, 1);
+    }
+
+    @Test
+    public void testProfileNanoVoid()
+    {
+        RuntimeStats stats = new RuntimeStats();
+        stats.profileNanosVoid(TEST_METRIC_NAME_NANO_3, () -> {});
+
+        assert stats.getMetric(TEST_METRIC_NAME_NANO_3).getSum() < ONE_SECOND_IN_NANOS;
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add Void Type profileNanos helper function to record `Runtime stats` metric

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
While adding additional metrics with no return type, we can't use existing helper function `RuntimeStats.profileNanos`. We need to have a new helper function that deals with void return.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

N/A

## Test Plan
<!---Please fill in how you tested your change-->

Unit test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

