### PR TITLE
Fix long overflow for OperatorStats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -659,21 +659,21 @@ public class OperatorStats
         long addInputCalls = this.addInputCalls;
         long addInputWall = this.addInputWall.roundTo(NANOSECONDS);
         long addInputCpu = this.addInputCpu.roundTo(NANOSECONDS);
-        long addInputAllocation = this.addInputAllocation.toBytes();
-        long rawInputDataSize = this.rawInputDataSize.toBytes();
+        double addInputAllocation = this.addInputAllocation.toBytes();
+        double rawInputDataSize = this.rawInputDataSize.toBytes();
         long rawInputPositions = this.rawInputPositions;
-        long inputDataSize = this.inputDataSize.toBytes();
+        double inputDataSize = this.inputDataSize.toBytes();
         long inputPositions = this.inputPositions;
         double sumSquaredInputPositions = this.sumSquaredInputPositions;
 
         long getOutputCalls = this.getOutputCalls;
         long getOutputWall = this.getOutputWall.roundTo(NANOSECONDS);
         long getOutputCpu = this.getOutputCpu.roundTo(NANOSECONDS);
-        long getOutputAllocation = this.getOutputAllocation.toBytes();
-        long outputDataSize = this.outputDataSize.toBytes();
+        double getOutputAllocation = this.getOutputAllocation.toBytes();
+        double outputDataSize = this.outputDataSize.toBytes();
         long outputPositions = this.outputPositions;
 
-        long physicalWrittenDataSize = this.physicalWrittenDataSize.toBytes();
+        double physicalWrittenDataSize = this.physicalWrittenDataSize.toBytes();
 
         long additionalCpu = this.additionalCpu.roundTo(NANOSECONDS);
         long blockedWall = this.blockedWall.roundTo(NANOSECONDS);
@@ -683,14 +683,14 @@ public class OperatorStats
         long finishCpu = this.finishCpu.roundTo(NANOSECONDS);
         long finishAllocation = this.finishAllocation.toBytes();
 
-        long memoryReservation = this.userMemoryReservation.toBytes();
-        long revocableMemoryReservation = this.revocableMemoryReservation.toBytes();
-        long systemMemoryReservation = this.systemMemoryReservation.toBytes();
-        long peakUserMemory = this.peakUserMemoryReservation.toBytes();
-        long peakSystemMemory = this.peakSystemMemoryReservation.toBytes();
-        long peakTotalMemory = this.peakTotalMemoryReservation.toBytes();
+        double memoryReservation = this.userMemoryReservation.toBytes();
+        double revocableMemoryReservation = this.revocableMemoryReservation.toBytes();
+        double systemMemoryReservation = this.systemMemoryReservation.toBytes();
+        double peakUserMemory = this.peakUserMemoryReservation.toBytes();
+        double peakSystemMemory = this.peakSystemMemoryReservation.toBytes();
+        double peakTotalMemory = this.peakTotalMemoryReservation.toBytes();
 
-        long spilledDataSize = this.spilledDataSize.toBytes();
+        double spilledDataSize = this.spilledDataSize.toBytes();
 
         Optional<BlockedReason> blockedReason = this.blockedReason;
 
@@ -774,21 +774,21 @@ public class OperatorStats
                 addInputCalls,
                 succinctNanos(addInputWall),
                 succinctNanos(addInputCpu),
-                succinctBytes(addInputAllocation),
-                succinctBytes(rawInputDataSize),
+                succinctBytes((long) addInputAllocation),
+                succinctBytes((long) rawInputDataSize),
                 rawInputPositions,
-                succinctBytes(inputDataSize),
+                succinctBytes((long) inputDataSize),
                 inputPositions,
                 sumSquaredInputPositions,
 
                 getOutputCalls,
                 succinctNanos(getOutputWall),
                 succinctNanos(getOutputCpu),
-                succinctBytes(getOutputAllocation),
-                succinctBytes(outputDataSize),
+                succinctBytes((long) getOutputAllocation),
+                succinctBytes((long) outputDataSize),
                 outputPositions,
 
-                succinctBytes(physicalWrittenDataSize),
+                succinctBytes((long) physicalWrittenDataSize),
 
                 succinctNanos(additionalCpu),
                 succinctNanos(blockedWall),
@@ -798,14 +798,14 @@ public class OperatorStats
                 succinctNanos(finishCpu),
                 succinctBytes(finishAllocation),
 
