### PR TITLE
[docs] Add Presto Clients category and CLI usage to documentation

### DIFF
--- a/presto-docs/src/main/sphinx/clients.rst
+++ b/presto-docs/src/main/sphinx/clients.rst
@@ -1,0 +1,8 @@
+**************
+Presto Clients
+**************
+
+.. toctree::
+    :maxdepth: 1
+
+    clients/presto-cli

--- a/presto-docs/src/main/sphinx/clients/presto-cli.rst
+++ b/presto-docs/src/main/sphinx/clients/presto-cli.rst
@@ -1,0 +1,205 @@
+======================
+Command Line Interface
+======================
+
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+Overview
+========
+
+The Presto Command Line Interface (CLI) is a terminal-based interactive shell 
+for running queries, and is a
+`self-executing <http://skife.org/java/unix/2011/06/20/really_executable_jars.html>`_
+JAR file that acts like a normal UNIX executable. The Presto CLI communicates 
+with the Presto server over HTTP using a REST API, documented at 
+:doc:`Presto Client REST API </develop/client-protocol>`.
+
+To install the Presto CLI, see :doc:`/installation/cli`.
+
+Configuration
+=============
+
+The Presto CLI paginates query results using the ``less`` program, which 
+is configured with preset options. To change the pagination of query results, set the 
+environment variable ``PRESTO_PAGER`` to the name of a different program such as ``more``, 
+or set it to an empty value to disable pagination.
+
+Connect to a Presto server using the Presto CLI
+===============================================
+
+To connect to a Presto server, run the CLI with the ``--server`` option.  
+
+.. code-block:: none
+
+    ./presto --server localhost:8080 --catalog hive --schema default
+
+``localhost:8080`` is the default for a Presto server, so if you have a Presto server running locally you can 
+leave it off. 
+
+To connect to a remote Presto server, use the Presto endpoint URL as in 
+the following example command:
+
+.. code-block:: none
+
+    ./presto --server http://www.example.net:8080
+
+
+
+Examples
+========
+
+Extract a Query Plan in JSON Format
+-----------------------------------
+The following example runs a SQL statement using ``--execute`` against a 
+specified catalog and schema, and saves the query plan of the statement in 
+JSON format in a file named ``plan.json``. 
+
+.. code-block:: none
+
+    ./presto --catalog catalogname --schema tpch \
+    --execute 'EXPLAIN (format JSON) SELECT 1 from lineitem' \
+    --output-format JSON | jq '.["Query Plan"] | fromjson' > plan.json
+
+Online Help
+===========
+
+Run the CLI with the ``--help`` option to see the online help.
+
+.. code-block:: none
+
+    ./presto --help
+
+SYNOPSIS
+        presto [--access-token <access token>] [--catalog <catalog>]
+                [--client-info <client-info>]
+                [--client-request-timeout <client request timeout>]
+                [--client-tags <client tags>] [--debug] [--disable-compression]
+                [--execute <execute>] [--extra-credential <extra-credential>...]
+                [(-f <file> | --file <file>)] [(-h | --help)]
+                [--http-proxy <http-proxy>] [--ignore-errors]
+                [--keystore-password <keystore password>]
+                [--keystore-path <keystore path>]
+                [--krb5-config-path <krb5 config path>]
+                [--krb5-credential-cache-path <krb5 credential cache path>]
+                [--krb5-disable-remote-service-hostname-canonicalization]
+                [--krb5-keytab-path <krb5 keytab path>]
+                [--krb5-principal <krb5 principal>]
+                [--krb5-remote-service-name <krb5 remote service name>]
+                [--log-levels-file <log levels file>] [--output-format <output-format>]
+                [--password] [--resource-estimate <resource-estimate>...]
+                [--schema <schema>] [--server <server>] [--session <session>...]
+                [--socks-proxy <socks-proxy>] [--source <source>]
+                [--truststore-password <truststore password>]
+                [--truststore-path <truststore path>] [--user <user>] [--version]
+
+OPTIONS
+        --access-token <access token>
+            Access token
+
+        --catalog <catalog>
+            Default catalog
+
+        --client-info <client-info>
+            Extra information about client making query
+
+        --client-request-timeout <client request timeout>
+            Client request timeout (default: 2m)
+
+        --client-tags <client tags>
+            Client tags
+
+        --debug
+            Enable debug information
+
+        --disable-compression
+            Disable compression of query results
+
+        --execute <execute>
+            Execute specified statements and exit
+
+        --extra-credential <extra-credential>
+            Extra credentials (property can be used multiple times; format is
+            key=value)
+
+        -f <file>, --file <file>
+            Execute statements from file and exit
+
+        -h, --help
+            Display help information
+
+        --http-proxy <http-proxy>
+            HTTP proxy to use for server connections
+
+        --ignore-errors
+            Continue processing in batch mode when an error occurs (default is
+            to exit immediately)
+
+        --keystore-password <keystore password>
+            Keystore password
+
+        --keystore-path <keystore path>
+            Keystore path
+
+        --krb5-config-path <krb5 config path>
+            Kerberos config file path (default: /etc/krb5.conf)
+
+        --krb5-credential-cache-path <krb5 credential cache path>
+            Kerberos credential cache path
+
+        --krb5-disable-remote-service-hostname-canonicalization
+            Disable service hostname canonicalization using the DNS reverse
+            lookup
+
+        --krb5-keytab-path <krb5 keytab path>
+            Kerberos key table path (default: /etc/krb5.keytab)
+
+        --krb5-principal <krb5 principal>
+            Kerberos principal to be used
+
+        --krb5-remote-service-name <krb5 remote service name>
+            Remote peer's kerberos service name
+
+        --log-levels-file <log levels file>
+            Configure log levels for debugging using this file
+
+        --output-format <output-format>
+            Output format for batch mode [ALIGNED, VERTICAL, CSV, TSV,
+            CSV_HEADER, TSV_HEADER, NULL] (default: CSV)
+
+        --password
+            Prompt for password
+
+        --resource-estimate <resource-estimate>
+            Resource estimate (property can be used multiple times; format is
+            key=value)
+
+        --schema <schema>
+            Default schema
+
+        --server <server>
+            Presto server location (default: localhost:8080)
+
+        --session <session>
+            Session property (property can be used multiple times; format is
+            key=value; use 'SHOW SESSION' to see available properties)
+
+        --socks-proxy <socks-proxy>
+            SOCKS proxy to use for server connections
+
+        --source <source>
+            Name of source making query
+
+        --truststore-password <truststore password>
+            Truststore password
+
+        --truststore-path <truststore path>
+            Truststore path
+
+        --user <user>
+            Username
+
+        --version
+            Display version information and exit

