### PR TITLE
[WIP] Use source file location to resolve test resources

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
@@ -14,8 +14,6 @@
 #include "presto_cpp/main/http/filters/InternalAuthenticationFilter.h"
 #include "presto_cpp/main/http/tests/HttpTestBase.h"
 
-namespace fs = boost::filesystem;
-
 using namespace facebook::presto;
 using namespace facebook::velox;
 using namespace facebook::velox::memory;

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTestBase.h
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTestBase.h
@@ -11,19 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
 #include <velox/common/base/VeloxException.h>
 #include <velox/common/base/tests/GTestUtils.h>
 #include <velox/common/memory/Memory.h>
+#include <filesystem>
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/http/HttpClient.h"
 #include "presto_cpp/main/http/HttpServer.h"
 #include "velox/common/base/StatsReporter.h"
-
-namespace fs = boost::filesystem;
 
 using namespace facebook::presto;
 using namespace facebook::velox;
@@ -32,28 +29,8 @@ using namespace facebook::velox::memory;
 namespace {
 
 std::string getCertsPath(const std::string& fileName) {
-  std::string currentPath = fs::current_path().c_str();
-  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
-    return currentPath +
-        "/github/presto-trunk/presto-native-execution/presto_cpp/main/http/tests/certs/" +
-        fileName;
-  }
-
-  // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
-  // directory. Hard-coded json files are not copied there and test fails with
-  // file not found. Fixing the path so that we can trigger these tests from
-  // CLion.
-  boost::algorithm::replace_all(currentPath, "cmake-build-release/", "");
-  boost::algorithm::replace_all(currentPath, "cmake-build-debug/", "");
-
-  // As with building/testing using CLion when using a manual build and
-  // running the test from the build path the certs are not found and
-  // their path must be updated.
-  // The path is used by CMake.
-  boost::algorithm::replace_all(currentPath, "_build/debug/", "");
-  boost::algorithm::replace_all(currentPath, "_build/release/", "");
-
-  return currentPath + "/certs/" + fileName;
+  using namespace std::filesystem;
+  return absolute(path{__FILE__}).parent_path() / "certs" / fileName;
 }
 
 class HttpServerWrapper {

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -12,35 +12,20 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/Announcer.h"
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
+#include <filesystem>
 #include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 
-namespace fs = boost::filesystem;
 using namespace facebook::presto;
 
 namespace {
 
 std::string getCertsPath(const std::string& fileName) {
-  std::string currentPath = fs::current_path().c_str();
-  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
-    return currentPath +
-        "/github/presto-trunk/presto-native-execution/presto_cpp/main/tests/certs/" +
-        fileName;
-  }
-
-  // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
-  // directory. Hard-coded json files are not copied there and test fails with
-  // file not found. Fixing the path so that we can trigger these tests from
-  // CLion.
-  boost::algorithm::replace_all(currentPath, "cmake-build-release/", "");
-  boost::algorithm::replace_all(currentPath, "cmake-build-debug/", "");
-
-  return currentPath + "/certs/" + fileName;
+  using namespace std::filesystem;
+  return absolute(path{__FILE__}).parent_path() / "certs" / fileName;
 }
 
 template <typename T>

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -14,9 +14,8 @@
 #include <folly/init/Init.h>
 #include <folly/portability/GMock.h>
 #include <gtest/gtest.h>
+#include <filesystem>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
@@ -31,7 +30,6 @@
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 
-namespace fs = boost::filesystem;
 using namespace facebook::presto;
 
 using namespace facebook::presto;
@@ -49,21 +47,8 @@ int main(int argc, char** argv) {
 
 namespace {
 std::string getCertsPath(const std::string& fileName) {
-  std::string currentPath = fs::current_path().c_str();
-  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
-    return currentPath +
-        "/github/presto-trunk/presto-native-execution/presto_cpp/main/tests/certs/" +
-        fileName;
-  }
-
-  // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
-  // directory. Hard-coded json files are not copied there and test fails with
-  // file not found. Fixing the path so that we can trigger these tests from
-  // CLion.
-  boost::algorithm::replace_all(currentPath, "cmake-build-release/", "");
-  boost::algorithm::replace_all(currentPath, "cmake-build-debug/", "");
-
-  return currentPath + "/certs/" + fileName;
+  using namespace std::filesystem;
+  return absolute(path{__FILE__}).parent_path() / "certs" / fileName;
 }
 
 class Producer {

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -11,10 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/replace.hpp>
-#include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
+#include <filesystem>
 
 #include "presto_cpp/main/common/tests/test_json.h"
 #include "presto_cpp/main/operators/LocalPersistentShuffle.h"
@@ -26,34 +24,13 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
-namespace fs = boost::filesystem;
-
 using namespace facebook::presto;
 using namespace facebook::velox;
 
 namespace {
 std::string getDataPath(const std::string& fileName) {
-  std::string currentPath = fs::current_path().c_str();
-
-  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
-    return currentPath +
-        "/github/presto-trunk/presto-native-execution/presto_cpp/main/types/tests/data/" +
-        fileName;
-  }
-
-  if (boost::algorithm::ends_with(currentPath, "fbsource")) {
-    return currentPath + "/third-party/presto_cpp/main/types/tests/data/" +
-        fileName;
-  }
-
-  // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
-  // directory. Hard-coded json files are not copied there and test fails with
-  // file not found. Fixing the path so that we can trigger these tests from
-  // CLion.
-  boost::algorithm::replace_all(currentPath, "cmake-build-release/", "");
-  boost::algorithm::replace_all(currentPath, "cmake-build-debug/", "");
-
-  return currentPath + "/data/" + fileName;
+  using namespace std::filesystem;
+  return absolute(path{__FILE__}).parent_path() / "data" / fileName;
 }
 
 std::shared_ptr<const core::PlanNode> assertToVeloxQueryPlan(

--- a/presto-native-execution/presto_cpp/main/types/tests/ValuesPipeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/ValuesPipeTest.cpp
@@ -13,8 +13,7 @@
  */
 #include <gtest/gtest.h>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <ios>
 
 #include "presto_cpp/main/common/tests/test_json.h"
@@ -23,32 +22,13 @@
 #include "velox/type/Type.h"
 #include "velox/vector/FlatVector.h"
 
-namespace fs = boost::filesystem;
-
 using namespace facebook::presto;
 using namespace facebook::velox;
 
 namespace {
 std::string getDataPath(const std::string& fileName) {
-  std::string currentPath = fs::current_path().c_str();
-  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
-    return currentPath +
-        "/github/presto-trunk/presto-native-execution/presto_cpp/main/types/tests/data/" +
-        fileName;
-  }
-  if (boost::algorithm::ends_with(currentPath, "fbsource")) {
-    return currentPath + "/third-party/presto_cpp/main/types/tests/data/" +
-        fileName;
-  }
-
-  // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
-  // directory. Hard-coded json files are not copied there and test fails with
-  // file not found. Fixing the path so that we can trigger these tests from
-  // CLion.
-  boost::algorithm::replace_all(currentPath, "cmake-build-release/", "");
-  boost::algorithm::replace_all(currentPath, "cmake-build-debug/", "");
-
-  return currentPath + "/data/" + fileName;
+  using namespace std::filesystem;
+  return absolute(path{__FILE__}).parent_path() / "data" / fileName;
 }
 } // namespace
 

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/PlanFragmentTest.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/PlanFragmentTest.cpp
@@ -11,34 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
+#include <filesystem>
 
 #include "presto_cpp/main/common/tests/test_json.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
-
-namespace fs = boost::filesystem;
 
 using namespace facebook::presto;
 
 namespace {
 std::string getDataPath(const std::string& fileName) {
-  std::string currentPath = fs::current_path().c_str();
-  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
-    return currentPath +
-        "/github/presto-trunk/presto-native-execution/presto_cpp/presto_protocol/tests/data/" +
-        fileName;
-  }
-
-  // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
-  // directory. Hard-coded json files are not copied there and test fails with
-  // file not found. Fixing the path so that we can trigger these tests from
-  // CLion.
-  boost::algorithm::replace_all(currentPath, "cmake-build-release/", "");
-  boost::algorithm::replace_all(currentPath, "cmake-build-debug/", "");
-
-  return currentPath + "/data/" + fileName;
+  using namespace std::filesystem;
+  return absolute(path{__FILE__}).parent_path() / "data" / fileName;
 }
 
 template <typename T>


### PR DESCRIPTION
## Description

Resolve test resources based on the source file location

## Motivation and Context

The logic in `get*Path` is quite convoluted and leaky. But essentially what is going on there is trying to figure out the source code location to read static files stored as part of the source tree.

The `__FILE__` macro provides source file location that can be used to resolve static resources

## Test Plan

CI

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

