### PR TITLE
Add a replaceColumn method to Page

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -456,6 +456,24 @@ public final class Page
         return retainedSizeInBytes.longValue();
     }
 
+    /**
+     * Returns a new page with the same columns as the original page except for the one column replaced.
+     *
+     * @param channelIndex the column to replace
+     * @param column the replacement column
+     * @return a new page with the replacement column substituted for the old column
+     */
+    public Page replaceColumn(int channelIndex, Block column)
+    {
+        if (column.getPositionCount() != positionCount) {
+            throw new IllegalArgumentException("New column does not have same number of rows as old column");
+        }
+
+        Block[] newBlocks = Arrays.copyOf(blocks, blocks.length);
+        newBlocks[channelIndex] = column;
+        return Page.wrapBlocksWithoutCopy(newBlocks.length, newBlocks);
+    }
+
     private static class DictionaryBlockIndexes
     {
         private final List<DictionaryBlock> blocks = new ArrayList<>();

--- a/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
@@ -143,6 +143,110 @@ public class TestPage
     }
 
     @Test
+    public void testDropColumn()
+    {
+        int entries = 10;
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, entries);
+        for (int i = 0; i < entries; i++) {
+            BIGINT.writeLong(blockBuilder, i);
+        }
+        Block block = blockBuilder.build();
+
+        Page page = new Page(block, block, block);
+        assertEquals(page.getChannelCount(), 3);
+        Page newPage = page.dropColumn(1);
+        assertEquals(page.getChannelCount(), 3, "Page was modified");
+        assertEquals(newPage.getChannelCount(), 2);
+
+        assertEquals(newPage.getBlock(0).getLong(0), 0);
+        assertEquals(newPage.getBlock(1).getLong(1), 1);
+    }
+
+    @Test
+    public void testReplaceColumn()
+    {
+        int entries = 10;
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, entries);
+        for (int i = 0; i < entries; i++) {
+            BIGINT.writeLong(blockBuilder, i);
+        }
+        Block block = blockBuilder.build();
+        Page page = new Page(block, block, block);
+        assertEquals(page.getBlock(1).getLong(0), 0);
+
+        BlockBuilder newBlockBuilder = BIGINT.createBlockBuilder(null, entries);
+        for (int i = 0; i < entries; i++) {
+            BIGINT.writeLong(newBlockBuilder, -i);
+        }
+        Block newBlock = newBlockBuilder.build();
+        Page newPage = page.replaceColumn(1, newBlock);
+
+        assertEquals(newPage.getChannelCount(), 3);
+        assertEquals(newPage.getBlock(1).getLong(0), 0);
+        assertEquals(newPage.getBlock(1).getLong(1), -1);
+    }
+
+    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    public void testReplaceColumn_channelTooLow()
+    {
+        int entries = 10;
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, entries);
+        for (int i = 0; i < entries; i++) {
+            BIGINT.writeLong(blockBuilder, i);
+        }
+        Block block = blockBuilder.build();
+        Page page = new Page(block, block, block);
+        assertEquals(page.getBlock(1).getLong(0), 0);
+
+        BlockBuilder newBlockBuilder = BIGINT.createBlockBuilder(null, entries);
+        for (int i = 0; i < entries; i++) {
+            BIGINT.writeLong(newBlockBuilder, -i);
+        }
+        Block newBlock = newBlockBuilder.build();
+        page.replaceColumn(-1, newBlock);
+    }
+
+    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    public void testReplaceColumn_channelTooHigh()
+    {
+        int entries = 10;
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, entries);
+        for (int i = 0; i < entries; i++) {
+            BIGINT.writeLong(blockBuilder, i);
+        }
+        Block block = blockBuilder.build();
+        Page page = new Page(block, block, block);
+        assertEquals(page.getBlock(1).getLong(0), 0);
+
+        BlockBuilder newBlockBuilder = BIGINT.createBlockBuilder(null, entries);
+        for (int i = 0; i < entries; i++) {
+            BIGINT.writeLong(newBlockBuilder, -i);
+        }
+        Block newBlock = newBlockBuilder.build();
+        page.replaceColumn(page.getChannelCount(), newBlock);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testReplaceColumn_WrongNumberOfRows()
+    {
+        int entries = 10;
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, entries);
+        for (int i = 0; i < entries; i++) {
+            BIGINT.writeLong(blockBuilder, i);
+        }
+        Block block = blockBuilder.build();
+        Page page = new Page(block, block, block);
+        assertEquals(page.getBlock(1).getLong(0), 0);
+
+        BlockBuilder newBlockBuilder = BIGINT.createBlockBuilder(null, entries);
+        for (int i = 0; i < entries - 5; i++) {
+            BIGINT.writeLong(newBlockBuilder, -i);
+        }
+        Block newBlock = newBlockBuilder.build();
+        page.replaceColumn(1, newBlock);
+    }
+
+    @Test
     public void testRetainedSizeIsCorrect()
     {
         BlockBuilder variableWidthBlockBuilder = VARCHAR.createBlockBuilder(null, 256);


### PR DESCRIPTION
## Description
Replace a column (block) in a page with a new column/bliock.

## Motivation and Context
#22078 For row IDs we need to replace a row number block with a row ID block. however the functionality seems generally useful and has no particular dependence on row IDs.

## Impact
Add new replaceColumn method to com.facebook.common.Page

## Test Plan
Added unit tests to TestPage class

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== RELEASE NOTES ==

General Changes
* com.facebook.common.Page has a new replaceColumn method.
```

