### PR TITLE
Fix aggregation metadata optimization when existing Limit/TopN

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -34,13 +34,11 @@ import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.FilterNode;
-import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TableScanNode;
-import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -384,8 +382,6 @@ public class MetadataQueryOptimizer
                 // allow any chain of linear transformations
                 if (source instanceof MarkDistinctNode ||
                         source instanceof FilterNode ||
-                        source instanceof LimitNode ||
-                        source instanceof TopNNode ||
                         source instanceof SortNode) {
                     source = source.getSources().get(0);
                 }


### PR DESCRIPTION
## Description

When LimitNode/TopNNode exists below the aggregation node, we should not do metadata optimization for the aggregation. As `LimitNode` and `TopNNode` are cardinality-sensitive, so they may lead in some problems. For example, on a hive table:

```
CREATE TABLE test_metadata_query_optimization_with_limit(a varchar, b int, c int) WITH (partitioned_by = ARRAY['b', 'c']);
INSERT INTO test_metadata_query_optimization_with_limit VALUES('1001', 1, 1), ('1002', 1, 1), ('1003', 1, 1), ('1004', 1, 2), ('1005', 1, 2), ('1006', 1, 2), ('1007', 2, 1), ('1008', 2, 1), ('1009', 2, 1);
```

It would not lead in wrong result when do metadata optimization in the following statement, as limit node exists above aggregation in the plan:

```
select distinct b, c from test_metadata_query_optimization_with_limit order by c desc limit 3;
 b | c 
---+---
 1 | 2 
 1 | 1 
 2 | 1 
(3 rows)
```

But when we try to do metadata optimization in the following statement:

```
with tt as (select b, c from test_metadata_query_optimization_with_limit order by c desc limit 3) select b, min(c), max(c) from tt group by b;
```

We would get a wrong result as follows, this is because the limit node exists below aggregation in the plan:

```
 b | min(c) | max(c) 
---+-------+-------
 1 |     1 |     2
 2 |     1 |     1
```

However, the correct result should be:

```
 b | min(c) | max(c) 
---+-------+-------
 1 |     2 |     2 
```

The PR fix this problem.

## Test Plan

 - Newly added tests for the cases described above

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
