### PR TITLE
[codemod] Remove unused lambda capture from foqs/common/TtlCache.h

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -815,7 +815,7 @@ folly::Future<std::unique_ptr<Result>> TaskManager::getResults(
         promise.setValue(createEmptyResult(token));
       });
 
-  auto timeoutFn = [this, token]() { return createEmptyResult(token); };
+  auto timeoutFn = [token]() { return createEmptyResult(token); };
 
   try {
     auto prestoTask = findOrCreateTask(taskId);


### PR DESCRIPTION
Summary:
`-Wunused-lambda-capture` has identified an unused lambda capture. This diff removes it.

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D55092504


