### PR TITLE
[docs] Update unsupported types in presto_cpp/limitations.rst

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/limitations.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/limitations.rst
@@ -14,16 +14,15 @@ The C++ evaluation engine has a number of limitations:
 
 * Not all built-in functions are implemented in C++. Attempting to use unimplemented functions results in a query failure. For supported functions, see `Function Coverage <https://facebookincubator.github.io/velox/functions/presto/coverage.html>`_.
 
-* Not all built-in types are implemented in C++. Attempting to use unimplemented types will result in a query failure. 
+* Not all built-in types are implemented in C++. Attempting to use unimplemented types will result in a query failure.
 
-  * All basic and structured types in :doc:`../language/types` are supported, except for ``CHAR``, ``TIME``, and ``TIME WITH TIMEZONE``. 
-    These are subsumed by ``VARCHAR``, ``TIMESTAMP`` and ``TIMESTAMP WITH TIMEZONE``.
+  * All basic and structured types in :doc:`../language/types` are supported, except for ``CHAR``, ``TIME``, and ``TIME WITH TIMEZONE``. These are subsumed by ``VARCHAR``, ``TIMESTAMP`` and ``TIMESTAMP WITH TIMEZONE``.
 
   * Presto C++ only supports unlimited length ``VARCHAR``, and does not honor the length ``n`` in ``varchar[n]``.
 
-  * The following types are not supported: ``IPADDRESS``, ``IPPREFIX``, ``UUID``, ``KHYPERLOGLOG``, ``P4HYPERLOGLOG``, ``QDIGEST``, ``TDIGEST``.
+  * The following types are not supported: ``IPADDRESS``, ``IPPREFIX``, ``UUID``, ``KHYPERLOGLOG``, ``P4HYPERLOGLOG``, ``QDIGEST``, ``TDIGEST``, ``GEOMETRY``, ``BINGTILE``.
 
-* Certain parts of the plugin SPI are not used by the C++ evaluation engine. In particular, C++ workers will not load any plugin in the plugins directory, and certain plugin types are either partially or completely unsupported.  
+* Certain parts of the plugin SPI are not used by the C++ evaluation engine. In particular, C++ workers will not load any plugin in the plugins directory, and certain plugin types are either partially or completely unsupported.
 
   * ``PageSourceProvider``, ``RecordSetProvider``, and ``PageSinkProvider`` do not work in the C++ evaluation engine.
 
@@ -33,7 +32,7 @@ The C++ evaluation engine has a number of limitations:
 
   * User-defined functions do not work in the same way, see `Remote Function Execution <features.html#remote-function-execution>`_.
 
-* Memory management works differently in the C++ evaluation engine. In particular: 
+* Memory management works differently in the C++ evaluation engine. In particular:
 
   * The OOM killer is not supported.
   * The reserved pool is not supported.


### PR DESCRIPTION
## Description
Add Geometry and Bingtile to unsupported data types in presto_cpp/limitations.rst

## Motivation and Context
Builds on #22772. 

## Impact
Documentation.

## Test Plan
Local build of docs, then CI. 

Screenshot of affected text in local docs build:
<img width="812" alt="Screenshot 2024-05-17 at 1 57 08 PM" src="https://github.com/prestodb/presto/assets/7013443/fdd1be65-cd0c-43e0-83fd-a3d76f5fba33">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

