### PR TITLE
Make HiveFileInfo thrift serializable

### DIFF
--- a/presto-hive-common/pom.xml
+++ b/presto-hive-common/pom.xml
@@ -90,10 +90,33 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-codec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-transport-netty</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-client</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/BlockLocation.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/BlockLocation.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+@ThriftStruct
+public class BlockLocation
+{
+    private final List<String> hosts;
+    private final long offset;
+    private final long length;
+
+    @ThriftConstructor
+    public BlockLocation(List<String> hosts, long offset, long length)
+    {
+        this.hosts = requireNonNull(hosts, "hosts is null");
+        this.offset = offset;
+        this.length = length;
+    }
+
+    public BlockLocation(org.apache.hadoop.fs.BlockLocation blockLocation)
+            throws IOException
+    {
+        this.hosts = ImmutableList.copyOf(requireNonNull(blockLocation, "blockLocation is null").getHosts());
+        this.offset = blockLocation.getOffset();
+        this.length = blockLocation.getLength();
+    }
+
+    public static List<BlockLocation> fromHiveBlockLocations(@Nullable org.apache.hadoop.fs.BlockLocation[] blockLocations)
+            throws IOException
+    {
+        if (blockLocations == null) {
+            return ImmutableList.of();
+        }
+
+        ImmutableList.Builder<BlockLocation> result = ImmutableList.builder();
+        for (org.apache.hadoop.fs.BlockLocation blockLocation : blockLocations) {
+            result.add(new BlockLocation(blockLocation));
+        }
+
+        return result.build();
+    }
+
+    @ThriftField(1)
+    public List<String> getHosts()
+    {
+        return hosts;
+    }
+
+    @ThriftField(2)
+    public long getOffset()
+    {
+        return offset;
+    }
+
+    @ThriftField(3)
+    public long getLength()
+    {
+        return length;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BlockLocation that = (BlockLocation) o;
+        return offset == that.offset
+                && length == that.length
+                && hosts.equals(that.hosts);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(hosts, offset, length);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("hosts", hosts)
+                .add("offset", offset)
+                .add("length", length)
+                .toString();
+    }
+}

--- a/presto-hive-common/src/test/java/com/facebook/presto/hive/TestHiveFileInfo.java
+++ b/presto-hive-common/src/test/java/com/facebook/presto/hive/TestHiveFileInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.airlift.http.client.thrift.ThriftProtocolUtils;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.facebook.drift.transport.netty.codec.Protocol.FB_COMPACT;
+import static com.facebook.presto.hive.HiveFileInfo.createHiveFileInfo;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.lang.Math.toIntExact;
+import static org.testng.Assert.assertEquals;
+
+public class TestHiveFileInfo
+{
+    @Test
+    public void testThriftRoundTrip()
+            throws IOException
+    {
+        ThriftCodec<HiveFileInfo> hiveFileInfoThriftCodec = new ThriftCodecManager().getCodec(HiveFileInfo.class);
+        HiveFileInfo hiveFileInfo = createHiveFileInfo(new LocatedFileStatus(
+                        100,
+                        false,
+                        0,
+                        0L,
+                        0L,
+                        0L,
+                        null,
+                        null,
+                        null,
+                        null,
+                        new Path("test"),
+                        new org.apache.hadoop.fs.BlockLocation[] {new BlockLocation(new String[1], new String[] {"localhost"}, 0, 100)}),
+                Optional.empty());
+
+        int thriftBufferSize = toIntExact(new DataSize(1000, BYTE).toBytes());
+        SliceOutput dynamicSliceOutput = new DynamicSliceOutput(thriftBufferSize);
+        ThriftProtocolUtils.write(hiveFileInfo, hiveFileInfoThriftCodec, FB_COMPACT, dynamicSliceOutput);
+        byte[] serialized = dynamicSliceOutput.slice().getBytes();
+
+        HiveFileInfo copy = ThriftProtocolUtils.read(hiveFileInfoThriftCodec, FB_COMPACT, Slices.wrappedBuffer(serialized).getInput());
+        assertEquals(copy, hiveFileInfo);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestParquetQuickStatsBuilder.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestParquetQuickStatsBuilder.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.IntStream;
 
 import static com.facebook.presto.hive.HiveCommonSessionProperties.READ_MASKED_VALUE_ENABLED;
 import static com.facebook.presto.hive.HivePartition.UNPARTITIONED_ID;
@@ -174,7 +173,9 @@ public class TestParquetQuickStatsBuilder
             while (fileList.hasNext()) {
                 LocatedFileStatus fileStatus = fileList.next();
                 // Add each discovered file repeatCount times - useful for simulating a large file test
-                IntStream.range(0, repeatCount).forEach(v -> fileInfoBuilder.add(HiveFileInfo.createHiveFileInfo(fileStatus, Optional.empty())));
+                for (int i = 0; i < repeatCount; i++) {
+                    fileInfoBuilder.add(HiveFileInfo.createHiveFileInfo(fileStatus, Optional.empty()));
+                }
             }
         }
         catch (Exception ex) {


### PR DESCRIPTION
## Description
Make HiveFileInfo thrift serializable

## Motivation and Context
CachingDirectoryLister currently uses local in-memory guava cache. But we would like to be able to cache in a distributed global cache as well. For that we need HiveFileInfo object to be serializable. This PR is to make HiveFileInfo thrift serializable.

## Impact
None. 

## Test Plan
existing tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

