### PR TITLE
[DOC] Update JMX connector documentation

### DIFF
--- a/presto-docs/src/main/sphinx/connector/jmx.rst
+++ b/presto-docs/src/main/sphinx/connector/jmx.rst
@@ -47,10 +47,13 @@ Commas in MBean names should be escaped in the following manner:
 Querying JMX
 ------------
 
-The JMX connector provides two schemas.
+The JMX connector provides three schemas: ``current``, ``history``, and ``information_schema``.
 
-The first one is ``current`` that contains every MBean from every node in the Presto
-cluster. You can see all of the available MBeans by running ``SHOW TABLES``::
+Current Schema
+^^^^^^^^^^^^^^
+
+The ``current`` schema contains every MBean from every node in the Presto
+cluster. To see all of the available MBeans, run ``SHOW TABLES``::
 
     SHOW TABLES FROM jmx.current;
 
@@ -97,6 +100,9 @@ returns information from the different Presto memory pools on each node::
       858993459 | example | com.facebook.presto.memory:type=MemoryPool,name=system
     (3 rows)
 
+History Schema
+^^^^^^^^^^^^^^
+
 The ``history`` schema contains the list of tables configured in the connector properties file.
 The tables have the same columns as those in the current schema, but with an additional
 timestamp column that stores the time at which the snapshot was taken::
@@ -111,3 +117,13 @@ timestamp column that stores the time at which the snapshot was taken::
      2016-01-28 10:19:00.000 |  21422
      2016-01-28 10:19:10.000 |  31412
     (3 rows)
+
+Information Schema
+^^^^^^^^^^^^^^^^^^
+
+The ``information_schema`` contains metadata about all the other schemas.
+To list all the available tables in this schema, run the following command:
+
+.. code-block:: sql
+
+    SHOW TABLES FROM jmx.information_schema;


### PR DESCRIPTION
## Description
[DOC] Update JMX connector documentation

## Motivation and Context
To provide more accurate and detailed information to users about the SQL operations supported by the JMX connector in Presto. The current documentation mentions only two schemas (current and history), but the JMX connector actually provides three schemas (current, history, and information_schema). We need to update this information to maintain consistency and accuracy. Also add few examples for information_schema.

Fixes https://github.com/prestodb/presto/issues/22247

## Impact
No impact. Changes in presto-docs(jmx.rst)

## Test Plan
Manually built and tested.
<img width="842" alt="Screenshot 2024-03-20 at 11 01 55 AM" src="https://github.com/prestodb/presto/assets/89628774/a676f69e-6554-4da0-a21c-29178daf628b">
<img width="774" alt="Screenshot 2024-03-20 at 11 02 03 AM" src="https://github.com/prestodb/presto/assets/89628774/5d372469-dcca-4006-9689-7a258d0afcce">
<img width="784" alt="Screenshot 2024-03-20 at 11 02 08 AM" src="https://github.com/prestodb/presto/assets/89628774/3de14aad-5d62-4e0b-b2db-058347cde7f6">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

