### PR TITLE
[native] Disable exchange_materialization_strategy

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -2025,8 +2025,11 @@ public final class SystemSessionProperties
         return !isStrategyNone && hasMaterializedCTE;
     }
 
-    public static ExchangeMaterializationStrategy getExchangeMaterializationStrategy(Session session)
+    public static ExchangeMaterializationStrategy getExchangeMaterializationStrategy(Session session, boolean nativeExecution)
     {
+        if (nativeExecution) {
+            return ExchangeMaterializationStrategy.NONE;
+        }
         return session.getSystemProperty(EXCHANGE_MATERIALIZATION_STRATEGY, ExchangeMaterializationStrategy.class);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -52,6 +52,7 @@ public class PlanFragmenter
     private final SqlParser sqlParser;
     private final PlanChecker distributedPlanChecker;
     private final PlanChecker singleNodePlanChecker;
+    private final boolean nativeExecution;
 
     @Inject
     public PlanFragmenter(Metadata metadata, NodePartitioningManager nodePartitioningManager, QueryManagerConfig queryManagerConfig, SqlParser sqlParser, FeaturesConfig featuresConfig)
@@ -62,6 +63,7 @@ public class PlanFragmenter
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.distributedPlanChecker = new PlanChecker(requireNonNull(featuresConfig, "featuresConfig is null"), false);
         this.singleNodePlanChecker = new PlanChecker(requireNonNull(featuresConfig, "featuresConfig is null"), true);
+        this.nativeExecution = featuresConfig.isNativeExecutionEnabled();
     }
 
     public SubPlan createSubPlans(Session session, Plan plan, boolean forceSingleNode, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
@@ -92,7 +94,7 @@ public class PlanFragmenter
         PlanNode root = SimplePlanRewriter.rewriteWith(fragmenter, plan.getRoot(), properties);
 
         SubPlan subPlan = fragmenter.buildRootFragment(root, properties);
-        return finalizeSubPlan(subPlan, config, metadata, nodePartitioningManager, session, forceSingleNode, warningCollector, subPlan.getFragment().getPartitioning());
+        return finalizeSubPlan(subPlan, config, metadata, nodePartitioningManager, session, forceSingleNode, warningCollector, subPlan.getFragment().getPartitioning(), nativeExecution);
     }
 
     private static class Fragmenter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
@@ -88,7 +88,8 @@ public class PlanFragmenterUtils
             Session session,
             boolean forceSingleNode,
             WarningCollector warningCollector,
-            PartitioningHandle partitioningHandle)
+            PartitioningHandle partitioningHandle,
+            boolean nativeExecution)
     {
         subPlan = reassignPartitioningHandleIfNecessary(metadata, session, subPlan, partitioningHandle);
         if (!forceSingleNode) {
@@ -102,7 +103,7 @@ public class PlanFragmenterUtils
         sanityCheckFragmentedPlan(
                 subPlan,
                 warningCollector,
-                getExchangeMaterializationStrategy(session),
+                getExchangeMaterializationStrategy(session, nativeExecution),
                 getQueryMaxStageCount(session),
                 config.getStageCountWarningThreshold());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -216,7 +216,7 @@ public class AddExchanges
             this.preferStreamingOperators = preferStreamingOperators(session);
             this.partitioningProviderCatalog = getPartitioningProviderCatalog(session);
             this.hashPartitionCount = getHashPartitionCount(session);
-            this.exchangeMaterializationStrategy = getExchangeMaterializationStrategy(session);
+            this.exchangeMaterializationStrategy = getExchangeMaterializationStrategy(session, nativeExecution);
             this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
             this.nativeExecution = nativeExecution;
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
@@ -48,7 +48,7 @@ public class PrestoSparkSettingsRequirements
     {
         // verify Presto configuration
         verify(!isDistributedSortEnabled(session), "distributed sort is not supported");
-        verify(getExchangeMaterializationStrategy(session) == NONE, "exchange materialization is not supported");
+        verify(getExchangeMaterializationStrategy(session, false) == NONE, "exchange materialization is not supported");
         verify(getPartitioningProviderCatalog(session).equals(GlobalSystemConnector.NAME), "partitioning provider other that system is not supported");
         verify(!isRecoverableGroupedExecutionEnabled(session) && !isGroupedExecutionEnabled(session), "grouped execution is not supported");
         verify(!isRedistributeWrites(session), "redistribute writes is not supported");

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -240,7 +240,8 @@ public class PrestoSparkAdaptiveQueryExecution
                 this.queryManagerConfig,
                 this.session,
                 this.warningCollector,
-                forceSingleNode);
+                forceSingleNode,
+                this.featuresConfig.isNativeExecutionEnabled());
     }
 
     @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/IterativePlanFragmenter.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/IterativePlanFragmenter.java
@@ -106,6 +106,7 @@ public class IterativePlanFragmenter
     // number 0
     private int nextFragmentId = ROOT_FRAGMENT_ID + 1;
     private final Map<PlanFragmentId, SubPlan> subPlanByFragmentId = new HashMap<>();
+    private final boolean nativeExecution;
 
     public IterativePlanFragmenter(
             Plan originalPlan,
@@ -118,7 +119,8 @@ public class IterativePlanFragmenter
             QueryManagerConfig queryManagerConfig,
             Session session,
             WarningCollector warningCollector,
-            boolean forceSingleNode)
+            boolean forceSingleNode,
+            boolean nativeExecution)
     {
         this.originalPlan = requireNonNull(originalPlan, "originalPlan is null");
         this.isFragmentFinished = requireNonNull(isFragmentFinished, "isSourceReady is null");
@@ -132,6 +134,7 @@ public class IterativePlanFragmenter
         this.session = requireNonNull(session, "session is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
         this.forceSingleNode = forceSingleNode;
+        this.nativeExecution = nativeExecution;
     }
 
     /**
@@ -186,7 +189,7 @@ public class IterativePlanFragmenter
         // and rewriting the partition handle
         PartitioningHandle partitioningHandle = properties.getPartitioningHandle();
         subPlans = subPlans.stream()
-                .map(subPlan -> finalizeSubPlan(subPlan, queryManagerConfig, metadata, nodePartitioningManager, session, forceSingleNode, warningCollector, partitioningHandle))
+                .map(subPlan -> finalizeSubPlan(subPlan, queryManagerConfig, metadata, nodePartitioningManager, session, forceSingleNode, warningCollector, partitioningHandle, nativeExecution))
                 .collect(toImmutableList());
 
         return new PlanAndFragments(remainingPlan, subPlans);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
@@ -232,6 +232,7 @@ public class TestIterativePlanFragmenter
                 new QueryManagerConfig(),
                 session,
                 WarningCollector.NOOP,
+                false,
                 false);
 
         PlanAndFragments nextPlanAndFragments = getNextPlanAndFragments(iterativePlanFragmenter, node);


### PR DESCRIPTION
exchange_materialization_strategy = 'ALL' is used to execute the query in Large Batch Mode (LBM). This mode is deprecated and is not supported by Prestissimo. This change is to ignore this session property when using Prestissimo.

```
== NO RELEASE NOTE ==
```

