### PR TITLE
Calculate row IDs in OrcSelectiveRecordReader

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -512,7 +512,10 @@ public class MaterializedResult
                 for (int channel = 0; channel < page.getChannelCount(); channel++) {
                     Type type = types.get(channel);
                     Block block = page.getBlock(channel);
-                    values.add(type.getObjectValue(session.getSqlFunctionProperties(), block, position));
+                    if (block != null) { // block is null for an unfilled $row_id
+                        Object value = type.getObjectValue(session.getSqlFunctionProperties(), block, position);
+                        values.add(value);
+                    }
                 }
                 values = Collections.unmodifiableList(values);
 


### PR DESCRIPTION
## Description
in HivePageSource we add an empty slice, but this is not enough. We need row numbers in this slice to be coerced.

## Motivation and Context
#22078

## Impact
row IDs are filled in

## Test Plan
TestOrcReaderPositions.testRowIDs

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

