### PR TITLE
[docs] Update connector/hive.rst for hidden metadata columns

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -866,12 +866,12 @@ The following procedures are available:
 Extra Hidden Columns
 --------------------
 
-The Hive connector exposes extra hidden metadata columns in Hive tables. You can query these
-columns as a part of SQL query like any other columns of the table.
+The Hive connector exposes extra hidden metadata columns in Hive tables. Query these
+columns as a part of the query like any other columns of the table.
 
 * ``$path`` : Filepath for the given row data
-* ``$file_size`` : Filesize for the given row
-* ``$file_modified_time`` : Last file modified time for the given row
+* ``$file_size`` : Filesize for the given row (int64_t)
+* ``$file_modified_time`` : Last file modified time for the given row (int64_t), in milliseconds since January 1, 1970 UTC
 
 How to invalidate metastore cache?
 ---------------------------------


### PR DESCRIPTION
## Description
Add int64_t information for $file_size and $file_modified_time in https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/connector/hive.rst. 

## Motivation and Context
Fixes #22627. 

## Impact
Documentation.

## Test Plan
Local doc build. 

Screenshot of changed topic: 
<img width="765" alt="Screenshot 2024-04-30 at 1 30 43 PM" src="https://github.com/prestodb/presto/assets/7013443/a06da445-a62a-404a-85f5-b172231fa935">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

