### PR TITLE
Prevent removal of aggregation nodes when grouping sets are present

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantAggregateDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantAggregateDistinct.java
@@ -45,7 +45,8 @@ public class RemoveRedundantAggregateDistinct
     private static boolean hasAggregations(AggregationNode node)
     {
         return ((GroupReference) node.getSource()).getLogicalProperties().isPresent() &&
-                !node.getAggregations().isEmpty();
+                !node.getAggregations().isEmpty() &&
+                node.getGroupingSetCount() == 1;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantDistinct.java
@@ -35,7 +35,7 @@ public class RemoveRedundantDistinct
 
     private static boolean distinctOfUniqueKey(AggregationNode node)
     {
-        return node.hasNonEmptyGroupingSet() &&
+        return node.getGroupingSetCount() == 1 &&
                 node.getAggregations().isEmpty() &&
                 ((GroupReference) node.getSource()).getLogicalProperties().isPresent() &&
                 ((GroupReference) node.getSource()).getLogicalProperties().get().isDistinct(node.getGroupingKeys().stream().collect(Collectors.toSet()));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.ValuesNode;
@@ -1635,6 +1636,33 @@ public class TestLogicalPlanner
                         node(DistinctLimitNode.class,
                                 anyTree(
                                         tableScan("orders")))));
+    }
+
+    @Test
+    public void testRedundantDistinctRemovalWithMultipleGroupingSets()
+    {
+        Session exploitConstraints = Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(EXPLOIT_CONSTRAINTS, Boolean.toString(true))
+                .build();
+
+        assertPlan("SELECT orderkey FROM (SELECT * FROM (SELECT * FROM orders WHERE 1=0)) GROUP BY ROLLUP (orderkey)",
+                exploitConstraints,
+                anyTree(
+                        node(AggregationNode.class,
+                                node(ProjectNode.class,
+                                        node(ValuesNode.class)))));
+
+        assertPlan("with t as (select orderkey, count(1) cnt from (select * from (select * from orders where 1=0) left join (select partkey, suppkey from lineitem where 1=0) on partkey=10 where suppkey is not null) group by rollup(orderkey)) select t1.orderkey, t1.cnt from t t1 cross join t t2",
+                exploitConstraints,
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        node(AggregationNode.class,
+                                                node(ProjectNode.class,
+                                                        node(ValuesNode.class)))),
+                                anyTree(node(AggregationNode.class,
+                                        node(ProjectNode.class,
+                                                node(ValuesNode.class)))))));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRedundantAggregateDistinctRemoval.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRedundantAggregateDistinctRemoval.java
@@ -131,6 +131,17 @@ public class TestRedundantAggregateDistinctRemoval
                         node(ProjectNode.class,
                                 aggregation(aggregations,
                                         tableScan("lineitem")))));
+
+        aggregations = ImmutableMap.of(
+                "count", functionCall("count", true, ImmutableList.of(anySymbol())),
+                "avg", functionCall("avg", true, ImmutableList.of(anySymbol())));
+
+        // Multiple grouping sets, so distinct's cannot be removed, even for unique groups
+        tester().assertThat(ImmutableSet.of(new RemoveRedundantAggregateDistinct()), logicalPropertiesProvider)
+                .on("SELECT count(distinct linenumber), avg(distinct tax) FROM lineitem GROUP BY GROUPING SETS ((orderkey), (partkey))")
+                .matches(anyTree(
+                        aggregation(aggregations,
+                                anyTree(tableScan("lineitem")))));
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7511,5 +7511,7 @@ public abstract class AbstractTestQueries
     {
         assertQuery("with t as (select orderkey, count(1) cnt from (select * from (select * from orders where 1=0) left join (select partkey, suppkey from lineitem where 1=0) on partkey=10 where suppkey is not null) group by rollup(orderkey)) select t1.orderkey, t1.cnt from t t1 cross join t t2",
                 "values (null, 0)");
+        assertQuery("select orderkey from (select * from (select * from orders where 1=0)) group by rollup(orderkey)",
+                "values (null)");
     }
 }


### PR DESCRIPTION
## Description
Fixes #22171



If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