--- a/presto-docs/src/main/sphinx/index.rst
+++ b/presto-docs/src/main/sphinx/index.rst
@@ -7,6 +7,7 @@ Presto Documentation
 
     overview
     installation
+    clients
     security
     admin
     cache

--- a/presto-docs/src/main/sphinx/installation/cli.rst
+++ b/presto-docs/src/main/sphinx/installation/cli.rst
@@ -14,9 +14,13 @@ Download :maven_download:`cli`.
 
 Rename the JAR file to ``presto`` with the following command: 
 
-    mv  :maven_download:`cli` presto
+.. code-block:: none
+
+    mv  presto-cli-0.286-executable.jar presto
 
 Use ``chmod +x`` to make the renamed file executable:
+
+.. code-block:: none
 
     chmod +x presto
 
@@ -25,7 +29,9 @@ Run the Presto CLI
 
 Start the Presto CLI using the name you gave it using the ``mv`` command:
 
-  ./presto
+.. code-block:: none
+
+    ./presto
 
 The Presto CLI starts and displays the prompt ``presto>``. 
 
@@ -33,27 +39,8 @@ To exit the Presto CLI, enter ``quit``.
 
 Run the CLI with the ``--help`` option to see the available options.
 
+.. code-block:: none
+
     ./presto --help
 
