### PR TITLE
Fix correctness issue in regr_r2

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
@@ -196,6 +196,9 @@ public final class AggregationUtils
 
     public static double getRegressionR2(RegressionState state)
     {
+        if (state.getM2X() != 0 && state.getM2Y() == 0) {
+            return 1.0;
+        }
         return Math.pow(state.getC2(), 2) / (state.getM2X() * state.getM2Y());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrR2Aggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleRegrR2Aggregation.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.aggregation;
 
 import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.testng.annotations.Test;
 
 import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -43,6 +44,19 @@ public class TestDoubleRegrR2Aggregation
             }
             return (double) regression.getRSquare();
         }
+    }
+
+    @Test
+    public void testTwoSpecialCase()
+    {
+        // when m2x = 0, result is null
+        Double[] y = new Double[] {1.0, 1.0, 1.0, 1.0, 1.0};
+        Double[] x = new Double[] {1.0, 1.0, 1.0, 1.0, 1.0};
+        testAggregation(null, createDoublesBlock(y), createDoublesBlock(x));
+
+        // when m2x != 0 and m2y = 0, result is 1.0
+        x = new Double[] {1.0, 2.0, 3.0, 4.0, 5.0};
+        testAggregation(1.0, createDoublesBlock(y), createDoublesBlock(x));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrR2Aggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealRegrR2Aggregation.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.aggregation;
 
 import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.testng.annotations.Test;
 
 import static com.facebook.presto.block.BlockAssertions.createBlockOfReals;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -43,6 +44,19 @@ public class TestRealRegrR2Aggregation
             }
             return (float) regression.getRSquare();
         }
+    }
+
+    @Test
+    public void testTwoSpecialCase()
+    {
+        // when m2x = 0, result is null
+        Float[] y = new Float[] {1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+        Float[] x = new Float[] {1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+        testAggregation(null, createBlockOfReals(y), createBlockOfReals(x));
+
+        // when m2x != 0 and m2y = 0, result is 1.0
+        x = new Float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+        testAggregation(1.0f, createBlockOfReals(y), createBlockOfReals(x));
     }
 
     @Override


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Fix regr_r2 result incorrect. There are two special cases:
1. m2X() = 0, then result should be NULL
2. m2X() != 0 and m2Y() = 0, then result shoule be 1.

Found by https://github.com/facebookincubator/velox/issues/9522

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix regr_r2 result incorrect.
```


