### PR TITLE
Support functionc call rewrite by Presto Verifier

### DIFF
--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -114,6 +114,8 @@ The following steps summarize the workflow of Verifier.
        * Artificial names are used for unnamed columns.
     * Rewrites ``Insert`` and ``CreateTableAsSelect`` queries to have their table names replaced.
        * Constructs a setup query to create the table necessary for an ``Insert`` query.
+    * Rewrites function calls according to ``nondeterministic-function-substitutes``
+      if the configuration is set.
 
 * **Query Execution**
     * Conceptually, Verifier is configured with a control cluster and a test cluster. However, they
@@ -290,6 +292,19 @@ Name                                        Description
                                             It only applies to ``Insert`` and ``CreateTableAsSelect`` queries.
                                             It would verify each partition's data checksum if the inserted table is partitioned.
                                             It would verify each bucket's data checksum if the inserted table is bucketed.
+``function-substitutes``                    Specification of function substitutions, in the format of
+                                            ``/foo(c0,_)/bar(c0)/,/fred(c0,c1)/baz(qux(c1,c0))/,/foobar(c0)/if(qux(c1),bar(c0),baz(c1))/,...``,
+                                            where ``foo(c0, _)`` would be substituted by ``bar(c0)``,
+                                            with the declared arguments applied to the corresponding positions.
+
+                                            Concatenate function substitutions with a comma.
+
+                                            Select a function substitute that has the return type and argument types
+                                            compatible with those of the original function, to produce a valid source query. For
+                                            example, ``/array_agg(z)/array_sort(array_agg(z))/,/approx_percentile(x,y)/avg(x)/``.
+
+                                            Declare the function arguments as identifiers if they need to be applied to
+                                            the function substitute.
 =========================================== ===============================================================================
 
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -468,6 +468,11 @@ public abstract class AbstractVerification<B extends QueryBundle, R extends Matc
         return SqlFormatter.formatSql(statement, Optional.empty());
     }
 
+    protected static String formatSql(Statement statement, Optional<String> comment)
+    {
+        return comment.isPresent() ? formatSql(statement) + "\n-- " + comment.get() : formatSql(statement);
+    }
+
     protected static List<String> formatSqls(List<Statement> statements)
     {
         return statements.stream()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -92,6 +92,7 @@ public class DataVerification
     protected void updateQueryInfoWithQueryBundle(QueryInfo.Builder queryInfo, Optional<QueryObjectBundle> queryBundle)
     {
         super.updateQueryInfoWithQueryBundle(queryInfo, queryBundle);
+        queryInfo.setQuery(queryBundle.map(bundle -> formatSql(bundle.getQuery(), bundle.getRewrittenFunctionCalls())));
         queryInfo.setOutputTableName(queryBundle.map(QueryObjectBundle::getObjectName).map(QualifiedName::toString));
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/FunctionCallRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/FunctionCallRewriter.java
@@ -386,7 +386,7 @@ public class FunctionCallRewriter
                     }
 
                     boolean rewrittenDistinct = originalInstance.isDistinct();
-                    boolean rewrittenIgnoreNulls = originalInstance.isIgnoreNulls();
+                    boolean rewrittenIgnoreNulls = false;
                     Optional<Expression> rewrittenFilter = defaultRewrite.getFilter().isPresent() ? defaultRewrite.getFilter() : originalInstance.getFilter();
                     Optional<OrderBy> rewrittenOrderBy = defaultRewrite.getOrderBy().isPresent() ? defaultRewrite.getOrderBy() : originalInstance.getOrderBy();
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/AbstractVerificationTest.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/AbstractVerificationTest.java
@@ -188,6 +188,7 @@ public abstract class AbstractVerificationTest
             settings.skipControl.ifPresent(verifierConfig::setSkipControl);
             settings.runningMode.ifPresent(verifierConfig::setRunningMode);
             settings.saveSnapshot.ifPresent(verifierConfig::setSaveSnapshot);
+            settings.functionSubstitutes.ifPresent(verifierConfig::setFunctionSubstitutes);
         });
         TypeManager typeManager = createTypeManager();
         PrestoAction prestoAction = mockPrestoAction.orElseGet(() -> getPrestoAction(Optional.of(sourceQuery.getControlConfiguration())));
@@ -195,7 +196,8 @@ public abstract class AbstractVerificationTest
                 sqlParser,
                 typeManager,
                 new QueryRewriteConfig().setTablePrefix(CONTROL_TABLE_PREFIX),
-                new QueryRewriteConfig().setTablePrefix(TEST_TABLE_PREFIX));
+                new QueryRewriteConfig().setTablePrefix(TEST_TABLE_PREFIX),
+                verifierConfig);
 
         VerificationFactory verificationFactory = new VerificationFactory(
                 sqlParser,
@@ -221,12 +223,15 @@ public abstract class AbstractVerificationTest
             skipControl = Optional.empty();
             runningMode = Optional.empty();
             saveSnapshot = Optional.empty();
+            functionSubstitutes = Optional.empty();
         }
 
         Optional<Boolean> concurrentControlAndTest;
         Optional<Boolean> skipControl;
         Optional<String> runningMode;
         Optional<Boolean> saveSnapshot;
+
+        Optional<String> functionSubstitutes;
     }
 
     public static class MockSnapshotSupplierAndConsumer

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
@@ -52,7 +52,8 @@ public class TestVerifierConfig
                 .setConcurrentControlAndTest(false)
                 .setRunningMode("control-test")
                 .setExtendedVerification(false)
-                .setSaveSnapshot(false));
+                .setSaveSnapshot(false)
+                .setFunctionSubstitutes(null));
     }
 
     @Test
@@ -84,6 +85,7 @@ public class TestVerifierConfig
                 .put("running-mode", "query-bank")
                 .put("extended-verification", "true")
                 .put("save-snapshot", "true")
+                .put("function-substitutes", "/approx_distinct(c)/count(c)/")
                 .build();
         VerifierConfig expected = new VerifierConfig()
                 .setWhitelist("a,b,c")
@@ -110,7 +112,8 @@ public class TestVerifierConfig
                 .setConcurrentControlAndTest(true)
                 .setRunningMode("query-bank")
                 .setExtendedVerification(true)
-                .setSaveSnapshot(true);
+                .setSaveSnapshot(true)
+                .setFunctionSubstitutes("/approx_distinct(c)/count(c)/");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
Enable Presto Verifier to substitute function call expressions in a source query, according to the user specified substitution pattern, by the config function-substitutes. Support function call substitutions when rewriting Query, CreateTableAsSelect and Insert source queries.

## Motivation and Context
Allow the Presto Verifier users to substitute functions, ex., nondeterministic functions, to make the test query comparable with TEST and CONTROL.

## Impact
The feature is enabled only when the parameter --function-substitutes is set.

## Test Plan
Unit tests in TestQueryRewriter.

## Release Notes

```
== RELEASE NOTES ==

Verifier Changes
* Support function call substitution based on the specified substitution pattern passed by the parameter --function-substitutes.
```


