### PR TITLE
Use separate ValuesWriterFactory instances for non-default page options when creating ParquetWriter

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
@@ -21,8 +21,8 @@ import static java.util.Objects.requireNonNull;
 
 public class ParquetWriterOptions
 {
-    private static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.valueOf("128MB");
-    private static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.valueOf("1MB");
+    protected static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.valueOf("128MB");
+    protected static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.valueOf("1MB");
     public static final WriterVersion DEFAULT_WRITER_VERSION = WriterVersion.PARQUET_2_0;
 
     public static ParquetWriterOptions.Builder builder()

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriters.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriters.java
@@ -33,7 +33,11 @@ import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.factory.DefaultV1ValuesWriterFactory;
+import org.apache.parquet.column.values.factory.DefaultV2ValuesWriterFactory;
+import org.apache.parquet.column.values.factory.ValuesWriterFactory;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
@@ -60,6 +64,18 @@ import static java.util.Objects.requireNonNull;
 class ParquetWriters
 {
     private ParquetWriters() {}
+
+    static ValuesWriterFactory getValuesWriterFactory(WriterVersion writerVersion)
+    {
+        switch (writerVersion) {
+            case PARQUET_1_0:
+                return new DefaultV1ValuesWriterFactory();
+            case PARQUET_2_0:
+                return new DefaultV2ValuesWriterFactory();
+            default:
+                throw new PrestoException(NOT_SUPPORTED, format("Unsupported Parquet writer version: %s", writerVersion));
+        }
+    }
 
     static List<ColumnWriter> getColumnWriters(MessageType messageType, Map<List<String>, Type> prestoTypes, ParquetProperties parquetProperties, CompressionCodecName compressionCodecName)
     {


### PR DESCRIPTION
Fix #22130

## Description

The sharing of a single `ValuesWriterFactory` among multiple `ParquetProperties` instances with different write options is not thread-safe and may lead to inconsistency issues.

This PR set a new separate `ValuesWriterFactory` instance into `ParquetProperties` on its creation when using a non-default writer options, so that it could work well in multi-thread environment.

## Test Plan

 - Make sure this change do not affect existing test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

