### PR TITLE
Record estimation stats during query optimization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -17,6 +17,8 @@ import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.cost.PlanCostEstimate;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
@@ -25,6 +27,7 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.Identity;
@@ -99,6 +102,8 @@ public final class Session
     private final OptimizerInformationCollector optimizerInformationCollector = new OptimizerInformationCollector();
     private final OptimizerResultCollector optimizerResultCollector = new OptimizerResultCollector();
     private final CTEInformationCollector cteInformationCollector = new CTEInformationCollector();
+    private final Map<PlanNodeId, PlanNodeStatsEstimate> planNodeStatsMap = new HashMap<>();
+    private final Map<PlanNodeId, PlanCostEstimate> planNodeCostMap = new HashMap<>();
 
     public Session(
             QueryId queryId,
@@ -335,6 +340,16 @@ public final class Session
     public CTEInformationCollector getCteInformationCollector()
     {
         return cteInformationCollector;
+    }
+
+    public Map<PlanNodeId, PlanNodeStatsEstimate> getPlanNodeStatsMap()
+    {
+        return planNodeStatsMap;
+    }
+
+    public Map<PlanNodeId, PlanCostEstimate> getPlanNodeCostMap()
+    {
+        return planNodeCostMap;
     }
 
     public Session beginTransactionId(TransactionId transactionId, TransactionManager transactionManager, AccessControl accessControl)

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -324,6 +324,7 @@ public final class SystemSessionProperties
     public static final String SKIP_HASH_GENERATION_FOR_JOIN_WITH_TABLE_SCAN_INPUT = "skip_hash_generation_for_join_with_table_scan_input";
     public static final String GENERATE_DOMAIN_FILTERS = "generate_domain_filters";
     public static final String REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION = "rewrite_expression_with_constant_expression";
+    public static final String PRINT_ESTIMATED_STATS_FROM_CACHE = "print_estimated_stats_from_cache";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -1915,6 +1916,12 @@ public final class SystemSessionProperties
                         "Rewrite left join with is null check to semi join",
                         featuresConfig.isRewriteExpressionWithConstantVariable(),
                         false),
