### PR TITLE
Implement large array constructing through chunk concatenation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -21,6 +21,8 @@ The ``||`` operator is used to concatenate an array with an array or an element 
 Array Functions
 ---------------
 
+When users write an array with a large number of elements, such as `ARRAY[1,2,3..1000]`, Presto automatically splits the array into multiple smaller arrays and concatenates them during the plan/RowExpression generation phase. 
+
 .. function:: all_match(array(T), function(T,boolean)) -> boolean
 
     Returns whether all elements of an array match the given predicate. Returns ``true`` if all the elements

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -99,13 +99,13 @@ import com.facebook.presto.sql.tree.WhenClause;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
+import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.regex.Pattern;
-import java.util.ArrayList;
 
 import static com.facebook.presto.common.function.OperatorType.BETWEEN;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
@@ -1023,7 +1023,6 @@ public final class SqlToRowExpressionTranslator
             }
             return call("ARRAY", functionResolution.arrayConstructor(argumentTypes), getType(node), arguments);
         }
-
 
         @Override
         protected RowExpression visitRow(Row node, Context context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -175,6 +175,7 @@ public final class SqlToRowExpressionTranslator
     private static final Pattern LIKE_PREFIX_MATCH_PATTERN = Pattern.compile("^[^%_]*%$");
     private static final Pattern LIKE_SUFFIX_MATCH_PATTERN = Pattern.compile("^%[^%_]*$");
     private static final Pattern LIKE_SIMPLE_EXISTS_PATTERN = Pattern.compile("^%[^%_]*%$");
+    private static final int MAX_LENGTH = 254;
 
     private SqlToRowExpressionTranslator() {}
 
@@ -1008,10 +1009,10 @@ public final class SqlToRowExpressionTranslator
                     .map(RowExpression::getType)
                     .collect(toImmutableList());
 
-            if (arguments.size() > 200) {
+            if (arguments.size() > MAX_LENGTH) {
                 List<RowExpression> concatenatedArguments = new ArrayList<>();
-                for (int i = 0; i < arguments.size(); i += 200) {
-                    int end = Math.min(i + 200, arguments.size());
+                for (int i = 0; i < arguments.size(); i += MAX_LENGTH) {
+                    int end = Math.min(i + MAX_LENGTH, arguments.size());
                     List<RowExpression> chunk = arguments.subList(i, end);
                     RowExpression chunkArray = call("ARRAY", functionResolution.arrayConstructor(argumentTypes.subList(i, end)), getType(node), chunk);
                     concatenatedArguments.add(chunkArray);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
@@ -22,27 +22,27 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static java.util.Collections.nCopies;
 
 public class TestArrayFunctions
-                extends AbstractTestFunctions
+    extends AbstractTestFunctions
 {
-        @Test
-        public void testArrayConstructor()
-        {
-                tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(200, "rand()")) + "]",
-                                new ArrayType(DOUBLE));
-                tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(1000, "rand()")) + "]",
-                                new ArrayType(DOUBLE));
-                assertNotSupported(
-                                "array[" + Joiner.on(", ").join(nCopies(254 * 254 + 1, "rand()")) + "]",
-                                "Too many arguments for vararg function");
-        }
+    @Test
+    public void testArrayConstructor()
+    {
+        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(200, "rand()")) + "]",
+            new ArrayType(DOUBLE));
+        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(1000, "rand()")) + "]",
+            new ArrayType(DOUBLE));
+        assertNotSupported(
+            "array[" + Joiner.on(", ").join(nCopies(254 * 254 + 1, "rand()")) + "]",
+            "Too many arguments for vararg function");
+    }
 
-        @Test
-        public void testArrayConcat()
-        {
-                assertFunction("CONCAT(" + Joiner.on(", ").join(nCopies(253, "array[1]")) + ")", new ArrayType(INTEGER),
-                                nCopies(253, 1));
-                assertNotSupported(
-                                "CONCAT(" + Joiner.on(", ").join(nCopies(255, "array[1]")) + ")",
-                                "Too many arguments for vararg function");
-        }
+    @Test
+    public void testArrayConcat()
+    {
+        assertFunction("CONCAT(" + Joiner.on(", ").join(nCopies(253, "array[1]")) + ")", new ArrayType(INTEGER),
+            nCopies(253, 1));
+        assertNotSupported(
+            "CONCAT(" + Joiner.on(", ").join(nCopies(255, "array[1]")) + ")",
+            "Too many arguments for vararg function");
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
@@ -22,22 +22,27 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static java.util.Collections.nCopies;
 
 public class TestArrayFunctions
-        extends AbstractTestFunctions {
-    @Test
-    public void testArrayConstructor() {
-        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(200, "rand()")) + "]", new ArrayType(DOUBLE));
-        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(1000, "rand()")) + "]", new ArrayType(DOUBLE));
-        assertNotSupported(
-                "array[" + Joiner.on(", ").join(nCopies(254 * 254 + 1, "rand()")) + "]",
-                "Too many arguments for vararg function");
-    }
+                extends AbstractTestFunctions
+{
+        @Test
+        public void testArrayConstructor()
+        {
+                tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(200, "rand()")) + "]",
+                                new ArrayType(DOUBLE));
+                tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(1000, "rand()")) + "]",
+                                new ArrayType(DOUBLE));
+                assertNotSupported(
+                                "array[" + Joiner.on(", ").join(nCopies(254 * 254 + 1, "rand()")) + "]",
+                                "Too many arguments for vararg function");
+        }
 
-    @Test
-    public void testArrayConcat() {
-        assertFunction("CONCAT(" + Joiner.on(", ").join(nCopies(253, "array[1]")) + ")", new ArrayType(INTEGER),
-                nCopies(253, 1));
-        assertNotSupported(
-                "CONCAT(" + Joiner.on(", ").join(nCopies(255, "array[1]")) + ")",
-                "Too many arguments for vararg function");
-    }
+        @Test
+        public void testArrayConcat()
+        {
+                assertFunction("CONCAT(" + Joiner.on(", ").join(nCopies(253, "array[1]")) + ")", new ArrayType(INTEGER),
+                                nCopies(253, 1));
+                assertNotSupported(
+                                "CONCAT(" + Joiner.on(", ").join(nCopies(255, "array[1]")) + ")",
+                                "Too many arguments for vararg function");
+        }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
@@ -27,10 +27,8 @@ public class TestArrayFunctions
     @Test
     public void testArrayConstructor()
     {
-        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(254, "rand()")) + "]", new ArrayType(DOUBLE));
-        assertNotSupported(
-                "array[" + Joiner.on(", ").join(nCopies(255, "rand()")) + "]",
-                "Too many arguments for array constructor");
+        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(200, "rand()")) + "]", new ArrayType(DOUBLE));
+        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(1000, "rand()")) + "]", new ArrayType(DOUBLE));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
@@ -22,27 +22,25 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static java.util.Collections.nCopies;
 
 public class TestArrayFunctions
