### PR TITLE
[native] Introduce delay for getResult requests on failed / aborted tasks

### DIFF
--- a/presto-docs/src/main/sphinx/develop/worker-protocol.rst
+++ b/presto-docs/src/main/sphinx/develop/worker-protocol.rst
@@ -146,3 +146,51 @@ incorrect results.
 To the client, these responses are indistinguishable from those of healthy tasks.
 To avoid request bursts, a standard delay before responding with an empty result
 set is applied.
+
+Diagnosing Issues
+~~~~~~~~~~~~~~~~~
+
+HTTP request logging can help to diagnose protocol related problems.
+
+Request logging can be enabled through the ``config.properties`` file.
+
+In Presto:
+
+.. code-block:: none
+
+    http-server.log.enabled=true
+    http-server.log.path=<request_log_file_path>
+
+
+In Prestissimo (logs are written to standard log):
+
+.. code-block:: none
+
+    http-server.enable-access-log=true
+
+Use grep to follow a certain protocol interaction.
+
+An Exchange:
+
+.. code-block:: none
+
+    cat stderr* | grep '/v1/task/20240402_223203_00000_kg5tr.11.0.455.0/results'
+    I0402 15:33:06.928076   625 AccessLogFilter.cpp:69] 2401:db00:126c:f2f:face:0:3e1:0 - - [2024-04-02 15:33:06] "GET /v1/task/20240402_223203_00000_kg5tr.11.0.455.0/results/213/0 HTTP/1.1" 200 0   57
+    I0402 15:33:07.181629   625 AccessLogFilter.cpp:69] 2401:db00:126c:f2f:face:0:3e1:0 - - [2024-04-02 15:33:07] "GET /v1/task/20240402_223203_00000_kg5tr.11.0.455.0/results/213/0 HTTP/1.1" 200 94024   0
+    I0402 15:33:25.392717   675 AccessLogFilter.cpp:69] 2401:db00:126c:f2f:face:0:3e1:0 - - [2024-04-02 15:33:25] "GET /v1/task/20240402_223203_00000_kg5tr.11.0.455.0/results/213/1 HTTP/1.1" 200 0   0
+    I0402 15:33:25.393162   675 AccessLogFilter.cpp:69] 2401:db00:126c:f2f:face:0:3e1:0 - - [2024-04-02 15:33:25] "DELETE /v1/task/20240402_223203_00000_kg5tr.11.0.455.0/results/213 HTTP/1.1" 200 0   0
+
+A ``TaskStatus`` update:
+
+.. code-block:: none
+
+    cat stderr* | grep '/v1/task/20240402_223203_00000_kg5tr.11.0.455.0/status'
+    I0402 15:33:34.629278   668 AccessLogFilter.cpp:69] 2401:db00:1210:4267:face:0:15:0 - - [2024-04-02 15:33:34] "GET /v1/task/20240402_223203_00000_kg5tr.11.0.455.0/status HTTP/1.1" 200 739   1000
+    I0402 15:33:35.636466   668 AccessLogFilter.cpp:69] 2401:db00:1210:4267:face:0:15:0 - - [2024-04-02 15:33:35] "GET /v1/task/20240402_223203_00000_kg5tr.11.0.455.0/status HTTP/1.1" 200 739   1000
+    I0402 15:33:36.644189   668 AccessLogFilter.cpp:69] 2401:db00:1210:4267:face:0:15:0 - - [2024-04-02 15:33:36] "GET /v1/task/20240402_223203_00000_kg5tr.11.0.455.0/status HTTP/1.1" 200 739   1000
+    I0402 15:33:36.768704   668 AccessLogFilter.cpp:69] 2401:db00:1210:4267:face:0:15:0 - - [2024-04-02 15:33:36] "GET /v1/task/20240402_223203_00000_kg5tr.11.0.455.0/status HTTP/1.1" 200 717   115
+
+
+The log records contain information such as response status, response size,
+and time to respond, which can help understand the interaction flow, including
+delays and timeouts, when examining them.

--- a/presto-docs/src/main/sphinx/develop/worker-protocol.rst
+++ b/presto-docs/src/main/sphinx/develop/worker-protocol.rst
@@ -125,3 +125,24 @@ upstream workers using buffer number 2.
 
 .. image:: worker-protocol-output-buffers.png
   :width: 600
