### PR TITLE
Implement new NaN behavior

### DIFF
--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseClient.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseClient.java
@@ -854,10 +854,10 @@ public class ClickHouseClient
         if (type == BIGINT) {
             return "Int64";
         }
-        if (type == REAL) {
+        if (type.equals(REAL)) {
             return "Float32";
         }
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return "Float64";
         }
         if (type instanceof DecimalType) {

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseColumnHandle.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseColumnHandle.java
@@ -195,10 +195,10 @@ public final class ClickHouseColumnHandle
         if (type == BIGINT) {
             return new ClickHouseTypeHandle(Types.BIGINT, Optional.of("bigint"), 8, 0, Optional.empty(), Optional.empty());
         }
-        if (type == REAL) {
+        if (type.equals(REAL)) {
             return new ClickHouseTypeHandle(Types.REAL, Optional.of("real"), 16, 4, Optional.empty(), Optional.empty());
         }
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return new ClickHouseTypeHandle(Types.DOUBLE, Optional.of("double precision"), 32, 4, Optional.empty(), Optional.empty());
         }
         if (type instanceof CharType || type instanceof VarcharType) {

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
@@ -21,6 +21,12 @@ import java.util.Objects;
 import static com.facebook.presto.common.array.ByteArrayUtils.compareRanges;
 import static com.facebook.presto.common.array.ByteArrayUtils.hash;
 import static com.facebook.presto.common.predicate.TupleDomainFilterUtils.checkArgument;
+import static com.facebook.presto.common.type.TypeUtils.doubleCompare;
+import static com.facebook.presto.common.type.TypeUtils.doubleEquals;
+import static com.facebook.presto.common.type.TypeUtils.doubleHashCode;
+import static com.facebook.presto.common.type.TypeUtils.realCompare;
+import static com.facebook.presto.common.type.TypeUtils.realEquals;
+import static com.facebook.presto.common.type.TypeUtils.realHashCode;
 import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.compare;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -744,15 +750,116 @@ public interface TupleDomainFilter
         protected DoubleRange(double lower, boolean lowerUnbounded, boolean lowerExclusive, double upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
         {
             super(lowerUnbounded, lowerExclusive, upperUnbounded, upperExclusive, nullAllowed);
+            this.lower = lower;
+            this.upper = upper;
+        }
+
+        public static TupleDomainFilter.DoubleRange of(double lower, boolean lowerUnbounded, boolean lowerExclusive, double upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
+        {
+            return new TupleDomainFilter.DoubleRange(lower, lowerUnbounded, lowerExclusive, upper, upperUnbounded, upperExclusive, nullAllowed);
+        }
+
+        public double getLower()
+        {
+            return lower;
+        }
+
+        public double getUpper()
+        {
+            return upper;
+        }
+
+        @Override
+        public boolean testDouble(double value)
+        {
+            if (!lowerUnbounded) {
+                int comparison = doubleCompare(value, lower);
+                if (comparison == -1) {
+                    return false;
+                }
+                if (lowerExclusive && comparison == 0) {
+                    return false;
+                }
+            }
+            if (!upperUnbounded) {
+                int comparison = doubleCompare(value, upper);
+                if (comparison == 1) {
+                    return false;
+                }
+                if (upperExclusive && comparison == 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            // we want to make sure the hashing for lower and upper matches the equals definition, so we pre-hash them
+            return Objects.hash(doubleHashCode(lower), lowerUnbounded, lowerExclusive, doubleHashCode(upper), upperUnbounded, upperExclusive, nullAllowed);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+
+            TupleDomainFilter.DoubleRange other = (TupleDomainFilter.DoubleRange) obj;
+            return doubleEquals(this.lower, other.lower) &&
+                    this.lowerUnbounded == other.lowerUnbounded &&
+                    this.lowerExclusive == other.lowerExclusive &&
+                    doubleEquals(this.upper, other.upper) &&
+                    this.upperUnbounded == other.upperUnbounded &&
+                    this.upperExclusive == other.upperExclusive &&
+                    this.nullAllowed == other.nullAllowed;
+        }
+
+        @Override
+        public String toString()
+        {
+            StringBuilder sb = new StringBuilder(this.getClass().getName());
+            sb.append("{lower='").append(lower);
+            sb.append(", lowerUnbounded=").append(lowerUnbounded);
+            sb.append(", lowerExclusive=").append(lowerExclusive);
+            sb.append(", upper='").append(upper);
+            sb.append(", upperUnbounded=").append(upperUnbounded);
+            sb.append(", upperExclusive=").append(upperExclusive);
+            sb.append(", nullAllowed=").append(nullAllowed);
+            sb.append("}");
+
+            return sb.toString();
+        }
+    }
+
+    /**
+     * This class is a DoubleRange that uses the old definition for NaN
+     */
+    @Deprecated
+    class OldDoubleRange
+            extends AbstractRange
+    {
+        private final double lower;
+        private final double upper;
+
+        protected OldDoubleRange(double lower, boolean lowerUnbounded, boolean lowerExclusive, double upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
+        {
+            super(lowerUnbounded, lowerExclusive, upperUnbounded, upperExclusive, nullAllowed);
             checkArgument(lowerUnbounded || !Double.isNaN(lower), "lower should either be unbounded or not NaN");
             checkArgument(upperUnbounded || !Double.isNaN(upper), "upper should either be unbounded or not NaN");
             this.lower = lower;
             this.upper = upper;
         }
 
-        public static DoubleRange of(double lower, boolean lowerUnbounded, boolean lowerExclusive, double upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
+        public static OldDoubleRange of(double lower, boolean lowerUnbounded, boolean lowerExclusive, double upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
         {
-            return new DoubleRange(lower, lowerUnbounded, lowerExclusive, upper, upperUnbounded, upperExclusive, nullAllowed);
+            return new OldDoubleRange(lower, lowerUnbounded, lowerExclusive, upper, upperUnbounded, upperExclusive, nullAllowed);
         }
 
         public double getLower()
@@ -807,7 +914,7 @@ public interface TupleDomainFilter
                 return false;
             }
 
-            DoubleRange other = (DoubleRange) obj;
+            OldDoubleRange other = (OldDoubleRange) obj;
             return this.lower == other.lower &&
                     this.lowerUnbounded == other.lowerUnbounded &&
                     this.lowerExclusive == other.lowerExclusive &&
@@ -843,8 +950,6 @@ public interface TupleDomainFilter
         private FloatRange(float lower, boolean lowerUnbounded, boolean lowerExclusive, float upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
         {
             super(lowerUnbounded, lowerExclusive, upperUnbounded, upperExclusive, nullAllowed);
-            checkArgument(lowerUnbounded || !Float.isNaN(lower), "lower should either be unbounded or not NaN");
-            checkArgument(upperUnbounded || !Float.isNaN(upper), "upper should either be unbounded or not NaN");
             this.lower = lower;
             this.upper = upper;
         }
@@ -852,6 +957,95 @@ public interface TupleDomainFilter
         public static FloatRange of(float lower, boolean lowerUnbounded, boolean lowerExclusive, float upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
         {
             return new FloatRange(lower, lowerUnbounded, lowerExclusive, upper, upperUnbounded, upperExclusive, nullAllowed);
+        }
+
+        @Override
+        public boolean testFloat(float value)
+        {
+            if (!lowerUnbounded) {
+                int comparison = realCompare(value, lower);
+                if (comparison == -1) {
+                    return false;
+                }
+                if (lowerExclusive && comparison == 0) {
+                    return false;
+                }
+            }
+            if (!upperUnbounded) {
+                int comparison = realCompare(value, upper);
+                if (comparison == 1) {
+                    return false;
+                }
+                if (upperExclusive && comparison == 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(realHashCode(lower), lowerUnbounded, lowerExclusive, realHashCode(upper), upperUnbounded, upperExclusive, nullAllowed);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+
+            FloatRange other = (FloatRange) obj;
+            return realEquals(this.lower, other.lower) &&
+                    this.lowerUnbounded == other.lowerUnbounded &&
+                    this.lowerExclusive == other.lowerExclusive &&
+                    realEquals(this.upper, other.upper) &&
+                    this.upperUnbounded == other.upperUnbounded &&
+                    this.upperExclusive == other.upperExclusive &&
+                    this.nullAllowed == other.nullAllowed;
+        }
+
+        @Override
+        public String toString()
+        {
+            StringBuilder sb = new StringBuilder(this.getClass().getName());
+            sb.append("{lower='").append(lower);
+            sb.append(", lowerUnbounded=").append(lowerUnbounded);
+            sb.append(", lowerExclusive=").append(lowerExclusive);
+            sb.append(", upper='").append(upper);
+            sb.append(", upperUnbounded=").append(upperUnbounded);
+            sb.append(", upperExclusive=").append(upperExclusive);
+            sb.append(", nullAllowed=").append(nullAllowed);
+            sb.append("}");
+
+            return sb.toString();
+        }
+    }
+
+    @Deprecated
+    class OldFloatRange
+            extends AbstractRange
+    {
+        private final float lower;
+        private final float upper;
+
+        private OldFloatRange(float lower, boolean lowerUnbounded, boolean lowerExclusive, float upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
+        {
+            super(lowerUnbounded, lowerExclusive, upperUnbounded, upperExclusive, nullAllowed);
+            checkArgument(lowerUnbounded || !Float.isNaN(lower), "lower should either be unbounded or not NaN");
+            checkArgument(upperUnbounded || !Float.isNaN(upper), "upper should either be unbounded or not NaN");
+            this.lower = lower;
+            this.upper = upper;
+        }
+
+        public static OldFloatRange of(float lower, boolean lowerUnbounded, boolean lowerExclusive, float upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
+        {
+            return new OldFloatRange(lower, lowerUnbounded, lowerExclusive, upper, upperUnbounded, upperExclusive, nullAllowed);
         }
 
         @Override
@@ -896,7 +1090,7 @@ public interface TupleDomainFilter
                 return false;
             }
 
-            FloatRange other = (FloatRange) obj;
+            OldFloatRange other = (OldFloatRange) obj;
             return this.lower == other.lower &&
                     this.lowerUnbounded == other.lowerUnbounded &&
                     this.lowerExclusive == other.lowerExclusive &&
@@ -1402,28 +1596,31 @@ public interface TupleDomainFilter
             extends AbstractTupleDomainFilter
     {
         private final TupleDomainFilter[] filters;
-        private final boolean nanAllowed;
+        // This  will only be set to true when we are using the old nan definition
+        // and have a not in filter. If we are using the new nan definition, DoubleRange.testDouble
+        // and FloatRange.testFloat already handle nans correctly and don't need special handling here.
+        private final boolean nanAllowedAndUsesOldNanDefinition;
 
-        private MultiRange(List<TupleDomainFilter> filters, boolean nullAllowed, boolean nanAllowed)
+        private MultiRange(List<TupleDomainFilter> filters, boolean nullAllowed, boolean nanAllowedAndUsesOldNanDefinition)
         {
             super(true, nullAllowed);
             requireNonNull(filters, "filters is null");
             checkArgument(filters.size() > 1, "filters must contain at least 2 entries");
 
             this.filters = filters.toArray(new TupleDomainFilter[0]);
-            this.nanAllowed = nanAllowed;
+            this.nanAllowedAndUsesOldNanDefinition = nanAllowedAndUsesOldNanDefinition;
         }
 
-        public static MultiRange of(List<TupleDomainFilter> filters, boolean nullAllowed, boolean nanAllowed)
+        public static MultiRange of(List<TupleDomainFilter> filters, boolean nullAllowed, boolean nanAllowedAndUsesOldNanDefinition)
         {
-            return new MultiRange(filters, nullAllowed, nanAllowed);
+            return new MultiRange(filters, nullAllowed, nanAllowedAndUsesOldNanDefinition);
         }
 
         @Override
         public boolean testDouble(double value)
         {
-            if (Double.isNaN(value)) {
-                return nanAllowed;
+            if (Double.isNaN(value) && nanAllowedAndUsesOldNanDefinition) {
+                return true;
             }
 
             for (TupleDomainFilter filter : filters) {
@@ -1437,8 +1634,8 @@ public interface TupleDomainFilter
         @Override
         public boolean testFloat(float value)
         {
-            if (Float.isNaN(value)) {
-                return nanAllowed;
+            if (Float.isNaN(value) && nanAllowedAndUsesOldNanDefinition) {
+                return nanAllowedAndUsesOldNanDefinition;
             }
 
             for (TupleDomainFilter filter : filters) {
@@ -1496,13 +1693,13 @@ public interface TupleDomainFilter
             MultiRange that = (MultiRange) o;
             return Arrays.equals(filters, that.filters) &&
                     nullAllowed == that.nullAllowed &&
-                    nanAllowed == that.nanAllowed;
+                    nanAllowedAndUsesOldNanDefinition == that.nanAllowedAndUsesOldNanDefinition;
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(Arrays.hashCode(filters), nullAllowed, nanAllowed);
+            return Objects.hash(Arrays.hashCode(filters), nullAllowed, nanAllowedAndUsesOldNanDefinition);
         }
 
         @Override
@@ -1511,7 +1708,7 @@ public interface TupleDomainFilter
             StringBuilder sb = new StringBuilder(this.getClass().getName());
             sb.append("{filters='").append(Arrays.toString(filters));
             sb.append(", nullAllowed=").append(nullAllowed);
-            sb.append(", nanAllowed=").append(nanAllowed);
+            sb.append(", nanAllowedAndUsesOldNanDefinition=").append(nanAllowedAndUsesOldNanDefinition);
             sb.append("}");
 
             return sb.toString();

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilterUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilterUtils.java
@@ -148,7 +148,7 @@ public class TupleDomainFilterUtils
 
     /**
      * Returns true is ranges represent != or NOT IN filter for double, float or string column.
-     *
+     * <p>
      * The logic is to return true if ranges are next to each other, but don't include the touch value.
      */
     private static boolean isNotIn(List<Range> ranges)
@@ -161,7 +161,7 @@ public class TupleDomainFilterUtils
         Marker previousHigh = firstRange.getHigh();
 
         Type type = previousHigh.getType();
-        if (type != DOUBLE && type != REAL && !isVarcharType(type) && !(type instanceof CharType)) {
+        if (!type.equals(DOUBLE) && !type.equals(REAL) && !isVarcharType(type) && !(type instanceof CharType)) {
             return false;
         }
 
@@ -219,10 +219,10 @@ public class TupleDomainFilterUtils
             checkArgument(range.isSingleValue(), "Unexpected range of boolean values");
             return BooleanValue.of(((Boolean) range.getSingleValue()).booleanValue(), nullAllowed);
         }
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return doubleRangeToFilter(range, nullAllowed);
         }
-        if (type == REAL) {
+        if (type.equals(REAL)) {
             return floatRangeToFilter(range, nullAllowed);
         }
         if (type instanceof DecimalType) {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
@@ -22,6 +22,9 @@ import com.facebook.presto.common.block.UncheckedBlock;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.common.type.TypeUtils.doubleCompare;
+import static com.facebook.presto.common.type.TypeUtils.doubleEquals;
+import static com.facebook.presto.common.type.TypeUtils.doubleHashCode;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.longBitsToDouble;
 
@@ -72,17 +75,19 @@ public final class DoubleType
     {
         double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition));
         double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition));
-
-        // direct equality is correct here
-        // noinspection FloatingPointEquality
-        return leftValue == rightValue;
+        if (!useNewNanDefintion) {
+            // direct equality is correct here
+            // noinspection FloatingPointEquality
+            return leftValue == rightValue;
+        }
+        return doubleEquals(leftValue, rightValue);
     }
 
     @Override
     public long hash(Block block, int position)
     {
         // convert to canonical NaN if necessary
-        return AbstractLongType.hash(doubleToLongBits(longBitsToDouble(block.getLong(position))));
+        return doubleHashCode(longBitsToDouble(block.getLong(position)));
     }
 
     @Override
@@ -90,7 +95,7 @@ public final class DoubleType
     {
         double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition));
         double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition));
-        return Double.compare(leftValue, rightValue);
+        return doubleCompare(leftValue, rightValue);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
@@ -29,11 +29,15 @@ public final class DoubleType
         extends AbstractPrimitiveType
         implements FixedWidthType
 {
-    public static final DoubleType DOUBLE = new DoubleType();
+    public static final DoubleType DOUBLE = new DoubleType(true);
+    public static final DoubleType OLD_NAN_DOUBLE = new DoubleType(false);
 
-    private DoubleType()
+    private final boolean useNewNanDefintion;
+
+    private DoubleType(boolean useNewNanDefintion)
     {
         super(parseTypeSignature(StandardTypes.DOUBLE), double.class);
+        this.useNewNanDefintion = useNewNanDefintion;
     }
 
     @Override
@@ -149,7 +153,7 @@ public final class DoubleType
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object other)
     {
-        return other == DOUBLE;
+        return other instanceof DoubleType;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
@@ -27,11 +27,14 @@ import static java.lang.String.format;
 public final class RealType
         extends AbstractIntType
 {
-    public static final RealType REAL = new RealType();
+    public static final RealType REAL = new RealType(true);
+    public static final RealType OLD_NAN_REAL = new RealType(false);
+    private final boolean useNewNanDefinition;
 
-    private RealType()
+    private RealType(boolean useNewNanDefinition)
     {
         super(parseTypeSignature(StandardTypes.REAL));
+        this.useNewNanDefinition = useNewNanDefinition;
     }
 
     @Override
@@ -86,7 +89,7 @@ public final class RealType
     @Override
     public boolean equals(Object other)
     {
-        return other == REAL;
+        return other instanceof RealType;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
@@ -175,10 +175,10 @@ public final class TypeUtils
         requireNonNull(type, "type is null");
         requireNonNull(value, "value is null");
 
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return Double.isNaN((double) value);
         }
-        if (type == REAL) {
+        if (type.equals(REAL)) {
             return Float.isNaN(intBitsToFloat(toIntExact((long) value)));
         }
         return false;

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestBlockRetainedSizeBreakdown.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestBlockRetainedSizeBreakdown.java
@@ -176,7 +176,7 @@ public class TestBlockRetainedSizeBreakdown
         if (type == VARCHAR) {
             return String.valueOf(value);
         }
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return (double) value;
         }
         throw new UnsupportedOperationException();

--- a/presto-common/src/test/java/com/facebook/presto/common/predicate/TestTupleDomainFilter.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/predicate/TestTupleDomainFilter.java
@@ -25,6 +25,8 @@ import com.facebook.presto.common.predicate.TupleDomainFilter.DoubleRange;
 import com.facebook.presto.common.predicate.TupleDomainFilter.FloatRange;
 import com.facebook.presto.common.predicate.TupleDomainFilter.LongDecimalRange;
 import com.facebook.presto.common.predicate.TupleDomainFilter.MultiRange;
+import com.facebook.presto.common.predicate.TupleDomainFilter.OldDoubleRange;
+import com.facebook.presto.common.predicate.TupleDomainFilter.OldFloatRange;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -37,7 +39,6 @@ import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 public class TestTupleDomainFilter
 {
@@ -166,13 +167,14 @@ public class TestTupleDomainFilter
         assertFalse(filter.testDouble(55.6));
         assertFalse(filter.testDouble(Double.NaN));
 
-        try {
-            DoubleRange.of(Double.NaN, false, false, Double.NaN, false, false, false);
-            fail("able to create a DoubleRange with NaN");
-        }
-        catch (IllegalArgumentException e) {
-            //expected
-        }
+        DoubleRange nanMaxRange = DoubleRange.of(0, false, false, Double.NaN, false, false, false);
+        assertTrue(nanMaxRange.testDouble(Double.POSITIVE_INFINITY));
+        assertTrue(nanMaxRange.testDouble(Double.NaN));
+
+        // with NaN as the lower, we have lower > upper
+        DoubleRange nanMinRange = DoubleRange.of(Double.NaN, false, false, Double.MAX_VALUE, false, false, false);
+        assertFalse(nanMinRange.testDouble(Double.POSITIVE_INFINITY));
+        assertFalse(nanMinRange.testDouble(Double.MAX_VALUE));
     }
 
     @Test
@@ -201,13 +203,14 @@ public class TestTupleDomainFilter
         assertFalse(filter.testFloat(15.632f));
         assertFalse(filter.testFloat(Float.NaN));
 
-        try {
-            FloatRange.of(Float.NaN, false, false, Float.NaN, false, false, false);
-            fail("able to create a FloatRange with NaN");
-        }
-        catch (IllegalArgumentException e) {
-            //expected
-        }
+        filter = FloatRange.of(0, false, false, Float.NaN, false, false, false);
+        assertTrue(filter.testFloat(Float.POSITIVE_INFINITY));
+        assertTrue(filter.testFloat(Float.NaN));
+
+        // with NaN as the lower, we have lower > upper
+        filter = FloatRange.of(Float.NaN, false, false, Float.MAX_VALUE, false, false, false);
+        assertFalse(filter.testFloat(Float.POSITIVE_INFINITY));
+        assertFalse(filter.testFloat(Float.MAX_VALUE));
     }
 
     @Test
@@ -360,7 +363,7 @@ public class TestTupleDomainFilter
     }
 
     @Test
-    public void testMultiRange()
+    public void testBytesMultiRange()
     {
         TupleDomainFilter filter = MultiRange.of(ImmutableList.of(
                 BytesRange.of(toBytes("abc"), false, toBytes("abc"), false, false),
@@ -373,8 +376,12 @@ public class TestTupleDomainFilter
 
         assertFalse(filter.testNull());
         assertFalse(filter.testBytes(toBytes("apple"), 0, 5));
+    }
 
-        filter = MultiRange.of(ImmutableList.of(
+    @Test
+    public void testDoubleMultiRange()
+    {
+        TupleDomainFilter filter = MultiRange.of(ImmutableList.of(
                 DoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
                 DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, false);
 
@@ -382,11 +389,30 @@ public class TestTupleDomainFilter
         assertTrue(filter.testDouble(1.3));
 
         assertFalse(filter.testNull());
+        assertTrue(filter.testDouble(Double.NaN));
+        assertFalse(filter.testDouble(1.2));
+    }
+
+    @Test
+    public void testLegacyDoubleMultiRange()
+    {
+        TupleDomainFilter filter = MultiRange.of(ImmutableList.of(
+                OldDoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
+                OldDoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, false);
+
+        assertTrue(filter.testDouble(1.1));
+        assertTrue(filter.testDouble(1.3));
+
+        assertFalse(filter.testNull());
         assertFalse(filter.testDouble(Double.NaN));
         assertFalse(filter.testDouble(1.2));
+    }
 
+    @Test
+    public void testDecimalMultiRange()
+    {
         Slice decimal = decimal("123.45");
-        filter = MultiRange.of(ImmutableList.of(
+        TupleDomainFilter filter = MultiRange.of(ImmutableList.of(
                 LongDecimalRange.of(Long.MIN_VALUE, Long.MIN_VALUE, true, true, decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, true, false),
                 LongDecimalRange.of(decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, true, Long.MAX_VALUE, Long.MAX_VALUE, true, true, false)), false, false);
 
@@ -394,10 +420,13 @@ public class TestTupleDomainFilter
         assertTrue(filter.testDecimal(decimal("12.34").getLong(0), decimal("12.34").getLong(SIZE_OF_LONG)));
 
         assertFalse(filter.testNull());
-        assertFalse(filter.testFloat(Float.NaN));
         assertFalse(filter.testDecimal(decimal.getLong(0), decimal.getLong(SIZE_OF_LONG)));
+    }
 
-        filter = MultiRange.of(ImmutableList.of(
+    @Test
+    public void testFloatMultiRange()
+    {
+        TupleDomainFilter filter = MultiRange.of(ImmutableList.of(
                 FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
                 FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, false);
 
@@ -405,45 +434,111 @@ public class TestTupleDomainFilter
         assertTrue(filter.testFloat(1.3f));
 
         assertFalse(filter.testNull());
+        assertTrue(filter.testFloat(Float.NaN));
         assertFalse(filter.testFloat(1.2f));
     }
 
     @Test
-    public void testMultiRangeWithNaNs()
+    public void testLegacyFloatMultiRange()
+    {
+        TupleDomainFilter filter = MultiRange.of(ImmutableList.of(
+                OldFloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                OldFloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, false);
+
+        assertTrue(filter.testFloat(1.1f));
+        assertTrue(filter.testFloat(1.3f));
+
+        assertFalse(filter.testNull());
+        assertFalse(filter.testFloat(Float.NaN));
+        assertFalse(filter.testFloat(1.2f));
+    }
+
+    @Test
+    public void testFloatNotEqualMultiRangeWithNans()
+    {
+        // x <> 1.2
+        TupleDomainFilter floatFilter = MultiRange.of(ImmutableList.of(
+                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, false);
+        assertTrue(floatFilter.testFloat(Float.NaN));
+        assertTrue(floatFilter.testFloat(1.0f));
+    }
+
+    @Test
+    public void testDoubleNotEqualMultiRangeWithNans()
+    {
+        TupleDomainFilter doubleFilter = MultiRange.of(ImmutableList.of(
+                DoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
+                DoubleRange.of(1.2d, false, true, Double.MAX_VALUE, true, true, false)), false, false);
+        assertTrue(doubleFilter.testDouble(Double.NaN));
+        assertTrue(doubleFilter.testDouble(1.4d));
+    }
+
+    @Test
+    public void testFloatNotInMultiRangeWithNans()
+    {
+        // x NOT IN (1.2, 1.3)
+        TupleDomainFilter filter = MultiRange.of(ImmutableList.of(
+                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                FloatRange.of(1.2f, false, true, 1.3f, false, true, false),
+                FloatRange.of(1.3f, false, true, Float.MAX_VALUE, true, true, false)), false, false);
+        assertTrue(filter.testFloat(Float.NaN));
+        assertFalse(filter.testFloat(1.2f));
+        assertFalse(filter.testFloat(1.3f));
+        assertTrue(filter.testFloat(1.4f));
+        assertTrue(filter.testFloat(1.1f));
+    }
+
+    @Test
+    public void testDoubleNotInMultiRangeWithNans()
+    {
+        TupleDomainFilter filter = MultiRange.of(ImmutableList.of(
+                DoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
+                DoubleRange.of(1.2d, false, true, 1.3d, false, true, false),
+                DoubleRange.of(1.3d, false, true, Double.MAX_VALUE, true, true, false)), false, false);
+        assertTrue(filter.testDouble(Double.NaN));
+        assertFalse(filter.testDouble(1.2d));
+        assertFalse(filter.testDouble(1.3d));
+        assertTrue(filter.testDouble(1.4d));
+        assertTrue(filter.testDouble(1.1d));
+    }
+
+    @Test
+    public void testLegacyMultiRangeWithNaNs()
     {
         // x <> 1.2 with nanAllowed true
         TupleDomainFilter filter = MultiRange.of(ImmutableList.of(
-                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
-                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, true);
+                OldFloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                OldFloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, true);
         assertTrue(filter.testFloat(Float.NaN));
         assertFalse(filter.testFloat(1.2f));
         assertTrue(filter.testFloat(1.1f));
 
         filter = MultiRange.of(ImmutableList.of(
-                DoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
-                DoubleRange.of(1.2d, false, true, Double.MAX_VALUE, true, true, false)), false, true);
+                OldDoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
+                OldDoubleRange.of(1.2d, false, true, Double.MAX_VALUE, true, true, false)), false, true);
         assertTrue(filter.testDouble(Double.NaN));
         assertFalse(filter.testDouble(1.2d));
         assertTrue(filter.testDouble(1.1d));
 
         // x <> 1.2 with nanAllowed false
         filter = MultiRange.of(ImmutableList.of(
-                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
-                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, false);
+                OldFloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                OldFloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, false);
         assertFalse(filter.testFloat(Float.NaN));
         assertTrue(filter.testFloat(1.0f));
 
         filter = MultiRange.of(ImmutableList.of(
-                DoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
-                DoubleRange.of(1.2d, false, true, Double.MAX_VALUE, true, true, false)), false, false);
+                OldDoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
+                OldDoubleRange.of(1.2d, false, true, Double.MAX_VALUE, true, true, false)), false, false);
         assertFalse(filter.testDouble(Double.NaN));
         assertTrue(filter.testDouble(1.4d));
 
-        // x NOT IN (1.2, 1.3) with nanAllowed true
+        // x NOT IN (1.2, 1.3)
         filter = MultiRange.of(ImmutableList.of(
-                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
-                FloatRange.of(1.2f, false, true, 1.3f, false, true, false),
-                FloatRange.of(1.3f, false, true, Float.MAX_VALUE, true, true, false)), false, true);
+                OldFloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                OldFloatRange.of(1.2f, false, true, 1.3f, false, true, false),
+                OldFloatRange.of(1.3f, false, true, Float.MAX_VALUE, true, true, false)), false, true);
         assertTrue(filter.testFloat(Float.NaN));
         assertFalse(filter.testFloat(1.2f));
         assertFalse(filter.testFloat(1.3f));
@@ -451,9 +546,9 @@ public class TestTupleDomainFilter
         assertTrue(filter.testFloat(1.1f));
 
         filter = MultiRange.of(ImmutableList.of(
-                DoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
-                DoubleRange.of(1.2d, false, true, 1.3d, false, true, false),
-                DoubleRange.of(1.3d, false, true, Double.MAX_VALUE, true, true, false)), false, true);
+                OldDoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
+                OldDoubleRange.of(1.2d, false, true, 1.3d, false, true, false),
+                OldDoubleRange.of(1.3d, false, true, Double.MAX_VALUE, true, true, false)), false, true);
         assertTrue(filter.testDouble(Double.NaN));
         assertFalse(filter.testDouble(1.2d));
         assertFalse(filter.testDouble(1.3d));
@@ -462,15 +557,15 @@ public class TestTupleDomainFilter
 
         // x NOT IN (1.2) with nanAllowed false
         filter = MultiRange.of(ImmutableList.of(
-                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
-                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, false);
+                OldFloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                OldFloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, false);
         assertFalse(filter.testFloat(Float.NaN));
         assertFalse(filter.testFloat(1.2f));
         assertTrue(filter.testFloat(1.3f));
 
         filter = MultiRange.of(ImmutableList.of(
-                DoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
-                DoubleRange.of(1.2d, false, true, Double.MAX_VALUE, true, true, false)), false, false);
+                OldDoubleRange.of(Double.MIN_VALUE, true, true, 1.2d, false, true, false),
+                OldDoubleRange.of(1.2d, false, true, Double.MAX_VALUE, true, true, false)), false, false);
         assertFalse(filter.testDouble(Double.NaN));
         assertFalse(filter.testDouble(1.2d));
         assertTrue(filter.testDouble(1.3d));

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeUtils.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeUtils.java
@@ -21,7 +21,12 @@ import java.util.Optional;
 
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TypeUtils.containsDistinctType;
+import static com.facebook.presto.common.type.TypeUtils.doubleCompare;
+import static com.facebook.presto.common.type.TypeUtils.doubleEquals;
+import static com.facebook.presto.common.type.TypeUtils.doubleHashCode;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static java.lang.Double.longBitsToDouble;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -51,5 +56,30 @@ public class TestTypeUtils
         assertFalse(containsDistinctType(ImmutableList.of(new ArrayType(RowType.anonymous(ImmutableList.of(INTEGER, VARCHAR))))));
         assertTrue(containsDistinctType(ImmutableList.of(new ArrayType(new ArrayType(distinctType)))));
         assertTrue(containsDistinctType(ImmutableList.of(new ArrayType(RowType.anonymous(ImmutableList.of(INTEGER, distinctType))))));
+    }
+
+    @Test
+    public void testDoubleHashCode()
+    {
+        assertEquals(doubleHashCode(0), doubleHashCode(Double.parseDouble("-0")));
+        //0x7ff8123412341234L is a different representation of NaN
+        assertEquals(doubleHashCode(Double.NaN), doubleHashCode(longBitsToDouble(0x7ff8123412341234L)));
+    }
+
+    @Test
+    public void testDoubleEquals()
+    {
+        assertTrue(doubleEquals(0, Double.parseDouble("-0")));
+        //0x7ff8123412341234L is a different representation of NaN
+        assertTrue(doubleEquals(Double.NaN, longBitsToDouble(0x7ff8123412341234L)));
+    }
+
+    @Test
+    public void testDoubleCompare()
+    {
+        assertEquals(doubleCompare(0, Double.parseDouble("-0")), 0);
+        assertEquals(doubleCompare(Double.NaN, Double.NaN), 0);
+        //0x7ff8123412341234L is a different representation of NaN
+        assertEquals(doubleCompare(Double.NaN, longBitsToDouble(0x7ff8123412341234L)), 0);
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeUtils.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeUtils.java
@@ -24,8 +24,12 @@ import static com.facebook.presto.common.type.TypeUtils.containsDistinctType;
 import static com.facebook.presto.common.type.TypeUtils.doubleCompare;
 import static com.facebook.presto.common.type.TypeUtils.doubleEquals;
 import static com.facebook.presto.common.type.TypeUtils.doubleHashCode;
+import static com.facebook.presto.common.type.TypeUtils.realCompare;
+import static com.facebook.presto.common.type.TypeUtils.realEquals;
+import static com.facebook.presto.common.type.TypeUtils.realHashCode;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static java.lang.Double.longBitsToDouble;
+import static java.lang.Float.intBitsToFloat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -81,5 +85,31 @@ public class TestTypeUtils
         assertEquals(doubleCompare(Double.NaN, Double.NaN), 0);
         //0x7ff8123412341234L is a different representation of NaN
         assertEquals(doubleCompare(Double.NaN, longBitsToDouble(0x7ff8123412341234L)), 0);
+    }
+
+    @Test
+    public void testRealHashCode()
+    {
+        assertEquals(realHashCode(0), realHashCode(Float.parseFloat("-0")));
+        // 0x7fc01234 is a different representation of NaN
+        assertEquals(realHashCode(Float.NaN), realHashCode(intBitsToFloat(0x7fc01234)));
+    }
+
+    @Test
+    public void testRealEquals()
+    {
+        assertTrue(realEquals(0, Float.parseFloat("-0")));
+        assertTrue(realEquals(Float.NaN, Float.NaN));
+        // 0x7fc01234 is a different representation of NaN
+        assertTrue(realEquals(Float.NaN, intBitsToFloat(0x7fc01234)));
+    }
+
+    @Test
+    public void testRealCompare()
+    {
+        assertEquals(realCompare(0, Float.parseFloat("-0")), 0);
+        assertEquals(realCompare(Float.NaN, Float.NaN), 0);
+        // 0x7fc01234 is a different representation of NaN
+        assertEquals(realCompare(Float.NaN, intBitsToFloat(0x7fc01234)), 0);
     }
 }

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -65,11 +65,21 @@ Floating-Point
 A real is a 32-bit inexact, variable-precision implementing the
 IEEE Standard 754 for Binary Floating-Point Arithmetic.
 
+Presto strays from the IEEE standard when handling NaNs.
+In Presto, NaN is considered larger than any other value for
+all comparison and sorting operations. Additionally, NaN=NaN will
+be true for all equality and distinctness purposes.
+
 ``DOUBLE``
 ^^^^^^^^^^
 
 A double is a 64-bit inexact, variable-precision implementing the
 IEEE Standard 754 for Binary Floating-Point Arithmetic.
+
+Presto strays from the IEEE standard when handling NaNs.
+In Presto, NaN is considered larger than any other value for
+all comparison and sorting operations. Additionally, NaN=NaN will
+be true for all equality and distinctness purposes.
 
 Fixed-Precision
 ---------------

--- a/presto-druid/src/main/java/com/facebook/presto/druid/column/ColumnReader.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/column/ColumnReader.java
@@ -35,13 +35,13 @@ public interface ColumnReader
         if (type == VARCHAR) {
             return new StringColumnReader(valueSelector);
         }
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return new DoubleColumnReader(valueSelector);
         }
         if (type == BIGINT) {
             return new LongColumnReader(valueSelector);
         }
-        if (type == REAL) {
+        if (type.equals(REAL)) {
             return new FloatColumnReader(valueSelector);
         }
         if (type == TIMESTAMP) {

--- a/presto-druid/src/main/java/com/facebook/presto/druid/column/DoubleColumnReader.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/column/DoubleColumnReader.java
@@ -35,7 +35,7 @@ public class DoubleColumnReader
     @Override
     public Block readBlock(Type type, int batchSize)
     {
-        checkArgument(type == DOUBLE);
+        checkArgument(type.equals(DOUBLE));
         BlockBuilder builder = type.createBlockBuilder(null, batchSize);
         for (int i = 0; i < batchSize; i++) {
             type.writeDouble(builder, valueSelector.getDouble());

--- a/presto-druid/src/main/java/com/facebook/presto/druid/column/FloatColumnReader.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/column/FloatColumnReader.java
@@ -36,7 +36,7 @@ public class FloatColumnReader
     @Override
     public Block readBlock(Type type, int batchSize)
     {
-        checkArgument(type == REAL);
+        checkArgument(type.equals(REAL));
         BlockBuilder builder = type.createBlockBuilder(null, batchSize);
         for (int i = 0; i < batchSize; i++) {
             type.writeLong(builder, floatToRawIntBits(valueSelector.getFloat()));

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchLoader.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchLoader.java
@@ -138,7 +138,7 @@ public class ElasticsearchLoader
             if (type == INTEGER) {
                 return ((Number) value).intValue();
             }
-            if (type == DOUBLE) {
+            if (type.equals(DOUBLE)) {
                 return ((Number) value).doubleValue();
             }
             throw new IllegalArgumentException("Unhandled type: " + type);

--- a/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/AbstractTestHiveFunctions.java
+++ b/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/AbstractTestHiveFunctions.java
@@ -108,7 +108,7 @@ public abstract class AbstractTestHiveFunctions
             for (int j = 0; j < numColumns; j++) {
                 Object actual = rows.get(i).getField(j);
                 Object expected = cols[j].values[i];
-                if (cols[j].type == DOUBLE) {
+                if (cols[j].type.equals(DOUBLE)) {
                     assertEquals(((Number) actual).doubleValue(), ((double) expected), 0.000001);
                 }
                 else {

--- a/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/TestHiveAggregationFunctions.java
+++ b/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/TestHiveAggregationFunctions.java
@@ -128,7 +128,7 @@ public class TestHiveAggregationFunctions
             for (int j = 0; j < numColumns; j++) {
                 Object actual = rows.get(i).getField(j);
                 Object expected = expectedColumns[j].values[i];
-                if (expectedColumns[j].type == DOUBLE) {
+                if (expectedColumns[j].type.equals(DOUBLE)) {
                     assertEquals(((Number) actual).doubleValue(), ((double) expected), 0.000001);
                 }
                 else {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/FilteringPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/FilteringPageSource.java
@@ -246,11 +246,11 @@ public class FilteringPageSource
             return filter.testBoolean(type.getBoolean(block, position));
         }
 
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return filter.testDouble(longBitsToDouble(block.getLong(position)));
         }
 
-        if (type == REAL) {
+        if (type.equals(REAL)) {
             return filter.testFloat(intBitsToFloat(block.getInt(position)));
         }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedNanQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedNanQueries.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestNanQueries;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Optional;
+
+public class TestHiveDistributedNanQueries
+        extends AbstractTestNanQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(ImmutableList.of(), ImmutableMap.of("use-new-nan-definition", "true"), ImmutableMap.of(), Optional.empty());
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -110,7 +110,8 @@ public class TestHivePushdownFilterQueries
     {
         DistributedQueryRunner queryRunner = HiveQueryRunner.createQueryRunner(getTables(),
                 ImmutableMap.of("experimental.pushdown-subfields-enabled", "true",
-                        "experimental.pushdown-dereference-enabled", "true"),
+                        "experimental.pushdown-dereference-enabled", "true",
+                        "use-new-nan-definition", "true"),
                 "sql-standard",
                 ImmutableMap.of("hive.pushdown-filter-enabled", "true",
                         "hive.enable-parquet-dereference-pushdown", "true",
@@ -1105,6 +1106,8 @@ public class TestHivePushdownFilterQueries
             assertQuery("SELECT double_value FROM test_nan WHERE double_value != 1", "SELECT cast('NaN' as DOUBLE) UNION SELECT 2");
             assertQuery("SELECT float_value FROM test_nan WHERE float_value != 1", "SELECT CAST('NaN' as REAL) UNION SELECT 2");
             assertQuery("SELECT double_value FROM test_nan WHERE double_value NOT IN (1, 2)", "SELECT CAST('NaN' as DOUBLE)");
+            assertQuery("SELECT double_value FROM test_nan WHERE double_value > 1", "SELECT cast('NaN' as DOUBLE) UNION SELECT 2");
+            assertQuery("SELECT float_value FROM test_nan WHERE float_value > 1", "SELECT cast('NaN' as REAL) UNION SELECT 2");
         }
         finally {
             assertUpdate("DROP TABLE test_nan");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueriesLegacyNans.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueriesLegacyNans.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.airlift.tpch.TpchTable.getTables;
+
+public class TestHivePushdownFilterQueriesLegacyNans
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = HiveQueryRunner.createQueryRunner(getTables(),
+                ImmutableMap.of("experimental.pushdown-subfields-enabled", "true",
+                        "experimental.pushdown-dereference-enabled", "true",
+                        "use-new-nan-definition", "false"),
+                "sql-standard",
+                ImmutableMap.of("hive.pushdown-filter-enabled", "true",
+                        "hive.enable-parquet-dereference-pushdown", "true",
+                        "hive.partial_aggregation_pushdown_enabled", "true",
+                        "hive.partial_aggregation_pushdown_for_variable_length_datatypes_enabled", "true"),
+                Optional.empty());
+
+        return queryRunner;
+    }
+
+    @Test
+    public void testNans()
+    {
+        assertUpdate("CREATE TABLE test_nan (double_value DOUBLE, float_value REAL)");
+        try {
+            assertUpdate("INSERT INTO test_nan VALUES (CAST('NaN' as DOUBLE), CAST('NaN' as REAL)), ((1, 1)), ((2, 2))", 3);
+            assertQuery("SELECT double_value FROM test_nan WHERE double_value != 1", "SELECT CAST('NaN' as DOUBLE) UNION SELECT 2");
+            assertQuery("SELECT float_value FROM test_nan WHERE float_value != 1", "SELECT CAST('NaN' as REAL) UNION SELECT 2");
+            assertQuery("SELECT double_value FROM test_nan WHERE double_value NOT IN (1, 2)", "SELECT CAST('NaN' as DOUBLE)");
+            assertQuery("SELECT double_value FROM test_nan WHERE double_value > 1", "SELECT 2.0");
+            assertQuery("SELECT float_value FROM test_nan WHERE float_value > 1", "SELECT  CAST(2.0 AS REAL)");
+        }
+        finally {
+            assertUpdate("DROP TABLE test_nan");
+        }
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/AbstractRowEncoder.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/AbstractRowEncoder.java
@@ -91,10 +91,10 @@ public abstract class AbstractRowEncoder
         else if (type == TINYINT) {
             appendByte(SignedBytes.checkedCast(type.getLong(block, position)));
         }
-        else if (type == DOUBLE) {
+        else if (type.equals(DOUBLE)) {
             appendDouble(type.getDouble(block, position));
         }
-        else if (type == REAL) {
+        else if (type.equals(REAL)) {
             appendFloat(intBitsToFloat(toIntExact(type.getLong(block, position))));
         }
         else if (isVarcharType(type)) {

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/raw/RawRowEncoder.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/raw/RawRowEncoder.java
@@ -196,7 +196,7 @@ public class RawRowEncoder
             else if (columnType == BOOLEAN) {
                 checkFieldTypeOneOf(fieldType, columnName, columnType, FieldType.BYTE, FieldType.SHORT, FieldType.INT, FieldType.LONG);
             }
-            else if (columnType == DOUBLE) {
+            else if (columnType.equals(DOUBLE)) {
                 checkFieldTypeOneOf(fieldType, columnName, columnType, FieldType.DOUBLE, FieldType.FLOAT);
             }
             else if (isVarcharType(columnType)) {

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/TypeHelper.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/TypeHelper.java
@@ -65,10 +65,10 @@ public class TypeHelper
         else if (type == TinyintType.TINYINT) {
             return org.apache.kudu.Type.INT8;
         }
-        else if (type == RealType.REAL) {
+        else if (type.equals(RealType.REAL)) {
             return org.apache.kudu.Type.FLOAT;
         }
-        else if (type == DoubleType.DOUBLE) {
+        else if (type.equals(DoubleType.DOUBLE)) {
             return org.apache.kudu.Type.DOUBLE;
         }
         else if (type == BooleanType.BOOLEAN) {
@@ -146,10 +146,10 @@ public class TypeHelper
         else if (type == TinyintType.TINYINT) {
             return ((Long) nativeValue).byteValue();
         }
-        else if (type == DoubleType.DOUBLE) {
+        else if (type.equals(DoubleType.DOUBLE)) {
             return nativeValue;
         }
-        else if (type == RealType.REAL) {
+        else if (type.equals(RealType.REAL)) {
             // conversion can result in precision lost
             return intBitsToFloat(((Long) nativeValue).intValue());
         }
@@ -191,10 +191,10 @@ public class TypeHelper
             else if (type == TinyintType.TINYINT) {
                 return row.getByte(field);
             }
-            else if (type == DoubleType.DOUBLE) {
+            else if (type.equals(DoubleType.DOUBLE)) {
                 return row.getDouble(field);
             }
-            else if (type == RealType.REAL) {
+            else if (type.equals(RealType.REAL)) {
                 return row.getFloat(field);
             }
             else if (type == BooleanType.BOOLEAN) {
@@ -229,7 +229,7 @@ public class TypeHelper
         else if (type == TinyintType.TINYINT) {
             return row.getByte(field);
         }
-        else if (type == RealType.REAL) {
+        else if (type.equals(RealType.REAL)) {
             return floatToRawIntBits(row.getFloat(field));
         }
         else if (type instanceof DecimalType) {
@@ -258,7 +258,7 @@ public class TypeHelper
 
     public static double getDouble(Type type, RowResult row, int field)
     {
-        if (type == DoubleType.DOUBLE) {
+        if (type.equals(DoubleType.DOUBLE)) {
             return row.getDouble(field);
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -316,6 +316,7 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.DoubleType.OLD_NAN_DOUBLE;
 import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.JsonType.JSON;
@@ -323,6 +324,7 @@ import static com.facebook.presto.common.type.KdbTreeType.KDB_TREE;
 import static com.facebook.presto.common.type.KllSketchParametricType.KLL_SKETCH;
 import static com.facebook.presto.common.type.P4HyperLogLogType.P4_HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.QuantileDigestParametricType.QDIGEST;
+import static com.facebook.presto.common.type.RealType.OLD_NAN_REAL;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TDigestParametricType.TDIGEST;
@@ -605,14 +607,14 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .build(CacheLoader.from(this::instantiateParametricType));
 
         registerBuiltInFunctions(getBuiltInFunctions(featuresConfig));
-        registerBuiltInTypes();
+        registerBuiltInTypes(featuresConfig);
 
         for (Type type : requireNonNull(types, "types is null")) {
             addType(type);
         }
     }
 
-    private void registerBuiltInTypes()
+    private void registerBuiltInTypes(FeaturesConfig featuresConfig)
     {
         // always add the built-in types; Presto will not function without these
         addType(UNKNOWN);
@@ -621,8 +623,14 @@ public class BuiltInTypeAndFunctionNamespaceManager
         addType(INTEGER);
         addType(SMALLINT);
         addType(TINYINT);
-        addType(DOUBLE);
-        addType(REAL);
+        if(!featuresConfig.getUseNewNanDefinition()) {
+            addType(OLD_NAN_DOUBLE);
+            addType(OLD_NAN_REAL);
+
+        } else {
+            addType(DOUBLE);
+            addType(REAL);
+        }
         addType(VARBINARY);
         addType(DATE);
         addType(TIME);

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -257,10 +257,12 @@ import com.facebook.presto.type.IpAddressOperators;
 import com.facebook.presto.type.IpPrefixOperators;
 import com.facebook.presto.type.KllSketchOperators;
 import com.facebook.presto.type.LegacyDoubleComparisonOperators;
+import com.facebook.presto.type.LegacyRealComparisonOperators;
 import com.facebook.presto.type.LikeFunctions;
 import com.facebook.presto.type.LongEnumOperators;
 import com.facebook.presto.type.MapParametricType;
 import com.facebook.presto.type.QuantileDigestOperators;
+import com.facebook.presto.type.RealComparisonOperators;
 import com.facebook.presto.type.RealOperators;
 import com.facebook.presto.type.SfmSketchOperators;
 import com.facebook.presto.type.SmallintOperators;
@@ -800,20 +802,22 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalar(SmallintOperators.SmallintDistinctFromOperator.class)
                 .scalars(TinyintOperators.class)
                 .scalar(TinyintOperators.TinyintDistinctFromOperator.class)
-                .scalars(DoubleOperators.class);
+                .scalars(DoubleOperators.class)
+                .scalars(RealOperators.class);
 
         if (featuresConfig.getUseNewNanDefinition()) {
             builder.scalars(DoubleComparisonOperators.class)
-                    .scalar(DoubleComparisonOperators.DoubleDistinctFromOperator.class);
+                    .scalar(DoubleComparisonOperators.DoubleDistinctFromOperator.class)
+                    .scalars(RealComparisonOperators.class)
+                    .scalar(RealComparisonOperators.RealDistinctFromOperator.class);
         }
         else {
-
             builder.scalars(LegacyDoubleComparisonOperators.class)
-                    .scalar(LegacyDoubleComparisonOperators.DoubleDistinctFromOperator.class);
+                    .scalar(LegacyDoubleComparisonOperators.DoubleDistinctFromOperator.class)
+                    .scalars(LegacyRealComparisonOperators.class)
+                    .scalar(LegacyRealComparisonOperators.RealDistinctFromOperator.class);
         }
-        builder.scalars(RealOperators.class)
-                .scalar(RealOperators.RealDistinctFromOperator.class)
-                .scalars(VarcharOperators.class)
+        builder.scalars(VarcharOperators.class)
                 .scalar(VarcharOperators.VarcharDistinctFromOperator.class)
                 .scalars(VarbinaryOperators.class)
                 .scalar(VarbinaryOperators.VarbinaryDistinctFromOperator.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -246,6 +246,7 @@ import com.facebook.presto.type.DateOperators;
 import com.facebook.presto.type.DateTimeOperators;
 import com.facebook.presto.type.DecimalOperators;
 import com.facebook.presto.type.DecimalParametricType;
+import com.facebook.presto.type.DoubleComparisonOperators;
 import com.facebook.presto.type.DoubleOperators;
 import com.facebook.presto.type.EnumCasts;
 import com.facebook.presto.type.HyperLogLogOperators;
@@ -255,6 +256,7 @@ import com.facebook.presto.type.IntervalYearMonthOperators;
 import com.facebook.presto.type.IpAddressOperators;
 import com.facebook.presto.type.IpPrefixOperators;
 import com.facebook.presto.type.KllSketchOperators;
+import com.facebook.presto.type.LegacyDoubleComparisonOperators;
 import com.facebook.presto.type.LikeFunctions;
 import com.facebook.presto.type.LongEnumOperators;
 import com.facebook.presto.type.MapParametricType;
@@ -623,11 +625,11 @@ public class BuiltInTypeAndFunctionNamespaceManager
         addType(INTEGER);
         addType(SMALLINT);
         addType(TINYINT);
-        if(!featuresConfig.getUseNewNanDefinition()) {
+        if (!featuresConfig.getUseNewNanDefinition()) {
             addType(OLD_NAN_DOUBLE);
             addType(OLD_NAN_REAL);
-
-        } else {
+        }
+        else {
             addType(DOUBLE);
             addType(REAL);
         }
@@ -798,9 +800,18 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalar(SmallintOperators.SmallintDistinctFromOperator.class)
                 .scalars(TinyintOperators.class)
                 .scalar(TinyintOperators.TinyintDistinctFromOperator.class)
-                .scalars(DoubleOperators.class)
-                .scalar(DoubleOperators.DoubleDistinctFromOperator.class)
-                .scalars(RealOperators.class)
+                .scalars(DoubleOperators.class);
+
+        if (featuresConfig.getUseNewNanDefinition()) {
+            builder.scalars(DoubleComparisonOperators.class)
+                    .scalar(DoubleComparisonOperators.DoubleDistinctFromOperator.class);
+        }
+        else {
+
+            builder.scalars(LegacyDoubleComparisonOperators.class)
+                    .scalar(LegacyDoubleComparisonOperators.DoubleDistinctFromOperator.class);
+        }
+        builder.scalars(RealOperators.class)
                 .scalar(RealOperators.RealDistinctFromOperator.class)
                 .scalars(VarcharOperators.class)
                 .scalar(VarcharOperators.VarcharDistinctFromOperator.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
@@ -191,7 +191,7 @@ public class DynamicFilterSourceOperator
         for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
             Type type = channels.get(channelIndex).getType();
             // Skipping DOUBLE and REAL in collectMinMaxValues to avoid dealing with NaN values
-            if (minMaxCollectionLimit > 0 && type.isOrderable() && type != DOUBLE && type != REAL) {
+            if (minMaxCollectionLimit > 0 && type.isOrderable() && !type.equals(DOUBLE) && !type.equals(REAL)) {
                 minMaxChannelsBuilder.add(channelIndex);
             }
             this.blockBuilders[channelIndex] = type.createBlockBuilder(null, EXPECTED_BLOCK_BUILDER_SIZE);

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
@@ -92,6 +92,7 @@ public class DynamicFilterSourceOperator
         private final int maxFilterPositionsCount;
         private final DataSize maxFilterSize;
         private final int minMaxCollectionLimit;
+        private final boolean useNewNanDefinition;
 
         private boolean closed;
 
@@ -102,7 +103,8 @@ public class DynamicFilterSourceOperator
                 List<Channel> channels,
                 int maxFilterPositionsCount,
                 DataSize maxFilterSize,
-                int minMaxCollectionLimit)
+                int minMaxCollectionLimit,
+                boolean useNewNanDefinition)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -117,6 +119,7 @@ public class DynamicFilterSourceOperator
             this.maxFilterPositionsCount = maxFilterPositionsCount;
             this.maxFilterSize = maxFilterSize;
             this.minMaxCollectionLimit = minMaxCollectionLimit;
+            this.useNewNanDefinition = useNewNanDefinition;
         }
 
         @Override
@@ -130,7 +133,8 @@ public class DynamicFilterSourceOperator
                     planNodeId,
                     maxFilterPositionsCount,
                     maxFilterSize,
-                    minMaxCollectionLimit);
+                    minMaxCollectionLimit,
+                    useNewNanDefinition);
         }
 
         @Override
@@ -153,6 +157,7 @@ public class DynamicFilterSourceOperator
     private final long maxFilterSizeInBytes;
     private final List<Channel> channels;
     private final List<Integer> minMaxChannels;
+    private final boolean useNewNanDefinition;
 
     private boolean finished;
     private Page current;
@@ -176,7 +181,8 @@ public class DynamicFilterSourceOperator
             PlanNodeId planNodeId,
             int maxFilterPositionsCount,
             DataSize maxFilterSize,
-            int minMaxCollectionLimit)
+            int minMaxCollectionLimit,
+            boolean useNewNanDefinition)
     {
         this.context = requireNonNull(context, "context is null");
         this.maxFilterPositionsCount = maxFilterPositionsCount;
@@ -208,6 +214,7 @@ public class DynamicFilterSourceOperator
             minValues = new Block[channels.size()];
             maxValues = new Block[channels.size()];
         }
+        this.useNewNanDefinition = useNewNanDefinition;
     }
 
     @Override
@@ -405,8 +412,8 @@ public class DynamicFilterSourceOperator
         for (int position = 0; position < block.getPositionCount(); ++position) {
             Object value = readNativeValue(type, block, position);
             if (value != null) {
-                // join doesn't match rows with NaN values.
-                if (!isFloatingPointNaN(type, value)) {
+                // join doesn't match rows with NaN values when using the old nan definition.
+                if (!isFloatingPointNaN(type, value) || useNewNanDefinition) {
                     values.add(value);
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/AbstractGreatestLeast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/AbstractGreatestLeast.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.annotation.UsedByGeneratedCode;
 import com.facebook.presto.bytecode.BytecodeBlock;
 import com.facebook.presto.bytecode.CallSiteBinder;
 import com.facebook.presto.bytecode.ClassDefinition;
@@ -30,7 +29,6 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.SqlScalarFunction;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.SqlFunctionVisibility;
@@ -50,7 +48,6 @@ import static com.facebook.presto.bytecode.ParameterizedType.type;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ArgumentProperty.valueTypeArgumentProperty;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.RETURN_NULL_ON_NULL;
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.function.Signature.orderableTypeParameter;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
@@ -61,7 +58,6 @@ import static com.facebook.presto.util.Failures.checkCondition;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.lang.String.format;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -69,8 +65,6 @@ import static java.util.stream.Collectors.joining;
 public abstract class AbstractGreatestLeast
         extends SqlScalarFunction
 {
-    private static final MethodHandle CHECK_NOT_NAN = methodHandle(AbstractGreatestLeast.class, "checkNotNaN", String.class, double.class);
-
     private final OperatorType operatorType;
 
     protected AbstractGreatestLeast(QualifiedObjectName name, OperatorType operatorType)
@@ -120,14 +114,6 @@ public abstract class AbstractGreatestLeast
                 methodHandle);
     }
 
-    @UsedByGeneratedCode
-    public static void checkNotNaN(String name, double value)
-    {
-        if (Double.isNaN(value)) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Invalid argument to %s(): NaN", name));
-        }
-    }
-
     private Class<?> generate(List<Class<?>> javaTypes, Type type, MethodHandle compareMethod)
     {
         checkCondition(javaTypes.size() <= 127, NOT_SUPPORTED, "Too many arguments for function call %s()", getSignature().getNameSuffix());
@@ -160,7 +146,6 @@ public abstract class AbstractGreatestLeast
         if (type.getTypeSignature().getBase().equals(StandardTypes.DOUBLE)) {
             for (Parameter parameter : parameters) {
                 body.append(parameter);
-                body.append(invoke(binder.bind(CHECK_NOT_NAN.bindTo(getSignature().getNameSuffix())), "checkNotNaN"));
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMinMaxUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMinMaxUtils.java
@@ -21,8 +21,6 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.util.Failures.internalError;
-import static java.lang.Double.NaN;
-import static java.lang.Double.isNaN;
 
 public final class ArrayMinMaxUtils
 {
@@ -97,9 +95,6 @@ public final class ArrayMinMaxUtils
                 double value = elementType.getDouble(block, i);
                 if ((boolean) compareMethodHandle.invokeExact(value, selectedValue)) {
                     selectedValue = value;
-                }
-                else if (isNaN(value)) {
-                    return NaN;
                 }
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -844,7 +844,7 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitDoubleLiteral(DoubleLiteral node, StackableAstVisitorContext<Context> context)
         {
-            return setExpressionType(node, DOUBLE);
+            return setExpressionType(node, functionAndTypeResolver.getType(DOUBLE.getTypeSignature()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -311,6 +311,8 @@ public class FeaturesConfig
     private CreateView.Security defaultViewSecurityMode = DEFINER;
     private boolean useHistograms;
 
+    private boolean useNewNanDefinition;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -3115,6 +3117,19 @@ public class FeaturesConfig
     public FeaturesConfig setUseHistograms(boolean useHistograms)
     {
         this.useHistograms = useHistograms;
+        return this;
+    }
+
+    public boolean getUseNewNanDefinition()
+    {
+        return useNewNanDefinition;
+    }
+
+    @Config("use-new-nan-definition")
+    @ConfigDescription("Enable functions to use the new consistent NaN definition where NaN=NaN and is sorted largest")
+    public FeaturesConfig setUseNewNanDefinition(boolean useNewNanDefinition)
+    {
+        this.useNewNanDefinition = useNewNanDefinition;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -311,7 +311,7 @@ public class FeaturesConfig
     private CreateView.Security defaultViewSecurityMode = DEFINER;
     private boolean useHistograms;
 
-    private boolean useNewNanDefinition;
+    private boolean useNewNanDefinition = true;
 
     public enum PartitioningPrecisionStrategy
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -176,6 +176,7 @@ import com.facebook.presto.spiller.StandaloneSpillerFactory;
 import com.facebook.presto.split.MappedRecordSet;
 import com.facebook.presto.split.PageSinkManager;
 import com.facebook.presto.split.PageSourceProvider;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -387,6 +388,7 @@ public class LocalExecutionPlanner
     private final ObjectMapper sortedMapObjectMapper;
     private final boolean tableFinishOperatorMemoryTrackingEnabled;
     private final StandaloneSpillerFactory standaloneSpillerFactory;
+    private final boolean useNewNanDefinition;
 
     private static final TypeSignature SPHERICAL_GEOGRAPHY_TYPE_SIGNATURE = parseTypeSignature("SphericalGeography");
 
@@ -406,6 +408,7 @@ public class LocalExecutionPlanner
             IndexJoinLookupStats indexJoinLookupStats,
             TaskManagerConfig taskManagerConfig,
             MemoryManagerConfig memoryManagerConfig,
+            FeaturesConfig featuresConfig,
             SpillerFactory spillerFactory,
             SingleStreamSpillerFactory singleStreamSpillerFactory,
             PartitioningSpillerFactory partitioningSpillerFactory,
@@ -455,6 +458,7 @@ public class LocalExecutionPlanner
                 .configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
         this.tableFinishOperatorMemoryTrackingEnabled = requireNonNull(memoryManagerConfig, "memoryManagerConfig is null").isTableFinishOperatorMemoryTrackingEnabled();
         this.standaloneSpillerFactory = requireNonNull(standaloneSpillerFactory, "standaloneSpillerFactory is null");
+        this.useNewNanDefinition = requireNonNull(featuresConfig, "featuresConfig is null").getUseNewNanDefinition();
     }
 
     public LocalExecutionPlan plan(
@@ -2483,7 +2487,8 @@ public class LocalExecutionPlanner
                     filterBuildChannels,
                     getDynamicFilteringMaxPerDriverRowCount(context.getSession()),
                     getDynamicFilteringMaxPerDriverSize(context.getSession()),
-                    getDynamicFilteringRangeRowLimitPerDriver(context.getSession()));
+                    getDynamicFilteringRangeRowLimitPerDriver(context.getSession()),
+                    useNewNanDefinition);
         }
 
         private Optional<LocalDynamicFilter> createDynamicFilter(PhysicalOperation buildSource, AbstractJoinNode node, LocalExecutionPlanContext context, int partitionCount)

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -358,7 +358,7 @@ public final class SqlToRowExpressionTranslator
         @Override
         protected RowExpression visitDoubleLiteral(DoubleLiteral node, Context context)
         {
-            return constant(node.getValue(), DOUBLE);
+            return constant(node.getValue(), functionAndTypeManager.getType(DOUBLE.getTypeSignature()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -936,6 +936,7 @@ public class LocalQueryRunner
                 new IndexJoinLookupStats(),
                 new TaskManagerConfig().setTaskConcurrency(4),
                 new MemoryManagerConfig(),
+                new FeaturesConfig(),
                 spillerFactory,
                 singleStreamSpillerFactory,
                 partitioningSpillerFactory,

--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleComparisonOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleComparisonOperators.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.IsNull;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.common.function.OperatorType.BETWEEN;
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.TypeUtils.doubleCompare;
+import static com.facebook.presto.common.type.TypeUtils.doubleEquals;
+import static com.facebook.presto.common.type.TypeUtils.doubleHashCode;
+
+public class DoubleComparisonOperators
+{
+    private DoubleComparisonOperators() {}
+
+    @ScalarOperator(EQUAL)
+    @SuppressWarnings("FloatingPointEquality")
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean equal(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return doubleEquals(left, right);
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @SuppressWarnings("FloatingPointEquality")
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean notEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return !equal(left, right);
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThan(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return doubleCompare(left, right) < 0;
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOrEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return doubleCompare(left, right) <= 0;
+    }
+
+    @ScalarOperator(GREATER_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThan(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return doubleCompare(left, right) == 1;
+    }
+
+    @ScalarOperator(GREATER_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThanOrEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return doubleCompare(left, right) >= 0;
+    }
+
+    @ScalarOperator(BETWEEN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean between(@SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double min, @SqlType(StandardTypes.DOUBLE) double max)
+    {
+        return lessThanOrEqual(min, value) && lessThanOrEqual(value, max);
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @SqlType(StandardTypes.BIGINT)
+    public static long hashCode(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        return doubleHashCode(value);
+    }
+
+    @ScalarOperator(IS_DISTINCT_FROM)
+    public static class DoubleDistinctFromOperator
+    {
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @SqlType(StandardTypes.DOUBLE) double left,
+                @IsNull boolean leftNull,
+                @SqlType(StandardTypes.DOUBLE) double right,
+                @IsNull boolean rightNull)
+        {
+            if (leftNull != rightNull) {
+                return true;
+            }
+            if (leftNull) {
+                return false;
+            }
+            return notEqual(left, right);
+        }
+
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @BlockPosition @SqlType(value = StandardTypes.DOUBLE, nativeContainerType = double.class) Block leftBlock,
+                @BlockIndex int leftPosition,
+                @BlockPosition @SqlType(value = StandardTypes.DOUBLE, nativeContainerType = double.class) Block rightBlock,
+                @BlockIndex int rightPosition)
+        {
+            if (leftBlock.isNull(leftPosition) != rightBlock.isNull(rightPosition)) {
+                return true;
+            }
+            if (leftBlock.isNull(leftPosition)) {
+                return false;
+            }
+            double left = DOUBLE.getDouble(leftBlock, leftPosition);
+            double right = DOUBLE.getDouble(rightBlock, rightPosition);
+            return notEqual(left, right);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -13,16 +13,11 @@
  */
 package com.facebook.presto.type;
 
-import com.facebook.presto.common.block.Block;
-import com.facebook.presto.common.type.AbstractLongType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.function.BlockIndex;
-import com.facebook.presto.spi.function.BlockPosition;
 import com.facebook.presto.spi.function.IsNull;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarOperator;
-import com.facebook.presto.spi.function.SqlNullable;
 import com.facebook.presto.spi.function.SqlType;
 import com.google.common.math.DoubleMath;
 import com.google.common.primitives.Shorts;
@@ -31,30 +26,19 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.common.function.OperatorType.ADD;
-import static com.facebook.presto.common.function.OperatorType.BETWEEN;
 import static com.facebook.presto.common.function.OperatorType.CAST;
 import static com.facebook.presto.common.function.OperatorType.DIVIDE;
-import static com.facebook.presto.common.function.OperatorType.EQUAL;
-import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
-import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
-import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.common.function.OperatorType.INDETERMINATE;
-import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
-import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
-import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.MODULUS;
 import static com.facebook.presto.common.function.OperatorType.MULTIPLY;
 import static com.facebook.presto.common.function.OperatorType.NEGATION;
-import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.SATURATED_FLOOR_CAST;
 import static com.facebook.presto.common.function.OperatorType.SUBTRACT;
 import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
-import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
-import static java.lang.Double.doubleToLongBits;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.math.RoundingMode.FLOOR;
@@ -127,59 +111,6 @@ public final class DoubleOperators
         return -value;
     }
 
-    @ScalarOperator(EQUAL)
-    @SuppressWarnings("FloatingPointEquality")
-    @SqlType(StandardTypes.BOOLEAN)
-    @SqlNullable
-    public static Boolean equal(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
-    {
-        return left == right;
-    }
-
-    @ScalarOperator(NOT_EQUAL)
-    @SuppressWarnings("FloatingPointEquality")
-    @SqlType(StandardTypes.BOOLEAN)
-    @SqlNullable
-    public static Boolean notEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
-    {
-        return left != right;
-    }
-
-    @ScalarOperator(LESS_THAN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean lessThan(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
-    {
-        return left < right;
-    }
-
-    @ScalarOperator(LESS_THAN_OR_EQUAL)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean lessThanOrEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
-    {
-        return left <= right;
-    }
-
-    @ScalarOperator(GREATER_THAN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean greaterThan(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
-    {
-        return left > right;
-    }
-
-    @ScalarOperator(GREATER_THAN_OR_EQUAL)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean greaterThanOrEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
-    {
-        return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double min, @SqlType(StandardTypes.DOUBLE) double max)
-    {
-        return min <= value && value <= max;
-    }
-
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean castToBoolean(@SqlType(StandardTypes.DOUBLE) double value)
@@ -250,13 +181,6 @@ public final class DoubleOperators
         return utf8Slice(String.valueOf(value));
     }
 
-    @ScalarOperator(HASH_CODE)
-    @SqlType(StandardTypes.BIGINT)
-    public static long hashCode(@SqlType(StandardTypes.DOUBLE) double value)
-    {
-        return AbstractLongType.hash(doubleToLongBits(value));
-    }
-
     @ScalarOperator(INDETERMINATE)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean indeterminate(@SqlType(StandardTypes.DOUBLE) double value, @IsNull boolean isNull)
@@ -316,50 +240,6 @@ public final class DoubleOperators
             return maxValue;
         }
         return DoubleMath.roundToLong(value, FLOOR);
-    }
-
-    @ScalarOperator(IS_DISTINCT_FROM)
-    public static class DoubleDistinctFromOperator
-    {
-        @SqlType(StandardTypes.BOOLEAN)
-        public static boolean isDistinctFrom(
-                @SqlType(StandardTypes.DOUBLE) double left,
-                @IsNull boolean leftNull,
-                @SqlType(StandardTypes.DOUBLE) double right,
-                @IsNull boolean rightNull)
-        {
-            if (leftNull != rightNull) {
-                return true;
-            }
-            if (leftNull) {
-                return false;
-            }
-            if (Double.isNaN(left) && Double.isNaN(right)) {
-                return false;
-            }
-            return notEqual(left, right);
-        }
-
-        @SqlType(StandardTypes.BOOLEAN)
-        public static boolean isDistinctFrom(
-                @BlockPosition @SqlType(value = StandardTypes.DOUBLE, nativeContainerType = double.class) Block leftBlock,
-                @BlockIndex int leftPosition,
-                @BlockPosition @SqlType(value = StandardTypes.DOUBLE, nativeContainerType = double.class) Block rightBlock,
-                @BlockIndex int rightPosition)
-        {
-            if (leftBlock.isNull(leftPosition) != rightBlock.isNull(rightPosition)) {
-                return true;
-            }
-            if (leftBlock.isNull(leftPosition)) {
-                return false;
-            }
-            double left = DOUBLE.getDouble(leftBlock, leftPosition);
-            double right = DOUBLE.getDouble(rightBlock, rightPosition);
-            if (Double.isNaN(left) && Double.isNaN(right)) {
-                return false;
-            }
-            return notEqual(left, right);
-        }
     }
 
     @ScalarOperator(XX_HASH_64)

--- a/presto-main/src/main/java/com/facebook/presto/type/LegacyDoubleComparisonOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LegacyDoubleComparisonOperators.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.AbstractLongType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.IsNull;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.common.function.OperatorType.BETWEEN;
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static java.lang.Double.doubleToLongBits;
+
+@Deprecated
+public class LegacyDoubleComparisonOperators
+{
+    private LegacyDoubleComparisonOperators()
+    {
+    }
+    @ScalarOperator(EQUAL)
+    @SuppressWarnings("FloatingPointEquality")
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean equal(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return left == right;
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @SuppressWarnings("FloatingPointEquality")
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean notEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return left != right;
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThan(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return left < right;
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOrEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return left <= right;
+    }
+
+    @ScalarOperator(GREATER_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThan(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return left > right;
+    }
+
+    @ScalarOperator(GREATER_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThanOrEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
+    {
+        return left >= right;
+    }
+
+    @ScalarOperator(BETWEEN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean between(@SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double min, @SqlType(StandardTypes.DOUBLE) double max)
+    {
+        return min <= value && value <= max;
+    }
+
+    @ScalarOperator(IS_DISTINCT_FROM)
+    public static class DoubleDistinctFromOperator
+    {
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @SqlType(StandardTypes.DOUBLE) double left,
+                @IsNull boolean leftNull,
+                @SqlType(StandardTypes.DOUBLE) double right,
+                @IsNull boolean rightNull)
+        {
+            if (leftNull != rightNull) {
+                return true;
+            }
+            if (leftNull) {
+                return false;
+            }
+            if (Double.isNaN(left) && Double.isNaN(right)) {
+                return false;
+            }
+            return notEqual(left, right);
+        }
+
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @BlockPosition @SqlType(value = StandardTypes.DOUBLE, nativeContainerType = double.class) Block leftBlock,
+                @BlockIndex int leftPosition,
+                @BlockPosition @SqlType(value = StandardTypes.DOUBLE, nativeContainerType = double.class) Block rightBlock,
+                @BlockIndex int rightPosition)
+        {
+            if (leftBlock.isNull(leftPosition) != rightBlock.isNull(rightPosition)) {
+                return true;
+            }
+            if (leftBlock.isNull(leftPosition)) {
+                return false;
+            }
+            double left = DOUBLE.getDouble(leftBlock, leftPosition);
+            double right = DOUBLE.getDouble(rightBlock, rightPosition);
+            if (Double.isNaN(left) && Double.isNaN(right)) {
+                return false;
+            }
+            return notEqual(left, right);
+        }
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @SqlType(StandardTypes.BIGINT)
+    public static long hashCode(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        return AbstractLongType.hash(doubleToLongBits(value));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/LegacyRealComparisonOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LegacyRealComparisonOperators.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.AbstractIntType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.IsNull;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.common.function.OperatorType.BETWEEN;
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static java.lang.Float.floatToIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@Deprecated
+public final class LegacyRealComparisonOperators
+{
+    private LegacyRealComparisonOperators()
+    {
+    }
+
+    @ScalarOperator(EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean equal(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return intBitsToFloat((int) left) == intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean notEqual(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return intBitsToFloat((int) left) != intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThan(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return intBitsToFloat((int) left) < intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOrEqual(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return intBitsToFloat((int) left) <= intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(GREATER_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThan(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return intBitsToFloat((int) left) > intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(GREATER_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThanOrEqual(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return intBitsToFloat((int) left) >= intBitsToFloat((int) right);
+    }
+
+    @ScalarOperator(BETWEEN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean between(@SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.REAL) long min, @SqlType(StandardTypes.REAL) long max)
+    {
+        return intBitsToFloat((int) min) <= intBitsToFloat((int) value) &&
+                intBitsToFloat((int) value) <= intBitsToFloat((int) max);
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @SqlType(StandardTypes.BIGINT)
+    public static long hashCode(@SqlType(StandardTypes.REAL) long value)
+    {
+        return AbstractIntType.hash(floatToIntBits(intBitsToFloat((int) value)));
+    }
+
+    @ScalarOperator(IS_DISTINCT_FROM)
+    public static class RealDistinctFromOperator
+    {
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @SqlType(StandardTypes.REAL) long left,
+                @IsNull boolean leftNull,
+                @SqlType(StandardTypes.REAL) long right,
+                @IsNull boolean rightNull)
+        {
+            if (leftNull != rightNull) {
+                return true;
+            }
+            if (leftNull) {
+                return false;
+            }
+            float leftFloat = intBitsToFloat((int) left);
+            float rightFloat = intBitsToFloat((int) right);
+            if (Float.isNaN(leftFloat) && Float.isNaN(rightFloat)) {
+                return false;
+            }
+            return notEqual(left, right);
+        }
+
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @BlockPosition @SqlType(value = StandardTypes.REAL, nativeContainerType = long.class) Block left,
+                @BlockIndex int leftPosition,
+                @BlockPosition @SqlType(value = StandardTypes.REAL, nativeContainerType = long.class) Block right,
+                @BlockIndex int rightPosition)
+        {
+            if (left.isNull(leftPosition) != right.isNull(rightPosition)) {
+                return true;
+            }
+            if (left.isNull(leftPosition)) {
+                return false;
+            }
+            return notEqual(REAL.getLong(left, leftPosition), REAL.getLong(right, rightPosition));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/RealComparisonOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RealComparisonOperators.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.IsNull;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.common.function.OperatorType.BETWEEN;
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.TypeUtils.realCompare;
+import static com.facebook.presto.common.type.TypeUtils.realEquals;
+import static com.facebook.presto.common.type.TypeUtils.realHashCode;
+import static java.lang.Float.intBitsToFloat;
+
+public final class RealComparisonOperators
+{
+    private RealComparisonOperators()
+    {
+    }
+
+    @ScalarOperator(EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean equal(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return realEquals(intBitsToFloat((int) left), intBitsToFloat((int) right));
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean notEqual(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return !realEquals(intBitsToFloat((int) left), intBitsToFloat((int) right));
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThan(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return realCompare(intBitsToFloat((int) left), intBitsToFloat((int) right)) == -1;
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOrEqual(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return realCompare(intBitsToFloat((int) left), intBitsToFloat((int) right)) <= 0;
+    }
+
+    @ScalarOperator(GREATER_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThan(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return realCompare(intBitsToFloat((int) left), intBitsToFloat((int) right)) == 1;
+    }
+
+    @ScalarOperator(GREATER_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThanOrEqual(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
+    {
+        return realCompare(intBitsToFloat((int) left), intBitsToFloat((int) right)) >= 0;
+    }
+
+    @ScalarOperator(BETWEEN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean between(@SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.REAL) long min, @SqlType(StandardTypes.REAL) long max)
+    {
+        return lessThanOrEqual(min, value) && lessThanOrEqual(value, max);
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @SqlType(StandardTypes.BIGINT)
+    public static long hashCode(@SqlType(StandardTypes.REAL) long value)
+    {
+        return realHashCode(intBitsToFloat((int) value));
+    }
+
+    @ScalarOperator(IS_DISTINCT_FROM)
+    public static class RealDistinctFromOperator
+    {
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @SqlType(StandardTypes.REAL) long left,
+                @IsNull boolean leftNull,
+                @SqlType(StandardTypes.REAL) long right,
+                @IsNull boolean rightNull)
+        {
+            if (leftNull != rightNull) {
+                return true;
+            }
+            if (leftNull) {
+                return false;
+            }
+            return notEqual(left, right);
+        }
+
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @BlockPosition @SqlType(value = StandardTypes.REAL, nativeContainerType = long.class) Block left,
+                @BlockIndex int leftPosition,
+                @BlockPosition @SqlType(value = StandardTypes.REAL, nativeContainerType = long.class) Block right,
+                @BlockIndex int rightPosition)
+        {
+            if (left.isNull(leftPosition) != right.isNull(rightPosition)) {
+                return true;
+            }
+            if (left.isNull(leftPosition)) {
+                return false;
+            }
+            return notEqual(REAL.getLong(left, leftPosition), REAL.getLong(right, rightPosition));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -781,7 +781,7 @@ public final class BlockAssertions
         else if (type == BIGINT) {
             block = createRandomLongsBlock(positionCount, primitiveNullRate);
         }
-        else if (type == INTEGER || type == REAL) {
+        else if (type == INTEGER || type.equals(REAL)) {
             block = createRandomIntsBlock(positionCount, primitiveNullRate);
         }
         else if (type == SMALLINT) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -52,6 +52,7 @@ import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.spiller.GenericSpillerFactory;
 import com.facebook.presto.split.PageSinkManager;
 import com.facebook.presto.split.PageSourceManager;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -168,6 +169,7 @@ public final class TaskTestUtils
                 new IndexJoinLookupStats(),
                 new TaskManagerConfig(),
                 new MemoryManagerConfig(),
+                new FeaturesConfig(),
                 new GenericSpillerFactory((types, spillContext, memoryContext) -> {
                     throw new UnsupportedOperationException();
                 }),

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkDynamicFilterSourceOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkDynamicFilterSourceOperator.java
@@ -90,7 +90,8 @@ public class BenchmarkDynamicFilterSourceOperator
                     ImmutableList.of(new DynamicFilterSourceOperator.Channel("0", BIGINT, 0)),
                     getDynamicFilteringMaxPerDriverRowCount(TEST_SESSION),
                     getDynamicFilteringMaxPerDriverSize(TEST_SESSION),
-                    getDynamicFilteringRangeRowLimitPerDriver(TEST_SESSION));
+                    getDynamicFilteringRangeRowLimitPerDriver(TEST_SESSION),
+                    true);
         }
 
         @TearDown

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -76,7 +76,9 @@ public abstract class AbstractTestFunctions
     protected AbstractTestFunctions(Session session, FeaturesConfig config)
     {
         this.session = requireNonNull(session, "session is null");
-        this.config = requireNonNull(config, "config is null").setLegacyLogFunction(true);
+        this.config = requireNonNull(config, "config is null")
+                .setLegacyLogFunction(true)
+                .setUseNewNanDefinition(true);
     }
 
     @BeforeClass

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToArrayCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToArrayCast.java
@@ -151,7 +151,7 @@ public class BenchmarkJsonToArrayCast
             if (valueType == BIGINT) {
                 return Long.toString(ThreadLocalRandom.current().nextLong());
             }
-            else if (valueType == DOUBLE) {
+            else if (valueType.equals(DOUBLE)) {
                 return Double.toString(ThreadLocalRandom.current().nextDouble());
             }
             else if (valueType == VARCHAR) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToMapCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToMapCast.java
@@ -155,7 +155,7 @@ public class BenchmarkJsonToMapCast
             if (valueType == BIGINT) {
                 return Long.toString(ThreadLocalRandom.current().nextLong());
             }
-            else if (valueType == DOUBLE) {
+            else if (valueType.equals(DOUBLE)) {
                 return Double.toString(ThreadLocalRandom.current().nextDouble());
             }
             else if (valueType == VARCHAR) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1127,9 +1127,6 @@ public class TestMathFunctions
         assertFunction("greatest(1.0, 2.0E0)", DOUBLE, 2.0);
         assertDecimalFunction("greatest(5, 4, 3.0, 2)", decimal("0000000005.0"));
 
-        // invalid
-        assertInvalidFunction("greatest(1.5E0, 0.0E0 / 0.0E0)", "Invalid argument to greatest(): NaN");
-
         // argument count limit
         tryEvaluateWithAll("greatest(" + Joiner.on(", ").join(nCopies(127, "rand()")) + ")", DOUBLE);
         assertNotSupported(
@@ -1198,15 +1195,14 @@ public class TestMathFunctions
         assertFunction("least(1.0, 2.0E0)", DOUBLE, 1.0);
         assertDecimalFunction("least(5, 4, 3.0, 2)", decimal("0000000002.0"));
 
-        // invalid
-        assertInvalidFunction("least(1.5E0, 0.0E0 / 0.0E0)", "Invalid argument to least(): NaN");
+        assertFunction("least(1.5E0, 0.0E0 / 0.0E0)", DOUBLE, 1.5E0);
     }
 
-    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "\\QInvalid argument to greatest(): NaN\\E")
+    @Test
     public void testGreatestWithNaN()
     {
-        functionAssertions.tryEvaluate("greatest(1.5E0, 0.0E0 / 0.0E0)", DOUBLE);
-        functionAssertions.tryEvaluate("greatest(1.5E0, REAL '0.0' / REAL '0.0')", DOUBLE);
+        assertFunction("greatest(1.5E0, 0.0E0 / 0.0E0)", DOUBLE, Double.NaN);
+        assertFunction("greatest(REAL '1.5E0', REAL '0.0' / REAL '0.0')", REAL, Float.NaN);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapKeyExists.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapKeyExists.java
@@ -55,7 +55,7 @@ public class TestMapKeyExists
         assertFunction(
                 "MAP_KEY_EXISTS(MAP(ARRAY[NAN(), 123.21], ARRAY['val1', 'val2']), NAN())",
                 BOOLEAN,
-                false);
+                true);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -271,8 +271,8 @@ public class TestFeaturesConfig
                 .setCteHeuristicReplicationThreshold(4)
                 .setLegacyJsonCast(true)
                 .setPrintEstimatedStatsFromCache(false)
-                .setUseHistograms(false));
-                .setUseNewNanDefinition(false));
+                .setUseHistograms(false)
+                .setUseNewNanDefinition(true));
     }
 
     @Test
@@ -488,7 +488,7 @@ public class TestFeaturesConfig
                 .put("cte-heuristic-replication-threshold", "2")
                 .put("optimizer.print-estimated-stats-from-cache", "true")
                 .put("optimizer.use-histograms", "true")
-                .put("use-new-nan-definition", "true")
+                .put("use-new-nan-definition", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -702,7 +702,7 @@ public class TestFeaturesConfig
                 .setLegacyJsonCast(false)
                 .setPrintEstimatedStatsFromCache(true)
                 .setUseHistograms(true)
-                .setUseNewNanDefinition(true);
+                .setUseNewNanDefinition(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -272,6 +272,7 @@ public class TestFeaturesConfig
                 .setLegacyJsonCast(true)
                 .setPrintEstimatedStatsFromCache(false)
                 .setUseHistograms(false));
+                .setUseNewNanDefinition(false));
     }
 
     @Test
@@ -487,6 +488,7 @@ public class TestFeaturesConfig
                 .put("cte-heuristic-replication-threshold", "2")
                 .put("optimizer.print-estimated-stats-from-cache", "true")
                 .put("optimizer.use-histograms", "true")
+                .put("use-new-nan-definition", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -699,7 +701,8 @@ public class TestFeaturesConfig
                 .setCteHeuristicReplicationThreshold(2)
                 .setLegacyJsonCast(false)
                 .setPrintEstimatedStatsFromCache(true)
-                .setUseHistograms(true);
+                .setUseHistograms(true)
+                .setUseNewNanDefinition(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestExpressionDomainTranslator.java
@@ -1556,7 +1556,7 @@ public class TestExpressionDomainTranslator
 
         public boolean isFractional()
         {
-            return type == DOUBLE || type == REAL || (type instanceof DecimalType && ((DecimalType) type).getScale() > 0);
+            return type.equals(DOUBLE) || type.equals(REAL) || (type instanceof DecimalType && ((DecimalType) type).getScale() > 0);
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
@@ -201,9 +201,9 @@ public class TestRowExpressionDomainTranslator
         assertEquals(toPredicate(tupleDomain), and(lessThan(C_BIGINT, bigintLiteral(4L)), not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L, 3L)))));
 
         testDomain = Domain.create(ValueSet.ofRanges(
-                Range.range(BIGINT, 1L, true, 3L, true),
-                Range.range(BIGINT, 5L, true, 7L, true),
-                Range.range(BIGINT, 9L, true, 11L, true)),
+                        Range.range(BIGINT, 1L, true, 3L, true),
+                        Range.range(BIGINT, 5L, true, 7L, true),
+                        Range.range(BIGINT, 9L, true, 11L, true)),
                 false);
 
         tupleDomain = withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder().put(C_BIGINT, testDomain).build());
@@ -212,7 +212,7 @@ public class TestRowExpressionDomainTranslator
 
         testDomain = Domain.create(
                 ValueSet.ofRanges(
-                        Range.lessThan(BIGINT, 4L))
+                                Range.lessThan(BIGINT, 4L))
                         .intersect(ValueSet.all(BIGINT)
                                 .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))))
                         .union(ValueSet.ofRanges(Range.range(BIGINT, 7L, true, 9L, true))), false);
@@ -1444,7 +1444,7 @@ public class TestRowExpressionDomainTranslator
 
         public boolean isFractional()
         {
-            return input.getType() == DOUBLE || input.getType() == REAL || (input.getType() instanceof DecimalType && ((DecimalType) input.getType()).getScale() > 0);
+            return input.getType().equals(DOUBLE) || input.getType().equals(REAL) || (input.getType() instanceof DecimalType && ((DecimalType) input.getType()).getScale() > 0);
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -1632,8 +1632,8 @@ public class TestArrayOperators
         assertFunction("ARRAY_REMOVE(ARRAY [-1.23E0, 3.14E0], 3.14E0)", new ArrayType(DOUBLE), ImmutableList.of(-1.23));
         assertFunction("ARRAY_REMOVE(ARRAY [3.14E0], 0.0E0)", new ArrayType(DOUBLE), ImmutableList.of(3.14));
         assertFunction("ARRAY_REMOVE(ARRAY [sqrt(-1), 3.14E0], 3.14E0)", new ArrayType(DOUBLE), ImmutableList.of(NaN));
-        assertFunction("ARRAY_REMOVE(ARRAY [-1.23E0, sqrt(-1)], nan())", new ArrayType(DOUBLE), ImmutableList.of(-1.23, NaN));
-        assertFunction("ARRAY_REMOVE(ARRAY [-1.23E0, nan()], nan())", new ArrayType(DOUBLE), ImmutableList.of(-1.23, NaN));
+        assertFunction("ARRAY_REMOVE(ARRAY [-1.23E0, sqrt(-1)], nan())", new ArrayType(DOUBLE), ImmutableList.of(-1.23));
+        assertFunction("ARRAY_REMOVE(ARRAY [-1.23E0, nan()], nan())", new ArrayType(DOUBLE), ImmutableList.of(-1.23));
         assertFunction("ARRAY_REMOVE(ARRAY [-1.23E0, infinity()], -1.23E0)", new ArrayType(DOUBLE), ImmutableList.of(POSITIVE_INFINITY));
         assertFunction("ARRAY_REMOVE(ARRAY [infinity(), 3.14E0], infinity())", new ArrayType(DOUBLE), ImmutableList.of(3.14));
         assertFunction("ARRAY_REMOVE(ARRAY [-1.23E0, NULL, 3.14E0], 3.14E0)", new ArrayType(DOUBLE), asList(-1.23, null));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -675,11 +675,11 @@ public class TestArrayOperators
         assertFunction("ARRAY_MIN(ARRAY [NULL, NULL, NULL])", UNKNOWN, null);
         assertFunction("ARRAY_MIN(ARRAY [NaN(), NaN(), NaN()])", DOUBLE, NaN);
         assertFunction("ARRAY_MIN(ARRAY [NULL, 2, 3])", INTEGER, null);
-        assertFunction("ARRAY_MIN(ARRAY [NaN(), 2, 3])", DOUBLE, NaN);
-        assertFunction("ARRAY_MIN(ARRAY [NULL, NaN(), 1])", DOUBLE, NaN);
-        assertFunction("ARRAY_MIN(ARRAY [NaN(), NULL, 3.0])", DOUBLE, NaN);
+        assertFunction("ARRAY_MIN(ARRAY [NaN(), 2, 3])", DOUBLE, 2.0);
+        assertFunction("ARRAY_MIN(ARRAY [NULL, NaN(), 1])", DOUBLE, null);
+        assertFunction("ARRAY_MIN(ARRAY [NaN(), NULL, 3.0])", DOUBLE, null);
         assertFunction("ARRAY_MIN(ARRAY [1.0E0, NULL, 3])", DOUBLE, null);
-        assertFunction("ARRAY_MIN(ARRAY [1.0, NaN(), 3])", DOUBLE, NaN);
+        assertFunction("ARRAY_MIN(ARRAY [1.0, NaN(), 3])", DOUBLE, 1.0);
         assertFunction("ARRAY_MIN(ARRAY ['1', '2', NULL])", createVarcharType(1), null);
         assertFunction("ARRAY_MIN(ARRAY [3, 2, 1])", INTEGER, 1);
         assertFunction("ARRAY_MIN(ARRAY [1, 2, 3])", INTEGER, 1);
@@ -706,8 +706,8 @@ public class TestArrayOperators
         assertFunction("ARRAY_MAX(ARRAY [NaN(), NaN(), NaN()])", DOUBLE, NaN);
         assertFunction("ARRAY_MAX(ARRAY [NULL, 2, 3])", INTEGER, null);
         assertFunction("ARRAY_MAX(ARRAY [NaN(), 2, 3])", DOUBLE, NaN);
-        assertFunction("ARRAY_MAX(ARRAY [NULL, NaN(), 1])", DOUBLE, NaN);
-        assertFunction("ARRAY_MAX(ARRAY [NaN(), NULL, 3.0])", DOUBLE, NaN);
+        assertFunction("ARRAY_MAX(ARRAY [NULL, NaN(), 1])", DOUBLE, null);
+        assertFunction("ARRAY_MAX(ARRAY [NaN(), NULL, 3.0])", DOUBLE, null);
         assertFunction("ARRAY_MAX(ARRAY [1.0E0, NULL, 3])", DOUBLE, null);
         assertFunction("ARRAY_MAX(ARRAY [1.0, NaN(), 3])", DOUBLE, NaN);
         assertFunction("ARRAY_MAX(ARRAY ['1', '2', NULL])", createVarcharType(1), null);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
@@ -30,6 +30,7 @@ import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.doubleToRawLongBits;
 import static java.lang.Double.isNaN;
 import static java.lang.Double.longBitsToDouble;
+import static java.lang.Double.parseDouble;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -113,6 +114,8 @@ public class TestDoubleOperators
         assertFunction("37.7E0 = 17.1E0", BOOLEAN, false);
         assertFunction("17.1E0 = 37.7E0", BOOLEAN, false);
         assertFunction("17.1E0 = 17.1E0", BOOLEAN, true);
+        assertFunction("DOUBLE'-0.0' = DOUBLE'0.0'", BOOLEAN, true);
+        assertFunction("nan() = nan()", BOOLEAN, true);
     }
 
     @Test
@@ -122,6 +125,8 @@ public class TestDoubleOperators
         assertFunction("37.7E0 <> 17.1E0", BOOLEAN, true);
         assertFunction("17.1E0 <> 37.7E0", BOOLEAN, true);
         assertFunction("17.1E0 <> 17.1E0", BOOLEAN, false);
+        assertFunction("DOUBLE'-0.0' <> DOUBLE'0.0'", BOOLEAN, false);
+        assertFunction("nan() <> nan()", BOOLEAN, false);
     }
 
     @Test
@@ -131,6 +136,8 @@ public class TestDoubleOperators
         assertFunction("37.7E0 < 17.1E0", BOOLEAN, false);
         assertFunction("17.1E0 < 37.7E0", BOOLEAN, true);
         assertFunction("17.1E0 < 17.1E0", BOOLEAN, false);
+        assertFunction("DOUBLE '-0.0' < DOUBLE '0.0'", BOOLEAN, false);
+        assertFunction("nan() < nan()", BOOLEAN, false);
     }
 
     @Test
@@ -140,6 +147,8 @@ public class TestDoubleOperators
         assertFunction("37.7E0 <= 17.1E0", BOOLEAN, false);
         assertFunction("17.1E0 <= 37.7E0", BOOLEAN, true);
         assertFunction("17.1E0 <= 17.1E0", BOOLEAN, true);
+        assertFunction("DOUBLE '-0.0' <= DOUBLE '0.0'", BOOLEAN, true);
+        assertFunction("nan() <= nan()", BOOLEAN, true);
     }
 
     @Test
@@ -149,6 +158,8 @@ public class TestDoubleOperators
         assertFunction("37.7E0 > 17.1E0", BOOLEAN, true);
         assertFunction("17.1E0 > 37.7E0", BOOLEAN, false);
         assertFunction("17.1E0 > 17.1E0", BOOLEAN, false);
+        assertFunction("DOUBLE '0.0' > DOUBLE '-0.0'", BOOLEAN, false);
+        assertFunction("nan() > nan()", BOOLEAN, false);
     }
 
     @Test
@@ -158,6 +169,8 @@ public class TestDoubleOperators
         assertFunction("37.7E0 >= 17.1E0", BOOLEAN, true);
         assertFunction("17.1E0 >= 37.7E0", BOOLEAN, false);
         assertFunction("17.1E0 >= 17.1E0", BOOLEAN, true);
+        assertFunction("DOUBLE'-0.0' >= DOUBLE'0.0'", BOOLEAN, true);
+        assertFunction("nan() >= nan()", BOOLEAN, true);
     }
 
     @Test
@@ -174,6 +187,8 @@ public class TestDoubleOperators
 
         assertFunction("17.1E0 BETWEEN 17.1E0 AND 37.7E0", BOOLEAN, true);
         assertFunction("17.1E0 BETWEEN 17.1E0 AND 17.1E0", BOOLEAN, true);
+        assertFunction("DOUBLE'-0.0' BETWEEN DOUBLE'0.0' AND DOUBLE '0.0'", BOOLEAN, true);
+        assertFunction("nan() BETWEEN nan() AND nan()", BOOLEAN, true);
     }
 
     @Test
@@ -300,6 +315,7 @@ public class TestDoubleOperators
         assertFunction("NULL IS DISTINCT FROM 37.7", BOOLEAN, true);
         assertFunction("37.7 IS DISTINCT FROM NULL", BOOLEAN, true);
         assertFunction("nan() IS DISTINCT FROM nan()", BOOLEAN, false);
+        assertFunction("DOUBLE '-0.0' IS DISTINCT FROM DOUBLE '0.0'", BOOLEAN, false);
     }
 
     @Test
@@ -321,7 +337,13 @@ public class TestDoubleOperators
             assertTrue(nanRepresentation == nanRepresentations[0]
                     || doubleToRawLongBits(longBitsToDouble(nanRepresentation)) != doubleToRawLongBits(longBitsToDouble(nanRepresentations[0])));
 
-            assertEquals(DoubleOperators.hashCode(longBitsToDouble(nanRepresentation)), DoubleOperators.hashCode(longBitsToDouble(nanRepresentations[0])));
+            assertEquals(DoubleComparisonOperators.hashCode(longBitsToDouble(nanRepresentation)), DoubleComparisonOperators.hashCode(longBitsToDouble(nanRepresentations[0])));
         }
+    }
+
+    @Test
+    public void testZeroHash()
+    {
+        assertEquals(DoubleComparisonOperators.hashCode(0), DoubleComparisonOperators.hashCode(parseDouble("-0.0")));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/khyperloglog/TestKHyperLogLogAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/khyperloglog/TestKHyperLogLogAggregationFunction.java
@@ -173,7 +173,7 @@ public class TestKHyperLogLogAggregationFunction
 
     private long toLong(Object value, Type type)
     {
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return Double.doubleToLongBits((double) value);
         }
         else if (type == VARCHAR) {
@@ -186,7 +186,7 @@ public class TestKHyperLogLogAggregationFunction
 
     private Block buildBlock(List<?> values, Type type)
     {
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return createDoublesBlock(values.stream().map(o -> (Double) o).collect(Collectors.toList()));
         }
         else if (type == VARCHAR) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -519,7 +519,7 @@ public class OrcSelectiveRecordReader
             return 20;
         }
 
-        if (type == REAL || type == DOUBLE) {
+        if (type.equals(REAL) || type.equals(DOUBLE)) {
             return 30;
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
@@ -167,7 +167,7 @@ public class TupleDomainOrcPredicate<C>
             return bloomFilter.testLong(((Number) predicateValue).longValue());
         }
 
-        if (sqlType == DOUBLE) {
+        if (sqlType.equals(DOUBLE)) {
             return bloomFilter.testDouble((Double) predicateValue);
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -38,7 +38,7 @@ public class DoubleStatisticsBuilder
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
                 double value;
-                if (type == RealType.REAL) {
+                if (type.equals(RealType.REAL)) {
                     value = Float.intBitsToFloat((int) type.getLong(block, position));
                 }
                 else {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -340,11 +340,11 @@ public class BenchmarkSelectiveStreamReaders
                 return Optional.of(BigintRange.of((long) (Byte.MIN_VALUE * selectionRateForNonNull), (long) (Byte.MAX_VALUE * selectionRateForNonNull), filterAllowNull));
             }
 
-            if (type == REAL) {
+            if (type.equals(REAL)) {
                 return Optional.of(FloatRange.of(0, false, false, selectionRateForNonNull, false, true, filterAllowNull));
             }
 
-            if (type == DOUBLE) {
+            if (type.equals(DOUBLE)) {
                 return Optional.of(DoubleRange.of(0, false, false, selectionRateForNonNull, false, true, filterAllowNull));
             }
 
@@ -423,11 +423,11 @@ public class BenchmarkSelectiveStreamReaders
                 return new SqlTimestamp(value, TimeZoneKey.UTC_KEY, MILLISECONDS);
             }
 
-            if (type == REAL) {
+            if (type.equals(REAL)) {
                 return random.nextFloat();
             }
 
-            if (type == DOUBLE) {
+            if (type.equals(DOUBLE)) {
                 return random.nextDouble();
             }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -360,9 +360,8 @@ public class OrcTester
     }
 
     /**
-     *
-     * @param type          Presto data type for the readValues.
-     * @param readValues    The values to be written, read and compared against.
+     * @param type Presto data type for the readValues.
+     * @param readValues The values to be written, read and compared against.
      * @param columnFilters The filters for the readers. For CHAR(n) values, the columnFilters should remove the paddings.
      * @param valuesFilters The filters for the readValues. For CHAR(n) values, valuesFilters keeps the original paddings.
      * @throws Exception
@@ -1279,11 +1278,11 @@ public class OrcTester
             return filter.testLong(((Number) value).longValue());
         }
 
-        if (type == REAL) {
+        if (type.equals(REAL)) {
             return filter.testFloat(((Number) value).floatValue());
         }
 
-        if (type == DOUBLE) {
+        if (type.equals(DOUBLE)) {
             return filter.testDouble((double) value);
         }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestWriterBlockRawSize.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestWriterBlockRawSize.java
@@ -183,7 +183,7 @@ public class TestWriterBlockRawSize
         BlockBuilder blockBuilder = type.createBlockBuilder(null, NUM_ELEMENTS * 2);
         for (int i = 0; i < NUM_ELEMENTS; i++) {
             blockBuilder.appendNull();
-            if (type == REAL) {
+            if (type.equals(REAL)) {
                 type.writeLong(blockBuilder, Float.floatToIntBits(i));
             }
             else {

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/raw/RawColumnDecoder.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/raw/RawColumnDecoder.java
@@ -138,7 +138,7 @@ public class RawColumnDecoder
             if (columnType == BOOLEAN) {
                 checkFieldTypeOneOf(fieldType, columnName, FieldType.BYTE, FieldType.SHORT, FieldType.INT, FieldType.LONG);
             }
-            if (columnType == DOUBLE) {
+            if (columnType.equals(DOUBLE)) {
                 checkFieldTypeOneOf(fieldType, columnName, FieldType.DOUBLE, FieldType.FLOAT);
             }
             if (isVarcharType(columnType)) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
@@ -299,6 +299,30 @@ public abstract class AbstractTestNanQueries
     }
 
     @Test
+    public void testDoubleArrayMinAgg()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT min(%s) FROM %s WHERE none_match(%s, x -> x IS NULL)", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME, SIMPLE_DOUBLE_ARRAY_COLUMN), "SELECT ARRAY[0, 1, -1, nan()]");
+    }
+
+    @Test
+    public void testRealArrayMinAgg()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT min(%s) FROM %s WHERE none_match(%s, x -> x IS NULL)", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME, SIMPLE_REAL_ARRAY_COLUMN), "SELECT ARRAY[REAL'0', REAL '1', REAL '-1', CAST(nan() AS REAL)]");
+    }
+
+    @Test
+    public void testDoubleArrayMaxAgg()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT max(%s) FROM %s WHERE none_match(%s, x -> x IS NULL)", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME, SIMPLE_DOUBLE_ARRAY_COLUMN), "SELECT ARRAY[nan(), nan()]");
+    }
+
+    @Test
+    public void testRealArrayMaxAgg()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT max(%s) FROM %s WHERE none_match(%s, x -> x IS NULL)", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME, SIMPLE_REAL_ARRAY_COLUMN), "SELECT ARRAY[CAST(nan() AS REAL), CAST(nan() AS REAL)]");
+    }
+
+    @Test
     public void testMax()
     {
         assertQueryWithSameQueryRunner(format("SELECT max(%s), max(%s), max(%s) FROM %s", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME), "SELECT nan(), nan(), nan()");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
@@ -30,6 +30,9 @@ public abstract class AbstractTestNanQueries
     public static final String DOUBLE_NAN_LAST_COLUMN = "_double_nan_last";
 
     public static final String REAL_NANS_TABLE_NAME = "real_nans_table";
+    public static final String REAL_NAN_FIRST_COLUMN = "_real_nan_first";
+    public static final String REAL_NAN_MIDDLE_COLUMN = "_real_nan_middle";
+    public static final String REAL_NAN_LAST_COLUMN = "_real_nan_last";
 
     @BeforeClass
     public void setup()
@@ -72,6 +75,13 @@ public abstract class AbstractTestNanQueries
     }
 
     @Test
+    public void testRealLessThan()
+    {
+        assertQuery(format("SELECT _real_nan_first < CAST(nan() AS REAL) from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+        assertQuery(format("SELECT CAST(nan() AS REAL) < _real_nan_first from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (false), (false), (false))");
+    }
+
+    @Test
     public void testDoubleGreaterThan()
     {
         assertQuery("SELECT nan() > 1.0", "SELECT true");
@@ -83,6 +93,12 @@ public abstract class AbstractTestNanQueries
     }
 
     @Test
+    public void testRealGreaterThan()
+    {
+        assertQuery(format("SELECT _real_nan_first > cast(nan() AS REAL) from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (false), (false), (false))");
+        assertQuery(format("SELECT CAST(nan() AS REAL)> _real_nan_first from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+    }
+
     @Test
     public void testDoubleLessThanOrEqualTo()
     {
@@ -92,6 +108,13 @@ public abstract class AbstractTestNanQueries
         assertQuery("SELECT nan() <= nan()", "SELECT true");
         assertQuery(format("SELECT _double_nan_first <= nan() from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (true), (true), (true))");
         assertQuery(format("SELECT nan() <= _double_nan_first from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+    }
+
+    @Test
+    public void testRealLessThanOrEqualTo()
+    {
+        assertQuery(format("SELECT _real_nan_first <= CAST(nan() AS REAL) from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (true), (true), (true))");
+        assertQuery(format("SELECT CAST(nan() AS REAL) <= _real_nan_first from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
     }
 
     @Test
@@ -106,12 +129,26 @@ public abstract class AbstractTestNanQueries
     }
 
     @Test
+    public void testRealGreaterThanOrEqualTo()
+    {
+        assertQuery(format("SELECT _real_nan_first >= CAST(nan() AS REAL) from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+        assertQuery(format("SELECT CAST(nan() AS REAL) >= _real_nan_first from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (true), (true), (true))");
+    }
+
+    @Test
     public void testDoubleEquals()
     {
         assertQuery("SELECT nan() = nan()", "SELECT true");
         assertQuery("SELECT nan() = 3", "SELECT false");
         assertQuery(format("SELECT _double_nan_first = nan() from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
         assertQuery(format("SELECT nan() = _double_nan_first from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+    }
+
+    @Test
+    public void testRealEquals()
+    {
+        assertQuery(format("SELECT _real_nan_first = CAST(nan() AS REAL) from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+        assertQuery(format("SELECT CAST(nan() AS REAL) = _real_nan_first from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
     }
 
     @Test
@@ -122,11 +159,26 @@ public abstract class AbstractTestNanQueries
         assertQuery(format("SELECT _double_nan_first <> nan() from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
         assertQuery(format("SELECT nan() <> _double_nan_first from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
     }
+
+    @Test
+    public void testRealNotEquals()
+    {
+        assertQuery(format("SELECT _real_nan_first <> CAST(nan() AS REAL) from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+        assertQuery(format("SELECT CAST(nan() AS REAL) <> _real_nan_first from %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+    }
+
     @Test
     public void testDoubleBetween()
     {
         assertQuery(format("SELECT nan() BETWEEN -infinity() AND _double_nan_first FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
         assertQuery(format("SELECT _double_nan_first BETWEEN -infinity() AND nan() FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES(true), (true), (true), (true))");
+    }
+
+    @Test
+    public void testRealBetween()
+    {
+        assertQuery(format("SELECT CAST(nan() AS REAL) BETWEEN CAST(-infinity() AS REAL) AND _real_nan_first FROM %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+        assertQuery(format("SELECT _real_nan_first BETWEEN CAST(-infinity() AS REAL) AND cast(nan() AS REAL) FROM %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES(true), (true), (true), (true))");
     }
 
     @Test
@@ -137,8 +189,23 @@ public abstract class AbstractTestNanQueries
     }
 
     @Test
+    public void testRealIn()
+    {
+        assertQuery(format("SELECT CAST(nan() as REAL) IN (REAL '1', REAL '2', _real_nan_first) FROM %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+        assertQuery(format("SELECT _real_nan_first IN (CAST(nan() as REAL), REAL '0', REAL '6')FROM %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES(true), (true), (false), (false))");
+    }
+
+    @Test
     public void testDoubleNotIn()
     {
         assertQuery(format("SELECT nan() NOT IN (1, 2, _double_nan_first) FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
         assertQuery(format("SELECT _double_nan_first NOT IN (nan(), 0, 6)FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES(false), (false), (true), (true))");
     }
+
+    @Test
+    public void testRealNotIn()
+    {
+        assertQuery(format("SELECT CAST(nan() as REAL) NOT IN (REAL '1', REAL '2', _real_nan_first) FROM %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+        assertQuery(format("SELECT _real_nan_first NOT IN (CAST(nan() as REAL), 0, 6)FROM %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES(false), (false), (true), (true))");
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
@@ -420,6 +420,29 @@ public abstract class AbstractTestNanQueries
     }
 
     @Test
+    public void testGreatest()
+    {
+        assertQueryWithSameQueryRunner("SELECT GREATEST(1.5E0, nan())", "SELECT nan()");
+        assertQueryWithSameQueryRunner(
+                format("SELECT greatest(%s, %s, %s) FROM %s", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES (nan()), (nan()), (infinity()), (nan()))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT greatest(%s, %s, %s) FROM %s", REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES (CAST(nan() AS REAL)), (CAST(nan() AS REAL)), CAST(infinity() AS REAL), (CAST(nan() AS REAL)))");
+    }
+
+    @Test
+    public void testLeast()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT least(%s, %s, %s) FROM %s", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES (DOUBLE '0.0'), (DOUBLE '0.0'), (DOUBLE '0.0'), (DOUBLE '-4.0'))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT least(%s, %s, %s) FROM %s", REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES (REAL '0.0'), (REAL '0.0'), (REAL'0.0'), REAL'-4.0')");
+    }
+
+    @Test
     public void testDoubleSetAgg()
     {
         assertQueryWithSameQueryRunner(format("SELECT set_agg(%s), set_agg(%s) FROM %s", DOUBLE_DISTINCT1_COLUMN, DOUBLE_DISTINCT2_COLUMN, DISTINCT_TABLE_NAME), "SELECT ARRAY[nan(), 0.0, null, 3.0], ARRAY[0, nan(), null, 3.0]");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.tests;
 
+import com.facebook.presto.Session;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -33,6 +34,21 @@ public abstract class AbstractTestNanQueries
     public static final String REAL_NAN_FIRST_COLUMN = "_real_nan_first";
     public static final String REAL_NAN_MIDDLE_COLUMN = "_real_nan_middle";
     public static final String REAL_NAN_LAST_COLUMN = "_real_nan_last";
+
+    public static final String DISTINCT_TABLE_NAME = "distinct_nans_table";
+    public static final String DOUBLE_DISTINCT1_COLUMN = "_double_distinct1";
+    public static final String DOUBLE_DISTINCT2_COLUMN = "_double_distinct2";
+    public static final String REAL_DISTINCT1_COLUMN = "_real_distinct1";
+    public static final String REAL_DISTINCT2_COLUMN = "_real_distinct2";
+    public static final String EXTRA_DISTINCT_COLUMN = "_extra_column";
+
+    public static final String ARRAY_TABLE_NAME = "array_nans_table";
+    public static final String SIMPLE_DOUBLE_ARRAY_COLUMN = "simple_double_array";
+    public static final String SIMPLE_REAL_ARRAY_COLUMN = "simple_real_array";
+
+    public static final String MAP_TABLE_NAME = "map_nans_table";
+    public static final String DOUBLE_MAP_COLUMN = "double_map";
+    public static final String REAL_MAP_COLUMN = "real_map";
 
     @BeforeClass
     public void setup()
@@ -54,6 +70,43 @@ public abstract class AbstractTestNanQueries
                 "(CAST(infinity() AS REAL), CAST(3 AS REAL),  CAST(0 AS REAL))," +
                 "( CAST(-4 AS REAL), CAST(2 AS REAL), CAST(nan() AS REAL))) as t (_real_nan_first, _real_nan_middle, _real_nan_last)";
         assertUpdate(createFloatTableQuery, 4);
+
+        @Language("SQL") String createDistinctTableQuery = "" +
+                "CREATE TABLE " + DISTINCT_TABLE_NAME + " AS " +
+                "SELECT * FROM (VALUES " +
+                "(nan(), DOUBLE '0.0', CAST(nan() as REAL), REAL '0.0', 'a'), " +
+                " (DOUBLE '0.0', nan(), REAL '0.0', CAST(nan() AS REAL), 'b'), " +
+                "(null, null, null, null, 'c'), " +
+                "(nan(), nan(), CAST(nan() as REAL), CAST(nan() as REAL), 'd'), " +
+                "(3.0, 3.0, REAL '3.0', REAL '3.0', 'e'), " +
+                "(0.0, 0.0, REAL '0.0', REAL '0.0', 'f'), " +
+                "(null, null, null, null, 'g'))" +
+                "AS t (" + DOUBLE_DISTINCT1_COLUMN + ", " + DOUBLE_DISTINCT2_COLUMN + ", " + REAL_DISTINCT1_COLUMN + ", " + REAL_DISTINCT2_COLUMN + ", " + EXTRA_DISTINCT_COLUMN + ")";
+        assertUpdate(createDistinctTableQuery, 7);
+
+        @Language("SQL") String createArrayTableQuery = "" +
+                "CREATE TABLE " + ARRAY_TABLE_NAME + " AS " +
+                "SELECT * FROM (VALUES " +
+                "(ARRAY[nan(), DOUBLE '0', DOUBLE '1', DOUBLE '-1'], ARRAY[cast(nan() AS REAL), REAL '0', REAL '1', REAL '-1']), " +
+                "(ARRAY[ DOUBLE '0', nan(), DOUBLE '1', DOUBLE '-1'], ARRAY[REAL '0', CAST(nan() AS REAL),  REAL '1', REAL '-1']), " +
+                "(ARRAY[ DOUBLE '0',  DOUBLE '1', DOUBLE '-1', nan()], ARRAY[REAL '0', REAL '1', REAL '-1',  CAST(nan() AS REAL)]), " +
+                "(ARRAY[null, nan(), DOUBLE '200'], ARRAY[null, CAST(nan() AS REAL), REAL '200']), " +
+                "(null, null), " +
+                "(ARRAY[nan(), nan()], ARRAY[CAST(nan() AS REAL), CAST(nan() AS REAL)]), " +
+                "(ARRAY[DOUBLE '0', DOUBLE '1', nan(), DOUBLE '-1', nan(), DOUBLE '1', DOUBLE '1', DOUBLE'0'], ARRAY [REAL '0', REAL '1', CAST(nan() AS REAL), REAL '-1', CAST(nan() AS REAL), REAL '1', REAL '1', REAL '0'])) " +
+                "AS t (" + SIMPLE_DOUBLE_ARRAY_COLUMN + ", " + SIMPLE_REAL_ARRAY_COLUMN + ")";
+
+        assertUpdate(createArrayTableQuery, 7);
+
+        @Language("SQL") String createMapTableQuery = "" +
+                "CREATE TABLE " + MAP_TABLE_NAME + " AS " +
+                "SELECT * FROM (VALUES " +
+                "(MAP(ARRAY[nan(), 1, 2], ARRAY[nan(), 100, 200]), MAP(ARRAY[CAST(nan() AS REAL), REAL '1', REAL '2'], ARRAY[CAST(nan() AS REAL), REAL '100', REAL '200']))," +
+                "(MAP(ARRAY[2, nan(), 1], ARRAY[200, nan(), 100]), MAP(ARRAY[REAL '2', CAST(nan() AS REAL), REAL '1'], ARRAY[REAL '200', CAST(nan() AS REAL), REAL '100'])), " +
+                "(MAP(ARRAY[2, 1, nan()], ARRAY[200, 100, nan()]), MAP(ARRAY[REAL '2', REAL '1', CAST(nan() AS REAL)], ARRAY[REAL '200', REAL '100', CAST(nan() AS REAL)]))) " +
+                "AS t(" + DOUBLE_MAP_COLUMN + ", " + REAL_MAP_COLUMN + ")";
+        System.out.println(createMapTableQuery);
+        assertUpdate(createMapTableQuery, 3);
     }
 
     @AfterClass
@@ -61,6 +114,9 @@ public abstract class AbstractTestNanQueries
     {
         assertUpdate("DROP TABLE " + DOUBLE_NANS_TABLE_NAME);
         assertUpdate("DROP TABLE " + REAL_NANS_TABLE_NAME);
+        assertUpdate("DROP TABLE " + DISTINCT_TABLE_NAME);
+        assertUpdate("DROP TABLE " + ARRAY_TABLE_NAME);
+        assertUpdate("DROP TABLE " + MAP_TABLE_NAME);
     }
 
     @Test
@@ -207,5 +263,1020 @@ public abstract class AbstractTestNanQueries
     {
         assertQuery(format("SELECT CAST(nan() as REAL) NOT IN (REAL '1', REAL '2', _real_nan_first) FROM %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
         assertQuery(format("SELECT _real_nan_first NOT IN (CAST(nan() as REAL), 0, 6)FROM %s", REAL_NANS_TABLE_NAME), "SELECT * FROM (VALUES(false), (false), (true), (true))");
+    }
+
+    @Test
+    public void testSelectDistinct()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT DISTINCT _double_distinct1 FROM %s", DISTINCT_TABLE_NAME), "SELECT * FROM (VALUES(nan()), (0.0), (null), (3.0))");
+        assertQueryWithSameQueryRunner(format("SELECT DISTINCT _real_distinct1 FROM %s", DISTINCT_TABLE_NAME), "SELECT * FROM (VALUES (CAST(nan() AS REAL)), (REAL '0.0'), (null), (REAL '3.0'))");
+    }
+
+    @Test
+    public void testSelectDistinctAggregations()
+    {
+        Session markDistinct = Session.builder(getQueryRunner().getDefaultSession()).setSystemProperty("use_mark_distinct", "true").build();
+        assertQuery(markDistinct, format("SELECT count(DISTINCT _double_distinct1), count(_double_distinct1), count(*) FROM %s", DISTINCT_TABLE_NAME), "SELECT 3, 5, 7");
+        assertQuery(markDistinct, format("SELECT count(DISTINCT _real_distinct1), count(_real_distinct1), count(*) FROM %s", DISTINCT_TABLE_NAME), "SELECT 3, 5, 7");
+
+        Session noMarkDistinct = Session.builder(getQueryRunner().getDefaultSession()).setSystemProperty("use_mark_distinct", "false").build();
+        assertQuery(noMarkDistinct, format("SELECT count(DISTINCT _double_distinct1), count(_double_distinct1), count(*) FROM %s", DISTINCT_TABLE_NAME), "SELECT 3, 5, 7");
+        assertQuery(noMarkDistinct, format("SELECT count(DISTINCT _real_distinct1), count(_real_distinct1), count(*) FROM %s", DISTINCT_TABLE_NAME), "SELECT 3, 5, 7");
+    }
+
+    @Test
+    public void testGroupBy()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT _double_distinct1, count(*) FROM %s GROUP BY _double_distinct1", DISTINCT_TABLE_NAME), "SELECT * FROM (VALUES (nan(), BIGINT '2'), (0.0, BIGINT '2'), (null, BIGINT '2'), (3.0, BIGINT '1'))");
+        assertQueryWithSameQueryRunner(format("SELECT _real_distinct1, count(*) FROM %s GROUP BY _real_distinct1", DISTINCT_TABLE_NAME), "SELECT * FROM (VALUES (CAST(nan() as REAL), BIGINT '2'), (REAL '0.0', BIGINT '2'), (null, BIGINT '2'), (REAL '3.0', BIGINT '1'))");
+    }
+
+    @Test
+    public void testMin()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT min(%s), min(%s), min(%s) FROM %s", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME), "SELECT DOUBLE '-4.0', DOUBLE '0.0', DOUBLE '0.0'");
+        assertQueryWithSameQueryRunner(format("SELECT min(%s), min(%s), min(%s) FROM %s", REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME), "SELECT REAL '-4.0', REAL '0.0', REAL '0.0'");
+    }
+
+    @Test
+    public void testMax()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT max(%s), max(%s), max(%s) FROM %s", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME), "SELECT nan(), nan(), nan()");
+        assertQueryWithSameQueryRunner(format("SELECT max(%s), max(%s), max(%s) FROM %s", REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME), "SELECT CAST(nan() AS REAL), CAST(nan() AS REAL), CAST(nan() AS REAL)");
+    }
+
+    @Test
+    public void testMinN()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT min(%s, 2), min(%s, 2), min(%s, 2) FROM %s", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME), "SELECT ARRAY [DOUBLE '-4.0', DOUBLE '0.0'], Array [DOUBLE '0.0', DOUBLE '2.0'], ARRAY[DOUBLE '0.0', DOUBLE '1.0']");
+        assertQueryWithSameQueryRunner(format("SELECT min(%s, 2), min(%s, 2), min(%s, 2) FROM %s", REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME), "SELECT ARRAY [REAL '-4.0', REAL '0.0'], Array [REAL '0.0', REAL '2.0'], ARRAY[REAL '0.0', REAL '1.0']");
+    }
+
+    @Test
+    public void testMaxN()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT max(%s, 2), max(%s, 2), max(%s, 2) FROM %s", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME), "SELECT ARRAY [nan(), infinity()], Array [nan(), 3.0], ARRAY[nan(), 2.0]");
+        assertQueryWithSameQueryRunner(format("SELECT max(%s, 2), max(%s, 2), max(%s, 2) FROM %s", REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME), "SELECT ARRAY [CAST(nan() AS REAL), CAST(infinity() AS REAL)], Array [CAST(nan() AS REAL), REAL '3.0'], ARRAY[CAST(nan() AS REAL), REAL '2.0']");
+    }
+
+    @Test
+    public void testMinBy()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT min_by(%s, %s), min_by(%s, %s), min_by(%s, %s) FROM %s",
+                        DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN,
+                        DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN,
+                        DOUBLE_NAN_LAST_COLUMN, DOUBLE_NAN_FIRST_COLUMN,
+                        DOUBLE_NANS_TABLE_NAME),
+                "SELECT nan(), DOUBLE '3.0', nan()");
+        assertQueryWithSameQueryRunner(
+                format("SELECT min_by(%s, %s), min_by(%s, %s), min_by(%s, %s) FROM %s",
+                        REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN,
+                        REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN,
+                        REAL_NAN_LAST_COLUMN, REAL_NAN_FIRST_COLUMN,
+                        REAL_NANS_TABLE_NAME),
+                "SELECT CAST(nan() AS REAL), REAL'3.0', CAST(nan() AS REAL)");
+    }
+
+    @Test
+    public void testMaxBy()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT max_by(%s, %s), max_by(%s, %s), max_by(%s, %s) FROM %s",
+                        DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN,
+                        DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN,
+                        DOUBLE_NAN_LAST_COLUMN, DOUBLE_NAN_FIRST_COLUMN,
+                        DOUBLE_NANS_TABLE_NAME),
+                "SELECT DOUBLE '0.0', DOUBLE '2.0', DOUBLE '1.0'");
+        assertQueryWithSameQueryRunner(
+                format("SELECT max_by(%s, %s), max_by(%s, %s), max_by(%s, %s) FROM %s",
+                        REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN,
+                        REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN,
+                        REAL_NAN_LAST_COLUMN, REAL_NAN_FIRST_COLUMN,
+                        REAL_NANS_TABLE_NAME),
+                "SELECT REAL '0.0', REAL'2.0', REAL '1.0'");
+    }
+
+    @Test
+    public void testMinByN()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT min_by(%s, %s, 2), min_by(%s, %s, 2), min_by(%s, %s, 2) FROM %s",
+                        DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN,
+                        DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN,
+                        DOUBLE_NAN_LAST_COLUMN, DOUBLE_NAN_FIRST_COLUMN,
+                        DOUBLE_NANS_TABLE_NAME),
+                "SELECT ARRAY[nan(), DOUBLE '-4.0'], ARRAY[DOUBLE '3.0', DOUBLE '0.0'], ARRAY[nan(), DOUBLE '2.0']");
+        assertQueryWithSameQueryRunner(
+                format("SELECT min_by(%s, %s, 2), min_by(%s, %s, 2), min_by(%s, %s, 2) FROM %s",
+                        REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN,
+                        REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN,
+                        REAL_NAN_LAST_COLUMN, REAL_NAN_FIRST_COLUMN,
+                        REAL_NANS_TABLE_NAME),
+                "SELECT ARRAY[CAST(nan() AS REAL), REAL '-4.0'], ARRAY[REAL '3.0', REAL '0.0'], ARRAY[CAST(nan() AS REAL), REAL '2.0']");
+    }
+
+    @Test
+    public void testMaxByN()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT max_by(%s, %s, 2), max_by(%s, %s, 2), max_by(%s, %s, 2) FROM %s",
+                        DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NAN_MIDDLE_COLUMN,
+                        DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN,
+                        DOUBLE_NAN_LAST_COLUMN, DOUBLE_NAN_FIRST_COLUMN,
+                        DOUBLE_NANS_TABLE_NAME),
+                "SELECT ARRAY [DOUBLE '0.0', infinity()], ARRAY[DOUBLE '2.0', nan()], ARRAY[DOUBLE '1.0', DOUBLE '0.0']");
+        assertQueryWithSameQueryRunner(
+                format("SELECT max_by(%s, %s, 2), max_by(%s, %s, 2), max_by(%s, %s, 2) FROM %s",
+                        REAL_NAN_FIRST_COLUMN, REAL_NAN_MIDDLE_COLUMN,
+                        REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN,
+                        REAL_NAN_LAST_COLUMN, REAL_NAN_FIRST_COLUMN,
+                        REAL_NANS_TABLE_NAME),
+                "SELECT ARRAY [REAL '0.0', CAST(infinity() AS REAL)], ARRAY[REAL '2.0', CAST(nan() AS REAL)], ARRAY[REAL '1.0', REAL '0.0']");
+    }
+
+    @Test
+    public void testDoubleSetAgg()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT set_agg(%s), set_agg(%s) FROM %s", DOUBLE_DISTINCT1_COLUMN, DOUBLE_DISTINCT2_COLUMN, DISTINCT_TABLE_NAME), "SELECT ARRAY[nan(), 0.0, null, 3.0], ARRAY[0, nan(), null, 3.0]");
+    }
+
+    @Test
+    public void testRealSetAgg()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT set_agg(%s), set_agg(%s) FROM %s", REAL_DISTINCT1_COLUMN, REAL_DISTINCT2_COLUMN, DISTINCT_TABLE_NAME),
+                "SELECT ARRAY[cast(nan() as REAL), 0.0, null, REAL '3.0'], ARRAY[REAL '0.0', cast(nan() as REAL), null, REAL '3.0']");
+    }
+
+    @Test
+    public void testDoubleSetUnion()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(set_union(%s)) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT ARRAY[-1, 0, 1, 200, nan(), null]");
+    }
+
+    @Test
+    public void testRealSetUnion()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(set_union(%s)) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT ARRAY[REAL '-1', REAL '0', REAL '1', REAL '200', CAST(nan() AS REAL), null]");
+    }
+
+    @Test
+    public void testDoubleHistogram()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT histogram(%s), histogram(%s) FROM %s", DOUBLE_DISTINCT1_COLUMN, DOUBLE_DISTINCT2_COLUMN, DISTINCT_TABLE_NAME),
+                "SELECT MAP(ARRAY[nan(), 0.0, 3.0], ARRAY[BIGINT '2', BIGINT '2', BIGINT '1']), MAP(ARRAY[0.0, nan(),  3.0], ARRAY[BIGINT '2', BIGINT '2', BIGINT '1'])");
+    }
+
+    @Test
+    public void testRealHistogram()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT histogram(%s), histogram(%s) FROM %s", REAL_DISTINCT1_COLUMN, REAL_DISTINCT2_COLUMN, DISTINCT_TABLE_NAME),
+                "SELECT MAP(ARRAY[CAST(nan() AS REAL), REAL '0.0', 3.0], ARRAY[BIGINT '2', BIGINT '2', BIGINT '1']), MAP(ARRAY[REAL '0.0', CAST(nan() AS REAL), REAL '3.0'], ARRAY[BIGINT '2', BIGINT '2', BIGINT '1'])");
+    }
+
+    @Test
+    public void testDoubleMapAgg()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(map_keys(map_agg(%1$s, %3$s))), array_sort(map_keys(map_agg(%2$s, %3$s)))  FROM %4$s WHERE %1$s IS NOT NULL AND %2$s IS NOT NULL",
+                        DOUBLE_DISTINCT1_COLUMN, DOUBLE_DISTINCT2_COLUMN, EXTRA_DISTINCT_COLUMN, DISTINCT_TABLE_NAME),
+                "SELECT ARRAY[0.0, 3.0, nan()], ARRAY[0.0, 3.0, nan()]");
+    }
+
+    @Test
+    public void testRealMapAgg()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(map_keys(map_agg(%1$s, %3$s))), array_sort(map_keys(map_agg(%2$s, %3$s)))  FROM %4$s WHERE %1$s IS NOT NULL AND %2$s IS NOT NULL",
+                        REAL_DISTINCT1_COLUMN, REAL_DISTINCT2_COLUMN, EXTRA_DISTINCT_COLUMN, DISTINCT_TABLE_NAME),
+                "SELECT ARRAY[REAL '0.0', REAL '3.0', CAST(nan() AS REAL)], ARRAY[REAL '0.0', REAL '3.0', CAST(nan() AS REAL)]");
+    }
+
+    @Test
+    public void testDoubleMapUnion()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(map_keys(map_union(%s))) FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT ARRAY[1, 2, nan()]");
+    }
+
+    @Test
+    public void testRealMapUnion()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(map_keys(map_union(%s))) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT ARRAY[REAL '1', REAL '2', CAST(nan() AS REAL)]");
+    }
+
+    @Test
+    public void testDoubleMapUnionSum()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT map_union_sum(%s) FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT MAP(ARRAY[1, 2, nan()], ARRAY[300, 600, nan()])");
+    }
+
+    @Test
+    public void testRealMapUnionSum()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT map_union_sum(%s) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT MAP(ARRAY[REAL '1', REAL '2', CAST(nan() AS REAL)], ARRAY[REAL '300', REAL '600', CAST(nan() AS REAL)])");
+    }
+
+    @Test
+    public void testDoubleMultimapAgg()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT multimap_agg(%1$s, %3$s), multimap_agg(%2$s, %3$s)  FROM %4$s WHERE %1$s IS NOT NULL AND %2$s IS NOT NULL",
+                        DOUBLE_DISTINCT1_COLUMN, DOUBLE_DISTINCT2_COLUMN, EXTRA_DISTINCT_COLUMN, DISTINCT_TABLE_NAME),
+                "SELECT MAP(ARRAY[nan(), 0.0, 3.0], ARRAY[ARRAY['a', 'd'], ARRAY['b', 'f'], ARRAY['e']]), MAP(ARRAY[0.0, nan(), 3.0], ARRAY[ARRAY['a', 'f'], ARRAY['b', 'd'], ARRAY['e']])");
+    }
+
+    @Test
+    public void testRealMultimapAgg()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT multimap_agg(%1$s, %3$s), multimap_agg(%2$s, %3$s)  FROM %4$s WHERE %1$s IS NOT NULL AND %2$s IS NOT NULL",
+                        REAL_DISTINCT1_COLUMN, REAL_DISTINCT2_COLUMN, EXTRA_DISTINCT_COLUMN, DISTINCT_TABLE_NAME),
+                "SELECT " +
+                        "MAP(ARRAY[CAST(nan() AS REAL), REAL '0.0', REAL '3.0'], ARRAY[ARRAY['a', 'd'], ARRAY['b', 'f'], ARRAY['e']]), " +
+                        "MAP(ARRAY[REAL '0.0', CAST(nan() AS REAL), REAL '3.0'], ARRAY[ARRAY['a', 'f'], ARRAY['b', 'd'], ARRAY['e']])");
+    }
+
+    @Test
+    public void testDoubleAllMatch()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT all_match(%s, x -> x = nan()) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (false), (false), (false), (null), (false), (true), (false))");
+    }
+
+    @Test
+    public void testRealAllMatch()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT all_match(%s, x -> x = nan()) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (false), (false), (false), (null), (false), (true), (false))");
+    }
+
+    @Test
+    public void testDoubleAnyMatch()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT any_match(%s, x -> x = nan()) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true), (null), (true), (true), (true))");
+    }
+
+    @Test
+    public void testRealAnyMatch()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT any_match(%s, x -> x = nan()) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true), (null), (true), (true), (true))");
+    }
+
+    @Test
+    public void testDoubleArrayDistinct()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_distinct(%s)) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[-1, 0, 1, nan()]), (ARRAY[-1, 0, 1, nan()]), (ARRAY[-1, 0, 1, nan()]), (ARRAY[200, nan(), null]), (null), (ARRAY[nan()]), (ARRAY[-1, 0, 1, nan()]))");
+    }
+
+    @Test
+    public void testRealArrayDistinct()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_distinct(%s)) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '200', CAST(nan() AS REAL), null]), (null), (ARRAY[CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]))");
+    }
+
+    @Test
+    public void testDoubleArrayDuplicates()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_duplicates(%s)) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[]), (ARRAY[]), (ARRAY[]), (ARRAY[]), (null), (ARRAY[nan()]), (ARRAY[0, 1, nan()]))");
+    }
+
+    @Test
+    public void testRealArrayDuplicates()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_duplicates(%s)) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[]), (ARRAY[]), (ARRAY[]), (ARRAY[]), (null), (ARRAY[CAST(nan() AS REAL)]), (ARRAY[REAL '0', REAL '1', CAST(nan() AS REAL)]))");
+    }
+
+    @Test
+    public void testDoubleArrayExcept()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_except(%s, ARRAY[nan()])) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1']), (ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1']), (ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1']), (ARRAY[DOUBLE '200', null]), (null), (ARRAY[]), (ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1']))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_except(ARRAY[nan()], %s)) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[]), (ARRAY[]), (ARRAY[]), (ARRAY[]), (null), (ARRAY[]), (ARRAY[]))");
+    }
+
+    @Test
+    public void testRealArrayExcept()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_except(%s, ARRAY[CAST(nan() AS REAL)])) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM " +
+                        "(VALUES (ARRAY[REAL '-1', REAL '0', REAL '1']), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1']), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1']), (ARRAY[REAL '200', null]), " +
+                        "(null), " +
+                        "(ARRAY[]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1']))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_except(ARRAY[cast(nan() AS REAL)], %s)) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[]), (ARRAY[]), (ARRAY[]), (ARRAY[]), (null), (ARRAY[]), (ARRAY[]))");
+    }
+
+    @Test
+    public void testDoubleArrayFrequency()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_frequency(filter(%s, x -> x IS NOT NULL)) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(map(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()], ARRAY[1, 1, 1, 1])), " +
+                        "(map(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()], ARRAY[1, 1, 1, 1])), " +
+                        "(map(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()], ARRAY[1, 1, 1, 1])), " +
+                        "(map(ARRAY[DOUBLE '200', nan()], ARRAY[1, 1])), " +
+                        "(null), " +
+                        "(map(ARRAY[nan()], ARRAY[2])), " +
+                        "(map(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()], ARRAY[1, 2, 3, 2])))");
+    }
+
+    @Test
+    public void testRealArrayFrequency()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_frequency(filter(%s, x -> x IS NOT NULL)) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(map(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)], ARRAY[1, 1, 1, 1])), " +
+                        "(map(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)], ARRAY[1, 1, 1, 1])), " +
+                        "(map(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)], ARRAY[1, 1, 1, 1])), " +
+                        "(map(ARRAY[REAL '200', CAST(nan() AS REAL)], ARRAY[1, 1])), " +
+                        "(null), " +
+                        "(map(ARRAY[CAST(nan() AS REAL)], ARRAY[2])), " +
+                        "(map(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)], ARRAY[1, 2, 3, 2])))");
+    }
+
+    @Test
+    public void testDoubleArrayHasDuplicates()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_has_duplicates(%s) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (false), (false), (false), (false), (null), (true), (true))");
+    }
+
+    @Test
+    public void testRealArrayHasDuplicates()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_has_duplicates(%s) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (false), (false), (false), (false), (null), (true), (true))");
+    }
+
+    @Test
+    public void testDoubleArrayIntersect1()
+    {
+        // Testing the two argument function signature
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_intersect(%s, ARRAY[nan()])) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan()]), (ARRAY[nan()]), (ARRAY[nan()]), (ARRAY[nan()]), (null), (ARRAY[nan()]), (ARRAY[nan()]))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_intersect(ARRAY[nan()], %s)) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan()]), (ARRAY[nan()]), (ARRAY[nan()]), (ARRAY[nan()]), (null), (ARRAY[nan()]), (ARRAY[nan()]))");
+    }
+
+    @Test
+    public void testRealArrayIntersect()
+    {
+        // Testing the two argument function signature
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_intersect(%s, ARRAY[nan()])) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan()]), (ARRAY[nan()]), (ARRAY[nan()]), (ARRAY[nan()]), (null), (ARRAY[nan()]), (ARRAY[nan()]))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_intersect(ARRAY[nan()], %s)) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan()]), (ARRAY[nan()]), (ARRAY[nan()]), (ARRAY[nan()]), (null), (ARRAY[nan()]), (ARRAY[nan()]))");
+    }
+
+    @Test
+    public void testDoubleArrayIntersect2()
+    {
+        // Test the array of arrays function signature
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_intersect(array_agg(%s))) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan()]))");
+    }
+
+    @Test
+    public void testRealArrayIntersect2()
+    {
+        // Test the array of arrays function signature
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_intersect(array_agg(%s))) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[CAST(nan() AS REAL)]))");
+    }
+
+    @Test
+    public void testDoubleArrayLeastFrequent()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_least_frequent(%s) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[-1]), (ARRAY[-1]), (ARRAY[-1]), (ARRAY[200]), (null), (ARRAY[nan()]), (ARRAY[-1]))");
+    }
+
+    @Test
+    public void testRealArrayLeastFrequent()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_least_frequent(%s) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[REAL '-1']), (ARRAY[REAL '-1']), (ARRAY[REAL '-1']), (ARRAY[REAL '200']), (null), (ARRAY[CAST(nan() AS REAL)]), (ARRAY[REAL '-1']))");
+    }
+
+    @Test
+    public void testDoubleArrayLeastFrequentN()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_least_frequent(%s, 3) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[-1, 0 , 1]), (ARRAY[-1, 0, 1]), (ARRAY[-1, 0, 1]), (ARRAY[200, nan()]), (null), (ARRAY[nan()]), (ARRAY[-1, 0, nan()]))");
+    }
+
+    @Test
+    public void testRealArrayLeastFrequentN()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_least_frequent(%s, 3) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[REAL '-1', REAL '0' , REAL '1']), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1']), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1']), " +
+                        "(ARRAY[REAL '200', CAST(nan() AS REAL)]), " +
+                        "(null), " +
+                        "(ARRAY[CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', CAST(nan() AS REAL)]))");
+    }
+
+    @Test
+    public void testDoubleArrayMax()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_max(%s) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (nan()), (nan()), (nan()), (null), (null), (nan()), (nan()))");
+    }
+
+    @Test
+    public void testRealArrayMax()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_max(%s) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (CAST(nan() AS REAL)), (CAST(nan() AS REAL)), (CAST(nan() AS REAL)), (null), (null), (CAST(nan() AS REAL)), (CAST(nan() AS REAL)))");
+    }
+
+    @Test
+    public void testDoubleArrayMaxBy()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_max_by(%s, x -> x + 1) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (nan()), (nan()), (nan()), (null), (null), (nan()), (nan()))");
+    }
+
+    @Test
+    public void testRealArrayMaxBy()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_max_by(%s, x -> x +1) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (CAST(nan() AS REAL)), (CAST(nan() AS REAL)), (CAST(nan() AS REAL)), (null), (null), (CAST(nan() AS REAL)), (CAST(nan() AS REAL)))");
+    }
+
+    @Test
+    public void testDoubleArrayMin()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_min(%s) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (-1), (-1), (-1), (null), (null), (nan()), (-1))");
+    }
+
+    @Test
+    public void testRealArrayMin()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_min(%s) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (REAL '-1'), (REAL '-1'), (REAL '-1'), (null), (null), (CAST(nan() AS REAL)), (REAL '-1'))");
+    }
+
+    @Test
+    public void testDoubleArrayMinBy()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_min_by(%s, x -> x + 1) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (-1), (-1), (-1), (null), (null), (nan()), (-1))");
+    }
+
+    @Test
+    public void testRealArrayMinBy()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_min_by(%s, x -> x + 1) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (REAL '-1'), (REAL '-1'), (REAL '-1'), (null), (null), (CAST(nan() AS REAL)), (REAL '-1'))");
+    }
+
+    @Test
+    public void testDoubleArrayPosition()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_position(%s, nan()) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (BIGINT '1'), (BIGINT '2'), (BIGINT '4'), (BIGINT '2'), (null), (BIGINT '1'), (BIGINT '3'))");
+    }
+
+    @Test
+    public void testRealArrayPosition()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_position(%s, nan()) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (BIGINT '1'), (BIGINT '2'), (BIGINT '4'), (BIGINT '2'), (null), (BIGINT '1'), (BIGINT '3'))");
+    }
+
+    @Test
+    public void testDoubleArrayPositionI()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_position(%s, nan(), 2) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (BIGINT '0'), (BIGINT '0'), (BIGINT '0'), (BIGINT '0'), (null), (BIGINT '2'), (BIGINT '5'))");
+    }
+
+    @Test
+    public void testRealArrayPositionI()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_position(%s, nan(), 2) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (BIGINT '0'), (BIGINT '0'), (BIGINT '0'), (BIGINT '0'), (null), (BIGINT '2'), (BIGINT '5'))");
+    }
+
+    @Test
+    public void testDoubleArrayRemove()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_remove(%s, nan()) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[DOUBLE '0', DOUBLE '1', DOUBLE '-1']), " +
+                        "(ARRAY[DOUBLE '0', DOUBLE '1', DOUBLE '-1']), " +
+                        "(ARRAY[DOUBLE '0', DOUBLE '1', DOUBLE '-1']), " +
+                        "(ARRAY[null, DOUBLE '200']), " +
+                        "(null), " +
+                        "(ARRAY[]), " +
+                        "(ARRAY[DOUBLE '0', DOUBLE '1', DOUBLE '-1', DOUBLE '1', DOUBLE '1', DOUBLE '0']))");
+    }
+
+    @Test
+    public void testRealArrayRemove()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_remove(%s, CAST(nan() AS REAL)) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[REAL '0', REAL '1', REAL '-1']), " +
+                        "(ARRAY[REAL '0', REAL '1', REAL '-1']), " +
+                        "(ARRAY[REAL '0', REAL '1', REAL '-1']), " +
+                        "(ARRAY[null, REAL '200']), " +
+                        "(null), " +
+                        "(ARRAY[]), " +
+                        "(ARRAY[REAL '0', REAL '1', REAL '-1', REAL '1', REAL '1', REAL '0']))");
+    }
+
+    @Test
+    public void testDoubleArraySort()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(%s) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[-1, 0, 1, nan()]), (ARRAY[-1, 0, 1, nan()]), (ARRAY[-1, 0, 1, nan()]), (ARRAY[200, nan(), null]), (null), (ARRAY[nan(), nan()]), (ARRAY[-1, 0, 0, 1, 1, 1, nan(), nan()]))");
+    }
+
+    @Test
+    public void testRealArraySort()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(%s) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '200', CAST(nan() AS REAL), null]), " +
+                        "(null), " +
+                        "(ARRAY[CAST(nan() AS REAL), CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '0', REAL '1', REAL '1', REAL '1', CAST(nan() AS REAL), CAST(nan() AS REAL)]))");
+    }
+
+    @Test
+    public void testDoubleArraySortLambda()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(%s, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1))) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[-1, 0, 1, nan()]), (ARRAY[-1, 0, 1, nan()]), (ARRAY[-1, 0, 1, nan()]), (ARRAY[200, nan(), null]), (null), (ARRAY[nan(), nan()]), (ARRAY[-1, 0, 0, 1, 1, 1, nan(), nan()]))");
+    }
+
+    @Test
+    public void testRealArraySortLambda()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(%s, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1))) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '200', CAST(nan() AS REAL), null]), " +
+                        "(null), (ARRAY[CAST(nan() AS REAL), CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '0', REAL'1', REAL '1', REAL '1', CAST(nan() AS REAL), CAST(nan() AS REAL)]))");
+    }
+
+    @Test
+    public void testDoubleArraySortDesc()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort_desc(%s) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan(), 1, 0, -1]), (ARRAY[nan(), 1, 0, -1]), (ARRAY[nan(), 1, 0, -1]), (ARRAY[nan(), 200, null]), (null), (ARRAY[nan(), nan()]), (ARRAY[nan(), nan(), 1, 1, 1, 0, 0, -1]))");
+    }
+
+    @Test
+    public void testRealArraySortDesc()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort_desc(%s) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[CAST(nan() AS REAL), REAL '1', REAL '0', REAL '-1']), " +
+                        "(ARRAY[CAST(nan() AS REAL), REAL '1', REAL '0', REAL '-1']), " +
+                        "(ARRAY[CAST(nan() AS REAL), REAL '1', REAL '0', REAL '-1']), " +
+                        "(ARRAY[CAST(nan() AS REAL), REAL '200', null])," +
+                        " (null)," +
+                        " (ARRAY[CAST(nan() AS REAL), CAST(nan() AS REAL)]), " +
+                        "(ARRAY[CAST(nan() AS REAL), CAST(nan() AS REAL), REAL '1', REAL '1', REAL '1', REAL '0', REAL '0', REAL '-1']))");
+    }
+
+    @Test
+    public void testDoubleArrayTopN()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_top_n(%s, 2) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan(), 1]), (ARRAY[nan(), 1]), (ARRAY[nan(), 1]), (ARRAY[nan(), 200]), (null), (ARRAY[nan(), nan()]), (ARRAY[nan(), nan()]))");
+    }
+
+    @Test
+    public void testRealArrayTopN()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_top_n(%s, 2) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[CAST(nan() AS REAL), REAL '1']), " +
+                        "(ARRAY[CAST(nan() AS REAL), REAL '1']), " +
+                        "(ARRAY[CAST(nan() AS REAL), REAL '1']), " +
+                        "(ARRAY[CAST(nan() AS REAL), REAL '200'])," +
+                        " (null)," +
+                        " (ARRAY[CAST(nan() AS REAL), CAST(nan() AS REAL)]), " +
+                        "(ARRAY[CAST(nan() AS REAL), CAST(nan() AS REAL)]))");
+    }
+
+    @Test
+    public void testDoubleArraysOverlap()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT arrays_overlap(%s, ARRAY[nan()]) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true), (true), (null), (true), (true))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT arrays_overlap(ARRAY[nan()], %s) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true), (true), (null), (true), (true))");
+    }
+
+    @Test
+    public void testRealArraysOverlap()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT arrays_overlap(%s, ARRAY[nan()]) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true), (true), (null), (true), (true))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT arrays_overlap(ARRAY[nan()], %s) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true), (true), (null), (true), (true))");
+    }
+
+    @Test
+    public void testDoubleArrayUnion()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_union(%s, ARRAY[nan()])) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()]), " +
+                        "(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()]), " +
+                        "(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()]), " +
+                        "(ARRAY[DOUBLE '200', nan(), null]), " +
+                        "(null), " +
+                        "(ARRAY[nan()]), " +
+                        "(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()]))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_union(ARRAY[nan()], %s)) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()]), " +
+                        "(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()]), " +
+                        "(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()]), " +
+                        "(ARRAY[DOUBLE '200', nan(), null]), " +
+                        "(null), " +
+                        "(ARRAY[nan()]), " +
+                        "(ARRAY[DOUBLE '-1', DOUBLE '0', DOUBLE '1', nan()]))");
+    }
+
+    @Test
+    public void testRealArrayUnion()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_union(%s, ARRAY[CAST(nan() AS REAL)])) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '200', CAST(nan() AS REAL), null]), " +
+                        "(null), " +
+                        "(ARRAY[CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]))");
+        assertQueryWithSameQueryRunner(
+                format("SELECT array_sort(array_union(ARRAY[CAST(nan() AS REAL)], %s)) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '200', CAST(nan() AS REAL), null]), " +
+                        "(null), " +
+                        "(ARRAY[CAST(nan() AS REAL)]), " +
+                        "(ARRAY[REAL '-1', REAL '0', REAL '1', CAST(nan() AS REAL)]))");
+    }
+
+    @Test
+    public void testDoubleContains()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT contains(%s, nan()) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true), (true), (null), (true), (true))");
+    }
+
+    @Test
+    public void testRealContains()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT contains(%s, CAST(nan() AS REAL)) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true), (true), (null), (true), (true))");
+    }
+
+    @Test
+    public void testDoubleNoneMatch()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT none_match(%s, x -> x = nan()) FROM %s", SIMPLE_DOUBLE_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (false), (false), (false), (null), (false), (false), (false))");
+    }
+
+    @Test
+    public void testRealNoneMatch()
+    {
+        assertQueryWithSameQueryRunner(
+                format("SELECT none_match(%s, x -> x = nan()) FROM %s", SIMPLE_REAL_ARRAY_COLUMN, ARRAY_TABLE_NAME),
+                "SELECT * FROM (VALUES (false), (false), (false), (null), (false), (false), (false))");
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Duplicate map keys \\(NaN\\) are not allowed")
+    public void testDoubleMapDuplicateKeys()
+    {
+        computeActual("select MAP(array[1, nan(), nan()], array['a', 'b','c'])");
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Duplicate map keys \\(NaN\\) are not allowed")
+    public void testRealMapDuplicateKeys()
+    {
+        computeActual("select MAP(array[REAL '1', CAST(nan() AS REAL), CAST(nan() AS REAL)], array['a', 'b','c'])");
+    }
+
+    @Test
+    public void testDoubleMapAccessor()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %s[nan()] FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (nan()), (nan()), (nan()))");
+    }
+
+    @Test
+    public void testRealMapAccessor()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %s[CAST(nan() AS REAL)] FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (CAST(nan() AS REAL)), CAST(nan() AS REAL), CAST(nan() AS REAL))");
+    }
+
+    @Test
+    public void testDoubleElementAt()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT element_at(%s, nan()) FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (nan()), (nan()), (nan()))");
+    }
+
+    @Test
+    public void testRealElementAt()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT element_at(%s, nan()) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (CAST(nan() AS REAL)), CAST(nan() AS REAL), CAST(nan() AS REAL))");
+    }
+
+    @Test
+    public void testDoubleMapSubset()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_subset(%s, ARRAY[nan()]) FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (MAP(ARRAY[nan()], ARRAY[nan()])), (MAP(ARRAY[nan()], ARRAY[nan()])), (MAP(ARRAY[nan()], ARRAY[nan()])))");
+    }
+
+    @Test
+    public void testRealMapSubset()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_subset(%s, ARRAY[CAST(nan() AS REAL)]) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (MAP(ARRAY[CAST(nan() AS REAL)], ARRAY[CAST(nan() AS REAL)])), (MAP(ARRAY[CAST(nan() AS REAL)], ARRAY[CAST(nan() AS REAL)])), (MAP(ARRAY[CAST(nan() AS REAL)], ARRAY[CAST(nan() AS REAL)])))");
+    }
+
+    @Test
+    public void testDoubleMapKeyExists()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_key_exists(%s, nan()) FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true))");
+    }
+
+    @Test
+    public void testRealMapKeyExists()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_key_exists(%s, CAST(nan() AS REAL)) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (true), (true), (true))");
+    }
+
+    @Test
+    public void testDoubleMapToNKeys()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_top_n_keys(%s, 2) FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan(), 2]), (ARRAY[nan(), 2]), (ARRAY[nan(), 2]))");
+    }
+
+    @Test
+    public void testRealMapToNKey()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_top_n_keys(%s, 2) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[CAST(nan() AS REAL), REAL '2']), (ARRAY[CAST(nan() AS REAL), REAL '2']), (ARRAY[CAST(nan() AS REAL), REAL '2']))");
+    }
+
+    @Test
+    public void testDoubleMapKeysByTopNValues()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_keys_by_top_n_values(%s, 2) FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan(), 2]), (ARRAY[nan(), 2]), (ARRAY[nan(), 2]))");
+    }
+
+    @Test
+    public void testRealMapKeysByTopNValues()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_keys_by_top_n_values(%s, 2) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[CAST(nan() AS REAL), REAL '2']), (ARRAY[CAST(nan() AS REAL), REAL '2']), (ARRAY[CAST(nan() AS REAL), REAL '2']))");
+    }
+
+    @Test
+    public void testDoubleMapToN()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_top_n(%s, 2) FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (MAP(ARRAY[nan(), 2], ARRAY[nan(), 200])), (MAP(ARRAY[nan(), 2], ARRAY[nan(), 200])), (MAP(ARRAY[nan(), 2], ARRAY[nan(), 200])))");
+    }
+
+    @Test
+    public void testRealMapToN()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_top_n(%s, 2) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES " +
+                        "(MAP(ARRAY[CAST(nan() AS REAL), REAL '2'], ARRAY[CAST(nan() AS REAL), REAL '200'])), " +
+                        "(MAP(ARRAY[CAST(nan() AS REAL), REAL '2'], ARRAY[CAST(nan() AS REAL), REAL '200'])), " +
+                        "(MAP(ARRAY[CAST(nan() AS REAL), REAL '2'], ARRAY[CAST(nan() AS REAL), REAL '200'])))");
+    }
+
+    @Test
+    public void testRealMapToNKeys()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_top_n_keys(%s, 2) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[CAST(nan() AS REAL), REAL '2']), (ARRAY[CAST(nan() AS REAL), REAL '2']), (ARRAY[CAST(nan() AS REAL), REAL '2']))");
+    }
+
+    @Test
+    public void testDoubleMapToNValues()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_top_n_values(%s, 2) FROM %s", DOUBLE_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[nan(), 200]), (ARRAY[nan(), 200]), (ARRAY[nan(), 200]))");
+    }
+
+    @Test
+    public void testRealMapToNValues()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT map_top_n_values(%s, 2) FROM %s", REAL_MAP_COLUMN, MAP_TABLE_NAME),
+                "SELECT * FROM (VALUES (ARRAY[CAST(nan() AS REAL), REAL '200']), (ARRAY[CAST(nan() AS REAL), REAL '200']), (ARRAY[CAST(nan() AS REAL), REAL '200']))");
+    }
+
+    @Test
+    public void testDoubleOrderBy()
+    {
+        assertQueryOrderedWithSameQueryRunner(format("SELECT %s FROM %s ORDER BY 1", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(-4), (0), (infinity()), (nan()))");
+        assertQueryOrderedWithSameQueryRunner(format("SELECT %s FROM %s ORDER BY 1 DESC", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(nan()), (infinity()), (0), (-4))");
+    }
+
+    @Test
+    public void testRealOrderBy()
+    {
+        assertQueryOrderedWithSameQueryRunner(format("SELECT %s FROM %s ORDER BY 1", REAL_NAN_FIRST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(REAL '-4'), (REAL '0'), (CAST(infinity() AS REAL)), (CAST(nan() AS REAL)))");
+        assertQueryOrderedWithSameQueryRunner(format("SELECT %s FROM %s ORDER BY 1 DESC", REAL_NAN_FIRST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(CAST(nan() AS REAL)), (CAST(infinity() AS REAL)), (REAL '0'), (REAL '-4'))");
+    }
+
+    @Test
+    public void testDoubleOrderByLimit()
+    {
+        assertQueryOrderedWithSameQueryRunner(format("SELECT %s FROM %s ORDER BY 1 LIMIT 2", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(DOUBLE '-4.0'), (DOUBLE '0.0'))");
+        assertQueryOrderedWithSameQueryRunner(format("SELECT %s FROM %s ORDER BY 1 DESC LIMIT 2", DOUBLE_NAN_FIRST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(nan()), (infinity()))");
+    }
+
+    @Test
+    public void testRealOrderByLimit()
+    {
+        assertQueryOrderedWithSameQueryRunner(format("SELECT %s FROM %s ORDER BY 1 LIMIT 2", REAL_NAN_FIRST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(REAL '-4'), (REAL '0'))");
+        assertQueryOrderedWithSameQueryRunner(format("SELECT %s FROM %s ORDER BY 1 DESC LIMIT 2", REAL_NAN_FIRST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(CAST(nan() AS REAL)), (CAST(infinity() AS REAL)))");
+    }
+
+    @Test
+    public void testDoubleInnerJoin()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %1$s FROM (SELECT %1$s from %3$s) JOIN (SELECT %2$s FROM %3$s) on %1$s = %2$s", DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(DOUBLE '0'), (DOUBLE '2'), (nan()))");
+    }
+
+    @Test
+    public void testRealInnerJoin()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %1$s FROM (SELECT %1$s from %3$s) JOIN (SELECT %2$s FROM %3$s) on %1$s = %2$s", REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(REAL '0'), (REAL '2'), (CAST(nan() AS REAL)))");
+    }
+
+    @Test
+    public void testDoubleLeftJoin()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %1$s, %2$s FROM (SELECT %1$s from %3$s) LEFT JOIN (SELECT %2$s FROM %3$s) on %1$s = %2$s", DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(DOUBLE '0', DOUBLE '0'), (DOUBLE '2', DOUBLE '2'), (nan(), nan()), (DOUBLE '3', null))");
+    }
+
+    @Test
+    public void testRealLeftJoin()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %1$s, %2$s FROM (SELECT %1$s from %3$s) LEFT JOIN (SELECT %2$s FROM %3$s) on %1$s = %2$s", REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(REAL '0', REAL '0'), (REAL '2', REAL '2'), (CAST(nan() AS REAL), CAST(nan() AS REAL)), (REAL '3', null))");
+    }
+
+    @Test
+    public void testDoubleRightJoin()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %1$s, %2$s FROM (SELECT %1$s from %3$s) RIGHT JOIN (SELECT %2$s FROM %3$s) on %1$s = %2$s", DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(DOUBLE '0', DOUBLE '0'), (DOUBLE '2', DOUBLE '2'), (nan(), nan()), (null, DOUBLE '1'))");
+    }
+
+    @Test
+    public void testRealRightJoin()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %1$s, %2$s FROM (SELECT %1$s from %3$s) RIGHT JOIN (SELECT %2$s FROM %3$s) on %1$s = %2$s", REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(REAL '0', REAL '0'), (REAL '2', REAL '2'), (CAST(nan() AS REAL), CAST(nan() AS REAL)), (null, REAL '1'))");
+    }
+
+    @Test
+    public void testDoubleFullJoin()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %1$s, %2$s FROM (SELECT %1$s from %3$s) FULL OUTER JOIN (SELECT %2$s FROM %3$s) on %1$s = %2$s", DOUBLE_NAN_MIDDLE_COLUMN, DOUBLE_NAN_LAST_COLUMN, DOUBLE_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(DOUBLE '0', DOUBLE '0'), (DOUBLE '2', DOUBLE '2'), (nan(), nan()), (DOUBLE '3', null), (null, DOUBLE '1'))");
+    }
+
+    @Test
+    public void testRealFullJoin()
+    {
+        assertQueryWithSameQueryRunner(format("SELECT %1$s, %2$s FROM (SELECT %1$s from %3$s) FULL OUTER JOIN (SELECT %2$s FROM %3$s) on %1$s = %2$s", REAL_NAN_MIDDLE_COLUMN, REAL_NAN_LAST_COLUMN, REAL_NANS_TABLE_NAME),
+                "SELECT * FROM (VALUES(REAL '0', REAL '0'), (REAL '2', REAL '2'), (CAST(nan() AS REAL), CAST(nan() AS REAL)), (REAL '3', null), (null, REAL '1'))");
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestNanQueries.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests;
+
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static java.lang.String.format;
+
+public abstract class AbstractTestNanQueries
+        extends AbstractTestQueryFramework
+{
+    public static final String DOUBLE_NANS_TABLE_NAME = "double_nans_table";
+    public static final String DOUBLE_NAN_FIRST_COLUMN = "_double_nan_first";
+    public static final String DOUBLE_NAN_MIDDLE_COLUMN = "_double_nan_middle";
+    public static final String DOUBLE_NAN_LAST_COLUMN = "_double_nan_last";
+
+    public static final String REAL_NANS_TABLE_NAME = "real_nans_table";
+
+    @BeforeClass
+    public void setup()
+    {
+        @Language("SQL") String createDoubleTableQuery = "" +
+                "CREATE TABLE " + DOUBLE_NANS_TABLE_NAME + " AS " +
+                "SELECT * FROM (VALUES " +
+                "(nan(), 0.0, 1.0)," +
+                " (0.0, nan(), 2.0)," +
+                "( infinity(), 3.0,  0.0)," +
+                "( -4.0, 2.0, nan())) as t (_double_nan_first, _double_nan_middle, _double_nan_last)";
+        assertUpdate(createDoubleTableQuery, 4);
+
+        @Language("SQL") String createFloatTableQuery = "" +
+                "CREATE TABLE " + REAL_NANS_TABLE_NAME + " AS " +
+                "SELECT * FROM (VALUES " +
+                "(CAST(nan() as REAL), CAST(0 AS REAL), CAST(1 AS REAL))," +
+                " (CAST(0 as REAL), CAST(nan() AS REAL), CAST(2 AS REAL))," +
+                "(CAST(infinity() AS REAL), CAST(3 AS REAL),  CAST(0 AS REAL))," +
+                "( CAST(-4 AS REAL), CAST(2 AS REAL), CAST(nan() AS REAL))) as t (_real_nan_first, _real_nan_middle, _real_nan_last)";
+        assertUpdate(createFloatTableQuery, 4);
+    }
+
+    @AfterClass
+    public void tearDown()
+    {
+        assertUpdate("DROP TABLE " + DOUBLE_NANS_TABLE_NAME);
+        assertUpdate("DROP TABLE " + REAL_NANS_TABLE_NAME);
+    }
+
+    @Test
+    public void testDoubleLessThan()
+    {
+        assertQuery("SELECT nan() < 1.0", "SELECT false");
+        assertQuery("SELECT infinity() < nan()", "SELECT true");
+        assertQuery("SELECT nan() < infinity()", "SELECT false");
+        assertQuery("SELECT nan() < nan()", "SELECT false");
+        assertQuery(format("SELECT _double_nan_first < nan() from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+        assertQuery(format("SELECT nan() < _double_nan_first from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (false), (false), (false))");
+    }
+
+    @Test
+    public void testDoubleGreaterThan()
+    {
+        assertQuery("SELECT nan() > 1.0", "SELECT true");
+        assertQuery("SELECT infinity() > nan()", "SELECT false");
+        assertQuery("SELECT nan() > infinity()", "SELECT true");
+        assertQuery("SELECT nan() > nan()", "SELECT false");
+        assertQuery(format("SELECT _double_nan_first > nan() from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (false), (false), (false))");
+        assertQuery(format("SELECT nan() > _double_nan_first from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+    }
+
+    @Test
+    @Test
+    public void testDoubleLessThanOrEqualTo()
+    {
+        assertQuery("SELECT nan() <= 1.0", "SELECT false");
+        assertQuery("SELECT infinity() <= nan()", "SELECT true");
+        assertQuery("SELECT nan() <= infinity()", "SELECT false");
+        assertQuery("SELECT nan() <= nan()", "SELECT true");
+        assertQuery(format("SELECT _double_nan_first <= nan() from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (true), (true), (true))");
+        assertQuery(format("SELECT nan() <= _double_nan_first from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+    }
+
+    @Test
+    public void testDoubleGreaterThanOrEqualTo()
+    {
+        assertQuery("SELECT nan() >= 1.0", "SELECT true");
+        assertQuery("SELECT infinity() >= nan()", "SELECT false");
+        assertQuery("SELECT nan() >= infinity()", "SELECT true");
+        assertQuery("SELECT nan() >= nan()", "SELECT true");
+        assertQuery(format("SELECT _double_nan_first >= nan() from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+        assertQuery(format("SELECT nan() >= _double_nan_first from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (true), (true), (true))");
+    }
+
+    @Test
+    public void testDoubleEquals()
+    {
+        assertQuery("SELECT nan() = nan()", "SELECT true");
+        assertQuery("SELECT nan() = 3", "SELECT false");
+        assertQuery(format("SELECT _double_nan_first = nan() from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+        assertQuery(format("SELECT nan() = _double_nan_first from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+    }
+
+    @Test
+    public void testDoubleNotEquals()
+    {
+        assertQuery("SELECT nan() <> nan()", "SELECT false");
+        assertQuery("SELECT nan() <> 3", "SELECT true");
+        assertQuery(format("SELECT _double_nan_first <> nan() from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+        assertQuery(format("SELECT nan() <> _double_nan_first from %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+    }
+    @Test
+    public void testDoubleBetween()
+    {
+        assertQuery(format("SELECT nan() BETWEEN -infinity() AND _double_nan_first FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+        assertQuery(format("SELECT _double_nan_first BETWEEN -infinity() AND nan() FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES(true), (true), (true), (true))");
+    }
+
+    @Test
+    public void testDoubleIn()
+    {
+        assertQuery(format("SELECT nan() IN (1, 2, _double_nan_first) FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (true), (false), (false), (false))");
+        assertQuery(format("SELECT _double_nan_first IN (nan(), 0, 6)FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES(true), (true), (false), (false))");
+    }
+
+    @Test
+    public void testDoubleNotIn()
+    {
+        assertQuery(format("SELECT nan() NOT IN (1, 2, _double_nan_first) FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES (false), (true), (true), (true))");
+        assertQuery(format("SELECT _double_nan_first NOT IN (nan(), 0, 6)FROM %s", DOUBLE_NANS_TABLE_NAME), "SELECT * FROM (VALUES(false), (false), (true), (true))");
+    }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -176,6 +176,12 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertQuery(queryRunner, session, actual, queryRunner, expected, false, false);
     }
 
+    protected void assertQueryOrderedWithSameQueryRunner(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        checkArgument(!actual.equals(expected));
+        QueryAssertions.assertQuery(queryRunner, getSession(), actual, queryRunner, expected, true, false);
+    }
+
     protected void assertQueryWithSameQueryRunner(Session actualSession, @Language("SQL") String query, Session expectedSession)
     {
         QueryAssertions.assertQuery(queryRunner, actualSession, query, queryRunner, expectedSession, query, false, false);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTupleDomainFilterUtils.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTupleDomainFilterUtils.java
@@ -28,6 +28,8 @@ import com.facebook.presto.common.predicate.TupleDomainFilter.DoubleRange;
 import com.facebook.presto.common.predicate.TupleDomainFilter.FloatRange;
 import com.facebook.presto.common.predicate.TupleDomainFilter.LongDecimalRange;
 import com.facebook.presto.common.predicate.TupleDomainFilter.MultiRange;
+import com.facebook.presto.common.predicate.TupleDomainFilter.OldDoubleRange;
+import com.facebook.presto.common.predicate.TupleDomainFilter.OldFloatRange;
 import com.facebook.presto.common.predicate.TupleDomainFilterUtils;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.RowFieldName;
@@ -35,6 +37,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.ExpressionDomainTranslator;
 import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.Symbol;
@@ -80,8 +83,10 @@ import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
 import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.DoubleType.OLD_NAN_DOUBLE;
 import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.OLD_NAN_REAL;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.StandardTypes.ARRAY;
@@ -182,13 +187,50 @@ public class TestTupleDomainFilterUtils
                     TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("field_1", false)), BOOLEAN.getTypeSignature())))))
             .build());
 
+    private static final TypeProvider OLD_NAN_DEFINITION_TYPES = TypeProvider.viewOf(ImmutableMap.<String, Type>builder()
+            .put(C_BIGINT.getName(), BIGINT)
+            .put(C_DOUBLE.getName(), OLD_NAN_DOUBLE)
+            .put(C_VARCHAR.getName(), VARCHAR)
+            .put(C_BOOLEAN.getName(), BOOLEAN)
+            .put(C_BIGINT_1.getName(), BIGINT)
+            .put(C_DOUBLE_1.getName(), OLD_NAN_DOUBLE)
+            .put(C_VARCHAR_1.getName(), VARCHAR)
+            .put(C_TIMESTAMP.getName(), TIMESTAMP)
+            .put(C_DATE.getName(), DATE)
+            .put(C_COLOR.getName(), COLOR) // Equatable, but not orderable
+            .put(C_HYPER_LOG_LOG.getName(), HYPER_LOG_LOG) // Not Equatable or orderable
+            .put(C_VARBINARY.getName(), VARBINARY)
+            .put(C_DECIMAL_26_5.getName(), createDecimalType(26, 5))
+            .put(C_DECIMAL_23_4.getName(), createDecimalType(23, 4))
+            .put(C_INTEGER.getName(), INTEGER)
+            .put(C_CHAR.getName(), createCharType(10))
+            .put(C_DECIMAL_21_3.getName(), createDecimalType(21, 3))
+            .put(C_DECIMAL_12_2.getName(), createDecimalType(12, 2))
+            .put(C_DECIMAL_6_1.getName(), createDecimalType(6, 1))
+            .put(C_DECIMAL_3_0.getName(), createDecimalType(3, 0))
+            .put(C_DECIMAL_2_0.getName(), createDecimalType(2, 0))
+            .put(C_SMALLINT.getName(), SMALLINT)
+            .put(C_TINYINT.getName(), TINYINT)
+            .put(C_REAL.getName(), OLD_NAN_REAL)
+            .put(C_ARRAY.getName(), FUNCTION_AND_TYPE_MANAGER.getParameterizedType(ARRAY, ImmutableList.of(TypeSignatureParameter.of(INTEGER.getTypeSignature()))))
+            .put(C_MAP.getName(), FUNCTION_AND_TYPE_MANAGER.getParameterizedType(MAP, ImmutableList.of(TypeSignatureParameter.of(INTEGER.getTypeSignature()), TypeSignatureParameter.of(BOOLEAN.getTypeSignature()))))
+            .put(C_STRUCT.getName(), FUNCTION_AND_TYPE_MANAGER.getParameterizedType(ROW, ImmutableList.of(
+                    TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("field_0", false)), INTEGER.getTypeSignature())),
+                    TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("field_1", false)), BOOLEAN.getTypeSignature())))))
+            .build());
+
     private Metadata metadata;
+    private Metadata oldNanDefinitionMetadata;
     private LiteralEncoder literalEncoder;
 
     @BeforeClass
     public void setup()
     {
-        metadata = createTestMetadataManager();
+        FeaturesConfig newNanDefinitionConfig = new FeaturesConfig().setUseNewNanDefinition(true);
+        metadata = createTestMetadataManager(newNanDefinitionConfig);
+
+        FeaturesConfig oldNanDefinitionConfig = new FeaturesConfig().setUseNewNanDefinition(false);
+        oldNanDefinitionMetadata = createTestMetadataManager(oldNanDefinitionConfig);
         literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
     }
 
@@ -225,8 +267,10 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(not(greaterThanOrEqual(C_BIGINT, bigintLiteral(2L)))), BigintRange.of(Long.MIN_VALUE, 1L, false));
 
         assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(1, 10, 100_000))), BigintValuesUsingHashTable.of(1, 100_000, new long[] {1, 10, 100_000}, false));
-        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(Long.MIN_VALUE, 10, 100_000))), BigintValuesUsingHashTable.of(Long.MIN_VALUE, 100_000, new long[] {Long.MIN_VALUE, 10, 100_000}, false));
-        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(Long.MIN_VALUE, Long.MAX_VALUE, 0))), BigintValuesUsingHashTable.of(Long.MIN_VALUE, Long.MAX_VALUE, new long[] {Long.MIN_VALUE, 0, Long.MAX_VALUE}, false));
+        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(Long.MIN_VALUE, 10, 100_000))), BigintValuesUsingHashTable.of(Long.MIN_VALUE, 100_000, new long[] {Long.MIN_VALUE, 10,
+                100_000}, false));
+        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(Long.MIN_VALUE, Long.MAX_VALUE, 0))), BigintValuesUsingHashTable.of(Long.MIN_VALUE, Long.MAX_VALUE, new long[] {
+                Long.MIN_VALUE, 0, Long.MAX_VALUE}, false));
         assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(1, 10, 100))), BigintValuesUsingBitmask.of(1, 100, new long[] {1, 10, 100}, false));
         assertEquals(toFilter(not(in(C_BIGINT, ImmutableList.of(1, 10, 100)))), BigintMultiRange.of(ImmutableList.of(
                 BigintRange.of(Long.MIN_VALUE, 0L, false),
@@ -267,39 +311,71 @@ public class TestTupleDomainFilterUtils
     public void testDouble()
     {
         assertEquals(toFilter(equal(C_DOUBLE, doubleLiteral(1.2))), DoubleRange.of(1.2, false, false, 1.2, false, false, false));
+        assertEquals(toFilterWithOldNanDefinition(equal(C_DOUBLE, doubleLiteral(1.2))), OldDoubleRange.of(1.2, false, false, 1.2, false, false, false));
         assertEquals(toFilter(notEqual(C_DOUBLE, doubleLiteral(1.2))), MultiRange.of(ImmutableList.of(
                 DoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
-                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, true));
+                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, false));
+        assertEquals(toFilter(notEqual(C_DOUBLE, doubleLiteral(1.2)), false), MultiRange.of(ImmutableList.of(
+                OldDoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
+                OldDoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, true));
 
         assertEquals(toFilter(in(C_DOUBLE, ImmutableList.of(1.2, 3.4, 5.6))), MultiRange.of(ImmutableList.of(
                 DoubleRange.of(1.2, false, false, 1.2, false, false, false),
                 DoubleRange.of(3.4, false, false, 3.4, false, false, false),
                 DoubleRange.of(5.6, false, false, 5.6, false, false, false)), false, false));
+        assertEquals(toFilter(in(C_DOUBLE, ImmutableList.of(1.2, 3.4, 5.6)), false), MultiRange.of(ImmutableList.of(
+                OldDoubleRange.of(1.2, false, false, 1.2, false, false, false),
+                OldDoubleRange.of(3.4, false, false, 3.4, false, false, false),
+                OldDoubleRange.of(5.6, false, false, 5.6, false, false, false)), false, false));
 
         assertEquals(toFilter(isDistinctFrom(C_DOUBLE, doubleLiteral(1.2))), MultiRange.of(ImmutableList.of(
                 DoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
-                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), true, true));
+                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), true, false));
+        assertEquals(toFilter(isDistinctFrom(C_DOUBLE, doubleLiteral(1.2)), false), MultiRange.of(ImmutableList.of(
+                OldDoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
+                OldDoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), true, true));
 
         assertEquals(toFilter(between(C_DOUBLE, doubleLiteral(1.2), doubleLiteral(3.4))), DoubleRange.of(1.2, false, false, 3.4, false, false, false));
+        assertEquals(toFilterWithOldNanDefinition(between(C_DOUBLE, doubleLiteral(1.2), doubleLiteral(3.4))), OldDoubleRange.of(1.2, false, false, 3.4, false, false, false));
 
-        assertEquals(toFilter(lessThan(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
-        assertEquals(toFilter(lessThanOrEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
-        assertEquals(toFilter(greaterThanOrEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
-        assertEquals(toFilter(greaterThan(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
-        assertEquals(toFilter(notEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+        assertEquals(toFilter(lessThan(C_DOUBLE, doubleLiteral(Double.NaN))), DoubleRange.of(Double.MIN_VALUE, true, true, Double.NaN, false, true, false));
+        assertEquals(toFilterWithOldNanDefinition(lessThan(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+
+        assertEquals(toFilter(lessThanOrEqual(C_DOUBLE, doubleLiteral(Double.NaN))), DoubleRange.of(Double.MIN_VALUE, true, true, Double.NaN, false, false, false));
+        assertEquals(toFilterWithOldNanDefinition(lessThanOrEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+        assertEquals(toFilter(greaterThanOrEqual(C_DOUBLE, doubleLiteral(Double.NaN))), DoubleRange.of(Double.NaN, false, false, Double.MAX_VALUE, true, true, false));
+        assertEquals(toFilterWithOldNanDefinition(greaterThanOrEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+        assertEquals(toFilter(greaterThan(C_DOUBLE, doubleLiteral(Double.NaN))), DoubleRange.of(Double.NaN, false, true, Double.MAX_VALUE, true, true, false));
+        assertEquals(toFilterWithOldNanDefinition(greaterThan(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+        assertEquals(toFilter(notEqual(C_DOUBLE, doubleLiteral(Double.NaN))), MultiRange.of(ImmutableList.of(
+                DoubleRange.of(Double.MIN_VALUE, true, true, Double.NaN, false, true, false),
+                DoubleRange.of(Double.NaN, false, true, Double.MAX_VALUE, true, true, false)), false, false));
+        assertEquals(toFilterWithOldNanDefinition(notEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
 
         assertEquals(toFilter(not(in(C_DOUBLE, ImmutableList.of(doubleLiteral(1.2))))), MultiRange.of(ImmutableList.of(
                 DoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
-                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, true));
+                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, false));
+        assertEquals(toFilterWithOldNanDefinition(not(in(C_DOUBLE, ImmutableList.of(doubleLiteral(1.2))))), MultiRange.of(ImmutableList.of(
+                OldDoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
+                OldDoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, true));
 
         assertEquals(toFilter(not(in(C_DOUBLE, ImmutableList.of(doubleLiteral(2.4), doubleLiteral(1.2))))), MultiRange.of(ImmutableList.of(
                 DoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
                 DoubleRange.of(1.2, false, true, 2.4, false, true, false),
-                DoubleRange.of(2.4, false, true, Double.MAX_VALUE, true, true, false)), false, true));
+                DoubleRange.of(2.4, false, true, Double.MAX_VALUE, true, true, false)), false, false));
+
+        assertEquals(toFilterWithOldNanDefinition(not(in(C_DOUBLE, ImmutableList.of(doubleLiteral(2.4), doubleLiteral(1.2))))), MultiRange.of(ImmutableList.of(
+                OldDoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
+                OldDoubleRange.of(1.2, false, true, 2.4, false, true, false),
+                OldDoubleRange.of(2.4, false, true, Double.MAX_VALUE, true, true, false)), false, true));
 
         assertEquals(toFilter((in(C_DOUBLE, ImmutableList.of(doubleLiteral(2.4), doubleLiteral(1.2))))), MultiRange.of(ImmutableList.of(
                 DoubleRange.of(1.2, false, false, 1.2, false, false, false),
                 DoubleRange.of(2.4, false, false, 2.4, false, false, false)), false, false));
+
+        assertEquals(toFilterWithOldNanDefinition((in(C_DOUBLE, ImmutableList.of(doubleLiteral(2.4), doubleLiteral(1.2))))), MultiRange.of(ImmutableList.of(
+                OldDoubleRange.of(1.2, false, false, 1.2, false, false, false),
+                OldDoubleRange.of(2.4, false, false, 2.4, false, false, false)), false, false));
     }
 
     @Test
@@ -308,35 +384,60 @@ public class TestTupleDomainFilterUtils
         Expression realLiteral = toExpression(realValue(1.2f), TYPES.get(C_REAL.toSymbolReference()));
         Expression realLiteralHigh = toExpression(realValue(2.4f), TYPES.get(C_REAL.toSymbolReference()));
         assertEquals(toFilter(equal(C_REAL, realLiteral)), FloatRange.of(1.2f, false, false, 1.2f, false, false, false));
+        assertEquals(toFilterWithOldNanDefinition(equal(C_REAL, realLiteral)), OldFloatRange.of(1.2f, false, false, 1.2f, false, false, false));
         assertEquals(toFilter(not(equal(C_REAL, realLiteral))), MultiRange.of(ImmutableList.of(
                 FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
-                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, true));
+                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, false));
+        assertEquals(toFilterWithOldNanDefinition(not(equal(C_REAL, realLiteral))), MultiRange.of(ImmutableList.of(
+                OldFloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                OldFloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, true));
 
         assertEquals(toFilter(or(isNull(C_REAL), equal(C_REAL, realLiteral))), FloatRange.of(1.2f, false, false, 1.2f, false, false, true));
+        assertEquals(toFilterWithOldNanDefinition(or(isNull(C_REAL), equal(C_REAL, realLiteral))), OldFloatRange.of(1.2f, false, false, 1.2f, false, false, true));
 
         Expression floatNaNLiteral = toExpression(realValue(Float.NaN), TYPES.get(C_REAL.toSymbolReference()));
-        assertEquals(toFilter(lessThan(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
-        assertEquals(toFilter(lessThanOrEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
-        assertEquals(toFilter(greaterThanOrEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
-        assertEquals(toFilter(greaterThan(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
-        assertEquals(toFilter(notEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+        assertEquals(toFilter(lessThan(C_REAL, floatNaNLiteral)), FloatRange.of(Float.MIN_VALUE, true, true, Float.NaN, false, true, false));
+        assertEquals(toFilterWithOldNanDefinition(lessThan(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+        assertEquals(toFilter(lessThanOrEqual(C_REAL, floatNaNLiteral)), FloatRange.of(Float.MIN_VALUE, true, true, Float.NaN, false, false, false));
+        assertEquals(toFilterWithOldNanDefinition(lessThanOrEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+        assertEquals(toFilter(greaterThanOrEqual(C_REAL, floatNaNLiteral)), FloatRange.of(Float.NaN, false, false, Float.MAX_VALUE, true, true, false));
+        assertEquals(toFilterWithOldNanDefinition(greaterThanOrEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+        assertEquals(toFilter(greaterThan(C_REAL, floatNaNLiteral)), FloatRange.of(Float.NaN, false, true, Float.MAX_VALUE, true, true, false));
+        assertEquals(toFilterWithOldNanDefinition(greaterThan(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+        assertEquals(toFilter(notEqual(C_REAL, floatNaNLiteral)), MultiRange.of(ImmutableList.of(
+                FloatRange.of(Float.MIN_VALUE, true, true, Float.NaN, false, true, false),
+                FloatRange.of(Float.NaN, false, true, Float.MAX_VALUE, true, true, false)), false, false));
+        assertEquals(toFilterWithOldNanDefinition(notEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
 
         assertEquals(toFilter(isDistinctFrom(C_REAL, realLiteral)), MultiRange.of(ImmutableList.of(
                 FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
-                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true, true));
+                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true, false));
+        assertEquals(toFilterWithOldNanDefinition(isDistinctFrom(C_REAL, realLiteral)), MultiRange.of(ImmutableList.of(
+                OldFloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                OldFloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true, true));
 
         assertEquals(toFilter(or(isNull(C_REAL), notEqual(C_REAL, realLiteral))), MultiRange.of(ImmutableList.of(
                 FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
-                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true, true));
+                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true, false));
+        assertEquals(toFilterWithOldNanDefinition(or(isNull(C_REAL), notEqual(C_REAL, realLiteral))), MultiRange.of(ImmutableList.of(
+                OldFloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                OldFloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true, true));
 
         assertEquals(toFilter(not(in(C_REAL, ImmutableList.of(realLiteral, realLiteralHigh)))), MultiRange.of(ImmutableList.of(
                 FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
                 FloatRange.of(1.2f, false, true, 2.4f, false, true, false),
-                FloatRange.of(2.4f, false, true, Float.MAX_VALUE, true, true, false)), false, true));
+                FloatRange.of(2.4f, false, true, Float.MAX_VALUE, true, true, false)), false, false));
+        assertEquals(toFilterWithOldNanDefinition(not(in(C_REAL, ImmutableList.of(realLiteral, realLiteralHigh)))), MultiRange.of(ImmutableList.of(
+                OldFloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                OldFloatRange.of(1.2f, false, true, 2.4f, false, true, false),
+                OldFloatRange.of(2.4f, false, true, Float.MAX_VALUE, true, true, false)), false, true));
 
         assertEquals(toFilter((in(C_REAL, ImmutableList.of(realLiteral, realLiteralHigh)))), MultiRange.of(ImmutableList.of(
                 FloatRange.of(1.2f, false, false, 1.2f, false, false, false),
                 FloatRange.of(2.4f, false, false, 2.4f, false, false, false)), false, false));
+        assertEquals(toFilterWithOldNanDefinition((in(C_REAL, ImmutableList.of(realLiteral, realLiteralHigh)))), MultiRange.of(ImmutableList.of(
+                OldFloatRange.of(1.2f, false, false, 1.2f, false, false, false),
+                OldFloatRange.of(2.4f, false, false, 2.4f, false, false, false)), false, false));
     }
 
     @Test
@@ -417,15 +518,25 @@ public class TestTupleDomainFilterUtils
 
     private TupleDomainFilter toFilter(Expression expression)
     {
-        Optional<Map<String, Domain>> domains = fromPredicate(expression).getTupleDomain().getDomains();
+        return toFilter(expression, true);
+    }
+
+    private TupleDomainFilter toFilterWithOldNanDefinition(Expression expression)
+    {
+        return toFilter(expression, false);
+    }
+
+    private TupleDomainFilter toFilter(Expression expression, boolean useNewNanDefitition)
+    {
+        Optional<Map<String, Domain>> domains = fromPredicate(expression, useNewNanDefitition).getTupleDomain().getDomains();
         assertTrue(domains.isPresent());
         Domain domain = Iterables.getOnlyElement(domains.get().values());
         return TupleDomainFilterUtils.toFilter(domain);
     }
 
-    private ExpressionDomainTranslator.ExtractionResult fromPredicate(Expression originalPredicate)
+    private ExpressionDomainTranslator.ExtractionResult fromPredicate(Expression originalPredicate, boolean useNewNanDefitition)
     {
-        return ExpressionDomainTranslator.fromPredicate(metadata, TEST_SESSION, originalPredicate, TYPES);
+        return ExpressionDomainTranslator.fromPredicate(useNewNanDefitition ? metadata : oldNanDefinitionMetadata, TEST_SESSION, originalPredicate, useNewNanDefitition ? TYPES : OLD_NAN_DEFINITION_TYPES);
     }
 
     private static ComparisonExpression equal(Symbol symbol, Expression expression)


### PR DESCRIPTION
## Description
This PR contains all the changes to overhaul the NaN operators to conform with the new definition proposed in https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md.

According to the new nan definition, Nan is larger than all other numbers and is equal to itself.  This PR also changes +0 and -0 to always be considered equal/not distinct, whereas previously there was inconsistency here as well.  

I recommend reviewing commit by commit as it is divided into logically distinct pieces that should be easier to review. If it would be helpful I can also split it up into smaller PRs.

Fixes the following issues:
https://github.com/prestodb/presto/issues/22040
https://github.com/prestodb/presto/issues/21936
https://github.com/prestodb/presto/issues/21877
https://github.com/prestodb/presto/issues/22679
https://github.com/prestodb/presto/issues/13807
https://github.com/prestodb/presto/issues/21065
https://github.com/prestodb/presto/issues/22716
https://github.com/facebookincubator/velox/pull/9511

It should also fix should also fix https://github.com/prestodb/presto/issues/16851, though I'm not sure how to create the file to test it.  

## Motivation and Context
The motivation for this change is to provide consistent NaN semantics across all of our functions and operators.  It is also to ensure that these semantics are consistent with velox as we move to native workers. For more details see the RFC: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md.

## Impact
nan will now be treated as greater than all other numbers for all functions and as equal to itself for all functions. This changes the behavior of many existing functions and operators. These differences include (but are not limited to) =, <, >, joins, various distincting functions like set_agg and array_distinct,  array_min.

It also fixes https://github.com/prestodb/presto/issues/22040, a wrong results bug with map_top_n in the presence of nans.

This PR also changes joins and aggregations to treat +0 and -0 as equal/not distinct.

## Test Plan
Added tests for all affected functions.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Change handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself.  It also changes the handling of positive and negative zero to always be considered equal to each other.  Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property ``use-new-nan-definition`` to ``false``. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release.
* Fix a bug where map_top_n could return wrong results if there is any NaN input
* Fix a bug with array_min/array_max where it would return NaN rather than null when there was both NaN and null input. 
```