-    extends AbstractTestFunctions
+        extends AbstractTestFunctions
 {
     @Test
     public void testArrayConstructor()
     {
-        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(200, "rand()")) + "]",
-            new ArrayType(DOUBLE));
-        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(1000, "rand()")) + "]",
-            new ArrayType(DOUBLE));
+        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(200, "rand()")) + "]", new ArrayType(DOUBLE));
+        tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(1000, "rand()")) + "]", new ArrayType(DOUBLE));
         assertNotSupported(
-            "array[" + Joiner.on(", ").join(nCopies(254 * 254 + 1, "rand()")) + "]",
-            "Too many arguments for vararg function");
+                "array[" + Joiner.on(", ").join(nCopies(254 * 254 + 1, "rand()")) + "]",
+                "Too many arguments for vararg function");
     }
 
     @Test
     public void testArrayConcat()
     {
         assertFunction("CONCAT(" + Joiner.on(", ").join(nCopies(253, "array[1]")) + ")", new ArrayType(INTEGER),
-            nCopies(253, 1));
+                nCopies(253, 1));
         assertNotSupported(
-            "CONCAT(" + Joiner.on(", ").join(nCopies(255, "array[1]")) + ")",
-            "Too many arguments for vararg function");
+                "CONCAT(" + Joiner.on(", ").join(nCopies(255, "array[1]")) + ")",
+                "Too many arguments for vararg function");
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
@@ -22,19 +22,20 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static java.util.Collections.nCopies;
 
 public class TestArrayFunctions
