### PR TITLE
Pull constant values out of loop and check  earlier

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -183,7 +183,6 @@ public class HivePageSourceProvider
             return createAggregatedPageSource(aggregatedPageSourceFactories, configuration, session, hiveSplit, hiveLayout, selectedColumns, fileContext, encryptionInformation);
         }
         if (hiveLayout.isPushdownFilterEnabled()) {
-            Optional<byte[]> rowIDPartitionComponent = hiveSplit.getRowIdPartitionComponent();
             Optional<ConnectorPageSource> selectivePageSource = createSelectivePageSource(
                     selectivePageSourceFactories,
                     configuration,
@@ -371,9 +370,10 @@ public class HivePageSourceProvider
                 .map(filter -> filter.transform(handle -> new Subfield(((HiveColumnHandle) handle).getName())).intersect(layout.getDomainPredicate()))
                 .orElse(layout.getDomainPredicate());
 
+        List<HiveColumnHandle> columnHandles = toColumnHandles(columnMappings, true);
+        Optional<byte[]> rowIDPartitionComponent = split.getRowIdPartitionComponent();
+        HiveUtil.checkRowIDPartitionComponent(columnHandles, rowIDPartitionComponent);
         for (HiveSelectivePageSourceFactory pageSourceFactory : selectivePageSourceFactories) {
-            List<HiveColumnHandle> columnHandles = toColumnHandles(columnMappings, true);
-            Optional<byte[]> rowIDPartitionComponent = split.getRowIdPartitionComponent();
             Optional<? extends ConnectorPageSource> pageSource = pageSourceFactory.createPageSource(
                     configuration,
                     session,


### PR DESCRIPTION
## Description
Pull constant values out of loop and check for $row_id earlier

## Motivation and Context
Debugging weird failures in prod. Code works in some clusters and fails in others. 

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

