### PR TITLE
Fix recoverable execution and enable flaky test in TestHiveRecoverableExecution

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
@@ -141,8 +141,7 @@ public class TestHiveRecoverableExecution
         return new Object[][] {{1, true}, {2, false}, {2, true}};
     }
 
-    // Flaky test: https://github.com/prestodb/presto/issues/20272
-    @Test(timeOut = TEST_TIMEOUT, dataProvider = "testSettings", invocationCount = INVOCATION_COUNT, enabled = false)
+    @Test(timeOut = TEST_TIMEOUT, dataProvider = "testSettings", invocationCount = INVOCATION_COUNT)
     public void testCreateBucketedTable(int writerConcurrency, boolean optimizedPartitionUpdateSerializationEnabled)
             throws Exception
     {


### PR DESCRIPTION

## Description

A committed `LIFESPAN_COMMIT` task may happens losing contact and being rescheduled. TableFinishOperator should handle this situation and do not try to make statistics for it again. Or we would meet the error described in #20466 and #20272.

This PR fix #20466 and #20272.

## Test Plan

 - Existing tests `testCreateBucketedTable` and `testInsertBucketedTable` in `TestHiveRecoverableExecution`
 - Before this fix, this error almost certain to occur when running the tests 300 times continuously. After this fix, it never occur again.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```

General Changes
* Fix bug with recoverable execution
```

