### PR TITLE
Shutdown thread pool executors properly on the destruction of beans

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/ClusterSizeMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ClusterSizeMonitor.java
@@ -127,6 +127,7 @@ public class ClusterSizeMonitor
     public void stop()
     {
         nodeManager.removeNodeChangeListener(listener);
+        executor.shutdownNow();
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -301,6 +301,7 @@ public class SqlTaskManager
                 Thread.currentThread().interrupt();
             }
         }
+        driverYieldExecutor.shutdownNow();
         taskNotificationExecutor.shutdownNow();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -265,6 +265,7 @@ public final class DiscoveryNodeManager
     public void stop()
     {
         nodeStateUpdateExecutor.shutdownNow();
+        nodeStateEventExecutor.shutdownNow();
     }
 
     @Override


### PR DESCRIPTION
## Description

Some thread pool executors are not shutdown properly on the destruction of beans that created them. The PR fix this problem.

## Motivation and Context

If some thread pool executors do not shutdown properly on the destruction of beans, we might not exit process elegantly and can only use force exit.

For example, when we use a `DistributedQueryRunner queryRunner` to do benchmark in `jmh`, we would found that it could not be closed and shutdown elegantly when calling `queryRunner.close()`.

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

