### PR TITLE
Support format arguments in EXPLAIN ANALYZE

### DIFF
--- a/presto-docs/src/main/sphinx/sql/explain-analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/explain-analyze.rst
@@ -7,7 +7,7 @@ Synopsis
 
 .. code-block:: none
 
-    EXPLAIN ANALYZE [VERBOSE] statement
+    EXPLAIN ANALYZE [VERBOSE] [(format <TEXT|JSON>)] statement
 
 Description
 -----------
@@ -17,6 +17,8 @@ along with the cost of each operation.
 
 The ``VERBOSE`` option will give more detailed information and low-level statistics;
 understanding these may require knowledge of Presto internals and implementation details.
+The format of the output can be set by the user with the ``format`` option. The default
+output format is ``TEXT``.
 
 .. note::
 

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -472,7 +472,8 @@ public class QueryMonitor
             if (queryInfo.getOutputStage().isPresent()) {
                 return Optional.of(jsonDistributedPlan(
                         queryInfo.getOutputStage().get(),
-                        functionAndTypeManager));
+                        functionAndTypeManager,
+                        queryInfo.getSession().toSession(sessionPropertyManager)));
             }
         }
         catch (Exception e) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/queryplan/JsonPrestoQueryPlanFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/queryplan/JsonPrestoQueryPlanFunctions.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -197,7 +198,7 @@ public final class JsonPrestoQueryPlanFunctions
         List<JsonRenderedNode> newChildren = node.getChildren().stream().map(x -> scrubJsonPlan(x)).collect(Collectors.toList());
         String newDetails = scrubDetails(node.getDetails());
 
-        return new JsonRenderedNode(node.getSourceLocation(), "PLANID", newName, newIdentifier, newDetails, newChildren, node.getRemoteSources(), ImmutableList.of());
+        return new JsonRenderedNode(node.getSourceLocation(), "PLANID", newName, newIdentifier, newDetails, newChildren, node.getRemoteSources(), ImmutableList.of(), Optional.empty());
     }
 
     private static String scrubName(String name)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -186,7 +186,7 @@ public class QueryExplainer
                 return jsonLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionAndTypeManager(), plan.getStatsAndCosts(), session);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
-                return jsonDistributedPlan(subPlan, metadata.getFunctionAndTypeManager());
+                return jsonDistributedPlan(subPlan, metadata.getFunctionAndTypeManager(), session);
             default:
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported explain plan type %s for JSON format", planType));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -998,7 +998,8 @@ public class LocalExecutionPlanner
                     node.getId(),
                     analyzeContext.getQueryPerformanceFetcher(),
                     metadata.getFunctionAndTypeManager(),
-                    node.isVerbose());
+                    node.isVerbose(),
+                    node.getFormat());
             return new PhysicalOperation(operatorFactory, makeLayout(node), context, source);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -215,7 +215,7 @@ public class UnaliasSymbolReferences
         public PlanNode visitExplainAnalyze(ExplainAnalyzeNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getSource());
-            return new ExplainAnalyzeNode(node.getSourceLocation(), node.getId(), source, canonicalize(node.getOutputVariable()), node.isVerbose());
+            return new ExplainAnalyzeNode(node.getSourceLocation(), node.getId(), source, canonicalize(node.getOutputVariable()), node.isVerbose(), node.getFormat());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExplainAnalyzeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExplainAnalyzeNode.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.tree.ExplainFormat.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -36,6 +37,7 @@ public class ExplainAnalyzeNode
     private final PlanNode source;
     private final VariableReferenceExpression outputVariable;
     private final boolean verbose;
+    private final Type format;
 
     @JsonCreator
     public ExplainAnalyzeNode(
@@ -43,9 +45,10 @@ public class ExplainAnalyzeNode
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
             @JsonProperty("outputVariable") VariableReferenceExpression outputVariable,
-            @JsonProperty("verbose") boolean verbose)
+            @JsonProperty("verbose") boolean verbose,
+            @JsonProperty("format") Type format)
     {
-        this(sourceLocation, id, Optional.empty(), source, outputVariable, verbose);
+        this(sourceLocation, id, Optional.empty(), source, outputVariable, verbose, format);
     }
 
     public ExplainAnalyzeNode(
@@ -54,12 +57,14 @@ public class ExplainAnalyzeNode
             Optional<PlanNode> statsEquivalentPlanNode,
             PlanNode source,
             VariableReferenceExpression outputVariable,
-            boolean verbose)
+            boolean verbose,
+            Type format)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
         this.source = requireNonNull(source, "source is null");
         this.outputVariable = requireNonNull(outputVariable, "outputVariable is null");
         this.verbose = verbose;
+        this.format = requireNonNull(format, "options is null");
     }
 
     @JsonProperty("outputVariable")
@@ -78,6 +83,12 @@ public class ExplainAnalyzeNode
     public boolean isVerbose()
     {
         return verbose;
+    }
+
+    @JsonProperty("format")
+    public Type getFormat()
+    {
+        return format;
     }
 
     @Override
