### PR TITLE
[verifier] Avoid checksum of map values if possible.

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/StructuredColumnMismatchResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/StructuredColumnMismatchResolver.java
@@ -68,22 +68,37 @@ public class StructuredColumnMismatchResolver
                 MapColumnChecksum controlChecksum = (MapColumnChecksum) mismatchedColumn.getControlChecksum();
                 MapColumnChecksum testChecksum = (MapColumnChecksum) mismatchedColumn.getTestChecksum();
 
+                // Cardinality mismatch. Do not resolve.
                 if (!isCardinalityMatched(controlChecksum, testChecksum)) {
                     return Optional.empty();
                 }
 
                 boolean keyContainsFloatingPoint = containsFloatingPointType(((MapType) columnType).getKeyType());
                 boolean valueContainsFloatingPoint = containsFloatingPointType(((MapType) columnType).getValueType());
+                // No pure floating point types. Do not resolve.
                 if (!keyContainsFloatingPoint && !valueContainsFloatingPoint) {
                     return Optional.empty();
                 }
+                // Not-floating point keys mismatch. Do not resolve.
                 if (!keyContainsFloatingPoint &&
                         !Objects.equals(controlChecksum.getKeysChecksum(), testChecksum.getKeysChecksum())) {
                     return Optional.empty();
                 }
-                if (!valueContainsFloatingPoint &&
-                        !Objects.equals(controlChecksum.getValuesChecksum(), testChecksum.getValuesChecksum())) {
-                    return Optional.empty();
+                // Not-floating point values.
+                if (!valueContainsFloatingPoint) {
+                    // If we got values checksums and they are not matching, then do not resolve.
+                    if (!Objects.equals(controlChecksum.getValuesChecksum(), testChecksum.getValuesChecksum())) {
+                        return Optional.empty();
+                    }
+
+                    // Values checksums either match or missing (being nulls).
+                    // They can be missing because omitted or in corner cases of no rows, null maps, no elements, etc.
+                    // Checking the whole checksum if the values checksums are missing.
+                    if (Objects.isNull(controlChecksum.getValuesChecksum())) {
+                        if (!Objects.equals(controlChecksum.getChecksum(), testChecksum.getChecksum())) {
+                            return Optional.empty();
+                        }
+                    }
                 }
             }
             else {


### PR DESCRIPTION
## Description
In some cases the checksum of map values produces different result because of the map elements order.
In most of the cases map values checksum is not needed.

```
== NO RELEASE NOTE ==
```

