### PR TITLE
[docs] fix formatting in language/types.rst

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -21,7 +21,7 @@ Boolean
 ``BOOLEAN``
 ^^^^^^^^^^^
 
-    This type captures boolean values ``true`` and ``false``.
+This type captures boolean values ``true`` and ``false``.
 
 Integer
 -------
@@ -29,27 +29,27 @@ Integer
 ``TINYINT``
 ^^^^^^^^^^^
 
-    A 8-bit signed two's complement integer with a minimum value of
-    ``-2^7`` and a maximum value of ``2^7 - 1``.
+A 8-bit signed two's complement integer with a minimum value of
+``-2^7`` and a maximum value of ``2^7 - 1``.
 
 ``SMALLINT``
 ^^^^^^^^^^^^
 
-    A 16-bit signed two's complement integer with a minimum value of
-    ``-2^15`` and a maximum value of ``2^15 - 1``.
+A 16-bit signed two's complement integer with a minimum value of
+``-2^15`` and a maximum value of ``2^15 - 1``.
 
 ``INTEGER``
 ^^^^^^^^^^^
 
-    A 32-bit signed two's complement integer with a minimum value of
-    ``-2^31`` and a maximum value of ``2^31 - 1``.  The name ``INT`` is
-    also available for this type.
+A 32-bit signed two's complement integer with a minimum value of
+``-2^31`` and a maximum value of ``2^31 - 1``.  The name ``INT`` is
+also available for this type.
 
 ``BIGINT``
 ^^^^^^^^^^
 
-    A 64-bit signed two's complement integer with a minimum value of
-    ``-2^63`` and a maximum value of ``2^63 - 1``.
+A 64-bit signed two's complement integer with a minimum value of
+``-2^63`` and a maximum value of ``2^63 - 1``.
 
 Floating-Point
 --------------
@@ -57,14 +57,14 @@ Floating-Point
 ``REAL``
 ^^^^^^^^
 
-    A real is a 32-bit inexact, variable-precision implementing the
-    IEEE Standard 754 for Binary Floating-Point Arithmetic.
+A real is a 32-bit inexact, variable-precision implementing the
+IEEE Standard 754 for Binary Floating-Point Arithmetic.
 
 ``DOUBLE``
 ^^^^^^^^^^
 
-    A double is a 64-bit inexact, variable-precision implementing the
-    IEEE Standard 754 for Binary Floating-Point Arithmetic.
+A double is a 64-bit inexact, variable-precision implementing the
+IEEE Standard 754 for Binary Floating-Point Arithmetic.
 
 Fixed-Precision
 ---------------
@@ -72,27 +72,27 @@ Fixed-Precision
 ``DECIMAL``
 ^^^^^^^^^^^
 
-    A fixed precision decimal number. Precision up to 38 digits is supported
-    but performance is best up to 18 digits.
+A fixed precision decimal number. Precision up to 38 digits is supported
+but performance is best up to 18 digits.
 
-    The decimal type takes two literal parameters:
+The decimal type takes two literal parameters:
 
-      - **precision** - total number of digits
+- **precision** - total number of digits
 
-      - **scale** - number of digits in fractional part. Scale is optional and defaults to 0.
+- **scale** - number of digits in fractional part. Scale is optional and defaults to 0.
 
-    Example type definitions: ``DECIMAL(10,3)``, ``DECIMAL(20)``
+Example type definitions: ``DECIMAL(10,3)``, ``DECIMAL(20)``
 
-    Example literals: ``DECIMAL '10.3'``, ``DECIMAL '1234567890'``, ``1.1``
+Example literals: ``DECIMAL '10.3'``, ``DECIMAL '1234567890'``, ``1.1``
 
-    .. note::
+.. note::
 
-        For compatibility reasons decimal literals without explicit type specifier (e.g. ``1.2``)
-        are treated as values of the ``DOUBLE`` type by default up to version 0.198. 
-        After 0.198 they are parsed as DECIMAL.
+    For compatibility reasons decimal literals without explicit type specifier (e.g. ``1.2``)
+    are treated as values of the ``DOUBLE`` type by default up to version 0.198. 
+    After 0.198 they are parsed as DECIMAL.
 
-          - System wide property: ``parse-decimal-literals-as-double``
-          - Session wide property: ``parse_decimal_literals_as_double``
+    - System wide property: ``parse-decimal-literals-as-double``
+    - Session wide property: ``parse_decimal_literals_as_double``
 
 String
 ------
