### PR TITLE
Correct check for $row_id column presence

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
@@ -40,7 +40,7 @@ import static java.util.Objects.requireNonNull;
 public class OrcSelectivePageSource
         implements ConnectorPageSource
 {
-    static final int ROW_ID_COLUMN_INDEX = -10;
+    private static final int ROW_ID_COLUMN_INDEX = -10;
 
     private final OrcSelectiveRecordReader recordReader;
     private final OrcDataSource orcDataSource;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -389,7 +389,7 @@ public class OrcSelectivePageSourceFactory
                     appendRowNumberEnabled,
                     partitionID,
                     rowGroupId,
-                    recordReader.isColumnPresent(OrcSelectivePageSource.ROW_ID_COLUMN_INDEX));
+                    supplyRowIDs);
         }
         catch (Exception e) {
             try {


### PR DESCRIPTION
## Description
Check selectedColumns for $row_id instead of presentColumns

## Motivation and Context
presentColumns doesn't include any columns with indexes less than zero. $row_id is -10.

## Impact
Hopefully fixes the $row_id omission bug

## Test Plan
In progress. Trying to come up with unit test. Also want to deploy from a local build and test in CLI. But it might be faster to just land this and see if it works. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

