### PR TITLE
Modify TestDirectoryListCacheInvalidation to fix flakiness

### DIFF
--- a/presto-product-tests/conf/presto/etc/catalog/hive_listcache.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/hive_listcache.properties
@@ -1,0 +1,25 @@
+#
+# WARNING
+# ^^^^^^^
+# This configuration file is for development only and should NOT be used be
+# used in production. For example configuration, see the Presto documentation.
+#
+
+connector.name=hive-hadoop2
+hive.metastore.uri=thrift://hadoop-master:9083
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
+hive.config.resources=/docker/volumes/conf/presto/etc/hive-default-fs-site.xml
+hive.allow-add-column=true
+hive.allow-drop-column=true
+hive.allow-rename-column=true
+hive.allow-drop-table=true
+hive.allow-rename-table=true
+hive.metastore-cache-ttl=0s
+hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100
+hive.collect-column-statistics-on-write=true
+
+# List file cache
+hive.file-status-cache-expire-time=24h
+hive.file-status-cache-size=100000000
+hive.file-status-cache-tables=*


### PR DESCRIPTION
## Description
Modify TestDirectoryListCacheInvalidation to fix flakiness

## Motivation and Context
TestDirectoryListCacheInvalidation test was failing because caching catalog `hivecached` is shared with https://github.com/prestodb/presto/blob/master/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSymlinkTableListCaching.java So the initial existing assert https://github.com/prestodb/presto/blob/master/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestDirectoryListCacheInvalidation.java#L45  may not be true if TestSymlinkTableListCaching is running first. Since the JMX for `hitcount` and `misscount` may already be populated as part of TestSymlinkTableListCaching

## Impact
Fixes https://github.com/prestodb/presto/issues/22425

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

