### PR TITLE
Support CTE nodes in SimplifyPlanWithEmptyInput optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/CTEInformationCollector.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/CTEInformationCollector.java
@@ -44,4 +44,11 @@ public class CTEInformationCollector
     {
         return cteInformationMap;
     }
+
+    public void disallowCteMaterialization(String cteId)
+    {
+        CTEInformation cteInfo = cteInformationMap.get(cteId);
+        cteInformationMap.put(cteId,
+                new CTEInformation(cteInfo.getCteName(), cteInfo.getCteId(), cteInfo.getNumberOfReferences(), cteInfo.getIsView(), false));
+    }
 }


### PR DESCRIPTION
## Description
Adding support to cte nodes in SimplifyPlanWithEmptyInput optimizers.
This makes sure that we are trimming producers and consumers as well the sequence node

## Motivation and Context
Found a few queries in production that worsened by a lot. On investigating it was this optimizer that was trimming to values

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

