### PR TITLE
Improve Independent cte scheduling

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -532,7 +532,7 @@ public class PruneUnreferencedOutputs
                     .map(leftSource -> context.rewrite(leftSource, leftInputs)).collect(toImmutableList());
             Set<VariableReferenceExpression> rightInputs = ImmutableSet.copyOf(node.getPrimarySource().getOutputVariables());
             PlanNode primarySource = context.rewrite(node.getPrimarySource(), rightInputs);
-            return new SequenceNode(node.getSourceLocation(), node.getId(), cteProducers, primarySource);
+            return new SequenceNode(node.getSourceLocation(), node.getId(), cteProducers, primarySource, node.getMarkerSet());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -188,7 +188,7 @@ public class UnaliasSymbolReferences
                             SimplePlanRewriter.rewriteWith(new Rewriter(types, functionAndTypeManager, warningCollector), c))
                     .collect(Collectors.toList());
             PlanNode primarySource = context.rewrite(node.getPrimarySource());
-            return new SequenceNode(node.getSourceLocation(), node.getId(), cteProducers, primarySource);
+            return new SequenceNode(node.getSourceLocation(), node.getId(), cteProducers, primarySource, node.getMarkerSet());
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -531,7 +531,8 @@ public class TestCostCalculator
                 Optional.empty(),
                 new PlanNodeId("sequence"),
                 ImmutableList.of(cteProducerNode1, cteProducerNode2),
