### PR TITLE
[native] Only detach worker when more than 1/2 of driver threads blocked.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -134,7 +134,7 @@ class PeriodicTaskManager {
 
   void addWatchdogTask();
 
-  void detachWorker();
+  void detachWorker(const char* reason);
   void maybeAttachWorker();
 
   folly::CPUThreadPoolExecutor* const driverCPUExecutor_;
@@ -172,6 +172,7 @@ class PeriodicTaskManager {
   // NOTE: declare last since the threads access other members of `this`.
   folly::FunctionScheduler oneTimeRunner_;
   folly::ThreadedRepeatingFunctionRunner repeatedRunner_;
+  size_t numDriverThreads_{0};
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -763,6 +763,13 @@ void PrestoServer::stop() {
   }
 }
 
+size_t PrestoServer::numDriverThreads() const {
+  VELOX_CHECK(
+      driverExecutor_ != nullptr,
+      "Driver executor is expected to be not null, but it is null!");
+  return driverExecutor_->numThreads();
+}
+
 void PrestoServer::detachWorker() {
   auto readLockedShuttingDown = shuttingDown_.rlock();
   if (!*readLockedShuttingDown && nodeState() == NodeState::kActive) {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -89,6 +89,9 @@ class PrestoServer {
     return coordinatorDiscoverer_ != nullptr;
   }
 
+  /// Returns the number of threads in the Driver executor.
+  size_t numDriverThreads() const;
+
   /// Returns true if the server got terminate signal and in the 'shutting down'
   /// mode. False otherwise.
   bool isShuttingDown() const {


### PR DESCRIPTION
## Description
We were detaching workers when only one stuck operator detected. This makes it possible for one bad query to disable the cluster. This change makes the detachment happen only in more dramatic situation than just one bad query.

```
== NO RELEASE NOTE ==
```

