### PR TITLE
Replace deprecated and removed Guava immediateCheckedFuture

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/execution/executor/SimulationSplit.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/executor/SimulationSplit.java
@@ -153,7 +153,7 @@ abstract class SimulationSplit
                 task.splitComplete(this);
             }
 
-            return Futures.immediateCheckedFuture(null);
+            return Futures.immediateFuture(null);
         }
 
         ListenableFuture<?> processResult = getProcessResult();


### PR DESCRIPTION
## Description
Replace a method removed in [Guava 26](https://github.com/google/guava/commit/87d87f5cac5a540d46a6382683722ead7b72d1b3).

## Motivation and Context
Let us upgrade Guava so we're no longer stuck on 6 year old release.

## Impact
This change is in one file in src/test so as long as the tests pass we're good. 

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

