### PR TITLE
Reduce logs from IcebergQueryRunner

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -576,6 +576,17 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <configuration>
+                        <!-- Ignore these because they are picked up as false-positives when configuring logging in the IcebergQueryRunner-->
+                        <ignoredUsedUndeclaredDependencies>
+                            <dependency>org.glassfish.jersey.core:jersey-common:jar</dependency>
+                            <dependency>org.eclipse.jetty:jetty-server:jar</dependency>
+                        </ignoredUsedUndeclaredDependencies>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.basepom.maven</groupId>
                     <artifactId>duplicate-finder-maven-plugin</artifactId>
                     <configuration>

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.BiFunction;
 
+import static com.facebook.airlift.log.Level.ERROR;
 import static com.facebook.airlift.log.Level.WARN;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -142,8 +143,8 @@ public final class IcebergQueryRunner
             Optional<Path> dataDirectory)
             throws Exception
     {
-        Logging logger = Logging.initialize();
-        logger.setLevel("org.apache.iceberg", WARN);
+        setupLogging();
+
         Session session = testSessionBuilder()
                 .setCatalog(ICEBERG_CATALOG)
                 .setSchema("tpch")
@@ -230,10 +231,25 @@ public final class IcebergQueryRunner
         throw new PrestoException(NOT_SUPPORTED, "Unsupported Presto Iceberg catalog type " + icebergCatalogType);
     }
 
+    private static void setupLogging()
+    {
+        Logging logging = Logging.initialize();
+        logging.setLevel("com.facebook.presto.event", WARN);
+        logging.setLevel("com.facebook.presto.security.AccessControlManager", WARN);
+        logging.setLevel("com.facebook.presto.server.PluginManager", WARN);
+        logging.setLevel("com.facebook.airlift.bootstrap.LifeCycleManager", WARN);
+        logging.setLevel("org.apache.parquet.hadoop", WARN);
+        logging.setLevel("org.eclipse.jetty.server.handler.ContextHandler", WARN);
+        logging.setLevel("org.eclipse.jetty.server.AbstractConnector", WARN);
+        logging.setLevel("org.glassfish.jersey.internal.inject.Providers", ERROR);
+        logging.setLevel("parquet.hadoop", WARN);
+        logging.setLevel("org.apache.iceberg", WARN);
+    }
+
     public static void main(String[] args)
             throws Exception
     {
-        Logging.initialize();
+        setupLogging();
         Optional<Path> dataDirectory = Optional.empty();
         if (args.length > 0) {
             if (args.length != 1) {


### PR DESCRIPTION
## Description

Reduce log level on some noisy classes in the query runner. Should allow us to view logs directly in the CI UI rather than having to download the full raw logs (regularly 30MB+)

## Motivation and Context

Iceberg consistently has the largest log size of all test modules in GitHub actions. Reduce logs to require CI to store less and also makes it easier+quicker to parse through when checking for failed tests.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

