### PR TITLE
Add property to skip empty files in Hive Connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -195,6 +195,9 @@ Property Name                                      Description                  
                                                    S3SelectPushdown.
 
 ``hive.metastore.load-balancing-enabled``          Enable load balancing between multiple Metastore instances
+
+``hive.skip-empty-files``                          Enable skipping empty files. Otherwise, it will produce an   ``false``
+                                                   error iterating through these files.
 ================================================== ============================================================ ============
 
 Metastore Configuration Properties

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -197,7 +197,7 @@ Property Name                                      Description                  
 ``hive.metastore.load-balancing-enabled``          Enable load balancing between multiple Metastore instances
 
 ``hive.skip-empty-files``                          Enable skipping empty files. Otherwise, it will produce an   ``false``
-                                                   error iterating through these files.
+                                                   error iterating through empty files.
 ================================================== ============================================================ ============
 
 Metastore Configuration Properties

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HadoopDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HadoopDirectoryLister.java
@@ -44,7 +44,8 @@ public class HadoopDirectoryLister
                 path,
                 p -> new HadoopFileInfoIterator(fileSystem.listLocatedStatus(p)),
                 namenodeStats,
-                hiveDirectoryContext.getNestedDirectoryPolicy());
+                hiveDirectoryContext.getNestedDirectoryPolicy(),
+                hiveDirectoryContext.isSkipEmptyFilesEnabled());
     }
 
     public static class HadoopFileInfoIterator

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -205,6 +205,8 @@ public class HiveClientConfig
 
     private boolean partitionFilteringFromMetastoreEnabled = true;
 
+    private boolean skipEmptyFiles;
+
     private boolean parallelParsingOfPartitionValuesEnabled;
     private int maxParallelParsingConcurrency = 100;
     private boolean quickStatsEnabled;
@@ -1831,5 +1833,18 @@ public class HiveClientConfig
     {
         this.affinitySchedulingFileSectionSize = affinitySchedulingFileSectionSize;
         return this;
+    }
+
+    @Config("hive.skip-empty-files")
+    @ConfigDescription("Enables skip of parquet empty files avoiding output error")
+    public HiveClientConfig setSkipEmptyFilesEnabled(boolean parallelParsingOfPartitionValuesEnabled)
+    {
+        this.skipEmptyFiles = parallelParsingOfPartitionValuesEnabled;
+        return this;
+    }
+
+    public boolean isSkipEmptyFilesEnabled()
+    {
+        return this.skipEmptyFiles;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -1836,10 +1836,10 @@ public class HiveClientConfig
     }
 
     @Config("hive.skip-empty-files")
-    @ConfigDescription("Enables skip of parquet empty files avoiding output error")
-    public HiveClientConfig setSkipEmptyFilesEnabled(boolean parallelParsingOfPartitionValuesEnabled)
+    @ConfigDescription("Enables skip of empty files avoiding output error")
+    public HiveClientConfig setSkipEmptyFilesEnabled(boolean skipEmptyFiles)
     {
-        this.skipEmptyFiles = parallelParsingOfPartitionValuesEnabled;
+        this.skipEmptyFiles = skipEmptyFiles;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
@@ -28,10 +28,12 @@ public class HiveDirectoryContext
     private final Map<String, String> additionalProperties;
     private final RuntimeStats runtimeStats;
     private boolean cacheable;
+    private boolean skipEmptyFiles;
 
     public HiveDirectoryContext(
             NestedDirectoryPolicy nestedDirectoryPolicy,
             boolean cacheable,
+            boolean skipEmptyFiles,
             ConnectorIdentity connectorIdentity,
             Map<String, String> additionalProperties,
             RuntimeStats runtimeStats)
@@ -43,6 +45,7 @@ public class HiveDirectoryContext
 
         // this can be disabled
         this.cacheable = cacheable;
+        this.skipEmptyFiles = skipEmptyFiles;
     }
 
     public NestedDirectoryPolicy getNestedDirectoryPolicy()
@@ -68,6 +71,11 @@ public class HiveDirectoryContext
     public Map<String, String> getAdditionalProperties()
     {
         return additionalProperties;
+    }
+
+    public boolean isSkipEmptyFilesEnabled()
+    {
+        return skipEmptyFiles;
     }
 
     public RuntimeStats getRuntimeStats()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -132,6 +132,7 @@ public final class HiveSessionProperties
     public static final String QUICK_STATS_BACKGROUND_BUILD_TIMEOUT = "quick_stats_background_build_timeout";
     public static final String DYNAMIC_SPLIT_SIZES_ENABLED = "dynamic_split_sizes_enabled";
     public static final String AFFINITY_SCHEDULING_FILE_SECTION_SIZE = "affinity_scheduling_file_section_size";
+    public static final String SKIP_EMPTY_FILES = "skip_empty_files";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -641,6 +642,11 @@ public final class HiveSessionProperties
                         AFFINITY_SCHEDULING_FILE_SECTION_SIZE,
                         "Size of file section for affinity scheduling",
                         hiveClientConfig.getAffinitySchedulingFileSectionSize(),
