### PR TITLE
Fix Removing Partition Builder

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingExtendedHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingExtendedHiveMetastore.java
@@ -164,9 +164,7 @@ public class TestingExtendedHiveMetastore
 
             Partition partition = partitions.get(partitionKey);
             if (partition != null) {
-                Partition.Builder builder = Partition.builder(partition)
-                        .setLastDataCommitTime(time);
-                result.put(partitionNameWithVersion.getPartitionName(), Optional.of(builder.build()));
+                result.put(partitionNameWithVersion.getPartitionName(), Optional.of(partition));
             }
             else {
                 result.put(partitionNameWithVersion.getPartitionName(), Optional.empty());


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Ensuring that the partition maintains its original type (e.g., child class) and associated information.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

The issue here is that the Partition class is a base class for other child-class Partition, and when using the Partition.builder() method to create a new instance of Partition, the resulting object will be of type Partition rather than child-class Partition. This means that any methods or properties specific to child-class Partition will not be available on the new object created by the builder.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

Unit Test in `TestMemcacheHiveMetastore.java` 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==



```
== NO RELEASE NOTE ==
```

