### PR TITLE
Update `io.jsonwebtoken` artifacts for Java 11 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -965,6 +965,12 @@
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>http-server</artifactId>
                 <version>${dep.airlift.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1282,8 +1288,19 @@
 
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
-                <artifactId>jjwt</artifactId>
-                <version>0.9.0</version>
+                <artifactId>jjwt-api</artifactId>
+                <version>0.11.5</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jsonwebtoken</groupId>
+                <artifactId>jjwt-impl</artifactId>
+                <version>0.11.5</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.jsonwebtoken</groupId>
+                <artifactId>jjwt-jackson</artifactId>
+                <version>0.11.5</version>
             </dependency>
 
             <dependency>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -173,7 +173,17 @@
 
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
+            <artifactId>jjwt-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverAuth.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverAuth.java
@@ -190,9 +190,10 @@ public class TestPrestoDriverAuth
     public void testFailedBadHmacSignature()
             throws Exception
     {
+        String badKey = "iPqFfWmGvClP953xU9110Q48qB4F5dcJ7QQel3O1k0xU52mlR6fT51SMa2f4KzhFRqqpwGUOud8Eo12pK9EW5H4N";
         String accessToken = Jwts.builder()
                 .setSubject("test")
-                .signWith(SignatureAlgorithm.HS512, Base64.getEncoder().encodeToString("bad-key".getBytes(US_ASCII)))
+                .signWith(SignatureAlgorithm.HS512, Base64.getEncoder().encodeToString(badKey.getBytes(US_ASCII)))
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -354,7 +354,17 @@
 
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
+            <artifactId>jjwt-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/presto-proxy/pom.xml
+++ b/presto-proxy/pom.xml
@@ -139,7 +139,17 @@
 
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
+            <artifactId>jjwt-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
The previous `io.jsonwebtoken.jjwt:0.9.0` is not compatible with Java 11 at runtime. For versions 10.0.0 and beyond, the `jjwt` api and implementation are split into separate artifacts.

## Motivation and Context
This was discovered while testing #22417, which has a depedency on `jjwt-api`.

See also: https://github.com/jwtk/jjwt#understanding-jjwt-dependencies

## Impact
Enhances Java 11 support

## Test Plan
An API update necessitated the update of one of the jdbc tests to include a longer key.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Upgrade io.jsonwebtoken artifacts to 0.11.5 :pr:`22762`
```

