### PR TITLE
Construct row ID block in OrcSelectivePageSource

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveAggregatedPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveAggregatedPageSourceFactory.java
@@ -31,6 +31,5 @@ public interface HiveAggregatedPageSourceFactory
             Storage storage,
             List<HiveColumnHandle> columns,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation,
-            boolean appendRowNumberEnabled);
+            Optional<EncryptionInformation> encryptionInformation);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1677,12 +1677,12 @@ public class HiveMetadata
                     handle,
                     table,
                     partitionUpdates);
-            // replace partitionUpdates before creating the zero-row files so that those files will be cleaned up if we end up rollback
+            // replace partitionUpdates before creating the zero-row files so that those files will be cleaned up if we roll back
             partitionUpdates = PartitionUpdate.mergePartitionUpdates(concat(partitionUpdates, partitionUpdatesForMissingBuckets));
             HdfsContext hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName(), table.getStorage().getLocation(), true);
             for (PartitionUpdate partitionUpdate : partitionUpdatesForMissingBuckets) {
                 Optional<Partition> partition = table.getPartitionColumns().isEmpty() ? Optional.empty() :
-                        Optional.of(partitionObjectBuilder.buildPartitionObject(session, table, partitionUpdate, prestoVersion, partitionEncryptionParameters, Optional.empty()));
+                        Optional.of(partitionObjectBuilder.buildPartitionObject(session, table, partitionUpdate, prestoVersion, partitionEncryptionParameters, Optional.empty(), Optional.empty()));
                 zeroRowFileCreator.createFiles(
                         session,
                         hdfsContext,
@@ -1725,7 +1725,7 @@ public class HiveMetadata
                 // Store list of file names and sizes in partition metadata when prefer_manifests_to_list_files and file_renaming_enabled are set to true
                 partitionParameters = updatePartitionMetadataWithFileNamesAndSizes(update, partitionParameters);
             }
-            Partition partition = partitionObjectBuilder.buildPartitionObject(session, table, update, prestoVersion, partitionParameters, Optional.empty());
+            Partition partition = partitionObjectBuilder.buildPartitionObject(session, table, update, prestoVersion, partitionParameters, Optional.empty(), Optional.empty());
             PartitionStatistics partitionStatistics = createPartitionStatistics(
                     session,
                     update.getStatistics(),
@@ -1737,7 +1737,7 @@ public class HiveMetadata
                     handle.getTableName(),
                     table.getStorage().getLocation(),
                     true,
-                    partitionObjectBuilder.buildPartitionObject(session, table, update, prestoVersion, partitionParameters, Optional.empty()),
+                    partition,
                     update.getWritePath(),
                     partitionStatistics);
         }
@@ -2010,6 +2010,7 @@ public class HiveMetadata
                                 handle.getEncryptionInformation()
                                         .map(encryptionInfo -> encryptionInfo.getDwrfEncryptionMetadata().map(DwrfEncryptionMetadata::getExtraMetadata).orElseGet(ImmutableMap::of))
                                         .orElseGet(ImmutableMap::of),
+                                Optional.empty(),
                                 Optional.empty()));
                 zeroRowFileCreator.createFiles(
                         session,
@@ -2111,7 +2112,8 @@ public class HiveMetadata
                         partitionUpdate,
                         prestoVersion,
                         extraPartitionMetadata,
-                        existingPartition);
+                        existingPartition,
+                        Optional.empty());
                 if (!partition.getStorage().getStorageFormat().getInputFormat().equals(handle.getPartitionStorageFormat().getInputFormat()) && isRespectTableFormat(session)) {
                     throw new PrestoException(HIVE_CONCURRENT_MODIFICATION_DETECTED, "Partition format changed during insert");
                 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
@@ -35,7 +35,8 @@ public class HivePartitionObjectBuilder
             PartitionUpdate partitionUpdate,
             String prestoVersion,
             Map<String, String> extraParameters,
-            Optional<Partition> previousPartition)
+            Optional<Partition> previousPartition,
+            Optional<byte[]> rowIDPartitionComponent)
     {
         ImmutableMap.Builder extraParametersBuilder = ImmutableMap.builder()
                 .put(MetastoreUtil.PRESTO_VERSION_NAME, prestoVersion)
@@ -59,6 +60,7 @@ public class HivePartitionObjectBuilder
                         .setBucketProperty(table.getStorage().getBucketProperty())
                         .setSerdeParameters(table.getStorage().getSerdeParameters())
                         .setParameters(table.getStorage().getParameters()))
