### PR TITLE
Add presto worker type to hive metastore

### DIFF
--- a/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
+++ b/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
@@ -170,7 +170,7 @@ public class S3SelectTestHelper
                 new HiveTypeTranslator(),
                 new HiveStagingFileCommitter(hdfsEnvironment, listeningDecorator(executor)),
                 new HiveZeroRowFileCreator(hdfsEnvironment, new OutputStreamDataSinkFactory(), listeningDecorator(executor)),
-                new NodeVersion("test_version"),
+                new NodeVersion("test_version", NodeVersion.PrestoWorkerType.JAVA),
                 new HivePartitionObjectBuilder(),
                 new HiveEncryptionInformationProvider(ImmutableSet.of()),
                 new HivePartitionStats(),

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
@@ -192,6 +192,7 @@ public class MetastoreUtil
     public static final String TABLE_COMMENT = "comment";
     public static final String PRESTO_VIEW_COMMENT = "Presto View";
     public static final String PRESTO_VERSION_NAME = "presto_version";
+    public static final String PRESTO_WORKER_TYPE = "presto_worker_type";
     public static final String PRESTO_VIEW_EXPANDED_TEXT_MARKER = "/* Presto View */";
 
     private MetastoreUtil()
@@ -1036,12 +1037,13 @@ public class MetastoreUtil
                 ImmutableMultimap.of());
     }
 
-    public static Map<String, String> createViewProperties(ConnectorSession session, String prestoVersion)
+    public static Map<String, String> createViewProperties(ConnectorSession session, String prestoVersion, String prestoWorkerType)
     {
         return ImmutableMap.<String, String>builder()
                 .put(TABLE_COMMENT, PRESTO_VIEW_COMMENT)
                 .put(PRESTO_VIEW_FLAG, "true")
                 .put(PRESTO_VERSION_NAME, prestoVersion)
+                .put(PRESTO_WORKER_TYPE, prestoWorkerType)
                 .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
                 .build();
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -125,7 +125,9 @@ public class HiveConnectorFactory
                     binder -> {
                         MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(platformMBeanServer));
-                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
+                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(
+                                context.getNodeManager().getCurrentNode().getVersion(),
+                                context.getConnectorSystemConfig().isNativeExecution() ? NodeVersion.PrestoWorkerType.CPP : NodeVersion.PrestoWorkerType.JAVA));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
                         binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -64,7 +64,7 @@ public class HiveMetadataFactory
     private final TypeTranslator typeTranslator;
     private final StagingFileCommitter stagingFileCommitter;
     private final ZeroRowFileCreator zeroRowFileCreator;
-    private final String prestoVersion;
+    private final NodeVersion nodeVersion;
     private final PartitionObjectBuilder partitionObjectBuilder;
     private final HiveEncryptionInformationProvider encryptionInformationProvider;
     private final HivePartitionStats hivePartitionStats;
@@ -128,7 +128,7 @@ public class HiveMetadataFactory
                 typeTranslator,
                 stagingFileCommitter,
                 zeroRowFileCreator,
-                nodeVersion.toString(),
+                nodeVersion,
                 partitionObjectBuilder,
                 encryptionInformationProvider,
                 hivePartitionStats,
@@ -164,7 +164,7 @@ public class HiveMetadataFactory
             TypeTranslator typeTranslator,
             StagingFileCommitter stagingFileCommitter,
             ZeroRowFileCreator zeroRowFileCreator,
-            String prestoVersion,
+            NodeVersion nodeVersion,
             PartitionObjectBuilder partitionObjectBuilder,
             HiveEncryptionInformationProvider encryptionInformationProvider,
             HivePartitionStats hivePartitionStats,
@@ -198,7 +198,7 @@ public class HiveMetadataFactory
         this.typeTranslator = requireNonNull(typeTranslator, "typeTranslator is null");
         this.stagingFileCommitter = requireNonNull(stagingFileCommitter, "stagingFileCommitter is null");
         this.zeroRowFileCreator = requireNonNull(zeroRowFileCreator, "zeroRowFileCreator is null");
-        this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
+        this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.partitionObjectBuilder = requireNonNull(partitionObjectBuilder, "partitionObjectBuilder is null");
         this.encryptionInformationProvider = requireNonNull(encryptionInformationProvider, "encryptionInformationProvider is null");
         this.hivePartitionStats = requireNonNull(hivePartitionStats, "hivePartitionStats is null");
