### PR TITLE
Add release notes for 0.287

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    Release-0.287 [2024-04-16] <release/release-0.287>
     Release-0.286 [2024-02-12] <release/release-0.286>
     Release-0.285.1 [2023-12-30] <release/release-0.285.1>
     Release-0.285 [2023-12-08] <release/release-0.285>

--- a/presto-docs/src/main/sphinx/release/release-0.287.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.287.rst
@@ -1,0 +1,99 @@
+=============
+Release 0.287
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a bug in CTE reference node creation, where different CTEs may be incorrectly considered as the same CTE. :pr:`22515`
+* Add Heuristic CTE Materialization strategy which auto materialized expensive CTEs. This is configurable by setting ``cte_materialization_strategy`` to ``HEURISTIC`` or ``HEURISTIC_COMPLEX_QUERIES_ONLY``. (default ``NONE``). :pr:`21720`
+* Fix an issue with heuristic CTE materialization strategy where incorrect CTEs were materialized. :pr:`22433`
+* Improve latency of materialized CTEs by scheduling multiple dependent subgraphs independently. :pr:`22205`
+* Add a session property ``track_history_based_plan_statistics_from_complete_stages_in_failed_query`` to enable tracking hbo statistics from complete stages in failed queries. :pr:`20947`
+* Add session property ``history_optimization_plan_canonicalize_strategy`` to specify the plan canonicalization strategies to use for HBO. :pr:`21832`
+* Add worker type and query ID information in HBO stats. :pr:`22234`
+* Add log of stats equivalent plan and canonicalized plan for HBO. This feature is controlled by session property ``log_query_plans_used_in_history_based_optimizer``. :pr:`22306`
+* Add limit to the amount of data written during CTE Materialization. This is configurable by the session property ``query_max_written_intermediate_bytes`` (default is 2TB). :pr:`22017`
+* Fix plan canonicalization by canonicalizing plan node ids. :pr:`22033`
+* Add a new plan canonicalization strategy ``ignore_scan_constants`` which canonicalizes predicates for both partitioned and non-partitioned columns in scan node. :pr:`21832`
+* Add an optimizer rule to get rid of map cast in map access functions when possible. :pr:`22059`
+* Add histogram column statistic to Presto for the optimizer. Connectors can now implement support for them. :pr:`21236`
+* Add Quick stats, a mechanism to build stats from metadata for tables and partitions that are missing stats. :pr:`21436`
+* Add DDL support for Table constraints (primary key and unique constraints). :pr:`20384`
+* Improve propagation of logical properties by enabling it by default. :pr:`22266`
+* Add optimization for query plans which contain RowNumber and TopNRowNumber nodes with empty input. :pr:`21914`
+* Fix bug with spilling in TopNRowNumber. :pr:`22281`
+* Fix problem when writing large varchar values to throw a user error when it exceeds internal limits. :pr:`22063`
+* Fix queries that filter with ``LIKE '%...%'`` over char columns. :pr:`22076`
+* Fix the regr_count, regr_avgx, regr_avgy, regr_syy, regr_sxx, and regr_sxy functions result to be null when the input data is null, not 0. :pr:`22112`
+* Fix precision loss when timestamp yielded from ``from_unixtime(double)`` function. :pr:`21899`
+* Improve accuracy and performance of HyperLogLog functions. :pr:`21943`
+* Add support for Apache DataSketches KLL sketch with the ``sketch_kll`` and related family of functions. :pr:`21568`
+* Improve repeat function to create RunLengthEncodedBlock to improve performance. :pr:`21984`
+* Fix CAST(str as INTEGER), CAST(str as BIGINT), CAST(str as SMALLINT), CAST(str as TINYINT) to allow leading and trailing spaces in the string. :pr:`22284`
+* Add support for ``map_key_exists`` builtin SQL UDF. :pr:`21966`
+* Optimize ``map_normalize`` builtin SQL UDF to avoid repeated reduce computation. :pr:`22211`
+* Add configuration property ``legacy_json_cast`` whose default value is ``true``. See `Legacy Compatible Properties <../admin/properties.html#legacy-compatible-properties>`_. :pr:`21869`
+* Add support for tracking of the input data size when there is a fragment result cache hit. This can be enabled by setting the configuration property ``fragment-result-cache.input-data-stats-enabled=true``. :pr:`22145`
+* Remove ``native_execution_enabled``, ``native_execution_executable_path`` and ``native_execution_program_arguments`` session properties. Corresponding configuration properties are still available. :pr:`22183`
+* Remove the configuration property ``use-legacy-scheduler`` and the corresponding session property ``use_legacy_scheduler``.   The property previously defaulted to true, and the new scheduler, which was intended to replace it eventually, was never productionized and is no longer needed. The configuration property ``max-stage-retries`` and the session property ``max_stage_retries`` have also been removed. :pr:`21952`
+* Add JSON as a supported output format in the Presto CLI. :pr:`22181`
+* Upgrade Alluxio to 310. :pr:`22012`
+* Upgrade Alluxio to 312. :pr:`22452`
+* Upgrade Airlift version to 0.209. :pr:`21943`
+* Add documentation for supported data `Type mapping <../connector/iceberg.html#type-mapping>`_  in the Iceberg connector. :pr:`22093`
+* Add usage documentation for :doc:`/clients/presto-cli`. :pr:`22265`
+* Add usage documentation for :doc:`/clients/presto-console`. :pr:`22349`
+* Add :doc:`Prestissimo Developer Guide <../prestissimo>` topic to the Presto documentation. :pr:`21953`
+
+Security Changes
+________________
+* Remove logback 1.2.3. :pr:`21819`
+* Add session property ``default-view-security-mode`` to choose the default security mode for view creation. :pr:`21956`
+
+Verifier Changes
+________________
+* Add support for extended bucket verification of INSERT and CTAS queries. This can be enabled by the configuration property ``extended-verification`` to verify each bucket's data checksum if the inserted table is bucketed. :pr:`22001`
+* Add support for extended partition verification of INSERT and CTAS queries. This can be enabled by the configuration property ``extended-verification`` to verify each partition's data checksum if the inserted table is partitioned. :pr:`21983`
+
+SPI Changes
+___________
+* Add replaceColumn method to com.facebook.common.Page. :pr:`22493`
+* Remove SPI method ConnectorMetadata.getTableLayouts() as deprecated. Add ConnectorMetadata.getTableLayoutForConstraint() as replacement. :pr:`21933`
+* Move `SortNode` to SPI module to be utilized in connector. :pr:`22497`
+
+Hive Connector Changes
+____________
+* Fix a potential wrong results bug when footer stats are marked unreliable and partial aggregation pushdown is enabled.  Such queries will now fail with an error. :pr:`22011`
+* Improve the ``hive.orc.use-column-names`` configuration setting to no longer fail on reading ORC files without column names, but fall back to using Hive's schema. This change improves compatibility with legacy ORC files. :pr:`21391`
+* Add session property ``hive.dynamic_split_sizes_enabled`` to use dynamic split sizes based on data selected by query.  :pr:`22051`
+* Add support for Filelist caching for symlink tables.  :pr:`19145`
+* Add $row_id as a new hidden column. :pr:`22008`
+* Add system procedure ``system.invalidate_directory_list_cache()`` to invalidate directory list cache in Hive Catalog. :pr:`19821`
+
+Iceberg Connector Changes
+_______________
+* Upgrade Iceberg from 1.4.3 to 1.5.0. :pr:`21961`
+* Fix identity and truncate transforms on DecimalType columns. :pr:`21958`
+* Fix the bug that ``CAST`` from non-legacy timestamp to date rounding to future when the timestamp is prior than `1970-01-01 00:00:00.000`. :pr:`21959`
+* Add support to set ``commit.retry.num-retries`` table property with table creation to make the number of attempts to make in case of concurrent upserts configurable. :pr:`21250`
+* Add year/month/day/hour transforms both on legacy and non-legacy TimestampType column. :pr:`21959`
+* Fix error encountered when attempting to execute an ``INSERT INTO`` statement where column names contain white spaces. :pr:`21827`
+* Add support for row-level deletes on Iceberg V2 tables. The delete mode can be changed from ``merge-on-read`` to ``copy-on-write`` by setting table property ``delete_mode``. :pr:`21571`
+* Add support for Iceberg V1 tables in Prestissimo. :pr:`22013`
+* Add support to read Iceberg V2 tables with Position Deletes in Prestissimo. :pr:`21980`
+* Add support for Iceberg concurrent insertions. :pr:`21250`
+
+MySQL Connector Changes
+_____________
+* Add support for timestamp column type. :pr:`21937`
+
+**Credits**
+===========
+
+8dukongjian, Ajay George, Amit Dutta, Anant Aneja, Andrii Rosa, Athmaja N, Avinash Jain, Bikramjeet Vig, Christian Zentgraf, Deepa George, Deepak Majeti, Eduard Tudenhoefner, Elliotte Rusty Harold, Emanuel F, Fazal Majid, Jalpreet Singh Nanda (:imjalpreet), Jialiang Tan, Jimmy Lu, Jonathan Hehir, Karteekmurthys, Ke, Kevin Wilfong, Konjac Huang, Lyublena Antova, Masha Basmanova, Mohan Dhar, Nikhil Collooru, Pranjal Shankhdhar, Pratik Joseph Dabre, Rebecca Schlussel, Reetika Agrawal, Rohit Jain, Sanika Babtiwale, Sergey Pershin, Sergii Druzkin, Sreeni Viswanadha, Steve Burnett, Sudheesh, Swapnil Tailor, Tai Le Manh, Timothy Meehan, Todd Gao, Vivek, Will, Yihong Wang, Ying, Zac Blanco, Zac Wen, Zhenxiao Luo, aditi-pandit, dnskr, feilong-liu, hainenber, ico01, jaystarshot, kedia,Akanksha, kiersten-stokes, polaris6, pratyakshsharma, s-akhtar-baig, sabbasani, wangd, wypb, xiaodou, xiaoxmeng