-        extends AbstractTestFunctions
-{
+        extends AbstractTestFunctions {
     @Test
-    public void testArrayConstructor()
-    {
+    public void testArrayConstructor() {
         tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(200, "rand()")) + "]", new ArrayType(DOUBLE));
         tryEvaluateWithAll("array[" + Joiner.on(", ").join(nCopies(1000, "rand()")) + "]", new ArrayType(DOUBLE));
+        assertNotSupported(
+                "array[" + Joiner.on(", ").join(nCopies(254 * 254 + 1, "rand()")) + "]",
+                "Too many arguments for vararg function");
     }
 
     @Test
-    public void testArrayConcat()
-    {
-        assertFunction("CONCAT(" + Joiner.on(", ").join(nCopies(253, "array[1]")) + ")", new ArrayType(INTEGER), nCopies(253, 1));
+    public void testArrayConcat() {
+        assertFunction("CONCAT(" + Joiner.on(", ").join(nCopies(253, "array[1]")) + ")", new ArrayType(INTEGER),
+                nCopies(253, 1));
         assertNotSupported(
                 "CONCAT(" + Joiner.on(", ").join(nCopies(255, "array[1]")) + ")",
                 "Too many arguments for vararg function");

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -155,7 +155,8 @@ public class TestRowExpressionSerde
     public void testLargeArraySplitting()
     {
         // Test array with more than the number of elements a single array constructor can store
-        int numElements = 900, maxLen = 254;
+        int numElements = 900;
+        int maxLen = 254;
         String sql = "ARRAY " + IntStream.rangeClosed(1, numElements)
                 .mapToObj(Integer::toString)
                 .collect(Collectors.joining(", ", "[", "]"));

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -152,21 +152,22 @@ public class TestRowExpressionSerde
     }
 
     @Test
-    public void testLargeArraySplitting() {
+    public void testLargeArraySplitting()
+    {
         // Test array with more than 200 elements
         int numElements = 900;
         String sql = "ARRAY " + IntStream.rangeClosed(1, numElements)
                 .mapToObj(Integer::toString)
                 .collect(Collectors.joining(", ", "[", "]"));
         List<String> sqlParts = new ArrayList<>();
-        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
+        for (int i = 0; i < (numElements - 1) / 200 + 1; i++) {
             sqlParts.add("ARRAY " + IntStream.rangeClosed(1 + 200 * i, Math.min(200 * (i + 1), numElements))
                     .mapToObj(Integer::toString)
                     .collect(Collectors.joining(", ", "[", "]")));
         }
         RowExpression roundTripExpression = getRoundTrip(sql, false);
         List<RowExpression> rowExpressionParts = new ArrayList<>();
-        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
+        for (int i = 0; i < (numElements - 1) / 200 + 1; i++) {
             rowExpressionParts.add(getRoundTrip(sqlParts.get(i), false));
         }
 
@@ -176,7 +177,6 @@ public class TestRowExpressionSerde
         List<RowExpression> arguments = callExpression.getArguments();
         assertEquals(arguments, rowExpressionParts);
     }
-
 
     @Test
     public void testArrayGet()

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -154,20 +154,20 @@ public class TestRowExpressionSerde
     @Test
     public void testLargeArraySplitting()
     {
-        // Test array with more than 200 elements
-        int numElements = 900;
+        // Test array with more than the number of elements a single array constructor can store
+        int numElements = 900, maxLen = 254;
         String sql = "ARRAY " + IntStream.rangeClosed(1, numElements)
                 .mapToObj(Integer::toString)
                 .collect(Collectors.joining(", ", "[", "]"));
         List<String> sqlParts = new ArrayList<>();
-        for (int i = 0; i < (numElements - 1) / 200 + 1; i++) {
-            sqlParts.add("ARRAY " + IntStream.rangeClosed(1 + 200 * i, Math.min(200 * (i + 1), numElements))
+        for (int i = 0; i < (numElements - 1) / maxLen + 1; i++) {
+            sqlParts.add("ARRAY " + IntStream.rangeClosed(1 + maxLen * i, Math.min(maxLen * (i + 1), numElements))
                     .mapToObj(Integer::toString)
                     .collect(Collectors.joining(", ", "[", "]")));
         }
         RowExpression roundTripExpression = getRoundTrip(sql, false);
         List<RowExpression> rowExpressionParts = new ArrayList<>();
-        for (int i = 0; i < (numElements - 1) / 200 + 1; i++) {
+        for (int i = 0; i < (numElements - 1) / maxLen + 1; i++) {
             rowExpressionParts.add(getRoundTrip(sqlParts.get(i), false));
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -3,7 +3,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +35,6 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
-import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
@@ -59,11 +58,7 @@ import org.intellij.lang.annotations.Language;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
@@ -98,227 +93,200 @@ import static org.testng.Assert.assertTrue;
 
 public class TestRowExpressionSerde
 {
-    private final Metadata metadata = MetadataManager.createTestMetadataManager();
-    private JsonCodec<RowExpression> codec;
+    private final Metadata metadata = MetadataManager.createTestMetadataManager();
+    private JsonCodec<RowExpression> codec;
 
-    @BeforeClass
-    public void setUp()
-            throws Exception
-    {
-        codec = getJsonCodec();
-    }
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        codec = getJsonCodec();
+    }
 
-    @Test
-    public void testSimpleLiteral()
-    {
-        assertLiteral("TRUE", constant(true, BOOLEAN));
-        assertLiteral("FALSE", constant(false, BOOLEAN));
-        assertLiteral("CAST(NULL AS BOOLEAN)", constant(null, BOOLEAN));
+    @Test
+    public void testSimpleLiteral()
+    {
+        assertLiteral("TRUE", constant(true, BOOLEAN));
+        assertLiteral("FALSE", constant(false, BOOLEAN));
+        assertLiteral("CAST(NULL AS BOOLEAN)", constant(null, BOOLEAN));
 
-        assertLiteral("TINYINT '1'", constant(1L, TINYINT));
-        assertLiteral("SMALLINT '1'", constant(1L, SMALLINT));
-        assertLiteral("1", constant(1L, INTEGER));
-        assertLiteral("BIGINT '1'", constant(1L, BIGINT));
+        assertLiteral("TINYINT '1'", constant(1L, TINYINT));
+        assertLiteral("SMALLINT '1'", constant(1L, SMALLINT));
+        assertLiteral("1", constant(1L, INTEGER));
+        assertLiteral("BIGINT '1'", constant(1L, BIGINT));
 
-        assertLiteral("1.1", constant(1.1, DOUBLE));
-        assertLiteral("nan()", constant(Double.NaN, DOUBLE));
-        assertLiteral("infinity()", constant(Double.POSITIVE_INFINITY, DOUBLE));
-        assertLiteral("-infinity()", constant(Double.NEGATIVE_INFINITY, DOUBLE));
+        assertLiteral("1.1", constant(1.1, DOUBLE));
+        assertLiteral("nan()", constant(Double.NaN, DOUBLE));
+        assertLiteral("infinity()", constant(Double.POSITIVE_INFINITY, DOUBLE));
+        assertLiteral("-infinity()", constant(Double.NEGATIVE_INFINITY, DOUBLE));
 
-        assertLiteral("CAST(1.1 AS REAL)", constant((long) floatToIntBits(1.1f), REAL));
-        assertLiteral("CAST(nan() AS REAL)", constant((long) floatToIntBits(Float.NaN), REAL));
-        assertLiteral("CAST(infinity() AS REAL)", constant((long) floatToIntBits(Float.POSITIVE_INFINITY), REAL));
-        assertLiteral("CAST(-infinity() AS REAL)", constant((long) floatToIntBits(Float.NEGATIVE_INFINITY), REAL));
+        assertLiteral("CAST(1.1 AS REAL)", constant((long) floatToIntBits(1.1f), REAL));
+        assertLiteral("CAST(nan() AS REAL)", constant((long) floatToIntBits(Float.NaN), REAL));
+        assertLiteral("CAST(infinity() AS REAL)", constant((long) floatToIntBits(Float.POSITIVE_INFINITY), REAL));
+        assertLiteral("CAST(-infinity() AS REAL)", constant((long) floatToIntBits(Float.NEGATIVE_INFINITY), REAL));
 
-        assertStringLiteral("'String Literal'", "String Literal", VarcharType.createVarcharType(14));
-        assertLiteral("CAST(NULL AS VARCHAR)", constant(null, VARCHAR));
+        assertStringLiteral("'String Literal'", "String Literal", VarcharType.createVarcharType(14));
+        assertLiteral("CAST(NULL AS VARCHAR)", constant(null, VARCHAR));
 
-        assertLiteral("DATE '1991-01-01'", constant(7670L, DATE));
-        assertLiteral("TIMESTAMP '1991-01-01 00:00:00.000'", constant(662727600000L, TIMESTAMP));
-    }
+        assertLiteral("DATE '1991-01-01'", constant(7670L, DATE));
+        assertLiteral("TIMESTAMP '1991-01-01 00:00:00.000'", constant(662727600000L, TIMESTAMP));
+    }
 
-    @Test
-    public void testArrayLiteral()
-    {
-        RowExpression rowExpression = getRoundTrip("ARRAY [1, 2, 3]", true);
-        assertTrue(rowExpression instanceof ConstantExpression);
-        Object value = ((ConstantExpression) rowExpression).getValue();
-        assertTrue(value instanceof IntArrayBlock);
-        IntArrayBlock block = (IntArrayBlock) value;
-        assertEquals(block.getPositionCount(), 3);
-        assertEquals(block.getInt(0), 1);
-        assertEquals(block.getInt(1), 2);
-        assertEquals(block.getInt(2), 3);
-    }
+    @Test
+    public void testArrayLiteral()
+    {
+        RowExpression rowExpression = getRoundTrip("ARRAY [1, 2, 3]", true);
+        assertTrue(rowExpression instanceof ConstantExpression);
+        Object value = ((ConstantExpression) rowExpression).getValue();
+        assertTrue(value instanceof IntArrayBlock);
+        IntArrayBlock block = (IntArrayBlock) value;
+        assertEquals(block.getPositionCount(), 3);
+        assertEquals(block.getInt(0), 1);
+        assertEquals(block.getInt(1), 2);
+        assertEquals(block.getInt(2), 3);
+    }
 
-    @Test
-    public void testLargeArraySplitting() {
-        // Test array with more than 200 elements
-        int numElements = 900;
-        String sql = "ARRAY " + IntStream.rangeClosed(1, numElements)
-                .mapToObj(Integer::toString)
-                .collect(Collectors.joining(", ", "[", "]"));
-        List<String> sqlParts = new ArrayList<>();
-        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
-            sqlParts.add("ARRAY " + IntStream.rangeClosed(1 + 200 * i, Math.min(200 * (i + 1), numElements))
-                    .mapToObj(Integer::toString)
-                    .collect(Collectors.joining(", ", "[", "]")));
-        }
-        RowExpression roundTripExpression = getRoundTrip(sql, false);
-        List<RowExpression> rowExpressionParts = new ArrayList<>();
-        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
-            rowExpressionParts.add(getRoundTrip(sqlParts.get(i), false));
-        }
+    @Test
+    public void testArrayGet()
+    {
+        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", false),
+                call(SUBSCRIPT.name(),
+                        operator(SUBSCRIPT, new ArrayType(INTEGER), BIGINT),
+                        INTEGER,
+                        call("array_constructor",
+                                function("array_constructor", INTEGER, INTEGER, INTEGER),
+                                new ArrayType(INTEGER),
+                                constant(1L, INTEGER),
+                                constant(2L, INTEGER),
+                                constant(3L, INTEGER)),
+                        constant(1L, INTEGER)));
+        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", true), constant(1L, INTEGER));
+    }
 
-        assertTrue(roundTripExpression instanceof CallExpression);
-        CallExpression callExpression = (CallExpression) roundTripExpression;
-        assertEquals(callExpression.getDisplayName(), "concat");
-        List<RowExpression> arguments = callExpression.getArguments();
-        assertEquals(arguments, rowExpressionParts);
-    }
+    @Test
+    public void testRowLiteral()
+    {
+        assertEquals(getRoundTrip("ROW(1, 1.1)", false),
+                specialForm(
+                        ROW_CONSTRUCTOR,
+                        RowType.anonymous(
+                                ImmutableList.of(
+                                        INTEGER,
+                                        DOUBLE)),
+                        constant(1L, INTEGER),
+                        constant(1.1, DOUBLE)));
+    }
 
+    @Test
+    public void testDereference()
+    {
+        String sql = "CAST(ROW(1) AS ROW(col1 integer)).col1";
+        RowExpression before = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), false);
+        RowExpression after = getRoundTrip(sql, false);
+        assertEquals(before, after);
+    }
 
-    @Test
-    public void testArrayGet()
-    {
-        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", false),
-                call(SUBSCRIPT.name(),
-                        operator(SUBSCRIPT, new ArrayType(INTEGER), BIGINT),
-                        INTEGER,
-                        call("array_constructor",
-                                function("array_constructor", INTEGER, INTEGER, INTEGER),
-                                new ArrayType(INTEGER),
-                                constant(1L, INTEGER),
-                                constant(2L, INTEGER),
-                                constant(3L, INTEGER)),
-                        constant(1L, INTEGER)));
-        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", true), constant(1L, INTEGER));
-    }
+    @Test
+    public void testHllLiteral()
+    {
+        RowExpression rowExpression = getRoundTrip("empty_approx_set()", true);
+        assertTrue(rowExpression instanceof ConstantExpression);
+        Object value = ((ConstantExpression) rowExpression).getValue();
+        assertEquals(HyperLogLog.newInstance((Slice) value).cardinality(), 0);
+    }
 
-    @Test
-    public void testRowLiteral()
-    {
-        assertEquals(getRoundTrip("ROW(1, 1.1)", false),
-                specialForm(
-                        ROW_CONSTRUCTOR,
-                        RowType.anonymous(
-                                ImmutableList.of(
-                                        INTEGER,
-                                        DOUBLE)),
-                        constant(1L, INTEGER),
-                        constant(1.1, DOUBLE)));
-    }
+    @Test
+    public void testUnserializableType()
+    {
+        assertThrowsWhenSerialize("CAST('$.a' AS JsonPath)", true);
+    }
 
-    @Test
-    public void testDereference()
-    {
-        String sql = "CAST(ROW(1) AS ROW(col1 integer)).col1";
-        RowExpression before = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), false);
-        RowExpression after = getRoundTrip(sql, false);
-        assertEquals(before, after);
-    }
+    private void assertThrowsWhenSerialize(@Language("SQL") String sql, boolean optimize)
+    {
+        RowExpression rowExpression = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), optimize);
+        assertThrows(IllegalArgumentException.class, () -> codec.toJson(rowExpression));
+    }
 
