### PR TITLE
made OutputMatcher take Collection

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OutputMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OutputMatcher.java
@@ -21,7 +21,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
 
-import java.util.List;
+import java.util.Collection;
 
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.createSymbolReference;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
@@ -32,9 +32,9 @@ import static java.util.Objects.requireNonNull;
 public class OutputMatcher
         implements Matcher
 {
-    private final List<String> aliases;
+    private final Collection<String> aliases;
 
-    OutputMatcher(List<String> aliases)
+    OutputMatcher(Collection<String> aliases)
     {
         this.aliases = ImmutableList.copyOf(requireNonNull(aliases, "aliases is null"));
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -821,7 +821,7 @@ public final class PlanMatchPattern
         return withOutputs(ImmutableList.copyOf(aliases));
     }
 
-    public PlanMatchPattern withOutputs(List<String> aliases)
+    public PlanMatchPattern withOutputs(Collection<String> aliases)
     {
         matchers.add(new OutputMatcher(aliases));
         return this;


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
OutputMatcher is being used in a method called withOutput in PlanMatchPattern class.
So i made the code changes in those files to take Collection instead of a List.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
Order is not important in OutputMatcher class so this is semantically correct, and in some cases it would have been mildly more convenient to pass in a Set instead of a List.
<!---If it fixes an open issue, please link to the issue here.-->
This fix is for the issue #22756

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

