### PR TITLE
Fix CTE reference in analyzer

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
@@ -1153,6 +1153,20 @@ public class TestCteExecution
         assertQueryFails(session, testQuery, "Query has exceeded WrittenIntermediate Limit of 0MB.*");
     }
 
+    @Test
+    public void testNestedCteWithSameName()
+    {
+        String testQuery = "with t1 as ( select orderkey k from orders where orderkey > 5), t2 as ( select orderkey k from orders where orderkey < 10 ), t3 as " +
+                "( select t1.k, t2.k from t1 left join t2 on t1.k=t2.k ), t4 as ( with t2 as ( select orderkey k from orders where orderkey > 5 ), " +
+                "t1 as ( select orderkey k from orders where orderkey < 10 ), t3 as ( select t1.k, t2.k from t1 left join t2 on t1.k=t2.k ) select * from t3 ) " +
+                "select * from t3 except select * from t4";
+        QueryRunner queryRunner = getQueryRunner();
+        compareResults(queryRunner.execute(getMaterializedSession(),
+                        testQuery),
+                queryRunner.execute(getSession(),
+                        testQuery));
+    }
+
     private void compareResults(MaterializedResult actual, MaterializedResult expected)
     {
         compareResults(actual, expected, false);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -190,7 +190,7 @@ class RelationPlanner
             }
             else {
                 // cte considered for materialization
-                String normalizedCteId = context.getCteInfo().normalize(analysis, namedQuery.getQuery(), cteName);
+                String normalizedCteId = context.getCteInfo().normalize(NodeRef.of(namedQuery.getQuery()), cteName);
                 session.getCteInformationCollector().addCTEReference(cteName, normalizedCteId, namedQuery.isFromView(), true);
                 subPlan = new RelationPlan(
                         new CteReferenceNode(getSourceLocation(node.getLocation()),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLogicalCteOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLogicalCteOptimizer.java
@@ -624,13 +624,13 @@ public class TestLogicalCteOptimizer
                         "SELECT * FROM a\n",
                 anyTree(
                         sequence(
-                                cteProducer(addQueryScopeDelimiter("a", 1), anyTree(tableScan("orders"))),
+                                cteProducer(addQueryScopeDelimiter("a", 2), anyTree(tableScan("orders"))),
                                 anyTree(PlanMatchPattern.union(
                                         PlanMatchPattern.union(
                                                 PlanMatchPattern.union(
-                                                        anyTree(tableScan("orders")), anyTree(cteConsumer(addQueryScopeDelimiter("a", 1)))),
-                                                anyTree(cteConsumer(addQueryScopeDelimiter("a", 1)))),
-                                        anyTree(cteConsumer(addQueryScopeDelimiter("a", 1))))))));
+                                                        anyTree(tableScan("orders")), anyTree(cteConsumer(addQueryScopeDelimiter("a", 2)))),
+                                                anyTree(cteConsumer(addQueryScopeDelimiter("a", 2)))),
+                                        anyTree(cteConsumer(addQueryScopeDelimiter("a", 2))))))));
     }
 
     @Test


### PR DESCRIPTION
## Description
Fix https://github.com/prestodb/presto/issues/22514

Currently when creating CTE Reference node, the NamedQuery used in the CTE is used to uniquely identify the CTE, which can lead to conflicts, which can be demonstrated with example in the linked issue.

Instead of trying to build the scope manually, we can simply rely on the underlying Query object linked to each CTE definition and reference, which refers to the same object if are referring to the same CTE.

Another advantage of this approach is that, it's much faster. I've seen query planning timeout due to the recursive query reference visit when dealing with large queries with nested ctes.

## Motivation and Context
Fix a bug in CTE materialization

## Impact
Bug fix.

## Test Plan
Add unit test.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix a bug in CTE reference node creation, where different CTEs may be incorrectly considered as the same CTE.
```


