### PR TITLE
[docs] Fix links in admin/function-namespace-managers.rst

### DIFF
--- a/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
@@ -94,4 +94,4 @@ Name                                        Description
 See Also
 --------
 
-:doc:`create-function`, :doc:`alter-function`, :doc:`drop-function`, :doc:`show-functions`
+:doc:`../sql/create-function`, :doc:`../sql/alter-function`, :doc:`../sql/drop-function`, :doc:`../sql/show-functions`


### PR DESCRIPTION
## Description
Noticed the links in [See Also](https://prestodb.io/docs/0.287/admin/function-namespace-managers.html#see-also) in Function Namespace Managers were broken. Fixed the broken links by finding the intended destinations and replacing with valid links. 

## Motivation and Context
Broken links can frustrate readers of the documentation. 

## Impact
Documentation. 

## Test Plan
Local build of docs to verify the new links built correctly, and that selecting the links opened the correct page. 

Before (and [current](https://prestodb.io/docs/0.287/admin/function-namespace-managers.html#see-also)): 

<img width="798" alt="Screenshot 2024-05-21 at 10 44 39 AM" src="https://github.com/prestodb/presto/assets/7013443/2d21a073-2bca-4bd6-96da-10e1ca1a77ac">

After: 

<img width="786" alt="Screenshot 2024-05-21 at 10 52 46 AM" src="https://github.com/prestodb/presto/assets/7013443/2b19158b-5016-4fbc-b020-ca6cff4dae93">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