+                booleanProperty(
+                        PRINT_ESTIMATED_STATS_FROM_CACHE,
+                        "When printing estimated plan stats after optimization is complete, such as in an EXPLAIN query or for logging in a QueryCompletedEvent, " +
+                                "get stats from a cache that was populated during query optimization rather than recalculating the stats on the final plan.",
+                        featuresConfig.isPrintEstimatedStatsFromCache(),
+                        false),
                 new PropertyMetadata<>(
                         DEFAULT_VIEW_SECURITY_MODE,
                         format("Set default view security mode. Options are: %s",
@@ -3217,5 +3224,10 @@ public final class SystemSessionProperties
     public static boolean isJoinPrefilterEnabled(Session session)
     {
         return session.getSystemProperty(JOIN_PREFILTER_BUILD_SIDE, Boolean.class);
+    }
+
+    public static boolean isPrintEstimatedStatsFromCacheEnabled(Session session)
+    {
+        return session.getSystemProperty(PRINT_ESTIMATED_STATS_FROM_CACHE, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/CachingCostProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CachingCostProvider.java
@@ -64,16 +64,20 @@ public class CachingCostProvider
 
         try {
             if (node instanceof GroupReference) {
-                return getGroupCost((GroupReference) node);
+                PlanCostEstimate result = getGroupCost((GroupReference) node);
+                session.getPlanNodeCostMap().put(node.getId(), result);
+                return result;
             }
 
             PlanCostEstimate cost = cache.get(node);
             if (cost != null) {
+                session.getPlanNodeCostMap().put(node.getId(), cost);
                 return cost;
             }
 
             cost = calculateCost(node);
             verify(cache.put(node, cost) == null, "Cost already set");
+            session.getPlanNodeCostMap().put(node.getId(), cost);
             return cost;
         }
         catch (RuntimeException e) {

--- a/presto-main/src/main/java/com/facebook/presto/cost/CachingStatsProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CachingStatsProvider.java
@@ -69,16 +69,20 @@ public final class CachingStatsProvider
 
         try {
             if (node instanceof GroupReference) {
-                return getGroupStats((GroupReference) node);
+                PlanNodeStatsEstimate result = getGroupStats((GroupReference) node);
+                session.getPlanNodeStatsMap().put(node.getId(), result);
+                return result;
             }
 
             PlanNodeStatsEstimate stats = cache.get(node);
             if (stats != null) {
+                session.getPlanNodeStatsMap().put(node.getId(), stats);
                 return stats;
             }
 
             stats = statsCalculator.calculateStats(node, this, lookup, session, types);
             verify(cache.put(node, stats) == null, "Stats already set");
+            session.getPlanNodeStatsMap().put(node.getId(), stats);
             return stats;
         }
         catch (RuntimeException e) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/Optimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/Optimizer.java
@@ -152,7 +152,7 @@ public class Optimizer
                         (node instanceof JoinNode) || (node instanceof SemiJoinNode)).matches()) {
             StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
             CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.empty(), session);
-            return StatsAndCosts.create(root, statsProvider, costProvider);
+            return StatsAndCosts.create(root, statsProvider, costProvider, session);
         }
         return StatsAndCosts.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -307,6 +307,7 @@ public class FeaturesConfig
     private long kHyperLogLogAggregationGroupNumberLimit;
     private boolean limitNumberOfGroupsForKHyperLogLogAggregations = true;
     private boolean generateDomainFilters;
+    private boolean printEstimatedStatsFromCache;
     private CreateView.Security defaultViewSecurityMode = DEFINER;
 
     public enum PartitioningPrecisionStrategy
@@ -3099,6 +3100,19 @@ public class FeaturesConfig
     public FeaturesConfig setDefaultViewSecurityMode(CreateView.Security securityMode)
     {
         this.defaultViewSecurityMode = securityMode;
+        return this;
+    }
+
+    public boolean isPrintEstimatedStatsFromCache()
+    {
+        return this.printEstimatedStatsFromCache;
+    }
+
+    @Config("optimizer.print-estimated-stats-from-cache")
+    @ConfigDescription("In the end of query optimization, print the estimation stats from cache populated during optimization instead of calculating from ground")
+    public FeaturesConfig setPrintEstimatedStatsFromCache(boolean printEstimatedStatsFromCache)
+    {
+        this.printEstimatedStatsFromCache = printEstimatedStatsFromCache;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -688,7 +688,7 @@ public class TestCostCalculator
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator(stats), session, typeProvider);
         CostProvider costProvider = new TestingCostProvider(costs, costCalculatorUsingExchanges, statsProvider, session);
         // Explicitly generate the statsAndCosts, bypass fragment generation and sanity checks for mock plans.
-        StatsAndCosts statsAndCosts = StatsAndCosts.create(node, statsProvider, costProvider).getForSubplan(node);
+        StatsAndCosts statsAndCosts = StatsAndCosts.create(node, statsProvider, costProvider, session).getForSubplan(node);
         return new CostAssertionBuilder(statsAndCosts.getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown()));
     }
 
@@ -807,7 +807,7 @@ public class TestCostCalculator
         TypeProvider typeProvider = TypeProvider.copyOf(types);
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, typeProvider);
         CostProvider costProvider = new CachingCostProvider(costCalculatorUsingExchanges, statsProvider, Optional.empty(), session);
-        SubPlan subPlan = fragment(new Plan(node, typeProvider, StatsAndCosts.create(node, statsProvider, costProvider)));
+        SubPlan subPlan = fragment(new Plan(node, typeProvider, StatsAndCosts.create(node, statsProvider, costProvider, session)));
         return subPlan.getFragment().getStatsAndCosts().getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -270,7 +270,8 @@ public class TestFeaturesConfig
                 .setDefaultWriterReplicationCoefficient(3.0)
                 .setDefaultViewSecurityMode(DEFINER)
                 .setCteHeuristicReplicationThreshold(4)
