### PR TITLE
[codemod] Remove `using namespace` from github/presto-trunk/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp +2

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -82,12 +82,12 @@ BroadcastExchangeSource::requestDataSizes(
 }
 
 // static
-std::shared_ptr<exec::ExchangeSource>
+std::shared_ptr<velox::exec::ExchangeSource>
 BroadcastExchangeSource::createExchangeSource(
     const std::string& url,
     int destination,
-    const std::shared_ptr<exec::ExchangeQueue>& queue,
-    memory::MemoryPool* pool) {
+    const std::shared_ptr<velox::exec::ExchangeQueue>& queue,
+    velox::memory::MemoryPool* pool) {
   if (::strncmp(url.c_str(), "batch://", 8) != 0) {
     return nullptr;
   }
@@ -102,7 +102,7 @@ BroadcastExchangeSource::createExchangeSource(
   try {
     broadcastFileInfo =
         BroadcastFileInfo::deserialize(broadcastInfoJson.value());
-  } catch (const VeloxException& e) {
+  } catch (const velox::VeloxException& e) {
     throw;
   } catch (const std::exception& e) {
     VELOX_USER_FAIL("BroadcastInfo deserialization failed: {}", e.what());

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastFactory.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastFactory.h
@@ -18,8 +18,6 @@
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/VectorStream.h"
 
-using namespace facebook::velox;
-
 namespace facebook::presto::operators {
 
 /// Struct for single broadcast file info.]
@@ -48,7 +46,7 @@ class BroadcastFileWriter {
   virtual ~BroadcastFileWriter() = default;
 
   /// Write to file.
-  void collect(const RowVectorPtr& input);
+  void collect(const velox::RowVectorPtr& input);
 
   /// Flush the data.
   void noMoreData();
@@ -110,8 +108,8 @@ class BroadcastFactory {
   virtual ~BroadcastFactory() = default;
 
   std::unique_ptr<BroadcastFileWriter> createWriter(
-      memory::MemoryPool* pool,
-      const RowTypePtr& inputType);
+      velox::memory::MemoryPool* pool,
+      const velox::RowTypePtr& inputType);
 
   std::shared_ptr<BroadcastFileReader> createReader(
       const std::unique_ptr<BroadcastFileInfo> fileInfo,


### PR DESCRIPTION
Summary:
Putting `using namespace` is a [_bad_ anti-pattern](https://stackoverflow.com/questions/1452721/whats-the-problem-with-using-namespace-std) and we have multiple linters and compiler errors to prevent it. But to get global coverage of `-Wheader-hygiene`, we need to draw down existing instances.

This diff removes `using namespace` from one more header files, qualifying entities in the headers. Implementation files may gain `using namespace` which is _not_ a functional change: it merely makes explicit what was previously an implicit reliance on `using namespace`. It does, however, isolate the `using namespace` to just that implementation file, which is a significant improvement over the status quo.

Differential Revision: D56272142


