### PR TITLE
Update proxygen to match Velox folly et al version

### DIFF
--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -14,7 +14,7 @@
 set -e
 set -x
 
-export FB_OS_VERSION=v2023.12.04.00
+export FB_OS_VERSION=v2024.02.26.00
 export RE2_VERSION=2021-04-01
 export nproc=$(getconf _NPROCESSORS_ONLN)
 

--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -17,7 +17,7 @@ set -eufx -o pipefail
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-macos.sh"
 
 MACOS_DEPS="${MACOS_DEPS} bison gperf"
-export FB_OS_VERSION=v2023.12.04.00
+export FB_OS_VERSION=v2024.02.26.00
 
 export PATH=$(brew --prefix bison)/bin:$PATH
 

--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -18,7 +18,7 @@ set -eufx -o pipefail
 
 # Run the velox setup script first.
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-ubuntu.sh"
-export FB_OS_VERSION=v2023.12.04.00
+export FB_OS_VERSION=v2024.02.26.00
 sudo apt install -y gperf
 
 function install_proxygen {


### PR DESCRIPTION
## Description
Velox has updated folly and other Meta related dependencies to v2024.02.26.00 in https://github.com/facebookincubator/velox/pull/8950
 which is now also in Prestissimo.
This may cause build issues when rebuilding the dependencies after updating the Velox dependencies. 

One observed error:
```
[2024-03-26T22:46:53.651Z] #14 1975.8 In file included from /setup/_deps/proxygen/proxygen/lib/http/sink/HTTPTransactionSink.cpp:9:
[2024-03-26T22:46:53.651Z] #14 1975.8 /setup/_deps/proxygen/proxygen/lib/http/session/HQSession.h: In member function 'virtual folly::EventBase* proxygen::HQSession::getEventBase() const':
[2024-03-26T22:46:53.651Z] #14 1975.8 /setup/_deps/proxygen/proxygen/lib/http/session/HQSession.h:260:33: error: cannot convert 'std::shared_ptr<quic::QuicEventBase>' to 'folly::EventBase*' in return
[2024-03-26T22:46:53.651Z] #14 1975.8   260 |       return sock_->getEventBase();
[2024-03-26T22:46:53.651Z] #14 1975.8       |              ~~~~~~~~~~~~~~~~~~~^~
[2024-03-26T22:46:53.651Z] #14 1975.8       |                                 |
[2024-03-26T22:46:53.651Z] #14 1975.8       |                                 std::shared_ptr<quic::QuicEventBase>
```


## Motivation and Context
Avoid build errors.
It makes sense to have version parity for the Meta related dependencies.

## Impact
n/a

## Test Plan
n/a

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

