### PR TITLE
Upgrade Alluxio to 312

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>310</dep.alluxio.version>
+        <dep.alluxio.version>312</dep.alluxio.version>
         <dep.slf4j.version>1.7.32</dep.slf4j.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.pinot.version>0.11.0</dep.pinot.version>


### PR DESCRIPTION
This upgraded version enhances cache TTL: don't load cache pages which exceed the TTL from local file after the worker restart.

```
== RELEASE NOTES ==

General Changes
* Upgrade Alluxio to 312.
```

