### PR TITLE
Don't call toString on an array

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
@@ -1116,9 +1116,9 @@ public interface TupleDomainFilter
         public String toString()
         {
             StringBuilder sb = new StringBuilder(this.getClass().getName());
-            sb.append("{lower='").append(lower);
+            sb.append("{lower='").append(Arrays.toString(lower));
             sb.append(", lowerExclusive=").append(lowerExclusive);
-            sb.append(", upper='").append(upper);
+            sb.append(", upper='").append(Arrays.toString(upper));
             sb.append(", upperExclusive=").append(upperExclusive);
             sb.append(", nullAllowed=").append(nullAllowed);
             sb.append("}");
@@ -1248,7 +1248,7 @@ public interface TupleDomainFilter
         public String toString()
         {
             StringBuilder sb = new StringBuilder(this.getClass().getName());
-            sb.append("{values='").append(values);
+            sb.append("{values='").append(Arrays.toString(values));
             sb.append(", nullAllowed=").append(nullAllowed);
             sb.append("}");
 
@@ -1390,7 +1390,7 @@ public interface TupleDomainFilter
         public String toString()
         {
             StringBuilder sb = new StringBuilder(this.getClass().getName());
-            sb.append("{ranges='").append(ranges);
+            sb.append("{ranges='").append(Arrays.toString(ranges));
             sb.append(", nullAllowed=").append(nullAllowed);
             sb.append("}");
 
@@ -1509,7 +1509,7 @@ public interface TupleDomainFilter
         public String toString()
         {
             StringBuilder sb = new StringBuilder(this.getClass().getName());
-            sb.append("{filters='").append(filters);
+            sb.append("{filters='").append(Arrays.toString(filters));
             sb.append(", nullAllowed=").append(nullAllowed);
             sb.append(", nanAllowed=").append(nanAllowed);
             sb.append("}");

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationImplementation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationImplementation.java
@@ -376,7 +376,7 @@ public class AggregationImplementation
                     builder.add(BLOCK_INDEX);
                 }
                 else {
-                    throw new IllegalArgumentException("Unsupported annotation: " + annotations[i]);
+                    throw new IllegalArgumentException("Unsupported annotation: " + baseTypeAnnotation);
                 }
             }
             return builder.build();


### PR DESCRIPTION
## Description
Use Arrays.toString instead of [].toString

## Motivation and Context
Fixing an IntelliJ warning while waiting for code review of more significant changes

## Impact
a few debugging strings are clearer

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