@@ -100,60 +100,56 @@ String
 ``VARCHAR``
 ^^^^^^^^^^^
 
-    Variable length character data with an optional maximum length.
+Variable length character data with an optional maximum length.
 
-    Example type definitions: ``varchar``, ``varchar(20)``.
+Example type definitions: ``varchar``, ``varchar(20)``.
 
-    SQL supports simple and Unicode string literals:
-     - Literal string : ``'Hello winter !'``
-     - Unicode string with default escape character: ``U&'Hello winter \2603 !'``
-     - Unicode string with custom escape character: ``U&'Hello winter #2603 !' UESCAPE '#'``
+SQL supports simple and Unicode string literals:
+ - Literal string : ``'Hello winter !'``
+ - Unicode string with default escape character: ``U&'Hello winter \2603 !'``
+ - Unicode string with custom escape character: ``U&'Hello winter #2603 !' UESCAPE '#'``
 
-    A Unicode string is prefixed with ``U&`` and requires an escape character
-    before any Unicode character usage with 4 digits. In these examples
-    ``\2603`` and ``#2603`` represent a snowman character. Long Unicode codes
-    with 6 digits require a plus symbol ``+`` before the code. For example,
-    use ``\+01F600`` for a grinning face emoji.
+A Unicode string is prefixed with ``U&`` and requires an escape character
+before any Unicode character usage with 4 digits. In these examples
+``\2603`` and ``#2603`` represent a snowman character. Long Unicode codes
+with 6 digits require a plus symbol ``+`` before the code. For example,
+use ``\+01F600`` for a grinning face emoji.
 
-    Single quotes in string literals can be escaped by using another single quote: ``'It''s a beautiful day!'``
+Single quotes in string literals can be escaped by using another single quote: ``'It''s a beautiful day!'``
 
 ``CHAR``
 ^^^^^^^^
 
-    Fixed length character data. A `CHAR` type without length specified has a
-    default length of 1. A `CHAR(x)` value always has `x` characters. For example,
-    casting `dog` to `CHAR(7)` adds 4 implicit trailing spaces. Leading and trailing
-    spaces are included in comparisons of `CHAR` values. As a result, two character
-    values with different lengths (`CHAR(x)` and `CHAR(y)` where `x != y`) are never
-    equal, but comparison of such values implicitly converts the types to the same
-    length and pads with spaces so that the following query returns `true`:
+Fixed length character data. A `CHAR` type without length specified has a
+default length of 1. A `CHAR(x)` value always has `x` characters. For example,
+casting `dog` to `CHAR(7)` adds 4 implicit trailing spaces. Leading and trailing
+spaces are included in comparisons of `CHAR` values. As a result, two character
+values with different lengths (`CHAR(x)` and `CHAR(y)` where `x != y`) are never
+equal, but comparison of such values implicitly converts the types to the same
+length and pads with spaces so that the following query returns `true`:
 
-    ```sql
-    SELECT cast('example' AS char(20)) = cast('example    ' AS char(25));
-    ```
+``SELECT cast('example' AS char(20)) = cast('example    ' AS char(25));``
     
-    As with `VARCHAR`, a single quote in a `CHAR`
-    literal can be escaped with another single quote:
+As with `VARCHAR`, a single quote in a `CHAR`
+literal can be escaped with another single quote:
     
-    ```sql
-    SELECT CHAR 'All right, Mr. DeMille, I''m ready for my close-up.'
-    ```
+``SELECT CHAR 'All right, Mr. DeMille, I''m ready for my close-up.'``
 
 
 ``VARBINARY``
 ^^^^^^^^^^^^^
 
-    Variable length binary data.
+Variable length binary data.
 
-    .. note::
+.. note::
 
-        Binary strings with length are not yet supported: ``varbinary(n)``
+    Binary strings with length are not yet supported: ``varbinary(n)``
 
 ``JSON``
 ^^^^^^^^
 
-    JSON value type, which can be a JSON object, a JSON array, a JSON number, a JSON string,
-    ``true``, ``false`` or ``null``.
+JSON value type, which can be a JSON object, a JSON array, a JSON number, a JSON string,
+``true``, ``false`` or ``null``.
 
 Date and Time
 -------------
@@ -161,55 +157,55 @@ Date and Time
 ``DATE``
 ^^^^^^^^
 
-    Calendar date (year, month, day).
+Calendar date (year, month, day).
 
