### PR TITLE
HBO test improvements

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.PlanCostEstimate;
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsProvider;
@@ -52,7 +53,7 @@ public final class PlanAssert
         // TODO (Issue #13231) add back printing unresolved plan once we have no need to translate OriginalExpression to RowExpression
         if (!matches.isMatch()) {
             PlanNode resolvedPlan = resolveGroupReferences(actual.getRoot(), lookup);
-            String resolvedFormattedPlan = textLogicalPlan(planSanitizer.apply(resolvedPlan), actual.getTypes(), StatsAndCosts.empty(), metadata.getFunctionAndTypeManager(), session, 0);
+            String resolvedFormattedPlan = textLogicalPlan(planSanitizer.apply(resolvedPlan), actual.getTypes(), StatsAndCosts.create(resolvedPlan, statsProvider, node -> PlanCostEstimate.unknown()), metadata.getFunctionAndTypeManager(), session, 0);
             throw new AssertionError(format(
                     "Plan does not match, expected [\n\n%s\n] but found [\n\n%s\n]",
                     pattern,

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -138,12 +138,9 @@ public class TestHistoryBasedStatsTracking
         assertPlan(session, sql, anyTree(anyTree(any()), anyTree(node(ProjectNode.class, node(FilterNode.class, any())).withOutputRowCount(Double.NaN))));
 
         // HBO Statistics
-        try {
-            getQueryRunner().execute(session, sql);
-        }
-        catch (Exception e) {
-            getHistoryProvider().waitProcessQueryEvents();
-        }
+        assertQueryFails(session, sql, ".*Key not present in map.*");
+        getHistoryProvider().waitProcessQueryEvents();
+
         assertPlan(session, sql, anyTree(anyTree(any()), anyTree(node(ProjectNode.class, node(FilterNode.class, any())).withOutputRowCount(15000))));
     }
 


### PR DESCRIPTION
## Description
1. Add the stats to the logged plan for plan mismatches.
Example new output:
```
- Output[PlanNodeId 6][nationkey, name, regionkey, comment] => [nationkey:bigint, name:varchar(25), regionkey:bigint, comment:varchar(152)]
        Estimates: {source: HistoryBasedSourceInfo, rows: 2 (199B), cpu: ?, memory: ?, network: ?}
    - ScanFilter[PlanNodeId 0,108][table = TableHandle {connectorId='tpch', connectorHandle='nation:sf0.01', layout='Optional[nation:sf0.01]'}, filterPredicate = (substr(name, BIGINT'1', BIGINT'1')) = (VARCHAR'A')] => [nationkey:bigint, name:varchar(25), regionkey:bigint, comment:varchar(152)]
            Estimates: {source: CostBasedSourceInfo, rows: 25 (2.67kB), cpu: ?, memory: ?, network: ?}/{source: HistoryBasedSourceInfo, rows: 0 (0B), cpu: ?, memory: ?, network: ?}
            regionkey := tpch:regionkey (1:15)
            name := tpch:name (1:15)
            nationkey := tpch:nationkey (1:15)
            comment := tpch:comment (1:15)
```

2.  improve the hbo failed queries test

## Motivation and Context
Improve debugging for failed planner tests. Helps with debugging for https://github.com/prestodb/presto/issues/22204
Improve a test to be more resilient to bad changes
 
## Impact
N/A

## Test Plan
ran tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

