### PR TITLE
Disable TestDirectoryListCacheInvalidation

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestDirectoryListCacheInvalidation.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestDirectoryListCacheInvalidation.java
@@ -33,7 +33,8 @@ public class TestDirectoryListCacheInvalidation
         query("CREATE TABLE hivecached.default.region_cache AS SELECT * FROM tpch.tiny.region");
     }
 
-    @Test(groups = {HIVE_LIST_CACHING})
+    // Flaky test: https://github.com/prestodb/presto/issues/22425
+    @Test(groups = {HIVE_LIST_CACHING}, enabled = false)
     public void testDirectoryListCacheInvalidation()
     {
         String jmxMetricsQuery = "SELECT sum(hitcount), sum(misscount) from jmx.current.\"com.facebook.presto.hive:name=hivecached,type=cachingdirectorylister\"";


### PR DESCRIPTION
## Description
Temporarily disabling this test because it is flaky.

## Motivation and Context
This test has become flaky recently.

## Impact
Less test coverage while #22425 is being root caused.

## Test Plan
Full CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

