### PR TITLE
Fix no value present scheduling failure with grouped execution

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -281,6 +281,8 @@ public class HiveSplit
                 .put("partitionName", partitionName)
                 .put("s3SelectPushdownEnabled", Boolean.toString(s3SelectPushdownEnabled))
                 .put("cacheQuotaRequirement", cacheQuotaRequirement.toString())
+                .put("readBucketNumber", readBucketNumber.toString())
+                .put("tableBucketNumber", tableBucketNumber.toString())
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -142,11 +142,9 @@ public class FixedSourcePartitionedScheduler
                 else {
                     LifespanScheduler lifespanScheduler;
                     if (bucketNodeMap.isDynamic()) {
-                        // Callee of the constructor guarantees dynamic bucket node map will only be
-                        // used when the stage has no remote source.
-                        //
-                        // When the stage has no remote source, any scan is grouped execution guarantees
-                        // all scan is grouped execution.
+                        // Caller of the constructor guarantees dynamic bucket node map will only be
+                        // used when the stage has no non-replicated remote sources and all scans use grouped
+                        // execution.
                         lifespanScheduler = new DynamicLifespanScheduler(bucketNodeMap, nodes, partitionHandles, concurrentLifespansPerTask);
                     }
                     else {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -30,6 +30,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
@@ -67,6 +68,7 @@ import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.Resour
 import static com.facebook.presto.execution.scheduler.NodeSelectionHashStrategy.CONSISTENT_HASHING;
 import static com.facebook.presto.metadata.InternalNode.NodeStatus.ALIVE;
 import static com.facebook.presto.spi.NodeState.ACTIVE;
+import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -75,6 +77,7 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.lang.Math.addExact;
 import static java.lang.Math.ceil;
 import static java.lang.Math.min;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -411,7 +414,11 @@ public class NodeScheduler
         Set<InternalNode> blockedNodes = new HashSet<>();
         for (Split split : splits) {
             // node placement is forced by the bucket to node map
-            InternalNode node = bucketNodeMap.getAssignedNode(split).get();
+            Optional<InternalNode> optionalNode = bucketNodeMap.getAssignedNode(split);
+            if (!optionalNode.isPresent()) {
+                throw new PrestoException(NO_NODES_AVAILABLE, format("No assignment for split in bucketNodeMap. Split Info: %s", split.getConnectorSplit().getInfoMap()));
+            }
+            InternalNode node = optionalNode.get();
             boolean isCacheable = bucketNodeMap.isSplitCacheable(split);
             SplitWeight splitWeight = split.getSplitWeight();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
@@ -361,9 +361,10 @@ public class SectionExecutionFactory
                 }
                 else {
                     // cannot use dynamic lifespan schedule
-                    verify(!plan.getFragment().getStageExecutionDescriptor().isDynamicLifespanSchedule());
+                    verify(!plan.getFragment().getStageExecutionDescriptor().isDynamicLifespanSchedule(),
+                            "Stage was planned with DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION, but is not eligible.");
 
-                    // remote source requires nodePartitionMap
+                    // Partitioned remote source requires nodePartitionMap
                     NodePartitionMap nodePartitionMap = partitioningCache.apply(plan.getFragment().getPartitioning());
                     if (groupedExecutionForStage) {
                         checkState(connectorPartitionHandles.size() == nodePartitionMap.getBucketToPartition().length);


### PR DESCRIPTION
## Description
Only use dynamic scheduling if all scans in a stage are using grouped execution

## Motivation and Context

Previously queries with a mix of ungrouped and grouped scans in the same fragment could fail with the following stack trace:
```
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.get(Optional.java:148)
	at com.facebook.presto.execution.scheduler.NodeScheduler.selectDistributionNodes(NodeScheduler.java:414)
	at com.facebook.presto.execution.scheduler.nodeSelection.SimpleNodeSelector.computeAssignments(SimpleNodeSelector.java:231)
	at com.facebook.presto.execution.scheduler.FixedSourcePartitionedScheduler$BucketedSplitPlacementPolicy.computeAssignments(FixedSourcePartitionedScheduler.java:316)
	at com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.schedule(SourcePartitionedScheduler.java:273)
	at com.facebook.presto.execution.scheduler.FixedSourcePartitionedScheduler$AsGroupedSourceScheduler.schedule(FixedSourcePartitionedScheduler.java:353)
	at com.facebook.presto.execution.scheduler.FixedSourcePartitionedScheduler.schedule(FixedSourcePartitionedScheduler.java:240)
	at com.facebook.presto.execution.scheduler.SqlQueryScheduler.schedule(SqlQueryScheduler.java:434)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

Example query shape:
`SELECT count(*) from bucketed_table1 t1 join (SELECT * FROM bucketed_table2
where some_column in (SELECTk key FROM my_small_broadcast_table) t2 on
t1.key=t2.key group by t1.key;`

The plan for the relevant fragment would look as follows:
```
          AGGREGATION
              |
           JOIN
           /    \
          /      \
TableScan(grouped) SemiJoin
                    /   \
 TableScan(ungrouped)   RemoteSource (replicated exchange)
```


## Impact
Fixes a bug with mix of joins and semijoins using grouped execution

## Test Plan
Added new test

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix an error for some queries using a mix of joins and semi-joins when grouped execution is enabled.
