### PR TITLE
[native] Fix docker compose to allow debug builds and clarify README

### DIFF
--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -40,7 +40,9 @@ not listed below.
 | [gperf](https://www.gnu.org/software/gperf) |`v3.1`|
 | [proxygen](https://github.com/facebook/proxygen) |`v2024.04.01.00`|
 
-### Supported operating systems and compilers
+### Supported architectures, operating systems, and compilers
+
+The supported architectures are `x86_64 (avx, sse)`, and `AArch64 (apple-m1+crc, neoverse-n1)`.
 
 Prestissimo can be built by a variety of compilers (and versions) but not all.
 Compilers (and versions) not mentioned are known to not work or have not been tried.

--- a/presto-native-execution/docker-compose.yml
+++ b/presto-native-execution/docker-compose.yml
@@ -18,8 +18,6 @@ services:
     #   podman compose build ubuntu-native-dependency
     image: presto/prestissimo-dependency:amd64-ubuntu-22.04
     build:
-      args:
-        - BUILD_TYPE=Release
       context: .
       dockerfile: scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
 
@@ -30,7 +28,6 @@ services:
     image: presto/prestissimo-runtime:amd64-ubuntu-22.04
     build:
       args:
-        - BUILD_TYPE=Release
         - DEPENDENCY_IMAGE=presto/prestissimo-dependency:amd64-ubuntu-22.04
         - BASE_IMAGE=amd64/ubuntu:22.04
         - OSNAME=ubuntu
@@ -46,8 +43,6 @@ services:
     #   podman compose build centos-native-dependency
     image: presto/prestissimo-dependency:centos8
     build:
-      args:
-        - BUILD_TYPE=Release
       context: .
       dockerfile: scripts/dockerfiles/centos-8-stream-dependency.dockerfile
 
@@ -58,7 +53,6 @@ services:
     image: presto/prestissimo-runtime:centos8
     build:
       args:
-        - BUILD_TYPE=Release
         - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON
       context: .
       dockerfile: scripts/dockerfiles/prestissimo-runtime.dockerfile

--- a/presto-native-execution/scripts/dockerfiles/README.md
+++ b/presto-native-execution/scripts/dockerfiles/README.md
@@ -3,14 +3,14 @@
 > 📝 _**Note:** Please post in Presto Slack if you have any questions_
 
 There are two kinds of Dockerfiles:
-1) A platform specific file to build dependencies. Current supported platforms are
+1) A platform specific file to build dependencies. Current supported platforms are:
    1) Centos-8-stream with gcc9.
    2) Ubuntu-22.04 with gcc11.
 2) A platform-agnostic file to build Prestissimo runtime on top of the dependency image.
 ### Dependency Dockerfiles
 These Dockerfiles install all the dependencies including those needed for testing.
 A list of dependencies can be found [here](../../README.md).
-By default, the dependencies are built in Release mode.
+These dependencies are always built in Release mode.
 The Dependency Image needs to be built only when some dependency is updated.
 Prestissimo dependencies change infrequently.
 
@@ -23,6 +23,7 @@ a base image and copies the binary and shared libraries that are required
 for execution.
 
 Run the following command to see the services available to build images.
+`docker` also can be used instead of `podman`.
 ```
 podman compose config --services
 ```
@@ -38,9 +39,6 @@ cd presto/presto-native-execution && make submodules
 
 ### 2. Build Dependency Image using docker/podman compose
 
-Specify the build type using the ``BUILD_TYPE`` (defaults to Release)
-environment variable.
-
 ```bash
 podman compose build centos-native-dependency
 ```
@@ -48,8 +46,11 @@ podman compose build centos-native-dependency
 ### 3. Build Runtime Image
 
 Specify the build type using ``BUILD_TYPE`` (defaults to Release)
-environment variable.
+build argument. The ``BUILD_TYPE`` value is used to set the ``CMAKE_BUILD_TYPE``
+CMake variable. The allowed values are specified [here](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html).
 
 ```bash
 podman compose build centos-native-runtime
+# For a debug build, specify the BUILD_TYPE argument.
+podman compose build --build-arg BUILD_TYPE=Debug centos-native-runtime
 ```

--- a/presto-native-execution/scripts/dockerfiles/centos-8-stream-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-8-stream-dependency.dockerfile
@@ -12,7 +12,6 @@
 
 FROM quay.io/centos/centos:stream8
 
-ARG BUILD_TYPE=Release
 ENV PROMPT_ALWAYS_RESPOND=n
 ENV CC=/opt/rh/gcc-toolset-9/root/bin/gcc
 ENV CXX=/opt/rh/gcc-toolset-9/root/bin/g++

--- a/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -12,7 +12,7 @@
 
 ARG base=amd64/ubuntu:22.04
 FROM ${base}
-ARG BUILD_TYPE=Release
+
 # Set a default timezone, can be overriden via ARG
 ARG tz="America/New_York"
 ARG DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
Add support to build Prestissimo in Debug mode.
Clarify dependencies can be built only in Release mode.
Clarify supported architectures.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

