### PR TITLE
[docs] Fix formatting in Hive Connector Procedures doc

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -840,28 +840,28 @@ The following procedures are available:
 
 * ``system.create_empty_partition(schema_name, table_name, partition_columns, partition_values)``
 
-    Create an empty partition in the specified table.
+  Create an empty partition in the specified table.
 
 * ``system.sync_partition_metadata(schema_name, table_name, mode, case_sensitive)``
 
-    Check and update partitions list in metastore. There are three modes available:
+  Check and update partitions list in metastore. There are three modes available:
 
-    * ``ADD`` : add any partitions that exist on the file system but not in the metastore.
-    * ``DROP``: drop any partitions that exist in the metastore but not on the file system.
-    * ``FULL``: perform both ``ADD`` and ``DROP``.
+  * ``ADD`` : add any partitions that exist on the file system but not in the metastore.
+  * ``DROP``: drop any partitions that exist in the metastore but not on the file system.
+  * ``FULL``: perform both ``ADD`` and ``DROP``.
 
-    The ``case_sensitive`` argument is optional. The default value is ``true`` for compatibility
-    with Hive's ``MSCK REPAIR TABLE`` behavior, which expects the partition column names in
-    file system paths to use lowercase (e.g. ``col_x=SomeValue``). Partitions on the file system
-    not conforming to this convention are ignored, unless the argument is set to ``false``.
+  The ``case_sensitive`` argument is optional. The default value is ``true`` for compatibility
+  with Hive's ``MSCK REPAIR TABLE`` behavior, which expects the partition column names in
+  file system paths to use lowercase (e.g. ``col_x=SomeValue``). Partitions on the file system
+  not conforming to this convention are ignored, unless the argument is set to ``false``.
 
 * ``system.invalidate_directory_list_cache()``
 
-    Flush full directory list cache.
+  Flush full directory list cache.
 
 * ``system.invalidate_directory_list_cache(directory_path)``
 
-    Invalidate directory list cache for specified directory_path.
+  Invalidate directory list cache for specified directory_path.
 
 Extra Hidden Columns
 --------------------


### PR DESCRIPTION
## Description
Fix formatting in [Hive Connector Procedures](http://prestodb.io/docs/current/connector/hive.html#procedures) doc. 

## Motivation and Context
Improves consistency of documentation formatting. Noticed while reviewing [PR 19821](https://github.com/prestodb/presto/pull/19821/) but it wasn't worth addressing in that PR.
 
## Impact
Documentation.

## Test Plan
Local build of documentation. 

Screenshot before
<img width="850" alt="Screenshot 2024-04-16 at 10 55 46 AM" src="https://github.com/prestodb/presto/assets/7013443/059ba9c6-4f72-4c5a-97a7-6126f7d8b0da">

Screenshot after 
<img width="851" alt="Screenshot 2024-04-16 at 10 56 02 AM" src="https://github.com/prestodb/presto/assets/7013443/0850e6ac-9e47-40c5-8a9b-0cdb64cd2132">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```