### PR TITLE
Add support for bucketed (but not partitioned) tables

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
@@ -1180,10 +1180,6 @@ HivePrestoToVeloxConnector::toVeloxInsertTableHandle(
   bool isPartitioned{false};
   const auto inputColumns = toHiveColumns(
       hiveOutputTableHandle->inputColumns, typeParser, isPartitioned);
-  VELOX_USER_CHECK(
-      hiveOutputTableHandle->bucketProperty == nullptr || isPartitioned,
-      "Bucketed table must be partitioned: {}",
-      toJsonString(*hiveOutputTableHandle));
   return std::make_unique<velox::connector::hive::HiveInsertTableHandle>(
       inputColumns,
       toLocationHandle(hiveOutputTableHandle->locationHandle),
@@ -1208,10 +1204,6 @@ HivePrestoToVeloxConnector::toVeloxInsertTableHandle(
   bool isPartitioned{false};
   const auto inputColumns = toHiveColumns(
       hiveInsertTableHandle->inputColumns, typeParser, isPartitioned);
-  VELOX_USER_CHECK(
-      hiveInsertTableHandle->bucketProperty == nullptr || isPartitioned,
-      "Bucketed table must be partitioned: {}",
-      toJsonString(*hiveInsertTableHandle));
 
   const auto table = hiveInsertTableHandle->pageSinkMetadata.table;
   VELOX_USER_CHECK_NOT_NULL(table, "Table must not be null for insert query");


### PR DESCRIPTION
## Description
Presto supports CTAS into bucketed (but not partitioned tables). The user cannot append/overwrite to existing bucketed tables (though can append to TEMPORARY ones).

Prestissimo didn't support these DML.

## Motivation and Context
The CTAS into bucketed tables has become important because such tables are used for CTE (WITH clause).
https://github.com/prestodb/presto/issues/22630

The main fixes are on the Velox side https://github.com/facebookincubator/velox/pull/9740. The Prestissimo impact is mainly around removing a validation in the code during conversion of the table handles for bucketed (but not partitioned) tables.

## Test Plan
e2e tests 

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Prestissimo support for CTAS into bucketed (but not partitioned) tables pr:`22737`