### PR TITLE
Update build configs with jdk11, per info from fengbin fang.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
             stages {
                 stage('Setup') {
                     steps {
-                        sh 'apt update && apt install -y awscli git tree'
+                        sh 'apt update && apt install -y awscli git libaio1 libaio-dev tree'
                         sh 'git config --global --add safe.directory ${WORKSPACE}'
                         script {
                             env.PRESTO_COMMIT_SHA = sh(script: "git rev-parse HEAD", returnStdout: true).trim()
@@ -100,6 +100,8 @@ pipeline {
                         echo "build prestodb source code with build version ${PRESTO_BUILD_VERSION}"
                         retry (5) {
                             sh '''
+                                cat jenkins/agent-maven.yaml
+                                cat pom.xml
                                 unset MAVEN_CONFIG && ./mvnw install -DskipTests -B -T 1C -P ci -pl '!presto-docs'
                                 tree /root/.m2/repository/com/facebook/presto/
                             '''
@@ -118,6 +120,11 @@ pipeline {
                                 aws s3 cp presto-server/target/${PRESTO_PKG}  ${AWS_S3_PREFIX}/${PRESTO_BUILD_VERSION}/ --no-progress
                                 aws s3 cp presto-cli/target/${PRESTO_CLI_JAR} ${AWS_S3_PREFIX}/${PRESTO_BUILD_VERSION}/ --no-progress
                             '''
+                        }
+                    }
+                    post {
+                        always {
+                            testNG()
                         }
                     }
                 }

--- a/jenkins/agent-maven.yaml
+++ b/jenkins/agent-maven.yaml
@@ -10,7 +10,7 @@ spec:
     serviceAccountName: oss-agent
     containers:
     - name: maven
-      image: maven:3.8.6-openjdk-8-slim
+      image: maven:3.8.6-openjdk-11-slim
       env:
       - name: MAVEN_OPTS
         value: "-Xmx8000m -Xms8000m"

--- a/pom.xml
+++ b/pom.xml
@@ -2240,7 +2240,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.1</version>
                 </plugin>
 
                 <plugin>
@@ -2271,11 +2271,15 @@
                     <groupId>org.gaul</groupId>
                     <artifactId>modernizer-maven-plugin</artifactId>
                     <configuration>
+                        <javaVersion>11</javaVersion>
                         <violationsFiles>
                             <violationsFile>${air.main.basedir}/src/modernizer/violations.xml</violationsFile>
                         </violationsFiles>
                         <exclusionPatterns>
                             <exclusionPattern>org/joda/time/.*</exclusionPattern>
+                            <exclusionPattern>com/google/common/collect/.*</exclusionPattern>
+                            <exclusionPattern>com/google/common/io/.*</exclusionPattern>
+                            <exclusionPattern>java/net/.*</exclusionPattern>
                         </exclusionPatterns>
                     </configuration>
                 </plugin>
@@ -2455,6 +2459,18 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>build-with-jdk-11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <properties>
+                <project.build.targetJdk>11</project.build.targetJdk>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <maven.compiler.release>11</maven.compiler.release>
+            </properties>
+        </profile>
         <profile>
             <id>tests-with-dependencies</id>
             <!--


### PR DESCRIPTION
## Description
Use JDK 11 to build Presto, and run tests.

## Motivation and Context
This is the first step to upgrading Java versions, to catch up with the development of the Java ecosystem.

## Impact
* No public interface impact.
* Will need to run performance tests.

## Test Plan
Build and deploy Presto using Docker to evaluate performance impact.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Update the Java build version from JDK 1.8 to JDK 11.
```
