### PR TITLE
Use Arrays.hashCode to hash array fields

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
@@ -604,7 +604,7 @@ public interface TupleDomainFilter
         @Override
         public int hashCode()
         {
-            return Objects.hash(min, max, size, containsEmptyMarker, hashTable, nullAllowed);
+            return Objects.hash(min, max, size, containsEmptyMarker, Arrays.hashCode(hashTable), nullAllowed);
         }
 
         @Override
@@ -1080,7 +1080,7 @@ public interface TupleDomainFilter
         @Override
         public int hashCode()
         {
-            return Objects.hash(lower, lowerExclusive, upper, upperExclusive, nullAllowed);
+            return Objects.hash(Arrays.hashCode(lower), lowerExclusive, Arrays.hashCode(upper), upperExclusive, nullAllowed);
         }
 
         public boolean isSingleValue()
@@ -1241,7 +1241,7 @@ public interface TupleDomainFilter
         @Override
         public int hashCode()
         {
-            return Objects.hash(values, nullAllowed);
+            return Objects.hash(Arrays.hashCode(values), nullAllowed);
         }
 
         @Override
@@ -1383,7 +1383,7 @@ public interface TupleDomainFilter
         @Override
         public int hashCode()
         {
-            return Objects.hash(ranges, nullAllowed);
+            return Objects.hash(Arrays.hashCode(ranges), nullAllowed);
         }
 
         @Override
@@ -1502,7 +1502,7 @@ public interface TupleDomainFilter
         @Override
         public int hashCode()
         {
-            return Objects.hash(filters, nullAllowed, nanAllowed);
+            return Objects.hash(Arrays.hashCode(filters), nullAllowed, nanAllowed);
         }
 
         @Override


### PR DESCRIPTION
## Description
Use Arrays.hashCode to hash array fields

## Motivation and Context
Objects.hash does not account for arrays

## Impact
Hash codes are more reproducible.

## Test Plan
ci

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