+                        false),
+                booleanProperty(
+                        SKIP_EMPTY_FILES,
+                        "If it is required empty files will be skipped",
+                        hiveClientConfig.isSkipEmptyFilesEnabled(),
                         false));
     }
 
@@ -1117,5 +1123,10 @@ public final class HiveSessionProperties
     public static DataSize getAffinitySchedulingFileSectionSize(ConnectorSession session)
     {
         return session.getProperty(AFFINITY_SCHEDULING_FILE_SECTION_SIZE, DataSize.class);
+    }
+
+    public static boolean isSkipEmptyFilesEnabled(ConnectorSession session)
+    {
+        return session.getProperty(SKIP_EMPTY_FILES, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HudiDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HudiDirectoryLister.java
@@ -98,7 +98,8 @@ public class HudiDirectoryLister
                         table.getStorage().getLocation(),
                         p),
                 namenodeStats,
-                hiveDirectoryContext.getNestedDirectoryPolicy());
+                hiveDirectoryContext.getNestedDirectoryPolicy(),
+                hiveDirectoryContext.isSkipEmptyFilesEnabled());
     }
 
     public static class HudiFileInfoIterator

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.hive.HiveManifestUtils.decompressFileSizes;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.isManifestVerificationEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isSkipEmptyFilesEnabled;
 import static com.facebook.presto.hive.HiveUtil.buildDirectoryContextProperties;
 import static com.facebook.presto.hive.HiveUtil.getInputFormat;
 import static com.facebook.presto.hive.NestedDirectoryPolicy.IGNORED;
@@ -191,6 +192,7 @@ public class ManifestPartitionLoader
         HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(
                 recursiveDirWalkerEnabled ? RECURSE : IGNORED,
                 false,
+                isSkipEmptyFilesEnabled(session),
                 hdfsContext.getIdentity(),
                 buildDirectoryContextProperties(session),
                 session.getRuntimeStats());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.hive.HiveMetadata.shouldCreateFilesForMissingB
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.isFileSplittable;
 import static com.facebook.presto.hive.HiveSessionProperties.isOrderBasedExecutionEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isSkipEmptyFilesEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
 import static com.facebook.presto.hive.HiveUtil.buildDirectoryContextProperties;
 import static com.facebook.presto.hive.HiveUtil.getFooterCount;
@@ -378,6 +379,7 @@ public class StoragePartitionLoader
         HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(
                 recursiveDirWalkerEnabled ? RECURSE : IGNORED,
                 cacheable,
+                isSkipEmptyFilesEnabled(session),
                 hdfsContext.getIdentity(),
                 buildDirectoryContextProperties(session),
                 session.getRuntimeStats());
@@ -410,6 +412,7 @@ public class StoragePartitionLoader
             Iterators.addAll(fileInfos, directoryLister.list(fileSystem, table, path, partition, namenodeStats, new HiveDirectoryContext(
                     FAIL,
                     isUseListDirectoryCache(session),
+                    isSkipEmptyFilesEnabled(session),
                     hdfsContext.getIdentity(),
                     buildDirectoryContextProperties(session),
                     session.getRuntimeStats())));
@@ -559,6 +562,7 @@ public class StoragePartitionLoader
         HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(
                 recursiveDirWalkerEnabled ? RECURSE : IGNORED,
                 isUseListDirectoryCache(session),
+                isSkipEmptyFilesEnabled(session),
                 hdfsContext.getIdentity(),
                 buildDirectoryContextProperties(session),
                 session.getRuntimeStats());
@@ -579,6 +583,7 @@ public class StoragePartitionLoader
             HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(
                     IGNORED,
                     isUseListDirectoryCache(session),
+                    isSkipEmptyFilesEnabled(session),
                     hdfsContext.getIdentity(),
                     buildDirectoryContextProperties(session),
                     session.getRuntimeStats());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/QuickStatsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/QuickStatsProvider.java
@@ -67,6 +67,7 @@ import static com.facebook.presto.hive.HivePartition.UNPARTITIONED_ID;
 import static com.facebook.presto.hive.HiveSessionProperties.getQuickStatsBackgroundBuildTimeout;
 import static com.facebook.presto.hive.HiveSessionProperties.getQuickStatsInlineBuildTimeout;
 import static com.facebook.presto.hive.HiveSessionProperties.isQuickStatsEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isSkipEmptyFilesEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
 import static com.facebook.presto.hive.HiveUtil.buildDirectoryContextProperties;
 import static com.facebook.presto.hive.NestedDirectoryPolicy.IGNORED;
@@ -329,7 +330,7 @@ public class QuickStatsProvider
 
         HdfsContext hdfsContext = new HdfsContext(session, table.getSchemaName(), table.getTableName(), partitionId, false);
         HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, isUseListDirectoryCache(session),
