### PR TITLE
Prefer JDK's StandardCharsets

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/encoding/StringUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/encoding/StringUtils.java
@@ -14,24 +14,22 @@
 
 package com.facebook.presto.common.type.encoding;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
-public final class StringUtils
+final class StringUtils
 {
     private StringUtils() {}
-
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
 
     static byte[] getBytesUtf8(final String string)
     {
         if (string == null) {
             return null;
         }
-        return string.getBytes(StringUtils.UTF_8);
+        return string.getBytes(StandardCharsets.UTF_8);
     }
 
     static String newStringUtf8(final byte[] bytes)
     {
-        return bytes == null ? null : new String(bytes, StringUtils.UTF_8);
+        return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ConsistentHashingNodeProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ConsistentHashingNodeProvider.java
@@ -27,9 +27,9 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import static com.facebook.presto.common.type.encoding.StringUtils.UTF_8;
 import static com.google.common.hash.Hashing.murmur3_32;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public class ConsistentHashingNodeProvider

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ModularHashingNodeProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ModularHashingNodeProvider.java
@@ -21,10 +21,10 @@ import com.google.common.hash.HashFunction;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.facebook.presto.common.type.encoding.StringUtils.UTF_8;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.google.common.hash.Hashing.murmur3_32;
 import static java.lang.Math.toIntExact;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.unmodifiableList;
 
 public class ModularHashingNodeProvider


### PR DESCRIPTION
## Description
Replace internal UTF-8 constant with JDK StandardCharsets.UTF_8

## Motivation and Context
Modernization. This hasn't been needed since Java 6.

## Impact
StringUtils.UTF_8 is deleted. 

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== NO RELEASE NOTES ==
```
