### PR TITLE
Use temurin distribution of OpenJDK

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,8 +30,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Install LaTeX dependencies
         run: |

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -42,8 +42,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven
@@ -93,8 +94,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -40,8 +40,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -26,8 +26,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -46,8 +46,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -46,8 +46,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven
@@ -96,8 +97,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -53,8 +53,9 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           echo "=== AFTER ==="
           df -h
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -41,8 +41,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -41,8 +41,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         id: cache-maven

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,9 +75,10 @@ jobs:
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         if: needs.changes.outputs.codechange == 'true'
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         if: needs.changes.outputs.codechange == 'true'


### PR DESCRIPTION
## Description
Potential fix for #22373, use Temurin since this is already installed locally in Actions runners, and it may have a more reliable mirror if not.

## Motivation and Context
#22373

## Impact
Hopefully, less failures fetching Java.

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

