### PR TITLE
[native ] Fix setup scripts to align with Velox setup scripts

### DIFF
--- a/presto-native-execution/Makefile
+++ b/presto-native-execution/Makefile
@@ -113,7 +113,8 @@ centos-container:			#: Build the linux container for CircleCi
 linux-container:
 	rm -rf /tmp/docker && \
 	mkdir -p /tmp/docker && \
-	cp scripts/setup-$(CONTAINER_NAME).sh scripts/$(CONTAINER_NAME)-container.dockfile velox/scripts/setup-helper-functions.sh /tmp/docker && \
+	$(eval VELOX_SETUP_SCRIPT=$(shell [ $(CONTAINER_NAME) == centos ] && echo setup-centos8.sh; [ $(CONTAINER_NAME) != centos ] && echo setup-$(CONTAINER_NAME).sh;)) \
+	cp scripts/setup-$(CONTAINER_NAME).sh scripts/$(CONTAINER_NAME)-container.dockfile velox/scripts/${VELOX_SETUP_SCRIPT} velox/scripts/setup-helper-functions.sh /tmp/docker && \
 	cd /tmp/docker && \
 	docker build --build-arg cpu_target=$(CPU_TARGET) --tag "prestocpp/prestocpp-$(CPU_TARGET)-$(CONTAINER_NAME):$(USER)-$(shell date +%Y%m%d)" -f $(CONTAINER_NAME)-container.dockfile .
 

--- a/presto-native-execution/scripts/centos-container.dockfile
+++ b/presto-native-execution/scripts/centos-container.dockfile
@@ -16,4 +16,4 @@ FROM ghcr.io/facebookincubator/velox-dev:centos8
 COPY setup-centos.sh /
 COPY setup-helper-functions.sh /
 RUN chmod +x ./setup-centos.sh
-RUN mkdir build && ( cd build && ../setup-centos.sh ) && rm -rf build
+RUN mkdir build && ( cd build && ../setup-centos.sh install_presto_deps ) && rm -rf build

--- a/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
+++ b/presto-native-execution/scripts/release-centos-dockerfile/Dockerfile
@@ -70,7 +70,6 @@ RUN --mount=type=ssh \
 WORKDIR ${DEPENDENCY_DIR}
 RUN --mount=type=ssh \
     set -exu && \
-    bash "${PRESTODB_HOME}/_repo/presto-native-execution/velox/scripts/setup-centos8.sh" && \
     bash "${PRESTODB_HOME}/_repo/presto-native-execution/scripts/setup-centos.sh" && \
     python3 -m pip install six && \
     set +exu && \

--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -16,10 +16,7 @@ set -eufx -o pipefail
 # Run the velox setup script first.
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-macos.sh"
 
-MACOS_DEPS="${MACOS_DEPS} bison gperf"
 export FB_OS_VERSION=v2024.04.01.00
-
-export PATH=$(brew --prefix bison)/bin:$PATH
 
 function install_proxygen {
   github_checkout facebook/proxygen "${FB_OS_VERSION}"
@@ -27,7 +24,7 @@ function install_proxygen {
 }
 
 function install_presto_deps {
-  install_velox_deps
+  install_from_brew "gperf"
   run_and_time install_proxygen
 }
 
@@ -35,6 +32,15 @@ if [[ $# -ne 0 ]]; then
   for cmd in "$@"; do
     run_and_time "${cmd}"
   done
+  echo "All specified dependencies installed!"
 else
+  if [ "${INSTALL_PREREQUISITES:-Y}" == "Y" ]; then
+    echo "Installing build dependencies"
+    run_and_time install_build_prerequisites
+  else
+    echo "Skipping installation of build dependencies since INSTALL_PREREQUISITES is not set"
+  fi
+  install_velox_deps
   install_presto_deps
+  echo "All dependencies for Prestissimo installed!"
 fi

--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -19,7 +19,10 @@ set -eufx -o pipefail
 # Run the velox setup script first.
 source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-ubuntu.sh"
 export FB_OS_VERSION=v2024.04.01.00
-sudo apt install -y gperf
+
+function install_presto_deps_from_apt {
+  sudo apt install -y gperf
+}
 
 function install_proxygen {
   github_checkout facebook/proxygen "${FB_OS_VERSION}"
@@ -27,7 +30,7 @@ function install_proxygen {
 }
 
 function install_presto_deps {
-  install_velox_deps
+  run_and_time install_presto_deps_from_apt
   run_and_time install_proxygen
 }
 
@@ -35,6 +38,15 @@ if [[ $# -ne 0 ]]; then
   for cmd in "$@"; do
     run_and_time "${cmd}"
   done
+  echo "All specified dependencies installed!"
 else
+  if [ "${INSTALL_PREREQUISITES:-Y}" == "Y" ]; then
+    echo "Installing build dependencies"
+    run_and_time install_build_prerequisites
+  else
+    echo "Skipping installation of build dependencies since INSTALL_PREREQUISITES is not set"
+  fi
+  install_velox_deps
   install_presto_deps
+  echo "All dependencies for Prestissimo installed!"
 fi


### PR DESCRIPTION
## Description
Velox setup scripts have been modified to not install the build dependencies by default.
Fix setup scripts to adopt that behavior.
Fix setup scripts to encapsulate presto packages into a function.
Fix setup-centos8.sh script to include Velox dependencies.

## Motivation and Context
Above

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

