### PR TITLE
[native] Extract SimpleFunctionApi.h from Type.h

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -27,6 +27,7 @@
 
 #include <folly/String.h>
 #include <folly/container/F14Set.h>
+#include <velox/type/Type.h>
 
 #include "presto_cpp/main/operators/BroadcastWrite.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
@@ -131,7 +132,7 @@ void setCellFromVariantByKind<TypeKind::VARBINARY>(
     vector_size_t row,
     const velox::variant& value) {
   auto values = column->as<FlatVector<StringView>>();
-  values->set(row, StringView(value.value<Varbinary>()));
+  values->set(row, StringView(value.value<TypeKind::VARBINARY>()));
 }
 
 template <>
@@ -140,7 +141,7 @@ void setCellFromVariantByKind<TypeKind::VARCHAR>(
     vector_size_t row,
     const velox::variant& value) {
   auto values = column->as<FlatVector<StringView>>();
-  values->set(row, StringView(value.value<Varchar>()));
+  values->set(row, StringView(value.value<TypeKind::VARCHAR>()));
 }
 
 void setCellFromVariant(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/9182

Extract types and templates used in Simple Function API from Type.h into separate header files: SimpleFunctionAPI.h and KindToSimpleType.

Extracted types include types used to register simple functions, e.g. Varchar, Varbinary, Array, Map, Row, Generic, Constant, etc.

Extracted templates include SimpleTypeTrait, MaterializeType.

Deleted unused IsRowType template.

Fixed incorrect usage of Date type.

Removed unnecessary usage of CppToType.

Differential Revision: D55136302