-    @Test
-    public void testHllLiteral()
-    {
-        RowExpression rowExpression = getRoundTrip("empty_approx_set()", true);
-        assertTrue(rowExpression instanceof ConstantExpression);
-        Object value = ((ConstantExpression) rowExpression).getValue();
-        assertEquals(HyperLogLog.newInstance((Slice) value).cardinality(), 0);
-    }
+    private void assertLiteral(@Language("SQL") String sql, ConstantExpression expected)
+    {
+        assertEquals(getRoundTrip(sql, true), expected);
+    }
 
-    @Test
-    public void testUnserializableType()
-    {
-        assertThrowsWhenSerialize("CAST('$.a' AS JsonPath)", true);
-    }
+    private void assertStringLiteral(@Language("SQL") String sql, String expectedString, Type expectedType)
+    {
+        RowExpression roundTrip = getRoundTrip(sql, true);
+        assertTrue(roundTrip instanceof ConstantExpression);
+        String roundTripValue = ((Slice) ((ConstantExpression) roundTrip).getValue()).toStringUtf8();
+        Type roundTripType = roundTrip.getType();
+        assertEquals(roundTripValue, expectedString);
+        assertEquals(roundTripType, expectedType);
+    }
 
-    private void assertThrowsWhenSerialize(@Language("SQL") String sql, boolean optimize)
-    {
-        RowExpression rowExpression = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), optimize);
-        assertThrows(IllegalArgumentException.class, () -> codec.toJson(rowExpression));
-    }
+    private RowExpression getRoundTrip(String sql, boolean optimize)
+    {
+        RowExpression rowExpression = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), optimize);
+        String json = codec.toJson(rowExpression);
+        return codec.fromJson(json);
+    }
 
-    private void assertLiteral(@Language("SQL") String sql, ConstantExpression expected)
-    {
-        assertEquals(getRoundTrip(sql, true), expected);
-    }
+    private FunctionHandle operator(OperatorType operatorType, Type... types)
+    {
+        return metadata.getFunctionAndTypeManager().resolveOperator(operatorType, fromTypes(types));
+    }
 
-    private void assertStringLiteral(@Language("SQL") String sql, String expectedString, Type expectedType)
-    {
-        RowExpression roundTrip = getRoundTrip(sql, true);
-        assertTrue(roundTrip instanceof ConstantExpression);
-        String roundTripValue = ((Slice) ((ConstantExpression) roundTrip).getValue()).toStringUtf8();
-        Type roundTripType = roundTrip.getType();
-        assertEquals(roundTripValue, expectedString);
-        assertEquals(roundTripType, expectedType);
-    }
+    private FunctionHandle function(String name, Type... types)
+    {
+        return metadata.getFunctionAndTypeManager().lookupFunction(name, fromTypes(types));
+    }
 
