### PR TITLE
Add row ID support to batch ORC reader

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBatchPageSourceFactory.java
@@ -38,5 +38,6 @@ public interface HiveBatchPageSourceFactory
             TupleDomain<HiveColumnHandle> effectivePredicate,
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation);
+            Optional<EncryptionInformation> encryptionInformation,
+            Optional<byte[]> rowIdPartitionComponent);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -96,9 +96,11 @@ public class HivePageSource
             if (columnMapping.getCoercionFrom().isPresent()) {
                 coercers[columnIndex] = createCoercer(typeManager, columnMapping.getCoercionFrom().get(), columnMapping.getHiveColumnHandle().getHiveType());
             }
-            else if (isRowIdColumnHandle(columnMapping.getHiveColumnHandle()) && rowIdPartitionComponent.isPresent()) {
+            else if (isRowIdColumnHandle(columnMapping.getHiveColumnHandle())) {
+                // If there's no row ID partition component, then path + row numbers will be supplied for $row_id
+                byte[] component = rowIdPartitionComponent.orElse(new byte[0]);
                 String rowGroupId = Paths.get(path).getFileName().toString();
-                coercers[columnIndex] = new RowIDCoercer(rowIdPartitionComponent.get(), rowGroupId);
+                coercers[columnIndex] = new RowIDCoercer(component, rowGroupId);
             }
 
             if (columnMapping.getKind() == PREFILLED) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -213,6 +213,14 @@ public final class HiveUtil
     private static final String USE_RECORD_READER_FROM_INPUT_FORMAT_ANNOTATION = "UseRecordReaderFromInputFormat";
     private static final String USE_FILE_SPLITS_FROM_INPUT_FORMAT_ANNOTATION = "UseFileSplitsFromInputFormat";
 
+    public static void checkRowIDPartitionComponent(List<HiveColumnHandle> columns, Optional<byte[]> rowIdPartitionComponent)
+    {
+        boolean supplyRowIDs = columns.stream().anyMatch(column -> HiveColumnHandle.isRowIdColumnHandle(column));
+        if (supplyRowIDs) {
+            checkArgument(rowIdPartitionComponent.isPresent(), "rowIDPartitionComponent required when supplying row IDs");
+        }
+    }
+
     static {
         DateTimeParser[] timestampWithoutTimeZoneParser = {
                 DateTimeFormat.forPattern("yyyy-M-d").getParser(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
@@ -98,7 +98,8 @@ public class DwrfBatchPageSourceFactory
             TupleDomain<HiveColumnHandle> effectivePredicate,
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            Optional<byte[]> rowIDPartitionComponent)
     {
         if (!OrcSerde.class.getName().equals(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();
@@ -132,6 +133,7 @@ public class DwrfBatchPageSourceFactory
                         .build(),
                 encryptionInformation,
                 dwrfEncryptionProvider,
-                session));
+                session,
+                rowIDPartitionComponent));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
+import static com.facebook.presto.hive.HiveUtil.checkRowIDPartitionComponent;
 import static com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory.createOrcPageSource;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static java.util.Objects.requireNonNull;
@@ -117,6 +118,8 @@ public class DwrfSelectivePageSourceFactory
         if (fileSplit.getFileSize() == 0) {
             throw new PrestoException(HIVE_BAD_DATA, "ORC file is empty: " + fileSplit.getPath());
         }
+
+        checkRowIDPartitionComponent(columns, rowIDPartitionComponent);
 
         return Optional.of(createOrcPageSource(
                 session,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.FileFormatDataSourceStats;
 import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.RowIDCoercer;
 import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcCorruptionException;
@@ -58,6 +59,7 @@ public class OrcBatchPageSource
 
     private final Block[] constantBlocks;
     private final int[] hiveColumnIndexes;
+    private final boolean[] rowIDColumnIndexes;
 
     private int batchId;
     private long completedPositions;
@@ -71,6 +73,8 @@ public class OrcBatchPageSource
 
     private final List<Boolean> isRowPositionList;
 
+    private final RowIDCoercer coercer;
+
     public OrcBatchPageSource(
             OrcBatchRecordReader recordReader,
             OrcDataSource orcDataSource,
@@ -78,9 +82,11 @@ public class OrcBatchPageSource
             TypeManager typeManager,
             OrcAggregatedMemoryContext systemMemoryContext,
             FileFormatDataSourceStats stats,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            byte[] rowIDPartitionComponent,
+            String rowGroupId)
     {
-        this(recordReader, orcDataSource, columns, typeManager, systemMemoryContext, stats, runtimeStats, nCopies(columns.size(), false));
+        this(recordReader, orcDataSource, columns, typeManager, systemMemoryContext, stats, runtimeStats, nCopies(columns.size(), false), rowIDPartitionComponent, rowGroupId);
     }
 
     /**
@@ -97,7 +103,9 @@ public class OrcBatchPageSource
             OrcAggregatedMemoryContext systemMemoryContext,
             FileFormatDataSourceStats stats,
             RuntimeStats runtimeStats,
-            List<Boolean> isRowPositionList)
+            List<Boolean> isRowPositionList,
+            byte[] rowIDPartitionComponent,
+            String rowGroupId)
     {
         this.recordReader = requireNonNull(recordReader, "recordReader is null");
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
@@ -107,9 +115,12 @@ public class OrcBatchPageSource
         this.stats = requireNonNull(stats, "stats is null");
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
         this.isRowPositionList = requireNonNull(isRowPositionList, "isRowPositionList is null");
+        // TODO don't create this if there's no rowID column
+        this.coercer = new RowIDCoercer(rowIDPartitionComponent, rowGroupId);
 
         this.constantBlocks = new Block[size];
         this.hiveColumnIndexes = new int[size];
+        this.rowIDColumnIndexes = new boolean[size];
 
         ImmutableList.Builder<String> namesBuilder = ImmutableList.builder();
         ImmutableList.Builder<Type> typesBuilder = ImmutableList.builder();
@@ -124,6 +135,7 @@ public class OrcBatchPageSource
             typesBuilder.add(type);
 
             hiveColumnIndexes[columnIndex] = column.getHiveColumnIndex();
+            rowIDColumnIndexes[columnIndex] = HiveColumnHandle.isRowIdColumnHandle(column);
 
             if (!recordReader.isColumnPresent(column.getHiveColumnIndex())) {
                 constantBlocks[columnIndex] = RunLengthEncodedBlock.create(type, null, MAX_BATCH_SIZE);
@@ -182,6 +194,11 @@ public class OrcBatchPageSource
             for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
                 if (isRowPositionColumn(fieldId)) {
                     blocks[fieldId] = getRowPosColumnBlock(recordReader.getFilePosition(), batchSize);
+                }
+                else if (isRowIDColumn(fieldId)) {
+                    Block rowNumbers = getRowPosColumnBlock(recordReader.getFilePosition(), batchSize);
+                    Block rowIDs = coercer.apply(rowNumbers);
+                    blocks[fieldId] = rowIDs;
                 }
                 else {
                     if (constantBlocks[fieldId] != null) {
@@ -260,6 +277,12 @@ public class OrcBatchPageSource
         return isRowPositionList.get(column);
     }
 
+    private boolean isRowIDColumn(int column)
+    {
+        return this.rowIDColumnIndexes[column];
+    }
+
+    // TODO verify these are row numbers and rename?
     private static Block getRowPosColumnBlock(long baseIndex, int size)
     {
         long[] rowPositions = new long[size];

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -283,9 +283,9 @@ public class OrcSelectivePageSourceFactory
         Path path = new Path(fileSplit.getPath());
 
         boolean supplyRowIDs = selectedColumns.stream().anyMatch(column -> HiveColumnHandle.isRowIdColumnHandle(column));
-        String rowGroupId = path.getName();
         checkArgument(!supplyRowIDs || rowIDPartitionComponent.isPresent(), "rowIDPartitionComponent required when supplying row IDs");
         byte[] partitionID = rowIDPartitionComponent.orElse(new byte[0]);
+        String rowGroupId = path.getName();
 
         DataSize maxMergeDistance = getOrcMaxMergeDistance(session);
         DataSize tinyStripeThreshold = getOrcTinyStripeThreshold(session);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSourceFactory.java
@@ -72,7 +72,8 @@ public class PageFilePageSourceFactory
             TupleDomain<HiveColumnHandle> effectivePredicate,
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            Optional<byte[]> rowIDPartitionComponent)
     {
         if (!PageInputFormat.class.getSimpleName().equals(storage.getStorageFormat().getInputFormat())) {
             return Optional.empty();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -512,7 +512,8 @@ public class ParquetPageSourceFactory
             TupleDomain<HiveColumnHandle> effectivePredicate,
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            Optional<byte[]> rowIdPartitionComponent)
     {
         if (!PARQUET_SERDE_CLASS_NAMES.contains(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSourceFactory.java
@@ -106,7 +106,8 @@ public class RcFilePageSourceFactory
             TupleDomain<HiveColumnHandle> effectivePredicate,
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            Optional<byte[]> rowIDPartitionComponent)
     {
         RcFileEncoding rcFileEncoding;
         if (LazyBinaryColumnarSerDe.class.getName().equals(storage.getStorageFormat().getSerDe())) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -507,6 +507,7 @@ public enum FileFormat
                                 OptionalLong.of(targetFile.length()),
                                 modificationTime,
                                 false),
+                        Optional.empty(),
                         Optional.empty())
                 .get();
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -617,7 +617,10 @@ public class IcebergPageSourceProvider
                             systemMemoryUsage,
                             stats,
                             runtimeStats,
-                            isRowPositionList),
+                            isRowPositionList,
+                            // Iceberg doesn't support row IDs
+                            new byte[0],
+                            ""),
                     Optional.empty(),
                     Optional.empty());
         }


### PR DESCRIPTION
## Description
Previously only done in selective reader

## Motivation and Context
Fill in row IDs on more paths

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