@@ -101,12 +112,12 @@ public class ExplainAnalyzeNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new ExplainAnalyzeNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), Iterables.getOnlyElement(newChildren), outputVariable, isVerbose());
+        return new ExplainAnalyzeNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), Iterables.getOnlyElement(newChildren), outputVariable, isVerbose(), format);
     }
 
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new ExplainAnalyzeNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, outputVariable, isVerbose());
+        return new ExplainAnalyzeNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, outputVariable, isVerbose(), format);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
@@ -36,12 +36,17 @@ public class HashCollisionPlanNodeStats
             PlanNodeId planNodeId,
             Duration planNodeScheduledTime,
             Duration planNodeCpuTime,
+            Duration planNodeBlockedWallTime,
+            Duration planNodeAddInputWallTime,
+            Duration planNodeGetOutputWallTime,
+            Duration planNodeFinishWallTime,
             long planNodeInputPositions,
             DataSize planNodeInputDataSize,
             long planNodeRawInputPositions,
             DataSize planNodeRawInputDataSize,
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
+            DataSize planNodePeakMemorySize,
             Map<String, OperatorInputStats> operatorInputStats,
             long planNodeNullJoinBuildKeyCount,
             long planNodeJoinBuildKeyCount,
@@ -50,9 +55,9 @@ public class HashCollisionPlanNodeStats
             Optional<DynamicFilterStats> dynamicFilterStats,
             Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats)
     {
-        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize,
-                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount,
-                planNodeJoinProbeKeyCount, dynamicFilterStats);
+        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeBlockedWallTime, planNodeAddInputWallTime, planNodeGetOutputWallTime, planNodeFinishWallTime,
+                planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize, planNodeOutputPositions, planNodeOutputDataSize,
+                planNodePeakMemorySize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount, planNodeJoinProbeKeyCount, dynamicFilterStats);
         this.operatorHashCollisionsStats = requireNonNull(operatorHashCollisionsStats, "operatorHashCollisionsStats is null");
     }
 
@@ -101,12 +106,17 @@ public class HashCollisionPlanNodeStats
                 merged.getPlanNodeId(),
                 merged.getPlanNodeScheduledTime(),
                 merged.getPlanNodeCpuTime(),
+                merged.getPlanNodeBlockedWallTime(),
+                merged.getPlanNodeAddInputWallTime(),
+                merged.getPlanNodeGetOutputWallTime(),
+                merged.getPlanNodeFinishWallTime(),
                 merged.getPlanNodeInputPositions(),
                 merged.getPlanNodeInputDataSize(),
                 merged.getPlanNodeRawInputPositions(),
                 merged.getPlanNodeRawInputDataSize(),
                 merged.getPlanNodeOutputPositions(),
                 merged.getPlanNodeOutputDataSize(),
+                merged.getPlanNodePeakMemorySize(),
                 merged.operatorInputStats,
                 merged.getPlanNodeNullJoinBuildKeyCount(),
                 merged.getPlanNodeJoinBuildKeyCount(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java
@@ -41,6 +41,7 @@ public class JsonRenderer
 {
     private final JsonCodec<Map<PlanFragmentId, JsonPlanFragment>> planMapCodec;
     private final JsonCodec<JsonRenderedNode> codec;
+    private final JsonCodec<Map<PlanFragmentId, JsonPlan>> deserializationCodec;
 
     public JsonRenderer(FunctionAndTypeManager functionAndTypeManager)
     {
@@ -51,6 +52,12 @@ public class JsonRenderer
         JsonCodecFactory codecFactory = new JsonCodecFactory(provider, true);
         this.codec = codecFactory.jsonCodec(JsonRenderedNode.class);
         this.planMapCodec = codecFactory.mapJsonCodec(PlanFragmentId.class, JsonPlanFragment.class);
+        this.deserializationCodec = codecFactory.mapJsonCodec(PlanFragmentId.class, JsonPlan.class);
+    }
+
+    public Map<PlanFragmentId, JsonPlan> deserialize(String serialized)
+    {
+        return deserializationCodec.fromJson(serialized);
     }
 
     @Override
@@ -84,7 +91,8 @@ public class JsonRenderer
                 node.getRemoteSources().stream()
                         .map(PlanFragmentId::toString)
                         .collect(toImmutableList()),
-                node.getEstimatedStats());
+                node.getEstimatedStats(),
+                node.getStats());
     }
 
     public static class JsonRenderedNode
@@ -97,9 +105,10 @@ public class JsonRenderer
         private final List<JsonRenderedNode> children;
         private final List<String> remoteSources;
         private final List<PlanNodeStatsEstimate> estimates;
+        private final Optional<PlanNodeStats> stats;
 
         @JsonCreator
