### PR TITLE
[native] Remove velox.properties file from e2e tests.

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -367,8 +367,7 @@ public class PrestoNativeQueryRunnerUtils
                         log.info("Temp directory for Worker #%d: %s", workerIndex, tempDirectoryPath.toString());
                         int port = 1234 + workerIndex;
 
-                        // Write config files
-                        Files.write(tempDirectoryPath.resolve("velox.properties"), "".getBytes());
+                        // Write config file
                         String configProperties = format("discovery.uri=%s%n" +
                                 "presto.version=testversion%n" +
                                 "system-memory-gb=4%n" +

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -80,7 +80,6 @@ public class NativeExecutionProcess
     private static final String NATIVE_EXECUTION_TASK_ERROR_MESSAGE = "Native process launch failed with multiple retries.";
     private static final String WORKER_CONFIG_FILE = "/config.properties";
     private static final String WORKER_NODE_CONFIG_FILE = "/node.properties";
-    private static final String WORKER_VELOX_CONFIG_FILE = "/velox.properties";
     private static final String WORKER_CONNECTOR_CONFIG_FILE = "/catalog/";
     private static final int SIGSYS = 31;
 
@@ -344,7 +343,6 @@ public class NativeExecutionProcess
         // the native execution process eventually for process initialization.
         workerProperty.getSystemConfig().setHttpServerPort(port);
         workerProperty.populateAllProperties(
-                Paths.get(configBasePath, WORKER_VELOX_CONFIG_FILE),
                 Paths.get(configBasePath, WORKER_CONFIG_FILE),
                 Paths.get(configBasePath, WORKER_NODE_CONFIG_FILE),
                 Paths.get(configBasePath, format("%s%s.properties", WORKER_CONNECTOR_CONFIG_FILE, getNativeExecutionCatalogName(session))));

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
@@ -103,10 +103,9 @@ public class WorkerProperty<T1 extends NativeExecutionConnectorConfig, T2 extend
         return veloxConfig;
     }
 
-    public void populateAllProperties(Path veloxConfigPath, Path systemConfigPath, Path nodeConfigPath, Path connectorConfigPath)
+    public void populateAllProperties(Path systemConfigPath, Path nodeConfigPath, Path connectorConfigPath)
             throws IOException
     {
-        populateProperty(veloxConfig.getAllProperties(), veloxConfigPath);
         populateProperty(systemConfig.getAllProperties(), systemConfigPath);
         populateProperty(nodeConfig.getAllProperties(), nodeConfigPath);
         populateProperty(connectorConfig.getAllProperties(), connectorConfigPath);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -196,11 +196,10 @@ public class TestNativeExecutionSystemConfig
         Path directory = null;
         try {
             directory = Files.createTempDirectory("presto");
-            Path veloxPropertiesPath = Paths.get(directory.toString(), "velox.properties");
             Path configPropertiesPath = Paths.get(directory.toString(), "config.properties");
             Path nodePropertiesPath = Paths.get(directory.toString(), "node.properties");
             Path connectorPropertiesPath = Paths.get(directory.toString(), "catalog/hive.properties");
-            workerProperty.populateAllProperties(veloxPropertiesPath, configPropertiesPath, nodePropertiesPath, connectorPropertiesPath);
+            workerProperty.populateAllProperties(configPropertiesPath, nodePropertiesPath, connectorPropertiesPath);
 
             verifyProperties(workerProperty.getSystemConfig().getAllProperties(), readPropertiesFromDisk(configPropertiesPath));
             verifyProperties(workerProperty.getNodeConfig().getAllProperties(), readPropertiesFromDisk(nodePropertiesPath));


### PR DESCRIPTION
## Description
Removing velox properties file which is not used with e2e tests. Since no config is passed, the file is not necessary.

## Motivation and Context
In https://github.com/prestodb/presto/pull/21962, we made velox properties file optional. Also no e2e tests utilizes this. It was added because the file was required to start the server. However as described in https://github.com/prestodb/presto/pull/21962, its optional now and hence removing from the tests as there isn't any usage in the test

## Impact
No impact

## Test Plan
Ran all e2e tests locally and in CI

```
== NO RELEASE NOTE ==
```

