### PR TITLE
Delay Presto map hash table build when lookups are few

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
@@ -40,6 +40,7 @@ public class SingleMapBlock
     private final int offset;
     private final int positionCount;  // The number of keys in this single map * 2
     private final AbstractMapBlock mapBlock;
+    private int mapLookups;
 
     SingleMapBlock(int positionInMap, int offset, int positionCount, AbstractMapBlock mapBlock)
     {
@@ -171,9 +172,24 @@ public class SingleMapBlock
     /**
      * @return position of the value under {@code nativeValue} key. -1 when key is not found.
      */
-    public int seekKey(Object nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    public int seekKey(Object nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode, int mapLookupsWithoutHashTable)
     {
         if (positionCount == 0) {
+            return -1;
+        }
+
+        mapLookups += 1;
+        if (mapLookups <= mapLookupsWithoutHashTable) {
+            for (int i = 0; i < positionCount / 2; i++) {
+                try {
+                    if ((Boolean) keyBlockNativeEquals.invoke(mapBlock.getRawKeyBlock(), offset / 2 + i, nativeValue)) {
+                        return 2 * i + 1;
+                    }
+                }
+                catch (Throwable throwable) {
+                    throw handleThrowable(throwable);
+                }
+            }
             return -1;
         }
 
@@ -218,9 +234,24 @@ public class SingleMapBlock
     // The next 5 seekKeyExact functions are the same as seekKey
     // except MethodHandle.invoke is replaced with invokeExact.
 
-    public int seekKeyExact(long nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    public int seekKeyExact(long nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode, int mapLookupsWithoutHashTable)
     {
         if (positionCount == 0) {
+            return -1;
+        }
+
+        mapLookups += 1;
+        if (mapLookups <= mapLookupsWithoutHashTable) {
+            for (int i = 0; i < positionCount / 2; i++) {
+                try {
+                    if ((Boolean) keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + i, nativeValue)) {
+                        return 2 * i + 1;
+                    }
+                }
+                catch (Throwable throwable) {
+                    throw handleThrowable(throwable);
+                }
+            }
             return -1;
         }
 
@@ -262,9 +293,24 @@ public class SingleMapBlock
         }
     }
 
-    public int seekKeyExact(boolean nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    public int seekKeyExact(boolean nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode, int mapLookupsWithoutHashTable)
     {
         if (positionCount == 0) {
+            return -1;
+        }
+
+        mapLookups += 1;
+        if (mapLookups <= mapLookupsWithoutHashTable) {
+            for (int i = 0; i < positionCount / 2; i++) {
+                try {
+                    if ((Boolean) keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + i, nativeValue)) {
+                        return 2 * i + 1;
+                    }
+                }
+                catch (Throwable throwable) {
+                    throw handleThrowable(throwable);
+                }
+            }
             return -1;
         }
 
@@ -306,9 +352,24 @@ public class SingleMapBlock
         }
     }
 
-    public int seekKeyExact(double nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    public int seekKeyExact(double nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode, int mapLookupsWithoutHashTable)
     {
         if (positionCount == 0) {
+            return -1;
+        }
+
+        mapLookups += 1;
+        if (mapLookups <= mapLookupsWithoutHashTable) {
+            for (int i = 0; i < positionCount / 2; i++) {
+                try {
+                    if ((Boolean) keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + i, nativeValue)) {
+                        return 2 * i + 1;
+                    }
+                }
+                catch (Throwable throwable) {
+                    throw handleThrowable(throwable);
+                }
+            }
             return -1;
         }
 
@@ -350,9 +411,24 @@ public class SingleMapBlock
         }
     }
 
-    public int seekKeyExact(Slice nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    public int seekKeyExact(Slice nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode, int mapLookupsWithoutHashTable)
     {
         if (positionCount == 0) {
+            return -1;
+        }
+
+        mapLookups += 1;
+        if (mapLookups <= mapLookupsWithoutHashTable) {
+            for (int i = 0; i < positionCount / 2; i++) {
+                try {
+                    if ((Boolean) keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + i, nativeValue)) {
+                        return 2 * i + 1;
+                    }
+                }
+                catch (Throwable throwable) {
+                    throw handleThrowable(throwable);
+                }
+            }
             return -1;
         }
 
@@ -401,9 +477,24 @@ public class SingleMapBlock
         }
     }
 
