### PR TITLE
[native] presto task info update code refactor and add cumulative memory test

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -88,11 +88,11 @@ struct PrestoTask {
   std::shared_ptr<velox::exec::Task> task;
   std::atomic_bool hasStuckOperator{false};
 
-  // Has the task been normally created and started.
-  // When you create task with error - it has never been started.
-  // When you create task from 'delete task' - it has never been started.
-  // When you create task from any other endpoint, such as 'get result' - it has
-  // not been started, until the actual 'create task' message comes.
+  /// Has the task been normally created and started.
+  /// When you create task with error - it has never been started.
+  /// When you create task from 'delete task' - it has never been started.
+  /// When you create task from any other endpoint, such as 'get result' - it
+  /// has not been started, until the actual 'create task' message comes.
   bool taskStarted{false};
 
   uint64_t lastHeartbeatMs{0};
@@ -150,14 +150,33 @@ struct PrestoTask {
   /// Returns process-wide CPU time in nanoseconds.
   static long getProcessCpuTime();
 
+  /// Invoked to update presto task status from the updated velox task stats.
   protocol::TaskStatus updateStatusLocked();
   protocol::TaskInfo updateInfoLocked();
-  void updateOutputBufferInfoLocked(const velox::exec::TaskStats& taskStats);
 
   folly::dynamic toJson() const;
 
  private:
   void recordProcessCpuTime();
+
+  void updateOutputBufferInfoLocked(
+      const velox::exec::TaskStats& veloxTaskStats,
+      std::unordered_map<std::string, velox::RuntimeMetric>& taskRuntimeStats);
+
+  void updateTimeInfoLocked(
+      const velox::exec::TaskStats& veloxTaskStats,
+      uint64_t currentTimeMs,
+      std::unordered_map<std::string, velox::RuntimeMetric>& taskRuntimeStats);
+
+  void updateExecutionInfoLocked(
+      const velox::exec::TaskStats& veloxTaskStats,
+      const protocol::TaskStatus& prestoTaskStatus,
+      std::unordered_map<std::string, velox::RuntimeMetric>& taskRuntimeStats);
+
+  void updateMemoryInfoLocked(
+      const velox::exec::TaskStats& veloxTaskStats,
+      uint64_t currentTimeMs,
+      std::unordered_map<std::string, velox::RuntimeMetric>& taskRuntimeStats);
 
   long processCpuTime_{0};
 };


### PR DESCRIPTION
Refactor Presto task info update code logic by splitting the update logic into a couple of methods
with one per each type info:
- updateOutputBufferInfoLocked: update output buffer related stats which is mostly used by scale
   writer by Presto coordinator.
- updateTimeInfoLocked: update task execution timing related stats such as task start time, end time etc.
- updateMemoryInfoLocked: update memory usage stats such as cumulative memory usage, peak memory
   usage etc.
- updateExecutionInfoLocked: update task internal execution stats such as operator and pipeline stats.

Add unit test to verify lastTaskStatsUpdateMs is initialized properly on the first call to get
task info. If not initialized, we might get very large cumulative memory usage if the task memory
usage is not zero.