### PR TITLE
[native] Centralize sslcontext creation.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -188,19 +188,9 @@ void PrestoServer::run() {
         VELOX_USER_FAIL(
             "Https Client Certificates are not configured correctly");
       }
-      clientCertAndKeyPath = optionalClientCertPath.value();
 
-      try {
-        sslContext_ = std::make_shared<folly::SSLContext>();
-        sslContext_->loadCertKeyPairFromFiles(
-            clientCertAndKeyPath.c_str(), clientCertAndKeyPath.c_str());
-        sslContext_->setCiphersOrThrow(ciphers);
-      } catch (const std::exception& ex) {
-        LOG(FATAL) << fmt::format(
-            "Unable to load certificate or key from {} : {}",
-            clientCertAndKeyPath,
-            ex.what());
-      }
+      sslContext_ =
+          util::createSSLContext(optionalClientCertPath.value(), ciphers);
     }
 
     if (systemConfig->internalCommunicationJwtEnabled()) {

--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -26,4 +26,21 @@ protocol::DateTime toISOTimestamp(uint64_t timeMilli) {
   return fmt::format("{}.{:03d}Z", buf, timeMilli % 1000);
 }
 
+std::shared_ptr<folly::SSLContext> createSSLContext(
+    const std::string& clientCertAndKeyPath,
+    const std::string& ciphers) {
+  try {
+    auto sslContext = std::make_shared<folly::SSLContext>();
+    sslContext->loadCertKeyPairFromFiles(
+        clientCertAndKeyPath.c_str(), clientCertAndKeyPath.c_str());
+    sslContext->setCiphersOrThrow(ciphers);
+    return sslContext;
+  } catch (const std::exception& ex) {
+    LOG(FATAL) << fmt::format(
+        "Unable to load certificate or key from {} : {}",
+        clientCertAndKeyPath,
+        ex.what());
+  }
+}
+
 } // namespace facebook::presto::util

--- a/presto-native-execution/presto_cpp/main/common/Utils.h
+++ b/presto-native-execution/presto_cpp/main/common/Utils.h
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #pragma once
+#include <folly/io/async/SSLContext.h>
 #include <glog/logging.h>
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 
@@ -25,5 +26,9 @@ namespace facebook::presto::util {
   LOG(severity) << PRESTO_SHUTDOWN_LOG_PREFIX
 
 protocol::DateTime toISOTimestamp(uint64_t timeMilli);
+
+std::shared_ptr<folly::SSLContext> createSSLContext(
+    const std::string& clientCertAndKeyPath,
+    const std::string& ciphers);
 
 } // namespace facebook::presto::util

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -104,9 +104,7 @@ class AnnouncerTestSuite : public ::testing::TestWithParam<bool> {
 
     std::string keyPath = getCertsPath("client_ca.pem");
     std::string ciphers = "ECDHE-ECDSA-AES256-GCM-SHA384,AES256-GCM-SHA384";
-    sslContext_ = std::make_shared<folly::SSLContext>();
-    sslContext_->loadCertKeyPairFromFiles(keyPath.c_str(), keyPath.c_str());
-    sslContext_->setCiphersOrThrow(ciphers);
+    sslContext_ = util::createSSLContext(keyPath, ciphers);
   }
 
  protected:

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -18,10 +18,10 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include "presto_cpp/main/PrestoExchangeSource.h"
+#include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
 #include "presto_cpp/main/tests/MultableConfigs.h"
-#include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/MemoryAllocator.h"
@@ -32,8 +32,6 @@
 DECLARE_bool(velox_memory_leak_check_enabled);
 
 namespace fs = boost::filesystem;
-using namespace facebook::presto;
-
 using namespace facebook::presto;
 using namespace facebook::velox;
 using namespace facebook::velox::memory;
@@ -413,9 +411,7 @@ class PrestoExchangeSourceTest : public ::testing::TestWithParam<Params> {
         GetParam().immediateBufferTransfer ? "true" : "false");
     const std::string keyPath = getCertsPath("client_ca.pem");
     const std::string ciphers = "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384";
-    sslContext_ = std::make_shared<folly::SSLContext>();
-    sslContext_->loadCertKeyPairFromFiles(keyPath.c_str(), keyPath.c_str());
-    sslContext_->setCiphersOrThrow(ciphers);
+    sslContext_ = facebook::presto::util::createSSLContext(keyPath, ciphers);
   }
 
   void TearDown() override {


### PR DESCRIPTION
Currently SSL context creation code is duplicated between PrestoServer and tests. This can led to a situation where tests create context in a different way than server, and thus skipping server's sslcontext creation code path. Here we centralize sslcontext creation, so that server and tests use exactly same code path.