### PR TITLE
Remove predicate in IcebergTableHandle to clarify the responsibilities

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -764,7 +764,7 @@ public class IcebergPageSourceProvider
                 split.getLength(),
                 split.getFileFormat(),
                 regularColumns,
-                table.getPredicate(),
+                icebergLayout.getValidPredicate(),
                 splitContext.isCacheable());
         ConnectorPageSource dataPageSource = connectorPageSourceWithRowPositions.getConnectorPageSource();
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
@@ -29,6 +29,7 @@ public class IcebergTableHandle
         extends BaseHiveTableHandle
 {
     private final IcebergTableName icebergTableName;
+    // TODO: this field is no longer useful, would be removed in a subsequent PR
     private final TupleDomain<IcebergColumnHandle> predicate;
     private final boolean snapshotSpecified;
     private final Optional<String> outputPath;


### PR DESCRIPTION
## Description

Maintaining the predicate in multiple places by different code paths currently is quite confusing.

This PR totally discard the predicate in `IcebergTableHandle`, and just maintain the information about predicate in `IcebergTableLayoutHandle` inside iceberg connector. So that the responsibilities of `IcebergTableHandle`, `IcebergTableLayoutHandle` and `ConnectorTableLayout` could be clarified more clearer, and the behaviors could be more consistent between iceberg.pushdown_filter_enabled on and off.

## Motivation and Context

Make Iceberg connector implementation more clearer

## Impact

N/A

## Test Plan

 - Make sure the refactor do not affect existing test cases
 - Make sure the simplification of predicate on partitioned columns do not lead to incorrect result

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

