### PR TITLE
Possibly fix flakiness of TestCreateViewVerification.testRunningInQueryBankMode()

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.sql.SqlFormatter;
 import com.facebook.presto.sql.tree.Statement;
@@ -73,6 +74,7 @@ import static java.util.Objects.requireNonNull;
 public abstract class AbstractVerification<B extends QueryBundle, R extends MatchResult, V>
         implements Verification
 {
+    private static final Logger LOG = Logger.get(AbstractVerification.class);
     private static final String INTERNAL_ERROR = "VERIFIER_INTERNAL_ERROR";
     private static final String SNAPSHOT_DOES_NOT_EXIST = "SNAPSHOT_DOES_NOT_EXIST";
 
@@ -277,6 +279,7 @@ public abstract class AbstractVerification<B extends QueryBundle, R extends Matc
         catch (Throwable t) {
             if (exceptionClassifier.shouldResubmit(t)
                     && verificationContext.getResubmissionCount() < verificationResubmissionLimit) {
+                LOG.info("Error during verification: %s", t);
                 return new VerificationResult(this, true, Optional.empty());
             }
             throwable = Optional.of(t);

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateViewVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateViewVerification.java
@@ -141,13 +141,14 @@ public class TestCreateViewVerification
     @Test
     public void testRunningInQueryBankMode()
     {
-        String query = "CREATE VIEW succeeded_not_exists AS SELECT * FROM tpch.tiny.nation";
+        String snapshotModeQuery = "CREATE VIEW succeeded_not_exists_snapshot AS SELECT * FROM tpch.tiny.nation";
 
-        Optional<VerifierQueryEvent> event = runVerification(query, query, saveSnapshotSettings);
+        Optional<VerifierQueryEvent> event = runVerification(snapshotModeQuery, snapshotModeQuery, saveSnapshotSettings);
         assertTrue(event.isPresent());
         assertEvent(event.get(), SUCCEEDED);
 
-        event = runVerification(query, query, queryBankModeSettings);
+        String queryBankModeQuery = "CREATE VIEW succeeded_not_exists_querybank AS SELECT * FROM tpch.tiny.nation";
+        event = runVerification(queryBankModeQuery, queryBankModeQuery, queryBankModeSettings);
         assertTrue(event.isPresent());
         assertEvent(event.get(), SUCCEEDED);
     }


### PR DESCRIPTION
## Description
1. Add logging to AbstractVerification to help with debugging flakiness in TestCreateViewVerification.testRunningInQueryBankMode(). 
2. Fix a possible source of the flakiness

## Motivation and Context
 the logs for https://github.com/prestodb/presto/issues/20863 aren't available anymore,  and I can't reproduce the failure locally, so 
1. added extra logging so that if the failure happens again we have more of the information we might need
3. Fix a possible source of the flakiness if view names that were reused weren't torn down properly

## Impact
n/a

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

