### PR TITLE
Fix typo in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,7 +52,7 @@ CODEOWNERS @prestodb/team-tsc
 
 #####################################################################
 # Presto Console UI
-/presto-main/src/main/resources/webapp/* @yhwang @prestodb/committers
+/presto-main/src/main/resources/webapp @yhwang @prestodb/committers
 
 #####################################################################
 # Presto documentation


### PR DESCRIPTION

## Description
Currently, @yhwang only has ability to approve PRs one level deep. Fix it so he can approve any PR in the UI module.

## Motivation and Context
Was curious why @yhwang couldn't approve #22478.

## Impact
See above.

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

