### PR TITLE
[native] Advance velox version

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -193,8 +193,6 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
       !SystemConfig::instance()->memoryArbitratorKind().empty()
           ? memory::MemoryReclaimer::create()
           : nullptr);
-  RECORD_HISTOGRAM_METRIC_VALUE(
-      kCounterQueryMemoryPoolInitCapacity, pool->capacity());
 
   auto queryCtx = std::make_shared<core::QueryCtx>(
       driverExecutor_,

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -90,16 +90,6 @@ void registerPrestoMetrics() {
       0,
       62l * 1024 * 1024 * 1024, // max bucket value: 62GB
       100);
-  DEFINE_HISTOGRAM_METRIC(
-      kCounterQueryMemoryPoolInitCapacity,
-      4l * 1024 * 1024, // 4MB bucket size
-      0,
-      1024l * 1024 * 1024, // 1GB max size
-      5,
-      50,
-      90,
-      95,
-      100);
 
   /// ================== AsyncDataCache Counters ==================
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -141,9 +141,6 @@ constexpr folly::StringPiece kCounterMmapRawAllocBytesSmall{
 /// Peak number of bytes queued in PrestoExchangeSource waiting for consume.
 constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
     "presto_cpp.exchange_source_peak_queued_bytes"};
-/// Initial capacity of the root memory pool of queries
-constexpr folly::StringPiece kCounterQueryMemoryPoolInitCapacity{
-    "presto_cpp.query_memory_pool_init_capacity"};
 
 /// ================== Memory Arbitrator Counters =================
 


### PR DESCRIPTION
Also deprecate presto_cpp.query_memory_pool_init_capacity which has been supported in velox