-                hdfsContext.getIdentity(), buildDirectoryContextProperties(session), session.getRuntimeStats());
+                isSkipEmptyFilesEnabled(session), hdfsContext.getIdentity(), buildDirectoryContextProperties(session), session.getRuntimeStats());
         ExtendedFileSystem fs;
         try {
             fs = hdfsEnvironment.getFileSystem(hdfsContext, path);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
@@ -43,6 +43,7 @@ public class HiveFileIterator
     private final ListDirectoryOperation listDirectoryOperation;
     private final NamenodeStats namenodeStats;
     private final NestedDirectoryPolicy nestedDirectoryPolicy;
+    private final boolean skipEmptyFiles;
 
     private Iterator<HiveFileInfo> remoteIterator = Collections.emptyIterator();
 
@@ -50,12 +51,14 @@ public class HiveFileIterator
             Path path,
             ListDirectoryOperation listDirectoryOperation,
             NamenodeStats namenodeStats,
-            NestedDirectoryPolicy nestedDirectoryPolicy)
+            NestedDirectoryPolicy nestedDirectoryPolicy,
+            boolean skipEmptyFiles)// Tipo Boolean
     {
         paths.addLast(requireNonNull(path, "path is null"));
         this.listDirectoryOperation = requireNonNull(listDirectoryOperation, "listDirectoryOperation is null");
         this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");
         this.nestedDirectoryPolicy = requireNonNull(nestedDirectoryPolicy, "nestedDirectoryPolicy is null");
+        this.skipEmptyFiles = skipEmptyFiles;
     }
 
     @Override
@@ -67,7 +70,7 @@ public class HiveFileIterator
 
                 // Ignore hidden files and directories. Hive ignores files starting with _ and . as well.
                 String fileName = fileInfo.getPath().getName();
-                if (fileName.startsWith("_") || fileName.startsWith(".")) {
+                if (fileName.startsWith("_") || fileName.startsWith(".") || (fileInfo.getLength() == 0 && skipEmptyFiles)) {
                     continue;
                 }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
@@ -52,7 +52,7 @@ public class HiveFileIterator
             ListDirectoryOperation listDirectoryOperation,
             NamenodeStats namenodeStats,
             NestedDirectoryPolicy nestedDirectoryPolicy,
-            boolean skipEmptyFiles)// Tipo Boolean
+            boolean skipEmptyFiles)
     {
         paths.addLast(requireNonNull(path, "path is null"));
         this.listDirectoryOperation = requireNonNull(listDirectoryOperation, "listDirectoryOperation is null");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -165,6 +165,7 @@ public class TestHiveClientConfig
                 .setMaxConcurrentQuickStatsCalls(100)
                 .setMaxConcurrentParquetQuickStatsCalls(500)
                 .setCteVirtualBucketCount(128)
+                .setSkipEmptyFilesEnabled(false)
                 .setAffinitySchedulingFileSectionSize(new DataSize(256, MEGABYTE)));
     }
 
@@ -414,7 +415,7 @@ public class TestHiveClientConfig
                 .setMaxConcurrentParquetQuickStatsCalls(399)
                 .setMaxConcurrentQuickStatsCalls(101)
                 .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE))
-                .setSkipEmptyFilesEnabled(true);
+                .setSkipEmptyFilesEnabled(true)
                 .setCteVirtualBucketCount(256)
                 .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE));
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -292,6 +292,7 @@ public class TestHiveClientConfig
                 .put("hive.quick-stats.max-concurrent-calls", "101")
                 .put("hive.cte-virtual-bucket-count", "256")
                 .put("hive.affinity-scheduling-file-section-size", "512MB")
