### PR TITLE
[native] Add virtual destructor to PeriodicMemoryChecker

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
@@ -67,6 +67,8 @@ class PeriodicMemoryChecker {
 
   explicit PeriodicMemoryChecker(Config config);
 
+  virtual ~PeriodicMemoryChecker() = default;
+
   /// Starts the 'PeriodicMemoryChecker'. A background scheduler will be
   /// launched to perform the checks. This should only be called once.
   void start();

--- a/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
@@ -39,6 +39,8 @@ class PeriodicMemoryCheckerTest : public testing::Test {
           periodicCb_(std::move(periodicCb)),
           heapDumpCb_(std::move(heapDumpCb)) {}
 
+    ~TestPeriodicMemoryChecker() override {}
+
     void setMallocBytes(int64_t mallocBytes) {
       mallocBytes_ = mallocBytes;
     }


### PR DESCRIPTION
Add virtual destructor to pass Meta's internal checks
```
== NO RELEASE NOTE ==
```

