### PR TITLE
[native]Fix flaky test UnsafeRowShuffleTest

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -317,6 +317,11 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
         std::make_unique<ShuffleWriteTranslator>());
   }
 
+  void TearDown() override {
+    exec::test::waitForAllTasksToBeDeleted();
+    exec::test::OperatorTestBase::TearDown();
+  }
+
   static std::string makeTaskId(
       const std::string& prefix,
       int num,


### PR DESCRIPTION
Test is flaky because lingering task caused memory leak. We need to make sure task is deleted before cleanup the test environment.
```
== NO RELEASE NOTE ==
```

