### PR TITLE
Allow alternative implementations of table writability checks

### DIFF
--- a/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
+++ b/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
@@ -40,6 +40,7 @@ import com.facebook.presto.hive.HivePartitionSkippabilityChecker;
 import com.facebook.presto.hive.HivePartitionStats;
 import com.facebook.presto.hive.HiveSplitManager;
 import com.facebook.presto.hive.HiveStagingFileCommitter;
+import com.facebook.presto.hive.HiveTableWritabilityChecker;
 import com.facebook.presto.hive.HiveTestUtils;
 import com.facebook.presto.hive.HiveTransactionManager;
 import com.facebook.presto.hive.HiveTypeTranslator;
@@ -175,7 +176,8 @@ public class S3SelectTestHelper
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 columnConverterProvider,
-                new QuickStatsProvider(hdfsEnvironment, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()));
+                new QuickStatsProvider(hdfsEnvironment, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new HiveTableWritabilityChecker(config));
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionManager,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -166,6 +166,7 @@ public class HiveClientModule
         binder.bind(StagingFileCommitter.class).to(HiveStagingFileCommitter.class).in(Scopes.SINGLETON);
         binder.bind(ZeroRowFileCreator.class).to(HiveZeroRowFileCreator.class).in(Scopes.SINGLETON);
         binder.bind(PartitionObjectBuilder.class).to(HivePartitionObjectBuilder.class).in(Scopes.SINGLETON);
+        binder.bind(TableWritabilityChecker.class).to(HiveTableWritabilityChecker.class).in(Scopes.SINGLETON);
         binder.bind(HiveTransactionManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorSplitManager.class).to(HiveSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(PartitionSkippabilityChecker.class).to(HivePartitionSkippabilityChecker.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -43,7 +43,6 @@ public class HiveMetadataFactory
     private final boolean skipDeletionForAlter;
     private final boolean skipTargetCleanupOnRollback;
     private final boolean undoMetastoreOperationsEnabled;
-    private final boolean writesToNonManagedTablesEnabled;
     private final boolean createsOfNonManagedTablesEnabled;
     private final int maxPartitionBatchSize;
     private final long perTransactionCacheMaximumSize;
@@ -72,6 +71,7 @@ public class HiveMetadataFactory
     private final HiveFileRenamer hiveFileRenamer;
     private final ColumnConverterProvider columnConverterProvider;
     private final QuickStatsProvider quickStatsProvider;
+    private final TableWritabilityChecker tableWritabilityChecker;
 
     @Inject
     @SuppressWarnings("deprecation")
@@ -99,7 +99,8 @@ public class HiveMetadataFactory
             HivePartitionStats hivePartitionStats,
             HiveFileRenamer hiveFileRenamer,
             ColumnConverterProvider columnConverterProvider,
-            QuickStatsProvider quickStatsProvider)
+            QuickStatsProvider quickStatsProvider,
+            TableWritabilityChecker tableWritabilityChecker)
     {
         this(
                 metastore,
@@ -109,7 +110,6 @@ public class HiveMetadataFactory
                 hiveClientConfig.getAllowCorruptWritesForTesting(),
                 hiveClientConfig.isSkipDeletionForAlter(),
                 hiveClientConfig.isSkipTargetCleanupOnRollback(),
-                hiveClientConfig.getWritesToNonManagedTablesEnabled(),
                 hiveClientConfig.getCreatesOfNonManagedTablesEnabled(),
                 hiveClientConfig.isUndoMetastoreOperationsEnabled(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
@@ -134,7 +134,8 @@ public class HiveMetadataFactory
                 hivePartitionStats,
                 hiveFileRenamer,
                 columnConverterProvider,
-                quickStatsProvider);
+                quickStatsProvider,
+                tableWritabilityChecker);
     }
 
     public HiveMetadataFactory(
@@ -145,7 +146,6 @@ public class HiveMetadataFactory
             boolean allowCorruptWritesForTesting,
             boolean skipDeletionForAlter,
             boolean skipTargetCleanupOnRollback,
-            boolean writesToNonManagedTablesEnabled,
             boolean createsOfNonManagedTablesEnabled,
             boolean undoMetastoreOperationsEnabled,
             int maxPartitionBatchSize,
@@ -170,12 +170,12 @@ public class HiveMetadataFactory
             HivePartitionStats hivePartitionStats,
             HiveFileRenamer hiveFileRenamer,
             ColumnConverterProvider columnConverterProvider,
-            QuickStatsProvider quickStatsProvider)
+            QuickStatsProvider quickStatsProvider,
+            TableWritabilityChecker tableWritabilityChecker)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
         this.skipDeletionForAlter = skipDeletionForAlter;
         this.skipTargetCleanupOnRollback = skipTargetCleanupOnRollback;
