### PR TITLE
[native] Introduce lastCoordinatorHeartbeatMs to PrestoTask.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -282,12 +282,29 @@ void PrestoTask::updateHeartbeatLocked() {
   info.lastHeartbeat = util::toISOTimestamp(lastHeartbeatMs);
 }
 
+void PrestoTask::updateCoordinatorHeartbeat() {
+  std::lock_guard<std::mutex> l(mutex);
+  updateCoordinatorHeartbeatLocked();
+}
+
+void PrestoTask::updateCoordinatorHeartbeatLocked() {
+  lastCoordinatorHeartbeatMs = velox::getCurrentTimeMs();
+}
+
 uint64_t PrestoTask::timeSinceLastHeartbeatMs() const {
   std::lock_guard<std::mutex> l(mutex);
   if (lastHeartbeatMs == 0UL) {
     return 0UL;
   }
   return getCurrentTimeMs() - lastHeartbeatMs;
+}
+
+uint64_t PrestoTask::timeSinceLastCoordinatorHeartbeatMs() const {
+  std::lock_guard<std::mutex> l(mutex);
+  if (lastCoordinatorHeartbeatMs == 0UL) {
+    return 0UL;
+  }
+  return getCurrentTimeMs() - lastCoordinatorHeartbeatMs;
 }
 
 void PrestoTask::recordProcessCpuTime() {

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -171,7 +171,7 @@ class TaskManager {
   // coordinator for a considerable time.
   void cancelAbandonedTasks();
 
-  std::unique_ptr<protocol::TaskInfo> createOrUpdateTask(
+  std::unique_ptr<protocol::TaskInfo> createOrUpdateTaskImpl(
       const protocol::TaskId& taskId,
       const velox::core::PlanFragment& planFragment,
       const std::vector<protocol::TaskSource>& sources,

--- a/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
@@ -14,6 +14,7 @@
 #include "presto_cpp/main/PrestoTask.h"
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/time/Timer.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 
@@ -63,4 +64,15 @@ TEST_F(PrestoTaskTest, runtimeMetricConversion) {
   EXPECT_EQ(veloxMetric.count, prestoMetric.count);
   EXPECT_EQ(veloxMetric.max, prestoMetric.max);
   EXPECT_EQ(veloxMetric.min, prestoMetric.min);
+}
+
+TEST_F(PrestoTaskTest, basic) {
+  PrestoTask task{"20201107_130540_00011_wrpkw.1.2.3.4", "node2", 0};
+
+  // Test coordinator heartbeat.
+  EXPECT_EQ(task.timeSinceLastCoordinatorHeartbeatMs(), 0);
+  task.updateCoordinatorHeartbeat();
+  /* sleep override */
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_GE(task.timeSinceLastCoordinatorHeartbeatMs(), 100);
 }


### PR DESCRIPTION
## Description
Right now we use 'lastHeartbeatMs' to determine if a Task has been abandoned by
the Coordinator (Coordinator restarted or crashed or anyhow gone).

This does not work too well, as 'lastHeartbeatMs' is updated on every message to the Task.
Including 'getResults', which workers send to each other and refreshing it.
As the result, the Tasks get abandoned in waves, starting from stage 0, then stage 1, etc.
A large number of stages is possible and with the timeout is 1-3 minutes, that can cause
a large waiting time after the Coordinator long gone.

The new 'lastCoordinatorHeartbeatMs' is only updated by the messages sent by the
Coordinator, which results in all Tasks being cancelled at the same time after just single
timeout period.
It is used to determine if Coordinator has abandoned the Task.

## Motivation and Context
Get rid of the Tasks, which were abandoned by the Coordinator, instead of leaving them
running forever.

## Test Plan
Orchestrated the restart in the cluster with a long running query.
Observed prompt restart of the workers compared with the previous version.

```
== NO RELEASE NOTE ==
```

