### PR TITLE
Improve error for bad row cast

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -650,11 +650,11 @@ public class ExpressionInterpreter
                 Type type = type(node.getValue());
                 List<Expression> expressionValues = toExpressions(values, types);
                 List<Expression> simplifiedExpressionValues = Stream.concat(
-                        expressionValues.stream()
-                                .filter(ExpressionDeterminismEvaluator::isDeterministic)
-                                .distinct(),
-                        expressionValues.stream()
-                                .filter((expression -> !isDeterministic(expression))))
+                                expressionValues.stream()
+                                        .filter(ExpressionDeterminismEvaluator::isDeterministic)
+                                        .distinct(),
+                                expressionValues.stream()
+                                        .filter((expression -> !isDeterministic(expression))))
                         .collect(toImmutableList());
                 return new InPredicate(toExpression(value, type), new InListExpression(simplifiedExpressionValues));
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -132,6 +132,7 @@ import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.createConstant
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.getSourceLocation;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.resolveEnumLiteral;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.DUPLICATE_COLUMN_NAME;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.gen.VarArgsToMapAdapterGenerator.generateVarArgsToMapAdapter;
 import static com.facebook.presto.sql.planner.ExpressionDeterminismEvaluator.isDeterministic;
@@ -332,7 +333,9 @@ public class ExpressionInterpreter
             for (int i = 0; i < fields.size(); i++) {
                 Field field = fields.get(i);
                 if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(fieldName)) {
-                    checkArgument(index < 0, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
+                    if (index >= 0) {
+                        throw new SemanticException(DUPLICATE_COLUMN_NAME, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
+                    }
                     index = i;
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -144,6 +144,7 @@ import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.WHEN;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.getSourceLocation;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.resolveEnumLiteral;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.DUPLICATE_COLUMN_NAME;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.relational.Expressions.call;
@@ -707,7 +708,9 @@ public final class SqlToRowExpressionTranslator
             for (int i = 0; i < fields.size(); i++) {
                 Field field = fields.get(i);
                 if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(fieldName)) {
-                    checkArgument(index < 0, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
+                    if (index >= 0) {
+                        throw new SemanticException(DUPLICATE_COLUMN_NAME, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
+                    }
                     index = i;
                 }
             }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -139,13 +139,6 @@ public abstract class AbstractTestFunctions
                 expectedResult);
     }
 
-    // this is not safe as it catches all RuntimeExceptions
-    @Deprecated
-    protected void assertInvalidFunction(String projection)
-    {
-        functionAssertions.assertInvalidFunction(projection);
-    }
-
     protected void assertInvalidFunction(String projection, StandardErrorCode errorCode, String messagePattern)
     {
         functionAssertions.assertInvalidFunction(projection, errorCode, messagePattern);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -341,19 +341,6 @@ public final class FunctionAssertions
         return Iterables.getOnlyElement(resultSet);
     }
 
-    // this is not safe as it catches all RuntimeExceptions
-    @Deprecated
-    public void assertInvalidFunction(String projection)
-    {
-        try {
-            Object value = evaluateInvalid(projection);
-            fail(format("Expected to throw but got %s", value));
-        }
-        catch (RuntimeException e) {
-            // Expected
-        }
-    }
-
     public void assertInvalidFunction(String projection, StandardErrorCode errorCode, String messagePattern)
     {
         try {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -59,6 +59,7 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.DUPLICATE_COLUMN_NAME;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_ATTRIBUTE;
 import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static com.facebook.presto.util.StructuralTestUtil.appendToBlockBuilder;
@@ -503,7 +504,7 @@ public class TestRowOperators
         assertFunction("cast(row(1,null,3) as row(aa bigint, bb boolean, cc boolean)).aa", BIGINT, 1L);
         assertFunction("cast(row(null,null,null) as row(aa bigint, bb boolean, cc boolean)).aa", BIGINT, null);
 
-        assertInvalidFunction("CAST(ROW(1, 2) AS ROW(a BIGINT, A DOUBLE)).a");
+        assertInvalidFunction("CAST(ROW(1, 2) AS ROW(a BIGINT, A DOUBLE)).a", DUPLICATE_COLUMN_NAME);
 
         // there are totally 7 field names
         String longFieldNameCast = "CAST(row(1.2E0, ARRAY[row(233, 6.9E0)], row(1000, 6.3E0)) AS ROW(%s VARCHAR, %s ARRAY(ROW(%s VARCHAR, %s VARCHAR)), %s ROW(%s VARCHAR, %s VARCHAR))).%s[1].%s";


### PR DESCRIPTION
## Description

Selecting from a row with two columns with the same name (or same name when all lower case) results in an ambiguous field reference.  Throw a semantic exception instead of a GENERIC_INTERNAL_ERRROR even though this exception gets caught after we've finished analysis.

For example
`SELECT CAST(ROW(1, 2) AS ROW(a BIGINT, A DOUBLE)).a` will now return a semantic exception.

This also improves the test for this case to check for a specific exception and removes a deprecated method for testing invalid functions that catches all runtime exceptions.

## Motivation and Context
Motivation is to improve an error to correctly reflect that it is a semantic error from the user.

## Impact
New exception type and error code for these queries

## Test Plan
unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