+
+Failure Handling
+~~~~~~~~~~~~~~~~
+
+Task failures are reported to the coordinator via ``TaskStatus`` and ``TaskInfo``
+updates.
+
+When a task failure is discovered, the coordinator aborts all remaining tasks and
+reports a query failure to the client. When a task failure occurs or an abort
+request is received, all further processing stops, and all remaining task output
+is discarded.
+
+Failed or aborted tasks continue responding to data plane requests as usual to
+prevent cascading failures. Because the output is fully discarded upon failure, all
+following responses are empty. The ``X-Presto-Buffer-Complete`` header is set to
+``false`` to prevent downstream tasks from finishing successfully and producing
+incorrect results.
+
+To the client, these responses are indistinguishable from those of healthy tasks.
+To avoid request bursts, a standard delay before responding with an empty result
+set is applied.

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -800,36 +800,42 @@ folly::Future<std::unique_ptr<Result>> TaskManager::getResults(
       std::max(1.0, maxWait.getValue(protocol::TimeUnit::MICROSECONDS));
   VLOG(1) << "TaskManager::getResults task:" << taskId
           << ", destination:" << destination << ", token:" << token;
-  auto [promise, future] =
-      folly::makePromiseContract<std::unique_ptr<Result>>();
-
-  auto promiseHolder = std::make_shared<PromiseHolder<std::unique_ptr<Result>>>(
-      std::move(promise));
-
-  // Error in fetching results or creating a task may prevent the promise from
-  // being fulfilled leading to a BrokenPromise exception on promise
-  // destruction. To avoid the BrokenPromise exception, fulfill the promise
-  // with incomplete empty pages.
-  promiseHolder->atDestruction(
-      [token](folly::Promise<std::unique_ptr<Result>> promise) {
-        promise.setValue(createEmptyResult(token));
-      });
-
-  auto timeoutFn = [this, token]() { return createEmptyResult(token); };
 
   try {
     auto prestoTask = findOrCreateTask(taskId);
 
     // If the task is aborted or failed, then return an error.
     if (prestoTask->info.taskStatus.state == protocol::TaskState::ABORTED) {
-      promiseHolder->promise.setValue(createEmptyResult(token));
-      return std::move(future).via(httpSrvCpuExecutor_);
+      // respond with a delay to prevent request "bursts"
+      return folly::futures::sleep(std::chrono::microseconds(maxWaitMicros))
+          .via(httpSrvCpuExecutor_)
+          .thenValue([token](auto&&) { return createEmptyResult(token); });
     }
     if (prestoTask->error != nullptr) {
       LOG(WARNING) << "Calling getResult() on a failed PrestoTask: " << taskId;
-      promiseHolder->promise.setValue(createEmptyResult(token));
-      return std::move(future).via(httpSrvCpuExecutor_);
+      // respond with a delay to prevent request "bursts"
+      return folly::futures::sleep(std::chrono::microseconds(maxWaitMicros))
+          .via(httpSrvCpuExecutor_)
+          .thenValue([token](auto&&) { return createEmptyResult(token); });
     }
+
+    auto [promise, future] =
+        folly::makePromiseContract<std::unique_ptr<Result>>();
+
+    auto promiseHolder =
+        std::make_shared<PromiseHolder<std::unique_ptr<Result>>>(
+            std::move(promise));
+
+    // Error in fetching results or creating a task may prevent the promise from
+    // being fulfilled leading to a BrokenPromise exception on promise
+    // destruction. To avoid the BrokenPromise exception, fulfill the promise
+    // with incomplete empty pages.
+    promiseHolder->atDestruction(
+        [token](folly::Promise<std::unique_ptr<Result>> p) {
+          p.setValue(createEmptyResult(token));
+        });
+
+    auto timeoutFn = [token]() { return createEmptyResult(token); };
 
     for (;;) {
       if (prestoTask->taskStarted) {
@@ -878,11 +884,11 @@ folly::Future<std::unique_ptr<Result>> TaskManager::getResults(
           .onTimeout(std::chrono::microseconds(maxWaitMicros), timeoutFn);
     }
   } catch (const velox::VeloxException& e) {
-    promiseHolder->promise.setException(e);
-    return std::move(future).via(httpSrvCpuExecutor_);
+    return folly::makeSemiFuture<std::unique_ptr<Result>>(e).via(
+        httpSrvCpuExecutor_);
   } catch (const std::exception& e) {
-    promiseHolder->promise.setException(e);
-    return std::move(future).via(httpSrvCpuExecutor_);
+    return folly::makeSemiFuture<std::unique_ptr<Result>>(e).via(
+        httpSrvCpuExecutor_);
   }
 }
 

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -1278,15 +1278,55 @@ TEST_F(TaskManagerTest, getResultsFromFailedTask) {
   taskManager_->createOrUpdateErrorTask(taskId, std::make_exception_ptr(e), 0);
 
   // We expect to get empty results, rather than an exception.
+  const uint64_t startTimeUs = velox::getCurrentTimeMicro();
   auto results = taskManager_
                      ->getResults(
                          taskId,
                          0,
                          0,
                          protocol::DataSize("32MB"),
-                         protocol::Duration("300s"),
+                         protocol::Duration("1s"),
                          http::CallbackRequestHandlerState::create())
                      .get();
+  const uint64_t finishTimeUs = velox::getCurrentTimeMicro();
+
+  {
+    // ensure response is returned with a delay
+    using namespace std::chrono;
+    ASSERT_GE(
+        finishTimeUs - startTimeUs,
+        duration_cast<microseconds>(milliseconds{500}).count());
+  }
+
+  ASSERT_FALSE(results->complete);
+  ASSERT_EQ(results->data->capacity(), 0);
+}
+
+TEST_F(TaskManagerTest, getResultsFromAbortedTask) {
+  const protocol::TaskId taskId = "aborted-task.0.0.0.0";
+  // deleting a non existing task creates an aborted task
+  taskManager_->deleteTask(taskId, true);
+
+  // We expect to get empty results, rather than an exception.
+  const uint64_t startTimeUs = velox::getCurrentTimeMicro();
+  auto results = taskManager_
+                     ->getResults(
+                         taskId,
+                         0,
+                         0,
+                         protocol::DataSize("32MB"),
+                         protocol::Duration("1s"),
+                         http::CallbackRequestHandlerState::create())
+                     .get();
+  const uint64_t finishTimeUs = velox::getCurrentTimeMicro();
+
+  {
+    // ensure response is returned with a delay
+    using namespace std::chrono;
+    ASSERT_GE(
+        finishTimeUs - startTimeUs,
+        duration_cast<microseconds>(milliseconds{500}).count());
+  }
 
   ASSERT_FALSE(results->complete);
   ASSERT_EQ(results->data->capacity(), 0);


### PR DESCRIPTION
Otherwise the client will keep sending the requests in a loop

## Description

When one of the tasks fails or is aborted the consumers may create a request burst impacting overall server throughput

## Motivation and Context

Discovered when debugging exchange protocol related problem

## Impact

-

## Test Plan

Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

