### PR TITLE
[native] Move static functions from PrestoTask to Util.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -147,11 +147,8 @@ struct PrestoTask {
   }
 
   /// Turns the task numbers (per state) into a string.
-  static std::string taskNumbersToString(
-      const std::array<size_t, 5>& taskNumbers);
-
-  /// Returns process-wide CPU time in nanoseconds.
-  static long getProcessCpuTime();
+  static std::string taskStatesToString(
+      const std::array<size_t, 5>& taskStates);
 
   /// Invoked to update presto task status from the updated velox task stats.
   protocol::TaskStatus updateStatusLocked();

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -1145,7 +1145,7 @@ void TaskManager::shutdown() {
     PRESTO_SHUTDOWN_LOG(INFO)
         << "Waited (" << seconds
         << " seconds so far) for 'Running' tasks to complete. " << numTasks
-        << " tasks left: " << PrestoTask::taskNumbersToString(taskNumbers);
+        << " tasks left: " << PrestoTask::taskStatesToString(taskNumbers);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     cancelAbandonedTasks();
     taskNumbers = getTaskNumbers(numTasks);

--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -14,6 +14,7 @@
 
 #include "presto_cpp/main/common/Utils.h"
 #include <fmt/format.h>
+#include <sys/resource.h>
 
 namespace facebook::presto::util {
 
@@ -41,6 +42,17 @@ std::shared_ptr<folly::SSLContext> createSSLContext(
         clientCertAndKeyPath,
         ex.what());
   }
+}
+
+long getProcessCpuTimeNs() {
+  struct rusage rusageEnd;
+  getrusage(RUSAGE_SELF, &rusageEnd);
+
+  auto tvNanos = [](struct timeval tv) {
+    return tv.tv_sec * 1'000'000'000 + tv.tv_usec * 1'000;
+  };
+
+  return tvNanos(rusageEnd.ru_utime) + tvNanos(rusageEnd.ru_stime);
 }
 
 } // namespace facebook::presto::util

--- a/presto-native-execution/presto_cpp/main/common/Utils.h
+++ b/presto-native-execution/presto_cpp/main/common/Utils.h
@@ -31,4 +31,7 @@ std::shared_ptr<folly::SSLContext> createSSLContext(
     const std::string& clientCertAndKeyPath,
     const std::string& ciphers);
 
+/// Returns current process-wide CPU time in nanoseconds.
+long getProcessCpuTimeNs();
+
 } // namespace facebook::presto::util


### PR DESCRIPTION
## Description
Minor refactor to move static tasks from PrestoTask struct to Util.

## Motivation and Context
We are trying to make PrestoTask a class instead of a struct for better encapsulation. Moving static methods out of the struct makes this easier. Besides the functions we are moving aren't a good fit for PrestoTask.

## Impact
No impact.

## Test Plan
Existing unit tests