### PR TITLE
Recognize row IDs hidden in Hadoop partitions

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -37,6 +37,7 @@ import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.security.SelectedRole;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -118,6 +119,7 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.Math.round;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -135,6 +137,7 @@ public final class ThriftMetastoreUtil
     private static final String PUBLIC_ROLE_NAME = "public";
     private static final String ADMIN_ROLE_NAME = "admin";
     public static final String LAST_DATA_COMMIT_TIME = "lastDataCommitTime";
+    public static final String ROW_ID_PARTITION_COMPONENT_KEY = "rowIDPartitionComponent";
 
     private ThriftMetastoreUtil() {}
 
@@ -511,6 +514,7 @@ public final class ThriftMetastoreUtil
                         .collect(toList()))
                 .setParameters(partition.getParameters())
                 .setCreateTime(partition.getCreateTime())
+                .setRowIdPartitionComponent(getRowIDPartitionComponent(partition))
                 .setLastDataCommitTime(getLastDataCommitTime(partition));
 
         // mutate apache partition to Presto partition
@@ -886,5 +890,18 @@ public final class ThriftMetastoreUtil
             return OptionalDouble.of(((double) totalSizeInBytes.getAsLong()) / nonNullsCount);
         }
         return OptionalDouble.empty();
+    }
+
+    @VisibleForTesting
+    static Optional<byte[]> getRowIDPartitionComponent(org.apache.hadoop.hive.metastore.api.Partition partition)
+    {
+        if (partition.isSetParameters()) {
+            Map<String, String> parameters = partition.getParameters();
+            if (parameters.containsKey(ROW_ID_PARTITION_COMPONENT_KEY)) {
+                String encoded = parameters.get(ROW_ID_PARTITION_COMPONENT_KEY);
+                return Optional.of(encoded.getBytes(ISO_8859_1));
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/TestThriftHiveMetastoreUtil.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/TestThriftHiveMetastoreUtil.java
@@ -58,6 +58,7 @@ import static org.apache.hadoop.hive.serde.serdeConstants.DECIMAL_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.DOUBLE_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.STRING_TYPE_NAME;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 public class TestThriftHiveMetastoreUtil
 {
@@ -387,5 +388,16 @@ public class TestThriftHiveMetastoreUtil
 
         partition.setParameters(ImmutableMap.of("lastDataCommitTime", "a"));
         assertEquals(ThriftMetastoreUtil.getLastDataCommitTime(partition), 0);
+    }
+
+    @Test
+    public void testGetRowIDPartitionComponent()
+    {
+        Partition partition = new Partition();
+        assertFalse(ThriftMetastoreUtil.getRowIDPartitionComponent(partition).isPresent());
+
+        partition.setParameters(ImmutableMap.of("rowIDPartitionComponent", "\u0000\u0001\u00FF"));
+        byte[] expected = {0, 1, (byte) 255};
+        assertEquals(ThriftMetastoreUtil.getRowIDPartitionComponent(partition).get(), expected);
     }
 }


### PR DESCRIPTION
## Description
Hadoop partitions don't have a place for row ID partition components so store them inside the parameters as a string created by mapping the bytes to chars in ISO-8859-1.

## Motivation and Context
Hive Partitions that were getting converted to and from org.apache.hadoop.hive.metastore.api.Partitions were losing the row ID partition component.

## Impact
None

## Test Plan
TestThriftHiveMetastoreUtil

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

