### PR TITLE
Avoid sharing state between tests in TestFullParquetReader

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -130,7 +130,7 @@ public abstract class AbstractTestParquetReader
     private static final int MAX_PRECISION_INT32 = (int) maxPrecision(4);
     private static final int MAX_PRECISION_INT64 = (int) maxPrecision(8);
 
-    private final ParquetTester tester;
+    protected ParquetTester tester;
 
     public AbstractTestParquetReader(ParquetTester tester)
     {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestFullParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestFullParquetReader.java
@@ -13,14 +13,21 @@
  */
 package com.facebook.presto.hive.parquet;
 
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Test(groups = "ci")
+@Test(groups = "ci", singleThreaded = true)
 public class TestFullParquetReader
         extends AbstractTestParquetReader
 {
     public TestFullParquetReader()
     {
         super(ParquetTester.fullParquetTester());
+    }
+
+    @BeforeMethod
+    public void newParquetTester()
+    {
+        super.tester = ParquetTester.fullParquetTester();
     }
 }


### PR DESCRIPTION
## Description
Creates a new ParquetTester object for each test in TestFullParquetReader

## Motivation and Context
TestFullParquetReader seems to flake in ways that point to state shared between test methods. Fixes #22130

## Impact
none

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

