### PR TITLE
Enable tests to fail

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -115,7 +115,7 @@ public class TestMetadataManager
             queryRunner.execute(sql);
             fail("expected exception");
         }
-        catch (Throwable t) {
+        catch (RuntimeException t) {
             // query should fail
         }
 


### PR DESCRIPTION
## Description
This is a bug pattern I haven't seen before. The AssertionError thrown by the fail method  was caught by an overly broad catch clause so the test couldn't fail. This wouldn't have happened with test first development.

## Motivation and Context
Tests should fail when broken

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

