### PR TITLE
Refactor IcebergAbstractMetadata to utilize newly defined SPI method

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -200,10 +200,10 @@ public abstract class IcebergAbstractMetadata
     protected abstract void unregisterTable(ConnectorSession clientSession, SchemaTableName schemaTableName);
 
     /**
-     * This class implements the default implementation for getTableLayouts which will be used in the case of a Java Worker
+     * This class implements the default implementation for getTableLayoutForConstraint which will be used in the case of a Java Worker
      */
     @Override
-    public List<ConnectorTableLayoutResult> getTableLayouts(
+    public ConnectorTableLayoutResult getTableLayoutForConstraint(
             ConnectorSession session,
             ConnectorTableHandle table,
             Constraint<ColumnHandle> constraint,
@@ -233,7 +233,7 @@ public abstract class IcebergAbstractMetadata
                         .setPartitions(Optional.empty())
                         .setTable(handle)
                         .build());
-        return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
+        return new ConnectorTableLayoutResult(layout, constraint.getSummary());
     }
 
     public static Subfield toSubfield(ColumnHandle columnHandle)


### PR DESCRIPTION
## Description

PR #21933 has deprecated SPI method `ConnectorMetadata.getTableLayouts()`, and introduced a new SPI method `ConnectorMetadata.getTableLayoutForConstraint()` to replace it.

This PR refactor IcebergAbstractMetadata to utilize the newly defined SPI method, and stop to use the deprecated method.

## Motivation and Context

Make the implementation in IcebergAbstractMetadata more clear and concise

## Test Plan

 - Make sure the refactor do not affect existing test cases

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

