### PR TITLE
[WIP] Optimize split generation

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileInfo.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileInfo.java
@@ -18,7 +18,6 @@ import com.facebook.drift.annotations.ThriftField;
 import com.facebook.drift.annotations.ThriftStruct;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.fs.LocatedFileStatus;
-import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 public class HiveFileInfo
         implements Comparable
 {
-    private final Path path;
+    private final String path;
     private final boolean isDirectory;
     private final List<BlockLocation> blockLocations;
     private final long length;
@@ -74,7 +73,7 @@ public class HiveFileInfo
             Optional<byte[]> extraFileInfo,
             Map<String, String> customSplitInfo)
     {
-        this.path = new Path(requireNonNull(pathString, "pathString is null"));
+        this.path = requireNonNull(pathString, "pathString is null");
         this.isDirectory = directory;
         this.blockLocations = requireNonNull(blockLocations, "blockLocations is null");
         this.length = length;
@@ -84,9 +83,9 @@ public class HiveFileInfo
     }
 
     @ThriftField(1)
-    public String getPathString()
+    public String getPath()
     {
-        return path.toString();
+        return path;
     }
 
     @ThriftField(2)
@@ -123,11 +122,6 @@ public class HiveFileInfo
     public Map<String, String> getCustomSplitInfo()
     {
         return customSplitInfo;
-    }
-
-    public Path getPath()
-    {
-        return path;
     }
 
     @Override
@@ -169,5 +163,10 @@ public class HiveFileInfo
     {
         HiveFileInfo other = (HiveFileInfo) o;
         return this.getPath().compareTo(other.getPath());
+    }
+
+    public String getFileName()
+    {
+        return path.substring(path.lastIndexOf('/') + 1);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
@@ -73,10 +72,10 @@ public final class HiveBucketing
 
     private HiveBucketing() {}
 
-    public static int getVirtualBucketNumber(int bucketCount, Path path)
+    public static int getVirtualBucketNumber(int bucketCount, String path)
     {
         // this is equivalent to bucketing the table on a VARCHAR column containing $path
-        return (hashBytes(0, utf8Slice(path.toString())) & Integer.MAX_VALUE) % bucketCount;
+        return (hashBytes(0, utf8Slice(path)) & Integer.MAX_VALUE) % bucketCount;
     }
 
     public static int getBucket(int bucketCount, List<Type> types, Page page, int position)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
@@ -16,17 +16,13 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.spi.ColumnHandle;
-import com.facebook.presto.spi.PrestoException;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
 import static java.util.Objects.requireNonNull;
 
@@ -39,7 +35,7 @@ public class HiveSplitPartitionInfo
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(HiveSplitPartitionInfo.class).instanceSize();
 
     private final Storage storage;
-    private final URI path;
+    private final String path;
     private final List<HivePartitionKey> partitionKeys;
     private final String partitionName;
     private final int partitionDataColumnCount;
@@ -53,7 +49,7 @@ public class HiveSplitPartitionInfo
 
     HiveSplitPartitionInfo(
             Storage storage,
-            URI path,
+            String path,
             List<HivePartitionKey> partitionKeys,
             String partitionName,
             int partitionDataColumnCount,
@@ -86,17 +82,12 @@ public class HiveSplitPartitionInfo
     // and Java URI has a bug where a.resolve(a.relativize(b))
     // doesn't equal 'b' if 'a' had any components after the last slash
     // https://bugs.openjdk.java.net/browse/JDK-6523089
-    private static URI ensurePathHasTrailingSlash(URI path)
+    private static String ensurePathHasTrailingSlash(String path)
     {
         // since this is the partition path, it's always a directory.
         // it's safe to add a trailing slash
-        if (!path.getPath().endsWith("/")) {
-            try {
-                path = new URI(path.toString() + "/");
-            }
-            catch (URISyntaxException e) {
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
-            }
+        if (!path.endsWith("/")) {
+            return path + "/";
         }
         return path;
     }
@@ -164,7 +155,7 @@ public class HiveSplitPartitionInfo
         return references.decrementAndGet();
     }
 
-    public URI getPath()
+    public String getPath()
     {
         return path;
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -326,7 +326,7 @@ public final class HiveUtil
         configuration.setBoolean(READ_ALL_COLUMNS, false);
     }
 
-    public static Optional<CompressionCodec> getCompressionCodec(TextInputFormat inputFormat, Path file)
+    public static Optional<CompressionCodec> getCompressionCodec(TextInputFormat inputFormat, String file)
     {
         CompressionCodecFactory compressionCodecFactory;
 
@@ -341,7 +341,7 @@ public final class HiveUtil
             return Optional.empty();
         }
 
-        return Optional.ofNullable(compressionCodecFactory.getCodec(file));
+        return Optional.ofNullable(compressionCodecFactory.getCodec(new Path(file)));
     }
 
     public static InputFormat<?, ?> getInputFormat(Configuration configuration, String inputFormatName, boolean symlinkTarget)
@@ -440,7 +440,7 @@ public final class HiveUtil
         return HIVE_TIMESTAMP_PARSER.withZone(timeZone).parseMillis(value);
     }
 