-                succinctBytes(memoryReservation),
-                succinctBytes(revocableMemoryReservation),
-                succinctBytes(systemMemoryReservation),
-                succinctBytes(peakUserMemory),
-                succinctBytes(peakSystemMemory),
-                succinctBytes(peakTotalMemory),
+                succinctBytes((long) memoryReservation),
+                succinctBytes((long) revocableMemoryReservation),
+                succinctBytes((long) systemMemoryReservation),
+                succinctBytes((long) peakUserMemory),
+                succinctBytes((long) peakSystemMemory),
+                succinctBytes((long) peakTotalMemory),
 
-                succinctBytes(spilledDataSize),
+                succinctBytes((long) spilledDataSize),
 
                 blockedReason,
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
@@ -187,11 +187,11 @@ public class PlanNodeStats
         checkArgument(planNodeId.equals(other.getPlanNodeId()), "planNodeIds do not match. %s != %s", planNodeId, other.getPlanNodeId());
 
         long planNodeInputPositions = this.planNodeInputPositions + other.planNodeInputPositions;
-        DataSize planNodeInputDataSize = succinctBytes(this.planNodeInputDataSize.toBytes() + other.planNodeInputDataSize.toBytes());
+        DataSize planNodeInputDataSize = succinctBytes((long) ((double) this.planNodeInputDataSize.toBytes() + (double) other.planNodeInputDataSize.toBytes()));
         long planNodeRawInputPositions = this.planNodeRawInputPositions + other.planNodeRawInputPositions;
-        DataSize planNodeRawInputDataSize = succinctBytes(this.planNodeRawInputDataSize.toBytes() + other.planNodeRawInputDataSize.toBytes());
+        DataSize planNodeRawInputDataSize = succinctBytes((long) ((double) this.planNodeRawInputDataSize.toBytes() + (double) other.planNodeRawInputDataSize.toBytes()));
         long planNodeOutputPositions = this.planNodeOutputPositions + other.planNodeOutputPositions;
-        DataSize planNodeOutputDataSize = succinctBytes(this.planNodeOutputDataSize.toBytes() + other.planNodeOutputDataSize.toBytes());
+        DataSize planNodeOutputDataSize = succinctBytes((long) ((double) this.planNodeOutputDataSize.toBytes() + (double) other.planNodeOutputDataSize.toBytes()));
 
         Map<String, OperatorInputStats> operatorInputStats = mergeMaps(this.operatorInputStats, other.operatorInputStats, OperatorInputStats::merge);
         long planNodeNullJoinBuildKeyCount = this.planNodeNullJoinBuildKeyCount + other.planNodeNullJoinBuildKeyCount;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -77,7 +77,7 @@ public class TestOperatorStats
             new Duration(18, NANOSECONDS),
             new DataSize(345, BYTE),
 
-            new DataSize(19, BYTE),
+            new DataSize(Long.MAX_VALUE, BYTE),
             new DataSize(20, BYTE),
             new DataSize(21, BYTE),
             new DataSize(22, BYTE),
@@ -198,7 +198,7 @@ public class TestOperatorStats
         assertEquals(actual.getFinishCpu(), new Duration(18, NANOSECONDS));
         assertEquals(actual.getFinishAllocation(), new DataSize(345, BYTE));
 
-        assertEquals(actual.getUserMemoryReservation(), new DataSize(19, BYTE));
+        assertEquals(actual.getUserMemoryReservation().toBytes(), Long.MAX_VALUE);
         assertEquals(actual.getRevocableMemoryReservation(), new DataSize(20, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(21, BYTE));
         assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(22, BYTE));
@@ -246,7 +246,7 @@ public class TestOperatorStats
         assertEquals(actual.getFinishCpu(), new Duration(3 * 18, NANOSECONDS));
         assertEquals(actual.getFinishAllocation(), new DataSize(3 * 345, BYTE));
 
-        assertEquals(actual.getUserMemoryReservation(), new DataSize(3 * 19, BYTE));
+        assertEquals(actual.getUserMemoryReservation().toBytes(), Long.MAX_VALUE);
         assertEquals(actual.getRevocableMemoryReservation(), new DataSize(3 * 20, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(3 * 21, BYTE));
         assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(22, BYTE));


### PR DESCRIPTION
In OperatorStats, summing long types leads to overflow.  Use double type to do calculation. 
If final result is larger than Long.MAX_VALUE, return Long.MAX_VALUE.

```
== NO RELEASE NOTE ==
```

