### PR TITLE
[native] Use Task::driverCounts() to report elaborate driver counters

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -23,11 +23,6 @@
 
 namespace facebook::presto {
 
-struct DriverCountStats {
-  size_t numBlockedDrivers{0};
-  size_t numRunningDrivers{0};
-};
-
 class TaskManager {
  public:
   TaskManager(
@@ -139,8 +134,8 @@ class TaskManager {
     return taskMap_.rlock()->size();
   }
 
-  // Returns the number of running drivers in all tasks.
-  DriverCountStats getDriverCountStats() const;
+  /// Stores the number of drivers in various states of execution.
+  velox::exec::Task::DriverCounts getDriverCounts() const;
 
   // Returns array with number of tasks for each of five TaskState (enum defined
   // in exec/Task.h).

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -63,8 +63,32 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(kCounterNumTasksDeadlock, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterNumTaskManagerLockTimeOut, facebook::velox::StatType::AVG);
-  DEFINE_METRIC(kCounterNumRunningDrivers, facebook::velox::StatType::AVG);
-  DEFINE_METRIC(kCounterNumBlockedDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterNumQueuedDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterNumOnThreadDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterNumSuspendedDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumBlockedWaitForConsumerDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumBlockedWaitForSplitDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumBlockedWaitForProducerDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumBlockedWaitForJoinBuildDrivers,
+      facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumBlockedWaitForJoinProbeDrivers,
+      facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumBlockedWaitForMergeJoinRightSideDrivers,
+      facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumBlockedWaitForMemoryDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumBlockedWaitForConnectorDrivers,
+      facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumBlockedWaitForSpillDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterNumBlockedYieldDrivers, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumStuckDrivers, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterMappedMemoryBytes, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterAllocatedMemoryBytes, facebook::velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -72,10 +72,33 @@ constexpr folly::StringPiece kCounterNumTasksDeadlock{
     "presto_cpp.num_tasks_deadlock"};
 constexpr folly::StringPiece kCounterNumTaskManagerLockTimeOut{
     "presto_cpp.num_tasks_manager_lock_timeout"};
-constexpr folly::StringPiece kCounterNumRunningDrivers{
-    "presto_cpp.num_running_drivers"};
-constexpr folly::StringPiece kCounterNumBlockedDrivers{
-    "presto_cpp.num_blocked_drivers"};
+
+constexpr folly::StringPiece kCounterNumQueuedDrivers{
+    "presto_cpp.num_queued_drivers"};
+constexpr folly::StringPiece kCounterNumOnThreadDrivers{
+    "presto_cpp.num_on_thread_drivers"};
+constexpr folly::StringPiece kCounterNumSuspendedDrivers{
+    "presto_cpp.num_suspended_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedWaitForConsumerDrivers{
+    "presto_cpp.num_blocked_wait_for_consumer_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedWaitForSplitDrivers{
+    "presto_cpp.num_blocked_wait_for_split_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedWaitForProducerDrivers{
+    "presto_cpp.num_blocked_wait_for_producer_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedWaitForJoinBuildDrivers{
+    "presto_cpp.num_blocked_wait_for_join_build_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedWaitForJoinProbeDrivers{
+    "presto_cpp.num_blocked_wait_fro_join_probe_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedWaitForMergeJoinRightSideDrivers{
+    "presto_cpp.num_blocked_wait_for_merge_join_right_side_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedWaitForMemoryDrivers{
+    "presto_cpp.num_blocked_wait_for_memory_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedWaitForConnectorDrivers{
+    "presto_cpp.num_blocked_wait_for_connector_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedWaitForSpillDrivers{
+    "presto_cpp.num_blocked_wait_for_spill_drivers"};
+constexpr folly::StringPiece kCounterNumBlockedYieldDrivers{
+    "presto_cpp.num_blocked_yield_drivers"};
 constexpr folly::StringPiece kCounterNumStuckDrivers{
     "presto_cpp.num_stuck_drivers"};
 


### PR DESCRIPTION
## Description
Use Task::driverCounts() to report elaborate driver counters.
To get a better picture of what is happenning on the server.

```
== NO RELEASE NOTE ==
```

