### PR TITLE
Improve query runner startup performance

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -36,6 +36,7 @@ import com.facebook.presto.tpcds.TpcdsPlugin;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.tpch.TextPool;
 import io.airlift.tpch.TpchTable;
 
 import java.io.File;
@@ -44,6 +45,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 
 import static com.facebook.airlift.log.Level.ERROR;
@@ -150,6 +152,10 @@ public final class IcebergQueryRunner
                 .setSchema("tpch")
                 .build();
 
+        // Amortize the cost of initializing the TPC-H text pool while the cluster is starting
+        if (createTpchTables) {
+            CompletableFuture.runAsync(TextPool::getDefaultTestPool);
+        }
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
                 .setExtraProperties(extraProperties)
                 .setDataDirectory(dataDirectory)


### PR DESCRIPTION
## Description

1. Parallelize launch of workers/coordinators
2. Parallelize copy of TPCH/DS tables
3. async initialize the TPC-H text pool

## Motivation and Context

Less wall time during CI

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

