### PR TITLE
Prefer local variables when possible in ORC selective reader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -120,7 +120,6 @@ public class OrcSelectiveRecordReader
 
     private Set<Integer>[] filterFunctionInputs;                      // aligned with filterFunctionsOrder
     private boolean reorderFilters;
-    private int[] reorderableColumns;                                 // values are hiveColumnIndices
 
     // non-deterministic filter functions with only constant inputs; evaluated before any column is read
     private List<FilterFunctionWithStats> filterFunctionsWithConstantInputs;
@@ -314,7 +313,7 @@ public class OrcSelectiveRecordReader
                 .collect(toImmutableList());
         filterFunctionsOrder = orderFilterFunctionsWithInputs(streamReaderOrder, filterFunctionsWithStats, this.filterFunctionInputMapping);
         filterFunctionInputs = collectFilterFunctionInputs(filterFunctionsOrder, this.filterFunctionInputMapping);
-        reorderableColumns = Arrays.stream(streamReaderOrder)
+        int[] reorderableColumns = Arrays.stream(streamReaderOrder)
                 .filter(columnIndex -> !columnsWithFilterScores.containsKey(columnIndex))
                 .filter(this.filterFunctionInputMapping::containsKey)
                 .toArray();


### PR DESCRIPTION
## Description
convert reorderableColumns to local variable

## Motivation and Context
More thread safe and bug resistant

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

