### PR TITLE
[native] Advance Velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/RemoteFunctionRegistererTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/RemoteFunctionRegistererTest.cpp
@@ -57,14 +57,14 @@ TEST_F(RemoteFunctionRegistererTest, singleFile) {
 
   // Write to a single output file.
   auto path = exec::test::TempFilePath::create();
-  writeToFile(path->path, json);
+  writeToFile(path->getPath(), json);
 
   // Check functions do not exist first.
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock1") == std::nullopt);
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock2") == std::nullopt);
 
   // Read and register functions in that file.
-  EXPECT_EQ(registerRemoteFunctions(path->path, {}), 2);
+  EXPECT_EQ(registerRemoteFunctions(path->getPath(), {}), 2);
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock1") != std::nullopt);
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock2") != std::nullopt);
 }
@@ -87,7 +87,7 @@ TEST_F(RemoteFunctionRegistererTest, prefixes) {
 
   // Write to a single output file.
   auto path = exec::test::TempFilePath::create();
-  writeToFile(path->path, json);
+  writeToFile(path->getPath(), json);
 
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock3") == std::nullopt);
   EXPECT_TRUE(
@@ -96,7 +96,7 @@ TEST_F(RemoteFunctionRegistererTest, prefixes) {
       exec::getVectorFunctionSignatures("json.mock_schema.mock3") ==
       std::nullopt);
 
-  EXPECT_EQ(registerRemoteFunctions(path->path, {}), 1);
+  EXPECT_EQ(registerRemoteFunctions(path->getPath(), {}), 1);
 
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock3") == std::nullopt);
   EXPECT_TRUE(
@@ -105,7 +105,7 @@ TEST_F(RemoteFunctionRegistererTest, prefixes) {
       exec::getVectorFunctionSignatures("json.mock_schema.mock3") ==
       std::nullopt);
 
-  EXPECT_EQ(registerRemoteFunctions(path->path, {}, "json"), 1);
+  EXPECT_EQ(registerRemoteFunctions(path->getPath(), {}, "json"), 1);
 
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock3") == std::nullopt);
   EXPECT_TRUE(

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
@@ -78,7 +78,8 @@ dwio::common::FileFormat toVeloxFileFormat(
       return dwio::common::FileFormat::JSON;
     }
   } else if (format.inputFormat == "com.facebook.alpha.AlphaInputFormat") {
-    return dwio::common::FileFormat::ALPHA;
+    // ALPHA has been renamed in Velox to NIMBLE.
+    return dwio::common::FileFormat::NIMBLE;
   }
   VELOX_UNSUPPORTED(
       "Unsupported file format: {} {}", format.inputFormat, format.serDe);
@@ -880,7 +881,8 @@ dwio::common::FileFormat toFileFormat(
     case protocol::HiveStorageFormat::PARQUET:
       return dwio::common::FileFormat::PARQUET;
     case protocol::HiveStorageFormat::ALPHA:
-      return dwio::common::FileFormat::ALPHA;
+      // This has been renamed in Velox from ALPHA to NIMBLE.
+      return dwio::common::FileFormat::NIMBLE;
     default:
       VELOX_UNSUPPORTED(
           "Unsupported file format in {}: {}.",


### PR DESCRIPTION
## Description
The `FileFormat::ALPHA` has been renamed `FileFormat::NIMBLE` - using the same defined value (8). A macro is av available to keep `FileFormat::ALPHA` but it doesn't work because elsewhere in Velox (in the dwio::common Options) `FileFormat::NIMBLE` is required. The macro `VELOX_ENABLE_BACKWARD_COMPATIBILITY` replaces the new name with the old but keeps using the new name.

I decided to replace the usage of FileFormat::ALPHA with the FileFormat::NIMBLE name.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Connector Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

