### PR TITLE
[docs] Casting strings to integer types allows leading and trailing spaces

### DIFF
--- a/presto-docs/src/main/sphinx/functions/conversion.rst
+++ b/presto-docs/src/main/sphinx/functions/conversion.rst
@@ -22,6 +22,14 @@ Conversion Functions
 
     Like :func:`cast`, but returns null if the cast fails.
 
+.. note::
+
+    When casting strings to integer types such as ``TINYINT``, 
+    ``SMALLINT``, ``INTEGER``, or ``BIGINT``, leading 
+    and trailing spaces in the string are allowed. See  `Integer <../language/types.html#integer>`_.
+
+
+
 Data Size
 ---------
 

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -26,6 +26,11 @@ This type captures boolean values ``true`` and ``false``.
 Integer
 -------
 
+.. note::
+
+    Cast conversion functions allow leading and trailing spaces when casting 
+    a string to ``TINYINT``, ``SMALLINT``, ``INTEGER``, or ``BIGINT``.
+
 ``TINYINT``
 ^^^^^^^^^^^
 


### PR DESCRIPTION
## Description
* Add Note to Integer in [Data Types](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/language/types.rst) that casting strings to integer types allows leading and trailing spaces. 
* Add Note to Cast in [Conversion Functions](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/functions/conversion.rst), including a link to the Integer doc in [Data Types](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/language/types.rst).

## Motivation and Context
* Updates the Presto documentation to address [PR 22284](https://github.com/prestodb/presto/pull/22284). 

## Impact
Documentation. 

## Test Plan
Local build of docs. Verified the doc built correctly, and that the link from Cast to Integer works. 

Screenshot of Integer in Data Types:
<img width="844" alt="Screenshot 2024-03-28 at 12 34 23 PM" src="https://github.com/prestodb/presto/assets/7013443/20b42734-139a-4e74-a2ac-62103141577b">

Screenshot of Cast in Conversion Functions: 
<img width="845" alt="Screenshot 2024-03-28 at 12 34 28 PM" src="https://github.com/prestodb/presto/assets/7013443/89cf64bd-4a1d-4308-b661-630bd883c78f">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

