### PR TITLE
Add \`log.path\` Configuration Property to Presto

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -912,6 +912,16 @@ CTE Materialization Properties
 Logging Properties
 ------------------
 
+``log.path``
+^^^^^^^^^^^^
+
+    * **Type:** ``string``
+    * **Default value:** ``<data_directory>/var/log/server.log``
+
+    The ``log.path`` property specifies the path to the server log file used by Presto.
+    This path is relative to the data directory, which is determined by the ``node.data-dir`` property.
+    If no value is provided for ``log.path``, the default value is used.
+
 ``log.max-history``
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description
This PR adds a new configuration property `log.path` to Presto. This property specifies the path to the log file used by Presto. The path is relative to the data directory. This addition comes after the changes introduced in [Pull Request 71](https://github.com/prestodb/airlift/pull/71).

## Motivation and Context
The motivation behind this change is to give users the ability to specify their own path for the server log file. This can be useful in scenarios where the default log file location needs to be changed due to system constraints or personal preference.

## Impact
no impact.

## Test Plan
Add the `log.path` property to the Presto configuration.
2. Start Presto and check the specified log file path to ensure that logging is happening at the correct location.
3. Change the `log.path` property value and restart Presto to ensure the new value is taken into effect.

Other Details:

This PR needs to be merged along with a related PR in the airlift repository. The airlift PR adjusts the launcher.py script to honor the log.path property. At present, even if we set this property, the default values from launcher.py override it, as shown in the attached screenshots. This is incorrect behavior - if a user sets the log.path property, that value should be used instead of the default.
![image1](https://github.com/prestodb/airlift/assets/89628774/3c851c71-fba2-4a5a-b37b-63cee11b21ec)
![image2](https://github.com/prestodb/airlift/assets/89628774/d27a7fdf-d5f5-44d4-af50-1d2a24abb8ef)
![image3](https://github.com/prestodb/airlift/assets/89628774/4d88f38c-8723-4c81-ab57-210ecc0438ca)

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

