### PR TITLE
Allow users to disable join flipping

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -811,6 +811,17 @@ Optimizer Properties
 
     Track history based plan statistics from complete plan fragments in failed queries.
 
+``optimizer.size-based-join-flipping-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``boolean``
+    * **Default value:** ``true``
+
+    When enabled, the optimizer may flip join sides when determining join distribution type based on
+    gathered statistics. Set to false to prevent flipping sides of the join.
+
+
+
 
 Planner Properties
 --------------------------------------

--- a/presto-docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
+++ b/presto-docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
@@ -69,6 +69,12 @@ The valid values are:
  * ``BROADCAST`` - broadcast join distribution is used for all joins
  * ``PARTITIONED`` - partitioned join distribution is used for all join
 
+Presto may flip the hash and probe sides of the join based on known statistics at optimization
+time. In some cases this may be undesirable. To prevent the hash and probe side from being flipped
+you can set ``optimizer.size-based-join-flipping-enabled`` coordinator property or
+ ``optimizer_size_based_join_flipping_enabled`` session property to ``false``.
+
+
 Capping replicated table size
 -----------------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -344,6 +344,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_EXECUTION_PROCESS_REUSE_ENABLED = "native_execution_process_reuse_enabled";
     public static final String NATIVE_DEBUG_VALIDATE_OUTPUT_FROM_OPERATORS = "native_debug_validate_output_from_operators";
     public static final String DEFAULT_VIEW_SECURITY_MODE = "default_view_security_mode";
+    public static final String SIZE_BASED_JOIN_FLIPPING_ENABLED = "optimizer_size_based_join_flipping_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1939,7 +1940,12 @@ public final class SystemSessionProperties
                         featuresConfig.getDefaultViewSecurityMode(),
                         false,
                         value -> CreateView.Security.valueOf(((String) value).toUpperCase()),
-                        CreateView.Security::name));
+                        CreateView.Security::name),
+                booleanProperty(
+                        SIZE_BASED_JOIN_FLIPPING_ENABLED,
+                        "flip join sides when determining join distribution type based on estimated statistics",
+                        featuresConfig.isSizeBasedJoinFlippingEnabled(),
+                        false));
     }
 
     public static boolean isSpoolingOutputBufferEnabled(Session session)
@@ -3215,5 +3221,10 @@ public final class SystemSessionProperties
     public static CreateView.Security getDefaultViewSecurityMode(Session session)
     {
         return session.getSystemProperty(DEFAULT_VIEW_SECURITY_MODE, CreateView.Security.class);
+    }
+
+    public static boolean isSizeBasedJoinFlippingEnabled(Session session)
+    {
+        return session.getSystemProperty(SIZE_BASED_JOIN_FLIPPING_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -306,6 +306,7 @@ public class FeaturesConfig
     private boolean limitNumberOfGroupsForKHyperLogLogAggregations = true;
     private boolean generateDomainFilters;
     private CreateView.Security defaultViewSecurityMode = DEFINER;
+    private boolean sizeBasedJoinFlippingEnabled = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -3072,5 +3073,18 @@ public class FeaturesConfig
     {
         this.defaultViewSecurityMode = securityMode;
         return this;
+    }
+
+    @Config("optimizer.size-based-join-flipping-enabled")
+    @ConfigDescription("flip join sides when determining join distribution type based on estimated statistics")
+    public FeaturesConfig setSizeBasedJoinFlippingEnabled(boolean enabled)
+    {
+        this.sizeBasedJoinFlippingEnabled = enabled;
+        return this;
+    }
+
+    public boolean isSizeBasedJoinFlippingEnabled()
+    {
+        return sizeBasedJoinFlippingEnabled;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -268,7 +268,8 @@ public class TestFeaturesConfig
                 .setRewriteExpressionWithConstantVariable(true)
                 .setDefaultWriterReplicationCoefficient(3.0)
                 .setDefaultViewSecurityMode(DEFINER)
-                .setCteHeuristicReplicationThreshold(4));
+                .setCteHeuristicReplicationThreshold(4)
+                .setSizeBasedJoinFlippingEnabled(true));
     }
 
     @Test
@@ -481,6 +482,7 @@ public class TestFeaturesConfig
                 .put("optimizer.default-writer-replication-coefficient", "5.0")
                 .put("default-view-security-mode", INVOKER.name())
                 .put("cte-heuristic-replication-threshold", "2")
+                .put("optimizer.size-based-join-flipping-enabled", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -690,7 +692,8 @@ public class TestFeaturesConfig
                 .setRewriteExpressionWithConstantVariable(false)
                 .setDefaultWriterReplicationCoefficient(5.0)
                 .setDefaultViewSecurityMode(INVOKER)
-                .setCteHeuristicReplicationThreshold(2);
+                .setCteHeuristicReplicationThreshold(2)
+                .setSizeBasedJoinFlippingEnabled(false);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
## Description

This adds a new feature config for the coordinator and a corresponding session property.

- feature config: optimizer.size-based-join-flipping-enabled
- session property: optimizer_size_based_join_flipping_enabled

By default this is true to preserve the previous behavior, but setting it to false will disable returning any results which flip the sides of the join in the DetermineJoinDistributionType rule.

## Motivation and Context

There are cases where users want to disable cost-based join re-ordering, but still want the join type to be automatically determined. Before this change, it was possible for the DetermineJoinDistributionType rule to flip the join order based on incorrect statistics, making an impact query performance.

## Impact

Two new configs

## Test Plan

New tests ensure for all existing test cases which checked for flipped joins, the new tests ensure the config property disables the flipping

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

