### PR TITLE
Log detail name for optimizers of RowExpressionRewriteRuleSet and StatsRecordingPlanOptimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
@@ -55,6 +55,7 @@ import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMap.builder;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class RowExpressionRewriteRuleSet
@@ -141,8 +142,18 @@ public class RowExpressionRewriteRuleSet
         return new AggregationRowExpressionRewrite();
     }
 
+    public abstract class RowExpressionRewriteRule<T>
+            implements Rule<T>
+    {
+        public String getOptimizerNameForLog()
+        {
+            String rewriterName = rewriter.getClass().getName();
+            return format("%s:%s", rewriterName.substring(rewriterName.lastIndexOf('.') + 1), this.getClass().getSimpleName());
+        }
+    }
+
     private final class ProjectRowExpressionRewrite
-            implements Rule<ProjectNode>
+            extends RowExpressionRewriteRule<ProjectNode>
     {
         @Override
         public boolean isEnabled(Session session)
@@ -177,7 +188,7 @@ public class RowExpressionRewriteRuleSet
     }
 
     private final class SpatialJoinRowExpressionRewrite
-            implements Rule<SpatialJoinNode>
+            extends RowExpressionRewriteRule<SpatialJoinNode>
     {
         @Override
         public boolean isEnabled(Session session)
@@ -215,7 +226,7 @@ public class RowExpressionRewriteRuleSet
     }
 
     private final class JoinRowExpressionRewrite
-            implements Rule<JoinNode>
+            extends RowExpressionRewriteRule<JoinNode>
     {
         @Override
         public boolean isEnabled(Session session)
@@ -259,7 +270,7 @@ public class RowExpressionRewriteRuleSet
     }
 
     private final class WindowRowExpressionRewrite
-            implements Rule<WindowNode>
+            extends RowExpressionRewriteRule<WindowNode>
     {
         @Override
         public boolean isEnabled(Session session)
@@ -316,7 +327,7 @@ public class RowExpressionRewriteRuleSet
     }
 
     private final class ApplyRowExpressionRewrite
-            implements Rule<ApplyNode>
+            extends RowExpressionRewriteRule<ApplyNode>
     {
         @Override
         public boolean isEnabled(Session session)
@@ -366,7 +377,7 @@ public class RowExpressionRewriteRuleSet
     }
 
     private final class FilterRowExpressionRewrite
-            implements Rule<FilterNode>
+            extends RowExpressionRewriteRule<FilterNode>
     {
         @Override
         public boolean isEnabled(Session session)
@@ -394,7 +405,7 @@ public class RowExpressionRewriteRuleSet
     }
 
     private final class ValuesRowExpressionRewrite
-            implements Rule<ValuesNode>
+            extends RowExpressionRewriteRule<ValuesNode>
     {
         @Override
         public boolean isEnabled(Session session)
@@ -432,7 +443,7 @@ public class RowExpressionRewriteRuleSet
     }
 
     private final class AggregationRowExpressionRewrite
-            implements Rule<AggregationNode>
+            extends RowExpressionRewriteRule<AggregationNode>
     {
         @Override
         public boolean isEnabled(Session session)
@@ -480,7 +491,7 @@ public class RowExpressionRewriteRuleSet
     }
 
     private final class TableFinishRowExpressionRewrite
-            implements Rule<TableFinishNode>
+            extends RowExpressionRewriteRule<TableFinishNode>
     {
         @Override
         public boolean isEnabled(Session session)
@@ -537,7 +548,7 @@ public class RowExpressionRewriteRuleSet
     }
 
     private final class TableWriterRowExpressionRewrite
-            implements Rule<TableWriterNode>
+            extends RowExpressionRewriteRule<TableWriterNode>
     {
         @Override
         public boolean isEnabled(Session session)


### PR DESCRIPTION
## Description
Currently optimizer log will record the class name of the optimizer, however this can be a problem for row expression optimizers, which extends RowExpressionRewriteRuleSet. All such optimizers will have the same name in the log, like "FilterRowExpressionRewrite", "ValuesRowExpressionRewrite" etc. These give no meaningful information on which optimizers are triggered.

This PR will log more verbose information for these optimizers, by including the rewriter class name.
For example instead of "ProjectRowExpressionRewrite" we will log RemoveMapCastRule$Rewriter:ProjectRowExpressionRewrite" now.

Similar for StatsRecordingPlanOptimizer, it's a wrapping optimizer, and it's the delegate optimizer within it doing the work. After the change, it will show as "StatsRecordingPlanOptimizer:HistoricalStatisticsEquivalentPlanMarkingOptimizer" instead of "StatsRecordingPlanOptimizer".

## Motivation and Context
To make optimizer log more meaningful.

## Impact
Improve optimizer log

## Test Plan
Test locally end to end

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve logging for RowExpressionRewriteRuleSet and StatsRecordingPlanOptimizer optimizers to include more information :pr:`22765`
```