-    public static boolean isSplittable(InputFormat<?, ?> inputFormat, FileSystem fileSystem, Path path)
+    public static boolean isSplittable(InputFormat<?, ?> inputFormat, FileSystem fileSystem, String path)
     {
         if ("OrcInputFormat".equals(inputFormat.getClass().getSimpleName()) ||
                 "RCFileInputFormat".equals(inputFormat.getClass().getSimpleName())) {
@@ -463,14 +463,14 @@ public final class HiveUtil
         }
         try {
             method.setAccessible(true);
-            return (boolean) method.invoke(inputFormat, fileSystem, path);
+            return (boolean) method.invoke(inputFormat, fileSystem, new Path(path));
         }
         catch (InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static boolean isSelectSplittable(InputFormat<?, ?> inputFormat, Path path, boolean s3SelectPushdownEnabled)
+    public static boolean isSelectSplittable(InputFormat<?, ?> inputFormat, String path, boolean s3SelectPushdownEnabled)
     {
         // S3 Select supports splitting for uncompressed CSV & JSON files
         // Previous checks for supported input formats, SerDes, column types and S3 path
@@ -478,7 +478,7 @@ public final class HiveUtil
         return !s3SelectPushdownEnabled || isUncompressed(inputFormat, path);
     }
 
-    private static boolean isUncompressed(InputFormat<?, ?> inputFormat, Path path)
+    private static boolean isUncompressed(InputFormat<?, ?> inputFormat, String path)
     {
         if (inputFormat instanceof TextInputFormat) {
             return !getCompressionCodec((TextInputFormat) inputFormat, path).isPresent();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -158,7 +158,8 @@ public class ManifestPartitionLoader
                 .map(p -> p.getColumns().size())
                 .orElse(table.getDataColumns().size());
         List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition(), partitionName);
-        Path path = new Path(getPartitionLocation(table, partition.getPartition()));
+        String location = getPartitionLocation(table, partition.getPartition());
+        Path path = new Path(location);
         Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
         InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);
         ExtendedFileSystem fileSystem = hdfsEnvironment.getFileSystem(hdfsContext, path);
@@ -172,7 +173,7 @@ public class ManifestPartitionLoader
                 false,
                 new HiveSplitPartitionInfo(
                         storage,
-                        path.toUri(),
+                        location,
                         partitionKeys,
                         partitionName,
                         partitionDataColumnCount,
@@ -199,7 +200,7 @@ public class ManifestPartitionLoader
         int fileCount = 0;
         while (fileInfoIterator.hasNext()) {
             HiveFileInfo fileInfo = fileInfoIterator.next();
-            String fileName = fileInfo.getPath().getName();
+            String fileName = fileInfo.getFileName();
             if (!manifestFileNames.contains(fileName)) {
                 throw new PrestoException(
                         MALFORMED_HIVE_FILE_STATISTICS,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3select/S3SelectPushdown.java
@@ -19,7 +19,6 @@ import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.spi.ConnectorSession;
 import com.google.common.collect.ImmutableSet;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.hadoop.io.compress.BZip2Codec;
 import org.apache.hadoop.io.compress.GzipCodec;
@@ -87,7 +86,7 @@ public class S3SelectPushdown
         return SUPPORTED_INPUT_FORMATS.contains(inputFormat);
     }
 
-    public static boolean isCompressionCodecSupported(InputFormat inputFormat, Path path)
+    public static boolean isCompressionCodecSupported(InputFormat inputFormat, String path)
     {
         if (inputFormat instanceof TextInputFormat) {
             return getCompressionCodec((TextInputFormat) inputFormat, path)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/ParquetQuickStatsBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/ParquetQuickStatsBuilder.java
@@ -323,7 +323,7 @@ public class ParquetQuickStatsBuilder
         while (files.hasNext()) {
             HiveFileInfo file = files.next();
             filesCount++;
-            Path path = file.getPath();
+            Path path = new Path(file.getPath());
             long fileSize = file.getLength();
 
             HiveFileContext hiveFileContext = new HiveFileContext(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
@@ -66,7 +66,7 @@ public class HiveFileIterator
                 HiveFileInfo fileInfo = getLocatedFileStatus(remoteIterator);
 
                 // Ignore hidden files and directories. Hive ignores files starting with _ and . as well.
-                String fileName = fileInfo.getPath().getName();
+                String fileName = fileInfo.getFileName();
                 if (fileName.startsWith("_") || fileName.startsWith(".")) {
                     continue;
                 }
@@ -76,7 +76,7 @@ public class HiveFileIterator
                         case IGNORED:
                             continue;
                         case RECURSE:
-                            paths.add(fileInfo.getPath());
+                            paths.add(new Path(fileInfo.getPath()));
                             continue;
                         case FAIL:
                             throw new NestedDirectoryNotAllowedException();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.DataSize;
-import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.time.Instant;
@@ -609,7 +608,7 @@ public class TestHiveSplitSource
                                     false,
                                     ImmutableMap.of(),
                                     ImmutableMap.of()),
-                            new Path("path").toUri(),
+                            "path",
                             ImmutableList.of(),
                             "partition-name",
                             id,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
@@ -127,7 +127,7 @@ public class TestHudiDirectoryLister
                     new RuntimeStats()));
             assertTrue(fileInfoIterator.hasNext());
             HiveFileInfo fileInfo = fileInfoIterator.next();
-            assertEquals(fileInfo.getPath().getName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");
+            assertEquals(fileInfo.getFileName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");
         }
         finally {
             hadoopConf = null;
@@ -154,7 +154,7 @@ public class TestHudiDirectoryLister
                     new RuntimeStats()));
             assertTrue(fileInfoIterator.hasNext());
             HiveFileInfo fileInfo = fileInfoIterator.next();
-            assertEquals(fileInfo.getPath().getName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");
+            assertEquals(fileInfo.getFileName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");
         }
         finally {
             hadoopConf = null;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3select/TestS3SelectPushdown.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3select/TestS3SelectPushdown.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
@@ -95,11 +94,11 @@ public class TestS3SelectPushdown
     @Test
     public void testIsCompressionCodecSupported()
     {
-        assertTrue(S3SelectPushdown.isCompressionCodecSupported(inputFormat, new Path("s3://fakeBucket/fakeObject.gz")));
-        assertTrue(S3SelectPushdown.isCompressionCodecSupported(inputFormat, new Path("s3://fakeBucket/fakeObject")));
-        assertFalse(S3SelectPushdown.isCompressionCodecSupported(inputFormat, new Path("s3://fakeBucket/fakeObject.lz4")));
-        assertFalse(S3SelectPushdown.isCompressionCodecSupported(inputFormat, new Path("s3://fakeBucket/fakeObject.snappy")));
-        assertTrue(S3SelectPushdown.isCompressionCodecSupported(inputFormat, new Path("s3://fakeBucket/fakeObject.bz2")));
+        assertTrue(S3SelectPushdown.isCompressionCodecSupported(inputFormat, "s3://fakeBucket/fakeObject.gz"));
+        assertTrue(S3SelectPushdown.isCompressionCodecSupported(inputFormat, "s3://fakeBucket/fakeObject"));
+        assertFalse(S3SelectPushdown.isCompressionCodecSupported(inputFormat, "s3://fakeBucket/fakeObject.lz4"));
+        assertFalse(S3SelectPushdown.isCompressionCodecSupported(inputFormat, "s3://fakeBucket/fakeObject.snappy"));
+        assertTrue(S3SelectPushdown.isCompressionCodecSupported(inputFormat, "s3://fakeBucket/fakeObject.bz2"));
     }
 
     @Test
@@ -196,20 +195,20 @@ public class TestS3SelectPushdown
     public void testShouldEnableSplits()
     {
         // Uncompressed CSV
-        assertTrue(isSelectSplittable(inputFormat, new Path("s3://fakeBucket/fakeObject.csv"), true));
+        assertTrue(isSelectSplittable(inputFormat, "s3://fakeBucket/fakeObject.csv", true));
         // Pushdown disabled
-        assertTrue(isSelectSplittable(inputFormat, new Path("s3://fakeBucket/fakeObject.csv"), false));
-        assertTrue(isSelectSplittable(inputFormat, new Path("s3://fakeBucket/fakeObject.json"), false));
-        assertTrue(isSelectSplittable(inputFormat, new Path("s3://fakeBucket/fakeObject.gz"), false));
-        assertTrue(isSelectSplittable(inputFormat, new Path("s3://fakeBucket/fakeObject.bz2"), false));
+        assertTrue(isSelectSplittable(inputFormat, "s3://fakeBucket/fakeObject.csv", false));
+        assertTrue(isSelectSplittable(inputFormat, "s3://fakeBucket/fakeObject.json", false));
+        assertTrue(isSelectSplittable(inputFormat, "s3://fakeBucket/fakeObject.gz", false));
+        assertTrue(isSelectSplittable(inputFormat, "s3://fakeBucket/fakeObject.bz2", false));
     }
 
     @Test
     public void testShouldNotEnableSplits()
     {
         // Compressed files
-        assertFalse(isSelectSplittable(inputFormat, new Path("s3://fakeBucket/fakeObject.gz"), true));
-        assertFalse(isSelectSplittable(inputFormat, new Path("s3://fakeBucket/fakeObject.bz2"), true));
+        assertFalse(isSelectSplittable(inputFormat, "s3://fakeBucket/fakeObject.gz", true));
+        assertFalse(isSelectSplittable(inputFormat, "s3://fakeBucket/fakeObject.bz2", true));
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
Avoid creating expensive Hadoop Path objects

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

