### PR TITLE
Fix a bug in cte materialization when SimplifyPlanWithEmptyInput optimizer updates a plan

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
@@ -72,6 +72,18 @@ public class TestCteExecution
     }
 
     @Test
+    public void testCteExecutionWhereChildPlanRemovedBySimplifyEmptyInputRule()
+    {
+        String sql = "WITH t as(SELECT * FROM orders LEFT JOIN (select orderkey from orders where false) ON TRUE) " +
+                "SELECT * FROM t";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(queryRunner.execute(getMaterializedSession(),
+                        sql),
+                queryRunner.execute(getSession(),
+                        sql));
+    }
+
+    @Test
     public void testSimplePersistentCte()
     {
         QueryRunner queryRunner = getQueryRunner();

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -71,6 +71,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -528,12 +529,16 @@ public class TestCostCalculator
                 cteConsumerNode2,
                 JoinDistributionType.PARTITIONED,
                 "orderkey", "custkey");
+        MutableGraph<Integer> sequenceGraph = GraphBuilder.directed().build();
+        // Add indexes to the graph
+        sequenceGraph.addNode(0);
+        sequenceGraph.addNode(1);
         SequenceNode sequenceNode = new SequenceNode(
                 Optional.empty(),
                 new PlanNodeId("sequence"),
                 ImmutableList.of(cteProducerNode1, cteProducerNode2),
                 joinNode,
-                GraphBuilder.directed().build());
+                sequenceGraph);
 
         // Define cost of sequence children
         Map<String, PlanCostEstimate> costs = ImmutableMap.of(


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

This is caused by a small bug due to refactor in the PR https://github.com/prestodb/presto/pull/22205

Fixed a bug in [removeCteProducersFromCteDependencyGraph](https://github.com/prestodb/presto/pull/22451/files#diff-6ca586a297cb2e366d7db3e19e749557829ff6e70132ac07be9823877340a4a5R126) function of Sequence node, currently used by SimplifyPlanWithEmptyInput optimizer where a cte producer was dropped from the graph (and from scheduling) if there were no edges leading from it leading to wrong results 


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Unit test which fails without this change

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

