### PR TITLE
array_join adds an extra delimeter if the last element is null

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayJoin.java
@@ -315,15 +315,19 @@ public final class ArrayJoin
             Slice nullReplacement)
     {
         int numElements = arrayBlock.getPositionCount();
+        boolean hasOutput = false;
 
         for (int i = 0; i < numElements; i++) {
+            if (arrayBlock.isNull(i) && nullReplacement == null) {
+                continue;
+            }
+
+            if (hasOutput) {
+                blockBuilder.writeBytes(delimiter, 0, delimiter.length());
+            }
+
             if (arrayBlock.isNull(i)) {
-                if (nullReplacement != null) {
-                    blockBuilder.writeBytes(nullReplacement, 0, nullReplacement.length());
-                }
-                else {
-                    continue;
-                }
+                blockBuilder.writeBytes(nullReplacement, 0, nullReplacement.length());
             }
             else {
                 try {
@@ -337,9 +341,7 @@ public final class ArrayJoin
                 }
             }
 
-            if (i != numElements - 1) {
-                blockBuilder.writeBytes(delimiter, 0, delimiter.length());
-            }
+            hasOutput = true;
         }
 
         blockBuilder.closeEntry();

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -617,6 +617,7 @@ public class TestArrayOperators
         assertFunction("array_join(ARRAY[1, NULL, 2], ',')", VARCHAR, "1,2");
         assertFunction("ARRAY_JOIN(ARRAY [1, 2, 3], ';', 'N/A')", VARCHAR, "1;2;3");
         assertFunction("ARRAY_JOIN(ARRAY [1, 2, null], ';', 'N/A')", VARCHAR, "1;2;N/A");
+        assertFunction("ARRAY_JOIN(ARRAY [1, 2, null], ';')", VARCHAR, "1;2");
         assertFunction("ARRAY_JOIN(ARRAY [1, 2, 3], 'x')", VARCHAR, "1x2x3");
         assertFunction("ARRAY_JOIN(ARRAY [BIGINT '1', 2, 3], 'x')", VARCHAR, "1x2x3");
         assertFunction("ARRAY_JOIN(ARRAY [null], '=')", VARCHAR, "");


### PR DESCRIPTION
## Description
array_join adds an extra trailing delimeter to the result string if the last element in the array is null

## Motivation and Context
this seems to be clearly incorrect, if the null replacement argument isn't set nulls are otherwise ignored by array_join

## Impact
this will change the results of array_join for cases where the last element is null

## Test Plan
added a testcase where the null replacement argument is not set and the last element is null, this was previously untested

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix array_join to not add a trailing delimeter when the last element in the array is NULL. :pr:`22652`

```

