### PR TITLE
Fix Flaky TestQueues.testQueuedQueryInteraction Test

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryTaskLimit.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryTaskLimit.java
@@ -33,7 +33,6 @@ import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.execution.TestQueryRunnerUtil.createQuery;
 import static com.facebook.presto.execution.TestQueryRunnerUtil.waitForQueryState;
-import static com.facebook.presto.execution.TestQueues.LONG_LASTING_QUERY;
 import static com.facebook.presto.execution.TestQueues.newSession;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_HAS_TOO_MANY_STAGES;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
@@ -47,6 +46,8 @@ import static org.testng.Assert.assertTrue;
 @Test(singleThreaded = true)
 public class TestQueryTaskLimit
 {
+    public static final String LONG_LASTING_QUERY = "SELECT COUNT(*) FROM lineitem";
+
     private ExecutorService executor;
     private Session defaultSession;
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Although, I could not reproduce the flakyness but since it was observed in the past that it got timed out after 60 seconds, increasing the timeout to 240 seconds as most other tests in com.facebook.presto.execution.TestQueues have similar timeout. The test was executed ~120 times locally to verify it is not flaky.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
#19633 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Re-enable flaky test: TestQueues.testQueuedQueryInteraction

## Test Plan
<!---Please fill in how you tested your change-->
The test was executed ~120 times locally to verify it is not flaky.
<img width="1646" alt="Screenshot 2024-03-22 at 3 33 18 AM" src="https://github.com/prestodb/presto/assets/6432146/5982a2d3-74fd-47cb-9742-fab66d1f3fae">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