+                .setRowIdPartitionComponent(rowIDPartitionComponent)
                 .build();
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSelectivePageSourceFactory.java
@@ -43,5 +43,6 @@ public interface HiveSelectivePageSourceFactory
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
             Optional<EncryptionInformation> encryptionInformation,
-            boolean appendRowNumberEnabled);
+            boolean appendRowNumberEnabled,
+            Optional<byte[]> rowIDPartitionComponent);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -588,7 +588,7 @@ public class HiveSplitManager
                                 tableToPartitionMapping,
                                 encryptionInformation,
                                 partitionSplitInfo.get(hivePartition.getPartitionId().getPartitionName()).getRedundantColumnDomains(),
-                                Optional.empty()));
+                                partition.getRowIdPartitionComponent()));
             }
             if (unreadablePartitionsSkipped > 0) {
                 StringBuilder warningMessage = new StringBuilder(format("Table '%s' has %s out of %s partitions unreadable: ", tableName, unreadablePartitionsSkipped, partitionBatch.size()));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
@@ -51,7 +51,7 @@ public class HiveSplitPartitionInfo
     // keep track of how many InternalHiveSplits reference this PartitionInfo.
     private final AtomicInteger references = new AtomicInteger(0);
 
-    public HiveSplitPartitionInfo(
+    HiveSplitPartitionInfo(
             Storage storage,
             URI path,
             List<HivePartitionKey> partitionKeys,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
@@ -39,7 +39,7 @@ import static java.util.Objects.requireNonNull;
 @NotThreadSafe
 public class InternalHiveSplit
 {
-    // Overhead of ImmutableList and ImmutableMap is not accounted because of its complexity.
+    // Overhead of ImmutableList and ImmutableMap is not accounted for because of its complexity.
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(InternalHiveSplit.class).instanceSize();
 
     private static final int HOST_ADDRESS_INSTANCE_SIZE = ClassLayout.parseClass(HostAddress.class).instanceSize() +

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import java.util.Map;
 import java.util.Optional;
 
+// TODO interface only has one implementation; inline it
 public interface PartitionObjectBuilder
 {
     Partition buildPartitionObject(
@@ -28,5 +29,6 @@ public interface PartitionObjectBuilder
             PartitionUpdate partitionUpdate,
             String prestoVersion,
             Map<String, String> extraParameters,
-            Optional<Partition> previousPartition);
+            Optional<Partition> previousPartition,
+            Optional<byte[]> rowIDPartitionComponent);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RowIDCoercer.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RowIDCoercer.java
@@ -29,13 +29,13 @@ import java.nio.charset.StandardCharsets;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-class RowIDCoercer
+public class RowIDCoercer
         implements HiveCoercer
 {
     private final byte[] rowIDPartitionComponent;
     private final byte[] rowGroupID; // file name
 
-    RowIDCoercer(byte[] rowIDPartitionComponent, String rowGroupID)
+    public RowIDCoercer(byte[] rowIDPartitionComponent, String rowGroupID)
     {
         this.rowIDPartitionComponent = requireNonNull(rowIDPartitionComponent);
         this.rowGroupID = rowGroupID.getBytes(StandardCharsets.UTF_8);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -304,8 +304,17 @@ public class StoragePartitionLoader
                 }
             }
         }
-        InternalHiveSplitFactory splitFactory = getHiveSplitFactory(fs, inputFormat, s3SelectPushdownEnabled, storage, path, partitionName,
-                partitionKeys, partitionDataColumnCount, partition, bucketConversionRequiresWorkerParticipation ? bucketConversion : Optional.empty());
+        InternalHiveSplitFactory splitFactory = getHiveSplitFactory(
+                fs,
+                inputFormat,
+                s3SelectPushdownEnabled,
+                storage,
+                path,
+                partitionName,
+                partitionKeys,
+                partitionDataColumnCount,
+                partition,
+                bucketConversionRequiresWorkerParticipation ? bucketConversion : Optional.empty());
 
         if (shouldUseFileSplitsFromInputFormat(inputFormat, directoryLister)) {
             return handleGetSplitsFromInputFormat(configuration, path, schema, inputFormat, stopped, hiveSplitSource, splitFactory);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfAggregatedPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfAggregatedPageSourceFactory.java
@@ -100,8 +100,7 @@ public class DwrfAggregatedPageSourceFactory
             Storage storage,
             List<HiveColumnHandle> columns,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation,
-            boolean appendRowNumberEnabled)
+            Optional<EncryptionInformation> encryptionInformation)
     {
         if (!OrcSerde.class.getName().equals(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();
@@ -127,6 +126,7 @@ public class DwrfAggregatedPageSourceFactory
                 hiveFileContext,
                 encryptionInformation,
                 NO_ENCRYPTION,
-                appendRowNumberEnabled));
+                false,
+                Optional.empty()));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
@@ -107,7 +107,8 @@ public class DwrfSelectivePageSourceFactory
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
             Optional<EncryptionInformation> encryptionInformation,
-            boolean appendRowNumberEnabled)
+            boolean appendRowNumberEnabled,
+            Optional<byte[]> rowIDPartitionComponent)
     {
         if (!OrcSerde.class.getName().equals(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();
@@ -144,6 +145,7 @@ public class DwrfSelectivePageSourceFactory
                 tupleDomainFilterCache,
                 encryptionInformation,
                 dwrfEncryptionProvider,
-                appendRowNumberEnabled));
+                appendRowNumberEnabled,
+                rowIDPartitionComponent));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcAggregatedPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcAggregatedPageSourceFactory.java
@@ -115,8 +115,7 @@ public class OrcAggregatedPageSourceFactory
             Storage storage,
             List<HiveColumnHandle> columns,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation,
