### PR TITLE
Also check for Presto Native operator names in QueryStats.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQueryFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQueryFactory.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.AnalyzerProvider;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.tracing.NoopTracerProvider;
 import com.facebook.presto.tracing.QueryStateTracingListener;
 import com.facebook.presto.transaction.TransactionManager;
@@ -65,6 +66,8 @@ public class LocalDispatchQueryFactory
 
     private final QueryPrerequisitesManager queryPrerequisitesManager;
 
+    private final FeaturesConfig featuresConfig;
+
     /**
      * Instantiates a new Local dispatch query factory.
      *
@@ -78,6 +81,7 @@ public class LocalDispatchQueryFactory
      * @param clusterSizeMonitor the cluster size monitor
      * @param dispatchExecutor the dispatch executor
      * @param queryPrerequisitesManager the query prerequisites manager
+     * @param featuresConfig the features config
      */
     @Inject
     public LocalDispatchQueryFactory(
@@ -90,7 +94,8 @@ public class LocalDispatchQueryFactory
             ExecutionFactoriesManager executionFactoriesManager,
             ClusterSizeMonitor clusterSizeMonitor,
             DispatchExecutor dispatchExecutor,
-            QueryPrerequisitesManager queryPrerequisitesManager)
+            QueryPrerequisitesManager queryPrerequisitesManager,
+            FeaturesConfig featuresConfig)
     {
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -104,6 +109,7 @@ public class LocalDispatchQueryFactory
 
         this.executor = requireNonNull(dispatchExecutor, "executorService is null").getExecutor();
         this.queryPrerequisitesManager = requireNonNull(queryPrerequisitesManager, "queryPrerequisitesManager is null");
+        this.featuresConfig = requireNonNull(featuresConfig, "featuresConfig is null");
     }
 
     /**
@@ -153,7 +159,8 @@ public class LocalDispatchQueryFactory
                 accessControl,
                 executor,
                 metadata,
-                warningCollector);
+                warningCollector,
+                featuresConfig.isNativeExecutionEnabled());
 
         stateMachine.addStateChangeListener(new QueryStateTracingListener(stateMachine.getSession().getTracer().orElse(NoopTracerProvider.NOOP_TRACER)));
         queryMonitor.queryCreatedEvent(stateMachine.getBasicQueryInfo(Optional.empty()));

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -79,6 +79,7 @@ import com.facebook.presto.server.remotetask.HttpRemoteTaskFactory;
 import com.facebook.presto.server.remotetask.RemoteTaskStats;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.security.SelectedRole;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanOptimizers;
@@ -195,6 +196,7 @@ public class CoordinatorModule
         newExporter(binder).export(DispatchExecutor.class).withGeneratedName();
 
         // local dispatcher
+        configBinder(binder).bindConfig(FeaturesConfig.class);
         binder.bind(DispatchQueryFactory.class).to(LocalDispatchQueryFactory.class);
 
         // cluster memory manager

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -224,6 +224,7 @@ public final class TaskTestUtils
                 new AllowAllAccessControl(),
                 executor,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
@@ -143,7 +143,8 @@ public class TestCreateMaterializedViewTask
                 accessControl,
                 executorService,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
         WarningCollector warningCollector = stateMachine.getWarningCollector();
         CreateMaterializedViewTask createMaterializedViewTask = new CreateMaterializedViewTask(parser);
         getFutureValue(createMaterializedViewTask.execute(statement, transactionManager, metadata, accessControl, testSession, emptyList(), warningCollector));
@@ -170,7 +171,8 @@ public class TestCreateMaterializedViewTask
                 accessControl,
                 executorService,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
         WarningCollector warningCollector = stateMachine.getWarningCollector();
         try {
             getFutureValue(new CreateMaterializedViewTask(parser).execute(statement, transactionManager, metadata, accessControl, testSession, emptyList(), warningCollector));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -640,7 +640,8 @@ public class TestQueryStateMachine
                 executor,
                 ticker,
                 metadata,
-                WarningCollector.NOOP);
+                WarningCollector.NOOP,
+                false);
         stateMachine.setInputs(INPUTS);
         stateMachine.setOutput(OUTPUT);
         stateMachine.setColumns(OUTPUT_FIELD_NAMES, OUTPUT_FIELD_TYPES);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -393,7 +393,7 @@ public class TestQueryStats
         List<StageInfo> allStages = StageInfo.getAllStages(rootStage);
         QueryStats queryStats = QueryStats.create(new QueryStateTimer(new TestingTicker()), rootStage, allStages, 0,
                 succinctBytes(0L), succinctBytes(0L), succinctBytes(0L), succinctBytes(0L), succinctBytes(0L),
-                new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1))));
+                new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1))), false);
 
         assertEquals(queryStats.getRawInputDataSize().toBytes(), 8620);
         assertEquals(queryStats.getRawInputPositions(), 150);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -296,7 +296,8 @@ public class PrestoSparkQueryExecutionFactory
             Optional<ExecutionFailureInfo> failureInfo,
             QueryStateTimer queryStateTimer,
             Optional<StageInfo> rootStage,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            boolean isNativeExecutionEnabled)
     {
         checkArgument(failureInfo.isPresent() || queryState != FAILED, "unexpected query state: %s", queryState);
 
@@ -335,7 +336,8 @@ public class PrestoSparkQueryExecutionFactory
                 succinctBytes(peakTaskUserMemoryInBytes),
                 succinctBytes(peakTaskTotalMemoryInBytes),
                 succinctBytes(peakNodeTotalMemoryInBytes),
-                session.getRuntimeStats());
+                session.getRuntimeStats(),
+                isNativeExecutionEnabled);
 
         Optional<PrestoSparkExecutionContext> prestoSparkExecutionContext = Optional.empty();
         if (planAndMore.isPresent()) {
@@ -654,7 +656,8 @@ public class PrestoSparkQueryExecutionFactory
                             Optional.empty(),
                             queryStateTimer,
                             Optional.empty(),
-                            warningCollector)));
+                            warningCollector,
+                            featuresConfig.isNativeExecutionEnabled())));
 
             // including queueing time
             Duration queryMaxRunTime = getQueryMaxRunTime(session);
@@ -805,7 +808,8 @@ public class PrestoSparkQueryExecutionFactory
                         failureInfo,
                         queryStateTimer,
                         Optional.empty(),
-                        warningCollector);
+                        warningCollector,
+                        featuresConfig.isNativeExecutionEnabled());
                 queryMonitor.queryCompletedEvent(queryInfo);
                 if (queryStatusInfoOutputLocation.isPresent()) {
                     PrestoSparkQueryStatusInfo prestoSparkQueryStatusInfo = createPrestoSparkQueryInfo(

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
@@ -601,7 +601,8 @@ public abstract class AbstractPrestoSparkQueryExecution
                 failureInfo,
                 queryStateTimer,
                 stageInfoOptional,
-                warningCollector);
+                warningCollector,
+                featuresConfig.isNativeExecutionEnabled());
 
         queryMonitor.queryCompletedEvent(queryInfo);
         historyBasedPlanStatisticsTracker.updateStatistics(queryInfo);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -261,7 +261,8 @@ public class PrestoSparkAdaptiveQueryExecution
                         Optional.empty(),
                         queryStateTimer,
                         Optional.of(createStageInfo(session.getQueryId(), planFragmenter.fragmentQueryPlan(session, planAndMore.getPlan(), warningCollector), ImmutableList.of())),
-                        warningCollector));
+                        warningCollector,
+                        featuresConfig.isNativeExecutionEnabled()));
 
         IterativePlanFragmenter.PlanAndFragments planAndFragments = iterativePlanFragmenter.createReadySubPlans(this.planAndMore.getPlan().getRoot());
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkStaticQueryExecution.java
@@ -191,7 +191,8 @@ public class PrestoSparkStaticQueryExecution
                         Optional.empty(),
                         queryStateTimer,
                         Optional.of(createStageInfo(session.getQueryId(), rootFragmentedPlan, ImmutableList.of())),
-                        warningCollector));
+                        warningCollector,
+                        featuresConfig.isNativeExecutionEnabled()));
 
         log.info(textDistributedPlan(rootFragmentedPlan, metadata.getFunctionAndTypeManager(), session, true));
         int hashPartitionCount = planAndMore.getPhysicalResourceSettings().getHashPartitionCount();


### PR DESCRIPTION
Presto Native operator names are different.

## Description
To properly report 'shuffled' and 'raw input' query stats when running Presto Native, we also check Presto Native operator names.

```
== NO RELEASE NOTE ==
```