### PR TITLE
[client] Add support for SphericalGeography type in the client.

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
@@ -49,6 +49,7 @@ import static com.facebook.presto.common.type.StandardTypes.MAP;
 import static com.facebook.presto.common.type.StandardTypes.REAL;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static com.facebook.presto.common.type.StandardTypes.SMALLINT;
+import static com.facebook.presto.common.type.StandardTypes.SPHERICAL_GEOGRAPHY;
 import static com.facebook.presto.common.type.StandardTypes.TIME;
 import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
 import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP_WITH_TIME_ZONE;
@@ -218,6 +219,7 @@ final class FixJsonDataUtils
             case DECIMAL:
             case CHAR:
             case GEOMETRY:
+            case SPHERICAL_GEOGRAPHY:
             case UUID:
                 return String.class.cast(value);
             case BING_TILE:

--- a/presto-client/src/test/java/com/facebook/presto/client/TestFixJsonDataUtils.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestFixJsonDataUtils.java
@@ -66,6 +66,7 @@ public class TestFixJsonDataUtils
         assertQueryResult(typePrefix + "ipaddress", "1.2.3.4", "1.2.3.4");
         assertQueryResult(typePrefix + "ipprefix", "1.2.3.4/32", "1.2.3.4/32");
         assertQueryResult(typePrefix + "Geometry", "POINT (1.2 3.4)", "POINT (1.2 3.4)");
+        assertQueryResult(typePrefix + "SphericalGeography", "POINT (1.2 3.4)", "POINT (1.2 3.4)");
         assertQueryResult(typePrefix + "map(BingTile,bigint)", ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1), ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1L));
         // test nested map structure
         assertQueryResult(typePrefix + "map(map(bigint,bigint),bigint)", ImmutableMap.of("{\n  \"1\" : \"2\",\n  \"3\" : \"4\",\n  \"5\" : \"6\"\n}", "3"), ImmutableMap.of(ImmutableMap.of(1L, 2L, 3L, 4L, 5L, 6L), 3L));

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
@@ -52,6 +52,7 @@ public final class StandardTypes
     public static final String IPADDRESS = "ipaddress";
     public static final String IPPREFIX = "ipprefix";
     public static final String GEOMETRY = "Geometry";
+    public static final String SPHERICAL_GEOGRAPHY = "SphericalGeography";
     public static final String BING_TILE = "BingTile";
     public static final String BIGINT_ENUM = "BigintEnum";
     public static final String VARCHAR_ENUM = "VarcharEnum";


### PR DESCRIPTION
## Description
Currently in the Presto client the following query would immediately yield "" error.
`SELECT TO_SPHERICAL_GEOGRAPHY(ST_POINT(-71.138715, 42.337546));`
This PR fixes it by adding the SphericalGeography type to the FixJsonDataUtils::fixValue().

```
== NO RELEASE NOTE ==
```

