### PR TITLE
[native] Move static functions from PrestoTask to Util.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -147,9 +147,6 @@ struct PrestoTask {
   static std::string taskNumbersToString(
       const std::array<size_t, 5>& taskNumbers);
 
-  /// Returns process-wide CPU time in nanoseconds.
-  static long getProcessCpuTime();
-
   /// Invoked to update presto task status from the updated velox task stats.
   protocol::TaskStatus updateStatusLocked();
   protocol::TaskInfo updateInfoLocked();

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -1112,7 +1112,7 @@ void TaskManager::shutdown() {
     PRESTO_SHUTDOWN_LOG(INFO)
         << "Waited (" << seconds
         << " seconds so far) for 'Running' tasks to complete. " << numTasks
-        << " tasks left: " << PrestoTask::taskNumbersToString(taskNumbers);
+        << " tasks left: " << util::taskNumbersToString(taskNumbers);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     taskNumbers = getTaskNumbers(numTasks);
     ++seconds;

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -14,6 +14,7 @@
 #include "presto_cpp/main/TaskResource.h"
 #include <presto_cpp/main/common/Exception.h>
 #include "presto_cpp/main/common/Configs.h"
+#include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/main/thrift/ProtocolToThrift.h"
 #include "presto_cpp/main/thrift/ThriftIO.h"
 #include "presto_cpp/main/thrift/gen-cpp2/PrestoThrift.h"
@@ -220,7 +221,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
         folly::via(
             httpSrvCpuExecutor_,
             [this, &body, taskId, createOrUpdateFunc]() {
-              const auto startProcessCpuTime = PrestoTask::getProcessCpuTime();
+              const auto startProcessCpuTime = util::getProcessCpuTime();
 
               // TODO Avoid copy
               std::ostringstream oss;

--- a/presto-native-execution/presto_cpp/main/common/Utils.h
+++ b/presto-native-execution/presto_cpp/main/common/Utils.h
@@ -31,4 +31,9 @@ std::shared_ptr<folly::SSLContext> createSSLContext(
     const std::string& clientCertAndKeyPath,
     const std::string& ciphers);
 
+/// Returns process-wide CPU time in nanoseconds.
+long getProcessCpuTime();
+
+std::string taskNumbersToString(const std::array<size_t, 5>& taskNumbers);
+
 } // namespace facebook::presto::util


### PR DESCRIPTION
## Description
Minor refactor to move static tasks from PrestoTask struct to Util.

## Motivation and Context
We are trying to make PrestoTask a class instead of a struct for better encapsulation. Moving static methods out of the struct makes this easier. Besides the functions we are moving aren't a good fit for PrestoTask.

## Impact
No impact.

## Test Plan
Existing unit tests