-                joinNode);
+                joinNode,
+                ImmutableSet.of());
 
         // Define cost of sequence children
         Map<String, PlanCostEstimate> costs = ImmutableMap.of(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLogicalCteOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLogicalCteOptimizer.java
@@ -117,11 +117,11 @@ public class TestLogicalCteOptimizer
                         "SELECT cte3.*, cte2.orderkey FROM cte3 JOIN cte2 ON cte3.custkey = cte2.orderkey",
                 anyTree(
                         sequence(
-                                cteProducer(addQueryScopeDelimiter("cte3", 0), anyTree(tableScan("customer"))),
                                 cteProducer(addQueryScopeDelimiter("cte2", 4), anyTree(cteConsumer(addQueryScopeDelimiter("cte3", 3)))),
                                 cteProducer(addQueryScopeDelimiter("cte3", 3), anyTree(cteConsumer(addQueryScopeDelimiter("cte4", 2)))),
                                 cteProducer(addQueryScopeDelimiter("cte4", 2), anyTree(cteConsumer(addQueryScopeDelimiter("cte1", 1)))),
                                 cteProducer(addQueryScopeDelimiter("cte1", 1), anyTree(tableScan("orders"))),
+                                cteProducer(addQueryScopeDelimiter("cte3", 0), anyTree(tableScan("customer"))),
                                 anyTree(
                                         join(
                                                 anyTree(cteConsumer(addQueryScopeDelimiter("cte3", 0))),
@@ -196,9 +196,9 @@ public class TestLogicalCteOptimizer
                         "SELECT * FROM cte2  JOIN cte1 ON true",
                 anyTree(
                         sequence(
-                                cteProducer(addQueryScopeDelimiter("cte2", 0), anyTree(tableScan("customer"))),
                                 cteProducer(addQueryScopeDelimiter("cte1", 2), anyTree(cteConsumer(addQueryScopeDelimiter("cte2", 1)))),
                                 cteProducer(addQueryScopeDelimiter("cte2", 1), anyTree(tableScan("orders"))),
+                                cteProducer(addQueryScopeDelimiter("cte2", 0), anyTree(tableScan("customer"))),
                                 anyTree(join(anyTree(cteConsumer(addQueryScopeDelimiter("cte2", 0))), anyTree(cteConsumer(addQueryScopeDelimiter("cte1", 2))))))));
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteConsumerNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteConsumerNode.java
@@ -104,7 +104,7 @@ public final class CteConsumerNode
         return cteId;
     }
 
-    private static void checkArgument(boolean condition, String message)
+    public static void checkArgument(boolean condition, String message)
     {
         if (!condition) {
             throw new IllegalArgumentException(message);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/SequenceNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/SequenceNode.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.spi.plan.CteConsumerNode.checkArgument;
 
 public class SequenceNode
         extends PlanNode
@@ -29,24 +32,36 @@ public class SequenceNode
     private final List<PlanNode> cteProducers;
     private final PlanNode primarySource;
 
+    // Marks index of the cte producer where a dependent subgraph ends
+    private final Set<Integer> markerSet;
+
     @JsonCreator
     public SequenceNode(Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId planNodeId,
-            @JsonProperty("cteProducers") List<PlanNode> left,
-            @JsonProperty("primarySource") PlanNode primarySource)
+            @JsonProperty("cteProducers") List<PlanNode> cteProducers,
+            @JsonProperty("primarySource") PlanNode primarySource,
+            @JsonProperty("markerSet") Set<Integer> markerSet)
     {
-        this(sourceLocation, planNodeId, Optional.empty(), left, primarySource);
+        this(sourceLocation, planNodeId, Optional.empty(), cteProducers, primarySource, markerSet);
     }
 
     public SequenceNode(Optional<SourceLocation> sourceLocation,
             PlanNodeId planNodeId,
             Optional<PlanNode> statsEquivalentPlanNode,
-            List<PlanNode> leftList,
-            PlanNode primarySource)
+            List<PlanNode> cteProducers,
+            PlanNode primarySource,
+            Set<Integer> markerSet)
     {
         super(sourceLocation, planNodeId, statsEquivalentPlanNode);
-        this.cteProducers = leftList;
+        this.cteProducers = cteProducers;
         this.primarySource = primarySource;
+        this.markerSet = markerSet;
+    }
+
+    @JsonProperty
+    public Set<Integer> getMarkerSet()
+    {
+        return markerSet;
     }
 
     @JsonProperty
@@ -78,19 +93,41 @@ public class SequenceNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
+        checkArgument(newChildren.size() == cteProducers.size() + 1, "expected newChildren to contain same number of nodes as current." +
+                " If the child count decreased please update the markers");
         return new SequenceNode(newChildren.get(0).getSourceLocation(), getId(), getStatsEquivalentPlanNode(),
-                newChildren.subList(0, newChildren.size() - 1), newChildren.get(newChildren.size() - 1));
+                newChildren.subList(0, newChildren.size() - 1), newChildren.get(newChildren.size() - 1), markerSet);
     }
 
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new SequenceNode(getSourceLocation(), getId(), statsEquivalentPlanNode, cteProducers, this.getPrimarySource());
+        return new SequenceNode(getSourceLocation(), getId(), statsEquivalentPlanNode, cteProducers, this.getPrimarySource(), markerSet);
     }
 
     @Override
     public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
         return visitor.visitSequence(this, context);
+    }
+
+    public List<List<PlanNode>> getIndependentCteProducers()
+    {
+        List<List<PlanNode>> independentCteProducerList = new ArrayList<>();
+        List<PlanNode> currentCteProducerSubgraph = new ArrayList<>();
+        for (int i = 0; i < cteProducers.size(); i++) {
+            currentCteProducerSubgraph.add(cteProducers.get(i));
+            if (markerSet.contains(i)) {
+                // This is the end of the current subgraph
+                if (!currentCteProducerSubgraph.isEmpty()) {
+                    independentCteProducerList.add(new ArrayList<>(currentCteProducerSubgraph));
+                    currentCteProducerSubgraph.clear();
+                }
+            }
+        }
+        if (!currentCteProducerSubgraph.isEmpty()) {
+            independentCteProducerList.add(currentCteProducerSubgraph);
+        }
+        return independentCteProducerList;
     }
 }


### PR DESCRIPTION
## Description
Fixes #21639.
This will decrease query latency when > 1 ctes are materialized

Added markers in SequenceNode to help identify dependent subgraphs which the BasePlanFragment uses to parallelize scheduling.
Adding markers is the simplest approach because all visitors expect sequenceNode to return a consistent List<CteProducers> each time they visit



## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improved CTE materialized query latency when > 1 cte was materialized

