### PR TITLE
[codemod] Deshim //folly:dynamic to //folly/json:dynamic in github

### DIFF
--- a/presto-native-execution/presto_cpp/main/JsonSignatureParser.cpp
+++ b/presto-native-execution/presto_cpp/main/JsonSignatureParser.cpp
@@ -13,7 +13,7 @@
  */
 
 #include "presto_cpp/main/JsonSignatureParser.h"
-#include <folly/json.h>
+#include <folly/json/json.h>
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::presto {


### PR DESCRIPTION
Summary:
The following headers were shimmed in //folly:dynamic and were modded:
  - folly/DynamicConverter.h -> folly/json/DynamicConverter.h
  - folly/dynamic.h -> folly/json/dynamic.h
  - folly/dynamic-inl.h -> folly/json/dynamic-inl.h
  - folly/json.h -> folly/json/json.h

`arc lint` was applied

Reviewed By: bcardosolopes

Differential Revision: D53837101