-    Example: ``DATE '2001-08-22'``
+Example: ``DATE '2001-08-22'``
 
 ``TIME``
 ^^^^^^^^
 
-    Time of day (hour, minute, second, millisecond) without a time zone.
-    Values of this type are parsed and rendered in the session time zone.
+Time of day (hour, minute, second, millisecond) without a time zone.
+Values of this type are parsed and rendered in the session time zone.
 
-    Example: ``TIME '01:02:03.456'``
+Example: ``TIME '01:02:03.456'``
 
 ``TIME WITH TIME ZONE``
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-    Time of day (hour, minute, second, millisecond) with a time zone.
-    Values of this type are rendered using the time zone from the value.
+Time of day (hour, minute, second, millisecond) with a time zone.
+Values of this type are rendered using the time zone from the value.
 
-    Example: ``TIME '01:02:03.456 America/Los_Angeles'``
+Example: ``TIME '01:02:03.456 America/Los_Angeles'``
 
 ``TIMESTAMP``
 ^^^^^^^^^^^^^
 
-    Instant in time that includes the date and time of day without a time zone.
-    Values of this type are parsed and rendered in the session time zone.
+Instant in time that includes the date and time of day without a time zone.
+Values of this type are parsed and rendered in the session time zone.
 
-    Example: ``TIMESTAMP '2001-08-22 03:04:05.321'``
+Example: ``TIMESTAMP '2001-08-22 03:04:05.321'``
 
 ``TIMESTAMP WITH TIME ZONE``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Instant in time that includes the date and time of day with a time zone.
-    Values of this type are rendered using the time zone from the value.
+Instant in time that includes the date and time of day with a time zone.
+Values of this type are rendered using the time zone from the value.
 
-    Example: ``TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles'``
+Example: ``TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles'``
 
 ``INTERVAL YEAR TO MONTH``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Span of years and months.
+Span of years and months.
 
-    Example: ``INTERVAL '3' MONTH``
+Example: ``INTERVAL '3' MONTH``
 
 ``INTERVAL DAY TO SECOND``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Span of days, hours, minutes, seconds and milliseconds.
+Span of days, hours, minutes, seconds and milliseconds.
 
-    Example: ``INTERVAL '2' DAY``
+Example: ``INTERVAL '2' DAY``
 
 Structural
 ----------
@@ -219,28 +215,28 @@ Structural
 ``ARRAY``
 ^^^^^^^^^
 
-    An array of the given component type.
+An array of the given component type.
 
-    Example: ``ARRAY[1, 2, 3]``
+Example: ``ARRAY[1, 2, 3]``
 
 .. _map_type:
 
 ``MAP``
 ^^^^^^^
 
-    A map between the given component types.
+A map between the given component types.
 
-    Example: ``MAP(ARRAY['foo', 'bar'], ARRAY[1, 2])``
+Example: ``MAP(ARRAY['foo', 'bar'], ARRAY[1, 2])``
 
 .. _row_type:
 
 ``ROW``
 ^^^^^^^
 
-    A structure made up of named fields. The fields may be of any SQL type, and are
-    accessed with field reference operator ``.``
+A structure made up of named fields. The fields may be of any SQL type, and are
+accessed with field reference operator ``.``
 
-    Example: ``CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))``
+Example: ``CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))``
 
 Network Address
 ---------------
@@ -250,37 +246,37 @@ Network Address
 ``IPADDRESS``
 ^^^^^^^^^^^^^
 
-    An IP address that can represent either an IPv4 or IPv6 address.
+An IP address that can represent either an IPv4 or IPv6 address.
 
-    Internally, the type is a pure IPv6 address. Support for IPv4 is handled
-    using the *IPv4-mapped IPv6 address* range (:rfc:`4291#section-2.5.5.2`).
-    When creating an ``IPADDRESS``, IPv4 addresses will be mapped into that range.
+Internally, the type is a pure IPv6 address. Support for IPv4 is handled
+using the *IPv4-mapped IPv6 address* range (:rfc:`4291#section-2.5.5.2`).
+When creating an ``IPADDRESS``, IPv4 addresses will be mapped into that range.
 
-    When formatting an ``IPADDRESS``, any address within the mapped range will
-    be formatted as an IPv4 address. Other addresses will be formatted as IPv6
-    using the canonical format defined in :rfc:`5952`.
+When formatting an ``IPADDRESS``, any address within the mapped range will
+be formatted as an IPv4 address. Other addresses will be formatted as IPv6
+using the canonical format defined in :rfc:`5952`.
 
