### PR TITLE
[native] Add back removed params in PrestoExchangeSourceTest

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -1012,11 +1012,11 @@ INSTANTIATE_TEST_CASE_P(
     PrestoExchangeSourceTest,
     PrestoExchangeSourceTest,
     ::testing::Values(
-        //        Params{true, true, 1, 1},
-        //        Params{true, false, 1, 1},
+        Params{true, true, 1, 1},
+        Params{true, false, 1, 1},
         Params{false, true, 1, 1},
         Params{false, false, 1, 1},
-        //        Params{true, true, 2, 10},
-        //        Params{true, false, 2, 10},
+        Params{true, true, 2, 10},
+        Params{true, false, 2, 10},
         Params{false, true, 2, 10},
         Params{false, false, 2, 10}));


### PR DESCRIPTION
The params in the test was accidentally removed in a previous fix. Add them back
```
== NO RELEASE NOTE ==
```

