### PR TITLE
[native] Add PeriodicMemoryChecker interface

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   Announcer.cpp
   CPUMon.cpp
   CoordinatorDiscoverer.cpp
+  PeriodicMemoryChecker.cpp
   PeriodicTaskManager.cpp
   PrestoExchangeSource.cpp
   PrestoServer.cpp
@@ -47,6 +48,7 @@ target_link_libraries(
   presto_http
   presto_operators
   velox_aggregates
+  velox_caching
   velox_core
   velox_dwio_common_exception
   velox_encode

--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/PeriodicMemoryChecker.h"
+#include "presto_cpp/main/common/Configs.h"
+#include "presto_cpp/main/common/Utils.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::presto {
+PeriodicMemoryChecker::PeriodicMemoryChecker(Config config)
+    : config_(std::move(config)) {
+  if (config_.systemMemPushbackEnabled) {
+    VELOX_CHECK_GT(config_.systemMemLimitBytes, 0);
+  }
+  if (config_.mallocMemHeapDumpEnabled) {
+    VELOX_CHECK(
+        !config_.heapDumpLogDir.empty(),
+        "heapDumpLogDir cannot be empty when heap dump is enabled.");
+    VELOX_CHECK(
+        !config_.heapDumpFilePrefix.empty(),
+        "heapDumpFilePrefix cannot be empty when heap dump is enabled.");
+  }
+}
+
+void PeriodicMemoryChecker::start() {
+  if (!config_.systemMemPushbackEnabled) {
+    PRESTO_STARTUP_LOG(INFO) << "Server memory pushback is not enabled";
+  } else {
+    VELOX_CHECK_GT(
+        config_.systemMemLimitBytes, 0, "Invalid system mem limit provided");
+    VELOX_CHECK_GT(
+        config_.systemMemShrinkBytes, 0, "Invalid system mem shrink provided");
+    PRESTO_STARTUP_LOG(INFO)
+        << "Creating server memory pushback checker, memory check interval "
+        << config_.memoryCheckerIntervalSec << "s, system memory limit: "
+        << velox::succinctBytes(config_.systemMemLimitBytes)
+        << ", memory shrink size: "
+        << velox::succinctBytes(config_.systemMemShrinkBytes);
+  }
+
+  if (!config_.mallocMemHeapDumpEnabled) {
+    PRESTO_STARTUP_LOG(INFO) << "Malloc memory heap dumper is not enabled";
+  } else {
+    PRESTO_STARTUP_LOG(INFO)
+        << "Enabling Malloc memory heap dumper"
+        << ", malloc'd memory dump threshold: "
+        << velox::succinctBytes(config_.mallocBytesUsageDumpThreshold)
+        << ", max dump files: " << config_.maxHeapDumpFiles
+        << ", heap dump folder: " << config_.heapDumpLogDir
+        << ", heap dump interval: " << config_.minHeapDumpIntervalSec
+        << " seconds";
+  }
+
+  VELOX_CHECK_NULL(scheduler_, "start() called more than once");
+  scheduler_ = std::make_shared<folly::FunctionScheduler>();
+  scheduler_->setThreadName("MemoryCheckerThread");
+  scheduler_->addFunction(
+      [&]() {
+        periodicCb();
+        if (config_.mallocMemHeapDumpEnabled) {
+          maybeDumpHeap();
+        }
+        if (config_.systemMemPushbackEnabled &&
+            systemUsedMemoryBytes() > config_.systemMemLimitBytes) {
+          pushbackMemory();
+        }
+      },
+      std::chrono::seconds(config_.memoryCheckerIntervalSec),
+      "periodic-sys-mem-check",
+      std::chrono::seconds(0));
+  scheduler_->start();
+}
+
+void PeriodicMemoryChecker::stop() {
+  VELOX_CHECK_NOT_NULL(scheduler_);
+  scheduler_->shutdown();
+  scheduler_.reset();
+}
+
+std::string PeriodicMemoryChecker::createHeapDumpFilePath() const {
+  const size_t now = velox::getCurrentTimeMs() / 1000;
+  // Format as follow:
+  // <heapDumpFilePrefix>.<pid>.<global_sequence>.i<sequence> =>
+  // prefix.1234.235.i565
+  return fmt::format(
+      "{}/{}.{}.{}.i{}.heap",
+      config_.heapDumpLogDir,
+      config_.heapDumpFilePrefix,
+      getpid(),
+      now,
+      now);
+}
+
+void PeriodicMemoryChecker::maybeDumpHeap() {
+  const auto now = velox::getCurrentTimeMs() / 1000;
+  const auto allocatedSize = mallocBytes();
+  if (allocatedSize >= config_.mallocBytesUsageDumpThreshold &&
+      now - lastHeapDumpAttemptTimestamp_ >= config_.minHeapDumpIntervalSec) {
+    lastHeapDumpAttemptTimestamp_ = now;
+    LOG(INFO) << fmt::format(
+        "Memory usage allocated via malloc exceeded threshold of {}, current "
+        "allocation: {}",
+        velox::succinctBytes(config_.mallocBytesUsageDumpThreshold),
+        velox::succinctBytes(allocatedSize));
+
+    const auto minMemUsageDumped = dumpFilesByHeapMemUsageMinPq_.empty()
+        ? 0
+        : dumpFilesByHeapMemUsageMinPq_.top().mallocUsedBytes;
+    if (dumpFilesByHeapMemUsageMinPq_.size() == config_.maxHeapDumpFiles &&
+        allocatedSize <= minMemUsageDumped) {
+      LOG(INFO) << fmt::format(
+          "Heap profile not dumped as current usage {} is below the "
+          "minimum usage dumped {} and we already have {} files in rotation",
+          velox::succinctBytes(allocatedSize),
+          velox::succinctBytes(minMemUsageDumped),
+          config_.maxHeapDumpFiles);
+      return;
+    }
+
+    const auto filePath = createHeapDumpFilePath();
+    if (!heapDumpCb(filePath)) {
+      LOG(ERROR) << "Error dumping Heap profile";
+      return;
+    }
+    LOG(INFO) << fmt::format(
+        "Heap profile with usage {} dumped to {}",
+        velox::succinctBytes(allocatedSize),
+        filePath);
+
+    dumpFilesByHeapMemUsageMinPq_.push({allocatedSize, filePath});
+    if (dumpFilesByHeapMemUsageMinPq_.size() <= config_.maxHeapDumpFiles) {
+      return;
+    }
+    auto& evicted = dumpFilesByHeapMemUsageMinPq_.top();
+    LOG(INFO) << fmt::format(
+        "Removing Heap profile with lowest usage {} : {}",
+        velox::succinctBytes(evicted.mallocUsedBytes),
+        evicted.filePath);
+    removeDumpFile(evicted.filePath.c_str());
+    dumpFilesByHeapMemUsageMinPq_.pop();
+  }
+}
+
+void PeriodicMemoryChecker::pushbackMemory() const {
+  const uint64_t currentMemBytes = systemUsedMemoryBytes();
+  VELOX_CHECK(config_.systemMemPushbackEnabled);
+  LOG(WARNING) << "System used memory " << velox::succinctBytes(currentMemBytes)
+               << " exceeded limit: "
+               << velox::succinctBytes(config_.systemMemLimitBytes);
+  const uint64_t targetMemBytes =
+      config_.systemMemLimitBytes - config_.systemMemShrinkBytes;
+  VELOX_CHECK_GT(currentMemBytes, targetMemBytes);
+  const uint64_t bytesToShrink = currentMemBytes - targetMemBytes;
+  VELOX_CHECK_GT(bytesToShrink, 0);
+
+  auto* cache = velox::cache::AsyncDataCache::getInstance();
+  auto systemConfig = SystemConfig::instance();
+  auto freedBytes = cache != nullptr ? cache->shrink(bytesToShrink) : 0;
+  if (freedBytes < bytesToShrink) {
+    try {
+      auto* memoryManager = velox::memory::memoryManager();
+      freedBytes += velox::memory::AllocationTraits::pageBytes(
+          memoryManager->allocator()->unmap(
+              velox::memory::AllocationTraits::numPages(
+                  bytesToShrink - freedBytes)));
+      if (freedBytes < bytesToShrink &&
+          systemConfig->systemMemPushBackAbortEnabled()) {
+        memoryManager->shrinkPools(
+            bytesToShrink - freedBytes,
+            /*allowSpill=*/false,
+            /*allowAbort=*/true);
+
+        // Try to shrink from cache again as aborted query might hold cache
+        // reference.
+        if (cache != nullptr) {
+          freedBytes += cache->shrink(bytesToShrink - freedBytes);
+        }
+        if (freedBytes < bytesToShrink) {
+          freedBytes += velox::memory::AllocationTraits::pageBytes(
+              memoryManager->allocator()->unmap(
+                  velox::memory::AllocationTraits::numPages(
+                      bytesToShrink - freedBytes)));
+        }
+      }
+    } catch (const velox::VeloxException& ex) {
+      LOG(ERROR) << ex.what();
+    }
+  }
+
+  LOG(INFO) << "Shrunk " << velox::succinctBytes(freedBytes);
+}
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <folly/experimental/FunctionScheduler.h>
+#include <cstdint>
+#include <queue>
+#include <string>
+
+namespace facebook::presto {
+/// Utility class that spawns a thread which periodically checks the memory
+/// usage and perform the following actions:
+class PeriodicMemoryChecker {
+ public:
+  struct Config {
+    /// The frequency 'PeriodicMemoryChecker' runs at.
+    uint64_t memoryCheckerIntervalSec{1};
+
+    /// If true, starts memory limit checker to trigger memory pushback when
+    /// server is under low memory pressure.
+    bool systemMemPushbackEnabled{false};
+
+    /// Specifies the system memory limit that triggers the memory pushback if
+    /// the server memory usage is beyond this limit. This only applies if
+    /// 'systemMemPushbackEnabled_' is true.
+    uint64_t systemMemLimitBytes{0};
+
+    /// Specifies the amount of memory to shrink when the memory pushback is
+    /// triggered. This only applies if 'systemMemPushbackEnabled' is true.
+    uint64_t systemMemShrinkBytes{0};
+
+    /// Starts memory limit checker that dumps the heap profile if memory
+    /// allocated via malloc exceeds 'mallocBytesUsageDumpThreshold'. See
+    /// mallocCheckingCb() for more details.
+    bool mallocMemHeapDumpEnabled{false};
+
+    /// Only applies if 'mallocMemHeapDumpEnabled' is true. Minimum Interval in
+    /// seconds between two consecutive heap dumps.
+    size_t minHeapDumpIntervalSec{10};
+
+    /// Only applies if 'mallocMemHeapDumpEnabled' is true. The directory where
+    /// heap profiles are dumped.
+    std::string heapDumpLogDir;
+
+    /// Only applies if 'mallocMemHeapDumpEnabled' is true. The prefix of
+    /// heapdump file name.
+    std::string heapDumpFilePrefix;
+
+    /// Only applies if 'mallocMemHeapDumpEnabled' is true. Maximum number of
+    /// heap dump files to maintain in rotation.
+    uint32_t maxHeapDumpFiles{10};
+
+    /// Only applies if 'mallocMemHeapDumpEnabled' is true. Memory (in bytes)
+    /// allocated via malloc() that triggers the heap dump. Default is 20GB.
+    size_t mallocBytesUsageDumpThreshold{20UL * 1024 * 1024 * 1024};
+  };
+
+  explicit PeriodicMemoryChecker(Config config);
+
+  /// Starts the 'PeriodicMemoryChecker'. A background scheduler will be
+  /// launched to perform the checks. This should only be called once.
+  void start();
+
+  /// Stops the 'PeriodicMemoryChecker'.
+  void stop();
+
+ protected:
+  /// Returns current system memory usage. The returned value is used to compare
+  /// with 'Config::systemMemLimitBytes'.
+  virtual int64_t systemUsedMemoryBytes() const = 0;
+
+  /// Returns current bytes allocated by malloc. The returned value is used to
+  /// compare with 'Config::mallocBytesUsageDumpThreshold'
+  virtual int64_t mallocBytes() const = 0;
+
+  /// Callback function that is invoked by 'PeriodicMemoryChecker' periodically.
+  /// Light operations such as stats reporting can be done in this call back.
+  virtual void periodicCb() const = 0;
+
+  /// Callback function that performs a heap dump. Returns true if dump is
+  /// successful.
+  virtual bool heapDumpCb(const std::string& filePath) const = 0;
+
+  /// Callback function that removes a dumped file with given 'filePath'.
+  /// Returns true if dump is successful.
+  virtual void removeDumpFile(const std::string& filePath) const = 0;
+
+  const Config config_;
+
+ private:
+  // Struct that stores the file names of the heap profiles dumped and the
+  // memory allocated by jemalloc when they were dumped. Used to create a min
+  // priority queue ordered by the memory allocated by jemalloc when the heap
+  // dump was generated. Used to determine which heap profile to delete when the
+  // number of files generated exceeds 'maxHeapDumpFiles_'.
+  struct DumpFileInfo {
+    // The memory allocated via jemalloc when the heap dump was generated.
+    int64_t mallocUsedBytes;
+    // Path to the heap dump file.
+    std::string filePath;
+
+    bool operator>(const DumpFileInfo& other) const {
+      return mallocUsedBytes > other.mallocUsedBytes;
+    }
+    bool operator<(const DumpFileInfo& other) const {
+      return mallocUsedBytes < other.mallocUsedBytes;
+    }
+  };
+
+  // Invoked by the periodic checker when 'Config::systemMemPushbackEnabled'
+  // is true and system memory usage is above 'Config::systemMemLimitBytes'.
+  void pushbackMemory() const;
+
+  // Invoked by the periodic checker when 'Config::mallocMemHeapDumpEnabled' is
+  // true.
+  void maybeDumpHeap();
+
+  std::string createHeapDumpFilePath() const;
+
+  std::shared_ptr<folly::FunctionScheduler> scheduler_;
+  size_t lastHeapDumpAttemptTimestamp_{0};
+  std::priority_queue<
+      DumpFileInfo,
+      std::vector<DumpFileInfo>,
+      std::greater<DumpFileInfo>>
+      dumpFilesByHeapMemUsageMinPq_;
+};
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
   CoordinatorDiscovererTest.cpp
   HttpServerWrapper.cpp
   MutableConfigs.cpp
+  PeriodicMemoryCheckerTest.cpp
   PrestoExchangeSourceTest.cpp
   PrestoTaskTest.cpp
   QueryContextCacheTest.cpp
@@ -29,6 +30,7 @@ add_test(
 
 target_link_libraries(
   presto_server_test
+  velox_caching
   velox_exec_test_lib
   presto_server_lib
   velox_dwio_common_test_utils

--- a/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/PeriodicMemoryChecker.h"
+#include <gtest/gtest.h>
+#include "velox/common/base/VeloxException.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/SsdCache.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook::velox;
+
+namespace facebook::presto {
+class PeriodicMemoryCheckerTest : public testing::Test {
+ protected:
+  class TestPeriodicMemoryChecker : public PeriodicMemoryChecker {
+   public:
+    explicit TestPeriodicMemoryChecker(
+        PeriodicMemoryChecker::Config config,
+        int64_t systemUsedMemoryBytes = 0,
+        int64_t mallocBytes = 0,
+        std::function<void()>&& periodicCb = nullptr,
+        std::function<bool(const std::string&)>&& heapDumpCb = nullptr)
+        : PeriodicMemoryChecker(config),
+          systemUsedMemoryBytes_(systemUsedMemoryBytes),
+          mallocBytes_(mallocBytes),
+          periodicCb_(std::move(periodicCb)),
+          heapDumpCb_(std::move(heapDumpCb)) {}
+
+    void setMallocBytes(int64_t mallocBytes) {
+      mallocBytes_ = mallocBytes;
+    }
+
+   protected:
+    int64_t systemUsedMemoryBytes() const override {
+      return systemUsedMemoryBytes_;
+    }
+
+    int64_t mallocBytes() const override {
+      return mallocBytes_;
+    }
+
+    void periodicCb() const override {
+      if (periodicCb_) {
+        periodicCb_();
+      }
+    }
+
+    bool heapDumpCb(const std::string& filePath) const override {
+      if (heapDumpCb_) {
+        return heapDumpCb_(filePath);
+      }
+      return false;
+    }
+
+    void removeDumpFile(const std::string& filePath) const override {}
+
+   private:
+    int64_t systemUsedMemoryBytes_{0};
+    int64_t mallocBytes_{0};
+    std::function<void()> periodicCb_;
+    std::function<bool(const std::string&)> heapDumpCb_;
+  };
+};
+
+TEST_F(PeriodicMemoryCheckerTest, basic) {
+  // Default config
+  ASSERT_NO_THROW(TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{}));
+
+  ASSERT_NO_THROW(TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{
+      1, true, 1024, 32, true, 5, "/path/to/dir", "prefix", 5, 512}));
+  VELOX_ASSERT_THROW(
+      TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{
+          1, true, 0, 32, true, 5, "/path/to/dir", "prefix", 5, 512}),
+      "(0 vs. 0)");
+  VELOX_ASSERT_THROW(
+      TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{
+          1, true, 1024, 32, true, 5, "", "prefix", 5, 512}),
+      "heapDumpLogDir cannot be empty when heap dump is enabled.");
+  VELOX_ASSERT_THROW(
+      TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{
+          1, true, 1024, 32, true, 5, "/path/to/dir", "", 5, 512}),
+      "heapDumpFilePrefix cannot be empty when heap dump is enabled.");
+  TestPeriodicMemoryChecker memChecker(PeriodicMemoryChecker::Config{
+      1, false, 0, 0, false, 5, "/path/to/dir", "prefix", 5, 512});
+  ASSERT_NO_THROW(memChecker.start());
+  VELOX_ASSERT_THROW(memChecker.start(), "start() called more than once");
+  ASSERT_NO_THROW(memChecker.stop());
+}
+
+TEST_F(PeriodicMemoryCheckerTest, periodicCb) {
+  auto testPeriodicCb = [](bool pushbackEnabled, bool heapDumpEnabled) {
+    std::atomic_bool periodicCbInvoked{false};
+    TestPeriodicMemoryChecker memChecker(
+        PeriodicMemoryChecker::Config{
+            1,
+            pushbackEnabled,
+            512,
+            32,
+            heapDumpEnabled,
+            5,
+            "/path/to/dir",
+            "prefix",
+            5,
+            512},
+        pushbackEnabled ? 768 : 256,
+        128,
+        [&]() { periodicCbInvoked = true; });
+    memChecker.start();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    memChecker.stop();
+    ASSERT_TRUE(periodicCbInvoked.load());
+  };
+  testPeriodicCb(true, true);
+  testPeriodicCb(true, false);
+  testPeriodicCb(false, true);
+  testPeriodicCb(false, false);
+}
+
+TEST_F(PeriodicMemoryCheckerTest, heapdump) {
+  // Malloc bytes less than dump threshold. Expect no dump trigger.
+  {
+    std::atomic_bool heapdumpCbCalled{false};
+    TestPeriodicMemoryChecker memChecker(
+        PeriodicMemoryChecker::Config{
+            1, false, 0, 0, true, 5, "/path/to/dir", "prefix", 5, 512},
+        1024,
+        256,
+        []() {},
+        [&](const std::string& filePath) {
+          heapdumpCbCalled = true;
+          return false;
+        });
+    memChecker.start();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    memChecker.stop();
+    ASSERT_FALSE(heapdumpCbCalled.load());
+  }
+
+  // Dump file count greater than max allowed, while malloc size is smaller than
+  // current smallest dump. Expect no dump trigger.
+  {
+    std::atomic_bool heapdumpCbCalled{false};
+    TestPeriodicMemoryChecker memChecker(
+        PeriodicMemoryChecker::Config{
+            1, false, 0, 0, true, 1, "/path/to/dir", "prefix", 2, 512},
+        1024,
+        768,
+        []() {},
+        [&](const std::string& filePath) {
+          heapdumpCbCalled = true;
+          return true;
+        });
+    memChecker.start();
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+    memChecker.setMallocBytes(513);
+    heapdumpCbCalled = false;
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    ASSERT_FALSE(heapdumpCbCalled.load());
+    memChecker.stop();
+  }
+}
+
+TEST_F(PeriodicMemoryCheckerTest, pushbackMemory) {
+  memory::MemoryManagerOptions options;
+  options.allocatorCapacity = 32L << 20;
+  memory::MemoryManager::testingSetInstance(options);
+  auto asyncDataCache =
+      cache::AsyncDataCache::create(memory::memoryManager()->allocator());
+  cache::AsyncDataCache::setInstance(asyncDataCache.get());
+  StringIdLease stringIdLease(fileIds(), "cache_file_name");
+
+  // Create a cache and drop the pin to make evictable memory
+  {
+    auto cachePin = cache::AsyncDataCache::getInstance()->findOrCreate(
+        {stringIdLease.id(), 0}, 32L << 20);
+    auto& allocation = cachePin.entry()->data();
+    for (int32_t i = 0; i < allocation.numRuns(); ++i) {
+      memory::Allocation::PageRun run = allocation.runAt(i);
+      int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
+      std::memset(ptr, 'x', run.numBytes());
+    }
+    cachePin.entry()->setExclusiveToShared();
+  }
+  ASSERT_EQ(memory::memoryManager()->getTotalBytes(), 32L << 20);
+
+  TestPeriodicMemoryChecker memChecker(
+      PeriodicMemoryChecker::Config{
+          1,
+          true,
+          16L << 20,
+          8L << 20,
+          false,
+          1,
+          "/path/to/dir",
+          "prefix",
+          2,
+          512},
+      32L << 20,
+      0,
+      []() {},
+      [&](const std::string& filePath) { return true; });
+  memChecker.start();
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  memChecker.stop();
+  ASSERT_EQ(memory::memoryManager()->getTotalBytes(), 0);
+
+  // Shutdown global memory setups
+  asyncDataCache->shutdown();
+  cache::AsyncDataCache::setInstance(nullptr);
+  memory::MemoryManager::testingSetInstance({});
+}
+} // namespace facebook::presto


### PR DESCRIPTION
Add PeriodicMemoryChecker that performs memory pushback and heapdump under extreme memory conditions. Users can implement this abstract class to accommodate different malloc used by process and its corresponding dumps.

The PeriodicMemoryChecker performs memory check jobs periodically. It checks 2 things (if they are enabled correspondingly):
1. It checks system memory and compares it with configured threshold. If it goes beyond the threshold the checker will perform a memory pushback action by clearing the cache and application mapped memory, and even killing queries if configured.
2. It checks malloc memory usage and compares it with configured threshold. If it goes beyond the threshold it performs a heap dump. 


```
== NO RELEASE NOTE ==
```

