### PR TITLE
Add rule to evaluate arbitrary(NULL) to NULL upfront

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -37,6 +37,7 @@ import com.facebook.presto.sql.planner.iterative.rule.DesugarLambdaExpression;
 import com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType;
 import com.facebook.presto.sql.planner.iterative.rule.DetermineSemiJoinDistributionType;
 import com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins;
+import com.facebook.presto.sql.planner.iterative.rule.EvaluateArbitraryNull;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroLimit;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroSample;
 import com.facebook.presto.sql.planner.iterative.rule.ExtractSpatialJoins;
@@ -376,6 +377,12 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(new EvaluateZeroLimit())),
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(new EvaluateArbitraryNull())),
                 new IterativeOptimizer(
                         metadata,
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateArbitraryNull.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EvaluateArbitraryNull.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
+import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+
+/**
+ * Evaluates arbitrary(NULL) operations to NULL.
+ * <p>
+ * From:
+ * <pre>
+ * - Aggregation (arbitrary(NULL), ...otherAggregations)
+ *   - Source
+ * </pre>
+ * To:
+ * <pre>
+ * - Project (arbitrary <- null)
+ *   - Aggregation (...otherAggregations)
+ *     - Source
+ * </pre>
+ * </p>
+ */
+public class EvaluateArbitraryNull
+        implements Rule<AggregationNode>
+{
+    private static final String ARBITRARY = "arbitrary";
+    private static final Pattern<AggregationNode> PATTERN = aggregation().matching(EvaluateArbitraryNull::hasArbitraryNull);
+
+    private static boolean hasArbitraryNull(AggregationNode aggregation)
+    {
+        return aggregation.getAggregations().values().stream()
+                .anyMatch(agg -> agg.getCall().getDisplayName().equals(ARBITRARY) && agg.getCall().getType() == UNKNOWN);
+    }
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(AggregationNode node, Captures captures, Context context)
+    {
+        ImmutableMap.Builder<VariableReferenceExpression, AggregationNode.Aggregation> existingAggregationsBuilder = ImmutableMap.builder();
+        Set<String> arbitraryNullsInputs = new HashSet<>();
+        Set<VariableReferenceExpression> arbitraryNulls = new HashSet<>();
+
+        // Record arbitrary(NULL) expressions and their inputs
+        node.getAggregations().forEach((key, value) -> {
+            if (value.getCall().getDisplayName().equals(ARBITRARY) && value.getCall().getType() == UNKNOWN) {
+                arbitraryNulls.add(key);
+                arbitraryNullsInputs.addAll(value.getArguments().stream().map(RowExpression::toString).collect(Collectors.toList()));
+            }
+            else {
+                existingAggregationsBuilder.put(key, value);
+            }
+        });
+
+        // Keep only the variables that are not inputs to arbitrary(NULL) expressions
+        Assignments.Builder sourceProjectAssignmentsBuilder = Assignments.builder();
+        node.getSource().getOutputVariables().forEach(variable -> {
+            if (!arbitraryNullsInputs.contains(variable.getName())) {
+                sourceProjectAssignmentsBuilder.put(variable, variable);
+            }
+        });
+
+        // Assign NULL for variables that were assigned the arbitrary(NULL) expressions, else keep as is
+        Assignments.Builder outputProjectAssignmentsBuilder = Assignments.builder();
+        node.getOutputVariables().forEach(variable -> {
+            if (arbitraryNulls.contains(variable)) {
+                outputProjectAssignmentsBuilder.put(variable, constant(null, UNKNOWN));
+            }
+            else {
+                outputProjectAssignmentsBuilder.put(variable, variable);
+            }
+        });
+
+        ImmutableMap<VariableReferenceExpression, AggregationNode.Aggregation> existingAggregations = existingAggregationsBuilder.build();
+        Assignments sourceProjectAssignments = sourceProjectAssignmentsBuilder.build();
+        Assignments outputProjectAssignments = outputProjectAssignmentsBuilder.build();
+
+        // Return an empty ValuesNode if there are no other aggregations and no outputs to pass from the source
+        if (existingAggregations.isEmpty() && sourceProjectAssignments.isEmpty()) {
+            return Result.ofPlanNode(
+                    new ProjectNode(context.getIdAllocator().getNextId(),
+                            new ValuesNode(
+                                    node.getSourceLocation(),
+                                    context.getIdAllocator().getNextId(),
+                                    ImmutableList.of(),
+                                    ImmutableList.of(ImmutableList.of()),
+                                    Optional.empty()),
+                            outputProjectAssignments));
+        }
+        return Result.ofPlanNode(
+                new ProjectNode(context.getIdAllocator().getNextId(),
+                        new AggregationNode(
+                                node.getSourceLocation(),
+                                context.getIdAllocator().getNextId(),
+                                new ProjectNode(context.getIdAllocator().getNextId(),
+                                        node.getSource(), sourceProjectAssignments),
+                                existingAggregations,
+                                node.getGroupingSets(),
+                                ImmutableList.of(),
+                                node.getStep(),
+                                node.getHashVariable(),
+                                node.getGroupIdVariable(),
+                                node.getAggregationId()),
+                        outputProjectAssignments));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEvaluateArbitraryNull.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEvaluateArbitraryNull.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
+import static com.facebook.presto.spi.plan.AggregationNode.groupingSets;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestEvaluateArbitraryNull
+        extends BaseRuleTest
+{
+    @Test
+    public void testSingleArbitraryNull()
+    {
+        tester().assertThat(new EvaluateArbitraryNull())
+                .on(p -> p.aggregation(builder -> builder
+                        .source(p.values())
+                        .addAggregation(p.variable("arbitrary", UNKNOWN), p.rowExpression("arbitrary(null)"))
+                        .globalGrouping()))
+                .matches(
+                        project(
+                                ImmutableMap.of("arbitrary", expression("null")),
+                                values(ImmutableList.of())));
+    }
+
+    @Test
+    public void testMultipleArbitrary()
+    {
+        tester().assertThat(new EvaluateArbitraryNull())
+                .on(p -> p.aggregation(builder -> {
+                    p.variable("col", BIGINT);
+                    builder
+                            .source(p.values(p.variable("col")))
+                            .addAggregation(p.variable("arbitrary_1", UNKNOWN), p.rowExpression("arbitrary(null)"))
+                            .addAggregation(p.variable("arbitrary_2"), p.rowExpression("arbitrary(col)"))
+                            .globalGrouping();
+                }))
+                .matches(
+                        project(
+                                ImmutableMap.of("arbitrary_1", expression("null")),
+                                aggregation(
+                                        ImmutableMap.of("arbitrary_2", functionCall("arbitrary", ImmutableList.of("col"))),
+                                        project(
+                                                ImmutableMap.of("col", expression("col")),
+                                                values("col")))));
+    }
+
+    @Test
+    public void testMultipleAggregations()
+    {
+        tester().assertThat(new EvaluateArbitraryNull())
+                .on(p -> p.aggregation(builder -> {
+                    p.variable("col", BIGINT);
+                    builder
+                            .source(p.values(p.variable("col")))
+                            .addAggregation(p.variable("arbitrary", UNKNOWN), p.rowExpression("arbitrary(null)"))
+                            .addAggregation(p.variable("count"), p.rowExpression("count(col)"))
+                            .globalGrouping();
+                }))
+                .matches(
+                        project(
+                                ImmutableMap.of("arbitrary", expression("null")),
+                                aggregation(
+                                        ImmutableMap.of("count", functionCall("count", ImmutableList.of("col"))),
+                                        project(
+                                                ImmutableMap.of("col", expression("col")),
+                                                values("col")))));
+    }
+
+    @Test
+    public void testWithGroupingSets()
+    {
+        tester().assertThat(new EvaluateArbitraryNull())
+                .on(p -> p.aggregation(builder -> {
+                    p.variable("col1", BIGINT);
+                    p.variable("col2", BIGINT);
+                    builder
+                            .source(p.values(p.variable("col1"), p.variable("col2")))
+                            .addAggregation(p.variable("arbitrary", UNKNOWN), p.rowExpression("arbitrary(null)"))
+                            .groupingSets(groupingSets(ImmutableList.of(p.variable("col1"), p.variable("col2")), 2, ImmutableSet.of(0)));
+                }))
+                .matches(
+                        project(
+                                ImmutableMap.of("arbitrary", expression("null")),
+                                aggregation(
+                                        ImmutableMap.of(),
+                                        project(
+                                                ImmutableMap.of("col1", expression("col1"), "col2", expression("col2")),
+                                                values("col1", "col2")))));
+    }
+
+    @Test
+    public void testNonNullArbitrary()
+    {
+        tester().assertThat(new EvaluateArbitraryNull())
+                .on(p -> p.aggregation(builder -> builder
+                        .source(p.values(p.variable("col")))
+                        .addAggregation(
+                                p.variable("arbitrary"),
+                                p.rowExpression("arbitrary(col)"))
+                        .globalGrouping()))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNoArbitrary()
+    {
+        tester().assertThat(new EvaluateArbitraryNull())
+                .on(p -> p.aggregation(builder -> builder
+                        .source(p.values(p.variable("col")))
+                        .addAggregation(
+                                p.variable("count"),
+                                p.rowExpression("count(col)"))
+                        .globalGrouping()))
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
## Description
Evaluates `arbitrary(NULL)` to `NULL` upfront during query optimization.

## Motivation and Context
`arbitrary(NULL)` can be an expensive operation, even though it is actually trivial to evaluate.

Fixes #21590 

## Impact
Before (it was doing a full table scan):
```
presto> SELECT ARBITRARY(NULL) FROM tpch.sf1.lineitem;
 _col0 
-------
 NULL  
(1 row)

[Latency: client-side: 0:02, server-side: 0:02] [6M rows, 0B] [2.89M rows/s, 0B/s]

presto> EXPLAIN SELECT ARBITRARY(NULL) FROM tpch.sf1.lineitem;
                                                                                                                    Query Plan                                                                                >
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 - Output[PlanNodeId 8][_col0] => [arbitrary:unknown]                                                                                                                                                         >
         _col0 := arbitrary (1:16)                                                                                                                                                                            >
     - Aggregate(FINAL)[PlanNodeId 3] => [arbitrary:unknown]                                                                                                                                                  >
             arbitrary := "presto.default.arbitrary"((arbitrary_4)) (1:16)                                                                                                                                    >
         - LocalExchange[PlanNodeId 265][SINGLE] () => [arbitrary_4:boolean]                                                                                                                                  >
             - RemoteStreamingExchange[PlanNodeId 271][GATHER] => [arbitrary_4:boolean]                                                                                                                       >
                 - Aggregate(PARTIAL)[PlanNodeId 269] => [arbitrary_4:boolean]                                                                                                                                >
                         arbitrary_4 := "presto.default.arbitrary"((expr)) (1:16)                                                                                                                             >
                     - ScanProject[PlanNodeId 0,1][table = TableHandle {connectorId='tpch', connectorHandle='lineitem:sf1.0', layout='Optional[lineitem:sf1.0]'}, projectLocality = LOCAL] => [expr:unknown]  >
                             Estimates: {source: CostBasedSourceInfo, rows: 6,001,215 (11.45MB), cpu: 0.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 6,001,215 (11.45MB), cpu: 6,001,2>
                             expr := null (1:26)                                                                                                                                                              >
                                                                                                                                                                                                              >
```

After:
```
presto> SELECT ARBITRARY(NULL) FROM tpch.sf1.lineitem;
 _col0 
-------
 NULL  
(1 row)

[Latency: client-side: 0:01, server-side: 0:01] [0 rows, 0B] [0 rows/s, 0B/s]

presto> EXPLAIN SELECT ARBITRARY(NULL) FROM tpch.sf1.lineitem;
                                                     Query Plan                                                     
--------------------------------------------------------------------------------------------------------------------
 - Output[PlanNodeId 8][_col0] => [arbitrary:unknown]                                                               
         Estimates: {source: CostBasedSourceInfo, rows: 1 (1B), cpu: 1.00, memory: 0.00, network: 0.00}             
         _col0 := arbitrary (1:16)                                                                                  
     - Project[PlanNodeId 49][projectLocality = LOCAL] => [arbitrary:unknown]                                       
             Estimates: {source: CostBasedSourceInfo, rows: 1 (1B), cpu: 1.00, memory: 0.00, network: 0.00}         
             arbitrary := null                                                                                      
         - LocalExchange[PlanNodeId 195][ROUND_ROBIN] () => []                                                      
                 Estimates: {source: CostBasedSourceInfo, rows: 1 (2B), cpu: 0.00, memory: 0.00, network: 0.00}     
             - Values[PlanNodeId 50] => []                                                                          
                     Estimates: {source: CostBasedSourceInfo, rows: 1 (2B), cpu: 0.00, memory: 0.00, network: 0.00} 
                     ()                                                                                             
                                                                                                                         
```

## Test Plan
Unit tests has been added on `presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEvaluateArbitraryNull.java`.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Add an optimization to optimize arbitrary(NULL)
```

