### PR TITLE
Allow leading and trailing spaces in CAST(str as INTEGER)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
@@ -179,7 +179,7 @@ public final class VarcharOperators
     public static long castToBigint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Long.parseLong(slice.toStringUtf8());
+            return Long.parseLong(slice.toStringUtf8().trim());
         }
         catch (Exception e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to BIGINT", slice.toStringUtf8()));
@@ -192,7 +192,7 @@ public final class VarcharOperators
     public static long castToInteger(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Integer.parseInt(slice.toStringUtf8());
+            return Integer.parseInt(slice.toStringUtf8().trim());
         }
         catch (Exception e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INT", slice.toStringUtf8()));
@@ -205,7 +205,7 @@ public final class VarcharOperators
     public static long castToSmallint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Short.parseShort(slice.toStringUtf8());
+            return Short.parseShort(slice.toStringUtf8().trim());
         }
         catch (Exception e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", slice.toStringUtf8()));
@@ -218,7 +218,7 @@ public final class VarcharOperators
     public static long castToTinyint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Byte.parseByte(slice.toStringUtf8());
+            return Byte.parseByte(slice.toStringUtf8().trim());
         }
         catch (Exception e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", slice.toStringUtf8()));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestVarcharOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestVarcharOperators.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import org.testng.annotations.Test;
 
@@ -20,6 +24,7 @@ import static com.facebook.presto.common.function.OperatorType.INDETERMINATE;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 
 public class TestVarcharOperators
         extends AbstractTestFunctions
@@ -139,5 +144,24 @@ public class TestVarcharOperators
         assertOperator(INDETERMINATE, "cast(123456 as varchar)", BOOLEAN, false);
         assertOperator(INDETERMINATE, "cast(12345.0123 as varchar)", BOOLEAN, false);
         assertOperator(INDETERMINATE, "cast(true as varchar)", BOOLEAN, false);
+    }
+
+    @Test
+    public void testCastVarcharAsInteger()
+    {
+        assertFunction("CAST('6' AS BIGINT)", BigintType.BIGINT, 6L);
+        assertFunction("CAST('7' AS INTEGER)", IntegerType.INTEGER, 7);
+        assertFunction("CAST('8' AS SMALLINT)", SmallintType.SMALLINT, (short) 8);
+        assertFunction("CAST('9' AS TINYINT)", TinyintType.TINYINT, (byte) 9);
+
+        assertFunction("CAST(' 6    ' AS BIGINT)", BigintType.BIGINT, 6L);
+        assertFunction("CAST('  7   ' AS INTEGER)", IntegerType.INTEGER, 7);
+        assertFunction("CAST('   8  ' AS SMALLINT)", SmallintType.SMALLINT, (short) 8);
+        assertFunction("CAST('    9 ' AS TINYINT)", TinyintType.TINYINT, (byte) 9);
+
+        assertInvalidFunction("CAST('6 7' AS BIGINT)", INVALID_CAST_ARGUMENT, "Cannot cast '6 7' to BIGINT");
+        assertInvalidFunction("CAST('7 8' AS INTEGER)", INVALID_CAST_ARGUMENT, "Cannot cast '7 8' to INT");
+        assertInvalidFunction("CAST('8 9' AS SMALLINT)", INVALID_CAST_ARGUMENT, "Cannot cast '8 9' to SMALLINT");
+        assertInvalidFunction("CAST('9 6' AS TINYINT)", INVALID_CAST_ARGUMENT, "Cannot cast '9 6' to TINYINT");
     }
 }


### PR DESCRIPTION
## Description
Allow leading and trailing spaces in CAST(str as INTEGER). Also as BIGINT, SMALLINT and TINYINT.
This is according to SQL standard.
Fixes https://github.com/prestodb/presto/issues/21315

## Motivation and Context
This is according to SQL standard.

## Impact
This is query behavior change.

## Test Plan
A new unit test that fails on the old code.
Also maybe need to update documentation to reflect this.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* CAST(str as INTEGER), CAST(str as BIGINT), CAST(str as SMALLINT), CAST(str as TINYINT) now allow leading and trailing spaces in the string.

```