### PR TITLE
[docs] Add Presto Console page to /clients/

### DIFF
--- a/presto-docs/src/main/sphinx/clients.rst
+++ b/presto-docs/src/main/sphinx/clients.rst
@@ -6,3 +6,4 @@ Presto Clients
     :maxdepth: 1
 
     clients/presto-cli
+    clients/presto-console

--- a/presto-docs/src/main/sphinx/clients/presto-console.rst
+++ b/presto-docs/src/main/sphinx/clients/presto-console.rst
@@ -1,0 +1,37 @@
+==============
+Presto Console
+==============
+
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+Overview
+========
+
+The Presto Console is a web-based UI that is included as part of a Presto server 
+installation. For more information about installing Presto, see 
+`Installing Presto <../installation/deployment.html#installing-presto>`_.
+
+Configuration
+=============
+
+The default port is 8080. To configure the Presto service to use a 
+different port, edit the Presto coordinator node's ``config.properties`` 
+file and change the configuration property ``http-server.http.port`` to 
+use a different port number. For more information, see 
+`Config Properties <../installation/deployment.html#config-properties>`_.
+
+Open the Presto Console
+=======================
+
+After starting Presto, you can access the web UI at the default port 
+``8080`` using the following link in a browser:
+
+.. code-block:: none
+
+    http://localhost:8080
+
+.. figure:: ../images/presto_console.png
+   :align: center

--- a/presto-docs/src/main/sphinx/installation/deploy-brew.rst
+++ b/presto-docs/src/main/sphinx/installation/deploy-brew.rst
@@ -64,17 +64,19 @@ To stop the Presto service in the background, run the following command:
 
 To stop the Presto service in the foreground, close the terminal or select Ctrl + C until the terminal prompt is shown. 
 
-Access the Presto Web Console
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Open the Presto Console
+^^^^^^^^^^^^^^^^^^^^^^^
 
-After starting Presto, you can access the web UI using the following link in a browser:
+After starting Presto, you can access the web UI at the default port ``8080`` using the following link in a browser:
 
-``http://localhost:8080``
+.. code-block:: none
 
-*Note*: The default port is 8080. To configure the Presto service to use a different port see `Config Properties <deployment.html#config-properties>`_.
+    http://localhost:8080
 
 .. figure:: ../images/presto_console.png
    :align: center
+
+For more information about the Presto Console, see :doc:`/clients/presto-console`.
 
 Start the Presto CLI
 ^^^^^^^^^^^^^^^^^^^^
@@ -160,17 +162,19 @@ To stop the Presto service in the background, run the following command:
 
 To stop the Presto service in the foreground, close the terminal or select Ctrl + C until the terminal prompt is shown. 
 
-Access the Presto Web Console
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Open the Presto Console
+^^^^^^^^^^^^^^^^^^^^^^^
 
-After starting Presto, you can access the web UI using the following link in a browser:
+After starting Presto, you can access the web UI at the default port ``8080`` using the following link in a browser:
 
-``http://localhost:8080``
+.. code-block:: none
 
-*Note*: The default port is 8080. To configure the Presto service to use a different port see `Config Properties <deployment.html#config-properties>`_.
+    http://localhost:8080
 
 .. figure:: ../images/presto_console.png
    :align: center
+
+For more information about the Presto Console, see :doc:`/clients/presto-console`.
 
 Start the Presto CLI
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
* Added a new page in /clients/ for the Presto Console as a parallel with the existing Presto CLI page. 
* Moved some of the content about the Presto Console from the installation doc [Deploy Presto on a Mac Using Homebrew](http://prestodb.io/docs/0.286/installation/deploy-brew.html#access-the-presto-web-console) and added a link to the new Presto Console page. 
Note: Intentionally left some minimal content about the Presto Console on [Deploy Presto on a Mac Using Homebrew](http://prestodb.io/docs/0.286/installation/deploy-brew.html#access-the-presto-web-console).
* Changed the formatting of the `http://localhost:8080` URI on both the new Presto Console page and [Deploy Presto on a Mac Using Homebrew](http://prestodb.io/docs/0.286/installation/deploy-brew.html#access-the-presto-web-console) to a one-line code block. This format change causes a "Copy to Clipboard" when the cursor is over the URI and makes it easier for the user to copy-paste the URI into a browser. 

## Motivation and Context
[PR 22265](https://github.com/prestodb/presto/pull/22265) added the Presto Clients top-level topic and the Presto CLI page to the documentation. The intent of [PR 22265](https://github.com/prestodb/presto/pull/22265) was _the new category also gives us a location to put currently-missing documentation for the Presto Console as well as potentially documenting other clients usable with Presto, such as Apache Superset_. 

This PR builds on [PR 22265](https://github.com/prestodb/presto/pull/22265) to create a page to initially document the minimal basics of the Presto Console, and to provide a page to expand and add documentation to about the many features of the Presto Console. 

## Impact
Documentation. 

## Test Plan
Local builds of the doc to verify that 
* the new page exists and all links on it work
* the new page exists on the clients.rst index page
* [Deploy Presto on a Mac Using Homebrew](http://prestodb.io/docs/0.286/installation/deploy-brew.html#access-the-presto-web-console) still contains useful but reduced content about the Console as well as a working link to the new Presto Console page

Screenshot of the upper part of the new Presto Console page, showing the left-side navbar and the right-side table of contents:

<img width="1371" alt="Screenshot 2024-03-27 at 3 25 39 PM" src="https://github.com/prestodb/presto/assets/7013443/e69bd209-d9b7-4f94-8e5d-8a3d6ab8f8fd">


Screenshot of the revised [Deploy Presto on a Mac Using Homebrew](http://prestodb.io/docs/0.286/installation/deploy-brew.html#access-the-presto-web-console):

<img width="1127" alt="Screenshot 2024-03-27 at 3 25 58 PM" src="https://github.com/prestodb/presto/assets/7013443/43656656-0632-4f7a-be3d-2d4d0a2eac65">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add usage documentation for :doc:`/clients/presto-console`
```

