### PR TITLE
Use murmur hash in ModularHashingNodeProvider

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ModularHashingNodeProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ModularHashingNodeProvider.java
@@ -17,16 +17,22 @@ import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.PrestoException;
+import com.google.common.hash.HashFunction;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.facebook.presto.common.type.encoding.StringUtils.UTF_8;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
+import static com.google.common.hash.Hashing.murmur3_32;
+import static java.lang.Math.toIntExact;
 import static java.util.Collections.unmodifiableList;
 
 public class ModularHashingNodeProvider
         implements NodeProvider
 {
+    private static final HashFunction HASH_FUNCTION = murmur3_32();
+
     private final List<InternalNode> sortedCandidates;
 
     public ModularHashingNodeProvider(List<InternalNode> sortedCandidates)
@@ -41,8 +47,7 @@ public class ModularHashingNodeProvider
     public List<HostAddress> get(String identifier, int count)
     {
         int size = sortedCandidates.size();
-        int mod = identifier.hashCode() % size;
-        int position = mod < 0 ? mod + size : mod;
+        int position = toIntExact((HASH_FUNCTION.hashString(identifier, UTF_8).asInt() & 0xFFFFFFFFL) % size);
         List<HostAddress> chosenCandidates = new ArrayList<>();
         if (count > size) {
             count = size;


### PR DESCRIPTION
## Description

Use more collision resilient hash in ModularHashingNodeProvider

## Motivation and Context

Murmur hash is slightly slower than the String#hashcode however it provides more uniformly distributed entropy resulting in fewer collisions

## Impact

Potentially better cache distribution

## Test Plan

CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

