### PR TITLE
[native] Update centos Dockerfile to use new setup script from velox

### DIFF
--- a/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
+++ b/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
@@ -70,8 +70,7 @@ RUN --mount=type=ssh \
 WORKDIR ${DEPENDENCY_DIR}
 RUN --mount=type=ssh \
     set -exu && \
-    sed -i 's/\(.*folly.*\)/# \1/g' "${PRESTODB_HOME}/_repo/presto-native-execution/velox/scripts/setup-circleci.sh" && \
-    bash "${PRESTODB_HOME}/_repo/presto-native-execution/velox/scripts/setup-circleci.sh" && \
+    bash "${PRESTODB_HOME}/_repo/presto-native-execution/velox/scripts/setup-centos8.sh" && \
     bash "${PRESTODB_HOME}/_repo/presto-native-execution/scripts/setup-centos.sh" && \
     python3 -m pip install six && \
     set +exu && \
@@ -106,7 +105,7 @@ RUN set -exu && \
     ) && \
     ( \
       mv ${PRESTODB_HOME}/_repo/presto-native-execution/_build/release/presto_cpp/main/* ${PRESTODB_HOME}/ && \
-      mv ${PRESTODB_HOME}/_repo/presto-native-execution/_build/release/presto_cpp/presto_protocol/tests/presto_protocol_test $${PRESTODB_HOME}/ || true \
+      mv ${PRESTODB_HOME}/_repo/presto-native-execution/_build/release/presto_cpp/presto_protocol/tests/presto_protocol_test ${PRESTODB_HOME}/ || true \
     ) && \
     [ ${CLEANUP_BUILD_ARTIFACTS} -eq 0 ] || \
     rm -rf ${PRESTODB_HOME}/_repo/presto-native-execution/_repo /opt/dependency/aws-sdk-cpp /tmp/* && \


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Update centos Dockerfile to use new setup script from velox

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
The Velox repository removed the script `setup-circleci.sh` [#8454](https://github.com/facebookincubator/velox/pull/8454). They've switched to using `setup-centos8.sh` in their CI Dockerfiles. This pull request updates the Prestissimo Dockerfile to adopt the new script for consistency.


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

