### PR TITLE
Renumber $file_modified_time and $file_size hidden columns

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
@@ -59,14 +59,12 @@ public class HiveColumnHandle
     public static final HiveType ROW_ID_TYPE = HIVE_BINARY;
     public static final TypeSignature ROW_ID_TYPE_SIGNATURE = ROW_ID_TYPE.getTypeSignature();
 
-    // TODO these are buggy. Column indexes less than -13 can conflict with partition key indexes.
-    // Renumber them if possible.
-    public static final int FILE_SIZE_COLUMN_INDEX = -15;
+    public static final int FILE_SIZE_COLUMN_INDEX = -9;
     public static final String FILE_SIZE_COLUMN_NAME = "$file_size";
     public static final HiveType FILE_SIZE_TYPE = HIVE_LONG;
     public static final TypeSignature FILE_SIZE_TYPE_SIGNATURE = FILE_SIZE_TYPE.getTypeSignature();
 
-    public static final int FILE_MODIFIED_TIME_COLUMN_INDEX = -14;
+    public static final int FILE_MODIFIED_TIME_COLUMN_INDEX = -8;
     public static final String FILE_MODIFIED_TIME_COLUMN_NAME = "$file_modified_time";
     public static final HiveType FILE_MODIFIED_TIME_TYPE = HIVE_LONG;
     public static final TypeSignature FILE_MODIFIED_TIME_TYPE_SIGNATURE = FILE_MODIFIED_TIME_TYPE.getTypeSignature();


### PR DESCRIPTION
## Description
Renumber $file_modified_time and $file_size hidden columns to avoid conflicts with partition key column indexes that start at -13 and decrease.

## Motivation and Context
Code is buggy and only works by accident. It can fail if these numbers are used somewhere else.

## Impact
Changes values of public constants.

* HiveColumnHandle.FILE_SIZE_COLUMN_INDEX has been changed from -15 to -9.* 
* HiveColumnHandle.FILE_MODIFIED_TIME_COLUMN_INDEX has been changed from -14 to -8.

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

