### PR TITLE
Optimize map_normalize

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapNormalizeFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapNormalizeFunction.java
@@ -28,6 +28,8 @@ public class MapNormalizeFunction
     @SqlType("map<varchar, double>")
     public static String arraySumDouble()
     {
-        return "RETURN transform_values(input, (k, v) -> (v / reduce(map_values(input), double '0.0', (s, x) -> (s + coalesce(x, double '0.0')), (s) -> s)))";
+        return "RETURN " +
+                "transform(array[ROW(input, cast(array_sum(map_values(input)) as double))], " +
+                "x->transform_values(x[1], (k, v) -> (v / x[2])))[1]";
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapNormalize.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapNormalize.java
@@ -42,6 +42,14 @@ public class TestMapNormalize
                 "map_normalize(map(array['w', 'x', 'y', 'z'], array[1, 2, -3, -4]))",
                 mapType(VARCHAR, DOUBLE),
                 ImmutableMap.of("w", -0.25, "x", -0.5, "y", 0.75, "z", 1.0));
+        assertFunction(
+                "map_normalize(map(array['1', '2'], array[1, -1]))",
+                mapType(VARCHAR, DOUBLE),
+                ImmutableMap.of("1", Double.POSITIVE_INFINITY, "2", Double.NEGATIVE_INFINITY));
+        assertFunction(
+                "map_normalize(map(array['1', '2'], array[0, 0]))",
+                mapType(VARCHAR, DOUBLE),
+                ImmutableMap.of("1", Double.NaN, "2", Double.NaN));
 
         Map<String, Double> expectedWithNull = new HashMap<>();
         expectedWithNull.put("w", 1.0 / 7);
@@ -56,5 +64,10 @@ public class TestMapNormalize
 
         assertFunction("map_normalize(map(array[], array[]))", mapType(VARCHAR, DOUBLE), ImmutableMap.of());
         assertFunction("map_normalize(null)", mapType(VARCHAR, DOUBLE), null);
+
+        Map<String, Double> expectedNullAndNan = new HashMap<>();
+        expectedNullAndNan.put("1", null);
+        expectedNullAndNan.put("2", Double.NaN);
+        assertFunction("map_normalize(map(array['1', '2'], array[null, 0]))", mapType(VARCHAR, DOUBLE), expectedNullAndNan);
     }
 }


### PR DESCRIPTION
## Description
Optimize MapNormalize function to not call reduce for every element.

## Motivation and Context
This function is a sql function and it calls (nested) reduce on the values array for every element which we don't optimize via cse currently (for nested lambdas) #22214. So we pull out the reduce to do it only once for performance.

## Impact
Improved UDF performance

## Test Plan
Tests exist and also added a couple for NaN/Infinity/null results

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Optimized `map_normalize` builtin SQL UDF to avoid repeated reduce computation
```