+                .put("hive.skip-empty-files", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -412,6 +413,8 @@ public class TestHiveClientConfig
                 .setParquetQuickStatsFileMetadataFetchTimeout(new Duration(30, TimeUnit.SECONDS))
                 .setMaxConcurrentParquetQuickStatsCalls(399)
                 .setMaxConcurrentQuickStatsCalls(101)
+                .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE))
+                .setSkipEmptyFilesEnabled(true);
                 .setCteVirtualBucketCount(256)
                 .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE));
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.hive.parquet.ParquetTester;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class TestHiveSkipEmptyFiles
+        extends AbstractTestQueryFramework
+{
+    private static final Logger logger = Logger.getLogger(TestHiveSkipEmptyFiles.class);
+    private static final String CATALOG = "hive";
+    private static final String SCHEMA = "skip_empty_files_schema";
+    private DistributedQueryRunner queryRunner;
+    private DistributedQueryRunner queryFailRunner;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        logger.info("Creating 'QueryRunner'");
+        Session session = testSessionBuilder().setCatalog(CATALOG).setSchema(SCHEMA).setTimeZoneKey(TimeZoneKey.UTC_KEY).build();
+        this.queryRunner = DistributedQueryRunner.builder(session).setExtraProperties(ImmutableMap.<String, String>builder().build()).build();
+
+        logger.info("  |-- Installing Plugin: " + CATALOG);
+        this.queryRunner.installPlugin(new HivePlugin(CATALOG));
+        Path catalogDirectory = this.queryRunner.getCoordinator().getDataDirectory().resolve("hive_data").getParent().resolve("catalog");
+        logger.info("  |-- Obtained catalog directory: " + catalogDirectory.toFile().toURI());
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
+                .put("hive.allow-drop-table", "true")
+                .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.parquet.use-column-names", "true")
+                .put("hive.compression-codec", "GZIP")
+                .put("hive.storage-format", "PARQUET")
+                .put("hive.skip-empty-files", "true")
+                .build();
+        logger.info("  |-- Properties loaded");
+
+        logger.info("  |-- Creating catalog '" + CATALOG + "' using plugin '" + CATALOG + '\'');
+        this.queryRunner.createCatalog(CATALOG, CATALOG, properties);
+        logger.info("  |-- Catalog '" + CATALOG + "' created");
+        logger.info("  |-- Creating schema '" + SCHEMA + "' on catalog '" + CATALOG + '\'');
+        this.queryRunner.execute(format("CREATE SCHEMA %s.%s", CATALOG, SCHEMA));
+        logger.info("  |-- Schema '" + SCHEMA + "' created");
+
+        logger.info("'QueryRunner' created succesfully");
+        return this.queryRunner;
+    }
+
+    @BeforeClass
+    private void createQueryFailRunner()
+            throws Exception
+    {
+        logger.info("Creating 'QueryFailRunner'");
+        Session session = testSessionBuilder().setCatalog(CATALOG).setSchema(SCHEMA).setTimeZoneKey(TimeZoneKey.UTC_KEY).build();
+        this.queryFailRunner = DistributedQueryRunner.builder(session).setExtraProperties(ImmutableMap.<String, String>builder().build()).build();
+
+        logger.info("  |-- Installing Plugin: " + CATALOG);
+        this.queryFailRunner.installPlugin(new HivePlugin(CATALOG));
+        Path catalogDirectory = this.queryFailRunner.getCoordinator().getDataDirectory().resolve("hive_data").getParent().resolve("catalog");
+        logger.info("  |-- Obtained catalog directory: " + catalogDirectory.toFile().toURI());
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
+                .put("hive.allow-drop-table", "true")
+                .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.parquet.use-column-names", "true")
+                .put("hive.compression-codec", "GZIP")
+                .put("hive.storage-format", "PARQUET")
+                .put("hive.skip-empty-files", "false")
+                .build();
+        logger.info("  |-- Properties loaded");
+
+        logger.info("  |-- Creating catalog '" + CATALOG + "' using plugin '" + CATALOG + '\'');
+        this.queryFailRunner.createCatalog(CATALOG, CATALOG, properties);
+        logger.info("  |-- Catalog '" + CATALOG + "' created");
+        logger.info("  |-- Creating schema '" + SCHEMA + "' on catalog '" + CATALOG + '\'');
+        this.queryFailRunner.execute(format("CREATE SCHEMA %s.%s", CATALOG, SCHEMA));
+        logger.info("  |-- Schema '" + SCHEMA + "' created");
+
+        logger.info("'QueryFailRunner' created succesfully");
+    }
+
+    /**
+     * Generates a temporary directory and creates two parquet files inside, one is empty and the other is not
+     * @return a {@link File} pointing to the newly created temporary directory
+     */
+    private static File generateMetadata(String tableName)
+            throws Exception
+    {
+        // obtains the root resouce directory in order to create temporary tables
+        URL url = TestHiveSkipEmptyFiles.class.getClassLoader().getResource(".");
+        if (url == null) {
+            throw new RuntimeException("Could not obtain resource URL");
+        }
+        File temporaryDirectory = new File(url.getPath(), tableName);
+        boolean created = temporaryDirectory.mkdirs();
+        if (!created) {
+            throw new RuntimeException("Could not create resource directory: " + temporaryDirectory.getPath());
+        }
+        logger.info("Created temporary directory: " + temporaryDirectory.toPath());
+        File firstParquetFile = new File(temporaryDirectory, randomUUID().toString());
+        ParquetTester.writeParquetFileFromPresto(firstParquetFile,
+                ImmutableList.of(IntegerType.INTEGER),
+                Collections.singletonList("field"),
+                new Iterable[] {Collections.singleton(1)},
+                1,
+                GZIP,
+                PARQUET_2_0);
+        logger.info("First file written");
+        File secondParquetFile = new File(temporaryDirectory, randomUUID().toString());
+        if (!secondParquetFile.createNewFile()){
+            throw new RuntimeException("Could not create empty file");
+        }
+        return temporaryDirectory;
+    }
+
+    /**
+     * Deletes the given directory and all of its contents recursively
+     * Does not follow symbolic links
+     * @param temporaryDirectory a {@link File} pointing to the directory to delete
+     */
+    private static void deleteMetadata(File temporaryDirectory)
+    {
+        File[] data = temporaryDirectory.listFiles();
+        if (data != null) {
+            for (File f : data) {
+                if (!Files.isSymbolicLink(f.toPath())) {
+                    deleteMetadata(f);
+                }
+            }
+        }
+        deleteAndLog(temporaryDirectory);
+    }
+
+    private static void deleteAndLog(File file)
+    {
+        String filePath = file.getAbsolutePath();
+        boolean isDirectory = file.isDirectory();
+        if (file.delete()) {
+            if (isDirectory) {
+                logger.info("   deleted temporary directory: " + filePath);
+            }
+            else {
+                logger.info("   deleted temporary file: " + filePath);
+            }
+        }
+        else {
+            logger.info("   could not delete temporary element: " + filePath);
+        }
+    }
+
+    @Test
+    public void testSkipEmptyFilesSuccessful()
+            throws Exception
+    {
+        String tableName = "skip_empty_files_success";
+        File resourcesLocation = generateMetadata(tableName);
+        executeCreationTestAndDropCycle(queryRunner, tableName, getResourceUrl(tableName), false, null);
+        deleteMetadata(resourcesLocation);
+    }
+
+    @Test
+    public void testSkipEmptyFilesError()
+            throws Exception
+    {
+        String tableName = "skip_empty_files_fail";
+        File resourcesLocation = generateMetadata(tableName);
+        executeCreationTestAndDropCycle(queryFailRunner, tableName, getResourceUrl(tableName), true,
+                ".* is not a valid Parquet File");
+        deleteMetadata(resourcesLocation);
+    }
+
+    /**
+     * Obtains the external location from the local resources directory of the project
+     * @param tableName a {@link String} containting the directory name to search for
+     * @return a {@link String} with the external location for the given table_name
+     */
+    private static String getResourceUrl(String tableName)
+    {
+        URL resourceUrl = TestHiveSkipEmptyFiles.class.getClassLoader().getResource(tableName);
+        if (resourceUrl == null) {
+            throw new RuntimeException("Cannot find resource path for table name: " + tableName);
+        }
+        logger.info("resource url: " + resourceUrl);
+        return resourceUrl.toString();
+    }
+
+    /**
+     * Tries a table with the configuration property desired. If succeeds, tests the output.
+     * Finally, it drops the table.
+     * @param queryRunner a {@link QueryRunner} with the desired configuration properties
+     * @param tableName a {@link String} containing the desired table name
+     * @param externalLocation a {@link String} with the external location to create the table against it
+     * @param shouldFail {@code true} if the table creation should fail, {@code false} otherwise
+     * @param errorMessage a {@link String} containing the expected error message. Will be checked if {@code shouldFail} is {@code true}
+     */
+    private void executeCreationTestAndDropCycle(DistributedQueryRunner queryRunner, String tableName, String externalLocation, boolean shouldFail, @Language("RegExp") String errorMessage)
+    {
+        logger.info("Executing Create - Test - Drop for: " + tableName);
+        try {
+            @Language("SQL") String createQuery = format(
+                    "CREATE TABLE %s.\"%s\".\"%s\" (field %s) WITH (external_location = '%s')",
+                    CATALOG,
+                    SCHEMA,
+                    tableName,
+                    IntegerType.INTEGER,
+                    externalLocation);
+            logger.info("Creating table: " + createQuery);
+            queryRunner.execute(createQuery);
+            @Language("SQL") String selectQuery = format("SELECT * FROM %s.\"%s\".\"%s\"", CATALOG,
+                    SCHEMA, tableName);
+            logger.info("Executing query: " + selectQuery);
+            if (shouldFail) {
+                assertQueryFails(queryRunner, selectQuery, errorMessage);
+            }
+            else {
+                MaterializedResult result = queryRunner.execute(selectQuery);
+                assertEquals(1, result.getRowCount());
+            }
+        }
+        finally {
+            @Language("SQL") String dropQuery = format("DROP TABLE IF EXISTS %s.\"%s\".\"%s\"", CATALOG,
+                    SCHEMA, tableName);
+            logger.info("Dropping table: " + dropQuery);
+            queryRunner.execute(dropQuery);
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
@@ -61,7 +61,7 @@ public class TestHiveSkipEmptyFiles
     private DistributedQueryRunner queryFailRunner;
     private DistributedQueryRunner queryBucketRunner;
     private DistributedQueryRunner queryBucketFailRunner;
-    File temporaryDirectory;
+    private File temporaryDirectory;
 
     @Override
     protected QueryRunner createQueryRunner()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
@@ -149,7 +149,7 @@ public class TestHiveSkipEmptyFiles
                 PARQUET_2_0);
         logger.info("First file written");
         File secondParquetFile = new File(temporaryDirectory, randomUUID().toString());
-        if (!secondParquetFile.createNewFile()){
+        if (!secondParquetFile.createNewFile()) {
             throw new RuntimeException("Could not create empty file");
         }
         return temporaryDirectory;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.hive.parquet.ParquetTester;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
@@ -49,6 +50,8 @@ public class TestHiveSkipEmptyFiles
     private static final String SCHEMA = "skip_empty_files_schema";
     private DistributedQueryRunner queryRunner;
     private DistributedQueryRunner queryFailRunner;
+    private DistributedQueryRunner queryBucketRunner;
+    private DistributedQueryRunner queryBucketFailRunner;
 
     @Override
     protected QueryRunner createQueryRunner()
@@ -67,6 +70,7 @@ public class TestHiveSkipEmptyFiles
                 .put("hive.parquet.use-column-names", "true")
                 .put("hive.compression-codec", "GZIP")
                 .put("hive.storage-format", "PARQUET")
+                .put("hive.bucket-execution", "false")
                 .put("hive.skip-empty-files", "true")
                 .build();
 
@@ -93,6 +97,7 @@ public class TestHiveSkipEmptyFiles
                 .put("hive.parquet.use-column-names", "true")
                 .put("hive.compression-codec", "GZIP")
                 .put("hive.storage-format", "PARQUET")
+                .put("hive.bucket-execution", "false")
                 .put("hive.skip-empty-files", "false")
                 .build();
 
@@ -100,9 +105,60 @@ public class TestHiveSkipEmptyFiles
         this.queryFailRunner.execute(format("CREATE SCHEMA %s.%s", CATALOG, SCHEMA));
     }
 
+    @BeforeClass
+    private void createQueryBucketRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder().setCatalog(CATALOG).setSchema(SCHEMA).setTimeZoneKey(TimeZoneKey.UTC_KEY).build();
+        this.queryBucketRunner = DistributedQueryRunner.builder(session).setExtraProperties(ImmutableMap.<String, String>builder().build()).build();
+
+        this.queryBucketRunner.installPlugin(new HivePlugin(CATALOG));
+        Path catalogDirectory = this.queryBucketRunner.getCoordinator().getDataDirectory().resolve("hive_data").getParent().resolve("catalog");
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
+                .put("hive.allow-drop-table", "true")
+                .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.parquet.use-column-names", "true")
+                .put("hive.compression-codec", "GZIP")
+                .put("hive.storage-format", "PARQUET")
+                .put("hive.bucket-execution", "true")
+                .put("hive.skip-empty-files", "true")
+                .build();
+
+        this.queryBucketRunner.createCatalog(CATALOG, CATALOG, properties);
+        this.queryBucketRunner.execute(format("CREATE SCHEMA %s.%s", CATALOG, SCHEMA));
+    }
+
+    @BeforeClass
+    private void createQueryBucketFailRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder().setCatalog(CATALOG).setSchema(SCHEMA).setTimeZoneKey(TimeZoneKey.UTC_KEY).build();
+        this.queryBucketFailRunner = DistributedQueryRunner.builder(session).setExtraProperties(ImmutableMap.<String, String>builder().build()).build();
+
+        this.queryBucketFailRunner.installPlugin(new HivePlugin(CATALOG));
+        Path catalogDirectory = this.queryBucketFailRunner.getCoordinator().getDataDirectory().resolve("hive_data").getParent().resolve("catalog");
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
+                .put("hive.allow-drop-table", "true")
+                .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.parquet.use-column-names", "true")
+                .put("hive.compression-codec", "GZIP")
+                .put("hive.storage-format", "PARQUET")
+                .put("hive.bucket-execution", "true")
+                .put("hive.skip-empty-files", "false")
+                .build();
+
+        this.queryBucketFailRunner.createCatalog(CATALOG, CATALOG, properties);
+        this.queryBucketFailRunner.execute(format("CREATE SCHEMA %s.%s", CATALOG, SCHEMA));
+    }
+
     /**
      * Generates a temporary directory and creates two parquet files inside, one is empty and the other is not
      *
+     * @param tableName a {@link String} containing the desired table name
      * @return a {@link File} pointing to the newly created temporary directory
      */
     private static File generateMetadata(String tableName)
