### PR TITLE
Skip IcebergPlanOptimizer for non-DATA tables

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
@@ -54,6 +54,7 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.FALSE_CONSTA
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
+import static com.facebook.presto.iceberg.IcebergTableType.DATA;
 import static com.facebook.presto.iceberg.IcebergUtil.getIcebergTable;
 import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -125,6 +126,9 @@ public class IcebergPlanOptimizer
             }
 
             TableScanNode tableScan = (TableScanNode) filter.getSource();
+            if (((IcebergTableHandle) tableScan.getTable().getConnectorHandle()).getIcebergTableName().getTableType() != DATA) {
+                return visitPlan(filter, context);
+            }
 
             Map<String, IcebergColumnHandle> nameToColumnHandlesMapping = tableScan.getAssignments().entrySet().stream()
                     .collect(Collectors.toMap(e -> e.getKey().getName(), e -> (IcebergColumnHandle) e.getValue()));

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableChangelog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableChangelog.java
@@ -15,11 +15,13 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -116,6 +118,36 @@ public class TestIcebergTableChangelog
         assertQuerySucceeds(String.format("SELECT * FROM \"ctas_orders@%d$changelog\" WHERE snapshotid != 0", snapshots[0]));
         assertQuerySucceeds(String.format("SELECT * FROM \"ctas_orders@%d$changelog\" WHERE operation != 'INSERT'", snapshots[0]));
         assertQuerySucceeds(String.format("SELECT * FROM \"ctas_orders@%d$changelog\" WHERE operation = 'INSERT'", snapshots[0]));
+    }
+
+    @Test
+    public void testVerifyProjectAndFilterOutput()
+    {
+        assertQuerySucceeds("CREATE TABLE test_changelog (a int, b int)  WITH (partitioning = ARRAY['a'], delete_mode = 'copy-on-write')");
+        assertQuerySucceeds("INSERT INTO test_changelog VALUES (1, 2)");
+        assertQuerySucceeds("INSERT INTO test_changelog VALUES (2, 2)");
+        assertQuerySucceeds("DELETE FROM test_changelog WHERE a = 2");
+        long[] testSnapshots = Lists.reverse(
+                        getQueryRunner().execute("SELECT snapshot_id FROM \"test_changelog$snapshots\" ORDER BY committed_at desc").getOnlyColumn()
+                                .collect(Collectors.toList()))
+                // skip the earliest snapshot since the changelog starts from there.
+                .stream().skip(1)
+                .mapToLong(Long.class::cast)
+                .toArray();
+        assertQuery("SELECT snapshotid FROM \"test_changelog$changelog\" order by ordinal asc", "VALUES " + Joiner.on(", ").join(Arrays.stream(testSnapshots).iterator()));
+        // Verify correct projections for single columns
+        assertQuery("SELECT ordinal FROM \"test_changelog$changelog\" order by ordinal asc", "VALUES 0, 1");
+        assertQuery("SELECT operation FROM \"test_changelog$changelog\" order by ordinal asc", "VALUES 'INSERT', 'DELETE'");
+        assertQuery("SELECT rowdata.a, rowdata.b FROM \"test_changelog$changelog\" order by ordinal asc", "VALUES (2, 2), (2, 2)"); // inserted then deleted
+        // Verify correct filters results on filters
+        assertQuery("SELECT ordinal, operation FROM \"test_changelog$changelog\" WHERE ordinal = 0 order by ordinal asc", "VALUES (0, 'INSERT')");
+        assertQuery("SELECT ordinal, operation FROM \"test_changelog$changelog\" WHERE ordinal = 1 order by ordinal asc", "VALUES (1, 'DELETE')");
+        assertQuery("SELECT ordinal, operation FROM \"test_changelog$changelog\" WHERE operation = 'INSERT' order by ordinal asc", "VALUES (0, 'INSERT')");
+        assertQuery("SELECT ordinal, operation FROM \"test_changelog$changelog\" WHERE operation = 'DELETE' order by ordinal asc", "VALUES (1, 'DELETE')");
+        assertQueryReturnsEmptyResult("SELECT * FROM \"test_changelog$changelog\" WHERE operation = 'AAABBBCCC'");
+        assertQuery(String.format("SELECT ordinal FROM \"test_changelog$changelog\" WHERE snapshotid = %d order by ordinal asc", testSnapshots[0]), "VALUES 0");
+        assertQuery(String.format("SELECT ordinal FROM \"test_changelog$changelog\" WHERE snapshotid = %d order by ordinal asc", testSnapshots[1]), "VALUES 1");
+        assertQuery("SELECT * FROM \"test_changelog$changelog\" WHERE rowdata.a = 2 order by ordinal asc", String.format("VALUES ('INSERT', 0, %d, (2, 2)), ('DELETE', 1, %d, (2, 2))", testSnapshots[0], testSnapshots[1]));
     }
 
     @Test


### PR DESCRIPTION
The rule was being incorrectly applied to the $changelog system table. It would assume certain columns were partition columns resulting in incorrect query output.

## Description

Added a conditional to skip the optimization if a non-DATA table is in use.

## Motivation and Context

Incorrect query results with the following example:

```sql
create table test_v2 (a int, b int) WITH (format_version = '2', delete_mode = 'copy-on-write', partitioning = Array['a']);
insert into test_v2 values (1,1);
insert into test_v2 values (2,2);
delete from test_v2 where a = 1;

presto:test_demo> select * from "test_v2$changelog";
 operation | ordinal |     snapshotid      |  rowdata   
-----------+---------+---------------------+------------
 INSERT    |       0 | 4301417906194409386 | {a=2, b=2} 
 DELETE    |       1 | 8675841727593397135 | {a=1, b=1} 
(2 rows)

presto:test_demo> select * from "test_v2$changelog" where ordinal = 0;     // correct 
 operation | ordinal |     snapshotid      |  rowdata   
-----------+---------+---------------------+------------
 INSERT    |       0 | 4301417906194409386 | {a=2, b=2} 
(1 row)

presto:test_demo> select * from "test_v2$changelog" where operation = 'INSERT'; // wrong result 
 operation | ordinal |     snapshotid      |  rowdata   
-----------+---------+---------------------+------------
 INSERT    |       0 | 4301417906194409386 | {a=2, b=2} 
 INSERT    |       1 | 8675841727593397135 | {a=1, b=1} 
(2 rows)

presto:test_demo> select * from "test_v2$changelog" where operation = 'BAD'; // wrong,  
 operation | ordinal |     snapshotid      |  rowdata   
-----------+---------+---------------------+------------
 BAD       |       1 | 8675841727593397135 | {a=1, b=1} 
 BAD       |       0 | 4301417906194409386 | {a=2, b=2} 
```

## Impact

N/A

## Test Plan

New test for the changelog table ensures query result output is correct.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