-    public int seekKeyExact(Block nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    public int seekKeyExact(Block nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode, int mapLookupsWithoutHashTable)
     {
         if (positionCount == 0) {
+            return -1;
+        }
+
+        mapLookups += 1;
+        if (mapLookups <= mapLookupsWithoutHashTable) {
+            for (int i = 0; i < positionCount / 2; i++) {
+                try {
+                    if ((Boolean) keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + i, nativeValue)) {
+                        return 2 * i + 1;
+                    }
+                }
+                catch (Throwable throwable) {
+                    throw handleThrowable(throwable);
+                }
+            }
             return -1;
         }
 
@@ -443,6 +534,36 @@ public class SingleMapBlock
                 position = 0;
             }
         }
+    }
+
+    public int seekKey(Object nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    {
+        return seekKey(nativeValue, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, 0);
+    }
+
+    public int seekKeyExact(long nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    {
+        return seekKeyExact(nativeValue, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, 0);
+    }
+
+    public int seekKeyExact(boolean nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    {
+        return seekKeyExact(nativeValue, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, 0);
+    }
+
+    public int seekKeyExact(double nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    {
+        return seekKeyExact(nativeValue, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, 0);
+    }
+
+    public int seekKeyExact(Slice nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    {
+        return seekKeyExact(nativeValue, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, 0);
+    }
+
+    public int seekKeyExact(Block nativeValue, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
+    {
+        return seekKeyExact(nativeValue, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, 0);
     }
 
     private static RuntimeException handleThrowable(Throwable throwable)

--- a/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
@@ -36,6 +36,7 @@ public class SqlFunctionProperties
     private final boolean fieldNamesInJsonCastEnabled;
     private final boolean legacyJsonCast;
     private final Map<String, String> extraCredentials;
+    private final int mapLookupsWithoutHashTable;
 
     private SqlFunctionProperties(
             boolean parseDecimalLiteralAsDouble,
@@ -48,7 +49,8 @@ public class SqlFunctionProperties
             String sessionUser,
             boolean fieldNamesInJsonCastEnabled,
             boolean legacyJsonCast,
-            Map<String, String> extraCredentials)
+            Map<String, String> extraCredentials,
+            int mapLookupsWithoutHashTable)
     {
         this.parseDecimalLiteralAsDouble = parseDecimalLiteralAsDouble;
         this.legacyRowFieldOrdinalAccessEnabled = legacyRowFieldOrdinalAccessEnabled;
@@ -61,6 +63,7 @@ public class SqlFunctionProperties
         this.fieldNamesInJsonCastEnabled = fieldNamesInJsonCastEnabled;
         this.legacyJsonCast = legacyJsonCast;
         this.extraCredentials = requireNonNull(extraCredentials, "extraCredentials is null");
+        this.mapLookupsWithoutHashTable = mapLookupsWithoutHashTable;
     }
 
     public boolean isParseDecimalLiteralAsDouble()
@@ -119,6 +122,11 @@ public class SqlFunctionProperties
         return legacyJsonCast;
     }
 
+    public int getMapLookupsWithoutHashTable()
+    {
+        return mapLookupsWithoutHashTable;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -167,6 +175,7 @@ public class SqlFunctionProperties
         private boolean fieldNamesInJsonCastEnabled;
         private boolean legacyJsonCast;
         private Map<String, String> extraCredentials = emptyMap();
+        private int mapLookupsWithoutHashTable;
 
         private Builder() {}
 
@@ -236,6 +245,12 @@ public class SqlFunctionProperties
             return this;
         }
 
+        public Builder setMapLookupsWithoutHashTable(int mapLookupsWithoutHashTable)
+        {
+            this.mapLookupsWithoutHashTable = mapLookupsWithoutHashTable;
+            return this;
+        }
+
         public SqlFunctionProperties build()
         {
             return new SqlFunctionProperties(
@@ -249,7 +264,8 @@ public class SqlFunctionProperties
                     sessionUser,
                     fieldNamesInJsonCastEnabled,
                     legacyJsonCast,
-                    extraCredentials);
+                    extraCredentials,
+                    mapLookupsWithoutHashTable);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -53,6 +53,7 @@ import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.LEGACY_JSON_CAST;
+import static com.facebook.presto.SystemSessionProperties.getMapLookupsWithoutHashTable;
 import static com.facebook.presto.SystemSessionProperties.isFieldNameInJsonCastEnabled;
 import static com.facebook.presto.SystemSessionProperties.isLegacyMapSubscript;
 import static com.facebook.presto.SystemSessionProperties.isLegacyRowFieldOrdinalAccessEnabled;
@@ -509,6 +510,7 @@ public final class Session
                 .setSessionUser(getUser())
                 .setFieldNamesInJsonCastEnabled(isFieldNameInJsonCastEnabled(this))
                 .setLegacyJsonCast(legacyJsonCast)
+                .setMapLookupsWithoutHashTable(getMapLookupsWithoutHashTable(this))
                 .setExtraCredentials(identity.getExtraCredentials())
                 .build();
     }

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -324,6 +324,7 @@ public final class SystemSessionProperties
     public static final String SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT = "skip_hash_generation_for_join_with_table_scan_input";
     public static final String GENERATE_DOMAIN_FILTERS = "generate_domain_filters";
     public static final String REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION = "rewrite_expression_with_constant_expression";
+    public static final String MAP_LOOKUPS_WITHOUT_HASHTABLE = "map_lookups_without_hashtable";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -1915,6 +1916,11 @@ public final class SystemSessionProperties
                         "Rewrite left join with is null check to semi join",
                         featuresConfig.isRewriteExpressionWithConstantVariable(),
                         false),
+                integerProperty(
+                        MAP_LOOKUPS_WITHOUT_HASHTABLE,
+                        "Threshold for lookups inside map, after which a hashtable is created for the map.",
+                        0,
+                        false),
                 new PropertyMetadata<>(
                         DEFAULT_VIEW_SECURITY_MODE,
                         format("Set default view security mode. Options are: %s",
@@ -3206,6 +3212,11 @@ public final class SystemSessionProperties
     public static boolean isRewriteExpressionWithConstantEnabled(Session session)
     {
         return session.getSystemProperty(REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION, Boolean.class);
+    }
+
+    public static int getMapLookupsWithoutHashTable(Session session)
+    {
+        return session.getSystemProperty(MAP_LOOKUPS_WITHOUT_HASHTABLE, Integer.class);
     }
 
     public static CreateView.Security getDefaultViewSecurityMode(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
@@ -116,7 +116,7 @@ public class MapSubscriptOperator
         SingleMapBlock mapBlock = (SingleMapBlock) map;
         int valuePosition;
         try {
-            valuePosition = mapBlock.seekKeyExact(key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode);
+            valuePosition = mapBlock.seekKeyExact(key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, properties.getMapLookupsWithoutHashTable());
         }
         catch (NotSupportedException e) {
             throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
@@ -137,7 +137,7 @@ public class MapSubscriptOperator
         SingleMapBlock mapBlock = (SingleMapBlock) map;
         int valuePosition;
         try {
-            valuePosition = mapBlock.seekKeyExact(key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode);
+            valuePosition = mapBlock.seekKeyExact(key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, properties.getMapLookupsWithoutHashTable());
         }
         catch (NotSupportedException e) {
             throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
@@ -158,7 +158,7 @@ public class MapSubscriptOperator
         SingleMapBlock mapBlock = (SingleMapBlock) map;
         int valuePosition;
         try {
-            valuePosition = mapBlock.seekKeyExact(key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode);
+            valuePosition = mapBlock.seekKeyExact(key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, properties.getMapLookupsWithoutHashTable());
         }
         catch (NotSupportedException e) {
             throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
@@ -179,7 +179,7 @@ public class MapSubscriptOperator
         SingleMapBlock mapBlock = (SingleMapBlock) map;
         int valuePosition;
         try {
-            valuePosition = mapBlock.seekKeyExact(key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode);
+            valuePosition = mapBlock.seekKeyExact(key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, properties.getMapLookupsWithoutHashTable());
         }
         catch (NotSupportedException e) {
             throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
@@ -200,7 +200,7 @@ public class MapSubscriptOperator
         SingleMapBlock mapBlock = (SingleMapBlock) map;
         int valuePosition;
         try {
-            valuePosition = mapBlock.seekKeyExact((Block) key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode);
+            valuePosition = mapBlock.seekKeyExact((Block) key, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode, properties.getMapLookupsWithoutHashTable());
         }
         catch (NotSupportedException e) {
             throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);


### PR DESCRIPTION
Add session property `map_lookups_without_hashtable`, which denotes how many map lookups will be done using linear search, before resorting to hash table build of the entire map. Default is 0.

Usually hashing cost is high enough that its best to not build the hash table for map objects. Only when number of lookups exceed some threshold, we should resort to build the hashtable. This change controls that using a session prop.

```
== RELEASE NOTES ==

General Changes
* Add session property `map_lookups_without_hashtable`, which denotes how many map lookups will be done using linear search, before resorting to hash table build of the entire map. Default is 0.