-        public JsonRenderedNode(Optional<SourceLocation> sourceLocation, String id, String name, String identifier, String details, List<JsonRenderedNode> children, List<String> remoteSources, List<PlanNodeStatsEstimate> estimates)
+        public JsonRenderedNode(Optional<SourceLocation> sourceLocation, String id, String name, String identifier, String details, List<JsonRenderedNode> children, List<String> remoteSources, List<PlanNodeStatsEstimate> estimates, Optional<PlanNodeStats> stats)
         {
             this.sourceLocation = sourceLocation;
             this.id = requireNonNull(id, "id is null");
@@ -109,6 +118,7 @@ public class JsonRenderer
             this.children = requireNonNull(children, "children is null");
             this.remoteSources = requireNonNull(remoteSources, "id is null");
             this.estimates = requireNonNull(estimates, "estimate is null");
+            this.stats = requireNonNull(stats, "stats is null");
         }
 
         @JsonProperty
@@ -159,6 +169,12 @@ public class JsonRenderer
             return estimates;
         }
 
+        @JsonProperty
+        public Optional<PlanNodeStats> getStats()
+        {
+            return stats;
+        }
+
         @Override
         public boolean equals(Object obj)
         {
@@ -176,13 +192,14 @@ public class JsonRenderer
                     Objects.equals(this.details, other.details) &&
                     Objects.equals(this.children, other.children) &&
                     Objects.equals(this.estimates, other.estimates) &&
-                    Objects.equals(this.remoteSources, other.remoteSources);
+                    Objects.equals(this.remoteSources, other.remoteSources) &&
+                    Objects.equals(this.stats, other.stats);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(name, id, sourceLocation, identifier, details, children, estimates, remoteSources);
+            return Objects.hash(name, id, sourceLocation, identifier, details, children, estimates, remoteSources, stats);
         }
     }
 
