### PR TITLE
[docs] Add Presto C++ data type limitations

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/limitations.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/limitations.rst
@@ -16,6 +16,13 @@ The C++ evaluation engine has a number of limitations:
 
 * Not all built-in types are implemented in C++. Attempting to use unimplemented types will result in a query failure. 
 
+  * All basic and structured types in :doc:`../language/types` are supported, except for ``CHAR``, ``TIME``, and ``TIME WITH TIMEZONE``. 
+    These are subsumed by ``VARCHAR``, ``TIMESTAMP`` and ``TIMESTAMP WITH TIMEZONE``.
+
+  * Presto C++ only supports unlimited length ``VARCHAR``, and does not honor the length ``n`` in ``varchar[n]``.
+
+  * The following types are not supported: ``IPADDRESS``, ``IPPREFIX``, ``UUID``, ``KHYPERLOGLOG``, ``P4HYPERLOGLOG``, ``QDIGEST``, ``TDIGEST``.
+
 * Certain parts of the plugin SPI are not used by the C++ evaluation engine. In particular, C++ workers will not load any plugin in the plugins directory, and certain plugin types are either partially or completely unsupported.  
 
   * ``PageSourceProvider``, ``RecordSetProvider``, and ``PageSinkProvider`` do not work in the C++ evaluation engine.


### PR DESCRIPTION
## Description
Add data type limitations from @aditi-pandit's [comment on PR 22717](https://github.com/prestodb/presto/pull/22717#discussion_r1604068390). 

## Motivation and Context
Builds on the work in #22717. 

## Impact
Documentation. 

## Test Plan
Local doc build, CI. 

Screenshot of local build showing added content. 
<img width="788" alt="Screenshot 2024-05-16 at 6 00 01 PM" src="https://github.com/prestodb/presto/assets/7013443/e094b997-3b4f-474f-9291-53015366baa6">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