-    private RowExpression getRoundTrip(String sql, boolean optimize)
-    {
-        RowExpression rowExpression = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), optimize);
-        String json = codec.toJson(rowExpression);
-        return codec.fromJson(json);
-    }
+    private JsonCodec<RowExpression> getJsonCodec()
+            throws Exception
+    {
+        Module module = binder -> {
+            binder.install(new JsonModule());
+            binder.install(new HandleJsonModule());
+            configBinder(binder).bindConfig(FeaturesConfig.class);
 
-    private FunctionHandle operator(OperatorType operatorType, Type... types)
-    {
-        return metadata.getFunctionAndTypeManager().resolveOperator(operatorType, fromTypes(types));
-    }
+            FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+            binder.bind(TypeManager.class).toInstance(functionAndTypeManager);
+            jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+            newSetBinder(binder, Type.class);
 
-    private FunctionHandle function(String name, Type... types)
-    {
-        return metadata.getFunctionAndTypeManager().lookupFunction(name, fromTypes(types));
-    }
+            binder.bind(BlockEncodingSerde.class).to(BlockEncodingManager.class).in(Scopes.SINGLETON);
+            newSetBinder(binder, BlockEncoding.class);
+            jsonBinder(binder).addSerializerBinding(Block.class).to(BlockJsonSerde.Serializer.class);
+            jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
+            jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
+        };
+        Bootstrap app = new Bootstrap(ImmutableList.of(module));
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+        return injector.getInstance(new Key<JsonCodec<RowExpression>>() {});
+    }
 
-    private JsonCodec<RowExpression> getJsonCodec()
-            throws Exception
-    {
-        Module module = binder -> {
-            binder.install(new JsonModule());
-            binder.install(new HandleJsonModule());
-            configBinder(binder).bindConfig(FeaturesConfig.class);
+    private RowExpression translate(Expression expression, boolean optimize)
+    {
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, getExpressionTypes(expression), ImmutableMap.of(), metadata.getFunctionAndTypeManager(), TEST_SESSION);
+        if (optimize) {
+            RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
+            return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+        }
+        return rowExpression;
+    }
 
-            FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
-            binder.bind(TypeManager.class).toInstance(functionAndTypeManager);
-            jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
-            newSetBinder(binder, Type.class);
-
-            binder.bind(BlockEncodingSerde.class).to(BlockEncodingManager.class).in(Scopes.SINGLETON);
-            newSetBinder(binder, BlockEncoding.class);
-            jsonBinder(binder).addSerializerBinding(Block.class).to(BlockJsonSerde.Serializer.class);
-            jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
-            jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
-        };
-        Bootstrap app = new Bootstrap(ImmutableList.of(module));
-        Injector injector = app
-                .doNotInitializeLogging()
-                .quiet()
-                .initialize();
-        return injector.getInstance(new Key<JsonCodec<RowExpression>>() {});
-    }
-
-    private RowExpression translate(Expression expression, boolean optimize)
-    {
-        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, getExpressionTypes(expression), ImmutableMap.of(), metadata.getFunctionAndTypeManager(), TEST_SESSION);
-        if (optimize) {
-            RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
-            return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
-        }
-        return rowExpression;
-    }
-
-    private Map<NodeRef<Expression>, Type> getExpressionTypes(Expression expression)
-    {
-        ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
-                metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
-                TEST_SESSION,
-                TypeProvider.empty(),
-                emptyMap(),
-                node -> new IllegalStateException("Unexpected node: %s" + node),
-                WarningCollector.NOOP,
-                false);
-        expressionAnalyzer.analyze(expression, Scope.create());
-        return expressionAnalyzer.getExpressionTypes();
-    }
+    private Map<NodeRef<Expression>, Type> getExpressionTypes(Expression expression)
+    {
+        ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
+                metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
+                TEST_SESSION,
+                TypeProvider.empty(),
+                emptyMap(),
+                node -> new IllegalStateException("Unexpected node: %s" + node),
+                WarningCollector.NOOP,
+                false);
+        expressionAnalyzer.analyze(expression, Scope.create());
+        return expressionAnalyzer.getExpressionTypes();
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -35,6 +35,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
@@ -59,6 +60,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
@@ -145,6 +150,32 @@ public class TestRowExpressionSerde
         assertEquals(block.getInt(1), 2);
         assertEquals(block.getInt(2), 3);
     }
+
+    @Test
+    public void testLargeArraySplitting() {
+        // Test array with more than 200 elements
+        int numElements = 900;
+        String sql = "ARRAY " + IntStream.rangeClosed(1, numElements)
+                .mapToObj(Integer::toString)
+                .collect(Collectors.joining(", ", "[", "]"));
+        List<String> sqlParts = new ArrayList<>();
+        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
+            sqlParts.add("ARRAY " + IntStream.rangeClosed(1 + 200 * i, Math.min(200 * (i + 1), numElements))
+                    .mapToObj(Integer::toString)
+                    .collect(Collectors.joining(", ", "[", "]")));
+        }
+        RowExpression roundTripExpression = getRoundTrip(sql, false);
+        List<RowExpression> rowExpressionParts = new ArrayList<>();
+        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
+            rowExpressionParts.add(getRoundTrip(sqlParts.get(i), false));
+        }
+
+        assertTrue(roundTripExpression instanceof CallExpression);
+        CallExpression callExpression = (CallExpression) roundTripExpression;
+        assertEquals(callExpression.getDisplayName(), "concat");
+        List<RowExpression> arguments = callExpression.getArguments();
+        assertEquals(arguments, rowExpressionParts);
+    }
 
     @Test
     public void testArrayGet()

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -35,7 +35,6 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
-import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
@@ -60,10 +59,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Map;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
@@ -150,32 +145,6 @@ public class TestRowExpressionSerde
         assertEquals(block.getInt(1), 2);
         assertEquals(block.getInt(2), 3);
     }