@@ -244,7 +244,7 @@ public class HiveMetadataFactory
                 partitionUpdateCodec,
                 partitionUpdateSmileCodec,
                 typeTranslator,
-                prestoVersion,
+                nodeVersion,
                 new MetastoreHiveStatisticsProvider(metastore, quickStatsProvider),
                 stagingFileCommitter,
                 zeroRowFileCreator,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
@@ -33,12 +33,13 @@ public class HivePartitionObjectBuilder
             ConnectorSession session,
             Table table,
             PartitionUpdate partitionUpdate,
-            String prestoVersion,
+            NodeVersion nodeVersion,
             Map<String, String> extraParameters,
             Optional<Partition> previousPartition)
     {
         ImmutableMap.Builder extraParametersBuilder = ImmutableMap.builder()
-                .put(MetastoreUtil.PRESTO_VERSION_NAME, prestoVersion)
+                .put(MetastoreUtil.PRESTO_VERSION_NAME, nodeVersion.getVersion())
+                .put(MetastoreUtil.PRESTO_WORKER_TYPE, nodeVersion.getPrestoWorkerType().toString())
                 .put(MetastoreUtil.PRESTO_QUERY_ID_NAME, session.getQueryId())
                 .putAll(extraParameters);
         getNewPartitionUserSuppliedParameter(session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/NodeVersion.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/NodeVersion.java
@@ -17,16 +17,34 @@ import static java.util.Objects.requireNonNull;
 
 public final class NodeVersion
 {
-    private final String version;
+    public enum PrestoWorkerType
+    {
+        JAVA,
+        CPP
+    }
 
-    public NodeVersion(String version)
+    private final String version;
+    private final PrestoWorkerType prestoWorkerType;
+
+    public NodeVersion(String version, PrestoWorkerType workerType)
     {
         this.version = requireNonNull(version, "version is null");
+        this.prestoWorkerType = requireNonNull(workerType, "prestoWorkerType is null");
+    }
+
+    public String getVersion()
+    {
+        return version;
+    }
+
+    public PrestoWorkerType getPrestoWorkerType()
+    {
+        return prestoWorkerType;
     }
 
     @Override
     public String toString()
     {
-        return version;
+        return prestoWorkerType.toString() + ":" + version;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
@@ -26,7 +26,7 @@ public interface PartitionObjectBuilder
             ConnectorSession session,
             Table table,
             PartitionUpdate partitionUpdate,
-            String prestoVersion,
+            NodeVersion nodeVersion,
             Map<String, String> extraParameters,
             Optional<Partition> previousPartition);
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -288,6 +288,7 @@ import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createInte
 import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createStringColumnStatistics;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_QUERY_ID_NAME;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VERSION_NAME;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_WORKER_TYPE;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.createDirectory;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getMetastoreHeaders;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.toPartitionValues;
@@ -356,6 +357,7 @@ public abstract class AbstractTestHiveClient
     protected static final String INVALID_COLUMN = "totally_invalid_column_name";
 
     protected static final String TEST_SERVER_VERSION = "test_version";
+    protected static final NodeVersion.PrestoWorkerType TEST_PRESTO_WORKER_TYPE = NodeVersion.PrestoWorkerType.JAVA;
 
     protected static final Executor EXECUTOR = Executors.newFixedThreadPool(5);
     protected static final PageSinkContext TEST_HIVE_PAGE_SINK_CONTEXT = PageSinkContext.builder().setCommitRequired(false).setConnectorMetadataUpdater(new HiveMetadataUpdater(EXECUTOR)).build();
@@ -1034,7 +1036,7 @@ public abstract class AbstractTestHiveClient
                 new HiveTypeTranslator(),
                 new HiveStagingFileCommitter(hdfsEnvironment, listeningDecorator(executor)),
                 new HiveZeroRowFileCreator(hdfsEnvironment, new OutputStreamDataSinkFactory(), listeningDecorator(executor)),
-                TEST_SERVER_VERSION,
+                new NodeVersion(TEST_SERVER_VERSION, TEST_PRESTO_WORKER_TYPE),
                 new HivePartitionObjectBuilder(),
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
                 new HivePartitionStats(),
@@ -2993,6 +2995,7 @@ public abstract class AbstractTestHiveClient
                 .setTableType(MANAGED_TABLE)
                 .setParameters(ImmutableMap.of(
                         PRESTO_VERSION_NAME, TEST_SERVER_VERSION,
+                        PRESTO_WORKER_TYPE, TEST_PRESTO_WORKER_TYPE.toString(),
                         PRESTO_QUERY_ID_NAME, queryId))
                 .setDataColumns(columns)
                 .withStorage(storage -> storage
@@ -3637,6 +3640,7 @@ public abstract class AbstractTestHiveClient
                     .setTableType(PrestoTableType.MANAGED_TABLE)
                     .setParameters(ImmutableMap.of(
                             PRESTO_VERSION_NAME, TEST_SERVER_VERSION,
+                            PRESTO_WORKER_TYPE, TEST_PRESTO_WORKER_TYPE.toString(),
                             PRESTO_QUERY_ID_NAME, session.getQueryId()))
                     .setDataColumns(columns)
                     .withStorage(storage -> storage
@@ -3858,6 +3862,7 @@ public abstract class AbstractTestHiveClient
                         .setBucketProperty(bucketProperty))
                 .setParameters(ImmutableMap.of(
                         PRESTO_VERSION_NAME, "testversion",
+                        PRESTO_WORKER_TYPE, "JAVA",
                         PRESTO_QUERY_ID_NAME, "20180101_123456_00001_x1y2z"))
                 .build();
     }
@@ -4082,6 +4087,7 @@ public abstract class AbstractTestHiveClient
             // verify the node version and query ID in table
             Table table = getMetastoreClient().getTable(metastoreContext, tableName.getSchemaName(), tableName.getTableName()).get();
             assertEquals(table.getParameters().get(PRESTO_VERSION_NAME), TEST_SERVER_VERSION);
+            assertEquals(table.getParameters().get(PRESTO_WORKER_TYPE), TEST_PRESTO_WORKER_TYPE);
             assertEquals(table.getParameters().get(PRESTO_QUERY_ID_NAME), queryId);
 
             // verify basic statistics
@@ -4145,6 +4151,7 @@ public abstract class AbstractTestHiveClient
 
             // verify the node version and query ID
             assertEquals(table.getParameters().get(PRESTO_VERSION_NAME), TEST_SERVER_VERSION);
+            assertEquals(table.getParameters().get(PRESTO_WORKER_TYPE), TEST_PRESTO_WORKER_TYPE);
             assertEquals(table.getParameters().get(PRESTO_QUERY_ID_NAME), queryId);
 
             // verify the table is empty
@@ -4412,6 +4419,7 @@ public abstract class AbstractTestHiveClient
             for (String partitionName : partitionNames) {
                 Partition partition = partitions.get(partitionName).get();
                 assertEquals(partition.getParameters().get(PRESTO_VERSION_NAME), TEST_SERVER_VERSION);
+                assertEquals(partition.getParameters().get(PRESTO_WORKER_TYPE), TEST_PRESTO_WORKER_TYPE);
                 assertEquals(partition.getParameters().get(PRESTO_QUERY_ID_NAME), queryId);
             }
 
@@ -5459,6 +5467,7 @@ public abstract class AbstractTestHiveClient
                     .setTableType(MANAGED_TABLE)
                     .setParameters(ImmutableMap.<String, String>builder()
                             .put(PRESTO_VERSION_NAME, TEST_SERVER_VERSION)
+                            .put(PRESTO_WORKER_TYPE, TEST_PRESTO_WORKER_TYPE.toString())
                             .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
                             .putAll(parameters)
                             .build())

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -218,7 +218,7 @@ public abstract class AbstractTestHiveFileSystem
                 new HiveTypeTranslator(),
                 new HiveStagingFileCommitter(hdfsEnvironment, listeningDecorator(executor)),
                 new HiveZeroRowFileCreator(hdfsEnvironment, new OutputStreamDataSinkFactory(), listeningDecorator(executor)),
-                new NodeVersion("test_version"),
+                new NodeVersion("test_version", NodeVersion.PrestoWorkerType.JAVA),
                 new HivePartitionObjectBuilder(),
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
                 new HivePartitionStats(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -211,7 +211,12 @@ public final class HiveTestUtils
     {
         HdfsEnvironment testHdfsEnvironment = createTestHdfsEnvironment(hiveClientConfig, metastoreClientConfig);
         return ImmutableSet.<HiveFileWriterFactory>builder()
-                .add(new RcFileFileWriterFactory(testHdfsEnvironment, FUNCTION_AND_TYPE_MANAGER, new NodeVersion("test_version"), hiveClientConfig, new FileFormatDataSourceStats()))
+                .add(new RcFileFileWriterFactory(
+                        testHdfsEnvironment,
+                        FUNCTION_AND_TYPE_MANAGER,
+                        new NodeVersion("test_version", NodeVersion.PrestoWorkerType.JAVA),
+                        hiveClientConfig,
+                        new FileFormatDataSourceStats()))
                 .add(new PageFileWriterFactory(testHdfsEnvironment, new OutputStreamDataSinkFactory(), new BlockEncodingManager()))
                 .add(getDefaultOrcFileWriterFactory(hiveClientConfig, metastoreClientConfig))
                 .build();
@@ -224,7 +229,7 @@ public final class HiveTestUtils
                 testHdfsEnvironment,
                 new OutputStreamDataSinkFactory(),
                 FUNCTION_AND_TYPE_MANAGER,
-                new NodeVersion("test_version"),
+                new NodeVersion("test_version", NodeVersion.PrestoWorkerType.JAVA),
                 hiveClientConfig,
                 new FileFormatDataSourceStats(),
                 new OrcFileWriterConfig(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.hive.HiveSplitManager.OBJECT_NOT_READABLE;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_QUERY_ID_NAME;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VERSION_NAME;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_WORKER_TYPE;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.toPartitionValues;
 import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
@@ -214,6 +215,7 @@ public class TestHiveClientFileMetastore
     {
         Map<String, String> staticPartitionParameters = ImmutableMap.of(
                 PRESTO_VERSION_NAME, "testversion",
+                PRESTO_WORKER_TYPE, "JAVA",
                 PRESTO_QUERY_ID_NAME, "20200101_123456_00001_x1y2z");
         Map<String, String> partitionParameters = ImmutableMap.<String, String>builder()
                 .putAll(staticPartitionParameters)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
@@ -64,6 +64,7 @@ import java.util.function.Function;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.hive.AbstractTestHiveClient.TEST_PRESTO_WORKER_TYPE;
 import static com.facebook.presto.hive.AbstractTestHiveClient.TEST_SERVER_VERSION;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
 import static com.facebook.presto.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
@@ -262,7 +263,7 @@ public class TestHiveCommitHandleOutput
                 new HiveTypeTranslator(),
                 new HiveStagingFileCommitter(hdfsEnvironment, listeningExecutor),
                 new HiveZeroRowFileCreator(hdfsEnvironment, new OutputStreamDataSinkFactory(), listeningExecutor),
-                TEST_SERVER_VERSION,
+                new NodeVersion(TEST_SERVER_VERSION, TEST_PRESTO_WORKER_TYPE),
                 new HivePartitionObjectBuilder(),
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
                 new HivePartitionStats(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -263,7 +263,12 @@ public class TestHiveFileFormats
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
                 .withSession(session)
-                .withFileWriterFactory(new RcFileFileWriterFactory(HDFS_ENVIRONMENT, FUNCTION_AND_TYPE_MANAGER, new NodeVersion("test"), HIVE_STORAGE_TIME_ZONE, STATS))
+                .withFileWriterFactory(new RcFileFileWriterFactory(
+                        HDFS_ENVIRONMENT,
+                        FUNCTION_AND_TYPE_MANAGER,
+                        new NodeVersion("test", NodeVersion.PrestoWorkerType.JAVA),
+                        HIVE_STORAGE_TIME_ZONE,
+                        STATS))
                 .isReadableByRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT))
                 .isReadableByPageSource(new RcFilePageSourceFactory(FUNCTION_AND_TYPE_MANAGER, HDFS_ENVIRONMENT, STATS));
     }
@@ -317,7 +322,12 @@ public class TestHiveFileFormats
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
                 .withSession(session)
-                .withFileWriterFactory(new RcFileFileWriterFactory(HDFS_ENVIRONMENT, FUNCTION_AND_TYPE_MANAGER, new NodeVersion("test"), HIVE_STORAGE_TIME_ZONE, STATS))
+                .withFileWriterFactory(new RcFileFileWriterFactory(
+                        HDFS_ENVIRONMENT,
+                        FUNCTION_AND_TYPE_MANAGER,
+                        new NodeVersion("test", NodeVersion.PrestoWorkerType.JAVA),
+                        HIVE_STORAGE_TIME_ZONE,
+                        STATS))
                 .isReadableByRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT))
                 .isReadableByPageSource(new RcFilePageSourceFactory(FUNCTION_AND_TYPE_MANAGER, HDFS_ENVIRONMENT, STATS));
     }
@@ -350,7 +360,15 @@ public class TestHiveFileFormats
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
                 .withSession(session)
-                .withFileWriterFactory(new OrcFileWriterFactory(HDFS_ENVIRONMENT, new OutputStreamDataSinkFactory(), FUNCTION_AND_TYPE_MANAGER, new NodeVersion("test"), HIVE_STORAGE_TIME_ZONE, STATS, new OrcFileWriterConfig(), NO_ENCRYPTION))
+                .withFileWriterFactory(new OrcFileWriterFactory(
+                        HDFS_ENVIRONMENT,
+                        new OutputStreamDataSinkFactory(),
+                        FUNCTION_AND_TYPE_MANAGER,
+                        new NodeVersion("test", NodeVersion.PrestoWorkerType.JAVA),
+                        HIVE_STORAGE_TIME_ZONE,
+                        STATS,
+                        new OrcFileWriterConfig(),
+                        NO_ENCRYPTION))
                 .isReadableByRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT))
                 .isReadableByPageSource(new OrcBatchPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, false, HDFS_ENVIRONMENT, STATS, 100, new StorageOrcFileTailSource(), StripeMetadataSourceFactory.of(new StorageStripeMetadataSource())));
     }