@@ -201,6 +218,27 @@ public class JsonRenderer
         public String getPlan()
         {
             return this.plan;
+        }
+    }
+
+    /**
+     * Used for deserializing rendered JSON plan
+     */
+    public static class JsonPlan
+    {
+        @JsonProperty
+        private final JsonRenderedNode plan;
+
+        @JsonCreator
+        public JsonPlan(@JsonProperty("plan") JsonRenderedNode plan)
+        {
+            this.plan = plan;
+        }
+
+        @JsonProperty
+        public JsonRenderedNode getPlan()
+        {
+            return plan;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/OperatorInputStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/OperatorInputStats.java
@@ -13,29 +13,39 @@
  */
 package com.facebook.presto.sql.planner.planPrinter;
 
-class OperatorInputStats
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OperatorInputStats
 {
     private final long totalDrivers;
     private final long inputPositions;
     private final double sumSquaredInputPositions;
 
-    public OperatorInputStats(long totalDrivers, long inputPositions, double sumSquaredInputPositions)
+    @JsonCreator
+    public OperatorInputStats(
+            @JsonProperty("totalDrivers") long totalDrivers,
+            @JsonProperty("inputPositions") long inputPositions,
+            @JsonProperty("sumSquaredInputPositions") double sumSquaredInputPositions)
     {
         this.totalDrivers = totalDrivers;
         this.inputPositions = inputPositions;
         this.sumSquaredInputPositions = sumSquaredInputPositions;
     }
 
+    @JsonProperty
     public long getTotalDrivers()
     {
         return totalDrivers;
     }
 
+    @JsonProperty
     public long getInputPositions()
     {
         return inputPositions;
     }
 
+    @JsonProperty
     public double getSumSquaredInputPositions()
     {
         return sumSquaredInputPositions;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
@@ -16,9 +16,12 @@ package com.facebook.presto.sql.planner.planPrinter;
 import com.facebook.presto.operator.DynamicFilterStats;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.util.Mergeable;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -39,6 +42,10 @@ public class PlanNodeStats
 
     private final Duration planNodeScheduledTime;
     private final Duration planNodeCpuTime;
+    private final Duration planNodeBlockedWallTime;
+    private final Duration planNodeAddInputWallTime;
+    private final Duration planNodeGetOutputWallTime;
+    private final Duration planNodeFinishWallTime;
     private final long planNodeInputPositions;
     private final DataSize planNodeInputDataSize;
     private final long planNodeRawInputPositions;
@@ -46,6 +53,7 @@ public class PlanNodeStats
     private final long planNodeOutputPositions;
     private final DataSize planNodeOutputDataSize;
 
+    private final DataSize planNodePeakMemorySize;
     protected final Map<String, OperatorInputStats> operatorInputStats;
     private final long planNodeNullJoinBuildKeyCount;
     private final long planNodeJoinBuildKeyCount;
@@ -53,27 +61,37 @@ public class PlanNodeStats
     private final long planNodeJoinProbeKeyCount;
     private final Optional<DynamicFilterStats> dynamicFilterStats;
 
-    PlanNodeStats(
-            PlanNodeId planNodeId,
-            Duration planNodeScheduledTime,
-            Duration planNodeCpuTime,
-            long planNodeInputPositions,
-            DataSize planNodeInputDataSize,
-            long planNodeRawInputPositions,
-            DataSize planNodeRawInputDataSize,
-            long planNodeOutputPositions,
-            DataSize planNodeOutputDataSize,
-            Map<String, OperatorInputStats> operatorInputStats,
-            long planNodeNullJoinBuildKeyCount,
-            long planNodeJoinBuildKeyCount,
-            long planNodeNullJoinProbeKeyCount,
-            long planNodeJoinProbeKeyCount,
-            Optional<DynamicFilterStats> dynamicFilterStats)
+    @JsonCreator
+    public PlanNodeStats(
+            @JsonProperty("planNodeId") PlanNodeId planNodeId,
+            @JsonProperty("planNodeScheduledTime") Duration planNodeScheduledTime,
+            @JsonProperty("planNodeCpuTime") Duration planNodeCpuTime,
+            @JsonProperty("planNodeBlockedWallTime") Duration planNodeBlockedWallTime,
+            @JsonProperty("planNodeAddInputWallTime") Duration planNodeAddInputWallTime,
+            @JsonProperty("planNodeGetOutputWallTime") Duration planNodeGetOutputWallTime,
+            @JsonProperty("planNodeFinishWallTime") Duration planNodeFinishWallTime,
+            @JsonProperty("planNodeInputPositions") long planNodeInputPositions,
+            @JsonProperty("planNodeInputDataSize") DataSize planNodeInputDataSize,
+            @JsonProperty("planNodeRawInputPositions") long planNodeRawInputPositions,
+            @JsonProperty("planNodeRawInputDataSize") DataSize planNodeRawInputDataSize,
+            @JsonProperty("planNodeOutputPositions") long planNodeOutputPositions,
+            @JsonProperty("planNodeOutputDataSize") DataSize planNodeOutputDataSize,
+            @JsonProperty("planNodePeakMemorySize") DataSize planNodePeakMemorySize,
+            @JsonProperty("operatorInputStats") Map<String, OperatorInputStats> operatorInputStats,
+            @JsonProperty("planNodeNullJoinBuildKeyCount") long planNodeNullJoinBuildKeyCount,
+            @JsonProperty("planNodeJoinBuildKeyCount") long planNodeJoinBuildKeyCount,
+            @JsonProperty("planNodeNullJoinProbeKeyCount") long planNodeNullJoinProbeKeyCount,
+            @JsonProperty("planNodeJoinProbeKeyCount") long planNodeJoinProbeKeyCount,
+            @JsonProperty("dynamicFilterStats") Optional<DynamicFilterStats> dynamicFilterStats)
     {
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
 
         this.planNodeScheduledTime = requireNonNull(planNodeScheduledTime, "planNodeScheduledTime is null");
         this.planNodeCpuTime = requireNonNull(planNodeCpuTime, "planNodeCpuTime is null");
+        this.planNodeBlockedWallTime = requireNonNull(planNodeBlockedWallTime, "planNodeBlockedWallTime is null");
+        this.planNodeAddInputWallTime = requireNonNull(planNodeAddInputWallTime, "planNodeAddInputWallTime is null");
+        this.planNodeGetOutputWallTime = requireNonNull(planNodeGetOutputWallTime, "planNodeGetOutputWallTime is null");
+        this.planNodeFinishWallTime = requireNonNull(planNodeFinishWallTime, "planNodeFinishWallTime is null");
         this.planNodeInputPositions = planNodeInputPositions;
         this.planNodeInputDataSize = planNodeInputDataSize;
         this.planNodeRawInputPositions = planNodeRawInputPositions;
@@ -82,6 +100,7 @@ public class PlanNodeStats
         this.planNodeOutputDataSize = planNodeOutputDataSize;
 
         this.operatorInputStats = requireNonNull(operatorInputStats, "operatorInputStats is null");
+        this.planNodePeakMemorySize = planNodePeakMemorySize;
         this.planNodeNullJoinBuildKeyCount = planNodeNullJoinBuildKeyCount;
         this.planNodeJoinBuildKeyCount = planNodeJoinBuildKeyCount;
         this.planNodeNullJoinProbeKeyCount = planNodeNullJoinProbeKeyCount;
@@ -97,19 +116,53 @@ public class PlanNodeStats
         return sqrt(max(variance, 0d));
     }
 
+    @JsonProperty
     public PlanNodeId getPlanNodeId()
     {
         return planNodeId;
     }
 
+    @JsonProperty
     public Duration getPlanNodeScheduledTime()
     {
         return planNodeScheduledTime;
     }
 
+    @JsonProperty
     public Duration getPlanNodeCpuTime()
     {
         return planNodeCpuTime;
+    }
+
+    @JsonProperty
+    public Duration getPlanNodeBlockedWallTime()
+    {
+        return planNodeBlockedWallTime;
+    }
+
+    @JsonProperty
+    public Duration getPlanNodeAddInputWallTime()
+    {
+        return planNodeAddInputWallTime;
+    }
+
+    @JsonProperty
+    public Duration getPlanNodeGetOutputWallTime()
+    {
+        return planNodeGetOutputWallTime;
+    }
+
+    @JsonProperty
+    public Duration getPlanNodeFinishWallTime()
+    {
+        return planNodeFinishWallTime;
+    }
+
+    @JsonProperty
+    public Map<String, OperatorInputStats> getOperatorInputStats()
+    {
+        // no need to copy, just prevent modifications
+        return Collections.unmodifiableMap(operatorInputStats);
     }
 
     public Set<String> getOperatorTypes()
@@ -117,31 +170,37 @@ public class PlanNodeStats
         return operatorInputStats.keySet();
     }
 
+    @JsonProperty
     public long getPlanNodeInputPositions()
     {
         return planNodeInputPositions;
     }
 
+    @JsonProperty
     public DataSize getPlanNodeInputDataSize()
     {
         return planNodeInputDataSize;
     }
 
+    @JsonProperty
     public long getPlanNodeRawInputPositions()
     {
         return planNodeRawInputPositions;
     }
 
+    @JsonProperty
     public DataSize getPlanNodeRawInputDataSize()
     {
         return planNodeRawInputDataSize;
     }
 
+    @JsonProperty
     public long getPlanNodeOutputPositions()
     {
         return planNodeOutputPositions;
     }
 
+    @JsonProperty
     public DataSize getPlanNodeOutputDataSize()
     {
         return planNodeOutputDataSize;
@@ -166,21 +225,31 @@ public class PlanNodeStats
                                 entry.getValue().getTotalDrivers())));
     }
 
