### PR TITLE
[native] Drop const from methods in PeriodicMemoryChecker

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
@@ -153,7 +153,7 @@ void PeriodicMemoryChecker::maybeDumpHeap() {
   }
 }
 
-void PeriodicMemoryChecker::pushbackMemory() const {
+void PeriodicMemoryChecker::pushbackMemory() {
   const uint64_t currentMemBytes = systemUsedMemoryBytes();
   VELOX_CHECK(config_.systemMemPushbackEnabled);
   LOG(WARNING) << "System used memory " << velox::succinctBytes(currentMemBytes)

--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
@@ -79,7 +79,7 @@ class PeriodicMemoryChecker {
  protected:
   /// Returns current system memory usage. The returned value is used to compare
   /// with 'Config::systemMemLimitBytes'.
-  virtual int64_t systemUsedMemoryBytes() const = 0;
+  virtual int64_t systemUsedMemoryBytes() = 0;
 
   /// Returns current bytes allocated by malloc. The returned value is used to
   /// compare with 'Config::mallocBytesUsageDumpThreshold'
@@ -121,7 +121,7 @@ class PeriodicMemoryChecker {
 
   // Invoked by the periodic checker when 'Config::systemMemPushbackEnabled'
   // is true and system memory usage is above 'Config::systemMemLimitBytes'.
-  void pushbackMemory() const;
+  void pushbackMemory();
 
   // Invoked by the periodic checker when 'Config::mallocMemHeapDumpEnabled' is
   // true.

--- a/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
@@ -46,7 +46,7 @@ class PeriodicMemoryCheckerTest : public testing::Test {
     }
 
    protected:
-    int64_t systemUsedMemoryBytes() const override {
+    int64_t systemUsedMemoryBytes() override {
       return systemUsedMemoryBytes_;
     }
 


### PR DESCRIPTION
Some system memory fetching methods like SIGAR require to keep some instance open and reuse the local connection to avoid initialization overhead. We need to drop the const to allow this to happen.
```
== NO RELEASE NOTE ==
```

