### PR TITLE
Fix cte filter pushdown wrong results by splitting SpecialFormExpressions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
@@ -31,6 +31,7 @@ import com.facebook.presto.sql.planner.RowExpressionVariableInliner;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.VariablesExtractor;
+import com.facebook.presto.sql.planner.iterative.rule.SimplifyRowExpressions;
 import com.facebook.presto.sql.planner.plan.SequenceNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.google.common.collect.ImmutableList;
@@ -48,7 +49,6 @@ import java.util.stream.Collectors;
 import static com.facebook.presto.SystemSessionProperties.getCteFilterAndProjectionPushdownEnabled;
 import static com.facebook.presto.SystemSessionProperties.isCteMaterializationApplicable;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
 import static com.facebook.presto.sql.planner.PlannerUtils.isConstant;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.facebook.presto.sql.relational.Expressions.constant;
@@ -370,14 +370,21 @@ public class CteProjectionAndPredicatePushDown
                 return node;
             }
 
-            RowExpression predicate;
+            RowExpression resultPredicate;
             if (predicates.size() == 1) {
-                predicate = predicates.get(0);
+                resultPredicate = predicates.get(0);
             }
             else {
-                predicate = new SpecialFormExpression(OR, BOOLEAN, predicates);
+                resultPredicate = predicates.get(0);
+                for (int i = 1; i < predicates.size(); i++) {
+                    resultPredicate = new SpecialFormExpression(
+                            SpecialFormExpression.Form.OR,
+                            BOOLEAN,
+                            resultPredicate, predicates.get(i));
+                }
             }
-            return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), node, predicate);
+            resultPredicate = SimplifyRowExpressions.rewrite(resultPredicate, metadata, session.toConnectorSession());
+            return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), node, resultPredicate);
         }
 
         private boolean isConstTrue(List<RowExpression> predicates)


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Fixes #22147. This is needed  due to a bug in SpecialFormExpressions #22698 if > 2 conditions are used.
Also simplified the extra filters so that predicatePushdown optimizer could push down the conditions further 


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix wrong results when queries using materialized CTEs have multiple common filters pushed into the CTE :pr:`22700 `

```
