### PR TITLE
Remove TestingHiveStorageFormat

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1237,9 +1237,9 @@ public class TestHiveIntegrationSmokeTest
     @Test
     public void testCreateEmptyBucketedPartition()
     {
-        for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
-            testCreateEmptyBucketedPartition(storageFormat.getFormat(), false);
-            testCreateEmptyBucketedPartition(storageFormat.getFormat(), true);
+        for (HiveStorageFormat storageFormat : getSupportedHiveStorageFormats()) {
+            testCreateEmptyBucketedPartition(storageFormat, false);
+            testCreateEmptyBucketedPartition(storageFormat, true);
         }
     }
 
@@ -6686,19 +6686,19 @@ public class TestHiveIntegrationSmokeTest
 
     private void testWithAllStorageFormats(BiConsumer<Session, HiveStorageFormat> test)
     {
-        for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
-            testWithStorageFormat(storageFormat, test);
+        Session session = getSession();
+        for (HiveStorageFormat storageFormat : getSupportedHiveStorageFormats()) {
+            testWithStorageFormat(session, storageFormat, test);
         }
     }
 
-    private static void testWithStorageFormat(TestingHiveStorageFormat storageFormat, BiConsumer<Session, HiveStorageFormat> test)
+    private static void testWithStorageFormat(Session session, HiveStorageFormat storageFormat, BiConsumer<Session, HiveStorageFormat> test)
     {
-        Session session = storageFormat.getSession();
         try {
-            test.accept(session, storageFormat.getFormat());
+            test.accept(session, storageFormat);
         }
         catch (Exception | AssertionError e) {
-            fail(format("Failure for format %s with properties %s", storageFormat.getFormat(), session.getConnectorProperties()), e);
+            fail(format("Failure for format %s with properties %s", storageFormat, session.getConnectorProperties()), e);
         }
     }
 
@@ -6708,35 +6708,5 @@ public class TestHiveIntegrationSmokeTest
         return Arrays.stream(HiveStorageFormat.values())
                 .filter(format -> format != HiveStorageFormat.CSV && format != HiveStorageFormat.ALPHA)
                 .collect(toImmutableList());
-    }
-
-    private List<TestingHiveStorageFormat> getAllTestingHiveStorageFormat()
-    {
-        Session session = getSession();
-        return getSupportedHiveStorageFormats().stream()
-                .map(format -> new TestingHiveStorageFormat(session, format))
-                .collect(toImmutableList());
-    }
-
-    private static class TestingHiveStorageFormat
-    {
-        private final Session session;
-        private final HiveStorageFormat format;
-
-        TestingHiveStorageFormat(Session session, HiveStorageFormat format)
-        {
-            this.session = requireNonNull(session, "session is null");
-            this.format = requireNonNull(format, "format is null");
-        }
-
-        public Session getSession()
-        {
-            return session;
-        }
-
-        public HiveStorageFormat getFormat()
-        {
-            return format;
-        }
     }
 }


### PR DESCRIPTION
## Description
Remove `TestHiveIntegrationSmokeTest.TestingHiveStorageFormat` as it wraps a few fields that don't need to be wrapped

## Motivation and Context
Fixes #22476

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
== NO RELEASE NOTE ==
```

