### PR TITLE
Fix memory revoke in `TopNRowNumberOperator`

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
@@ -296,9 +296,6 @@ public class TopNRowNumberOperator
     @Override
     public ListenableFuture<?> startMemoryRevoke()
     {
-        if (finishing) {
-            return NOT_BLOCKED;
-        }
         return groupedTopNBuilder.startMemoryRevoke();
     }
 


### PR DESCRIPTION
## Description

Fix #22127 .

`TopNRowNumberOperator` should not simply return a completed future for `startMemoryRevoke()` when it's flag `finishing` is true. That could lead in the problem described in #22127 when events occur in following order:

 1. Have successfully executed spilling at least once, so that the spiller is existing.
 2. Then handle some new input pages.
 3. Next, the `finish()` method is called by upstream operator, and the flag `memoryRevokingRequested` is set by `MemoryRevokingScheduler`.
 4. After that, when driver try to execute `handleMemoryRevoke()`, the error above would appear.

## Test Plan

 - Existing test case `TestDistributedSpilledQueriesWithTempStorage.testRowNumberLimit`
 - Before this fix, this error almost certain to occur when running the test 2000 times in a loop. After this fix, it never occur again. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix bug with spilling in TopNRowNumber
```