-        this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
         this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
         this.undoMetastoreOperationsEnabled = undoMetastoreOperationsEnabled;
         this.maxPartitionBatchSize = maxPartitionBatchSize;
@@ -205,6 +205,7 @@ public class HiveMetadataFactory
         this.hiveFileRenamer = requireNonNull(hiveFileRenamer, "hiveFileRenamer is null");
         this.columnConverterProvider = requireNonNull(columnConverterProvider, "columnConverterProvider is null");
         this.quickStatsProvider = requireNonNull(quickStatsProvider, "quickStatsProvider is null");
+        this.tableWritabilityChecker = requireNonNull(tableWritabilityChecker, "tableWritabilityChecker is null");
 
         if (!allowCorruptWritesForTesting && !timeZone.equals(DateTimeZone.getDefault())) {
             log.warn("Hive writes are disabled. " +
@@ -232,7 +233,6 @@ public class HiveMetadataFactory
                 partitionManager,
                 timeZone,
                 allowCorruptWritesForTesting,
-                writesToNonManagedTablesEnabled,
                 createsOfNonManagedTablesEnabled,
                 maxPartitionBatchSize,
                 typeManager,
@@ -251,6 +251,7 @@ public class HiveMetadataFactory
                 partitionObjectBuilder,
                 encryptionInformationProvider,
                 hivePartitionStats,
-                hiveFileRenamer);
+                hiveFileRenamer,
+                tableWritabilityChecker);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableWritabilityChecker.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableWritabilityChecker.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.PrestoTableType;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.PrestoException;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveWriteUtils.checkWritable;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
+import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
+import static com.facebook.presto.hive.metastore.PrestoTableType.MATERIALIZED_VIEW;
+import static com.facebook.presto.hive.metastore.PrestoTableType.TEMPORARY_TABLE;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+
+public class HiveTableWritabilityChecker
+        implements TableWritabilityChecker
+{
+    private final boolean writesToNonManagedTablesEnabled;
+
+    @Inject
+    public HiveTableWritabilityChecker(HiveClientConfig hiveClientConfig)
+    {
+        this(requireNonNull(hiveClientConfig, "hiveClientConfig is null").getWritesToNonManagedTablesEnabled());
+    }
+
+    public HiveTableWritabilityChecker(boolean writesToNonManagedTablesEnabled)
+    {
+        this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
+    }
+
+    @Override
+    public void checkTableWritable(Table table)
+    {
+        PrestoTableType tableType = table.getTableType();
+        if (!writesToNonManagedTablesEnabled
+                && !tableType.equals(MANAGED_TABLE)
+                && !tableType.equals(MATERIALIZED_VIEW)
+                && !tableType.equals(TEMPORARY_TABLE)) {
+            throw new PrestoException(NOT_SUPPORTED, "Cannot write to non-managed Hive table");
+        }
+
+        checkWritable(
+                table.getSchemaTableName(),
+                Optional.empty(),
+                getProtectMode(table),
+                table.getParameters(),
+                table.getStorage());
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/TableWritabilityChecker.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/TableWritabilityChecker.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Table;
+
+public interface TableWritabilityChecker
+{
+    void checkTableWritable(Table table);
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1016,7 +1016,6 @@ public abstract class AbstractTestHiveClient
                 true,
                 false,
                 false,
-                false,
                 true,
                 true,
                 getHiveClientConfig().getMaxPartitionBatchSize(),
@@ -1041,7 +1040,8 @@ public abstract class AbstractTestHiveClient
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 DEFAULT_COLUMN_CONVERTER_PROVIDER,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()));
+                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new HiveTableWritabilityChecker(false));
 
         transactionManager = new HiveTransactionManager();
         encryptionInformationProvider = new HiveEncryptionInformationProvider(ImmutableList.of());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -224,7 +224,8 @@ public abstract class AbstractTestHiveFileSystem
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 columnConverterProvider,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()));
+                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new HiveTableWritabilityChecker(config));
 
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestTableWritabilityChecker.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestTableWritabilityChecker.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.PrestoTableType;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.hadoop.hive.metastore.ProtectMode;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.hive.HiveStorageFormat.ORC;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_OFFLINE;
+import static com.facebook.presto.hive.metastore.PrestoTableType.EXTERNAL_TABLE;
+import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
+import static com.facebook.presto.hive.metastore.PrestoTableType.MATERIALIZED_VIEW;
+import static com.facebook.presto.hive.metastore.PrestoTableType.TEMPORARY_TABLE;
+import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public abstract class AbstractTestTableWritabilityChecker
+{
+    private final TableWritabilityChecker writesToNonManagedTablesEnabled;
+    private final TableWritabilityChecker writesToNonManagedTablesDisabled;
+
+    protected AbstractTestTableWritabilityChecker(
+            TableWritabilityChecker writesToNonManagedTablesEnabled,
+            TableWritabilityChecker writesToNonManagedTablesDisabled)
+    {
+        this.writesToNonManagedTablesEnabled = requireNonNull(writesToNonManagedTablesEnabled, "writesToNonManagedTablesEnabled is null");
+        this.writesToNonManagedTablesDisabled = requireNonNull(writesToNonManagedTablesDisabled, "writesToNonManagedTablesDisabled is null");
+    }
+
+    @Test
+    public void testTableTypeCheck()
+    {
+        writesToNonManagedTablesEnabled.checkTableWritable(createTableWithType(MANAGED_TABLE));
+        writesToNonManagedTablesDisabled.checkTableWritable(createTableWithType(MANAGED_TABLE));
+        writesToNonManagedTablesEnabled.checkTableWritable(createTableWithType(MATERIALIZED_VIEW));
+        writesToNonManagedTablesDisabled.checkTableWritable(createTableWithType(MATERIALIZED_VIEW));
+        writesToNonManagedTablesEnabled.checkTableWritable(createTableWithType(TEMPORARY_TABLE));
+        writesToNonManagedTablesDisabled.checkTableWritable(createTableWithType(TEMPORARY_TABLE));
+        writesToNonManagedTablesEnabled.checkTableWritable(createTableWithType(EXTERNAL_TABLE));
+        assertThatThrownBy(() -> writesToNonManagedTablesDisabled.checkTableWritable(createTableWithType(EXTERNAL_TABLE)))
+                .isInstanceOf(PrestoException.class)
+                .hasMessage("Cannot write to non-managed Hive table");
+    }
+
+    @Test
+    public void testProtectedTables()
+    {
+        assertThatThrownBy(() -> writesToNonManagedTablesDisabled.checkTableWritable(tableBuilder()
+                .setTableType(MANAGED_TABLE)
+                .setParameter(ProtectMode.PARAMETER_NAME, ProtectMode.FLAG_READ_ONLY)
+                .build()))
+                .isInstanceOf(HiveReadOnlyException.class);
+        assertThatThrownBy(() -> writesToNonManagedTablesDisabled.checkTableWritable(tableBuilder()
+                .setTableType(MANAGED_TABLE)
+                .setParameter(ProtectMode.PARAMETER_NAME, ProtectMode.FLAG_OFFLINE)
+                .build()))
+                .isInstanceOf(TableOfflineException.class);
+        assertThatThrownBy(() -> writesToNonManagedTablesDisabled.checkTableWritable(tableBuilder()
+                .setTableType(MANAGED_TABLE)
+                .setParameter(PRESTO_OFFLINE, "true")
+                .build()))
+                .isInstanceOf(TableOfflineException.class);
+    }
+
+    @Test
+    public void testSkewedTables()
+    {
+        assertThatThrownBy(() -> writesToNonManagedTablesDisabled.checkTableWritable(tableBuilder()
+                .setTableType(MANAGED_TABLE)
+                .withStorage(builder -> builder
+                        .setStorageFormat(fromHiveStorageFormat(ORC))
+                        .setLocation("file://tmp/location")
+                        .setSkewed(true)
+                        .build())
+                .build()))
+                .isInstanceOf(PrestoException.class)
+                .hasMessageContaining("Inserting into bucketed tables with skew is not supported");
+    }
+
+    private static Table createTableWithType(PrestoTableType tableType)
+    {
+        return tableBuilder()
+                .setTableType(tableType)
+                .build();
+    }
+
+    private static Table.Builder tableBuilder()
+    {
+        return Table.builder()
+                .setDatabaseName("test_schema")
+                .setTableName("test_table")
+                .setOwner("test_owner")
+                .withStorage(builder -> builder
+                        .setStorageFormat(fromHiveStorageFormat(ORC))
+                        .setLocation("file://tmp/location")
+                        .build());
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
@@ -244,7 +244,6 @@ public class TestHiveCommitHandleOutput
                 true,
                 false,
                 false,
-                false,
                 true,
                 true,
                 hiveClientConfig.getMaxPartitionBatchSize(),
@@ -269,7 +268,8 @@ public class TestHiveCommitHandleOutput
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()));
+                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new HiveTableWritabilityChecker(false));
         return hiveMetadataFactory.get();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2806,6 +2806,10 @@ public class TestHiveIntegrationSmokeTest
         actual = computeActual("SELECT name FROM test_create_external");
         assertEquals(actual.getOnlyColumnAsSet(), ImmutableSet.of("hello", "world"));
 
