### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from galileo/realtime/RealtimeInvertedIndex.cpp

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
@@ -212,7 +212,7 @@ std::string PrestoServerOperations::taskOperation(
         limit = limitStr == proxygen::empty_string
             ? std::numeric_limits<uint32_t>::max()
             : stoi(limitStr);
-      } catch (std::exception& ex) {
+      } catch (std::exception&) {
         VELOX_USER_FAIL("Invalid limit provided '{}'.", limitStr);
       }
       std::stringstream oss;

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -233,14 +233,14 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
               try {
                 taskInfo =
                     createOrUpdateFunc(taskId, updateJson, startProcessCpuTime);
-              } catch (const velox::VeloxException& e) {
+              } catch (const velox::VeloxException&) {
                 // Creating an empty task, putting errors inside so that next
                 // status fetch from coordinator will catch the error and well
                 // categorize it.
                 try {
                   taskInfo = taskManager_.createOrUpdateErrorTask(
                       taskId, std::current_exception(), startProcessCpuTime);
-                } catch (const velox::VeloxUserError& e) {
+                } catch (const velox::VeloxUserError&) {
                   throw;
                 }
               }

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -33,7 +33,7 @@ void sendOkResponse(proxygen::ResponseHandler* downstream, const json& body) {
   std::string messageBody;
   try {
     messageBody = body.dump();
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     messageBody =
         body.dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
     LOG(WARNING) << "Failed to serialize json to string. "

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -102,7 +102,7 @@ BroadcastExchangeSource::createExchangeSource(
   try {
     broadcastFileInfo =
         BroadcastFileInfo::deserialize(broadcastInfoJson.value());
-  } catch (const VeloxException& e) {
+  } catch (const VeloxException&) {
     throw;
   } catch (const std::exception& e) {
     VELOX_USER_FAIL("BroadcastInfo deserialization failed: {}", e.what());


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D55548545


