### PR TITLE
[native] Fix protocol::FileFormat::ORC mapping to use dwio::common::FileFormat::ORC

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
@@ -88,7 +88,7 @@ dwio::common::FileFormat toVeloxFileFormat(
 dwio::common::FileFormat toVeloxFileFormat(
     const presto::protocol::FileFormat format) {
   if (format == protocol::FileFormat::ORC) {
-    return dwio::common::FileFormat::DWRF;
+    return dwio::common::FileFormat::ORC;
   } else if (format == protocol::FileFormat::PARQUET) {
     return dwio::common::FileFormat::PARQUET;
   }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Iceberg's ORC format should be mapped to Velox's ORC format, not the DWRF format.

Because the open source Velox does not currently support reading ORC files (some adaptation is required), adding tests to read ORC will fail on the native side. So I didn't add the test to read ORC.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

