### PR TITLE
[native] Add spiller executor stats

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -43,11 +43,12 @@ class PrestoServer;
 class PeriodicTaskManager {
  public:
   explicit PeriodicTaskManager(
-      folly::CPUThreadPoolExecutor* const driverCPUExecutor,
-      folly::IOThreadPoolExecutor* const httpExecutor,
-      TaskManager* const taskManager,
-      const velox::memory::MemoryAllocator* const memoryAllocator,
-      const velox::cache::AsyncDataCache* const asyncDataCache,
+      folly::CPUThreadPoolExecutor* driverCPUExecutor,
+      folly::CPUThreadPoolExecutor* spillerExecutor,
+      folly::IOThreadPoolExecutor* httpExecutor,
+      TaskManager* taskManager,
+      const velox::memory::MemoryAllocator* memoryAllocator,
+      const velox::cache::AsyncDataCache* asyncDataCache,
       const std::unordered_map<
           std::string,
           std::shared_ptr<velox::connector::Connector>>& connectors,
@@ -124,16 +125,17 @@ class PeriodicTaskManager {
   void detachWorker(const char* reason);
   void maybeAttachWorker();
 
-  folly::CPUThreadPoolExecutor* const driverCPUExecutor_;
-  folly::IOThreadPoolExecutor* const httpExecutor_;
-  TaskManager* const taskManager_;
-  const velox::memory::MemoryAllocator* const memoryAllocator_;
-  const velox::cache::AsyncDataCache* const asyncDataCache_;
-  const velox::memory::MemoryArbitrator* const arbitrator_;
+  folly::CPUThreadPoolExecutor* driverCPUExecutor_;
+  folly::CPUThreadPoolExecutor* spillerExecutor_;
+  folly::IOThreadPoolExecutor* httpExecutor_;
+  TaskManager* taskManager_;
+  const velox::memory::MemoryAllocator* memoryAllocator_;
+  const velox::cache::AsyncDataCache* asyncDataCache_;
+  const velox::memory::MemoryArbitrator* arbitrator_;
   const std::unordered_map<
       std::string,
       std::shared_ptr<velox::connector::Connector>>& connectors_;
-  PrestoServer* const server_;
+  PrestoServer* server_;
 
   // Cache related stats
   int64_t lastMemoryCacheHits_{0};

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -494,6 +494,7 @@ void PrestoServer::run() {
   auto* asyncDataCache = cache::AsyncDataCache::getInstance();
   periodicTaskManager_ = std::make_unique<PeriodicTaskManager>(
       driverExecutor_.get(),
+      spillerExecutor_.get(),
       httpServer_->getExecutor(),
       taskManager_.get(),
       memoryAllocator,

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -22,6 +22,10 @@ void registerPrestoMetrics() {
       kCounterDriverCPUExecutorQueueSize, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterDriverCPUExecutorLatencyMs, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterSpillerExecutorQueueSize, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterSpillerExecutorLatencyMs, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterHTTPExecutorLatencyMs, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumHTTPRequest, facebook::velox::StatType::COUNT);
   DEFINE_METRIC(kCounterNumHTTPRequestError, facebook::velox::StatType::COUNT);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -26,7 +26,10 @@ constexpr folly::StringPiece kCounterDriverCPUExecutorQueueSize{
     "presto_cpp.driver_cpu_executor_queue_size"};
 constexpr folly::StringPiece kCounterDriverCPUExecutorLatencyMs{
     "presto_cpp.driver_cpu_executor_latency_ms"};
-
+constexpr folly::StringPiece kCounterSpillerExecutorQueueSize{
+    "presto_cpp.spiller_executor_queue_size"};
+constexpr folly::StringPiece kCounterSpillerExecutorLatencyMs{
+    "presto_cpp.spiller_executor_latency_ms"};
 constexpr folly::StringPiece kCounterHTTPExecutorLatencyMs{
     "presto_cpp.http_executor_latency_ms"};
 constexpr folly::StringPiece kCounterNumHTTPRequest{


### PR DESCRIPTION
Added stats for spiller executor. Stats include executor queue size and executor latency
```
== NO RELEASE NOTE ==
```