-            boolean appendRowNumberEnabled)
+            Optional<EncryptionInformation> encryptionInformation)
     {
         if (!OrcSerde.class.getName().equals(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();
@@ -143,7 +142,8 @@ public class OrcAggregatedPageSourceFactory
                 hiveFileContext,
                 encryptionInformation,
                 NO_ENCRYPTION,
-                appendRowNumberEnabled));
+                false,
+                Optional.empty()));
     }
 
     public static ConnectorPageSource createOrcPageSource(
@@ -162,7 +162,8 @@ public class OrcAggregatedPageSourceFactory
             HiveFileContext hiveFileContext,
             Optional<EncryptionInformation> encryptionInformation,
             DwrfEncryptionProvider dwrfEncryptionProvider,
-            boolean appendRowNumberEnabled)
+            boolean appendRowNumberEnabled,
+            Optional<byte[]> rowIDPartitionComponent)
     {
         OrcDataSource orcDataSource = getOrcDataSource(session, fileSplit, hdfsEnvironment, configuration, hiveFileContext, stats);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
@@ -16,7 +16,9 @@ package com.facebook.presto.hive.orc;
 import com.facebook.presto.common.InvalidFunctionArgumentException;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.hive.FileFormatDataSourceStats;
+import com.facebook.presto.hive.RowIDCoercer;
 import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSource;
@@ -26,6 +28,7 @@ import com.facebook.presto.spi.PrestoException;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
@@ -37,26 +40,41 @@ import static java.util.Objects.requireNonNull;
 public class OrcSelectivePageSource
         implements ConnectorPageSource
 {
+    static final int ROW_ID_COLUMN_INDEX = -10;
+
     private final OrcSelectiveRecordReader recordReader;
     private final OrcDataSource orcDataSource;
     private final OrcAggregatedMemoryContext systemMemoryContext;
     private final FileFormatDataSourceStats stats;
     private final RuntimeStats runtimeStats;
-
+    private final boolean appendRowNumberEnabled;
+    private final RowIDCoercer coercer;
+    private final boolean supplyRowIDs;
+    private final OptionalInt rowIDColumnIndex;
     private boolean closed;
 
-    public OrcSelectivePageSource(
+    OrcSelectivePageSource(
             OrcSelectiveRecordReader recordReader,
             OrcDataSource orcDataSource,
             OrcAggregatedMemoryContext systemMemoryContext,
             FileFormatDataSourceStats stats,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            boolean appendRowNumberEnabled,
+            byte[] rowIDPartitionComponent,
+            String rowGroupId,
+            boolean supplyRowIDs)
     {
         this.recordReader = requireNonNull(recordReader, "recordReader is null");
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
         this.stats = requireNonNull(stats, "stats is null");
         this.runtimeStats = runtimeStats;
+        this.appendRowNumberEnabled = appendRowNumberEnabled;
+        this.coercer = new RowIDCoercer(rowIDPartitionComponent, rowGroupId);
+        // TODO can we combine supplyRowIDs and rowIDColumnIndex by using
+        // rowIDColumnIndex.isPresent() instead of a separate supplyRowIDs argument?
+        this.supplyRowIDs = supplyRowIDs;
+        this.rowIDColumnIndex = recordReader.toZeroBasedColumnIndex(ROW_ID_COLUMN_INDEX);
     }
 
     @Override
@@ -97,6 +115,9 @@ public class OrcSelectivePageSource
             if (page == null) {
                 close();
             }
+            else if (supplyRowIDs) { // If we need a row ID block, synthesize it here.
+                page = fillInRowIDs(page);
+            }
             return page;
         }
         catch (InvalidFunctionArgumentException e) {
@@ -115,6 +136,22 @@ public class OrcSelectivePageSource
             closeWithSuppression(e);
             throw new PrestoException(HIVE_CURSOR_ERROR, format("Failed to read ORC file: %s", orcDataSource.getId()), e);
         }
+    }
+
+    private Page fillInRowIDs(Page page)
+    {
+        // rowNumbers is always the last block in the page
+        Block rowNumbers = page.getBlock(page.getChannelCount() - 1);
+        Block rowIDs = coercer.apply(rowNumbers);
+
+        // figure out which block is the row ID and replace it
+        page = page.replaceColumn(rowIDColumnIndex.getAsInt(), rowIDs);
+
+        if (!appendRowNumberEnabled) {
+            // remove the row number block now that the row IDs have been constructed unless it was also requested
+            page = page.dropColumn(page.getChannelCount() - 1);
+        }
+        return page;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -194,7 +194,7 @@ public class OrcSelectivePageSourceFactory
             ConnectorSession session,
             HiveFileSplit fileSplit,
             Storage storage,
-            List<HiveColumnHandle> columns,
+            List<HiveColumnHandle> selectedColumns,
             Map<Integer, String> prefilledValues,
             Map<Integer, HiveCoercer> coercers,
             Optional<BucketAdaptation> bucketAdaptation,
@@ -204,7 +204,8 @@ public class OrcSelectivePageSourceFactory
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
             Optional<EncryptionInformation> encryptionInformation,
-            boolean appendRowNumberEnabled)
+            boolean appendRowNumberEnabled,
+            Optional<byte[]> rowIDPartitionComponent)
     {
         if (!OrcSerde.class.getName().equals(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();
@@ -221,7 +222,7 @@ public class OrcSelectivePageSourceFactory
                 hdfsEnvironment,
                 configuration,
                 fileSplit,
-                columns,
+                selectedColumns,
                 prefilledValues,
                 coercers,
                 bucketAdaptation,
@@ -242,7 +243,8 @@ public class OrcSelectivePageSourceFactory
                 tupleDomainFilterCache,
                 encryptionInformation,
                 NO_ENCRYPTION,
-                appendRowNumberEnabled));
+                appendRowNumberEnabled,
+                rowIDPartitionComponent));
     }
 
     public static ConnectorPageSource createOrcPageSource(
@@ -251,7 +253,7 @@ public class OrcSelectivePageSourceFactory
             HdfsEnvironment hdfsEnvironment,
             Configuration configuration,
             HiveFileSplit fileSplit,
-            List<HiveColumnHandle> columns,
+            List<HiveColumnHandle> selectedColumns,
             Map<Integer, String> prefilledValues,
             Map<Integer, HiveCoercer> coercers,
             Optional<BucketAdaptation> bucketAdaptation,
@@ -272,12 +274,18 @@ public class OrcSelectivePageSourceFactory
             TupleDomainFilterCache tupleDomainFilterCache,
             Optional<EncryptionInformation> encryptionInformation,
             DwrfEncryptionProvider dwrfEncryptionProvider,
-            boolean appendRowNumberEnabled)
+            boolean appendRowNumberEnabled,
+            Optional<byte[]> rowIDPartitionComponent)
     {
         checkArgument(domainCompactionThreshold >= 1, "domainCompactionThreshold must be at least 1");
 
         OrcDataSource orcDataSource = getOrcDataSource(session, fileSplit, hdfsEnvironment, configuration, hiveFileContext, stats);
         Path path = new Path(fileSplit.getPath());
+
+        boolean supplyRowIDs = selectedColumns.stream().anyMatch(column -> HiveColumnHandle.isRowIdColumnHandle(column));
+        String rowGroupId = path.getName();
+        checkArgument(!supplyRowIDs || rowIDPartitionComponent.isPresent(), "rowIDPartitionComponent required when supplying row IDs");
+        byte[] partitionID = rowIDPartitionComponent.orElse(new byte[0]);
 
         DataSize maxMergeDistance = getOrcMaxMergeDistance(session);
         DataSize tinyStripeThreshold = getOrcTinyStripeThreshold(session);
@@ -287,7 +295,7 @@ public class OrcSelectivePageSourceFactory
                 .withTinyStripeThreshold(tinyStripeThreshold)
                 .withMaxBlockSize(maxReadBlockSize)
                 .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
-                .withAppendRowNumber(appendRowNumberEnabled)
+                .withAppendRowNumber(appendRowNumberEnabled || supplyRowIDs)
                 .build();
         OrcAggregatedMemoryContext systemMemoryUsage = new HiveOrcAggregatedMemoryContext();
         try {
@@ -295,7 +303,7 @@ public class OrcSelectivePageSourceFactory
 
             OrcReader reader = getOrcReader(
                     orcEncoding,
-                    columns,
+                    selectedColumns,
                     useOrcColumnNames,
                     orcFileTailSource,
                     stripeMetadataSourceFactory,
@@ -306,11 +314,11 @@ public class OrcSelectivePageSourceFactory
                     orcDataSource,
                     path);
 
-            List<HiveColumnHandle> physicalColumns = getPhysicalHiveColumnHandles(columns, useOrcColumnNames, reader.getTypes(), path);
+            List<HiveColumnHandle> physicalColumns = getPhysicalHiveColumnHandles(selectedColumns, useOrcColumnNames, reader.getTypes(), path);
 
-            Map<Integer, Integer> indexMapping = IntStream.range(0, columns.size())
+            Map<Integer, Integer> indexMapping = IntStream.range(0, selectedColumns.size())
                     .boxed()
-                    .collect(toImmutableMap(i -> columns.get(i).getHiveColumnIndex(), i -> physicalColumns.get(i).getHiveColumnIndex()));
+                    .collect(toImmutableMap(i -> selectedColumns.get(i).getHiveColumnIndex(), i -> physicalColumns.get(i).getHiveColumnIndex()));
 
             Map<Integer, String> columnNames = physicalColumns.stream()
                     .collect(toImmutableMap(HiveColumnHandle::getHiveColumnIndex, HiveColumnHandle::getName));
@@ -377,7 +385,11 @@ public class OrcSelectivePageSourceFactory
                     reader.getOrcDataSource(),
                     systemMemoryUsage,
                     stats,
-                    hiveFileContext.getStats());
+                    hiveFileContext.getStats(),
+                    appendRowNumberEnabled,
+                    partitionID,
+                    rowGroupId,
+                    recordReader.isColumnPresent(OrcSelectivePageSource.ROW_ID_COLUMN_INDEX));
         }
         catch (Exception e) {
             try {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetAggregatedPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetAggregatedPageSourceFactory.java
@@ -83,8 +83,7 @@ public class ParquetAggregatedPageSourceFactory
             Storage storage,
             List<HiveColumnHandle> columns,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation,
-            boolean appendRowNumberEnabled)
+            Optional<EncryptionInformation> encryptionInformation)
     {
         if (!PARQUET_SERDE_CLASS_NAMES.contains(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetSelectivePageSourceFactory.java
@@ -70,7 +70,8 @@ public class ParquetSelectivePageSourceFactory
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
             Optional<EncryptionInformation> encryptionInformation,
-            boolean appendRowNumberEnabled)
+            boolean appendRowNumberEnabled,
+            Optional<byte[]> rowIDPartitionComponent)
     {
         if (!PARQUET_SERDE_CLASS_NAMES.contains(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
@@ -649,7 +649,25 @@ public class TestHivePageSourceProvider
             implements HiveSelectivePageSourceFactory
     {
         @Override
-        public Optional<? extends ConnectorPageSource> createPageSource(Configuration configuration, ConnectorSession session, HiveFileSplit fileSplit, Storage storage, List<HiveColumnHandle> columns, Map<Integer, String> prefilledValues, Map<Integer, HiveCoercer> coercers, Optional<BucketAdaptation> bucketAdaptation, List<Integer> outputColumns, TupleDomain<Subfield> domainPredicate, RowExpression remainingPredicate, DateTimeZone hiveStorageTimeZone, HiveFileContext hiveFileContext, Optional<EncryptionInformation> encryptionInformation, boolean appendRowNumberEnabled)
+        public Optional<? extends ConnectorPageSource> createPageSource(
+                Configuration configuration,
+                ConnectorSession session,
+                HiveFileSplit fileSplit,
+                Storage storage,
+                List<HiveColumnHandle> columns,
+                Map<Integer,
+                String> prefilledValues,
+                Map<Integer,
+                HiveCoercer> coercers,
+                Optional<BucketAdaptation> bucketAdaptation,
+                List<Integer> outputColumns,
+                TupleDomain<Subfield> domainPredicate,
+                RowExpression remainingPredicate,
+                DateTimeZone hiveStorageTimeZone,
+                HiveFileContext hiveFileContext,
+                Optional<EncryptionInformation> encryptionInformation,
+                boolean appendRowNumberEnabled,
+                Optional<byte[]> rowIDPartitionComponent)
         {
             if (!OrcSerde.class.getName().equals(storage.getStorageFormat().getSerDe())) {
                 return Optional.empty();
@@ -662,7 +680,7 @@ public class TestHivePageSourceProvider
             implements HiveAggregatedPageSourceFactory
     {
         @Override
-        public Optional<? extends ConnectorPageSource> createPageSource(Configuration configuration, ConnectorSession session, HiveFileSplit fileSplit, Storage storage, List<HiveColumnHandle> columns, HiveFileContext hiveFileContext, Optional<EncryptionInformation> encryptionInformation, boolean appendRowNumberEnabled)
+        public Optional<? extends ConnectorPageSource> createPageSource(Configuration configuration, ConnectorSession session, HiveFileSplit fileSplit, Storage storage, List<HiveColumnHandle> columns, HiveFileContext hiveFileContext, Optional<EncryptionInformation> encryptionInformation)
         {
             if (!OrcSerde.class.getName().equals(storage.getStorageFormat().getSerDe())) {
                 return Optional.empty();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -519,6 +519,8 @@ public class TestHiveSplitSource
     private static class TestSplit
             extends InternalHiveSplit
     {
+        private static final byte[] TEST_ROW_ID_PARTITION_COMPONENT = {9, 76, 32, 11};
+
         private TestSplit(int id)
         {
             this(id, OptionalInt.empty());
@@ -558,7 +560,7 @@ public class TestHiveSplitSource
                             TableToPartitionMapping.empty(),
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.empty()),
+                            Optional.of(TEST_ROW_ID_PARTITION_COMPONENT)),
                     Optional.empty(),
                     Optional.empty(),
                     ImmutableMap.of());

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -99,7 +100,7 @@ public class OrcSelectiveRecordReader
     private static final Page EMPTY_PAGE = new Page(0);
 
     private final int[] hiveColumnIndices;                            // elements are hive column indices
-    private final List<Integer> outputColumns;                        // elements are hive column indices
+    private final List<Integer> outputColumns;                        // elements are zero based column indices
     private final Map<Integer, Type> columnTypes;                     // key: index into hiveColumnIndices array
     private final Object[] constantValues;                            // aligned with hiveColumnIndices array
     private final Function<Block, Block>[] coercers;                   // aligned with hiveColumnIndices array
@@ -895,6 +896,19 @@ public class OrcSelectiveRecordReader
             rowNumbers[i] = positionsToRead[i] + startRowNumber;
         }
         return new LongArrayBlock(positionCount, Optional.empty(), rowNumbers);
+    }
+
+    /**
+     * Convert from Hive column index to zero based column index.
+     */
+    public OptionalInt toZeroBasedColumnIndex(int hiveColumnIndex)
+    {
+        for (int i = 0; i < hiveColumnIndices.length; i++) {
+            if (hiveColumnIndices[i] == hiveColumnIndex) {
+                return OptionalInt.of(outputColumns.get(i));
+            }
+        }
+        return OptionalInt.empty();
     }
 
     private final class OrcBlockLoader


### PR DESCRIPTION
## Description
Provide a row ID block after the ORC/Dwrf file has been read. Also remove appendRowNumber from aggregated page factories and sources where it wasn't needed or used. 

## Motivation and Context
#22078 

## Impact
Row ID should be available in HIve

## Test Plan
CI, and unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

