### PR TITLE
[docs] document Native Session Properties

### DIFF
--- a/presto-docs/src/main/sphinx/prestissimo/prestissimo-features.rst
+++ b/presto-docs/src/main/sphinx/prestissimo/prestissimo-features.rst
@@ -184,3 +184,184 @@ for cleanup. Only applicable when ``enable-old-task-cleanup`` is ``true``.
 Old task is defined as a PrestoTask which has not received heartbeat for at least
 ``old-task-cleanup-ms``, or is not running and has an end time more than
 ``old-task-cleanup-ms`` ago.
+
+
+Session Properties
+------------------
+
+The following are the native session properties for Prestissimo.
+
+``driver_cpu_time_slice_limit_ms``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``1000``
+
+Native Execution only. Defines the maximum CPU time in milliseconds that a driver thread
+is permitted to run before it must yield to other threads,facilitating fair CPU usage across
+multiple threads.
+
+A positive value enforces this limit, ensuring threads do not monopolize CPU resources.
+
+Negative values are considered invalid and are treated as a request to use the system default setting,
+which is ``1000`` ms in this case.
+
+Note: Setting the property to ``0`` allows a thread to run indefinitely
+without yielding, which is not recommended in a shared environment as it can lead to
+resource contention.
+
+``legacy_timestamp``
+^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Native Execution only. Use legacy TIME and TIMESTAMP semantics.
+
+``native_aggregation_spill_memory_threshold``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Native Execution only. Specifies the maximum memory in bytes
+that a final aggregation operation can utilize before it starts spilling to disk.
+If set to ``0``, there is no limit, allowing the aggregation to consume unlimited memory resources,
+which may impact system performance.
+
+``native_debug_validate_output_from_operators``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+If set to ``true``, then during the execution of tasks, the output vectors of every operator are validated for consistency.
+It can help identify issues where a malformed vector causes failures or crashes, facilitating the debugging of operator output issues.
+
+Note: This is an expensive check and should only be used for debugging purposes.
+
+``native_join_spill_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Native Execution only. Enable join spilling on native engine.
+
+``native_join_spill_memory_threshold``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Native Execution only. Specifies the maximum memory, in bytes, that a hash join operation can use before starting to spill to disk.
+A value of ``0`` indicates no limit, permitting the join operation to use unlimited memory resources, which might affect overall system performance.
+
+``native_join_spiller_partition_bits``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``2``
+
+Native Execution only. Specifies the number of bits (N)
+used to calculate the spilling partition number for hash join and RowNumber operations.
+The partition number is determined as ``2`` raised to the power of N, defining how data is partitioned during the spill process.
+
+``native_max_spill_file_size``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Specifies the maximum allowed spill file size in bytes. If set to ``0``, there is no limit on the spill file size,
+allowing spill files to grow as large as necessary based on available disk space.
+Use ``native_max_spill_file_size`` to manage disk space usage during operations that require spilling to disk.
+
+``native_max_spill_level``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``4``
+
+Native Execution only. The maximum allowed spilling level for hash join build.
+``0`` is the initial spilling level, ``-1`` means unlimited.
+
+``native_order_by_spill_memory_threshold``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Native Execution only. Specifies the maximum memory, in bytes, that the `ORDER BY` operation can utilize before starting to spill data to disk.
+If set to ``0``, there is no limit on memory usage, potentially leading to large memory allocations for sorting operations.
+Use this threshold to manage memory usage more efficiently during `ORDER BY` operations.
+
+``native_row_number_spill_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Native Execution only. Enable row number spilling on native engine.
+
+``native_simplified_expression_evaluation_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Native Execution only. Enable simplified path in expression evaluation.
+
+``native_spill_compression_codec``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Default value:** ``none``
+
+Native Execution only. Specifies the compression CODEC used to compress spilled data.
+Supported compression CODECs are: ZLIB, SNAPPY, LZO, ZSTD, LZ4, and GZIP.
+Setting this property to ``none`` disables compression.
+
+``native_spill_file_create_config``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Default value:** ``""``
+
+Native Execution only. Specifies the configuration parameters used to create spill files.
+These parameters are provided to the underlying file system, allowing for customizable spill file creation based on the requirements of the environment.
+The format and options of these parameters are determined by the capabilities of the underlying file system
+and may include settings such as file location, size limits, and file system-specific optimizations.
+
+``native_spill_write_buffer_size``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``bigint``
+* **Default value:** ``1048576``
+
+Native Execution only. The maximum size in bytes to buffer the serialized spill data before writing to disk for IO efficiency.
+If set to ``0``, buffering is disabled.
+
+``native_topn_row_number_spill_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Native Execution only. Enable topN row number spilling on native engine.
+
+``native_window_spill_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Native Execution only. Enable window spilling on native engine.
+
+``native_writer_spill_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Native Execution only. Enable writer spilling on native engine.


### PR DESCRIPTION
## Description

Added documentation for Native Session Properties.

This PR introduces a comprehensive "Session Properties" section to the "Prestissimo Features" page within the Prestissimo Developer Guide. This new section provides detailed descriptions and configurations of the session properties available in Prestissimo.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact

Documentation

## Test Plan

Screenshots of the local build of documentation:

Prestissimo Features page in Prestissimo Developer Guide index page, showing the session properties description in context.

<img width="1644" alt="Screenshot 2024-04-03 at 11 52 16 AM" src="https://github.com/prestodb/presto/assets/47949499/81796a5f-b34b-407a-b37c-c335700be0e9">




## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

