### PR TITLE
Add UDAF noisy_approx_set_sfm_from_index_and_zeros

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -102,6 +102,8 @@ import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyApproximat
 import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyApproximateSetSfmAggregation;
 import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyApproximateSetSfmAggregationDefaultBucketsPrecision;
 import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyApproximateSetSfmAggregationDefaultPrecision;
+import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyApproximateSetSfmFromIndexAndZerosAggregation;
+import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyApproximateSetSfmFromIndexAndZerosAggregationDefaultPrecision;
 import com.facebook.presto.operator.aggregation.noisyaggregation.NoisyCountIfGaussianAggregation;
 import com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchMergeAggregation;
 import com.facebook.presto.operator.aggregation.reservoirsample.ReservoirSampleFunction;
@@ -681,6 +683,8 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregate(NoisyApproximateSetSfmAggregation.class)
                 .aggregate(NoisyApproximateSetSfmAggregationDefaultBucketsPrecision.class)
                 .aggregate(NoisyApproximateSetSfmAggregationDefaultPrecision.class)
+                .aggregate(NoisyApproximateSetSfmFromIndexAndZerosAggregation.class)
+                .aggregate(NoisyApproximateSetSfmFromIndexAndZerosAggregationDefaultPrecision.class)
                 .aggregate(NoisyApproximateDistinctCountSfmAggregation.class)
                 .aggregate(NoisyApproximateDistinctCountSfmAggregationDefaultBucketsPrecision.class)
                 .aggregate(NoisyApproximateDistinctCountSfmAggregationDefaultPrecision.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyApproximateSetSfmFromIndexAndZerosAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyApproximateSetSfmFromIndexAndZerosAggregation.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.type.SfmSketchType;
+
+import static com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchAggregationUtils.addIndexAndZerosToSketch;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchAggregationUtils.mergeStates;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchAggregationUtils.writeSketch;
+
+@AggregationFunction(value = "noisy_approx_set_sfm_from_index_and_zeros")
+public final class NoisyApproximateSetSfmFromIndexAndZerosAggregation
+{
+    private NoisyApproximateSetSfmFromIndexAndZerosAggregation() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState SfmSketchState state,
+            @SqlType(StandardTypes.BIGINT) long index,
+            @SqlType(StandardTypes.BIGINT) long nzeros,
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.BIGINT) long numberOfBuckets,
+            @SqlType(StandardTypes.BIGINT) long precision)
+    {
+        addIndexAndZerosToSketch(state, index, nzeros, epsilon, numberOfBuckets, precision);
+    }
+
+    @CombineFunction
+    public static void combineState(@AggregationState SfmSketchState state, @AggregationState SfmSketchState otherState)
+    {
+        mergeStates(state, otherState);
+    }
+
+    @OutputFunction(SfmSketchType.NAME)
+    public static void evaluateFinal(@AggregationState SfmSketchState state, BlockBuilder out)
+    {
+        writeSketch(state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyApproximateSetSfmFromIndexAndZerosAggregationDefaultPrecision.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyApproximateSetSfmFromIndexAndZerosAggregationDefaultPrecision.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.type.SfmSketchType;
+
+import static com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchAggregationUtils.DEFAULT_PRECISION;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchAggregationUtils.addIndexAndZerosToSketch;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchAggregationUtils.mergeStates;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.SfmSketchAggregationUtils.writeSketch;
+
+@AggregationFunction(value = "noisy_approx_set_sfm_from_index_and_zeros")
+public final class NoisyApproximateSetSfmFromIndexAndZerosAggregationDefaultPrecision
+{
+    private NoisyApproximateSetSfmFromIndexAndZerosAggregationDefaultPrecision() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState SfmSketchState state,
+            @SqlType(StandardTypes.BIGINT) long index,
+            @SqlType(StandardTypes.BIGINT) long nzeros,
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.BIGINT) long numberOfBuckets)
+    {
+        addIndexAndZerosToSketch(state, index, nzeros, epsilon, numberOfBuckets, DEFAULT_PRECISION);
+    }
+
+    @CombineFunction
+    public static void combineState(@AggregationState SfmSketchState state, @AggregationState SfmSketchState otherState)
+    {
+        mergeStates(state, otherState);
+    }
+
+    @OutputFunction(SfmSketchType.NAME)
+    public static void evaluateFinal(@AggregationState SfmSketchState state, BlockBuilder out)
+    {
+        writeSketch(state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/SfmSketchAggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/SfmSketchAggregationUtils.java
@@ -61,6 +61,12 @@ public final class SfmSketchAggregationUtils
         state.getSketch().addHash(hash);
     }
 
+    public static void addIndexAndZerosToSketch(SfmSketchState state, long index, long zeros, double epsilon, long numberOfBuckets, long precision)
+    {
+        ensureStateInitialized(state, epsilon, numberOfBuckets, precision);
+        state.getSketch().addIndexAndZeros(index, zeros);
+    }
+
     public static long hashLong(MethodHandle methodHandle, long value)
     {
         long hash;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/SfmSketch.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/SfmSketch.java
@@ -126,6 +126,19 @@ public class SfmSketch
         flipBitOn(index, zeros);
     }
 
+    public void addIndexAndZeros(long index, long zeros)
+    {
+        long buckets = numberOfBuckets(indexBitLength);
+        checkArgument(index >= 0 && index < buckets,
+                "index %s must be between zero (inclusive) and the number of buckets-1 %s", index, buckets - 1);
+        checkArgument(zeros >= 0 && zeros <= 64,
+                "zeros %s must be between 0 and 64", zeros);
+        // cap zeros at precision - 1
+        // essentially, we're looking at a (precision - 1)-bit hash
+        zeros = Math.min(precision - 1, zeros);
+        flipBitOn((int) index, (int) zeros);
+    }
+
     /**
      * Estimates cardinality via maximum psuedolikelihood (Newton's method)
      */

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/AbstractTestNoisySfmAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/AbstractTestNoisySfmAggregation.java
@@ -37,7 +37,7 @@ import static com.facebook.presto.operator.aggregation.AggregationTestUtils.asse
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 
 /**
- * Parent class for testing noisy_approx_set_sfm and noisy_approx_distinct_sfm.
+ * Parent class for testing noisy_approx_set_sfm* and noisy_approx_distinct_sfm.
  * The tests will essentially be the same, but since noisy_approx_set_sfm returns the sketch object itself,
  * we will map this to a cardinality, giving us something equivalent to noisy_approx_distinct_sfm.
  */

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyApproximateSetSfmFromIndexAndZerosAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyApproximateSetSfmFromIndexAndZerosAggregation.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.SfmSketch;
+import com.facebook.presto.type.IntegerOperators;
+import org.testng.annotations.Test;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.block.BlockAssertions.createDoubleRepeatBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongRepeatBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static java.lang.Math.min;
+
+/**
+ * Tests for the noisy_approx_set_sfm function.
+ * Overall, these are similar to the tests of noisy_approx_distinct_sfm, but with an extra check
+ * to ensure that the size of the returned sketch matches the parameters specified (or defaulted).
+ */
+public class TestNoisyApproximateSetSfmFromIndexAndZerosAggregation
+        extends AbstractTestNoisySfmAggregation
+{
+    protected String getFunctionName()
+    {
+        return "noisy_approx_set_sfm_from_index_and_zeros";
+    }
+
+    protected long getCardinalityFromResult(Object result)
+    {
+        return getSketchFromResult(result).cardinality();
+    }
+
+    private boolean sketchSizesMatch(Object a, Object b)
+    {
+        SfmSketch sketchA = getSketchFromResult(a);
+        SfmSketch sketchB = getSketchFromResult(b);
+        return sketchA.getBitmap().length() == sketchB.getBitmap().length();
+    }
+
+    public static Block createLongSequenceIndexBlock(int start, int end, int indexBits)
+    {
+        int shift = 64 - indexBits;
+        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(end - start);
+
+        for (int i = start; i < end; i++) {
+            long h = IntegerOperators.xxHash64(i);
+            BIGINT.writeLong(builder, h >>> shift);
+        }
+
+        return builder.build();
+    }
+
+    public static Block createLongSequenceZerosBlock(int start, int end, int indexBits, int precision)
+    {
+        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(end - start);
+        precision = min(precision - 1, 64 - indexBits);
+
+        for (int i = start; i < end; i++) {
+            long h = IntegerOperators.xxHash64(i);
+            BIGINT.writeLong(builder, min(Long.numberOfTrailingZeros(h), precision));
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Run assertion on function with signature F(value1, value2, epsilon, numberOfBuckets, precision)
+     */
+    protected void assertFunction(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, int numberOfBuckets, int precision, BiFunction<Object, Object, Boolean> assertion, Object expected)
+    {
+        assert (valuesBlock1.getPositionCount() == valuesBlock2.getPositionCount());
+        assertAggregation(
+                getAggregator(getFunctionName(), valueType1, valueType2, DOUBLE, BIGINT, BIGINT),
+                assertion,
+                null,
+                new Page(
+                        valuesBlock1,
+                        valuesBlock2,
+                        createDoubleRepeatBlock(epsilon, valuesBlock1.getPositionCount()),
+                        createLongRepeatBlock(numberOfBuckets, valuesBlock1.getPositionCount()),
+                        createLongRepeatBlock(precision, valuesBlock1.getPositionCount())),
+                expected);
+    }
+
+    /**
+     * Run assertion on function with signature F(value1, value2, epsilon, numberOfBuckets)
+     */
+    protected void assertFunction(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, int numberOfBuckets, BiFunction<Object, Object, Boolean> assertion, Object expected)
+    {
+        assert (valuesBlock1.getPositionCount() == valuesBlock2.getPositionCount());
+        assertAggregation(
+                getAggregator(getFunctionName(), valueType1, valueType2, DOUBLE, BIGINT),
+                assertion,
+                null,
+                new Page(
+                        valuesBlock1,
+                        valuesBlock2,
+                        createDoubleRepeatBlock(epsilon, valuesBlock1.getPositionCount()),
+                        createLongRepeatBlock(numberOfBuckets, valuesBlock1.getPositionCount())),
+                expected);
+    }
+
+    /**
+     * Run assertion on function with signature F(value1, value2, epsilon)
+     */
+    protected void assertFunction(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, BiFunction<Object, Object, Boolean> assertion, Object expected)
+    {
+        assert (valuesBlock1.getPositionCount() == valuesBlock2.getPositionCount());
+        assertAggregation(
+                getAggregator(getFunctionName(), valueType1, valueType2, DOUBLE),
+                assertion,
+                null,
+                new Page(
+                        valuesBlock1,
+                        valuesBlock2,
+                        createDoubleRepeatBlock(epsilon, valuesBlock1.getPositionCount())),
+                expected);
+    }
+
+    protected void assertEquivalence(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, int numberOfBuckets, Object expected)
+    {
+        assertFunction(valuesBlock1, valueType1, valuesBlock2, valueType2, epsilon, numberOfBuckets, Objects::equals, expected);
+    }
+
+    /**
+     * Assert (approximate) cardinality match on function with signature F(value1, value2, epsilon, numberOfBuckets, precision)
+     */
+    protected void assertCardinality(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, int numberOfBuckets, int precision, Object expected, long delta)
+    {
+        assertFunction(valuesBlock1, valueType1, valuesBlock2, valueType2, epsilon, numberOfBuckets, precision,
+                (actualValue, expectedValue) -> equalCardinalityWithAbsoluteError(actualValue, expectedValue, delta),
+                expected);
+    }
+
+    /**
+     * Assert (approximate) cardinality match on function with signature F(value1, value2, epsilon, numberOfBuckets)
+     */
+    protected void assertCardinality(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, int numberOfBuckets, Object expected, long delta)
+    {
+        assertFunction(valuesBlock1, valueType1, valuesBlock2, valueType2, epsilon, numberOfBuckets,
+                (actualValue, expectedValue) -> equalCardinalityWithAbsoluteError(actualValue, expectedValue, delta),
+                expected);
+    }
+
+    /**
+     * Assert (approximate) cardinality match on function with signature F(value1, value2, epsilon)
+     */
+    protected void assertCardinality(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, Object expected, long delta)
+    {
+        assertFunction(valuesBlock1, valueType1, valuesBlock2, valueType2, epsilon,
+                (actualValue, expectedValue) -> equalCardinalityWithAbsoluteError(actualValue, expectedValue, delta),
+                expected);
+    }
+
+    private void assertSketchSize(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, int numberOfBuckets, int precision, SqlVarbinary expected)
+    {
+        assertFunction(valuesBlock1, valueType1, valuesBlock2, valueType2, epsilon, numberOfBuckets, precision, this::sketchSizesMatch, expected);
+    }
+
+    private void assertSketchSize(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, int numberOfBuckets, SqlVarbinary expected)
+    {
+        assertFunction(valuesBlock1, valueType1, valuesBlock2, valueType2, epsilon, numberOfBuckets, this::sketchSizesMatch, expected);
+    }
+
+    private void assertSketchSize(Block valuesBlock1, Type valueType1, Block valuesBlock2, Type valueType2, double epsilon, SqlVarbinary expected)
+    {
+        assertFunction(valuesBlock1, valueType1, valuesBlock2, valueType2, epsilon, this::sketchSizesMatch, expected);
+    }
+
+    /**
+     * Verify SFMs created using the value or using index and zeros are identical
+     */
+    @Test
+    public void testSfmEquivalence()
+    {
+        SqlVarbinary refSketch = toSqlVarbinary(createLongSketch(8192, 24, 1, 100_000));
+
+        Block indexValuesBlock = createLongSequenceIndexBlock(1, 100_000, 13);
+        Block zerosValuesBlock = createLongSequenceZerosBlock(1, 100_000, 13, 24);
+
+        assertEquivalence(indexValuesBlock, BIGINT, zerosValuesBlock, BIGINT, SfmSketch.NON_PRIVATE_EPSILON, 8192, refSketch);
+    }
+
+    @Test
+    public void testNonPrivateInteger()
+    {
+        Block indexValuesBlockBits13 = createLongSequenceIndexBlock(1, 100_000, 13);
+        Block zerosValuesBlockBits13 = createLongSequenceZerosBlock(1, 100_000, 13, 24);
+
+        SqlVarbinary refSketch = toSqlVarbinary(createLongSketch(8192, 24, 1, 100_000));
+        assertCardinality(indexValuesBlockBits13, BIGINT, zerosValuesBlockBits13, BIGINT, SfmSketch.NON_PRIVATE_EPSILON, 8192, refSketch, 0);
+        assertSketchSize(indexValuesBlockBits13, BIGINT, zerosValuesBlockBits13, BIGINT, SfmSketch.NON_PRIVATE_EPSILON, 8192, refSketch);
+
+        Block indexValuesBlockBits11 = createLongSequenceIndexBlock(1, 100_000, 11);
+        Block zerosValuesBlockBits11 = createLongSequenceZerosBlock(1, 100_000, 11, 32);
+
+        refSketch = toSqlVarbinary(createLongSketch(2048, 32, 1, 100_000));
+        assertCardinality(indexValuesBlockBits11, BIGINT, zerosValuesBlockBits11, BIGINT, SfmSketch.NON_PRIVATE_EPSILON, 2048, 32, refSketch, 0);
+        assertSketchSize(indexValuesBlockBits11, BIGINT, zerosValuesBlockBits11, BIGINT, SfmSketch.NON_PRIVATE_EPSILON, 2048, 32, refSketch);
+    }
+
+    @Test
+    public void testPrivateInteger()
+    {
+        Block indexValuesBlockBits13 = createLongSequenceIndexBlock(1, 100_000, 13);
+        Block zerosValuesBlockBits13 = createLongSequenceZerosBlock(1, 100_000, 13, 24);
+
+        SqlVarbinary refSketch = toSqlVarbinary(createLongSketch(8192, 24, 1, 100_000));
+        assertCardinality(indexValuesBlockBits13, BIGINT, zerosValuesBlockBits13, BIGINT, 8, 8192, refSketch, 50_000);
+        assertSketchSize(indexValuesBlockBits13, BIGINT, zerosValuesBlockBits13, BIGINT, 8, 8192, refSketch);
+
+        Block indexValuesBlockBits11 = createLongSequenceIndexBlock(1, 100_000, 11);
+        Block zerosValuesBlockBits11 = createLongSequenceZerosBlock(1, 100_000, 11, 32);
+
+        refSketch = toSqlVarbinary(createLongSketch(2048, 32, 1, 100_000));
+        assertCardinality(indexValuesBlockBits11, BIGINT, zerosValuesBlockBits11, BIGINT, 8, 2048, 32, refSketch, 50_000);
+        assertSketchSize(indexValuesBlockBits11, BIGINT, zerosValuesBlockBits11, BIGINT, 8, 2048, 32, refSketch);
+    }
+}


### PR DESCRIPTION
## Description
`noisy_approx_set_sfm()` allows the creation of a Sketch-Flip-Merge sketch, essentially a differentially private alternative to the HyperLogLog sketch. The current implementation of `noisy_approx_set_sfm()` requires a key to be passed to it, which then gets hashed. Internally it calculates a 64-bit hash using Murmur3, takes the first log2(buckets) of the hash as a bucket index and a count of trailing zeroes in the remaining bits of the hash, capped to the precision of the SFM

The new UDAF noisy_approx_set_sfm_from_index_and_zeros() added in this PR allows bypassing this and supplying the bucket index and number of zeros directly.

## Motivation and Context
The new function variant helps with data minimization in privacy-sensitive applications.

## Impact
This does not affect any existing functionality.

Added two new UDAFs `noisy_approx_set_sfm_from_index_and_zeros()`, variants of `noisy_approx_set_sfm()`:

* `noisy_approx_set_sfm_from_index_and_zeros(index bigint, zeros bigint, epsilon double, buckets int, precision int) SfmSketch`
* `noisy_approx_set_sfm_from_index_and_zeros(index bigint, zeros bigint, epsilon double, buckets int) SfmSketch` (same as above with precision defaulting to 24)

## Test Plan
Added unit test cases for the new functions and verifying the SfmSketch structures returned are the same as the existing functions.

Unit tested using:
```
mvn -Dsurefire.failIfNoSpecifiedTests=false -Dtest='*Sfm*' test -pl presto-main -am -T2C
```

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

