### PR TITLE
construct row IDs while reading ORC file

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -238,7 +238,8 @@ public class HivePageSourceProvider
                 hiveLayout.getRemainingPredicate(),
                 hiveLayout.isPushdownFilterEnabled(),
                 rowExpressionService,
-                encryptionInformation);
+                encryptionInformation,
+                hiveSplit.getRowIdPartitionComponent());
         if (pageSource.isPresent()) {
             return pageSource.get();
         }
@@ -274,7 +275,7 @@ public class HivePageSourceProvider
                     toColumnHandles(regularAndInterimColumnMappings, true),
                     fileContext,
                     encryptionInformation,
-                    hiveLayout.isAppendRowNumberEnabled());
+                    hiveLayout.isAppendRowNumberEnabled() || hiveLayout.isAppendRowId());
             if (pageSource.isPresent()) {
                 return pageSource.get();
             }
@@ -385,7 +386,7 @@ public class HivePageSourceProvider
                     hiveStorageTimeZone,
                     fileContext,
                     encryptionInformation,
-                    layout.isAppendRowNumberEnabled());
+                    layout.isAppendRowNumberEnabled() || layout.isAppendRowId());
             if (pageSource.isPresent()) {
                 return Optional.of(pageSource.get());
             }
@@ -420,7 +421,8 @@ public class HivePageSourceProvider
             RowExpression remainingPredicate,
             boolean isPushdownFilterEnabled,
             RowExpressionService rowExpressionService,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            Optional<byte[]> rowIdPartitionComponent)
     {
         List<HiveColumnHandle> allColumns;
 
@@ -501,7 +503,9 @@ public class HivePageSourceProvider
                         bucketAdaptation,
                         hiveStorageTimeZone,
                         typeManager,
-                        pageSource.get());
+                        pageSource.get(),
+                        fileSplit.getPath(),
+                        rowIdPartitionComponent);
 
                 if (isPushdownFilterEnabled) {
                     return Optional.of(new FilteringPageSource(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RowIDCoercer.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RowIDCoercer.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.predicate.TupleDomainFilter;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarbinaryType;
+import io.airlift.slice.Slices;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+class RowIDCoercer
+        implements HiveCoercer
+{
+    private final byte[] rowIDPartitionComponent;
+    private final byte[] rowGroupID; // file name
+
+    RowIDCoercer(byte[] rowIDPartitionComponent, String rowGroupID)
+    {
+        this.rowIDPartitionComponent = requireNonNull(rowIDPartitionComponent);
+        this.rowGroupID = rowGroupID.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public TupleDomainFilter toCoercingFilter(TupleDomainFilter filter, Subfield subfield)
+    {
+        checkArgument(subfield.getPath().isEmpty(), "Subfields on primitive types are not allowed");
+        return filter;
+    }
+
+    @Override
+    public Type getToType()
+    {
+        return VarbinaryType.VARBINARY;
+    }
+
+    @Override
+    public Block apply(Block in)
+    {
+        BlockBuilder out = VarbinaryType.VARBINARY.createBlockBuilder(null, in.getPositionCount());
+        for (int i = 0; i < in.getPositionCount(); i++) {
+            if (in.isNull(i)) {
+                out.appendNull();
+                continue;
+            }
+            long rowNumber = BigintType.BIGINT.getLong(in, i);
+            ByteBuffer rowID = ByteBuffer.allocateDirect(this.rowIDPartitionComponent.length + this.rowGroupID.length + 8).order(ByteOrder.LITTLE_ENDIAN);
+            rowID.putLong(rowNumber);
+            rowID.put(this.rowGroupID);
+            rowID.put(this.rowIDPartitionComponent);
+            rowID.flip();
+            VarbinaryType.VARBINARY.writeSlice(out, Slices.wrappedBuffer(rowID));
+        }
+        return out.build();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
@@ -171,7 +171,7 @@ public class HiveFilterPushdown
 
             Optional<Set<HiveColumnHandle>> requestedColumns = currentLayoutHandle.map(layout -> ((HiveTableLayoutHandle) layout).getRequestedColumns()).orElse(Optional.empty());
 
-            boolean appendRowNumbereEnabled = currentLayoutHandle.map(layout -> ((HiveTableLayoutHandle) layout).isAppendRowNumberEnabled()).orElse(false);
+            boolean appendRowNumber = currentLayoutHandle.map(layout -> ((HiveTableLayoutHandle) layout).isAppendRowNumberEnabled()).orElse(false);
 
             return new ConnectorPushdownFilterResult(
                     metadata.getTableLayout(
@@ -193,7 +193,7 @@ public class HiveFilterPushdown
                                     .setLayoutString(layoutString)
                                     .setRequestedColumns(requestedColumns)
                                     .setPartialAggregationsPushedDown(false)
-                                    .setAppendRowNumberEnabled(appendRowNumbereEnabled)
+                                    .setAppendRowNumberEnabled(appendRowNumber)
                                     .setHiveTableHandle(hiveTableHandle)
                                     .build()),
                     remainingExpressions.getDynamicFilterExpression());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -941,6 +941,7 @@ public class TestHiveFileFormats
                 TRUE_CONSTANT,
                 false,
                 ROW_EXPRESSION_SERVICE,
+                Optional.empty(),
                 Optional.empty());
 
         RecordCursor cursor = ((RecordPageSource) pageSource.get()).getCursor();
@@ -1010,6 +1011,7 @@ public class TestHiveFileFormats
                 TRUE_CONSTANT,
                 false,
                 ROW_EXPRESSION_SERVICE,
+                Optional.empty(),
                 Optional.empty());
 
         assertTrue(pageSource.isPresent());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
@@ -251,6 +251,7 @@ public class TestHivePageSourceProvider
                 null,
                 false,
                 null,
+                Optional.empty(),
                 Optional.empty());
         assertTrue(pageSource.isPresent());
         assertTrue(pageSource.get() instanceof RecordPageSource);
@@ -303,6 +304,7 @@ public class TestHivePageSourceProvider
                 null,
                 false,
                 null,
+                Optional.empty(),
                 Optional.empty());
         assertTrue(pageSource.isPresent());
         assertTrue(pageSource.get() instanceof HivePageSource);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableLayoutHandle.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTableLayoutHandle.java
@@ -15,11 +15,21 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.CharType;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.common.plan.PlanCanonicalizationStrategy.CONNECTOR;
 import static com.facebook.presto.common.predicate.Domain.singleValue;
@@ -30,10 +40,52 @@ import static com.facebook.presto.hive.HiveTableLayoutHandle.canonicalizeDomainP
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static io.airlift.slice.Slices.utf8Slice;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestHiveTableLayoutHandle
 {
+    @Test
+    public void testIsAppendRowNumberEnabled()
+    {
+        List<Column> dataColumns = new ArrayList<>();
+        List<BaseHiveColumnHandle> partitionColumns = new ArrayList<>();
+        Map<String, String> tableParameters = Collections.emptyMap();
+        TupleDomain<Subfield> domainPredicate = TupleDomain.none();
+        boolean appendRowNumber = false;
+        RowExpression remainingPredicate = new ConstantExpression(null, CharType.createCharType(5));
+        Map<String, HiveColumnHandle> predicateColumns = Collections.emptyMap();
+        TupleDomain<ColumnHandle> partitionColumnPredicate = TupleDomain.none();
+        Optional<HiveBucketHandle> bucketHandle = Optional.empty();
+        Optional<HiveBucketing.HiveBucketFilter> bucketFilter = Optional.empty();
+        Optional<Set<HiveColumnHandle>> requestedColumns = Optional.empty();
+        SchemaTableName schemaTableName = SchemaTableName.valueOf("schema.TableName");
+        Optional<List<HivePartition>> partitions = Optional.empty();
+        Optional<HiveTableHandle> hiveTableHandle = Optional.empty();
+        HiveTableLayoutHandle handle = new HiveTableLayoutHandle(
+                schemaTableName,
+                "tablePath",
+                partitionColumns,
+                dataColumns,
+                tableParameters,
+                domainPredicate,
+                remainingPredicate,
+                predicateColumns,
+                partitionColumnPredicate,
+                bucketHandle,
+                bucketFilter,
+                false,
+                "layoutString",
+                requestedColumns,
+                false,
+                appendRowNumber,
+                partitions,
+                false,
+                hiveTableHandle);
+
+        assertFalse(handle.isAppendRowNumberEnabled());
+    }
+
     @Test
     public void testCanonicalizeDomain()
     {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
@@ -487,6 +487,7 @@ public class TestOrcBatchPageSourceMemoryTracking
                     null,
                     false,
                     ROW_EXPRESSION_SERVICE,
+                    Optional.empty(),
                     Optional.empty())
                     .get();
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestRowIDCoercer.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestRowIDCoercer.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.LongArrayBlockBuilder;
+import com.facebook.presto.common.type.VarbinaryType;
+import com.google.common.primitives.Longs;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestRowIDCoercer
+{
+    private final byte[] rowIdPartitionComponent = {(byte) 8, (byte) 9};
+    private HiveCoercer coercer = new RowIDCoercer(rowIdPartitionComponent, "some_filename.dat");
+
+    @Test
+    public void testGetToType()
+    {
+        assertEquals(coercer.getToType(), VarbinaryType.VARBINARY);
+    }
+
+    @Test
+    public void testApply()
+    {
+        Block rowNumbers = new LongArrayBlockBuilder(null, 5)
+                .writeLong(7L)
+                .writeLong(Long.MIN_VALUE)
+                .writeLong(0L)
+                .writeLong(1L)
+                .writeLong(-1L)
+                .writeLong(Long.MAX_VALUE)
+                .build();
+        Block rowIDs = coercer.apply(rowNumbers);
+        assertEquals(rowIDs.getPositionCount(), rowNumbers.getPositionCount());
+        assertRowId(rowIDs, 0, 7L);
+        assertRowId(rowIDs, 1, Long.MIN_VALUE);
+        assertRowId(rowIDs, 2, 0L);
+        assertRowId(rowIDs, 3, 1L);
+        assertRowId(rowIDs, 4, -1L);
+        assertRowId(rowIDs, 5, Long.MAX_VALUE);
+    }
+
+    private static void assertRowId(Block rowIDs, int position, long expected)
+    {
+        byte[] rowID = rowIDs.getSlice(position, 0, rowIDs.getSliceLength(position)).getBytes();
+        assertEquals(rowID.length, 27);
+        assertEquals(rowID[25], (byte) 8);
+        assertEquals(rowID[26], (byte) 9);
+        byte[] rowNumber = reverse(Arrays.copyOf(rowID, 8));
+        assertEquals(Longs.fromByteArray(rowNumber), expected);
+    }
+
+    // I'm sure this can be micro-optimized. It's only a test. Clarity matters more.
+    private static byte[] reverse(byte[] in)
+    {
+        byte[] out = new byte[in.length];
+        for (int i = 0; i < in.length; i++) {
+            out[i] = in[in.length - i - 1];
+        }
+        return out;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -184,7 +184,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
         ImmutableSet.Builder<Integer> presentColumns = ImmutableSet.builder();
         OrcType root = types.get(0);
         for (int column : includedColumns.keySet()) {
-            // an old file can have less columns since columns can be added
+            // an old file can have fewer columns since columns can be added
             // after the file was written
             if (column >= 0 && column < root.getFieldCount()) {
                 presentColumns.add(column);


### PR DESCRIPTION
## Description
When a query references a column named $row_id, a row number block will be appended by the ORC reader. The HivePageSource then coerces this row_number (long) block into a row_id (VARBINARY) block by adding the partition ID and the row Group ID (file name) to each row. 

## Motivation and Context
Part of # 22078

## Impact
The Hive page source now recognize and supply values for the $row_id hidden column.

## Test Plan
 mvn test  -pl :presto-hive   

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

