### PR TITLE
Add a config property to allow turning row IDs off

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -218,6 +218,8 @@ public class HiveClientConfig
     private int quickStatsMaxConcurrentCalls = 100;
     private DataSize affinitySchedulingFileSectionSize = new DataSize(256, MEGABYTE);
 
+    private boolean rowIDEnabled = true;
+
     @Min(0)
     public int getMaxInitialSplits()
     {
@@ -1776,6 +1778,19 @@ public class HiveClientConfig
     {
         this.partitionFilteringFromMetastoreEnabled = partitionFilteringFromMetastoreEnabled;
         return this;
+    }
+
+    @Config("hive.row-id-enabled")
+    @ConfigDescription("Support the $row_id hidden column")
+    public HiveClientConfig setRowIDEnabled(boolean rowIDEnabled)
+    {
+        this.rowIDEnabled = rowIDEnabled;
+        return this;
+    }
+
+    public boolean isRowIDEnabled()
+    {
+        return this.rowIDEnabled;
     }
 
     @Config("hive.parallel-parsing-of-partition-values-enabled")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -131,6 +131,7 @@ public final class HiveSessionProperties
     public static final String QUICK_STATS_BACKGROUND_BUILD_TIMEOUT = "quick_stats_background_build_timeout";
     public static final String DYNAMIC_SPLIT_SIZES_ENABLED = "dynamic_split_sizes_enabled";
     public static final String AFFINITY_SCHEDULING_FILE_SECTION_SIZE = "affinity_scheduling_file_section_size";
+    public static final String ROW_ID_ENABLED = "row_id_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -601,6 +602,11 @@ public final class HiveSessionProperties
                         hiveClientConfig.isHudiMetadataEnabled(),
                         false),
                 booleanProperty(
+                        ROW_ID_ENABLED,
+                        "Support the $row_id hidden column",
+                        hiveClientConfig.isRowIDEnabled(),
+                        false),
+                booleanProperty(
                         PARALLEL_PARSING_OF_PARTITION_VALUES_ENABLED,
                         "Enables parallel parsing of partition values from partition names using thread pool",
                         hiveClientConfig.isParallelParsingOfPartitionValuesEnabled(),
@@ -666,6 +672,11 @@ public final class HiveSessionProperties
     public static InsertExistingPartitionsBehavior getInsertExistingPartitionsBehavior(ConnectorSession session)
     {
         return session.getProperty(INSERT_EXISTING_PARTITIONS_BEHAVIOR, InsertExistingPartitionsBehavior.class);
+    }
+
+    public static boolean isRowIDEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ROW_ID_ENABLED, Boolean.class);
     }
 
     public static DataSize getOrcStringStatisticsLimit(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -941,7 +941,7 @@ public final class HiveUtil
         return partitionKey;
     }
 
-    public static List<HiveColumnHandle> hiveColumnHandles(Table table)
+    public static List<HiveColumnHandle> hiveColumnHandles(Table table, boolean rowIDEnabled)
     {
         ImmutableList.Builder<HiveColumnHandle> columns = ImmutableList.builder();
 
@@ -958,7 +958,9 @@ public final class HiveUtil
         }
         columns.add(fileSizeColumnHandle());
         columns.add(fileModifiedTimeColumnHandle());
-        columns.add(rowIdColumnHandle());
+        if (rowIDEnabled) {
+            columns.add(rowIdColumnHandle());
+        }
 
         return columns.build();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -164,7 +164,8 @@ public class TestHiveClientConfig
                 .setParquetQuickStatsFileMetadataFetchTimeout(new Duration(60, TimeUnit.SECONDS))
                 .setMaxConcurrentQuickStatsCalls(100)
                 .setMaxConcurrentParquetQuickStatsCalls(500)
-                .setAffinitySchedulingFileSectionSize(new DataSize(256, MEGABYTE)));
+                .setAffinitySchedulingFileSectionSize(new DataSize(256, MEGABYTE))
+                .setRowIDEnabled(true));
     }
 
     @Test
@@ -290,6 +291,7 @@ public class TestHiveClientConfig
                 .put("hive.quick-stats.parquet.max-concurrent-calls", "399")
                 .put("hive.quick-stats.max-concurrent-calls", "101")
                 .put("hive.affinity-scheduling-file-section-size", "512MB")
+                .put("hive.row-id-enabled", "false")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -410,8 +412,8 @@ public class TestHiveClientConfig
                 .setParquetQuickStatsFileMetadataFetchTimeout(new Duration(30, TimeUnit.SECONDS))
                 .setMaxConcurrentParquetQuickStatsCalls(399)
                 .setMaxConcurrentQuickStatsCalls(101)
-                .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE));
-
+                .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE))
+                .setRowIDEnabled(false);
         ConfigAssertions.assertFullMapping(properties, expected);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
@@ -105,11 +105,11 @@ public class TestHiveMetadata
                 Optional.empty(),
                 Optional.empty());
 
-        ColumnMetadata actual = HiveMetadata.columnMetadataGetter(mockTable, mockTypeManager, new HiveColumnConverter()).apply(hiveColumnHandle1);
+        ColumnMetadata actual = HiveMetadata.columnMetadataGetter(mockTable, mockTypeManager, new HiveColumnConverter(), true).apply(hiveColumnHandle1);
         ColumnMetadata expected = new ColumnMetadata("c1", IntegerType.INTEGER);
         assertEquals(actual, expected);
 
-        actual = HiveMetadata.columnMetadataGetter(mockTable, mockTypeManager, new TestColumnConverter()).apply(hidden);
+        actual = HiveMetadata.columnMetadataGetter(mockTable, mockTypeManager, new TestColumnConverter(), true).apply(hidden);
         expected = ColumnMetadata.builder().setName(HiveColumnHandle.PATH_COLUMN_NAME).setType(IntegerType.INTEGER).setHidden(true).build();
         assertEquals(actual, expected);
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -537,7 +537,7 @@ public class IcebergHiveMetadata
         List<String> partitionColumnNames = partitionColumns.stream()
                 .map(Column::getName)
                 .collect(toImmutableList());
-        List<HiveColumnHandle> hiveColumnHandles = hiveColumnHandles(table);
+        List<HiveColumnHandle> hiveColumnHandles = hiveColumnHandles(table, false);
         Map<String, Type> columnTypes = hiveColumnHandles.stream()
                 .filter(columnHandle -> !columnHandle.isHidden())
                 .collect(toImmutableMap(HiveColumnHandle::getName, column -> column.getHiveType().getType(typeManager)));


### PR DESCRIPTION
## Description
Add the config property hive.row-id-enabled that can guard the $row_id column so we can turn it off if it's problematic for whatever reasons.

## Motivation and Context
safety and paranoia

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Add ``setRowIDEnabled`` configuration property to
```


