### PR TITLE
Initialize node.id with $HOSTNAME in docker image by default

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 set -e
-echo "node.id=$HOSTNAME" >> $PRESTO_HOME/etc/node.properties
 
 $PRESTO_HOME/bin/launcher run

--- a/docker/etc/node.properties
+++ b/docker/etc/node.properties
@@ -1,2 +1,3 @@
+node.id=${ENV:HOSTNAME}
 node.environment=test
 node.data-dir=/var/lib/presto/data


### PR DESCRIPTION
## Description

The PR changes default `node.id` initialization approach in docker image by using `$HOSTNAME` environment variable explicitly.

## Motivation and Context

Presto supports environment variable substitution in configs after upgrading `airlift` from `207` to `209` version:
 - [prestodb/airlift - Support Environment Variable Replacement in Airlift Configuration](https://github.com/prestodb/airlift/commit/4987dc2cd3589cf2e965cc97175fa21d8b6df943)
 - [prestodb/presto - Upgrade airlift version #21943](https://github.com/prestodb/presto/pull/21943/files)

Current approach (write to `$PRESTO_HOME/etc/node.properties` file) doesn't work if Presto running by non-root user or if the file is not editable (`ConfigMap` mounted as file in Kubernetes).

## Test Plan
The change has been tested in Kubernetes cluster by deploying Presto `0.287-edge16` via Helm chart.

Presto nodes:
```shell
[root@presto-coordinator-67657dd9db-9mcxn opt]# /opt/presto-cli 
presto> SELECT * FROM system.runtime.nodes;
               node_id               |        http_uri         |     node_version     | coordinator | state  
-------------------------------------+-------------------------+----------------------+-------------+--------
 presto-coordinator-67657dd9db-9mcxn | http://10.244.0.13:8080 | 0.287-edge16-19b02dc | true        | active 
 presto-worker-7b48f96967-dhpxq      | http://10.244.0.11:8080 | 0.287-edge16-19b02dc | false       | active 
 presto-worker-7b48f96967-vt78f      | http://10.244.0.12:8080 | 0.287-edge16-19b02dc | false       | active 
(3 rows)
```
Config `node.properties`:
```shell
[root@presto-coordinator-67657dd9db-9mcxn opt]# cat /opt/presto-server/etc/node.properties 
node.id=${ENV:HOSTNAME}
node.location=presto.local
node.environment=development
node.data-dir=/var/presto/data
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