@@ -134,22 +190,69 @@ public class TestHiveSkipEmptyFiles
     }
 
     /**
+     * Generates a temporary directory and inserts data in every partition of the bucketed table, including an empty file in the first partition
+     *
+     * @param queryRunner a {@link QueryRunner} with the desired configuration properties
+     * @param tableName a {@link String} containing the desired table name
+     * @return a {@link File} pointing to the newly created temporary directory
+     */
+    private File generateBucketedMetadata(DistributedQueryRunner queryRunner, String tableName, boolean replace) throws Exception
+    {
+        URL url = TestHiveSkipEmptyFiles.class.getClassLoader().getResource(".");
+        if (url == null) {
+            throw new RuntimeException("Could not obtain resource URL");
+        }
+        File temporaryDirectory = new File(url.getPath(), tableName);
+        boolean created = temporaryDirectory.mkdirs();
+        if (!created) {
+            throw new RuntimeException("Could not create resource directory: " + temporaryDirectory.getPath());
+        }
+        @Language("SQL") String createQuery = format("CREATE TABLE %s.\"%s\".\"%s\" (id %s, field %s) WITH (external_location = '%s'," +
+                        "format = 'Parquet',partitioned_by = ARRAY['field']," +
+                        "  bucketed_by = ARRAY['id']," +
+                        "  bucket_count = 3)",
+                CATALOG, SCHEMA, tableName, IntegerType.INTEGER, VarcharType.VARCHAR, getResourceUrl(tableName));
+        queryRunner.execute(createQuery);
+        String partitionDirectoryPath = temporaryDirectory.getPath() + "/field=field1";
+        String name = "field";
+        @Language("SQL") String insertQuery;
+        for (int i = 1; i <= 5; i++) {
+            insertQuery = format("INSERT INTO %s.\"%s\".\"%s\" VALUES (%s,'%s')",
+                    CATALOG, SCHEMA, tableName, i, name + i);
+            queryRunner.execute(insertQuery);
+            if (i == 1) {
+                File secondParquetFile = new File(partitionDirectoryPath, randomUUID().toString());
+                if (!secondParquetFile.createNewFile()) {
+                    throw new RuntimeException("Could not create empty file");
+                }
+            }
+        }
+        if (replace) {
+            File partitionDirectory = new File(partitionDirectoryPath);
+            deleteMetadata(partitionDirectory, true);
+        }
+        return temporaryDirectory;
+    }
+
+    /**
      * Deletes the given directory and all of its contents recursively
      * Does not follow symbolic links
      *
      * @param temporaryDirectory a {@link File} pointing to the directory to delete
+     * @param hasPattern a {@code true} if it is necessary to delete only one directory file, {@code false} otherwise
      */