+    @JsonProperty
+    public DataSize getPlanNodePeakMemorySize()
+    {
+        return planNodePeakMemorySize;
+    }
+
+    @JsonProperty
     public long getPlanNodeNullJoinBuildKeyCount()
     {
         return planNodeNullJoinBuildKeyCount;
     }
 
+    @JsonProperty
     public long getPlanNodeJoinBuildKeyCount()
     {
         return planNodeJoinBuildKeyCount;
     }
 
+    @JsonProperty
     public long getPlanNodeNullJoinProbeKeyCount()
     {
         return planNodeNullJoinProbeKeyCount;
     }
 
+    @JsonProperty
     public long getPlanNodeJoinProbeKeyCount()
     {
         return planNodeJoinProbeKeyCount;
@@ -216,6 +285,7 @@ public class PlanNodeStats
         DataSize planNodeRawInputDataSize = succinctBytes((long) ((double) this.planNodeRawInputDataSize.toBytes() + (double) other.planNodeRawInputDataSize.toBytes()));
         long planNodeOutputPositions = this.planNodeOutputPositions + other.planNodeOutputPositions;
         DataSize planNodeOutputDataSize = succinctBytes((long) ((double) this.planNodeOutputDataSize.toBytes() + (double) other.planNodeOutputDataSize.toBytes()));
+        DataSize planNodePeakMemorySize = succinctBytes(Math.max(this.planNodePeakMemorySize.toBytes(), other.planNodePeakMemorySize.toBytes()));
 
         Map<String, OperatorInputStats> operatorInputStats = mergeMaps(this.operatorInputStats, other.operatorInputStats, OperatorInputStats::merge);
         long planNodeNullJoinBuildKeyCount = this.planNodeNullJoinBuildKeyCount + other.planNodeNullJoinBuildKeyCount;
@@ -228,10 +298,16 @@ public class PlanNodeStats
                 planNodeId,
                 new Duration(planNodeScheduledTime.toMillis() + other.getPlanNodeScheduledTime().toMillis(), MILLISECONDS),
                 new Duration(planNodeCpuTime.toMillis() + other.getPlanNodeCpuTime().toMillis(), MILLISECONDS),
+                new Duration(planNodeBlockedWallTime.toMillis() + other.getPlanNodeBlockedWallTime().toMillis(), MILLISECONDS),
+                new Duration(planNodeAddInputWallTime.toMillis() + other.getPlanNodeAddInputWallTime().toMillis(), MILLISECONDS),
+                new Duration(planNodeGetOutputWallTime.toMillis() + other.getPlanNodeGetOutputWallTime().toMillis(), MILLISECONDS),
+                new Duration(planNodeFinishWallTime.toMillis() + other.getPlanNodeFinishWallTime().toMillis(), MILLISECONDS),
                 planNodeInputPositions, planNodeInputDataSize,
                 planNodeRawInputPositions, planNodeRawInputDataSize,
                 planNodeOutputPositions, planNodeOutputDataSize,
+                planNodePeakMemorySize,
                 operatorInputStats,
+
                 planNodeNullJoinBuildKeyCount,
                 planNodeJoinBuildKeyCount,
                 planNodeNullJoinProbeKeyCount,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -82,6 +82,11 @@ public class PlanNodeStatsSummarizer
         Map<PlanNodeId, Long> planNodeOutputBytes = new HashMap<>();
         Map<PlanNodeId, Long> planNodeScheduledMillis = new HashMap<>();
         Map<PlanNodeId, Long> planNodeCpuMillis = new HashMap<>();
+        Map<PlanNodeId, Long> planNodePeakMemory = new HashMap<>();
+        Map<PlanNodeId, Long> planNodeBlockedMillis = new HashMap<>();
+        Map<PlanNodeId, Long> planNodeAddInputMillis = new HashMap<>();
+        Map<PlanNodeId, Long> planNodeGetOutputMillis = new HashMap<>();
+        Map<PlanNodeId, Long> planNodeFinishMillis = new HashMap<>();
         Map<PlanNodeId, Long> planNodeNullJoinBuildKeyCount = new HashMap<>();
         Map<PlanNodeId, Long> planNodeJoinBuildKeyCount = new HashMap<>();
         Map<PlanNodeId, Long> planNodeNullJoinProbeKeyCount = new HashMap<>();
@@ -114,6 +119,11 @@ public class PlanNodeStatsSummarizer
 
                 long cpuMillis = operatorStats.getAddInputCpu().toMillis() + operatorStats.getGetOutputCpu().toMillis() + operatorStats.getFinishCpu().toMillis();
                 planNodeCpuMillis.merge(planNodeId, cpuMillis, Long::sum);
+                planNodeBlockedMillis.merge(planNodeId, operatorStats.getBlockedWall().toMillis(), Long::sum);
+                planNodeAddInputMillis.merge(planNodeId, operatorStats.getAddInputWall().toMillis(), Long::sum);
+                planNodeFinishMillis.merge(planNodeId, operatorStats.getFinishWall().toMillis(), Long::sum);
+                planNodeGetOutputMillis.merge(planNodeId, operatorStats.getGetOutputWall().toMillis(), Long::sum);
+                planNodePeakMemory.merge(planNodeId, operatorStats.getPeakTotalMemoryReservation().toBytes(), Math::max);
 
                 // A pipeline like hash build before join might link to another "internal" pipelines which provide actual input for this plan node
                 if (operatorStats.getPlanNodeId().equals(inputPlanNode) && !pipelineStats.isInputPipeline()) {
@@ -212,12 +222,17 @@ public class PlanNodeStatsSummarizer
                         planNodeId,
                         new Duration(planNodeScheduledMillis.get(planNodeId), MILLISECONDS),
                         new Duration(planNodeCpuMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeBlockedMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeAddInputMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeGetOutputMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeFinishMillis.get(planNodeId), MILLISECONDS),
                         planNodeInputPositions.get(planNodeId),
                         succinctDataSize(planNodeInputBytes.get(planNodeId), BYTE),
                         planNodeRawInputPositions.get(planNodeId),
                         succinctDataSize(planNodeRawInputBytes.get(planNodeId), BYTE),
                         outputPositions,
                         succinctDataSize(planNodeOutputBytes.getOrDefault(planNodeId, 0L), BYTE),
+                        succinctDataSize(planNodePeakMemory.get(planNodeId), BYTE),
                         operatorInputStats.get(planNodeId),
                         planNodeNullJoinBuildKeyCount.get(planNodeId),
                         planNodeJoinBuildKeyCount.get(planNodeId),
@@ -231,12 +246,17 @@ public class PlanNodeStatsSummarizer
                         planNodeId,
                         new Duration(planNodeScheduledMillis.get(planNodeId), MILLISECONDS),
                         new Duration(planNodeCpuMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeBlockedMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeAddInputMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeGetOutputMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeFinishMillis.get(planNodeId), MILLISECONDS),
                         planNodeInputPositions.get(planNodeId),
                         succinctDataSize(planNodeInputBytes.get(planNodeId), BYTE),
                         planNodeRawInputPositions.get(planNodeId),
                         succinctDataSize(planNodeRawInputBytes.get(planNodeId), BYTE),
                         outputPositions,
                         succinctDataSize(planNodeOutputBytes.getOrDefault(planNodeId, 0L), BYTE),
+                        succinctDataSize(planNodePeakMemory.get(planNodeId), BYTE),
                         operatorInputStats.get(planNodeId),
                         planNodeNullJoinBuildKeyCount.get(planNodeId),
                         planNodeJoinBuildKeyCount.get(planNodeId),
@@ -250,12 +270,17 @@ public class PlanNodeStatsSummarizer
                         planNodeId,
                         new Duration(planNodeScheduledMillis.get(planNodeId), MILLISECONDS),
                         new Duration(planNodeCpuMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeBlockedMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeAddInputMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeGetOutputMillis.get(planNodeId), MILLISECONDS),
+                        new Duration(planNodeFinishMillis.get(planNodeId), MILLISECONDS),
                         planNodeInputPositions.get(planNodeId),
                         succinctDataSize(planNodeInputBytes.get(planNodeId), BYTE),
                         planNodeRawInputPositions.get(planNodeId),
                         succinctDataSize(planNodeRawInputBytes.get(planNodeId), BYTE),
                         outputPositions,
                         succinctDataSize(planNodeOutputBytes.getOrDefault(planNodeId, 0L), BYTE),
+                        succinctDataSize(planNodePeakMemory.get(planNodeId), BYTE),
                         operatorInputStats.get(planNodeId),
                         planNodeNullJoinBuildKeyCount.get(planNodeId),
                         planNodeJoinBuildKeyCount.get(planNodeId),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -326,18 +326,20 @@ public class PlanPrinter
         return new PlanPrinter(plan, types, stageExecutionStrategy, estimatedStatsAndCosts, stats, functionAndTypeManager, session).toJson();
     }
 
-    public static String jsonDistributedPlan(StageInfo outputStageInfo, FunctionAndTypeManager functionAndTypeManager)
+    public static String jsonDistributedPlan(StageInfo outputStageInfo, FunctionAndTypeManager functionAndTypeManager, Session session)
     {
+        List<StageInfo> allStages = getAllStages(Optional.of(outputStageInfo));
+        Map<PlanNodeId, PlanNodeStats> aggregatedStats = aggregateStageStats(allStages);
         List<PlanFragment> allFragments = getAllStages(Optional.of(outputStageInfo)).stream()
                 .map(StageInfo::getPlan)
                 .map(Optional::get)
                 .collect(toImmutableList());
-        return formatJsonFragmentList(allFragments, functionAndTypeManager);
+        return formatJsonFragmentList(allFragments, Optional.of(aggregatedStats), functionAndTypeManager, session);
     }
 
-    public static String jsonDistributedPlan(SubPlan plan, FunctionAndTypeManager functionAndTypeManager)
+    public static String jsonDistributedPlan(SubPlan plan, FunctionAndTypeManager functionAndTypeManager, Session session)
     {
-        return formatJsonFragmentList(plan.getAllFragments(), functionAndTypeManager);
+        return formatJsonFragmentList(plan.getAllFragments(), Optional.empty(), functionAndTypeManager, session);
     }
 
     private String formatSourceLocation(Optional<SourceLocation> sourceLocation1, Optional<SourceLocation> sourceLocation2)
@@ -358,12 +360,14 @@ public class PlanPrinter
         return "";
     }
 
