### PR TITLE
Reduce log spam

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -148,8 +148,6 @@ public class AccessControlManager
 
         checkState(systemAccessControlLoading.compareAndSet(false, true), "System access control already initialized");
 
-        log.info("-- Loading system access control --");
-
         SystemAccessControlFactory systemAccessControlFactory = systemAccessControlFactories.get(name);
         checkState(systemAccessControlFactory != null, "Access control %s is not registered", name);
 

--- a/presto-main/src/main/java/com/facebook/presto/storage/TempStorageManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/storage/TempStorageManager.java
@@ -131,8 +131,6 @@ public class TempStorageManager
         requireNonNull(name, "name is null");
         requireNonNull(properties, "properties is null");
 
-        log.info("-- Loading temp storage %s --", name);
-
         String tempStorageFactoryName = null;
         ImmutableMap.Builder<String, String> tempStorageProperties = ImmutableMap.builder();
         for (Map.Entry<String, String> entry : properties.entrySet()) {


### PR DESCRIPTION
## Description
Removed loading logs

## Motivation and Context

Some logs where I'm searching for a bug are stuffed with many pages of:

```
2024-04-17T19:01:39.700+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:39.701+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:39.701+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:39.724+0545 INFO -- Loading system access control --
2024-04-17T19:01:39.725+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:01:39.726+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:39.726+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:39.727+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:39.727+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:40.149+0545 INFO -- Loading system access control --
2024-04-17T19:01:40.149+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:01:40.150+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:40.151+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:40.151+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:40.152+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:41.007+0545 INFO -- Loading system access control --
2024-04-17T19:01:41.007+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:01:41.008+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:41.008+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:41.009+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:41.010+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:41.641+0545 INFO -- Loading system access control --
2024-04-17T19:01:41.641+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:01:41.642+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:41.642+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:41.643+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:41.644+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:43.425+0545 INFO -- Loading system access control --
2024-04-17T19:01:43.425+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:01:43.426+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:43.426+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:43.427+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:43.428+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:43.734+0545 INFO -- Loading system access control --
2024-04-17T19:01:43.734+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:01:43.735+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:43.735+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:43.736+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:43.736+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:43.776+0545 INFO -- Loading system access control --
2024-04-17T19:01:43.776+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:01:43.777+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:43.778+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:43.778+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:43.779+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:44.175+0545 INFO -- Loading system access control --
2024-04-17T19:01:44.175+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:01:44.176+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:44.176+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:44.177+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:44.178+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:46.017+0545 INFO -- Loading system access control --
2024-04-17T19:01:46.017+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:01:46.018+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:46.019+0545 INFO -- Loaded temp storage local --
2024-04-17T19:01:46.019+0545 INFO -- Loading temp storage local --
2024-04-17T19:01:46.020+0545 INFO -- Loaded temp storage local --
2024-04-17T19:03:10.729+0545 INFO -- Loading system access control --
2024-04-17T19:03:10.730+0545 INFO -- Loaded system access control allow-all --
2024-04-17T19:03:10.731+0545 INFO -- Loading temp storage local --
2024-04-17T19:03:10.732+0545 INFO -- Loaded temp storage local --
2024-04-17T19:03:10.733+0545 INFO -- Loading temp storage local --
2024-04-17T19:03:10.734+0545 INFO -- Loaded temp storage local --
```

I'm not sure any of these are ever helpful, but at the very least we can cut half of them to make real issues easier to find. 

## Impact
Logs are more succinct and easier to read

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

