### PR TITLE
[native]Add io throttling configs to tune remote io

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -224,6 +224,8 @@ SystemConfig::SystemConfig() {
           STR_PROP(kCacheVeloxTtlThreshold, "2d"),
           STR_PROP(kCacheVeloxTtlCheckInterval, "1h"),
           BOOL_PROP(kEnableRuntimeMetricsCollection, false),
+          NUM_PROP(kIoMinBackoffTimeMs, 200),
+          NUM_PROP(kIoMaxBackoffTimeMs, 30'000),
       };
 }
 
@@ -625,6 +627,18 @@ std::chrono::duration<double> SystemConfig::cacheVeloxTtlCheckInterval() const {
 
 bool SystemConfig::enableRuntimeMetricsCollection() const {
   return optionalProperty<bool>(kEnableRuntimeMetricsCollection).value();
+}
+
+uint64_t SystemConfig::ioMinBackoffTimeMs() const {
+  static constexpr uint64_t kIoMinBackoffTimeMsDefault = {200}; // 200 ms.
+  return optionalProperty<uint64_t>(kIoMinBackoffTimeMs)
+      .value_or(kIoMinBackoffTimeMsDefault);
+}
+
+uint64_t SystemConfig::ioMaxBackoffTimeMs() const {
+  static constexpr uint64_t kIoMaxBackoffTimeMsDefault = {30'000}; // 30 secs.
+  return optionalProperty<uint64_t>(kIoMaxBackoffTimeMs)
+      .value_or(kIoMaxBackoffTimeMsDefault);
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -517,6 +517,15 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kDriverMaxPagePartitioningBufferSize{
       "driver.max-page-partitioning-buffer-size"};
 
+  /// The minimal delay to be injected upon io throttling signals from remote
+  /// storage.
+  static constexpr std::string_view kIoMinBackoffTimeMs{
+      "io.throttle.min-backoff-time-ms"};
+  /// The maximal delay to be injected upon io throttling signals from remote
+  /// storage.
+  static constexpr std::string_view kIoMaxBackoffTimeMs{
+      "io.throttle.max-backoff-time-ms"};
+
   SystemConfig();
 
   virtual ~SystemConfig() = default;
@@ -710,6 +719,9 @@ class SystemConfig : public ConfigBase {
   std::chrono::duration<double> cacheVeloxTtlCheckInterval() const;
 
   bool enableRuntimeMetricsCollection() const;
+
+  uint64_t ioMinBackoffTimeMs() const;
+  uint64_t ioMaxBackoffTimeMs() const;
 };
 
 /// Provides access to node properties defined in node.properties file.


### PR DESCRIPTION
This used to control backoff on remote storage io congestion. We will use it for Meta internally.

