### PR TITLE
[native] Temporarily disable two unit tests.

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -1112,7 +1112,9 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperatorWhenSinglePartition) {
   testPartitionAndSerialize(plan, data);
 }
 
-TEST_F(UnsafeRowShuffleTest, shuffleWriterToString) {
+// TODO(spershin): Enable when PlanNode::toString() is modified and Velox
+// version is updated.
+TEST_F(UnsafeRowShuffleTest, DISABLED_shuffleWriterToString) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
@@ -1134,7 +1136,9 @@ TEST_F(UnsafeRowShuffleTest, shuffleWriterToString) {
       "-- ShuffleWrite[4, test-shuffle] -> partition:INTEGER, data:VARBINARY\n");
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeToString) {
+// TODO(spershin): Enable when PlanNode::toString() is modified and Velox
+// version is updated.
+TEST_F(UnsafeRowShuffleTest, DISABLED_partitionAndSerializeToString) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),


### PR DESCRIPTION
## Description
For upcoming change in Velox these tests need to be disabled because they will start to fail.
After the Velox change is landed and used, we will re-enable the tests with the fix.

Velox PR: https://github.com/facebookincubator/velox/pull/9663

```
== NO RELEASE NOTE ==
```

