### PR TITLE
[docs] Fix heading formatting in admin/properties.rst

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -201,7 +201,7 @@ Spilling Properties
     This config property can be overridden by the ``order_by_aggregation_spill_enabled`` session property.
 
 ``experimental.window-spill-enabled``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     * **Type:** ``boolean``
     * **Default value:** ``true``
@@ -212,7 +212,7 @@ Spilling Properties
     This config property can be overridden by the ``window_spill_enabled`` session property.
 
 ``experimental.order-by-spill-enabled``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     * **Type:** ``boolean``
     * **Default value:** ``true``
@@ -284,7 +284,7 @@ Spilling Properties
     is ignored for any other spilling strategy.
 
 ``experimental.max-revocable-memory-per-node``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     * **Type:** ``data size``
     * **Default value:** ``16GB``
 
@@ -305,7 +305,7 @@ Spilling Properties
     cause JVM to pause for lengthy periods, causing queries to fail.
 
 ``experimental.spiller-max-used-space-threshold``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     * **Type:** ``double``
     * **Default value:** ``0.9``
@@ -758,7 +758,7 @@ Optimizer Properties
     also be specified on a per-query basis using the ``join_reordering_strategy`` session property.
 
 ``optimizer.max-reordered-joins``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     * **Type:** ``integer``
     * **Default value:** ``9``
@@ -829,10 +829,10 @@ Optimizer Properties
     a query plan. The optimizer may then use these properties to perform various optimizations.
 
 Planner Properties
---------------------------------------
+------------------
 
 ``planner.query-analyzer-timeout``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     * **Type:** ``duration``
     * **Default value:** ``3m``
@@ -888,10 +888,10 @@ The following properties allow tuning the :doc:`/functions/regexp`.
     The more rows you are processing, the larger this value should be.
 
 CTE Materialization Properties
---------------------------------------
+------------------------------
 
 ``cte-materialization-strategy``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     * **Type:** ``string``
     * **Allowed values:** ``ALL``, ``NONE``


### PR DESCRIPTION
## Description
Fix formatting of headings in admin/properties.rst.

## Motivation and Context
When reviewing [PR 22266](https://github.com/prestodb/presto/pull/22266) I noticed some of the heading formatters were different lengths than the text of the headings. Addressing this minor problem in that PR was out of scope for that PR.

## Impact
Documentation.

## Test Plan
Local build of docs after changes succeeded, also verified the built page had no new concerns introduced by the changes. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

