### PR TITLE
[doc] fix formatting of Synopsis code block in update.rst

### DIFF
--- a/presto-docs/src/main/sphinx/sql/update.rst
+++ b/presto-docs/src/main/sphinx/sql/update.rst
@@ -5,12 +5,14 @@ UPDATE
 Synopsis
 --------
 
-.. code-block:: text
+.. code-block:: none
+
     UPDATE table_name SET [ ( column = expression [, ... ] ) ] [ WHERE condition ]
+
 Description
 -----------
 
-Update selected columns values in existing rows in a table.
+Update selected columns values in existing rows in a table. 
 
 The columns named in the ``column = expression`` assignments will be updated
 for all rows that match the ``WHERE`` condition.  The values of all column update


### PR DESCRIPTION
## Description
Fixed formatting of code block in Synopsis section of http://prestodb.io/docs/0.286/sql/update.html. 

## Motivation and Context
The code block for the Synopsis topic was present in the RST file, but badly formatted so that it did not display. 

## Impact
Documentation. 

## Test Plan
Local doc build. 

Screenshot of current page: 
<img width="632" alt="Screenshot 2024-03-25 at 3 16 41 PM" src="https://github.com/prestodb/presto/assets/7013443/6b08eead-239c-4658-a490-da5b16ba4de1">

Screenshot of fix in this PR: 
<img width="870" alt="Screenshot 2024-03-25 at 3 16 04 PM" src="https://github.com/prestodb/presto/assets/7013443/f659952e-03a4-4103-959f-47d2a6128b34">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