-                .setLegacyJsonCast(true));
+                .setLegacyJsonCast(true)
+                .setPrintEstimatedStatsFromCache(false));
     }
 
     @Test
@@ -485,6 +486,7 @@ public class TestFeaturesConfig
                 .put("optimizer.default-writer-replication-coefficient", "5.0")
                 .put("default-view-security-mode", INVOKER.name())
                 .put("cte-heuristic-replication-threshold", "2")
+                .put("optimizer.print-estimated-stats-from-cache", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -696,7 +698,8 @@ public class TestFeaturesConfig
                 .setDefaultWriterReplicationCoefficient(5.0)
                 .setDefaultViewSecurityMode(INVOKER)
                 .setCteHeuristicReplicationThreshold(2)
-                .setLegacyJsonCast(false);
+                .setLegacyJsonCast(false)
+                .setPrintEstimatedStatsFromCache(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
@@ -53,7 +53,7 @@ public final class PlanAssert
         // TODO (Issue #13231) add back printing unresolved plan once we have no need to translate OriginalExpression to RowExpression
         if (!matches.isMatch()) {
             PlanNode resolvedPlan = resolveGroupReferences(actual.getRoot(), lookup);
-            String resolvedFormattedPlan = textLogicalPlan(planSanitizer.apply(resolvedPlan), actual.getTypes(), StatsAndCosts.create(resolvedPlan, statsProvider, node -> PlanCostEstimate.unknown()), metadata.getFunctionAndTypeManager(), session, 0);
+            String resolvedFormattedPlan = textLogicalPlan(planSanitizer.apply(resolvedPlan), actual.getTypes(), StatsAndCosts.create(resolvedPlan, statsProvider, node -> PlanCostEstimate.unknown(), session), metadata.getFunctionAndTypeManager(), session, 0);
             throw new AssertionError(format(
                     "Plan does not match, expected [\n\n%s\n] but found [\n\n%s\n]",
                     pattern,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -240,7 +240,7 @@ public class RuleAssert
     {
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
         CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, session);
-        return inTransaction(session -> textLogicalPlan(plan, types, StatsAndCosts.create(plan, statsProvider, costProvider), metadata.getFunctionAndTypeManager(), session, 2, false, isVerboseOptimizerInfoEnabled(session)));
+        return inTransaction(session -> textLogicalPlan(plan, types, StatsAndCosts.create(plan, statsProvider, costProvider, session), metadata.getFunctionAndTypeManager(), session, 2, false, isVerboseOptimizerInfoEnabled(session)));
     }
 
     private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)


### PR DESCRIPTION
## Description
When optimizer returns a optimized plan, it will also return the estimation of stats for each node with the plan, https://github.com/prestodb/presto/blob/5240412564458d1960d79a14139c58611dc686dc/presto-main/src/main/java/com/facebook/presto/sql/Optimizer.java#L139 
However, instead of returning the exact stats which are used in optimization, it's actually recalculating the stats. 

This can be a problem. For example, currently CBO returns empty stats if the aggregation step is not single for an aggregation https://github.com/prestodb/presto/blob/5240412564458d1960d79a14139c58611dc686dc/presto-main/src/main/java/com/facebook/presto/cost/AggregationStatsRule.java#L56
This means that, we will not get any CBO stats for partial and final aggregation, and all other node which are downstream of the aggregation.

In this PR, it will record the stats during query optimization. For the same node, later stats will override previous ones.


With this change, we can see estimations for aggregations and join
```
presto:tpch> explain (type distributed) select name, price from (select custkey, sum(totalprice) price from orders group by custkey) t join customer using(custkey);
                                                                                                                                                   >
--------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                               >
     Output layout: [name, sum]                                                                                                                    >
     Output partitioning: SINGLE []                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                 >
     - Output[PlanNodeId 17][name, price] => [name:varchar(25), sum:double]                                                                        >
             price := sum (1:41)                                                                                                                   >
         - RemoteSource[1] => [name:varchar(25), sum:double]                                                                                       >
                                                                                                                                                   >
 Fragment 1 [HASH]                                                                                                                                 >
     Output layout: [name, sum]                                                                                                                    >
     Output partitioning: SINGLE []                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                 >
     - InnerJoin[PlanNodeId 366][("custkey_9" = "custkey")][$hashvalue, $hashvalue_30] => [name:varchar(25), sum:double]                           >
             Estimates: {source: CostBasedSourceInfo, rows: 1,001 (31.29kB), cpu: 1,309,503.16, memory: 35,640.00, network: 335,820.00}            >
             Distribution: PARTITIONED                                                                                                             >
         - RemoteSource[2] => [custkey_9:bigint, name:varchar(25), $hashvalue:bigint]                                                              >
         - Project[PlanNodeId 489][projectLocality = LOCAL] => [custkey:bigint, sum:double, $hashvalue_30:bigint]                                  >
                 $hashvalue_30 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:143)                               >
             - Aggregate(FINAL)[custkey][PlanNodeId 3] => [custkey:bigint, sum:double]                                                             >
                     Estimates: {source: CostBasedSourceInfo, rows: 990 (61.88kB), cpu: ?, memory: ?, network: ?}                                  >
                     sum := "presto.default.sum"((sum_25)) (1:69)                                                                                  >
                 - LocalExchange[PlanNodeId 446][HASH][$hashvalue_27] (custkey) => [custkey:bigint, sum_25:double, $hashvalue_27:bigint]           >
                     - RemoteSource[3] => [custkey:bigint, sum_25:double, $hashvalue_28:bigint]                                                    >
                                                                                                                                                   >
 Fragment 2 [SOURCE]                                                                                                                               >
     Output layout: [custkey_9, name, $hashvalue_26]                                                                                               >
     Output partitioning: HASH [custkey_9][$hashvalue_26]                                                                                          >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                 >
     - ScanProject[PlanNodeId 8,487][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=customer,>
             Estimates: {source: CostBasedSourceInfo, rows: 1,500 (60.06kB), cpu: ?, memory: ?, network: ?}/{source: CostBasedSourceInfo, rows: ? (>
             $hashvalue_26 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_9), BIGINT'0')) (1:128)                                 >
             LAYOUT: tpch.customer{}                                                                                                               >
             custkey_9 := custkey:bigint:0:REGULAR (1:128)                                                                                         >
             name := name:varchar(25):1:REGULAR (1:128)                                                                                            >
                                                                                                                                                   >
 Fragment 3 [SOURCE]                                                                                                                               >
     Output layout: [custkey, sum_25, $hashvalue_29]                                                                                               >
     Output partitioning: HASH [custkey][$hashvalue_29]                                                                                            >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                 >
     - Project[PlanNodeId 488][projectLocality = LOCAL] => [custkey:bigint, sum_25:double, $hashvalue_29:bigint]                                   >
             $hashvalue_29 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:112)                                   >
         - Aggregate(PARTIAL)[custkey][PlanNodeId 450] => [custkey:bigint, sum_25:double]                                                          >
                 sum_25 := "presto.default.sum"((totalprice)) (1:69)                                                                               >
             - TableScan[PlanNodeId 0][TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyze>
                     Estimates: {source: CostBasedSourceInfo, rows: 15,000 (395.51kB), cpu: ?, memory: ?, network: ?}                              >
                     LAYOUT: tpch.orders{}                                                                                                         >
                     custkey := custkey:bigint:1:REGULAR (1:96)                                                                                    >
                     totalprice := totalprice:double:3:REGULAR (1:96)                                                                              >
                                                                                                                                                   >
                                                                                                                                                   >
(1 row)
```

Without this change, we cannot see these stats:
```
presto:tpch> explain (type distributed) select name, price from (select custkey, sum(totalprice) price from orders group by custkey) t join customer using(custkey);
                                                                                                                                                   >
--------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                               >
     Output layout: [name, sum]                                                                                                                    >
     Output partitioning: SINGLE []                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                 >
     - Output[PlanNodeId 17][name, price] => [name:varchar(25), sum:double]                                                                        >
             price := sum (1:41)                                                                                                                   >
         - RemoteSource[1] => [name:varchar(25), sum:double]                                                                                       >
                                                                                                                                                   >
 Fragment 1 [HASH]                                                                                                                                 >
     Output layout: [name, sum]                                                                                                                    >
     Output partitioning: SINGLE []                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                 >
     - InnerJoin[PlanNodeId 366][("custkey_9" = "custkey")][$hashvalue, $hashvalue_30] => [name:varchar(25), sum:double]                           >
             Distribution: PARTITIONED                                                                                                             >
         - RemoteSource[2] => [custkey_9:bigint, name:varchar(25), $hashvalue:bigint]                                                              >
         - Project[PlanNodeId 489][projectLocality = LOCAL] => [custkey:bigint, sum:double, $hashvalue_30:bigint]                                  >
                 $hashvalue_30 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:143)                               >
             - Aggregate(FINAL)[custkey][PlanNodeId 3] => [custkey:bigint, sum:double]                                                             >
                     sum := "presto.default.sum"((sum_25)) (1:69)                                                                                  >
                 - LocalExchange[PlanNodeId 446][HASH][$hashvalue_27] (custkey) => [custkey:bigint, sum_25:double, $hashvalue_27:bigint]           >
                     - RemoteSource[3] => [custkey:bigint, sum_25:double, $hashvalue_28:bigint]                                                    >
                                                                                                                                                   >
 Fragment 2 [SOURCE]                                                                                                                               >
     Output layout: [custkey_9, name, $hashvalue_26]                                                                                               >
     Output partitioning: HASH [custkey_9][$hashvalue_26]                                                                                          >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                 >
     - ScanProject[PlanNodeId 8,487][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=customer,>
             Estimates: {source: CostBasedSourceInfo, rows: 1,500 (60.06kB), cpu: 48,000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceI>
             $hashvalue_26 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_9), BIGINT'0')) (1:128)                                 >
             LAYOUT: tpch.customer{}                                                                                                               >
             custkey_9 := custkey:bigint:0:REGULAR (1:128)                                                                                         >
             name := name:varchar(25):1:REGULAR (1:128)                                                                                            >
                                                                                                                                                   >
 Fragment 3 [SOURCE]                                                                                                                               >
     Output layout: [custkey, sum_25, $hashvalue_29]                                                                                               >
     Output partitioning: HASH [custkey][$hashvalue_29]                                                                                            >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                 >
     - Project[PlanNodeId 488][projectLocality = LOCAL] => [custkey:bigint, sum_25:double, $hashvalue_29:bigint]                                   >
             $hashvalue_29 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:112)                                   >
         - Aggregate(PARTIAL)[custkey][PlanNodeId 450] => [custkey:bigint, sum_25:double]                                                          >
                 sum_25 := "presto.default.sum"((totalprice)) (1:69)                                                                               >
             - TableScan[PlanNodeId 0][TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyze>
                     Estimates: {source: CostBasedSourceInfo, rows: 15,000 (395.51kB), cpu: 270,000.00, memory: 0.00, network: 0.00}               >
                     LAYOUT: tpch.orders{}                                                                                                         >
                     custkey := custkey:bigint:1:REGULAR (1:96)                                                                                    >
                     totalprice := totalprice:double:3:REGULAR (1:96)                                                                              >
                                                                                                                                                   >
                                                                                                                                                   >
(1 row)
```

## Motivation and Context
To make the stats recorded more accurate.

## Impact
To make the stats recorded more accurate, and easier to debug query optimization problem.

## Test Plan
Existing unit tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve the estimation stats recorded during query optimization :pr:`22769 `
```

