### PR TITLE
[native] Wire PeriodicStatsReporter in Velox to Presto native

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(
   presto_operators
   velox_aggregates
   velox_caching
+  velox_common_base
   velox_core
   velox_dwio_common_exception
   velox_encode

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -53,10 +53,6 @@ class PeriodicTaskManager {
           std::shared_ptr<velox::connector::Connector>>& connectors,
       PrestoServer* server);
 
-  ~PeriodicTaskManager() {
-    stop();
-  }
-
   /// Invoked to start all registered, and fundamental periodic tasks running at
   /// the background.
   ///
@@ -170,7 +166,6 @@ class PeriodicTaskManager {
   int64_t lastForcedContextSwitches_{0};
   // Renabled this after update velox.
   velox::common::SpillStats lastSpillStats_;
-  velox::memory::MemoryArbitrator::Stats lastArbitratorStats_;
 
   // NOTE: declare last since the threads access other members of `this`.
   folly::FunctionScheduler oneTimeRunner_;

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -244,23 +244,6 @@ void registerPrestoMetrics() {
       100);
   DEFINE_METRIC(kCounterSpillMaxLevelExceeded, facebook::velox::StatType::SUM);
 
-  /// ================== Memory Arbitrator Counters =================
-
-  DEFINE_METRIC(kCounterArbitratorNumRequests, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterArbitratorNumAborted, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterArbitratorNumFailures, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterArbitratorQueueTimeUs, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(
-      kCounterArbitratorArbitrationTimeUs, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(
-      kCounterArbitratorNumShrunkBytes, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(
-      kCounterArbitratorNumReclaimedBytes, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(
-      kCounterArbitratorFreeCapacityBytes, facebook::velox::StatType::AVG);
-  DEFINE_METRIC(
-      kCounterArbitratorNonReclaimableAttempts, facebook::velox::StatType::SUM);
-
   // NOTE: Metrics type exporting for file handle cache counters are in
   // PeriodicTaskManager because they have dynamic names. The following counters
   // have their type exported there:

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -165,37 +165,6 @@ constexpr folly::StringPiece kCounterMmapRawAllocBytesSmall{
 constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
     "presto_cpp.exchange_source_peak_queued_bytes"};
 
-/// ================== Memory Arbitrator Counters =================
-
-/// The number of arbitration requests.
-constexpr folly::StringPiece kCounterArbitratorNumRequests{
-    "presto_cpp.arbitrator_num_requests"};
-/// The number of aborted arbitration requests.
-constexpr folly::StringPiece kCounterArbitratorNumAborted{
-    "presto_cpp.arbitrator_num_aborted"};
-/// The number of arbitration request failures.
-constexpr folly::StringPiece kCounterArbitratorNumFailures{
-    "presto_cpp.arbitrator_num_failures"};
-/// The sum of all the arbitration request queue times in microseconds.
-constexpr folly::StringPiece kCounterArbitratorQueueTimeUs{
-    "presto_cpp.arbitrator_queue_time_us"};
-/// The sum of all the arbitration run times in microseconds.
-constexpr folly::StringPiece kCounterArbitratorArbitrationTimeUs{
-    "presto_cpp.arbitrator_arbitration_time_us"};
-/// The amount of memory bytes freed by reducing the memory pool's capacity
-/// without actually freeing memory.
-constexpr folly::StringPiece kCounterArbitratorNumShrunkBytes{
-    "presto_cpp.arbitrator_num_shrunk_bytes"};
-/// The amount of memory bytes freed by memory reclamation.
-constexpr folly::StringPiece kCounterArbitratorNumReclaimedBytes{
-    "presto_cpp.arbitrator_num_reclaimed_bytes"};
-/// The free memory capacity in bytes.
-constexpr folly::StringPiece kCounterArbitratorFreeCapacityBytes{
-    "presto_cpp.arbitrator_free_capacity_bytes"};
-/// The number of non-reclaimable operator reclaim attempts.
-constexpr folly::StringPiece kCounterArbitratorNonReclaimableAttempts{
-    "presto_cpp.arbitrator_non_reclaimable_attempts"};
-
 /// ================== Disk Spilling Counters =================
 
 /// The number of times that spilling runs on a velox operator.


### PR DESCRIPTION
Wire up PeriodicStatsReporter in Velox to Presto native. Remove periodic stats reporting for arbitrator in presto native. This stats reporting has been done by PeriodicStatasReporter in Velox.
```
== NO RELEASE NOTE ==
```