@@ -374,7 +392,11 @@ public class TestHiveFileFormats
                 .withSession(session)
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
-                .withFileWriterFactory(new ParquetFileWriterFactory(HDFS_ENVIRONMENT, FUNCTION_AND_TYPE_MANAGER, new NodeVersion("test"), HIVE_STORAGE_TIME_ZONE))
+                .withFileWriterFactory(new ParquetFileWriterFactory(
+                        HDFS_ENVIRONMENT,
+                        FUNCTION_AND_TYPE_MANAGER,
+                        new NodeVersion("test", NodeVersion.PrestoWorkerType.JAVA),
+                        HIVE_STORAGE_TIME_ZONE))
                 .isReadableByPageSource(new ParquetPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, HDFS_ENVIRONMENT, STATS, METADATA_READER));
     }
 
@@ -518,7 +540,15 @@ public class TestHiveFileFormats
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
                 .withSession(session)
-                .withFileWriterFactory(new OrcFileWriterFactory(HDFS_ENVIRONMENT, new OutputStreamDataSinkFactory(), FUNCTION_AND_TYPE_MANAGER, new NodeVersion("test"), HIVE_STORAGE_TIME_ZONE, STATS, new OrcFileWriterConfig(), NO_ENCRYPTION))
+                .withFileWriterFactory(new OrcFileWriterFactory(
+                        HDFS_ENVIRONMENT,
+                        new OutputStreamDataSinkFactory(),
+                        FUNCTION_AND_TYPE_MANAGER,
+                        new NodeVersion("test", NodeVersion.PrestoWorkerType.JAVA),
+                        HIVE_STORAGE_TIME_ZONE,
+                        STATS,
+                        new OrcFileWriterConfig(),
+                        NO_ENCRYPTION))
                 .isReadableByRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT))
                 .isReadableByPageSource(new DwrfBatchPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, HIVE_CLIENT_CONFIG, HDFS_ENVIRONMENT, STATS, new StorageOrcFileTailSource(), StripeMetadataSourceFactory.of(new StorageStripeMetadataSource()), NO_ENCRYPTION));
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -90,6 +90,7 @@ import static org.testng.Assert.assertTrue;
 public class TestHiveMetadataFileFormatEncryptionSettings
 {
     private static final String TEST_SERVER_VERSION = "test_version";
+    private static final NodeVersion.PrestoWorkerType TEST_PRESTO_WORKER_TYPE = NodeVersion.PrestoWorkerType.JAVA;
     private static final String TEST_DB_NAME = "test_db";
     private static final JsonCodec<PartitionUpdate> PARTITION_CODEC = jsonCodec(PartitionUpdate.class);
     private static final ConnectorSession SESSION = new TestingConnectorSession(
@@ -135,7 +136,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 new HiveTypeTranslator(),
                 new HiveStagingFileCommitter(HDFS_ENVIRONMENT, listeningDecorator(executor)),
                 new HiveZeroRowFileCreator(HDFS_ENVIRONMENT, new OutputStreamDataSinkFactory(), listeningDecorator(executor)),
-                TEST_SERVER_VERSION,
+                new NodeVersion(TEST_SERVER_VERSION, TEST_PRESTO_WORKER_TYPE),
                 new HivePartitionObjectBuilder(),
                 new HiveEncryptionInformationProvider(ImmutableList.of(new TestDwrfEncryptionInformationSource())),
                 new HivePartitionStats(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -82,6 +82,7 @@ import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.hive.AbstractTestHiveClient.TEST_PRESTO_WORKER_TYPE;
 import static com.facebook.presto.hive.AbstractTestHiveClient.TEST_SERVER_VERSION;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
@@ -511,7 +512,7 @@ public class TestHiveSplitManager
                 new HiveTypeTranslator(),
                 new HiveStagingFileCommitter(hdfsEnvironment, executor),
                 new HiveZeroRowFileCreator(hdfsEnvironment, new OutputStreamDataSinkFactory(), executor),
-                TEST_SERVER_VERSION,
+                new NodeVersion(TEST_SERVER_VERSION, TEST_PRESTO_WORKER_TYPE),
                 new HivePartitionObjectBuilder(),
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
                 new HivePartitionStats(),

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConnectorFactory.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiConnectorFactory.java
@@ -86,7 +86,9 @@ public class HudiConnectorFactory
                     new CachingModule(),
                     new HiveCommonModule(),
                     binder -> {
-                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
+                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(
+                                context.getNodeManager().getCurrentNode().getVersion(),
+                                context.getConnectorSystemConfig().isNativeExecution() ? NodeVersion.PrestoWorkerType.CPP : NodeVersion.PrestoWorkerType.JAVA));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
                         binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -348,7 +348,7 @@ public class IcebergHiveMetadata
         Table table = createTableObjectForViewCreation(
                 session,
                 viewMetadata,
-                createIcebergViewProperties(session, nodeVersion.toString()),
+                createIcebergViewProperties(session, nodeVersion.getVersion(), nodeVersion.getPrestoWorkerType().toString()),
                 new HiveTypeTranslator(),
                 metastoreContext,
                 encodeViewData(viewData));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -128,6 +128,7 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_QUERY_ID_N
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VERSION_NAME;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VIEW_COMMENT;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VIEW_FLAG;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_WORKER_TYPE;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.TABLE_COMMENT;
 import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
 import static com.facebook.presto.iceberg.FileContent.POSITION_DELETES;
@@ -375,12 +376,13 @@ public final class IcebergUtil
         }
     }
 
-    public static Map<String, String> createIcebergViewProperties(ConnectorSession session, String prestoVersion)
+    public static Map<String, String> createIcebergViewProperties(ConnectorSession session, String prestoVersion, String prestoWorkerType)
     {
         return ImmutableMap.<String, String>builder()
                 .put(TABLE_COMMENT, PRESTO_VIEW_COMMENT)
                 .put(PRESTO_VIEW_FLAG, "true")
                 .put(PRESTO_VERSION_NAME, prestoVersion)
+                .put(PRESTO_WORKER_TYPE, prestoWorkerType)
                 .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
                 .put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE)
                 .build();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
@@ -91,7 +91,9 @@ public final class InternalIcebergConnectorFactory
                     binder -> {
                         MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(platformMBeanServer));
-                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
+                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(
+                                context.getNodeManager().getCurrentNode().getVersion(),
+                                context.getConnectorSystemConfig().isNativeExecution() ? NodeVersion.PrestoWorkerType.CPP : NodeVersion.PrestoWorkerType.JAVA));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
                         binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
For debuggability, add presto worker type to hive metastore to identify which engine wrote the files