-
-    @Test
-    public void testLargeArraySplitting() {
-        // Test array with more than 200 elements
-        int numElements = 900;
-        String sql = "ARRAY " + IntStream.rangeClosed(1, numElements)
-                .mapToObj(Integer::toString)
-                .collect(Collectors.joining(", ", "[", "]"));
-        List<String> sqlParts = new ArrayList<>();
-        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
-            sqlParts.add("ARRAY " + IntStream.rangeClosed(1 + 200 * i, Math.min(200 * (i + 1), numElements))
-                    .mapToObj(Integer::toString)
-                    .collect(Collectors.joining(", ", "[", "]")));
-        }
-        RowExpression roundTripExpression = getRoundTrip(sql, false);
-        List<RowExpression> rowExpressionParts = new ArrayList<>();
-        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
-            rowExpressionParts.add(getRoundTrip(sqlParts.get(i), false));
-        }
-
-        assertTrue(roundTripExpression instanceof CallExpression);
-        CallExpression callExpression = (CallExpression) roundTripExpression;
-        assertEquals(callExpression.getDisplayName(), "concat");
-        List<RowExpression> arguments = callExpression.getArguments();
-        assertEquals(arguments, rowExpressionParts);
-    }
 
     @Test
     public void testArrayGet()

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -3,7 +3,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,6 +35,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
@@ -58,7 +59,11 @@ import org.intellij.lang.annotations.Language;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
@@ -93,200 +98,227 @@ import static org.testng.Assert.assertTrue;
 
 public class TestRowExpressionSerde
 {
-    private final Metadata metadata = MetadataManager.createTestMetadataManager();
-    private JsonCodec<RowExpression> codec;
+    private final Metadata metadata = MetadataManager.createTestMetadataManager();
+    private JsonCodec<RowExpression> codec;
 
-    @BeforeClass
-    public void setUp()
-            throws Exception
-    {
-        codec = getJsonCodec();
-    }
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        codec = getJsonCodec();
+    }
 
-    @Test
-    public void testSimpleLiteral()
-    {
-        assertLiteral("TRUE", constant(true, BOOLEAN));
-        assertLiteral("FALSE", constant(false, BOOLEAN));
-        assertLiteral("CAST(NULL AS BOOLEAN)", constant(null, BOOLEAN));
+    @Test
+    public void testSimpleLiteral()
+    {
+        assertLiteral("TRUE", constant(true, BOOLEAN));
+        assertLiteral("FALSE", constant(false, BOOLEAN));
+        assertLiteral("CAST(NULL AS BOOLEAN)", constant(null, BOOLEAN));
 
-        assertLiteral("TINYINT '1'", constant(1L, TINYINT));
-        assertLiteral("SMALLINT '1'", constant(1L, SMALLINT));
-        assertLiteral("1", constant(1L, INTEGER));
-        assertLiteral("BIGINT '1'", constant(1L, BIGINT));
+        assertLiteral("TINYINT '1'", constant(1L, TINYINT));
+        assertLiteral("SMALLINT '1'", constant(1L, SMALLINT));
+        assertLiteral("1", constant(1L, INTEGER));
+        assertLiteral("BIGINT '1'", constant(1L, BIGINT));
 
-        assertLiteral("1.1", constant(1.1, DOUBLE));
-        assertLiteral("nan()", constant(Double.NaN, DOUBLE));
-        assertLiteral("infinity()", constant(Double.POSITIVE_INFINITY, DOUBLE));
-        assertLiteral("-infinity()", constant(Double.NEGATIVE_INFINITY, DOUBLE));
+        assertLiteral("1.1", constant(1.1, DOUBLE));
+        assertLiteral("nan()", constant(Double.NaN, DOUBLE));
+        assertLiteral("infinity()", constant(Double.POSITIVE_INFINITY, DOUBLE));
+        assertLiteral("-infinity()", constant(Double.NEGATIVE_INFINITY, DOUBLE));
 
-        assertLiteral("CAST(1.1 AS REAL)", constant((long) floatToIntBits(1.1f), REAL));
-        assertLiteral("CAST(nan() AS REAL)", constant((long) floatToIntBits(Float.NaN), REAL));
-        assertLiteral("CAST(infinity() AS REAL)", constant((long) floatToIntBits(Float.POSITIVE_INFINITY), REAL));
-        assertLiteral("CAST(-infinity() AS REAL)", constant((long) floatToIntBits(Float.NEGATIVE_INFINITY), REAL));
+        assertLiteral("CAST(1.1 AS REAL)", constant((long) floatToIntBits(1.1f), REAL));
+        assertLiteral("CAST(nan() AS REAL)", constant((long) floatToIntBits(Float.NaN), REAL));
+        assertLiteral("CAST(infinity() AS REAL)", constant((long) floatToIntBits(Float.POSITIVE_INFINITY), REAL));
+        assertLiteral("CAST(-infinity() AS REAL)", constant((long) floatToIntBits(Float.NEGATIVE_INFINITY), REAL));
 
-        assertStringLiteral("'String Literal'", "String Literal", VarcharType.createVarcharType(14));
-        assertLiteral("CAST(NULL AS VARCHAR)", constant(null, VARCHAR));
+        assertStringLiteral("'String Literal'", "String Literal", VarcharType.createVarcharType(14));
+        assertLiteral("CAST(NULL AS VARCHAR)", constant(null, VARCHAR));
 
-        assertLiteral("DATE '1991-01-01'", constant(7670L, DATE));
-        assertLiteral("TIMESTAMP '1991-01-01 00:00:00.000'", constant(662727600000L, TIMESTAMP));
-    }
+        assertLiteral("DATE '1991-01-01'", constant(7670L, DATE));
+        assertLiteral("TIMESTAMP '1991-01-01 00:00:00.000'", constant(662727600000L, TIMESTAMP));
+    }
 
-    @Test
-    public void testArrayLiteral()
-    {
-        RowExpression rowExpression = getRoundTrip("ARRAY [1, 2, 3]", true);
-        assertTrue(rowExpression instanceof ConstantExpression);
-        Object value = ((ConstantExpression) rowExpression).getValue();
-        assertTrue(value instanceof IntArrayBlock);
-        IntArrayBlock block = (IntArrayBlock) value;
-        assertEquals(block.getPositionCount(), 3);
-        assertEquals(block.getInt(0), 1);
-        assertEquals(block.getInt(1), 2);
-        assertEquals(block.getInt(2), 3);
-    }
+    @Test
+    public void testArrayLiteral()
+    {
+        RowExpression rowExpression = getRoundTrip("ARRAY [1, 2, 3]", true);
+        assertTrue(rowExpression instanceof ConstantExpression);
+        Object value = ((ConstantExpression) rowExpression).getValue();
+        assertTrue(value instanceof IntArrayBlock);
+        IntArrayBlock block = (IntArrayBlock) value;
+        assertEquals(block.getPositionCount(), 3);
+        assertEquals(block.getInt(0), 1);
+        assertEquals(block.getInt(1), 2);
+        assertEquals(block.getInt(2), 3);
+    }
 
