### PR TITLE
Fix analyzer for lambda in aggregation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -199,8 +199,12 @@ public final class ExpressionTreeUtils
             tempExpression = ((Cast) tempExpression).getExpression();
         }
 
-        if (tempExpression instanceof Literal || tempExpression instanceof ArrayConstructor) {
+        if (tempExpression instanceof Literal) {
             return true;
+        }
+
+        if (tempExpression instanceof ArrayConstructor) {
+            return ((ArrayConstructor) tempExpression).getValues().stream().allMatch(ExpressionTreeUtils::isConstant);
         }
 
         // ROW an MAP are special so we explicitly do that here.


### PR DESCRIPTION
## Description
Fix issue https://github.com/prestodb/presto/issues/22558
Fix query compilation error for lambda function in aggregation.
Sample query
```
SELECT
    id,
    REDUCE_AGG(value, 0, (a, b) -> a + b + 0, (a, b) -> a + b)
FROM (
    VALUES
        (1, 2),
        (1, 3),
        (1, 4),
        (2, 20),
        (2, 30),
        (2, 40)
) AS t(id, value)
GROUP BY
    id
```
It will throw error `(GENERIC_INTERNAL_ERROR) no type found for symbol 'expr_10'`
This is because the 0 inside the lambda was rewritten to symbol 'expr_10'. The fix is to skip rewrite for constants within lambda function.

## Motivation and Context
Fix bug.

## Impact
Fix compilation error for query

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix compilation error for queries with lambda in aggregation function
```