### PR DESCRIPTION
# Missing Release Notes
## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/22473 [native] Remove redundant move in PrestoToVeloxConnectorTest (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22438 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22378 [native] Centralize sslcontext creation. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22362 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22318 [native] Remove unused includes. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22037 [native] Advance velox. (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/21946 [native] Advance velox. (Merged by: Amit Dutta)

## Anant Aneja
- [ ] https://github.com/prestodb/presto/pull/22293 Retry docker compose (Merged by: Timothy Meehan)

## Avinash Jain
- [ ] https://github.com/prestodb/presto/pull/21966 Add support for map_key_exists (Merged by: Nikhil Collooru)

## Bikramjeet Vig
- [ ] https://github.com/prestodb/presto/pull/21972 [native] Use PrestoSerializer to deserialize base64 encoded constants in presto plan (Merged by: Aditi Pandit)

## Eduard Tudenhoefner
- [ ] https://github.com/prestodb/presto/pull/21961 Upgrade Iceberg from 1.4.3 to 1.5.0 (Merged by: Timothy Meehan)

## Jimmy Lu
- [ ] https://github.com/prestodb/presto/pull/22335 [native] Report driver level runtime statistics (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22102 [native] Change shuffle maxWait unit (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/22100 [native] Advance Velox (Merged by: Maria Basmanova)
- [ ] https://github.com/prestodb/presto/pull/22096 [native] Allow single zero to be passed as X-Presto-Buffer-Remaining-Bytes (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/21995 [native] Prepare for the exchange protocol upgrade (Merged by: Maria Basmanova)

## Kevin Wilfong
- [ ] https://github.com/prestodb/presto/pull/21896 [native] Call renamed createIterativeSerializer in Velox's VectorSerde (Merged by: spershin)

## Masha Basmanova
- [ ] https://github.com/prestodb/presto/pull/22050 [native] Fix 'Number of sorting keys must be greater than zero' (Merged by: Maria Basmanova)

## Pratik Joseph Dabre
- [ ] https://github.com/prestodb/presto/pull/22469 [native] Add e2e tests for from_ieee754_32, to_ieee754_32 scalar functions (Merged by: Deepak Majeti)
- [ ] https://github.com/prestodb/presto/pull/20936 [native] Add CTAS tests (Merged by: Deepak Majeti)

## Timothy Meehan
- [ ] https://github.com/prestodb/presto/pull/22023 Fix link in CONTRIBUTING.md (Merged by: Timothy Meehan)

## Vivek
- [ ] https://github.com/prestodb/presto/pull/22115 Make PRIMARY a non-reserved keyword (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/20384 DDL for Table Constraints (Merged by: Vivek)

## Zac Blanco
- [ ] https://github.com/prestodb/presto/pull/22327 [Iceberg] Collect data size statistics for Iceberg tables (Merged by: Zac Blanco)

## feilong-liu
- [ ] https://github.com/prestodb/presto/pull/22171 Revert "Enable logical property propagation by default" (Merged by: feilong-liu)

## polaris6
- [ ] https://github.com/prestodb/presto/pull/21986 Fix checkArgument message in `DefaultOrcWriterFlushPolicy` (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/21987 Fix typo in `IcebergColumnHandle` (Merged by: Timothy Meehan)

## sabbasani
- [ ] https://github.com/prestodb/presto/pull/21994 Documentation on Enabling SSL/TLS support for hana. (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/21938 Documentation on Enabling SSL/TLS support for SQL Server. (Merged by: Sudheesh)

## wangd
- [ ] https://github.com/prestodb/presto/pull/22314 Fix recoverable execution and enable flaky test in TestHiveRecoverableExecution (Merged by: Timothy Meehan)

## wypb
- [ ] https://github.com/prestodb/presto/pull/22107 [native] Update timestampWithTimezone unit test in Base64Test (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22109 Fix multiple entries with same value when we enable delete as join (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/22106 Fix the issue where query with DistinctLimit failed due to turning on delete as join optimization (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/21974 [native] Disable timestampWithTimezone ut in Base64Test (Merged by: spershin)
- [ ] https://github.com/prestodb/presto/pull/21975 Fix incorrect result due to different column order in equality delete filter in Iceberg (Merged by: Ying)

## xiaodou
- [ ] https://github.com/prestodb/presto/pull/21857 [native] Add more e2e cases for division short decimals (Merged by: Deepak Majeti)

## xiaoxmeng
- [ ] https://github.com/prestodb/presto/pull/22527 [native] Advance velox version and update temp file access code (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22509 Fix flaky TaskManagerTest.aggregationSpill (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/22471 [native] Advance velox version (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/22432 [native] Fix peakNodeTotalMemoryReservationInBytes report in TaskStatus (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22374 [native] change TaskManagerTest to use shared arbitrator (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22343 [native] presto task info update code refactor and add cumulative memory test (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22328 [native] Fix cumulative memory usage calculation issue (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22315 [native] remove unused spill config (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22292 [native] rename task memory reclaim runtime stats (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22236 [native] advance velox version (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22228 [native] advance velox version (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/22132 [native] Advance velox version (Merged by: Aditi Pandit)

# Extracted Release Notes
- #19145 (Author: Reetika Agrawal): Add support for Filelist caching for symlink tables
  - Add support for Filelist caching for symlink tables.
- #19821 (Author: Reetika Agrawal): Procedure to invalidate directory list cache
  - Introduce system procedure to invalidate directory list cache in Hive Catalog.
- #20947 (Author: feilong-liu): Collect HBO stats from complete stages in failed queries
  - Add a session property `track_history_based_plan_statistics_from_complete_stages_in_failed_query` to enable tracking hbo statistics from complete stages in failed queries.
- #21236 (Author: Zac Blanco): Add histograms for optimizer cost calculation
  - Add histogram column statistic to Presto for the optimizer. Connectors can now implement support for them.
- #21250 (Author: pratyakshsharma): Fix concurrent insertions for Iceberg tables
  - Add the support to set commit.retry.num-retries table property with table creation to make the number of attempts to make in case of concurrent upserts configurable.
- #21391 (Author: ico01): enhancing compatibility with legacy ORC files
  - Improves the `hive.orc.use-column-names` configuration setting to no longer fail on reading ORC files without column names but falls back to using Hive's schema, enhancing compatibility with legacy ORC files.
- #21436 (Author: Anant Aneja): Quick stats
  - Added quick stats, a mechanism to build stats from metadata for tables/partitions that are missing stats.
- #21568 (Author: Zac Blanco): Add KLL Sketch Functions
  - New support for Apache DataSketches KLL sketch with the sketch_kll and related family of functions.
- #21571 (Author: s-akhtar-baig): Iceberg MOR support - implement row-level deletes
  - Added support for row-level deletes on Iceberg V2 tables. The delete mode can be changed from ``merge-on-read`` to ``copy-on-write`` by setting table property ``delete_mode``.
- #21584 (Author: Jalpreet Singh Nanda (:imjalpreet)): [iceberg] [native] Add support for V1 tables
  - Introduce Iceberg Connector in Prestissimo.
- #21720 (Author: jaystarshot): Add Heuristic CTE Materialization Strategy
  - Add Heuristic CTE Materialization strategy which auto materialized expensive ctes. This is configurable by setting ``cte_materialization_strategy`` to ``HEURISTIC`` or ``HEURISTIC_COMPLEX_QUERIES_ONLY``. (default ``NONE``).
- #21765 (Author: Jalpreet Singh Nanda (:imjalpreet)): [native] Add support for Iceberg connector in presto_protocol
  - Add support for Iceberg connector in presto_protocol.
- #21819 (Author: kedia,Akanksha): Remove logback core depenency as it's not been used anywhere
  - Remove logback 1.2.3.
- #21827 (Author: Deepa George): Fix error thrown when trying to execute INSERT INTO statement when white spaces are present in column names in Iceberg connector
  - Fixes: Fix error encountered when attempting to execute an INSERT INTO statement, in cases where column names contain white spaces.
- #21832 (Author: feilong-liu): Add a new plan canonicalization strategy for history based optimizer
  - Add session property `history_optimization_plan_canonicalize_strategy` to specify the plan canonicalization strategies to use for HBO.
  - Add a new plan canonicalization strategy `ignore_scan_constants` which canonicalize predicates for both partitioned and non-partitioned columns in scan node.