-    private static void deleteMetadata(File temporaryDirectory)
+    private static void deleteMetadata(File temporaryDirectory, boolean hasPattern)
     {
+        @Language("RegExp") String nameStart = "000000_.*";
         File[] metadataFiles = temporaryDirectory.listFiles();
         if (metadataFiles != null) {
             for (File file : metadataFiles) {
-                if (!Files.isSymbolicLink(file.toPath())) {
-                    deleteMetadata(file);
+                if ((!Files.isSymbolicLink(file.toPath()) && !hasPattern) || (hasPattern && file.getName().matches(nameStart))) {
+                    deleteMetadata(file, false);
                 }
             }
         }
-        if (!temporaryDirectory.delete()) {
+        if (!hasPattern && !temporaryDirectory.delete()) {
             throw new RuntimeException("Could not to delete metadata");
         }
     }
@@ -161,7 +264,7 @@ public class TestHiveSkipEmptyFiles
         String tableName = "skip_empty_files_success";
         File resourcesLocation = generateMetadata(tableName);
         executeCreationTestAndDropCycle(queryRunner, tableName, getResourceUrl(tableName), false, null);
-        deleteMetadata(resourcesLocation);
+        deleteMetadata(resourcesLocation, false);
     }
 
     @Test
@@ -172,7 +275,37 @@ public class TestHiveSkipEmptyFiles
         File resourcesLocation = generateMetadata(tableName);
         executeCreationTestAndDropCycle(queryFailRunner, tableName, getResourceUrl(tableName), true,
                 ".* is not a valid Parquet File");
-        deleteMetadata(resourcesLocation);
+        deleteMetadata(resourcesLocation, false);
+    }
+
+    @Test
+    public void testSkipEmptyFilesBucketSuccessful()
+            throws Exception
+    {
+        String tableName = "skip_empty_files_bucket_success";
+        File resourcesLocation = generateBucketedMetadata(queryBucketRunner, tableName, false);
+        checkBucketedResult(queryBucketRunner, tableName, false, null);
+        deleteMetadata(resourcesLocation, false);
+    }
+
+    @Test
+    public void testSkipEmptyFilesBucketInsertFileFail()
+            throws Exception
+    {
+        String tableName = "skip_empty_files_bucket_insert_fail";
+        File resourcesLocation = generateBucketedMetadata(queryBucketFailRunner, tableName, false);
+        checkBucketedResult(queryBucketFailRunner, tableName, true, ".* is corrupt.* does not match the standard naming pattern, and the number of files in the directory .* does not match the declared bucket count.*");
+        deleteMetadata(resourcesLocation, false);
+    }
+
+    @Test
+    public void testSkipEmptyFilesBucketReplaceFileFail()
+            throws Exception
+    {
+        String tableName = "skip_empty_files_bucket_replace_fail";
+        File resourcesLocation = generateBucketedMetadata(queryBucketFailRunner, tableName, true);
+        checkBucketedResult(queryBucketFailRunner, tableName, true, ".* is not a valid Parquet File");
+        deleteMetadata(resourcesLocation, false);
     }
 
     /**
@@ -188,6 +321,35 @@ public class TestHiveSkipEmptyFiles
             throw new RuntimeException("Cannot find resource path for table name: " + tableName);
         }
         return resourceUrl.toString();
+    }
+
+    /**
+     * Tries a table with the configuration property desired. If succeeds, tests the output.
+     * Finally, it drops the table.
+     *
+     * @param queryRunner a {@link QueryRunner} with the desired configuration properties
+     * @param tableName a {@link String} containing the desired table name
+     * @param shouldFail {@code true} if the table creation should fail, {@code false} otherwise
+     * @param errorMessage a {@link String} containing the expected error message. Will be checked if {@code shouldFail} is {@code true}
+     */
+    private void checkBucketedResult(DistributedQueryRunner queryRunner, String tableName, boolean shouldFail, @Language("RegExp") String errorMessage)
+    {
+        try {
+            @Language("SQL") String selectQuery = format("SELECT * FROM %s.\"%s\".\"%s\"", CATALOG,
+                    SCHEMA, tableName);
+            if (shouldFail) {
+                assertQueryFails(queryRunner, selectQuery, errorMessage);
+            }
+            else {
+                MaterializedResult result = queryRunner.execute(selectQuery);
+                assertEquals(5, result.getRowCount());
+            }
+        }
+        finally {
+            @Language("SQL") String dropQuery = format("DROP TABLE IF EXISTS %s.\"%s\".\"%s\"", CATALOG,
+                    SCHEMA, tableName);
+            queryRunner.execute(dropQuery);
+        }
     }
 
     /**

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
@@ -122,6 +122,7 @@ public class TestHudiDirectoryLister
             Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, Optional.empty(), new NamenodeStats(), new HiveDirectoryContext(
                     IGNORED,
                     false,
+                    false,
                     new ConnectorIdentity("test", Optional.empty(), Optional.empty()),
                     ImmutableMap.of(),
                     new RuntimeStats()));
@@ -148,6 +149,7 @@ public class TestHudiDirectoryLister
             ExtendedFileSystem fs = (ExtendedFileSystem) path.getFileSystem(hadoopConf);
             Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, Optional.empty(), new NamenodeStats(), new HiveDirectoryContext(
                     IGNORED,
+                    false,
                     false,
                     new ConnectorIdentity("test", Optional.empty(), Optional.empty()),
                     ImmutableMap.of(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.hive.HiveColumnConverterProvider.DEFAULT_COLUM
 import static com.facebook.presto.hive.HiveSessionProperties.QUICK_STATS_BACKGROUND_BUILD_TIMEOUT;
 import static com.facebook.presto.hive.HiveSessionProperties.QUICK_STATS_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.QUICK_STATS_INLINE_BUILD_TIMEOUT;
+import static com.facebook.presto.hive.HiveSessionProperties.SKIP_EMPTY_FILES;
 import static com.facebook.presto.hive.HiveSessionProperties.USE_LIST_DIRECTORY_CACHE;
 import static com.facebook.presto.hive.HiveStorageFormat.PARQUET;
 import static com.facebook.presto.hive.HiveTestUtils.createTestHdfsEnvironment;
@@ -118,6 +119,11 @@ public class TestQuickStatsProvider
             booleanProperty(
                     USE_LIST_DIRECTORY_CACHE,
                     "Directory list caching",
+                    false,
+                    false),
+            booleanProperty(
+                    SKIP_EMPTY_FILES,
+                    "If it is required empty files will be skipped",
                     false,
                     false));
     public static final ConnectorSession SESSION = new TestingConnectorSession(quickStatsProperties);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -290,6 +290,11 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertQueryFails(queryRunner, getSession(), sql, expectedMessageRegExp);
     }
 
+    protected void assertQueryFails(QueryRunner queryRunner, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
+    {
+        QueryAssertions.assertQueryFails(queryRunner, getSession(), sql, expectedMessageRegExp);
+    }
+
     protected void assertQueryFails(Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
     {
         QueryAssertions.assertQueryFails(queryRunner, session, sql, expectedMessageRegExp);


### PR DESCRIPTION
Ignore empty files when hive.skip_empty_files is set to true (false by default). Otherwise, it produces an error when iterating through these files.

## Description
This support allows to configure a hive connector property to decide if Presto should ignore these empty files or it should fail (default behavior). The new connector property is called hive.skip_empty_files. The following diagram shows the flow of the property to the HiveFileIterator:

![skipEmptyFilesPropertyFlow](https://github.com/prestodb/presto/assets/152906521/9f8289e8-6f82-4a4c-9c0a-b26daf0de379)
## Motivation and Context

Currently, if Presto reads a Parquet folder where one of the files is an empty file the query fails. This is a problem in some environments.

Solves issue: [14759](https://github.com/prestodb/presto/issues/14759)

## Impact
No impact

## Test Plan
TestHiveSkipEmptyFiles contains two tests. Both reads a directory that contains an empty file. One has the property set to true and the query execution finish with no errors skipping the empty file. The other one has the property set to false and the execution fails as before these changes

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Add support to skip empty files using configuration property ``hive.skip_empty_files`` :pr:`22727`
```