-    private static String formatJsonFragmentList(List<PlanFragment> fragments, FunctionAndTypeManager functionAndTypeManager)
+    private static String formatJsonFragmentList(List<PlanFragment> fragments, Optional<Map<PlanNodeId, PlanNodeStats>> executionStats, FunctionAndTypeManager functionAndTypeManager, Session session)
     {
         ImmutableSortedMap.Builder<PlanFragmentId, JsonPlanFragment> fragmentJsonMap = ImmutableSortedMap.naturalOrder();
         for (PlanFragment fragment : fragments) {
             PlanFragmentId fragmentId = fragment.getId();
-            JsonPlanFragment jsonPlanFragment = new JsonPlanFragment(fragment.getJsonRepresentation().get());
+            TypeProvider typeProvider = TypeProvider.fromVariables(fragment.getVariables());
+            PlanPrinter printer = new PlanPrinter(fragment.getRoot(), typeProvider, Optional.of(fragment.getStageExecutionDescriptor()), fragment.getStatsAndCosts().orElse(StatsAndCosts.empty()), executionStats, functionAndTypeManager, session);
+            JsonPlanFragment jsonPlanFragment = new JsonPlanFragment(printer.toJson());
             fragmentJsonMap.put(fragmentId, jsonPlanFragment);
         }
         return new JsonRenderer(functionAndTypeManager).render(fragmentJsonMap.build());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanRepresentation.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-class PlanRepresentation
+public class PlanRepresentation
 {
     private final PlanNode root;
     private final Optional<Duration> totalCpuTime;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
@@ -32,12 +32,17 @@ public class WindowPlanNodeStats
             PlanNodeId planNodeId,
             Duration planNodeScheduledTime,
             Duration planNodeCpuTime,
+            Duration planNodeBlockedWallTime,
+            Duration planNodeAddInputWallTime,
+            Duration planNodeGetOutputWallTime,
+            Duration planNodeFinishWallTime,
             long planNodeInputPositions,
             DataSize planNodeInputDataSize,
             long planNodeRawInputPositions,
             DataSize planNodeRawInputDataSize,
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
+            DataSize planNodePeakMemorySize,
             Map<String, OperatorInputStats> operatorInputStats,
             long planNodeNullJoinBuildKeyCount,
             long planNodeJoinBuildKeyCount,
@@ -46,9 +51,8 @@ public class WindowPlanNodeStats
             Optional<DynamicFilterStats> dynamicFilterStats,
             WindowOperatorStats windowOperatorStats)
     {
-        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize,
-                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount,
-                planNodeJoinProbeKeyCount, dynamicFilterStats);
+        super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeBlockedWallTime, planNodeAddInputWallTime, planNodeGetOutputWallTime, planNodeFinishWallTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize,
+                planNodeOutputPositions, planNodeOutputDataSize, planNodePeakMemorySize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount, planNodeJoinProbeKeyCount, dynamicFilterStats);
         this.windowOperatorStats = windowOperatorStats;
     }
 
