### PR TITLE
[native] Remove usage of Varchar and Varbinary classes

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -131,7 +131,7 @@ void setCellFromVariantByKind<TypeKind::VARBINARY>(
     vector_size_t row,
     const velox::variant& value) {
   auto values = column->as<FlatVector<StringView>>();
-  values->set(row, StringView(value.value<Varbinary>()));
+  values->set(row, StringView(value.value<TypeKind::VARBINARY>()));
 }
 
 template <>
@@ -140,7 +140,7 @@ void setCellFromVariantByKind<TypeKind::VARCHAR>(
     vector_size_t row,
     const velox::variant& value) {
   auto values = column->as<FlatVector<StringView>>();
-  values->set(row, StringView(value.value<Varchar>()));
+  values->set(row, StringView(value.value<TypeKind::VARCHAR>()));
 }
 
 void setCellFromVariant(


### PR DESCRIPTION
Varchar and Varbinary structs are designed to be used when registering simple functions. These should not be used outside of that use case.

This change is needed to unblock refactoring of Type.h in Velox: https://github.com/facebookincubator/velox/pull/9182

```
== NO RELEASE NOTE ==
```

