### PR TITLE
Document and test HiveFileSplit

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveFileSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveFileSplit.java
@@ -24,6 +24,11 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Identifies a piece of a file at a given path starting at a given position and continuing for length bytes.
+ * This class does not check whether the file exists, or, if it exists, that it is long enough to
+ * contain all the indicated bytes.
+ */
 public class HiveFileSplit
 {
     private final String path;
@@ -34,6 +39,15 @@ public class HiveFileSplit
     private final Optional<byte[]> extraFileInfo;
     private final Map<String, String> customSplitInfo;
 
+    /**
+     * @param path the absolute path to the file that contains the split
+     * @param start the position in the containing file of the first byte of the split
+     * @param length the number of bytes in the split
+     * @param fileSize the total length of the file that contains the split
+     * @param fileModifiedTime the most recent time when the file containing the split was modified
+     * @throws NullPointerException if any object parameter is null
+     * @throws IllegalArgumentException if any numeric parameter is less than zero
+     */
     @JsonCreator
     public HiveFileSplit(
             @JsonProperty("path") String path,
@@ -44,10 +58,10 @@ public class HiveFileSplit
             @JsonProperty("extraFileInfo") Optional<byte[]> extraFileInfo,
             @JsonProperty("customSplitInfo") Map<String, String> customSplitInfo)
     {
-        checkArgument(start >= 0, "start must be positive");
-        checkArgument(length >= 0, "length must be positive");
-        checkArgument(fileSize >= 0, "fileSize must be positive");
-        checkArgument(fileModifiedTime >= 0, "modificationTime must be positive");
+        checkArgument(start >= 0, "start must be non-negative");
+        checkArgument(length >= 0, "length must be non-negative");
+        checkArgument(fileSize >= 0, "fileSize must be non-negative");
+        checkArgument(fileModifiedTime >= 0, "modificationTime must be non-negative");
         requireNonNull(path, "path is null");
         requireNonNull(extraFileInfo, "extraFileInfo is null");
         requireNonNull(customSplitInfo, "customSplitInfo is null");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileSplit.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class TestHiveFileSplit
+{
+    @Test
+    public void testGetters()
+    {
+        HiveFileSplit split = new HiveFileSplit("path", 0, 200, 3, 400, Optional.of(new byte[21]), Collections.emptyMap());
+        assertEquals(split.getPath(), "path");
+        assertEquals(split.getLength(), 200L);
+        assertEquals(split.getStart(), 0L);
+        assertEquals(split.getFileSize(), 3L);
+        assertEquals(split.getFileModifiedTime(), 400L);
+        assertEquals(split.getExtraFileInfo().get().length, 21);
+        assertEquals(split.getCustomSplitInfo().size(), 0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "start must be non-negative")
+    public void testNegativeStart()
+    {
+        new HiveFileSplit("path", -1, 200, 3, 400, Optional.of(new byte[21]), Collections.emptyMap());
+    }
+}


### PR DESCRIPTION
## Description
Added tests and API doc for HiveFileSplit

## Motivation and Context
"split" does not seem to be a common term of the art in computer science. The only references I could find to it referred to splitting ML data sets into training and verification data, which is not what this is. Also "split" is very hard to google for, and zero is not a positive number.

## Impact
More accurate precondition violation messages.

## Test Plan
CI


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

