### PR TITLE
Add invalidateAll for Metastore caching

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/AbstractCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/AbstractCachingHiveMetastore.java
@@ -81,6 +81,8 @@ public abstract class AbstractCachingHiveMetastore
         }
     }
 
+    protected abstract void invalidateAll();
+
     protected abstract void invalidateDatabase(String databaseName);
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryCachingHiveMetastore.java
@@ -299,7 +299,8 @@ public class InMemoryCachingHiveMetastore
     }
 
     @Managed
-    public void flushCache()
+    @Override
+    public void invalidateAll()
     {
         databaseNamesCache.invalidateAll();
         tableNamesCache.invalidateAll();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/TestInMemoryCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/TestInMemoryCachingHiveMetastore.java
@@ -107,7 +107,7 @@ public class TestInMemoryCachingHiveMetastore
         assertEquals(metastore.getAllDatabases(TEST_METASTORE_CONTEXT), ImmutableList.of(TEST_DATABASE));
         assertEquals(mockClient.getAccessCount(), 1);
 
-        metastore.flushCache();
+        metastore.invalidateAll();
 
         assertEquals(metastore.getAllDatabases(TEST_METASTORE_CONTEXT), ImmutableList.of(TEST_DATABASE));
         assertEquals(mockClient.getAccessCount(), 2);
@@ -122,7 +122,7 @@ public class TestInMemoryCachingHiveMetastore
         assertEquals(metastore.getAllTables(TEST_METASTORE_CONTEXT, TEST_DATABASE).get(), ImmutableList.of(TEST_TABLE, TEST_TABLE_WITH_CONSTRAINTS));
         assertEquals(mockClient.getAccessCount(), 1);
 
-        metastore.flushCache();
+        metastore.invalidateAll();
 
         assertEquals(metastore.getAllTables(TEST_METASTORE_CONTEXT, TEST_DATABASE).get(), ImmutableList.of(TEST_TABLE, TEST_TABLE_WITH_CONSTRAINTS));
         assertEquals(mockClient.getAccessCount(), 2);
@@ -142,7 +142,7 @@ public class TestInMemoryCachingHiveMetastore
         assertNotNull(metastore.getTable(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE));
         assertEquals(mockClient.getAccessCount(), 1);
 
-        metastore.flushCache();
+        metastore.invalidateAll();
 
         assertNotNull(metastore.getTable(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE));
         assertEquals(mockClient.getAccessCount(), 2);
@@ -167,7 +167,7 @@ public class TestInMemoryCachingHiveMetastore
         assertEquals(metastore.getPartitionNames(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE).get(), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 1);
 
-        metastore.flushCache();
+        metastore.invalidateAll();
 
         assertEquals(metastore.getPartitionNames(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE).get(), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 2);
@@ -190,7 +190,7 @@ public class TestInMemoryCachingHiveMetastore
         assertEquals(metastore.getPartitionNamesByFilter(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE, ImmutableMap.of()), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 1);
 
-        metastore.flushCache();
+        metastore.invalidateAll();
 
         assertEquals(metastore.getPartitionNamesByFilter(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE, ImmutableMap.of()), expectedPartitions);
         assertEquals(mockClient.getAccessCount(), 2);
@@ -389,7 +389,7 @@ public class TestInMemoryCachingHiveMetastore
         assertEquals(metastore.getPartitionsByNames(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE, ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2)).size(), 2);
         assertEquals(mockClient.getAccessCount(), 3);
 
-        metastore.flushCache();
+        metastore.invalidateAll();
 
         // Fetching both should only result in one batched access
         assertEquals(metastore.getPartitionsByNames(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE, ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2)).size(), 2);
@@ -408,7 +408,7 @@ public class TestInMemoryCachingHiveMetastore
         assertEquals(metastore.listRoles(TEST_METASTORE_CONTEXT), TEST_ROLES);
         assertEquals(mockClient.getAccessCount(), 1);
 
-        metastore.flushCache();
+        metastore.invalidateAll();
 
         assertEquals(metastore.listRoles(TEST_METASTORE_CONTEXT), TEST_ROLES);
         assertEquals(mockClient.getAccessCount(), 2);
@@ -463,7 +463,7 @@ public class TestInMemoryCachingHiveMetastore
         assertEquals(mockClient.getAccessCount(), 2);
         metastore.getTableConstraints(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE_WITH_CONSTRAINTS);
         assertEquals(mockClient.getAccessCount(), 2);
-        metastore.flushCache();
+        metastore.invalidateAll();
         metastore.getTableConstraints(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE_WITH_CONSTRAINTS);
         assertEquals(mockClient.getAccessCount(), 4);
     }


### PR DESCRIPTION
## Description
Add invalidateAll for Metastore caching 

## Motivation and Context
Adding invalidateAll method to invalidate all caches.

## Test Plan
Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

