### PR TITLE
Adjust split weights by actual data read

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -541,7 +541,7 @@ class HiveSplitSource
                         cacheQuotaRequirement,
                         internalSplit.getEncryptionInformation(),
                         internalSplit.getPartitionInfo().getRedundantColumnDomains(),
-                        splitWeightProvider.weightForSplitSizeInBytes(splitBytes),
+                        splitWeightProvider.weightForSplitSizeInBytes((long) (splitBytes * splitScanRatio)),
                         internalSplit.getPartitionInfo().getRowIdPartitionComponent()));
 
                 internalSplit.increaseStart(splitBytes);


### PR DESCRIPTION
We recently added dynamic split sizes support in https://github.com/prestodb/presto/pull/22051

This would result in larger split sizes when Presto doesn't really read all of the split.

However, this would also assign large split weights(as they are based on sizes) than earlier - which could mess with some of the weighted split scheduling configs.

This readjusts the split weight to the actual data that the presto worker will read.



```
== NO RELEASE NOTE ==
```