-    Examples: ``IPADDRESS '10.0.0.1'``, ``IPADDRESS '2001:db8::1'``
+Examples: ``IPADDRESS '10.0.0.1'``, ``IPADDRESS '2001:db8::1'``
 
 .. _ipprefix_type:
 
 ``IPPREFIX``
 ^^^^^^^^^^^^
 
-    An IP routing prefix that can represent either an IPv4 or IPv6 address.
+An IP routing prefix that can represent either an IPv4 or IPv6 address.
 
-    Internally, an address is a pure IPv6 address. Support for IPv4 is handled
-    using the *IPv4-mapped IPv6 address* range (:rfc:`4291#section-2.5.5.2`).
-    When creating an ``IPPREFIX``, IPv4 addresses will be mapped into that range.
-    Additionally, addresses will be reduced to the first address of a network.
+Internally, an address is a pure IPv6 address. Support for IPv4 is handled
+using the *IPv4-mapped IPv6 address* range (:rfc:`4291#section-2.5.5.2`).
+When creating an ``IPPREFIX``, IPv4 addresses will be mapped into that range.
+Additionally, addresses will be reduced to the first address of a network.
 
-    ``IPPREFIX`` values will be formatted in CIDR notation, written as an IP
-    address, a slash ('/') character, and the bit-length of the prefix. Any
-    address within the IPv4-mapped IPv6 address range will be formatted as an
-    IPv4 address. Other addresses will be formatted as IPv6 using the canonical
-    format defined in :rfc:`5952`.
+``IPPREFIX`` values will be formatted in CIDR notation, written as an IP
+address, a slash ('/') character, and the bit-length of the prefix. Any
+address within the IPv4-mapped IPv6 address range will be formatted as an
+IPv4 address. Other addresses will be formatted as IPv6 using the canonical
+format defined in :rfc:`5952`.
 
-    Examples: ``IPPREFIX '10.0.1.0/24'``, ``IPPREFIX '2001:db8::/48'``
+Examples: ``IPPREFIX '10.0.1.0/24'``, ``IPPREFIX '2001:db8::/48'``
 
 UUID
 ----
@@ -290,10 +286,10 @@ UUID
 ``UUID``
 ^^^^^^^^
 
-    This type represents a UUID (Universally Unique IDentifier), also known as a
-    GUID (Globally Unique IDentifier), using the format defined in :rfc:`4122`.
+This type represents a UUID (Universally Unique IDentifier), also known as a
+GUID (Globally Unique IDentifier), using the format defined in :rfc:`4122`.
 
-    Example: ``UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59'``
+Example: ``UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59'``
 
 HyperLogLog
 -----------
@@ -306,16 +302,16 @@ Calculating the approximate distinct count can be done much more cheaply than an
 ``HyperLogLog``
 ^^^^^^^^^^^^^^^
 
-    A HyperLogLog sketch allows efficient computation of :func:`approx_distinct`. It starts as a
-    sparse representation, switching to a dense representation when it becomes more efficient.
+A HyperLogLog sketch allows efficient computation of :func:`approx_distinct`. It starts as a
+sparse representation, switching to a dense representation when it becomes more efficient.
 
 .. _p4hyperloglog_type:
 
 ``P4HyperLogLog``
 ^^^^^^^^^^^^^^^^^
 
-    A P4HyperLogLog sketch is similar to :ref:`hyperloglog_type`, but it starts (and remains)
-    in the dense representation.
+A P4HyperLogLog sketch is similar to :ref:`hyperloglog_type`, but it starts (and remains)
+in the dense representation.
 
 KHyperLogLog
 ------------
@@ -325,8 +321,8 @@ KHyperLogLog
 ``KHyperLogLog``
 ^^^^^^^^^^^^^^^^
 
-    A KHyperLogLog is a data sketch that can be used to compactly represents the association of two
-    columns. See :doc:`/functions/khyperloglog`.
+A KHyperLogLog is a data sketch that can be used to compactly represents the association of two
+columns. See :doc:`/functions/khyperloglog`.
 
 SetDigest
 ---------
@@ -361,35 +357,35 @@ Quantile Digest
 ``QDigest``
 ^^^^^^^^^^^
 
-    A quantile digest (qdigest) is a summary structure which captures the approximate
-    distribution of data for a given input set, and can be queried to retrieve approximate
-    quantile values from the distribution.  The level of accuracy for a qdigest
-    is tunable, allowing for more precise results at the expense of space.
+A quantile digest (qdigest) is a summary structure which captures the approximate
+distribution of data for a given input set, and can be queried to retrieve approximate
+quantile values from the distribution.  The level of accuracy for a qdigest
+is tunable, allowing for more precise results at the expense of space.
 