+        assertQueryFails(
+                "INSERT INTO test_create_external VALUES ('somevalue')",
+                ".*Cannot write to non-managed Hive table.*");
+
         assertUpdate("DROP TABLE test_create_external");
 
         // file should still exist after drop

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -117,7 +117,6 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 true,
                 false,
                 false,
-                false,
                 true,
                 true,
                 HIVE_CLIENT_CONFIG.getMaxPartitionBatchSize(),
@@ -142,7 +141,8 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, HiveTestUtils.DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()));
+                new QuickStatsProvider(HDFS_ENVIRONMENT, HiveTestUtils.DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new HiveTableWritabilityChecker(false));
 
         metastore.createDatabase(METASTORE_CONTEXT, Database.builder()
                 .setDatabaseName(TEST_DB_NAME)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -493,7 +493,6 @@ public class TestHiveSplitManager
                 true,
                 false,
                 false,
-                false,
                 true,
                 true,
                 hiveClientConfig.getMaxPartitionBatchSize(),
@@ -518,7 +517,8 @@ public class TestHiveSplitManager
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()));
+                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new HiveTableWritabilityChecker(false));
 
         HiveSplitManager splitManager = new HiveSplitManager(
                 new TestingHiveTransactionManager(metadataFactory),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableWritabilityChecker.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableWritabilityChecker.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+public class TestHiveTableWritabilityChecker
+        extends AbstractTestTableWritabilityChecker
+{
+    public TestHiveTableWritabilityChecker()
+    {
+        super(new HiveTableWritabilityChecker(true), new HiveTableWritabilityChecker(false));
+    }
+}


### PR DESCRIPTION
## Description

Allows specifying different table writability in connectors derived from Hive

## Motivation and Context

In certain situation custom implementation of Hive like connectors may introduce additional table types that must be allowed to be writable.

## Impact

No user visible impact

## Test Plan

CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