-    @Test
-    public void testArrayGet()
-    {
-        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", false),
-                call(SUBSCRIPT.name(),
-                        operator(SUBSCRIPT, new ArrayType(INTEGER), BIGINT),
-                        INTEGER,
-                        call("array_constructor",
-                                function("array_constructor", INTEGER, INTEGER, INTEGER),
-                                new ArrayType(INTEGER),
-                                constant(1L, INTEGER),
-                                constant(2L, INTEGER),
-                                constant(3L, INTEGER)),
-                        constant(1L, INTEGER)));
-        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", true), constant(1L, INTEGER));
-    }
+    @Test
+    public void testLargeArraySplitting() {
+        // Test array with more than 200 elements
+        int numElements = 900;
+        String sql = "ARRAY " + IntStream.rangeClosed(1, numElements)
+                .mapToObj(Integer::toString)
+                .collect(Collectors.joining(", ", "[", "]"));
+        List<String> sqlParts = new ArrayList<>();
+        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
+            sqlParts.add("ARRAY " + IntStream.rangeClosed(1 + 200 * i, Math.min(200 * (i + 1), numElements))
+                    .mapToObj(Integer::toString)
+                    .collect(Collectors.joining(", ", "[", "]")));
+        }
+        RowExpression roundTripExpression = getRoundTrip(sql, false);
+        List<RowExpression> rowExpressionParts = new ArrayList<>();
+        for (int i = 0; i < (numElements - 1) / 200 + 1; i++){
+            rowExpressionParts.add(getRoundTrip(sqlParts.get(i), false));
+        }
 
-    @Test
-    public void testRowLiteral()
-    {
-        assertEquals(getRoundTrip("ROW(1, 1.1)", false),
-                specialForm(
-                        ROW_CONSTRUCTOR,
-                        RowType.anonymous(
-                                ImmutableList.of(
-                                        INTEGER,
-                                        DOUBLE)),
-                        constant(1L, INTEGER),
-                        constant(1.1, DOUBLE)));
-    }
+        assertTrue(roundTripExpression instanceof CallExpression);
+        CallExpression callExpression = (CallExpression) roundTripExpression;
+        assertEquals(callExpression.getDisplayName(), "concat");
+        List<RowExpression> arguments = callExpression.getArguments();
+        assertEquals(arguments, rowExpressionParts);
+    }
 
-    @Test
-    public void testDereference()
-    {
-        String sql = "CAST(ROW(1) AS ROW(col1 integer)).col1";
-        RowExpression before = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), false);
-        RowExpression after = getRoundTrip(sql, false);
-        assertEquals(before, after);
-    }
 
-    @Test
-    public void testHllLiteral()
-    {
-        RowExpression rowExpression = getRoundTrip("empty_approx_set()", true);
-        assertTrue(rowExpression instanceof ConstantExpression);
-        Object value = ((ConstantExpression) rowExpression).getValue();
-        assertEquals(HyperLogLog.newInstance((Slice) value).cardinality(), 0);
-    }
+    @Test
+    public void testArrayGet()
+    {
+        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", false),
+                call(SUBSCRIPT.name(),
+                        operator(SUBSCRIPT, new ArrayType(INTEGER), BIGINT),
+                        INTEGER,
+                        call("array_constructor",
+                                function("array_constructor", INTEGER, INTEGER, INTEGER),
+                                new ArrayType(INTEGER),
+                                constant(1L, INTEGER),
+                                constant(2L, INTEGER),
+                                constant(3L, INTEGER)),
+                        constant(1L, INTEGER)));
+        assertEquals(getRoundTrip("(ARRAY [1, 2, 3])[1]", true), constant(1L, INTEGER));
+    }
 
-    @Test
-    public void testUnserializableType()
-    {
-        assertThrowsWhenSerialize("CAST('$.a' AS JsonPath)", true);
-    }
+    @Test
+    public void testRowLiteral()
+    {
+        assertEquals(getRoundTrip("ROW(1, 1.1)", false),
+                specialForm(
+                        ROW_CONSTRUCTOR,
+                        RowType.anonymous(
+                                ImmutableList.of(
+                                        INTEGER,
+                                        DOUBLE)),
+                        constant(1L, INTEGER),
+                        constant(1.1, DOUBLE)));
+    }
 
-    private void assertThrowsWhenSerialize(@Language("SQL") String sql, boolean optimize)
-    {
-        RowExpression rowExpression = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), optimize);
-        assertThrows(IllegalArgumentException.class, () -> codec.toJson(rowExpression));
-    }
+    @Test
+    public void testDereference()
+    {
+        String sql = "CAST(ROW(1) AS ROW(col1 integer)).col1";
+        RowExpression before = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), false);
+        RowExpression after = getRoundTrip(sql, false);
+        assertEquals(before, after);
+    }
 
-    private void assertLiteral(@Language("SQL") String sql, ConstantExpression expected)
-    {
-        assertEquals(getRoundTrip(sql, true), expected);
-    }
+    @Test
+    public void testHllLiteral()
+    {
+        RowExpression rowExpression = getRoundTrip("empty_approx_set()", true);
+        assertTrue(rowExpression instanceof ConstantExpression);
+        Object value = ((ConstantExpression) rowExpression).getValue();
+        assertEquals(HyperLogLog.newInstance((Slice) value).cardinality(), 0);
+    }
 
-    private void assertStringLiteral(@Language("SQL") String sql, String expectedString, Type expectedType)
-    {
-        RowExpression roundTrip = getRoundTrip(sql, true);
-        assertTrue(roundTrip instanceof ConstantExpression);
-        String roundTripValue = ((Slice) ((ConstantExpression) roundTrip).getValue()).toStringUtf8();
-        Type roundTripType = roundTrip.getType();
-        assertEquals(roundTripValue, expectedString);
-        assertEquals(roundTripType, expectedType);
-    }
+    @Test
+    public void testUnserializableType()
+    {
+        assertThrowsWhenSerialize("CAST('$.a' AS JsonPath)", true);
+    }
 