@@ -67,12 +71,17 @@ public class WindowPlanNodeStats
                 merged.getPlanNodeId(),
                 merged.getPlanNodeScheduledTime(),
                 merged.getPlanNodeCpuTime(),
+                merged.getPlanNodeBlockedWallTime(),
+                merged.getPlanNodeAddInputWallTime(),
+                merged.getPlanNodeGetOutputWallTime(),
+                merged.getPlanNodeFinishWallTime(),
                 merged.getPlanNodeInputPositions(),
                 merged.getPlanNodeInputDataSize(),
                 merged.getPlanNodeRawInputPositions(),
                 merged.getPlanNodeRawInputDataSize(),
                 merged.getPlanNodeOutputPositions(),
                 merged.getPlanNodeOutputDataSize(),
+                merged.getPlanNodePeakMemorySize(),
                 merged.operatorInputStats,
                 merged.getPlanNodeNullJoinBuildKeyCount(),
                 merged.getPlanNodeJoinBuildKeyCount(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -86,6 +86,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.WINDOW_REQUIRES
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -844,6 +845,31 @@ public class TestAnalyzer
     public void testExplainAnalyze()
     {
         analyze("EXPLAIN ANALYZE SELECT * FROM t1");
+    }
+
+    @Test
+    public void testExplainAnalyzeFormatJson()
+    {
+        analyze("EXPLAIN ANALYZE (format JSON) SELECT * FROM t1");
+    }
+
+    public void testExplainAnalyzeFormatJsonHasStats()
+    {
+        analyze("EXPLAIN ANALYZE (format JSON) SELECT * FROM t1");
+    }
+
+    @Test
+    public void testExplainAnalyzeFormatJsonTypeDistributed()
+    {
+        analyze("EXPLAIN ANALYZE (format JSON, type DISTRIBUTED) SELECT * FROM t1");
+    }
+
+    @Test
+    public void testExplainAnalyzeIllegalArgs()
+    {
+        assertThrows(IllegalStateException.class, () -> analyze("EXPLAIN ANALYZE (type LOGICAL) SELECT * FROM t1"));
+        assertThrows(IllegalStateException.class, () -> analyze("EXPLAIN ANALYZE (format TEXT, type LOGICAL) SELECT * FROM t1"));
+        assertThrows(IllegalStateException.class, () -> analyze("EXPLAIN ANALYZE (format JSON, format TEXT) SELECT * FROM t1"));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
+import com.facebook.presto.sql.tree.ExplainFormat;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
@@ -67,7 +68,8 @@ public class TestVerifyOnlyOneOutputNode
                                                 Assignments.of()
                                         ), ImmutableList.of(), ImmutableList.of()
                                 ), new VariableReferenceExpression(Optional.empty(), "a", BIGINT),
