### PR TITLE
[Native] Remove duplicate call to registerStatsCounters

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -218,7 +218,6 @@ void PrestoServer::run() {
     exit(EXIT_FAILURE);
   }
 
-  registerStatsCounters();
   registerFileSinks();
   registerFileSystems();
   registerMemoryArbitrators();

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -140,8 +140,6 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(
       kCounterMemoryCacheTotalPrefetchBytes, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
-      kCounterMemoryCacheTotalTinyPaddingBytes, facebook::velox::StatType::AVG);
-  DEFINE_METRIC(
       kCounterMemoryCacheSumEvictScore, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterMemoryCacheNumCumulativeHit, facebook::velox::StatType::AVG);


### PR DESCRIPTION
## Description
The startup flow registers the stats twice. I have retained the registerStatsCounter call in the context of `enableRuntimeMetrics` check, refer: https://github.com/prestodb/presto/blob/master/presto-native-execution/presto_cpp/main/PrestoServer.cpp#L1104.

Also removed double registration of this metric `kCounterMemoryCacheTotalTinyPaddingBytes`.



