### PR TITLE
Document  hidden $row_id column

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -872,6 +872,7 @@ columns as a part of SQL query like any other columns of the table.
 * ``$path`` : Filepath for the given row data
 * ``$file_size`` : Filesize for the given row
 * ``$file_modified_time`` : Last file modified time for the given row
+* ``$row_id`` : A persistent, globally unique, binary identifier for the row that can be compared for equality, byte by byte
 
 How to invalidate metastore cache?
 ---------------------------------


### PR DESCRIPTION
## Description
Announce that $row_id exists

## Motivation and Context
fixes #22078

## Impact
We now have row IDs.

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Hive Connector Changes
* Adds a $row_id hidden column that provides a persistent, globally unique, binary identifier for reach row.
```

