### PR TITLE
[native] Fix UnsafeRowShuffleTest.shuffleWriterExceptions

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -744,7 +744,7 @@ TEST_F(UnsafeRowShuffleTest, operators) {
   TestShuffleWriter::reset();
 }
 
-TEST_F(UnsafeRowShuffleTest, shuffleWriterExceptions) {
+DEBUG_ONLY_TEST_F(UnsafeRowShuffleTest, shuffleWriterExceptions) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>({1, 2, 3, 4}),
       makeFlatVector<int64_t>({10, 20, 30, 40}),
@@ -774,6 +774,7 @@ TEST_F(UnsafeRowShuffleTest, shuffleWriterExceptions) {
       "ShuffleWriter::collect failed");
 
   TestShuffleWriter::reset();
+  exec::test::waitForAllTasksToBeDeleted();
 }
 
 TEST_F(UnsafeRowShuffleTest, shuffleReaderExceptions) {


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