-                                false),
+                                false,
+                                ExplainFormat.Type.TEXT),
                         ImmutableList.of(), ImmutableList.of());
         new VerifyOnlyOneOutputNode().validate(root, null, null, null, null, WarningCollector.NOOP);
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -2016,6 +2016,20 @@ public class TestSqlParser
     }
 
     @Test
+    public void testExplainAnalyzeFormatJson()
+    {
+        assertStatement("EXPLAIN ANALYZE (format JSON) SELECT * FROM t",
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, false, ImmutableList.of(new ExplainFormat(ExplainFormat.Type.JSON))));
+    }
+
+    @Test
+    public void testExplainAnalyzeFormatJsonTypeDistributed()
+    {
+        assertStatement("EXPLAIN ANALYZE (format JSON, type DISTRIBUTED) SELECT * FROM t",
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, false, ImmutableList.of(new ExplainFormat(ExplainFormat.Type.JSON), new ExplainType(ExplainType.Type.DISTRIBUTED))));
+    }
+
+    @Test
     public void testExplainAnalyzeVerbose()
     {
         assertStatement("EXPLAIN ANALYZE VERBOSE SELECT * FROM t",
@@ -2027,6 +2041,13 @@ public class TestSqlParser
     {
         assertStatement("EXPLAIN ANALYZE VERBOSE (type DISTRIBUTED) SELECT * FROM t",
                 new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, true, ImmutableList.of(new ExplainType(ExplainType.Type.DISTRIBUTED))));
+    }
+
+    @Test
+    public void testExplainAnalyzeVerboseFormatJson()
+    {
+        assertStatement("EXPLAIN ANALYZE VERBOSE (format JSON) SELECT * FROM t",
+                new Explain(simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))), true, true, ImmutableList.of(new ExplainFormat(ExplainFormat.Type.JSON))));
     }
 
     @Test


### PR DESCRIPTION
## Description

This change adds two features:

1. Support for `format <X>` in EXPLAIN ANALYZE
2. Adds support for a `stats` field in each plan node representation

This allows the user to get a computer-friendly representation of the plan with the statistics. This can be useful for visualization or as input to other systems for plan node-level performance analysis.

## Motivation and Context

- Additional execution analysis capabilities through query plan JSON

## Impact

- The JSON representation of a plan from now includes a "stats" field representation statistics at runtime. Its contents map to `PlanNodeStats.java`
  - This effects the plans sent from the event listener framework
  - Backwards compatibility should be preserved as the change only introduces a new field in the JSON representation without modifying previously-present fields.

## Test Plan

- New tests in the parser and statement analyzer to verify user-supplied arguments.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve :doc:`/sql/explain-analyze` statement to support a ``format`` argument with values of ``<TEXT|JSON>`` :pr:`22733`
```

