### PR TITLE
Include parameters in logged test name

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestMapColumnStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestMapColumnStatisticsBuilder.java
@@ -48,7 +48,7 @@ public class TestMapColumnStatisticsBuilder
     }
 
     @Test
-    public void testAddMapStatisticsNoValues()
+    public void testAddEmptyMapStatistics()
     {
         MapColumnStatisticsBuilder builder = new MapColumnStatisticsBuilder(true);
         ColumnStatistics columnStatistics = builder.buildColumnStatistics();

--- a/presto-testng-services/src/main/java/com/facebook/presto/testng/services/LogTestDurationListener.java
+++ b/presto-testng-services/src/main/java/com/facebook/presto/testng/services/LogTestDurationListener.java
@@ -185,6 +185,6 @@ public class LogTestDurationListener
 
     private static String getName(IInvokedMethod method)
     {
-        return format("%s::%s", method.getTestMethod().getTestClass().getName(), method.getTestMethod().getMethodName());
+        return format("%s::%s(%s)", method.getTestMethod().getTestClass().getName(), method.getTestMethod().getMethodName(), method.getTestMethod().getConstructorOrMethod().stringifyParameterTypes());
     }
 }


### PR DESCRIPTION
Include method parameters in the test name used in LogTestDurationListener.  This fixes the listener when there are multiple tests in the same class with the same name, but different numbers of parameters.

Also updated the same named tests to have different names because it is better for tests to use distinct names.

Fixes: https://github.com/prestodb/presto/issues/20807

## Description
Include method parameters in the test name used in LogTestDurationListener.  
Also updated the same named tests to have different names because it is better for tests to use distinct names

Previously the name would look like:
```
com.facebook.presto.orc.metadata.statistics.TestMapColumnStatisticsBuilder::testAddMapStatisticsNoValues
```
Now it will look like: 
```
com.facebook.presto.orc.metadata.statistics.TestMapColumnStatisticsBuilder::testAddMapStatisticsNoValues([Lcom.facebook.presto.orc.proto.DwrfProto$KeyInfo;)
```

## Motivation and Context
This fixes the listener when there are multiple tests in the same class with the same name, but different numbers of parameters.

Fixes https://github.com/prestodb/presto/issues/20807

## Impact
n/a

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