- #21869 (Author: wangd): Preserve case for RowType's field name and JSON content when ``CAST``
  - Add configuration property `legacy_json_cast` whose default value is `true`. See [Properties Reference](http://prestodb.io/docs/current/admin/properties.html#legacy-compatible-properties).
- #21899 (Author: hainenber): Fix precision loss in from_unixtime(double) function
  - Fixes precision loss when timestamp yielded from `from_unixtime(double)` function.
- #21914 (Author: feilong-liu): Simplify RowNumber and TopNRowNumber node with empty input
  - Add optimization for query plans which contains RowNumber and TopNRowNumber nodes with empty input.
- #21933 (Author: wangd): Refactor ConnectorMetadata to deprecate multi-layouts returning method
  - Deprecate SPI method ConnectorMetadata.getTableLayouts(), replace by ConnectorMetadata.getTableLayoutForConstraint().
- #21937 (Author: wangd): Support timestamp type in mysql jdbc connector
  - Support timestamp column type.
- #21943 (Author: Pranjal Shankhdhar): Upgrade airlift version
  - Improve accuracy and performance of HyperLogLog functions.
- #21952 (Author: Rebecca Schlussel): Remove the newer SqlQueryScheduler
  - Remove the configuration property ``use-legacy-scheduler`` and the corresponding session property ``use_legacy_scheduler`.   The property previously defaulted to true, and the new scheduler, which was intended to replace it eventually, was never productionized and is no longer needed. The configuration property ``max-stage-retries`` and the session property ``max_stage_retries`` have also been removed.
- #21953 (Author: Steve Burnett): [documentation] restructure Prestissimo developer documentation in Presto docs
  - Add Prestissimo Developer Guide topic to the Presto documentation.
- #21956 (Author: Rohit Jain): Add config for default view security mode
  - Add a config `default-view-security-mode` to choose the default security mode for view creation.
- #21958 (Author: wangd): [Iceberg]Fix identity and truncate transform on DecimalType column
  - Fix identity and truncate transforms on DecimalType columns.
- #21959 (Author: wangd): [Iceberg]Support year/month/day/hour transforms both on legacy and non-legacy TimestampType column
  - Support year/month/day/hour transforms both on legacy and non-legacy TimestampType column.
  - Fix the bug that `CAST` from non-legacy timestamp to date rounding to future when the timestamp is prior than `1970-01-01 00:00:00.000`.
- #21980 (Author: Jalpreet Singh Nanda (:imjalpreet)): [native] Support reading Iceberg V2 tables with Position deletes
  - Add support to read Iceberg V2 tables with Position Deletes.
- #21983 (Author: Ke): Add partition verification for INSERT and CreateTableAsSelect  queries
  - Add support to do extended partition verification for INSERT and CreateTableAsSelect queries. This can be enabled by the configuration property ``extended-verification``. It would verify each partition's data checksum if the inserted table is partitioned.
- #21984 (Author: feilong-liu): Optimize repeat function by creating runlength block
  - Improve repeat function to create RunLengthEncodedBlock to improve performance.
- #22001 (Author: Ke): Add bucket verification for INSERT and CreateTableAsSelect queries
  - Add support to do extended bucket verification for INSERT and CreateTableAsSelect queries. This can be enabled by the configuration property ``extended-verification``. It would verify each bucket's data checksum if the inserted table is bucketed.
- #22008 (Author: Elliotte Rusty Harold): start adding row_id hidden column to Hive
  - $row_id is a new hidden column.
- #22011 (Author: Rebecca Schlussel): Improve error handling for partial aggregation pushdown
  - Fix a potential wrong results bug when footer stats are marked unreliable and partial aggregation pushdown is enabled.  Such queries will now fail with an error.
- #22012 (Author: Zac Wen): Upgrade Alluxio to 310
  - Upgrade Alluxio to 310.
- #22013 (Author: Vivek): Enable logical property propagation by default
  - Enable propagation of logical properties by default.
- #22017 (Author: jaystarshot): Add option to restrict the amount of data written during CTE Materialization
  - Add limit to the amount of data written during CTE Materialization. This is configurable by the session property ``query_max_written_intermediate_bytes`` (default is 2TB).
- #22033 (Author: jaystarshot): Fix CanonicalPlanGenerate to canonicalize without plan ID
  - Fix plan canonicalization by canonicalizing plan node ids.
- #22051 (Author: Pranjal Shankhdhar): Use dynamic split sizes in hive connector
  - Add session property ``hive.dynamic_split_sizes_enabled`` to use dynamic split sizes based on data selected by query.
- #22059 (Author: feilong-liu): Remove map cast for element access
  - Add an optimizer rule to get rid of map cast in map access functions when possible.
- #22063 (Author: Swapnil Tailor): Adding necessary validation when writingBytes to VariableWidthBlockBuilder 
  - Fix problem when writing large varchar values to throw a user error when it exceeds internal limits.
- #22076 (Author: Timothy Meehan): Fix LIKE expressions for CHAR
  - Fix queries that filter with LIKE '%...%' over char columns.
- #22093 (Author: Sanika Babtiwale): Document Iceberg connector supported data types mapping #21998
  - Add documentation for supported data types mapping in the Iceberg connector.
- #22112 (Author: 8dukongjian): Fix regr functions result to be null when the input data is null
  - Fix the regr_count, regr_avgx, regr_avgy, regr_syy, regr_sxx, and regr_sxy functions result to be null when the input data is null, not 0.
- #22145 (Author: Nikhil Collooru): Track bytes read even when its a FragmentResultCache hit
  - Add support for tracking of the input data size even when there is a fragment result cache hit. This can be enabled by setting the config ```fragment-result-cache.input-data-stats-enabled=true```.
- #22181 (Author: Zac Blanco): Add JSON output format to CLI
  - JSON is now a supported output format in the Presto CLI.
- #22183 (Author: Masha Basmanova): Delete native_execution_enabled/executable_path/program_arguments session properties
  - Remove native_execution_enabled, native_execution_executable_path and native_execution_program_arguments session properties. These are no longer used. Corresponding configuration properties are still available.
- #22205 (Author: jaystarshot): Improve cte scheduling
  - Improved latency of materialized ctes by scheduling multiple dependent subgraphs independently.
- #22211 (Author: Sreeni Viswanadha): Optimize map_normalize
  - Optimized `map_normalize` builtin SQL UDF to avoid repeated reduce computation.
- #22234 (Author: feilong-liu): Record source information of HBO stats 
  - Add worker type and query ID information in HBO stats.
- #22265 (Author: Steve Burnett): [docs] Add Presto Clients category and CLI usage to documentation
  - Add usage documentation for :doc:`/clients/presto-cli`.
- #22266 (Author: Vivek): Enable logical property propagation by default
  - Enable propagation of logical properties by default.
- #22281 (Author: wangd): Fix memory revoke in `TopNRowNumberOperator`
  - Fix bug with spilling in TopNRowNumber.
- #22284 (Author: Sergey Pershin): Allow leading and trailing spaces in CAST(str as INTEGER)
  - CAST(str as INTEGER), CAST(str as BIGINT), CAST(str as SMALLINT), CAST(str as TINYINT) now allow leading and trailing spaces in the string.
- #22306 (Author: feilong-liu): Add log for canonicalized plans in HBO
  - Add log of stats equivalent plan and canonicalized plan for HBO. This feature is controlled by session property `log_query_plans_used_in_history_based_optimizer`.
- #22349 (Author: Steve Burnett): [docs] Add Presto Console page to /clients/
  - Add usage documentation for :doc:`/clients/presto-console`.
- #22433 (Author: jaystarshot): Fix unwanted cte materialization in heurisitic strategy
  - Fixed an issue with heuristic cte materialization strategy where incorrect ctes were materialized.
- #22452 (Author: Zac Wen): Upgrade Alluxio to 312
  - Upgrade Alluxio to 312.
- #22493 (Author: Elliotte Rusty Harold): Add a replaceColumn method to Page
  - Com.facebook.common.Page has a new replaceColumn method.
- #22497 (Author: wangd): Move SortNode to spi so that it could be used in connector
  - Move `SortNode` to SPI module to be utilized in connector.
- #22515 (Author: feilong-liu): Fix CTE reference in analyzer
  - Fix a bug in CTE reference node creation, where different CTEs may be incorrectly considered as the same CTE.

# All Commits
- d33246d46061992a11d16e71f7d2c4087ebf7fe2 [native] Advance velox version and update temp file access code (xiaoxmeng)
- 23f43a86343b4b84357a61104151303a29d16009 Make HiveFileInfo thrift serializable (Nikhil Collooru)
- 5bb47de788196ff446c77a389828140332f9d6bc Fix some equals bugs (Elliotte Rusty Harold)
- 3bc8f60dfe6ec17a799b3186d659906642a39a39 [native] Fix centos container dockfile and update CI image (Deepak Majeti)
- 949410682454b0aa65995c884c05574e3bb7d4c8 Use Arrays.hashCode to hash array fields (Elliotte Rusty Harold)
- c4ebd520ae493bd1baaa3cf33230d72a73600473 Don't call toString on an array (Elliotte Rusty Harold)
- a846d78f35fb75a59e6671872245bd1e67b35376 Add support to track the input bytes read even when we hit fragment result cache (Nikhil Collooru)
- c466a7038739aa55176b32e9d7af469014e21523 Enable flaky testPrestoBenchTables (Karteekmurthys)
- 29fd5441c17750c610ed3f6d75bc6ae72df1dd1b Fix CTE reference in analyzer (feilong-liu)
- a38afd6d93899e6fbdcc38b75c727321d47195e6 Fix format string mismatches (Elliotte Rusty Harold)
- 63aa9f7843d1655886cc22665c3bb7b9b75625a0 Allow reading of legacy ORC files with default column names (ico01)
- 12aa20235a5f4c25a47ecdb5c8c015c201049e5e Fix formatting in Hive Connector Procedures doc (Steve Burnett)
- 5b7cda2e8ff94fff3c96514a90f9ee5f34cbf3f0 Preserve case for RowType's field name and JSON content when ``CAST`` (wangd)
- 877bc2e01cfdc2ebe3d4b6ffd2c609757bc4dbf3 Upgrade really-executable-jar-maven-plugin to 2.1.1 (dnskr)
- 25ee92ca8059410b6dc4a5f4a6adaf86e0d69461 Add LONG_LASTING_QUERY in com.facebook.presto.tests.TestQueryTaskLimit (Jalpreet Singh Nanda (:imjalpreet))
- ef197ad39460ddfa8ebbd6ee0b0459569edac10a Fix and enable Flaky Test TestQueues#testQueuedQueryInteraction (Jalpreet Singh Nanda (:imjalpreet))
- 06edc73cca2f83916e8a18d371bba56e6b32f93f Fix bug in resolving quick stats for partitioned tables (Anant Aneja)
- e37785e28c190c2b7a13947397ec4c8cebb9cde1 Remove Mockito dependency (Anant Aneja)
- 09e5b6937cd1feed290146b461ebd965c8b12885 [native] Drop const from methods in PeriodicMemoryChecker (Jialiang Tan)
- 7b855277560c834c3e83109d16d3eb74dad229fb Fix duplicate key problem when querying iceberg equality deletes table (wangd)
- 6c2bf821c4c75446ce4d98c5772dcf93f1e9dc8a Add a replaceColumn method to Page (Elliotte Rusty Harold)
- decef5af4dc165564448da66be054b8847d0f99e Fix flaky TaskManagerTest.aggregationSpill (xiaoxmeng)
- 457d81241134f69297bd9dfbb8c286a629b48dd9 Collect data size statistics for Iceberg tables (Zac Blanco)
- b9d9de1cb8ed8689dab63c2b35b43eb81f204d00 Add test cases for non-identity partition predicate pushing down (wangd)
- 7e24d5d72cabe04127000f02d41df59b050c43b3 Support non-identity partition predicate for thoroughly push down (wangd)
- f74b4272c4cad17d62b0f05bce32614d16b52b87 Re-enable testAlterColumns in JDBC & add lock timeout param (kiersten-stokes)
- 58e721b83c59544eab399dbf90682f0bf8802fdc Update presto protocol for moving `SortNode` to SPI module (wangd)
- 11639f0016902337b7c46b40626c1151308698b8 Move SortNode to spi so that it could be used in connector (wangd)
- 2718a3d060885486b088401f9b9f1cb8e43cb6d3 Track directory listing cache hit/miss in RuntimeStats (Nikhil Collooru)
- 38bbcdb40925cb7df42bc508b81cc0b606fbcbca Replace assertTrue(false) with fail (Elliotte Rusty Harold)
- fdfa3fefa3993435c1bd81a2df7510a72dc8791d Add request logging section (Andrii Rosa)
- 7ef86c6af575f4700e4e2dbba3c790853978e18c Document failure handling in Presto worker protocol (Andrii Rosa)
- 3f34db97fd9d5eb26222acb8e36546b031c27797 Introduce delay for getResult requests on failed / aborted tasks (Andrii Rosa)
- 2af1ff44e7801ddd76b783a355c454670c46d32d Fix heading formatting in admin/properties.rst (Steve Burnett)
- 0daae2bd4f7cc033ab6e3b15d74b8c0a99c2b7f0 Remove unneeded null checks in private methods (Elliotte Rusty Harold)
- d33a7dc3b659bba469c64303446dc1ba53d78314 Add UDAF noisy_approx_set_sfm_from_index_and_zeros (Fazal Majid)
- 7bbb2dea3400a4bb3e72f358f425e14ddba70713 [native]Fix flaky test UnsafeRowShuffleTest (Jialiang Tan)
- 5df99766f2effe2e208e97a20497371241e2b4ea [native] Fix a typo in a counter. (Sergey Pershin)
- 4ff3d0392e6dbcd024e2455705ab879355f1fe43 [native] Use Task::driverCounts() to report elaborate driver counters (Sergey Pershin)
- 6fc59a4fc2d4b51ddd04a14c996d75dffd20c17c Fix unwanted cte materialization in heurisitic strategy (jaystarshot)
- bde747d1716c2e235f1ea3e18b9f4dd6e77450e3 [native] Advance velox version (xiaoxmeng)
- 61d95a073818a5c473e8e18dc16a52cf60b83e38 [native] Update two tests in QueryContextManagerTest. (Sergey Pershin)
- 94e53c4bb5114acc4ceb6d674ad4908cdaaf7558 Privatize method (Elliotte Rusty Harold)
- a3028d26f39c57aa44e484f84305411b8adfae5e Check for $row_id by number rather than name (Elliotte Rusty Harold)
- 0619997add3c556bdc54c9bcdbe36154634a490b Modify TestDirectoryListCacheInvalidation to fix flakiness (Reetika Agrawal)
- af5866249210fdafac967f8cd90f729bfffa75c5 Fix typo in CODEOWNERS (Timothy Meehan)
- ffc89b99b904076abef694eecb7f6d602106ac22 Fix port config for sql_client (Todd Gao)
- 0879f0266ec7a1be4cb28f7c8a5718af775a428e [native] Remove redundant move in PrestoToVeloxConnectorTest (Amit Dutta)
- e3e5158f44dd295851ca3b7fcb2ee50733b87d89 [native] Fix possible SEGV when registering connectors with same name (Christian Zentgraf)
- 912ddfb77d7832370bcfaaae98db877e08b87dba [native] Add e2e tests for from_ieee754_32, to_ieee754_32 scalar functions (Pratik Joseph Dabre)
- 746c6fedea7a493c93716aa026e1741a024785ce [native] update proxygen (Christian Zentgraf)
- c93927273371b5a8276f9539d3b1505d82969d0d Streamline Partition and PartitionStatistics cache invalidation (Ajay George)
- 0da9f4be8711c932489ed4df01bca183422d04c7 Add Partition version support for getPartitionNames (Ajay George)
- 3d28d35b59ca578b7bddb85902b476c85f5c2a22 Add Partition version support for getPartitionNamesByFilter and getPartitionsByNames (Ajay George)
- 5594e84fb761d7b85acbc5417e64cd072477ee26 Move PartitionNameWithVersion to hive-common (Ajay George)
- 098ac8c774417611f85a261ad749fde5a6169560 Fix flaky test in Bitmap (Jonathan Hehir)
- 02208b92df49405c0d51f706d758dba6d080b44c Document and test HiveFileSplit (Elliotte Rusty Harold)
- db41f56db7c9674f72056dfc4ffd6dbd69b4c1fb Renumber $file_modified_time and $file_size hidden columns (Elliotte Rusty Harold)
- 9e0958a258276ca7d292db43d53cb7dff3c41410 Enable logical property propagation by default (Vivek)
- 323d5879b771a5eb2c760072c0f2cf6e6b8796c0 Fix a bug where a cte producer was dropped due to errors creating the cloned cte dependency graph in SimplifyPlanWithEmptyInput optimizer (jaystarshot)
- 0e319149dc5f25aa8d028cdbc8d09cce5cb422e5 Start adding row_id hidden column (Elliotte Rusty Harold)
- 8cd928fca974c1c2df7ebecd8a997583e71d8b19 Deflake TestNoisySumGaussianShortDecimalAggregation (Tim Meehan)
- 949ecfebf9bc6de41bc7552cf08d0bd1a633c559 Construct row IDs while reading ORC file (Elliotte Rusty Harold)
- ae0be4fb84014a6dee26a5e6cac6f0e1ae66bf42 Make tests independent so they don't interfere (Elliotte Rusty Harold)
- fb1a4c8a1b55ff3540c9c16970f453867d98443a Make hidden column tests independent (Elliotte Rusty Harold)
- c9d1a8cd0779061df660045415b87a78a509fa60 Upgrade Alluxio to 312 (Zac Wen)
- d38295ad098e298bad6b5c4e974c211c17f48e9b Use temurin distribution of OpenJDK (Tim Meehan)
- 477f72081052680cdfe700be143115ca44d25055 [native] Add virtual destructor to PeriodicMemoryChecker (Jialiang Tan)
- 4f91dee002238717c90886d9f90b668fa8dda3fa Disable TestDirectoryListCacheInvalidation (Tim Meehan)
- 352fe6b6001cbd0315a1f1d1a1954de9eee0f13c [native] Advance velox. (Amit Dutta)
- 63ae5ec336ec9f1b07b65145be3a6d4639335e34 Reduce logs from IcebergQueryRunner (Zac Blanco)
- e66597ffe604d29c7ce832fd611f37eb5fc8abc1 [native] Fix the peak node usage report in TaskStatus (xiaoxmeng)
- 5e0825b61e1a9b9883fb76af5609196321ed0aa3 Improve cte scheduling by scheduling subgraphs independently (jaystarshot)
- 4e1ac1910681194acb1ede85ff83bbcdf5616da6 Move sequence plannode to presto-main (jaystarshot)
- c5674d6e7c1008eb7935542a836f8f90d6bf09c6 Add flag to remove redundant progress logs in CIs (Tai Le Manh)
- f024583bc5841856895a99997253e24f09fb74db Skip IcebergPlanOptimizer for non-DATA tables (Zac Blanco)
- 6ff2a97e65c99099f981cb55c8ceea34b1eadaad Fix population of history based stats entry info (feilong-liu)
- 244d203952c4a283891ac6c817a8f4a732aa89c4 Added documentation for Native Session Properties (Athmaja N)
- a417714ebac0c8e7d94e4a1ccbb50e355ac3e010 Use different view names for querybank verification (Rebecca Schlussel)
- 4bd91159a3cd0373b5db89f93ba10be50684b26e Add logging to AbstractVerification (Rebecca Schlussel)
- 42e76484369f8d5a1d4fa60870272f2197f36cc8 Initialize node.id with $HOSTNAME in docker image by default (dnskr)
- baaa962efb092c0b40df9cc63c51e37a8f6ced72 Shutdown thread pool executors properly on the destruction of beans (wangd)
- 83798a2dfbf6e15ab3717afa6732d77f07e7731f [native] Add query init memory metrics (Jialiang Tan)
- 190dceb557ad771f4353271bb6d2550d00977266 [native] Change PeriodicMemoryChecker to use millisecond interval (Jialiang Tan)
- 3ba3d613baf3d896b2259afca3435e669764e87b Fix typo in github product test yml (Ajay George)
- b2ae88d261251aab9257ea84ec9db80b10bbb2bc Add a dev page for viewing query plan (Yihong Wang)
- e8c465902a6b4025721d9fd4bf7936a155ba6a79 Add histograms for optimizer cost calculation (Zac Blanco)
- c41850181c64e7775bd48fb8bcb088f295d023f7 Fix formatting in SHOW ROLES and SHOW ROLE GRANTS docs (Steve Burnett)
- 5d00343ee9d269a202b0c45c05fd398939a4b73c [native] Fix UnsafeRowShuffleTest.shuffleReaderExceptions (Jialiang Tan)
- a0e71db521ce7d3bbb2d0fc93af18a9aa5f4575f [native] Fix UnsafeRowShuffleTest.shuffleWriterExceptions (Jialiang Tan)
- c6648dfee9a9d90ba31219495f718a2251e7941f Update PR template release notes example (Steve Burnett)
- 54e706843143092dd5203a03b4e413cc88377d24 Fix heading formatting in prestissimo/prestissimo-features.rst (Steve Burnett)
- 8e352df77ff00e35fe1c96fc889cd277fbacc13d Warn about practices that lead to flaky tests (Elliotte Rusty Harold)
- 2871210b95dcc5e9046c4e8d5d62a7d802b696c4 Add binary IDs for Hive partitions (Elliotte Rusty Harold)
- 4f59b5da841523d1dcc65bc7e48d866f4fadf1d1 Delete develop/presto-native.rst (Steve Burnett)
- ca5749d866ff59de1aaaa88f1be3531db5c3c58d Add JavaDoc for byte-ish blocks (Elliotte Rusty Harold)
- 32e4ab3e3102cc8461cecd444beb4d76bada60d7 [native] Fix PrestoExchangeSourceTest.slowProducerAndEarlyTerminatingConsumer (Jialiang Tan)
- 3f13505f314c6726a473c215b7002c429ce192b7 Update maven wrapper (Elliotte Rusty Harold)
- 402b6dae44125f40ad36ed8007dde87e408ea5c5 Refactor IcebergAbstractMetadata to utilize newly defined SPI method (wangd)
- c5bcd37e466951a4339a2ed66a887890f43a5ce9 [native] Refactor PrestoExchangeSource to have separate response handle methods (Jialiang Tan)
- 993945b38c07ea90e1bb73a0333f8ee01c22f7ab [native] Add PeriodicMemoryChecker interface (Jialiang Tan)
- 0a67bd73abbc9e44496880ba7e9e9150877b4722 [native] Add back removed params in PrestoExchangeSourceTest (Jialiang Tan)
- 53fc6abeff946b7cd4ecbbbe934adafdf8209b13 [native] Centralize sslcontext creation. (Amit Dutta)
- 8c3808a0a573e91d43e64c5da6aa74deba02de14 [native] Fix PrestoExchangeSourceTest.closeRaceCondition (Jialiang Tan)
- 4bb4a5de5bc3b7d812e95ce3bad80563e2b9ef0d [native] change TaskManagerTest to use shared arbitrator (xiaoxmeng)
- 5ae6d69d9190bcb1c3fe1b7ef242abc3342cd6ad Ignore TestPrestoSparkNativeGeneralQueries.testUnionAllInsert (Elliotte Rusty Harold)
- 2c226fc1e0518b94f1faac01b3ee92ad0fd2c64c Add log for canonicalized plans in HBO (feilong-liu)
- 7b31f086ea3b7dc8ff6afcbbe78068d6d7a9da3e [native] Advance velox. (Amit Dutta)
- 416ea2b62b420365401e6bf09836a7169c622f6b [native] Allow config values to have = (Jialiang Tan)
- fd4c51758ba8c120c3decb8e5c4850c98b20c9cf Add TestingExtendedHiveMetastore (Ajay George)
- 3d071e06e67a17cb65907a04b464cc1d694f1b67 Fix Flaky RedisHboProvider test (jaystarshot)
- 46d42c3a956de03b2090308f380d4d299cd4e92e Improve initialization and error hanlding of RedisProviderPlugin (jaystarshot)
- 5be46b68deb6a328c44e8fc5d00a05177362e9f8 [native] presto task info update code refactor and add cumulative memory test (xiaoxmeng)
- a79e67329f6f566549c015357522934141999475 Add Presto Console page to /clients/ (Steve Burnett)
- 866ab93616759a1e3052334bfc121f77fc93317d Support CTE nodes in SimplifyPlanWithEmptyInput optimizer (jaystarshot)
- 32f3122a0b55cdfdc1861b74e5b6f672bfd130a3 Add Presto Clients category and Presto CLI usage to documentation (Steve Burnett)
- 43a53de3847f1224c31ef68abf7191c288286691 Fix and enable flaky test TestQueryManager.testQueryCountMetrics (Vivek)
- 62dca4aa08466a93deb7942b17e6bd2a76ea2d9b Retry docker compose (Anant Aneja)
- 28ee728ee7a8b68c3e98834ded9747bdaa724e49 Delete native_execution_enabled/executable_path/program_arguments session properties (Masha Basmanova)
- 9e4396c0c4f48d08fdc2772d7b27cbc69dbead34 fix formatting in language/types.rst (Steve Burnett)
- 2914b470bc5f96b07feaf586f31d10d99640239b Add @yhwang as UI codeowner (Tim Meehan)
- 3ed32da0dcec7fe6e9d53635caf0506d694a4f97 Allow TSC to approve CODEOWNERS changes (Tim Meehan)
- cd749375e5f4d8563f7225548caab85b3fdc8781 Add @hantangwangd as Iceberg code owner (Tim Meehan)
- 290876b120b80ef917384e17e159326c8b1c901d [native] Report driver level runtime statistics (Jimmy Lu)
- 8b8c9e4a548c589683e8b794d01a3181ca776395 Record source information for HBO stats (feilong-liu)
- 59bd30154c40a31ac1b309cdfac2133f6ef93780 [Doc]Document all the currently supported SQL operation for memory  connector (kedia,Akanksha)
- 333cb0490fc2ff36b0a80a7e2ac2690314510149 [DOC] Update JMX connector documentation (kedia,Akanksha)
- f76694669d17126f5bb0db6a2aaaccc354439556 [Doc]Document all the currently supported SQL operation for postgresql connector (kedia,Akanksha)
- 9a130de665f135ce73698dd2d43ccb68ddb06859 Document all the currently supported SQL operation for Mysql connector (kedia,Akanksha)
- 49a9915f62f364618619e664c5b1bdffe2d03c17 fix formatting of Synopsis code block in update.rst (Steve Burnett)
- ec9c9ffc2d56b85d1c024daa5973f22f9d71463e [native] Fix cumulative memory usage calculation issue (xiaoxmeng)
- 0d56f004284aba265c489aa693ed3cf25ab88108 [native] Advance Velox version. (Sergey Pershin)
- 98d15a2804828b9a2d0c43c70a327502bf727cdd Relax assertions in TestNoisySumGaussianRealAggregation (Elliotte Rusty Harold)
- 600681dc6894f1f476fb1d7aec4c98ab943e6278 Fix recoverable execution and enable flaky test in TestHiveRecoverableExecution (wangd)
- 013cb506fcc6979a9bbad4742a2af4f63aed71be Allow leading and trailing spaces in CAST(str as INTEGER) (Sergey Pershin)
- f62eb9aab0905c4ce1c9c4feb488744dcd01288e [verifier] Add option to validate array(float) via error margin. (Sergey Pershin)
- 7d9c85d4e2487eba19a7e1c50ee490ae0152ffbc Rename cache invalidate methods for clarity (Ajay George)
- 71bb174452828d684ea1cf147004214b2aac5a39 [native] Minor refactor in ConfigReader. (Amit Dutta)
- 4e2320c90301aec1c1d53b4541fe33e8096aadd3 [native] Remove unused includes. (Amit Dutta)
- 24b0460484ff2f718bf08900f9cbd3ed46eacf04 [native] remove unused spill config (xiaoxmeng)
- c726fc8ad2af7abd294b5de979e4fba2282c4452 [Native] Refactor timestampWithTimezone ut in Base64Test (wypb)
- 48c5a291688e0d405c51c1ada3c10ff2b1db00f7 Add invalidateAll for Metastore caching (Ajay George)
- e4c52115f75f6c5b26db58dbbfa2b1989b5ae149 Fix flaky test testRunawayRegexAnalyzerTimeout (Vivek)
- 8b3b079e38c4c9fa5984902d0b8dffd8b4c20c6e Fix AbstractTestQueries.testRandomizeNullKeyOuterJoin (Tim Meehan)
- 8fc6cd36df4d0c7566a831dc237a6eec716b5dab Clear cache between hive HBO tests (Rebecca Schlussel)
- 0d518c9a2e786958dd24402057d31de5ab8a51ea Derandomize test data (Elliotte Rusty Harold)
- 7e37ed624de24b5cf97f3574ae80285c1e79aa31 Include parameters in logged test name (Rebecca Schlussel)
- c4a8f0e998415110386c0df7e2cc8a4269db628e Increase timeout for runaway regex test and reenable (Rebecca Schlussel)
- 35fc350cb7bb94c555140284d4af46d0b61a0e35 Make TestDistributedQueuesDb less hot (Tim Meehan)
- 754171d98548f94ada2f7a0df132fe878f331814 Add support for map_key_exists (Avinash Jain)
- b3646c4929d1f6478e24da6cb249863ab8de48f6 [native] rename task memory reclaim runtime stats (xiaoxmeng)
- dac83332046253ee493978e068f222c42239214f describe blocks and pages (Elliotte Rusty Harold)
- a789b5fa88999ede3258d3a8dcffa1a4356dc365 Increase timeout for flaky MergeOperator test (wangd)
- 621f7b36898e518588bed97ea59454a9304e7037 Add InMemory CachingHiveMetastore (Ajay George)
- 0868131bc6e1cfd636544a49a27a2fc27f77aa3a Add Abstract CachingHiveMetastore (Ajay George)
- 21ef564500b79a74660d8b2ab86722a57f78eb07 Double timeout for testLargeQuery to one minute (Elliotte Rusty Harold)
- 8b1b81a996bd6cb317f6a68487a211ebd78bd6a5 [native] Update centos Dockerfile to use new setup script from velox (Will)
- 6f1da7f13087615631961718d9a608cf17ad32e5 Fix memory revoke in `TopNRowNumberOperator` (wangd)
- bd811a6b8c2dd5b7af7035536e05a1797481ed78 Fix Title Underline Length in Sphinx Documentation (kedia,Akanksha)
- 961b557fe302e148f4ffbfcd87ea61ccf508ee22 Add @jaystarshot as code owner (Tim Meehan)
- c2e459589c00b58cf83ad7d56c9205f0346c11db Add formatting and comments to CODEOWNERS file (Tim Meehan)
- f81be45a1f5752acb0b3caa7fa5b72cae77ceead Use assertQueryFails in HBO failing queries tests (Rebecca Schlussel)
- 81e111b4bf6cfb773585c2424fe4296ba0e45630 Add statistics to logged mismatched plan (Rebecca Schlussel)
- 331e3d8df4a18745a8642dcc8ddbf88d0405a2ca Allow alternative implementations of table writability checks (Andrii Rosa)
- 2216cc61b6afcd8298b3f95b0138cc47f128214e Add @steveburnett as doc codeowner (Tim Meehan)
- 2f8410d13bbb0a6b0f1db5533f88450638571d7c [native] Remove usage of Varchar and Varbinary structs (Masha Basmanova)
- 12bfa3d4b9b13b5f75be2d04773257c0817dc055 [Iceberg] Skip data size stat on fixed-width types (Zac Blanco)
- b72b286300ef45dc5a55230accc30411603296f6 Prefer local variables when possible (Elliotte Rusty Harold)
- e17757c51398a08be0b631a03622fe0af08d82d0 Fix long overflow for OperatorStats (Ke)
- e254c6c4bb83fe88299b69a1718a97f4ee063d70 Update session property for num_spill_partition_bits (Ke)
- b4e92d8970245924275295956032e6b1aff2fff0 [native] Let API report correct query memory reservations (Jialiang Tan)
- 7543c0a1cfcbe2e4243403222546bcdc2cb7ff27 Skip prefilled columns in pushdown of partial aggregation for hive file formats (Vivek)
- f730f2646bb05e93078ce7d303d41e0c6b4c9eed Do not remove aggregation nodes when multiple grouping sets are present (Vivek)
- 4e35b4e56388cef9454d2c48bb8c5d8bd0ac610a [native] advance velox version (xiaoxmeng)
- 1a16936cb36dc7851a4314ac06f90e91722715da Add docs for isRowPositionList (Elliotte Rusty Harold)
- c6bdff4e9f25ec4e75fe54e216435779459a2c18 [native] advance velox version (xiaoxmeng)
- b23ba0989d45a3a3e0e6101de80dcaa0aab8470e Optimize MapNormalize (Sreeni Viswanadha)
- 938cd1da2442edbb51ddca3024501250f112d64a Fix aggregation metadata optimization when existing Limit/TopN (wangd)
- 8e82ee4eac203ed6e1221e9d019a8fb953f2ff1a Add test for constraint framework (feilong-liu)
- 33803249111cb69cb29b50d3335a7c80bd23397b Fix regr functions result to be null when the input data is null (8dukongjian)
- 0dd8d827e727c8a294ce431944a86b75019ae25e Minor refactoring of HivePageSourceProvider (Sergii Druzkin)
- ee2e5c48c6020b6e3e1be48115fd20077ffae2be Bump Iceberg from 1.4.3 to 1.5.0 (Eduard Tudenhoefner)
- 4622e6e043270568fce437baa94b621bd2ce4728 Fix multiple entries with same value when we enable delete as join (wypb)
- f801da73aa5516f61f89c29b39d951f9f7e270a1 [native] Remove threshold spill session properties (Jialiang Tan)
- 05721900687ba44a2425547a1237d0f8b6fc266f Add test cases for helper function profileNanos (Konjac Huang)
- e51a143f5f0844b376f2011f3eff37b834e44b04 Fix bug in pushing projections in nested CTEs (Lyublena Antova)
- f60711544e1aa64bee989459d98747ffb8e013c5 Use ThreadLocalRandom instead of RandomizationStrategy (Mohan Dhar)
- 4d129de29b967aba26df9944f1f970c980901e8d [native] Disable dynamic filter pushdown (Masha Basmanova)
- fe9947ba6aaf34491e7f94b929848029be73db70 Add JSON output format to CLI (Zac Blanco)
- e088622b9fab0cf6cb8a02d6c96b29bf45d54d20 Record stats of successful stages of failed queries in HBO (feilong-liu)
- 58d5767e964e881cde1cdc2faf4255fe3cfbff56 Add bucket verification for extended verification (Ke)
- 577e0ea47d2b1fb38423b8651fbb08476f25a154 Cosmetic change to ExtendedVerification (Ke)
- d3bd8178a379a2fbbbd03f7fc7013cd49c47fa68 [native Only detach worker when more than 1/2 of driver threads blocked. (Sergey Pershin)
- 7a574363832f09188243b93b734798d9f74191fb Make assertion failures more precise (Elliotte Rusty Harold)
- c6cce8a6aabbccf553f5d52380996a3fc1414bcb Don't spam logs with download messages (Elliotte Rusty Harold)
- 99ad96ef1abc727a8f8fb74ee4bdf7b0c43d5a3f [native] Introduce PrestoToVeloxConnector (Andrii Rosa)
- 7ff45f87e33d9a06ae8f07687f4a524934b20e40 [native] Introduce connector protocol extension point (Andrii Rosa)
- 1ff16a9910fc5a47a654ed9802c2a2af1a7aab89 Removes Unknown file extension warning. (Emanuel F)
- 696f7f0edfa6aadb643ab81ea2aedb3f76591e03 Exclude Omnigraffle files from license checks. (Emanuel F)
- bacf9c3c68f5785a547ce7ea65a857007b574b4d [native] Add system-memory-pushback-by-abort-enabled config (Jialiang Tan)
- 444369192a7dfd817ad2bbe51c64336702263353 [native] Add a comment for adding LocalExchange for join spilling (Masha Basmanova)
- 6a9f3cd9ef9f25855af9c4c6eb54d8612621eb84 Fix precision loss in from_unixtime(double) function (hainenber)
- 6804b4441f318324efada3485966ba031475c5d6 Advance Velox version (Jialiang Tan)
- 4d6b143c9f9d7bef349dace5b2e4bd926c2be81b Revert "Enable logical property propagation by default" (feilong-liu)
- 635d2d2759cd5f493c9a808365f6e21e20aa7994 Remove unused code from HivePartialAggregationPushdown (Masha Basmanova)
- ad469ddf89586dd2bdcc484ab77825536d1e06ca [native] Disable aggregation pushdown for Hive Connector (Masha Basmanova)
- bb330a5a5d7db4660fd88d2e5ec6202d81ab7611 Remove unused variables from TestHiveLogicalPlanner (Masha Basmanova)
- 88cda163580204c3736a290f8612bee51391bdf2 Add support for Filelist caching for symlink tables (Reetika Agrawal)
- 98e17224bec6c004f26a0fec76f3d1a76463d028 [native] Deprecate native_execution_executable_path/program_arguments session props (Masha Basmanova)
- dbc0f230cd303ba513531767fce652b6a26b072c [native] Deprecate native_execution_enabled session property (Masha Basmanova)
- 29cc1963bb6f1f268e4a46044385616e715e2214 Fix resource leak in aggregatePageSourceFactories (Rebecca Schlussel)
- c787e80ed290be9b3bfc18a3494f3761fc53d787 Fix parquet exception handling (Rebecca Schlussel)
- d9d300f52200dd9cdb4451e8b7b226baaa270ede remove redundant cast (Elliotte Rusty Harold)
- c1f0066a560ed1e67897cae909653a13d216e8b4 [native] Do not add extra LocalExchange for native queries with join spill enabled (Masha Basmanova)
- a27685067c592c024058c526f0990506311bc49a Adding necessary validation when writingBytes to VariableWidthBlockBuilder (Swapnil Tailor)
- 2ff43e238a94eb182629ba04882d26ad21c3c8cc Update CONTRIBUTING.md to mention testing standards (Timothy Meehan)
- 42311f800e92a26c0807427be34fe6b37e3f44f0 Disable and split up flaky native tests (Rebecca Schlussel)
- f69c948dfbfb30af3c6d8da5248a02747d25a16e [native] Advance velox version (xiaoxmeng)
- b2db272eef99665195985b4864c195c2781d9d11 Add experimental noisyCardinality function (Mohan Dhar)
- 0dd2b9ed3616909c64f4efa589d6d2eb5c9e78dc Reduce log junk (Elliotte Rusty Harold)
- 0836d831bf006fcedecbcb8f05089b6d3ee349bc use single threaded tests to reduce flakiness (Elliotte Rusty Harold)
- 14e81aeaae5e0085c5a78363cc2cf41f98e02fb2 don't not run linux tests just because there is a doc change (Elliotte Rusty Harold)
- 75ebaf15f176a0b1b4a71074d249ae5f350e859e Make PRIMARY a non-reserved keyword (Vivek)
- 67eb17d3391dca7f21b3ca087ea98ce31e9cf33f Fix equality delete with DistinctLimit (wypb)
- 71d827e605bfd14803d8e83579cdbdac7b5e3075 [Native] Add support to query $file_size and $file_modified_time for each HiveSplit (aditi-pandit)
- 4629ca5745c8bf1e9c8f0c30de3e63235de9619b Remove map cast for element access (feilong-liu)
- 4b453a554148bdc2fcb2c14aaa64f8c9248d871f Enable logical property propagation by default (Vivek)
- 8c9178d87ca94673f9b5fd27896e018a22ab9301 Add function inlining in a later optimizer pass (Zac Blanco)
- 21340d8e31891eef2bbc88ae3181f44f2036c34f Make AbstractTestDistributedQueries single threaded to avoid flakes (Elliotte Rusty Harold)
- 0d664cbf1190fb2d2f690e081c75ede39a60c605 Raise user error for invalid session property (Andrii Rosa)
- 03a19b08bba75e6806d5c70c0ea67095dace5c75 Re-enable TaskManagerTest.aggregationSpill (Jialiang Tan)
- 68c507d87862825875cf165a94813125de101ad2 Add Heuristic CTE Materialization Strategy (jaystarshot)
- e0635c345635a47a5382fe6c87bb2f3047d43625 Remove unused field (Elliotte Rusty Harold)
- 53d79f8aa2c944f5f0b094a9f7fc10f47bd95b54 [native] Change shuffle maxWait unit (Jimmy Lu)
- d80e49aa3ebf4a98aa3a1a726508ba903e66aafb Consolidate error handling for ParquetPageSourceFactory (Rebecca Schlussel)
- 15de989b597a01572144d2fbe07f53063fdfc802 Remove unneeded error handling from page source factories (Rebecca Schlussel)
- 0c40421b6c0f1cf672b866ca1f5cbb1acea96b61 Improve error handling for partial aggregation pushdown (Rebecca Schlussel)
- 2ba4852a199f0cf5288ce7ca787db5e5d233499c Refactor OrcPageSourceFactories to share code (Rebecca Schlussel)
- 7e5f88564ab35d0dec8521f45663ec507ebd7506 Fix default invoker view test (Rebecca Schlussel)
- 9dfc461cc61fa8d10ffc53adb50bb8068c16ec07 [native] Advance Velox (Jimmy Lu)
- 9f4e7ed47f3016de0da617e61fae1951fb67ecd4 Fix bug in Quick Stats in-progress tracker (Anant Aneja)
- b7184d5ed5124708f1a4c6b936811584866c748c Add documentation for HBO (feilong-liu)
- a4c2639ebf66735dae05a40a7fc1616988c0b6d4 Procedure to invalidate directory list cache (Reetika Agrawal)
- 908327e1e99bdf4728aa6cbf9f7eb5d5c94d7737 Make tests more independent (Elliotte Rusty Harold)
- c23d1bd83092a02e2ce0629704a5310c674621ca Refactor ConnectorMetadata to deprecate multi-layouts returning method (wangd)
- ec9236786161dda21838e3c189d2b6ca6c477e82 [native] Allow single zero to be passed as X-Presto-Buffer-Remaining-Bytes (Jimmy Lu)
- 96187ad5371355644478345bd8665782633cb53a Use dynamic sized splits in Hive (Pranjal Shankhdhar)
- 38b843ec9b66458d10221d13d22650af0f2e10f0 Document missing Iceberg configuration properties (Reetika Agrawal)
- 36b8629881f3b484f650f9ebcd6df9bc81d1a7b4 Document supported Iceberg data types mapping (Sanika Babtiwale)
- ece77417644a5a55801ca313ea6f2cc6ce908681 Add buffered bytes metadata to task results (Tim Meehan)
- d5bb1d95df8bd2a477c484082ce548346aa08626 [native] Change node.ip in error message to node.internal-address (Christian Zentgraf)
- aadfba5efb4be366a0418c49b738298ce1659e8d Fix CanonicalPlanGenerate to canonicalize plans without the plan ID (jaystarshot)
- 5afd695c1410f542e8e11a09637a724b574f7f9a Fix LIKE expressions for CHAR (Tim Meehan)
- e0e9a592bbc83f5eda7c921f9e0deb152bb9a7a9 Add KLL Sketch Support (Zac Blanco)
- 07837e782445d40976ab736a4c316da3f72b33ab [native] Prepare for deprecating testSpillPct (Jialiang Tan)
- 8b15be638fa424256e7db1ff0f570d55ffdb3ea9 [native] Fix bug in creation of HashNode(kLeftSemiProject). (Sergey Pershin)
- 245c93f60bb514f8e66a233bd95a1e85ceb0b88c Enforce written intermediate bytes limit for cte materialization (jaystarshot)
- d05abfb099e250f9c242ce03a80aad4641dfa349 Add partition verification for extended verification (Ke)
- fe7b3f605ebd941ebcc0045752547aec3cd77a11 Add config to run extended verification for INSERT and CTAS queries (Ke)
- 000e99543d3f69bee200b322d97a2330bde04330 [Native] Replace deprecated node.ip with node.internal-address in NativeQueryRunner classes (aditi-pandit)
- e7b2b2c3707ba21cb0f4d37474fd4c1245e986b7 [native] Support reading Iceberg V2 tables with Position deletes (Jalpreet Singh Nanda (:imjalpreet))
- 959e562a198ab411196ca4867453b3d4e4082ac6 [native] Add CTAS tests (Pratik Joseph Dabre)
- 6da49ceb313c4f21fa526df35c33d633801bf290 Improve quick stats test reliability (Anant Aneja)
- cec0968ef0d0374041530138768157b601c82251 [native] Fix 'Number of sorting keys must be greater than zero' (Masha Basmanova)
- 61794f05632a8bf84a7f3b2b97916e127d403713 Create RunLengthBlock in repeat function (feilong-liu)
- 63f4a635c15a385c6c887b0334f4ad6225b8b7e9 exclude Pacific/Kanton from testNamedZones (Elliotte Rusty Harold)
- 40e1ee7de8a440098d27d9777d68cec05a131f3a Add Tpcds tests for Native Iceberg catalog (Reetika Agrawal)
- e3a95c83ee96a04ceff80f39ff1e1024d7194cfa Add Native IcebergExternalWorkerQueryRunner (Reetika Agrawal)
- 99c97ca94f0117e92dbc5131538264735e1eecdc Add Tpch tests for Native Iceberg catalog (Reetika Agrawal)
- 1fd81283cda893ac0a7bdb0e1f515a3ff94b2e97 Add Native IcebergQueryRunner (Reetika Agrawal)
- 3df58d1e0f801a331aa9e461375c1027ba5f866f Use indicative mood in the body (Elliotte Rusty Harold)
- 51959cdbc9dec4d7329250549ab6b488e16edaa4 Fix cast from timestamp to date when legacyTimestamp is false (wangd)
- f87f8c855a692c51dba06b11790a21e9c9a4365b Fix transforms both on legacy and non-legacy TimestampType column (wangd)
- e8db1fa28d4c3139776eb8d3a5a068d28ddbdb39 Upgrade Alluxio to 310 (Zac)
- 665cafda947c62553367c6f21b06f34efe09d572 Fix link in CONTRIBUTING.md (Tim Meehan)
- 584f112126ffdc23983cc5b3f2774844ba4de8bf Trivial spelling fix (Elliotte Rusty Harold)
- eeda9c4b8aa644bf4badc476dd80bc05c74bc4da Add TLS documentation for hana (sabbasani)
- d4e9213222fa85544331469b4c68e2ff8b4d8d5b [native] Advance velox. (Amit Dutta)
- fda906eea23e6a512a08f3453aa7fde08238ff1a Increase wait time in test (Anant Aneja)
- be661487f69b4a0e606b3b55b006a1fa80dec68c [native] Prepare for the exchange protocol upgrade (Jimmy Lu)
- 5c8fc862c7170f33aa2dac2c7124464fad523191 [native] Fix documentation on async data cache and ssd cache (Deepak Majeti)
- 1e1963ce3100dc4ac87fcc90c240066b66187c2b Remove the newer SqlQueryScheduler (Rebecca Schlussel)
- 09fe67e05efe4000c31d7a74f3edb7f1e7867c92 [native] Return TableScan split weights in TaskStatus. (Sergey Pershin)
- 269727183dd58f55e5c3041c92e1544dcf17ea8a Propagate directly if its a PrestoException (Nikhil Collooru)
- 58349ebd173bdb0933cff8ed11f6db675c98b9af [native] Advance Velox. (Sergey Pershin)
- 492aeeb03f90e2fe724b5096301b524548b64acd Disallow writes into hive tables that have any enforced constraints (Vivek)
- b0f28f5560bf1fcfde91642b5877fc0ab90b3b40 Add documentation for DDL for table constraints (primary and unique) (Vivek)
- 08c49debf27a9668af0db15c163bfa74406bf0d2 Add DDL support for table constraints (primary key and unique - 3/3) (Vivek)
- 36234f602799b3d0cbee29f0b6887965f6c5ac69 Add DDL support for table constraints (primary key and unique - 2/3) (Vivek)
- d094682a25547815eafaa95fb8dfc71721fa62d1 Add DDL support for table constraints (primary key and unique - 1/3) (Vivek)
- 8ebd6f11265c16999d0fa45744816d52077825ff Add table constraint properties "enforced" and "enabled" (Vivek)
- dccb5a437f82958aeb314abaab3b654f575a14a2 Quick stats (Anant Aneja)
- fcfc1144362e0ff59653b23bfcff90bfacdb88a9 Add config for default view security mode (Rohit Jain)
- c33c3a30a9c8d82ca8b3c4f685595b6e9c06c712 Update and standardize the documentation on how to commit to Presto (FaulyJuggler)
- d4f079ab3ade73e9a5b54283b47da8494c7d8c56 [native] Advance Velox (Christian Zentgraf)
- 4271a87a0dc408195c050f43a8bf1286610f6661 [native] Add more e2e cases for division short decimals (xiaodou)
- aaff94bd7174de96f4165869bec907469fbc3fe3 [native] Use PrestoSerializer to deserialize base64 encoded constants (Bikramjeet Vig)
- 43feeb6da25bf62ca778ea46c65300bbe512505e Fix checkArgument message in `DefaultOrcWriterFlushPolicy` (polaris6)
- 9d7b77c500484c220af454972e3ca56d65892a1f Add TLS documentation for SQL Server (sabbasani)
- dd25670a8cf59b0639fd9a5848462e98b38b39a6 Document Prestissimo reduce_agg behavior (Steve Burnett)
- e29557c44bfbdb228c87fedfb4e6ae529cca9bce Add support for whitespace in Iceberg column names (Deepa George)
- f6c748c94d2fce667537b6dda22e67b921ce83a9 Fix typo in `IcebergColumnHandle` (polaris6)
- 36575b0ca7d61a0ecf0be8eac7efc0b2b0d3ec85 [Native] Advance Velox (aditi-pandit)
- 3f42047158c7cb1d9d771e535cc50cee3b6b1798 [native] Propagate task.max-partial-aggregation-memory to Velox. (Sergey Pershin)
- 14620ca1c1f89db4ebc9fffd01ae7048eae50704 Add support for row-level deletes (s-akhtar-baig)
- 91b0bb38da42cc8f76903129df142a211f89d3b3 Support timestamp type in mysql jdbc connector (wangd)
- 05cc11858da3c1409eed413da8344f9c89dbffde Fix code block formatting in array and map functions docs (Steve Burnett)
- f90055668bf7813c05726f87cc1afaf2869a09db [native] Call renamed createIterativeSerializer in Velox's VectorSerde (Kevin Wilfong)
- 250f898fc13467b44ec86d7b22a1db5622bd93ce [native] Disable timestampWithTimezone ut in Base64Test (wypb)
- 2352a900a0aab5f945ba7dc8e04ea4cd367514f5 Fix incorrect result due to different column order in equality delete filter in Iceberg (wypb)
- 4665527ac81b7689c934ed604ae54eab970ef710 Fix transforms both on legacy and non-legacy TimestampType column (wangd)
- 6998a7362764a73186a13a713a651ec71314c5f7 Add workflow to build PDF for Presto documentation (hainenber)
- d4bdf97afefc4981f029dd9989ab97cfd84301c4 reorganize Prestissimo developer documentation (Steve Burnett)
- 2bd3f5ef02dab2909a920f63eac573de76c34f97 [native] Add support for optional velox.properties file (Deepak Majeti)
- fb8f04dca391362c1f998476f46aaf3f7631febd Refactor base lakehouse connector classes in presto-hive-common (Jalpreet Singh Nanda (:imjalpreet))
- e5ba4bbc79053f552bde5a32af45ae7ea76ad1f5 [native] Remove defunct config from hive catalog (Jalpreet Singh Nanda (:imjalpreet))
- 49e4e1e8c3e30600bed9f7af183114a3071f7b34 [native] Register iceberg catalog as part of Hive Connectors (Jalpreet Singh Nanda (:imjalpreet))
- 69295a7671370fb21c654ccfd1358c909d88a358 [native] Support converting Presto Iceberg Split to Velox Split (Reetika Agrawal)
- 3c7e01efc80fcd179fa611ac4ffb7e3e08977dd5 [native] Support converting Presto Iceberg Plan to Velox Plan (Jalpreet Singh Nanda (:imjalpreet))
- 7d7df5c7075577a3dadcf200be5c062d752b1dd8 Use integer column statistics for byte columns (Sergii Druzkin)
- 2ee8140e5edd00a3687b0d1a8f3ed3117d293405 Refactor code in HivePartitionManager (Nikhil Collooru)
- 0525e3cd9fa445c65f1906d38ba67a5b72d0152c Update Logging Properties Documentation (kedia,Akanksha)
- 0bc6f916327086aad5c2c977dcdcafcba0f58fa7 [native] Advance velox. (Amit Dutta)
- 366005e63e9c7af0d4a8cf2f12cc39580d52fe47 UI: Allow to hide runtime metrics (Masha Basmanova)
- 60cdb2feb0b1c9ac2e26fa661da8fda4ded92c2b Upgrade airlift version (Pranjal Shankhdhar)
- 32628cda20db48d10f58b2fcb7aeae29a0e1fbfb Add a new plan canonicalization strategy for history based optimizer (feilong-liu)
- b4e837de7ad3cca11a0e3ff1e26c8ee8f205ab98 Simplify RowNumber and TopNRowNumber node with empty input (feilong-liu)
- 56a0910dc39eb8c2b11d042ebac2f28d0978d31a [native] Report elapsedTimeInNanos for running tasks (Masha Basmanova)
- 28114d2e864c2d2ffa326dbeb01b28f5417f8644 [native] Always report createTime task runtime stat (Masha Basmanova)
- 1b01319b479ca2804776837e0395050c68094c24 [native] Add missing operator runtime stats to task runtime stats (Masha Basmanova)
- bef3e1917b01a6e2ef1bd4d1037f3829607b6da2 [native] Reduce copy-paste in PrestoTask::updateInfoLocked (Masha Basmanova)
- 7b6b5fc81b554cd929059c488c9f18ab27440536 [native] Propagate join stats from Velox operator to Presto (Pranjal Shankhdhar)
- 9098ac7fea76aab00c514f0f8d578aeaa1fc88a7 [native] Advance velox version (Pranjal Shankhdhar)
- 7ea2f53e14d60a52a263e6c6cfe298486fb8b1e7 f (Lyublena Antova)
- 50e51cdfd5bb10db9713dcdb148a4654a61884c6 f (Lyublena Antova)
- 705dc2cab592978bcae2c82a71ba7a954d32d4d3 Fix bug during filter pushdown in CTE producers (Lyublena Antova)
- 80a75022d1cc83fa282c6c565669a7946549b19d Disable cte pushdown (jaystarshot)
- 946d4cdb004148bbe968edf655d894503a88d911 Support CTE nodes in cost calculator (jaystarshot)
- 6d749f9e91e8ef74aaed288646c93982b8c74666 Remove erroneous resource group documentation (kedia,Akanksha)
- e579a3f41a5763c6cd1196661c3948b4d0d36cef Add support for iceberg concurrent insertions (pratyakshsharma)
- c84d8210c6f9551014093cdbfaa10ec040588269 [native] Add test for MergeExchange (Masha Basmanova)
- 1a4e945ed9f8c1c9a6a966ea9e62e68f9585fa66 [native] Add support for Iceberg connector in presto_protocol (Jalpreet Singh Nanda (:imjalpreet))
- 28f665b4a2a81a5a555480eca13b6a262a1faac0 [native] Replace 'FOLLY_FALLTHROUGH' by '[[fallthrough]]'. (Sergey Pershin)
- 376144fe8cbb05efaaebccbae89249fdaff5b4bd [native] Backing out commit 6eba1f7330de2879ca2f4012c8bbd9b1f7a5f727 (Sergey Pershin)
- 468de33ca4daba0df4c0430acd0201224dcb1ed2 Remove logback core depenency as its not been used anywhere (kedia,Akanksha)
- f0bb8966f3be920db6a9d9f947f1a7d7b1acee09 Add RuntimeStats to MetastoreContext (Nikhil Collooru)
- 8dba12952f27735fd5e3e5ef6dd1a3da2c57e37f Add Session Properties support (Yihong Wang)
- cafbdd3ef379f45980cb11b8484dd78fabf2bcd9 Free up disk space for SingleStore CI (hainenber)
- 64d22305107cdbecb2b7bfdac03387537c6cd3aa Refactor getCachingKey in CachingHiveMetastore for simplicity (Ajay George)
- e1b1ccf94ae3dd0c1c67f5d97ec8d8f4e893bdfd [native] Revisit stuck operator detection. (Sergey Pershin)
- 7d1951652af763cfc0cb3421a66ff2b4f8df2d52 Update default spill compression codec for native engine. (Kevin Wilfong)
- d16053d70ca991271d47c51e71a9a349f49b97f1 revision of redis-hbo-provider.rst (Steve Burnett)