### PR TITLE
Access static members in static fashion

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -303,10 +303,10 @@ public class EffectivePredicateExtractor
                         nullConjuncts.add(specialForm(IS_NULL, BOOLEAN, variable));
                     }
 
-                    resultDisjunct.add(logicalRowExpressions.and(nullConjuncts.build()));
+                    resultDisjunct.add(LogicalRowExpressions.and(nullConjuncts.build()));
                 }
 
-                return logicalRowExpressions.or(resultDisjunct.build());
+                return LogicalRowExpressions.or(resultDisjunct.build());
             };
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -132,7 +132,7 @@ public class PlanNodeDecorrelator
             }
 
             RowExpression predicate = node.getPredicate();
-            Map<Boolean, List<RowExpression>> predicates = logicalRowExpressions.extractConjuncts(predicate).stream()
+            Map<Boolean, List<RowExpression>> predicates = LogicalRowExpressions.extractConjuncts(predicate).stream()
                     .collect(Collectors.partitioningBy(PlanNodeDecorrelator.DecorrelatingVisitor.this::isCorrelated));
             List<RowExpression> correlatedPredicates = ImmutableList.copyOf(predicates.get(true));
             List<RowExpression> uncorrelatedPredicates = ImmutableList.copyOf(predicates.get(false));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java
@@ -39,8 +39,8 @@ import static java.util.Objects.requireNonNull;
 public class JsonRenderer
         implements Renderer<String>
 {
-    private static JsonCodec<JsonRenderedNode> codec = JsonCodec.jsonCodec(JsonRenderedNode.class);
-    private static JsonCodec<Map<PlanFragmentId, JsonPlanFragment>> planMapCodec = JsonCodec.mapJsonCodec(PlanFragmentId.class, JsonPlanFragment.class);
+    private final JsonCodec<Map<PlanFragmentId, JsonPlanFragment>> planMapCodec;
+    private final JsonCodec<JsonRenderedNode> codec;
 
     public JsonRenderer(FunctionAndTypeManager functionAndTypeManager)
     {

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotBrokerPageSource.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotBrokerPageSource.java
@@ -182,7 +182,7 @@ public class TestPinotBrokerPageSource
                 new MockPinotClusterInfoFetcher(pinotConfig),
                 objectMapper,
                 PinotBrokerAuthenticationProvider.create(PinotEmptyAuthenticationProvider.instance()));
-        assertEquals(pageSource.getRequestPayload(generatedPinotQuery), "{\"sql\":\"SELECT * FROM myTable\"}");
+        assertEquals(PinotBrokerPageSource.getRequestPayload(generatedPinotQuery), "{\"sql\":\"SELECT * FROM myTable\"}");
 
         generatedPinotQuery = new PinotQueryGenerator.GeneratedPinotQuery(
                 pinotTable.getTableName(),
@@ -190,7 +190,7 @@ public class TestPinotBrokerPageSource
                 ImmutableList.of(),
                 false,
                 false);
-        assertEquals(pageSource.getRequestPayload(generatedPinotQuery), "{\"sql\":\"SELECT * FROM myTable WHERE jsonStr = '\\\"{\\\"abc\\\" : \\\"def\\\"}\\\"'\"}");
+        assertEquals(PinotBrokerPageSource.getRequestPayload(generatedPinotQuery), "{\"sql\":\"SELECT * FROM myTable WHERE jsonStr = '\\\"{\\\"abc\\\" : \\\"def\\\"}\\\"'\"}");
     }
 
     @Test(dataProvider = "sqlResponses")

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
@@ -178,7 +178,7 @@ public class TestTpcdsMetadataStatistics
 
         Entry<ColumnHandle, ColumnStatistics> entry = tableStatistics.getColumnStatistics().entrySet().iterator().next();
 
-        TableStatistics expectedTableStatistics = tableStatistics.builder()
+        TableStatistics expectedTableStatistics = TableStatistics.builder()
                 .setRowCount(tableStatistics.getRowCount())
                 .setColumnStatistics(entry.getKey(), entry.getValue())
                 .build();


### PR DESCRIPTION
## Description
Don't treat static members as instance memebrs

## Motivation and Context
This fixes an ugly race condition in JsonRenderer where different objects could overwrite each other's CODEC via shared static state. 

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

