### PR TITLE
[native] Add query init memory metrics

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -15,6 +15,8 @@
 #include "presto_cpp/main/QueryContextManager.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include "presto_cpp/main/common/Configs.h"
+#include "presto_cpp/main/common/Counters.h"
+#include "velox/common/base/StatsReporter.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -191,6 +193,8 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
       !SystemConfig::instance()->memoryArbitratorKind().empty()
           ? memory::MemoryReclaimer::create()
           : nullptr);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kCounterQueryMemoryPoolInitCapacity, pool->capacity());
 
   auto queryCtx = std::make_shared<core::QueryCtx>(
       driverExecutor_,

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -90,6 +90,16 @@ void registerPrestoMetrics() {
       0,
       62l * 1024 * 1024 * 1024, // max bucket value: 62GB
       100);
+  DEFINE_HISTOGRAM_METRIC(
+      kCounterQueryMemoryPoolInitCapacity,
+      4l * 1024 * 1024, // 4MB bucket size
+      0,
+      1024l * 1024 * 1024, // 1GB max size
+      5,
+      50,
+      90,
+      95,
+      100);
 
   /// ================== AsyncDataCache Counters ==================
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -138,10 +138,12 @@ constexpr folly::StringPiece kCounterMmapExternalMappedBytes{
 /// NOTE: This applies only to MmapAllocator
 constexpr folly::StringPiece kCounterMmapRawAllocBytesSmall{
     "presto_cpp.mmap_raw_alloc_bytes_small"};
-
 /// Peak number of bytes queued in PrestoExchangeSource waiting for consume.
 constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
     "presto_cpp.exchange_source_peak_queued_bytes"};
+/// Initial capacity of the root memory pool of queries
+constexpr folly::StringPiece kCounterQueryMemoryPoolInitCapacity{
+    "presto_cpp.query_memory_pool_init_capacity"};
 
 /// ================== Memory Arbitrator Counters =================
 


### PR DESCRIPTION
Add histogram type query initial memory capacity metrics to be exported
```
== NO RELEASE NOTE ==
```

