### PR TITLE
Support forwarded https

### DIFF
--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -89,6 +89,9 @@ Property                                                Description
                                                         used to secure TLS.
 ``http-server.https.keystore.key``                      The password for the keystore. This must match the
                                                         password you specified when creating the keystore.
+``http-server.authentication.allow-forwarded-https``    Enable treating forwarded HTTPS requests over HTTP as secure.
+                                                        Requires the ``X-Forwarded-Proto`` header to be set to ``https`` on forwarded requests.
+                                                        Default value is ``false``.
 ======================================================= ======================================================
 
 Password Authenticator Configuration

--- a/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private List<AuthenticationType> authenticationTypes = ImmutableList.of();
+    private boolean allowForwardedHttps;
     private boolean authorizedIdentitySelectionEnabled;
 
     public enum AuthenticationType
@@ -66,6 +67,19 @@ public class SecurityConfig
         authenticationTypes = stream(SPLITTER.split(types))
                 .map(AuthenticationType::valueOf)
                 .collect(toImmutableList());
+        return this;
+    }
+
+    public boolean getAllowForwardedHttps()
+    {
+        return allowForwardedHttps;
+    }
+
+    @Config("http-server.authentication.allow-forwarded-https")
+    @ConfigDescription("Allow forwarded HTTPS requests")
+    public SecurityConfig setAllowForwardedHttps(boolean allowForwardedHttps)
+    {
+        this.allowForwardedHttps = allowForwardedHttps;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -30,6 +30,7 @@ public class TestSecurityConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SecurityConfig.class)
                 .setAuthenticationTypes("")
+                .setAllowForwardedHttps(false)
                 .setAuthorizedIdentitySelectionEnabled(false));
     }
 
@@ -38,11 +39,13 @@ public class TestSecurityConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
+                .put("http-server.authentication.allow-forwarded-https", "true")
                 .put("permissions.authorized-identity-selection-enabled", "true")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
                 .setAuthenticationTypes(ImmutableList.of(KERBEROS, PASSWORD))
+                .setAllowForwardedHttps(true)
                 .setAuthorizedIdentitySelectionEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);


### PR DESCRIPTION
## Description
Currently Presto will skip authentication when request is inSecure(http), but in a common situation that presto is deployed behind a load balancer which will handle SSL termination, we expect presto can recognize `X-Forwarded-Proto` header and continue with configured authentication. 
This feature was added in Ahana presto by this [PR](https://github.com/Ahana-Inc/prestodb/pull/14/).

## Motivation and Context
Support authentication for Presto behind a proxy

## Impact
The flag is turned off by default.

## Test Plan
Deploy presto with password authentication behind nginx, authentication method applied.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add `http-server.authentication.allow-forwarded-https` configuration property to recognize X-Forwarded-Proto header, :pr:`22492`


```