-    A qdigest can be used to give approximate answer to queries asking for what value
-    belongs at a certain quantile.  A useful property of qdigests is that they are
-    additive, meaning they can be merged together without losing precision.
+A qdigest can be used to give approximate answer to queries asking for what value
+belongs at a certain quantile.  A useful property of qdigests is that they are
+additive, meaning they can be merged together without losing precision.
 
-    A qdigest may be helpful whenever the partial results of ``approx_percentile``
-    can be reused.  For example, one may be interested in a daily reading of the 99th
-    percentile values that are read over the course of a week.  Instead of calculating
-    the past week of data with ``approx_percentile``, ``qdigest``\ s could be stored
-    daily, and quickly merged to retrieve the 99th percentile value.
+A qdigest may be helpful whenever the partial results of ``approx_percentile``
+can be reused.  For example, one may be interested in a daily reading of the 99th
+percentile values that are read over the course of a week.  Instead of calculating
+the past week of data with ``approx_percentile``, ``qdigest``\ s could be stored
+daily, and quickly merged to retrieve the 99th percentile value.
 
-    See :doc:`/functions/qdigest`.
+See :doc:`/functions/qdigest`.
 
 T-Digest
----------------
+--------
 
 .. _tdigest_type:
 
 ``TDigest``
 ^^^^^^^^^^^
 
-    A t-digest is similar to :ref:`qdigest <qdigest_type>`, but it uses `a different algorithm
-    <http://dx.doi.org/10.1145/347090.347195>`_ to represent the approximate distribution of a set
-    of numbers. T-digest has better performance than quantile digests but only supports the
-    ``DOUBLE`` type. See :doc:`/functions/tdigest`.
+A t-digest is similar to :ref:`qdigest <qdigest_type>`, but it uses `a different algorithm
+<http://dx.doi.org/10.1145/347090.347195>`_ to represent the approximate distribution of a set
+of numbers. T-digest has better performance than quantile digests but only supports the
+``DOUBLE`` type. See :doc:`/functions/tdigest`.
 
 KLL Sketch
 ----------
@@ -399,12 +395,12 @@ KLL Sketch
 ``KLL Sketch``
 ^^^^^^^^^^^^^^
 
-    A KLL sketch is similar to the :ref:`qdigest <qdigest_type>`, but, like the
-    T-Digest uses a `different algorithm
-    <https://datasketches.apache.org/docs/KLL/KLLSketch.html>`_ to represent the
-    approximate distribution of a set of values. The KLL sketch in Presto
-    supports int, bigint, double, varchar, and boolean types. See
-    :doc:`/functions/sketch` for more information. In serialized form, the
-    ``kllsketch`` type stored by Presto can be read directly by any other
-    application which utilizes the Apache DataSketches library to read KLL
-    sketches.
+A KLL sketch is similar to the :ref:`qdigest <qdigest_type>`, but, like the
+T-Digest uses a `different algorithm
+<https://datasketches.apache.org/docs/KLL/KLLSketch.html>`_ to represent the
+approximate distribution of a set of values. The KLL sketch in Presto
+supports int, bigint, double, varchar, and boolean types. See
+:doc:`/functions/sketch` for more information. In serialized form, the
+``kllsketch`` type stored by Presto can be read directly by any other
+application which utilizes the Apache DataSketches library to read KLL
+sketches.


### PR DESCRIPTION
## Description
Fix formatting in https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/language/types.rst to remove unneeded indenting of most of the text and the examples. 

## Motivation and Context
Improving the formatting and consistency of the doc improves readability. 

## Impact
Documentation. 

## Test Plan
Local build to verify that the changes both fix the problem and add no new formatting problems. 

Screenshot showing a sample of the current state of the page:
<img width="906" alt="Screenshot 2024-03-26 at 3 05 17 PM" src="https://github.com/prestodb/presto/assets/7013443/e4dca6f7-2a93-45d1-bcc1-be8da3eb1b1e">

Screenshot showing the same area of the page built from this PR:
<img width="843" alt="Screenshot 2024-03-26 at 3 08 36 PM" src="https://github.com/prestodb/presto/assets/7013443/e87c9358-e81d-4de0-ba57-42ce354b5edb">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```