-    private RowExpression getRoundTrip(String sql, boolean optimize)
-    {
-        RowExpression rowExpression = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), optimize);
-        String json = codec.toJson(rowExpression);
-        return codec.fromJson(json);
-    }
+    private void assertThrowsWhenSerialize(@Language("SQL") String sql, boolean optimize)
+    {
+        RowExpression rowExpression = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), optimize);
+        assertThrows(IllegalArgumentException.class, () -> codec.toJson(rowExpression));
+    }
 
-    private FunctionHandle operator(OperatorType operatorType, Type... types)
-    {
-        return metadata.getFunctionAndTypeManager().resolveOperator(operatorType, fromTypes(types));
-    }
+    private void assertLiteral(@Language("SQL") String sql, ConstantExpression expected)
+    {
+        assertEquals(getRoundTrip(sql, true), expected);
+    }
 
-    private FunctionHandle function(String name, Type... types)
-    {
-        return metadata.getFunctionAndTypeManager().lookupFunction(name, fromTypes(types));
-    }
+    private void assertStringLiteral(@Language("SQL") String sql, String expectedString, Type expectedType)
+    {
+        RowExpression roundTrip = getRoundTrip(sql, true);
+        assertTrue(roundTrip instanceof ConstantExpression);
+        String roundTripValue = ((Slice) ((ConstantExpression) roundTrip).getValue()).toStringUtf8();
+        Type roundTripType = roundTrip.getType();
+        assertEquals(roundTripValue, expectedString);
+        assertEquals(roundTripType, expectedType);
+    }
 
-    private JsonCodec<RowExpression> getJsonCodec()
-            throws Exception
-    {
-        Module module = binder -> {
-            binder.install(new JsonModule());
-            binder.install(new HandleJsonModule());
-            configBinder(binder).bindConfig(FeaturesConfig.class);
+    private RowExpression getRoundTrip(String sql, boolean optimize)
+    {
+        RowExpression rowExpression = translate(expression(sql, new ParsingOptions(AS_DOUBLE)), optimize);
+        String json = codec.toJson(rowExpression);
+        return codec.fromJson(json);
+    }
 
-            FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
-            binder.bind(TypeManager.class).toInstance(functionAndTypeManager);
-            jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
-            newSetBinder(binder, Type.class);
+    private FunctionHandle operator(OperatorType operatorType, Type... types)
+    {
+        return metadata.getFunctionAndTypeManager().resolveOperator(operatorType, fromTypes(types));
+    }
 
-            binder.bind(BlockEncodingSerde.class).to(BlockEncodingManager.class).in(Scopes.SINGLETON);
-            newSetBinder(binder, BlockEncoding.class);
-            jsonBinder(binder).addSerializerBinding(Block.class).to(BlockJsonSerde.Serializer.class);
-            jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
-            jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
-        };
-        Bootstrap app = new Bootstrap(ImmutableList.of(module));
-        Injector injector = app
-                .doNotInitializeLogging()
-                .quiet()
-                .initialize();
-        return injector.getInstance(new Key<JsonCodec<RowExpression>>() {});
-    }
+    private FunctionHandle function(String name, Type... types)
+    {
+        return metadata.getFunctionAndTypeManager().lookupFunction(name, fromTypes(types));
+    }
 
-    private RowExpression translate(Expression expression, boolean optimize)
-    {
-        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, getExpressionTypes(expression), ImmutableMap.of(), metadata.getFunctionAndTypeManager(), TEST_SESSION);
-        if (optimize) {
-            RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
-            return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
-        }
-        return rowExpression;
-    }
+    private JsonCodec<RowExpression> getJsonCodec()
+            throws Exception
+    {
+        Module module = binder -> {
+            binder.install(new JsonModule());
+            binder.install(new HandleJsonModule());
+            configBinder(binder).bindConfig(FeaturesConfig.class);
 
-    private Map<NodeRef<Expression>, Type> getExpressionTypes(Expression expression)
-    {
-        ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
-                metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
-                TEST_SESSION,
-                TypeProvider.empty(),
-                emptyMap(),
-                node -> new IllegalStateException("Unexpected node: %s" + node),
-                WarningCollector.NOOP,
-                false);
-        expressionAnalyzer.analyze(expression, Scope.create());
-        return expressionAnalyzer.getExpressionTypes();
-    }
+            FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+            binder.bind(TypeManager.class).toInstance(functionAndTypeManager);
+            jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+            newSetBinder(binder, Type.class);
+
+            binder.bind(BlockEncodingSerde.class).to(BlockEncodingManager.class).in(Scopes.SINGLETON);
+            newSetBinder(binder, BlockEncoding.class);
+            jsonBinder(binder).addSerializerBinding(Block.class).to(BlockJsonSerde.Serializer.class);
+            jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
+            jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
+        };
+        Bootstrap app = new Bootstrap(ImmutableList.of(module));
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+        return injector.getInstance(new Key<JsonCodec<RowExpression>>() {});
+    }
+
+    private RowExpression translate(Expression expression, boolean optimize)
+    {
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, getExpressionTypes(expression), ImmutableMap.of(), metadata.getFunctionAndTypeManager(), TEST_SESSION);
+        if (optimize) {
+            RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
+            return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+        }
+        return rowExpression;
+    }
+
+    private Map<NodeRef<Expression>, Type> getExpressionTypes(Expression expression)
+    {
+        ExpressionAnalyzer expressionAnalyzer = ExpressionAnalyzer.createWithoutSubqueries(
+                metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver(),
+                TEST_SESSION,
+                TypeProvider.empty(),
+                emptyMap(),
+                node -> new IllegalStateException("Unexpected node: %s" + node),
+                WarningCollector.NOOP,
+                false);
+        expressionAnalyzer.analyze(expression, Scope.create());
+        return expressionAnalyzer.getExpressionTypes();
+    }
 }


### PR DESCRIPTION
## Description
This PR splits long array literals into chunks concatenated together. It addressed the challenge of creating large arrays with over 200 elements, which makes it complicated for users to create arrays of such sizes

## Motivation and Context
Previously, any array of size 255 or greater is not supported, so users need to concatenate together many arrays to create a array of a large size (e.g. 1000), which would be very inconvenient using large arrays.
Fixes #21601 

## Impact
Users will now be able to create arrays of size more than 255 directly (New maximum would be 50800)

## Test Plan
Incorporated unit tests to test our function that implemented the large array splitting logic and verify that the array output is correct. Ensured arrays with size of 255 or more can be created directly.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* #22622: Automatically split and concatenate Presto SQL arrays with more than 200 elements. Large arrays like ARRAY[1,2,3..1000] are now automatically handled during the plan/RowExpression generation phase, simplifying query construction and execution.
```

