### PR TITLE
[native] Minor refactor in ConfigReader.

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
+++ b/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
@@ -32,13 +32,14 @@ std::unordered_map<std::string, std::string> readConfig(
   std::string line;
   while (getline(configFile, line)) {
     line.erase(std::remove_if(line.begin(), line.end(), isspace), line.end());
-    if (line[0] == '#' || line.empty()) {
+    if (line.empty() || line[0] == '#') {
       continue;
     }
-    auto delimiterPos = line.find('=');
-    auto name = line.substr(0, delimiterPos);
-    auto value = line.substr(delimiterPos + 1);
-    properties.emplace(name, value);
+
+    std::vector<std::string> configParts;
+    folly::split('=', line, configParts);
+    VELOX_USER_CHECK_EQ(configParts.size(), 2, "Malformed config: {}", line);
+    properties.emplace(configParts[0], configParts[1]);
   }
 
   return properties;


### PR DESCRIPTION
## Description
Minor refactor in config reading code path.

## Motivation and Context
We use [folly::split to parse task id](https://github.com/prestodb/presto/blob/24b0460484ff2f718bf08900f9cbd3ed46eacf04/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h#L22-L35). Keeping the parsing consistent in ConfigReader to parse config key and value with one pass.

## Impact
Existing config parsing behavior stay as is so no impact in config parsing.

## Test Plan
Existing unit tests pass

## Release Notes
== NO RELEASE NOTE ==
