### PR TITLE
Increase timeout for flaky MergeOperator test

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
@@ -53,7 +53,7 @@ import static org.testng.Assert.fail;
 public final class OperatorAssertion
 {
     private static final Duration BLOCKED_DEFAULT_TIMEOUT = new Duration(10, MILLISECONDS);
-    private static final Duration UNBLOCKED_DEFAULT_TIMEOUT = new Duration(1, SECONDS);
+    private static final Duration UNBLOCKED_DEFAULT_TIMEOUT = new Duration(5, SECONDS);
 
     private OperatorAssertion()
     {


### PR DESCRIPTION
## Description

Couldn't reproduce the flakiness at all after over 10000 continuous runs. So this issue may be related to CI running environment, as a one-second timeout is not so reliable when GC occurs. Increase the timeout to 5S to make the test more reliable.

Fixs: #20541 

## Test Plan

 - Continuously run test case `TestMergeOperator.testMergeDifferentTypes()` 10000 times

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