-Connect to a Presto server using the Presto CLI
-===============================================
-
-To connect to a Presto server, run the CLI with the ``--server`` option.  
-
-    ./presto --server localhost:8080 --catalog hive --schema default
-
-``localhost:8080`` is the default for a Presto server, so if you have a Presto server running locally you can 
-leave it off. 
-
-To connect to a remote Presto server, use the Presto endpoint URL as in 
-the following example command
-
-   ./presto --server http://www.example.net:8080
-
-The Presto CLI paginates query results using the ``less`` program, which 
-is configured with preset options. To change the pagination of query results, set the 
-environment variable ``PRESTO_PAGER`` to the name of a different program such as ``more``, 
-or set it to an empty value to disable pagination.
-
-The Presto engine and client communicate over HTTP using a REST API, documented at 
-:doc:`Presto Client REST API </develop/client-protocol>`.
+To configure the Presto CLI, or for use and examples, see :doc:`/clients/presto-cli`.


### PR DESCRIPTION
## Description
* Add top-level category "Presto Clients" to Presto documentation 
* Add Presto CLI usage and example
* Move CLI configuration content from [the existing CLI doc](http://prestodb.io/docs/current/installation/cli.html) to new page

## Motivation and Context
[PR 22181](https://github.com/prestodb/presto/pull/22181) made me think about where to document the change to ``--output-format`` because it is a user-facing option. I realized that we don't document almost all of the command line options for the CLI.  @ZacBlanco also provided an example of how to use the new CLI option `--output-format=JSON` in [a comment on PR 22181](https://github.com/prestodb/presto/pull/22181#issuecomment-1993591264) that I thought would be good to add to the Presto docs instead of in a merged PR. 

I didn't want to expand [the existing CLI doc](http://prestodb.io/docs/current/installation/cli.html) because I wanted to keep the focus of the existing CLI page on Installation - the category the existing page is in - but that page also contained some additional information about the CLI that could be added to a new page. 

Adding a new category "Presto Clients" and creating a new page for config, examples, and usage of the Presto CLI seemed a good solution because the new category also gives us a location to put currently-missing documentation for the Presto Console as well as potentially documenting other clients usable with Presto, such as Apache Superset. 

I moved CLI description and configuration from the existing page to the new page to focus the existing page on installation, and added Zac's example of how to use `--output-format=JSON` to the new page. As we think of new examples of how to use the CLI we now have a place to put them. 

I also added the output of the CLI option `--help` to this page in a topic named "Online Help". The output is intentionally copied and pasted from a terminal unedited because I would like to investigate the possibility in future of automating the updating of this output in the docs when they are generated.  Additional content relating to individual options can be added as subheadings in "Examples". 

## Impact
Documentation. 

## Test Plan
Local build of docs to verify that the new category "Presto Clients" appears in the contents and displays the link to the new page "Command Line Interface". Reviewed content and formatting of the new page, the edited existing CLI page, and that the links I added between the two pages work correctly. 

Screenshots:
left-side navbar contents showing new category and new page
<img width="642" alt="Screenshot 2024-03-20 at 5 38 50 PM" src="https://github.com/prestodb/presto/assets/7013443/0a2454fa-49e0-43d3-a6ad-55aa33042e01">

part of the new Command Line Interface page showing left-side navbar and right-side page-level table of contents
<img width="1595" alt="Screenshot 2024-03-20 at 5 39 20 PM" src="https://github.com/prestodb/presto/assets/7013443/e26a7299-67d8-401d-8511-852ed397d735">


## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add usage documentation for :doc:`/clients/presto-cli`
```

