### PR TITLE
Adds runtime-stats option to CLI

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -110,6 +110,9 @@ public class ClientOptions
     @Option(name = "--debug", title = "debug", description = "Enable debug information")
     public boolean debug;
 
+    @Option(name = "--runtime-stats", title = "runtime stats", description = "Enable runtime stats information. Flag must be used in conjunction with the --debug flag")
+    public boolean runtime;
+
     @Option(name = "--log-levels-file", title = "log levels file", description = "Configure log levels for debugging using this file")
     public String logLevelsFile;
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -124,6 +124,7 @@ public class Console
         try (QueryRunner queryRunner = new QueryRunner(
                 session,
                 clientOptions.debug,
+                clientOptions.runtime,
                 Optional.ofNullable(clientOptions.socksProxy),
                 Optional.ofNullable(clientOptions.httpProxy),
                 Optional.ofNullable(clientOptions.keystorePath),

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -58,12 +58,14 @@ public class Query
     private final AtomicBoolean ignoreUserInterrupt = new AtomicBoolean();
     private final StatementClient client;
     private final boolean debug;
+    private final boolean runtime;
     private Optional<Long> clientStopTimestamp = Optional.empty();
 
-    public Query(StatementClient client, boolean debug)
+    public Query(StatementClient client, boolean debug, boolean runtime)
     {
         this.client = requireNonNull(client, "client is null");
         this.debug = debug;
+        this.runtime = runtime;
     }
 
     public Optional<String> getSetCatalog()
@@ -148,7 +150,7 @@ public class Query
         WarningsPrinter warningsPrinter = new PrintStreamWarningsPrinter(System.err);
 
         if (interactive) {
-            statusPrinter = new StatusPrinter(client, out, debug);
+            statusPrinter = new StatusPrinter(client, out, debug, runtime);
             statusPrinter.printInitialStatusUpdates();
         }
         else {

--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -46,12 +46,14 @@ public class QueryRunner
 {
     private final AtomicReference<ClientSession> session;
     private final boolean debug;
+    private final boolean runtime;
     private final OkHttpClient httpClient;
     private final Consumer<OkHttpClient.Builder> sslSetup;
 
     public QueryRunner(
             ClientSession session,
             boolean debug,
+            boolean runtime,
             Optional<HostAndPort> socksProxy,
             Optional<HostAndPort> httpProxy,
             Optional<String> keystorePath,
@@ -71,6 +73,7 @@ public class QueryRunner
     {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
         this.debug = debug;
+        this.runtime = runtime;
 
         this.sslSetup = builder -> setupSsl(builder, keystorePath, keystorePassword, truststorePath, truststorePassword);
 
@@ -120,7 +123,7 @@ public class QueryRunner
 
     public Query startQuery(String query)
     {
-        return new Query(startInternalQuery(session.get(), query), debug);
+        return new Query(startInternalQuery(session.get(), query), debug, runtime);
     }
 
     public StatementClient startInternalQuery(String query)

--- a/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
@@ -126,6 +126,7 @@ public abstract class AbstractCliTest
         return new QueryRunner(
                 clientSession,
                 false,
+                false,
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
@@ -34,7 +34,6 @@ public class TestClientOptions
         assertEquals(session.getServer().toString(), "http://localhost:8080");
         assertEquals(session.getSource(), "presto-cli");
     }
-
     @Test
     public void testSource()
     {
@@ -139,6 +138,13 @@ public class TestClientOptions
     {
         Console console = singleCommand(Console.class).parse("--disable-redirects");
         assertTrue(console.clientOptions.disableRedirects);
+    }
+
+    @Test
+    public void testRunTimeStat()
+    {
+        Console console = singleCommand(Console.class).parse("--runtime-stats");
+        assertTrue(console.clientOptions.runtime);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
## Description
Hides runtime stats from Presto CLI in debug mode. Instead use --runtime-stats to show query statistics.


## Motivation and Context
Resolves visibility issues explained in #22041 .


## Impact
User must opt in to view runtime stats. 

## Test Plan
Use the --debug option and make a query. Then use the --runtime-stats option to view difference.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

