### PR TITLE
Retry docker compose

### DIFF
--- a/presto-hive-hadoop2/bin/common.sh
+++ b/presto-hive-hadoop2/bin/common.sh
@@ -100,7 +100,7 @@ function start_docker_containers() {
   fi
 
   # start containers
-  docker-compose -f "${DOCKER_COMPOSE_LOCATION}" up -d
+  retry docker-compose -f "${DOCKER_COMPOSE_LOCATION}" up -d
 
   # start docker logs for hadoop container
   docker-compose -f "${DOCKER_COMPOSE_LOCATION}" logs --no-color hadoop-master &


### PR DESCRIPTION
Fix for https://github.com/prestodb/presto/issues/22140

## Testing
- Started a background hms3 container (port 9083 was blocked)
- Executed `run_hive_s3_tests.sh`
- Failure observed - `ERROR: for hadoop-master  Cannot start service hadoop-master: driver failed programming external connectivity on endpoint conf_hadoop-master_1 (c0b7cfeed18fc6426fbcb7f328873f78aa666c34da0c6f05f5f2e76c5765a94c): Error starting userland proxy: listen tcp4 0.0.0.0:9083: bind: address already in use`
- Retry kicks in and keeps attempting retry for 600s or until the port frees up