### PR TITLE
Fix hashcode bug in HiveBloomFilter in presto-orc

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/HiveBloomFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/HiveBloomFilter.java
@@ -67,7 +67,7 @@ public class HiveBloomFilter
     @Override
     public int hashCode()
     {
-        return Objects.hash(numBits, numHashFunctions, bitSet.getData());
+        return Objects.hash(numBits, numHashFunctions, Arrays.hashCode(bitSet.getData()));
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestHiveBloomFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestHiveBloomFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestHiveBloomFilter
+{
+    @Test
+    public void testHashCode()
+    {
+        List<Long> bitset1 = ImmutableList.of(2L);
+        List<Long> bitset2 = ImmutableList.of(2L);
+        HiveBloomFilter filter1 = new HiveBloomFilter(bitset1, 1, 1);
+        HiveBloomFilter filter2 = new HiveBloomFilter(bitset2, 1, 1);
+        assertEquals(filter1, filter2);
+        assertEquals(filter1.hashCode(), filter2.hashCode());
+    }
+}


### PR DESCRIPTION
## Description
Use Arrays.hashCode on array field

## Motivation and Context
consistency with equals

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

