### PR TITLE
[native] Remove spill stats reporting from presto native

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -16,7 +16,6 @@
 #include <folly/experimental/FunctionScheduler.h>
 #include <folly/experimental/ThreadedRepeatingFunctionRunner.h>
 #include "velox/common/memory/Memory.h"
-#include "velox/exec/Spill.h"
 #include "velox/exec/Task.h"
 
 namespace folly {
@@ -112,9 +111,6 @@ class PeriodicTaskManager {
   void addOperatingSystemStatsUpdateTask();
   void updateOperatingSystemStats();
 
-  void addSpillStatsUpdateTask();
-  void updateSpillStatsTask();
-
   // Adds task that periodically prints http endpoint latency metrics.
   void addHttpEndpointLatencyStatsTask();
   void printHttpEndpointLatencyStats();
@@ -135,19 +131,6 @@ class PeriodicTaskManager {
       std::shared_ptr<velox::connector::Connector>>& connectors_;
   PrestoServer* const server_;
 
-  // Cache related stats
-  int64_t lastMemoryCacheHits_{0};
-  int64_t lastMemoryCacheHitsBytes_{0};
-  int64_t lastMemoryCacheInserts_{0};
-  int64_t lastMemoryCacheEvictions_{0};
-  int64_t lastMemoryCacheEvictionChecks_{0};
-  int64_t lastMemoryCacheStalls_{0};
-  int64_t lastMemoryCacheAllocClocks_{0};
-  int64_t lastMemoryCacheAgedOuts_{0};
-  int64_t lastSsdCacheCheckpointsWritten_{0};
-  int64_t lastSsdCacheCheckpointsRead_{0};
-  int64_t lastSsdCacheRegionsEvicted_{0};
-
   // Operating system related stats.
   int64_t lastUserCpuTimeUs_{0};
   int64_t lastSystemCpuTimeUs_{0};
@@ -155,8 +138,6 @@ class PeriodicTaskManager {
   int64_t lastHardPageFaults_{0};
   int64_t lastVoluntaryContextSwitches_{0};
   int64_t lastForcedContextSwitches_{0};
-  // Renabled this after update velox.
-  velox::common::SpillStats lastSpillStats_;
 
   // NOTE: declare last since the threads access other members of `this`.
   folly::FunctionScheduler oneTimeRunner_;

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -110,28 +110,6 @@ void registerPrestoMetrics() {
       62l * 1024 * 1024 * 1024, // max bucket value: 62GB
       100);
 
-  /// ================== Disk Spilling Counters =================
-
-  DEFINE_METRIC(kCounterSpillRuns, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpilledFiles, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpilledRows, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpilledBytes, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpillFillTimeUs, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpillSortTimeUs, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(
-      kCounterSpillSerializationTimeUs, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpillWrites, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpillFlushTimeUs, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpillWriteTimeUs, facebook::velox::StatType::SUM);
-  DEFINE_METRIC(kCounterSpillMemoryBytes, facebook::velox::StatType::AVG);
-  DEFINE_HISTOGRAM_METRIC(
-      kCounterSpillPeakMemoryBytes,
-      1l * 512 * 1024 * 1024,
-      0,
-      20l * 1024 * 1024 * 1024, // max bucket value: 20GB
-      100);
-  DEFINE_METRIC(kCounterSpillMaxLevelExceeded, facebook::velox::StatType::SUM);
-
   // NOTE: Metrics type exporting for file handle cache counters are in
   // PeriodicTaskManager because they have dynamic names. The following counters
   // have their type exported there:

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -138,50 +138,6 @@ constexpr folly::StringPiece kCounterOsNumVoluntaryContextSwitches{
 constexpr folly::StringPiece kCounterOsNumForcedContextSwitches{
     "presto_cpp.os_num_forced_context_switches"};
 
-/// ================== Disk Spilling Counters =================
-
-/// The number of times that spilling runs on a velox operator.
-constexpr folly::StringPiece kCounterSpillRuns{"presto_cpp.spill_run_count"};
-/// The number of spilled files.
-constexpr folly::StringPiece kCounterSpilledFiles{
-    "presto_cpp.spilled_file_count"};
-/// The number of spilled rows.
-constexpr folly::StringPiece kCounterSpilledRows{
-    "presto_cpp.spilled_row_count"};
-/// The number of bytes spilled to disks.
-///
-/// NOTE: if compression is enabled, this counts the compressed bytes.
-constexpr folly::StringPiece kCounterSpilledBytes{"presto_cpp.spilled_bytes"};
-/// The time spent on filling rows for spilling.
-constexpr folly::StringPiece kCounterSpillFillTimeUs{
-    "presto_cpp.spill_fill_time_us"};
-/// The time spent on sorting rows for spilling.
-constexpr folly::StringPiece kCounterSpillSortTimeUs{
-    "presto_cpp.spill_sort_time_us"};
-/// The time spent on serializing rows for spilling.
-constexpr folly::StringPiece kCounterSpillSerializationTimeUs{
-    "presto_cpp.spill_serialization_time_us"};
-/// The number of disk writes to spill rows.
-constexpr folly::StringPiece kCounterSpillWrites{
-    "presto_cpp.spill_write_count"};
-/// The time spent on copy out serialized rows for disk write. If compression
-/// is enabled, this includes the compression time.
-constexpr folly::StringPiece kCounterSpillFlushTimeUs{
-    "presto_cpp.spill_flush_time_us"};
-/// The time spent on writing spilled rows to disk.
-constexpr folly::StringPiece kCounterSpillWriteTimeUs{
-    "presto_cpp.spill_write_time_us"};
-/// The number of times that a spillable operator exceeds the max spill level
-/// limit that can't spill.
-constexpr folly::StringPiece kCounterSpillMaxLevelExceeded{
-    "presto_cpp.spill_exceeded_max_level_count"};
-/// The current spilling memory usage in bytes.
-constexpr folly::StringPiece kCounterSpillMemoryBytes{
-    "presto_cpp.spill_memory_bytes"};
-/// The peak spilling memory usage in bytes.
-constexpr folly::StringPiece kCounterSpillPeakMemoryBytes{
-    "presto_cpp.spill_peak_memory_bytes"};
-
 /// ================== HiveConnector Counters ==================
 /// Format template strings use 'constexpr std::string_view' to be 'fmt::format'
 /// compatible.


### PR DESCRIPTION
Removes spill related stats reporting from presto native. Migrated the reporting to velox's PeriodicStatsReporter.
```
== RELEASE NOTES ==
Since there are metrics removed from reporting, dashboards might be affected. Migrate the dashboard to point to the velox reported metrics instead.
The removed spill related metrics are going to be replaced by velox reported metrics in the following way:
original: presto_cpp.spill_metrics_name
new: velox.spill_metrics_name
```

