### PR TITLE
added weighted split scheduling doc to Presto Developer Guide #22009

### DIFF
--- a/presto-docs/src/main/sphinx/develop.rst
+++ b/presto-docs/src/main/sphinx/develop.rst
@@ -19,3 +19,4 @@ This guide is intended for Presto contributors and plugin developers.
     develop/client-protocol
     develop/worker-protocol
     develop/serialized-page
+    develop/weighted_split_scheduling

--- a/presto-docs/src/main/sphinx/develop/weighted_split_scheduling.rst
+++ b/presto-docs/src/main/sphinx/develop/weighted_split_scheduling.rst
@@ -1,0 +1,70 @@
+Weighted Split Scheduling
+===========================================
+
+Weighted split scheduling is a feature introduced in Presto to enhance resource allocation and optimize query performance in distributed environments. This document provides an overview of weighted split scheduling and guides developers on how to leverage this feature effectively.
+Understanding Weighted Split Scheduling
+
+Code
+----
+
+The Example HTTP connector can be found in the ``presto-hive``
+directory in the root of the Presto source tree.
+
+-----------------------
+
+Assigning Weights to Splits
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Developers can assign weights to splits using various metrics such as data size, complexity, or priority. Here's an example of assigning weights based on data size:
+
+.. code-block:: java
+
+    ConnectorSession session = ...;
+    ConnectorSplit split = ...;
+    long dataSize = split.getDataSizeInBytes();
+    double weight = calculateWeight(dataSize);  // Custom method to calculate weight based on data size
+    session.setProperty("split_weight", weight);
+
+Scheduler Integration
+~~~~~~~~~~~~~~~~~~~~~~
+
+The weighted split scheduler integrates with Presto's existing scheduler to prioritize splits based on their assigned weights. Here's an example of integrating weighted split scheduling into the scheduler:
+
+.. code-block:: java
+
+    WeightedSplitScheduler scheduler = new WeightedSplitScheduler();
+    scheduler.setWeightedSplitEnabled(true);
+
+Resource Allocation
+~~~~~~~~~~~~~~~~~~~~
+
+Worker nodes receive splits from the scheduler based on their weights. Nodes with higher weights may receive more splits or additional resources to process them efficiently. Here's an example of resource allocation based on split weights:
+
+.. code-block:: java
+
+    double nodeCapacity = getNodeCapacity();  // Custom method to get node capacity
+    double nodeWeight = getNodeWeight();      // Custom method to get node weight
+    double splitWeight = getSplitWeight(split);  // Custom method to get split weight
+    if (nodeWeight >= splitWeight) {
+        allocateResources(split);  // Custom method to allocate resources to the split
+    }
+
+Enabling Weighted Split Scheduling
+-----------------------------------
+
+To enable weighted split scheduling, follow these steps:
+
+1. Configuration: Adjust the configuration settings in the Presto cluster to enable weighted split scheduling. This may involve specifying parameters related to split weights, scheduler behavior, and resource allocation policies.
+
+2. Query Planning: During query planning, developers can specify split weights or define rules to automatically assign weights based on predefined criteria.
+
+3. Testing and Optimization: Before deploying weighted split scheduling in production environments, thoroughly test its impact on query performance and resource utilization. Fine-tune the weights and configuration settings as needed to optimize performance.
+
+Best Practices
+--------------
+
+Consider the following best practices when using weighted split scheduling:
+
+- Fine-tune Split Weights: Continuously monitor and adjust split weights based on evolving data characteristics and workload patterns.
+- Monitor Performance: Regularly monitor query performance metrics to identify any bottlenecks or inefficiencies introduced by weighted split scheduling.
+- Optimize Configuration: Experiment with different configuration settings to find the optimal balance between resource utilization and query performance.


### PR DESCRIPTION
## Description
added a new file at develop/weighted_split_scheduling.rst and added a Weighted Split Scheduling at sphinx/develop.rst

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

