### PR TITLE
[native] Change PeriodicMemoryChecker to use millisecond interval

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
@@ -44,7 +44,7 @@ void PeriodicMemoryChecker::start() {
         config_.systemMemShrinkBytes, 0, "Invalid system mem shrink provided");
     PRESTO_STARTUP_LOG(INFO)
         << "Creating server memory pushback checker, memory check interval "
-        << config_.memoryCheckerIntervalSec << "s, system memory limit: "
+        << config_.memoryCheckerIntervalMs << "ms, system memory limit: "
         << velox::succinctBytes(config_.systemMemLimitBytes)
         << ", memory shrink size: "
         << velox::succinctBytes(config_.systemMemShrinkBytes);
@@ -77,7 +77,7 @@ void PeriodicMemoryChecker::start() {
           pushbackMemory();
         }
       },
-      std::chrono::seconds(config_.memoryCheckerIntervalSec),
+      std::chrono::milliseconds(config_.memoryCheckerIntervalMs),
       "periodic-sys-mem-check",
       std::chrono::seconds(0));
   scheduler_->start();

--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
@@ -24,7 +24,7 @@ class PeriodicMemoryChecker {
  public:
   struct Config {
     /// The frequency 'PeriodicMemoryChecker' runs at.
-    uint64_t memoryCheckerIntervalSec{1};
+    uint64_t memoryCheckerIntervalMs{1'000};
 
     /// If true, starts memory limit checker to trigger memory pushback when
     /// server is under low memory pressure.

--- a/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
@@ -80,21 +80,21 @@ TEST_F(PeriodicMemoryCheckerTest, basic) {
   ASSERT_NO_THROW(TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{}));
 
   ASSERT_NO_THROW(TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{
-      1, true, 1024, 32, true, 5, "/path/to/dir", "prefix", 5, 512}));
+      1'000, true, 1024, 32, true, 5, "/path/to/dir", "prefix", 5, 512}));
   VELOX_ASSERT_THROW(
       TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{
-          1, true, 0, 32, true, 5, "/path/to/dir", "prefix", 5, 512}),
+          1'000, true, 0, 32, true, 5, "/path/to/dir", "prefix", 5, 512}),
       "(0 vs. 0)");
   VELOX_ASSERT_THROW(
       TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{
-          1, true, 1024, 32, true, 5, "", "prefix", 5, 512}),
+          1'000, true, 1024, 32, true, 5, "", "prefix", 5, 512}),
       "heapDumpLogDir cannot be empty when heap dump is enabled.");
   VELOX_ASSERT_THROW(
       TestPeriodicMemoryChecker(PeriodicMemoryChecker::Config{
-          1, true, 1024, 32, true, 5, "/path/to/dir", "", 5, 512}),
+          1'000, true, 1024, 32, true, 5, "/path/to/dir", "", 5, 512}),
       "heapDumpFilePrefix cannot be empty when heap dump is enabled.");
   TestPeriodicMemoryChecker memChecker(PeriodicMemoryChecker::Config{
-      1, false, 0, 0, false, 5, "/path/to/dir", "prefix", 5, 512});
+      1'000, false, 0, 0, false, 5, "/path/to/dir", "prefix", 5, 512});
   ASSERT_NO_THROW(memChecker.start());
   VELOX_ASSERT_THROW(memChecker.start(), "start() called more than once");
   ASSERT_NO_THROW(memChecker.stop());
@@ -105,7 +105,7 @@ TEST_F(PeriodicMemoryCheckerTest, periodicCb) {
     std::atomic_bool periodicCbInvoked{false};
     TestPeriodicMemoryChecker memChecker(
         PeriodicMemoryChecker::Config{
-            1,
+            1'000,
             pushbackEnabled,
             512,
             32,
@@ -135,7 +135,7 @@ TEST_F(PeriodicMemoryCheckerTest, heapdump) {
     std::atomic_bool heapdumpCbCalled{false};
     TestPeriodicMemoryChecker memChecker(
         PeriodicMemoryChecker::Config{
-            1, false, 0, 0, true, 5, "/path/to/dir", "prefix", 5, 512},
+            1'000, false, 0, 0, true, 5, "/path/to/dir", "prefix", 5, 512},
         1024,
         256,
         []() {},
@@ -155,7 +155,7 @@ TEST_F(PeriodicMemoryCheckerTest, heapdump) {
     std::atomic_bool heapdumpCbCalled{false};
     TestPeriodicMemoryChecker memChecker(
         PeriodicMemoryChecker::Config{
-            1, false, 0, 0, true, 1, "/path/to/dir", "prefix", 2, 512},
+            1'000, false, 0, 0, true, 1, "/path/to/dir", "prefix", 2, 512},
         1024,
         768,
         []() {},
@@ -198,7 +198,7 @@ TEST_F(PeriodicMemoryCheckerTest, pushbackMemory) {
 
   TestPeriodicMemoryChecker memChecker(
       PeriodicMemoryChecker::Config{
-          1,
+          1'000,
           true,
           16L << 20,
           8L << 20,


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

