### PR TITLE
Make number of preferred nodes configurable

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaSplit.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaSplit.java
@@ -128,9 +128,8 @@ public class DeltaSplit
     public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         if (getNodeSelectionStrategy() == SOFT_AFFINITY) {
-            // SOFT_AFFINITY node selection strategy scheduler would choose 2 workers (preferred, secondary preferred)
-            // for scheduling
-            return nodeProvider.get(filePath, 2);
+            // SOFT_AFFINITY node selection strategy scheduler would choose preferred nodes for scheduling
+            return nodeProvider.get(filePath);
         }
         return ImmutableList.of(); // empty list indicates no preference.
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -167,7 +167,7 @@ public class HiveSplit
     public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         if (getNodeSelectionStrategy() == SOFT_AFFINITY) {
-            return nodeProvider.get(fileSplit.getPath() + "#" + fileSplit.getAffinitySchedulingFileSectionIndex(), 2);
+            return nodeProvider.get(fileSplit.getPath() + "#" + fileSplit.getAffinitySchedulingFileSectionIndex());
         }
         return addresses;
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -167,7 +167,7 @@ public class TestHiveSplitSource
     private static String getAffinitySchedulingKey(HiveSplit split)
     {
         AtomicReference<String> reference = new AtomicReference<>();
-        split.getPreferredNodes((key, count) -> {
+        split.getPreferredNodes((key) -> {
             reference.set(key);
             return ImmutableList.of();
         });

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplit.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiSplit.java
@@ -109,7 +109,7 @@ public class HudiSplit
     public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         if (getNodeSelectionStrategy() == SOFT_AFFINITY) {
-            return baseFile.map(file -> nodeProvider.get(file.getPath(), 2)).orElse(addresses);
+            return baseFile.map(file -> nodeProvider.get(file.getPath())).orElse(addresses);
         }
         return addresses;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
@@ -143,7 +143,7 @@ public class IcebergSplit
     public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         if (getNodeSelectionStrategy() == SOFT_AFFINITY) {
-            return nodeProvider.get(path, 2);
+            return nodeProvider.get(path);
         }
         return addresses;
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ConsistentHashingNodeProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ConsistentHashingNodeProvider.java
@@ -15,7 +15,6 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.spi.HostAddress;
-import com.facebook.presto.spi.NodeProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashFunction;
 
@@ -34,7 +33,6 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class ConsistentHashingNodeProvider
-        implements NodeProvider
 {
     private static final HashFunction HASH_FUNCTION = murmur3_32();
     private final NavigableMap<Integer, InternalNode> candidates;
@@ -57,7 +55,6 @@ public class ConsistentHashingNodeProvider
         this.nodeCount = nodeCount;
     }
 
-    @Override
     public List<HostAddress> get(String key, int count)
     {
         if (count > nodeCount) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ModularHashingNodeProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ModularHashingNodeProvider.java
@@ -15,7 +15,6 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.spi.HostAddress;
-import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.hash.HashFunction;
 
@@ -29,7 +28,6 @@ import static java.lang.Math.toIntExact;
 import static java.util.Collections.unmodifiableList;
 
 public class ModularHashingNodeProvider
-        implements NodeProvider
 {
     private static final HashFunction HASH_FUNCTION = murmur3_32();
 
@@ -43,7 +41,6 @@ public class ModularHashingNodeProvider
         this.sortedCandidates = sortedCandidates;
     }
 
-    @Override
     public List<HostAddress> get(String identifier, int count)
     {
         int size = sortedCandidates.size();

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeMap.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.lang.String.format;
-
 public class NodeMap
 {
     private final Map<String, InternalNode> activeNodesByNodeId;
@@ -92,15 +90,12 @@ public class NodeMap
         return allNodesByHostAndPort;
     }
 
-    public NodeProvider getActiveNodeProvider(NodeSelectionHashStrategy nodeSelectionHashStrategy)
+    public NodeProvider getNodeProvider(int nodeCount)
     {
-        switch (nodeSelectionHashStrategy) {
-            case MODULAR_HASHING:
-                return new ModularHashingNodeProvider(activeNodes);
-            case CONSISTENT_HASHING:
-                return consistentHashingNodeProvider.get();
-            default:
-                throw new IllegalArgumentException(format("Unknown NodeSelectionHashStrategy: %s", nodeSelectionHashStrategy));
+        if (consistentHashingNodeProvider.isPresent()) {
+            return (key) -> consistentHashingNodeProvider.get().get(key, nodeCount);
         }
+        ModularHashingNodeProvider modularHashingNodeProvider = new ModularHashingNodeProvider(allNodes);
+        return (key) -> modularHashingNodeProvider.get(key, nodeCount);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -101,6 +101,7 @@ public class NodeScheduler
     private final SimpleTtlNodeSelectorConfig simpleTtlNodeSelectorConfig;
     private final NodeSelectionHashStrategy nodeSelectionHashStrategy;
     private final int minVirtualNodeCount;
+    private final int maxPreferredNodes;
 
     @Inject
     public NodeScheduler(
@@ -167,6 +168,7 @@ public class NodeScheduler
         this.simpleTtlNodeSelectorConfig = requireNonNull(simpleTtlNodeSelectorConfig, "simpleTtlNodeSelectorConfig is null");
         this.nodeSelectionHashStrategy = config.getNodeSelectionHashStrategy();
         this.minVirtualNodeCount = config.getMinVirtualNodeCount();
+        this.maxPreferredNodes = config.getMaxPreferredNodes();
     }
 
     @PreDestroy
@@ -222,7 +224,7 @@ public class NodeScheduler
                     topologicalSplitCounters,
                     networkLocationSegmentNames,
                     networkLocationCache,
-                    nodeSelectionHashStrategy);
+                    maxPreferredNodes);
         }
 
         SimpleNodeSelector simpleNodeSelector = new SimpleNodeSelector(
@@ -236,7 +238,7 @@ public class NodeScheduler
                 maxPendingSplitsWeightPerTask,
                 maxUnacknowledgedSplitsPerTask,
                 maxTasksPerStage,
-                nodeSelectionHashStrategy);
+                maxPreferredNodes);
 
         if (resourceAwareSchedulingStrategy == TTL) {
             return new SimpleTtlNodeSelector(

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
@@ -40,6 +40,7 @@ public class NodeSchedulerConfig
     private NodeSelectionHashStrategy nodeSelectionHashStrategy = NodeSelectionHashStrategy.MODULAR_HASHING;
     private int minVirtualNodeCount = 1000;
     private ResourceAwareSchedulingStrategy resourceAwareSchedulingStrategy = ResourceAwareSchedulingStrategy.RANDOM;
+    private int maxPreferredNodes = 2;
 
     @NotNull
     public String getNetworkTopology()
@@ -157,6 +158,19 @@ public class NodeSchedulerConfig
     public NodeSchedulerConfig setResourceAwareSchedulingStrategy(ResourceAwareSchedulingStrategy resourceAwareSchedulingStrategy)
     {
         this.resourceAwareSchedulingStrategy = resourceAwareSchedulingStrategy;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxPreferredNodes()
+    {
+        return maxPreferredNodes;
+    }
+
+    @Config("node-scheduler.max-preferred-nodes")
+    public NodeSchedulerConfig setMaxPreferredNodes(int maxPreferredNodes)
+    {
+        this.maxPreferredNodes = maxPreferredNodes;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -246,7 +246,8 @@ public class TestNodeScheduler
         Set<Split> splits = ImmutableSet.of(split);
 
         Map.Entry<InternalNode, Split> assignment = Iterables.getOnlyElement(nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments().entries());
-        assertEquals(assignment.getKey().getHostAndPort(), split.getPreferredNodes(new ModularHashingNodeProvider(nodeSelector.getAllNodes())).get(0));
+        ModularHashingNodeProvider modularHashingNodeProvider = new ModularHashingNodeProvider(nodeSelector.getAllNodes());
+        assertEquals(assignment.getKey().getHostAndPort(), split.getPreferredNodes((key) -> modularHashingNodeProvider.get(key, 3)).get(0));
         assertEquals(assignment.getValue(), split);
     }
 
@@ -361,10 +362,11 @@ public class TestNodeScheduler
         }
         unassigned = Sets.difference(unassigned, new HashSet<>(assignments.values()));
         assertEquals(unassigned.size(), 3);
+        ModularHashingNodeProvider modularHashingNodeProvider = new ModularHashingNodeProvider(nodeSelector.getAllNodes());
         int rack1 = 0;
         int rack2 = 0;
         for (Split split : unassigned) {
-            String rack = topology.locate(split.getPreferredNodes(new ModularHashingNodeProvider(nodeSelector.getAllNodes())).get(0)).getSegments().get(0);
+            String rack = topology.locate(split.getPreferredNodes((key) -> modularHashingNodeProvider.get(key, 2)).get(0)).getSegments().get(0);
             switch (rack) {
                 case "rack1":
                     rack1++;
@@ -1353,7 +1355,7 @@ public class TestNodeScheduler
         @Override
         public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
-            return nodeProvider.get(format("split%d", scheduleIdentifierId), 1);
+            return nodeProvider.get(format("split%d", scheduleIdentifierId));
         }
 
         @Override
@@ -1393,7 +1395,7 @@ public class TestNodeScheduler
         @Override
         public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
-            return nodeProvider.get(String.valueOf(new Random().nextInt()), 1);
+            return nodeProvider.get(String.valueOf(new Random().nextInt()));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
@@ -40,7 +40,8 @@ public class TestNodeSchedulerConfig
                 .setIncludeCoordinator(true)
                 .setNodeSelectionHashStrategy(MODULAR_HASHING)
                 .setMinVirtualNodeCount(1000)
-                .setResourceAwareSchedulingStrategy(RANDOM));
+                .setResourceAwareSchedulingStrategy(RANDOM)
+                .setMaxPreferredNodes(2));
     }
 
     @Test
@@ -56,6 +57,7 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.node-selection-hash-strategy", "CONSISTENT_HASHING")
                 .put("node-scheduler.consistent-hashing-min-virtual-node-count", "2000")
                 .put("experimental.resource-aware-scheduling-strategy", "TTL")
+                .put("node-scheduler.max-preferred-nodes", "5")
                 .build();
 
         NodeSchedulerConfig expected = new NodeSchedulerConfig()
@@ -67,7 +69,8 @@ public class TestNodeSchedulerConfig
                 .setMinCandidates(11)
                 .setNodeSelectionHashStrategy(CONSISTENT_HASHING)
                 .setMinVirtualNodeCount(2000)
-                .setResourceAwareSchedulingStrategy(TTL);
+                .setResourceAwareSchedulingStrategy(TTL)
+                .setMaxPreferredNodes(5);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/NodeProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/NodeProvider.java
@@ -19,8 +19,7 @@ public interface NodeProvider
 {
     /**
      * @param identifier   an unique identifier used to obtain the nodes
-     * @param count        how many desirable nodes to be returned
-     * @return a list of the chosen nodes by specific hash function
+     * @return a list of the chosen nodes
      */
-    List<HostAddress> get(String identifier, int count);
+    List<HostAddress> get(String identifier);
 }


### PR DESCRIPTION
## Description

Allow changing number of preferred nodes when soft affinity scheduling is enabled

## Motivation and Context

The default number of `2` may not always be sufficient. We've seen cases when there are too many fallbacks to "random" nodes.

## Test Plan

CI


```
== RELEASE NOTES ==

General Changes
* Add `node-scheduler.max-preferred-nodes` configuration property to allow changing number of preferred nodes when soft affinity scheduling is enabled. :pr:`22562`
```

