### PR TITLE
[docs] Fix links in sql/revoke.rst grant.rst show-grants.rst

### DIFF
--- a/presto-docs/src/main/sphinx/sql/grant.rst
+++ b/presto-docs/src/main/sphinx/sql/grant.rst
@@ -48,5 +48,4 @@ See connector documentation for more details.
 See Also
 --------
 
-:doc:`revoke`
-:doc:`show-grants`
+:doc:`revoke`, :doc:`show-grants`

--- a/presto-docs/src/main/sphinx/sql/revoke.rst
+++ b/presto-docs/src/main/sphinx/sql/revoke.rst
@@ -48,5 +48,4 @@ See connector documentation for more details.
 See Also
 --------
 
-:doc:`grant`
-:doc:`show-grants`
+:doc:`grant`, :doc:`show-grants`

--- a/presto-docs/src/main/sphinx/sql/show-grants.rst
+++ b/presto-docs/src/main/sphinx/sql/show-grants.rst
@@ -42,5 +42,4 @@ See connector documentation for more details.
 See Also
 --------
 
-:doc:`grant`
-:doc:`revoke`
+:doc:`grant`, :doc:`revoke`


### PR DESCRIPTION
## Description
After working on #22796 I quickly reviewed the "See Also" topics of the pages in the Presto docs /sql directory, and found the three files [sql/revoke.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/sql/revoke.rst), [sql/grant.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/sql/grant.rst), and [sql/show-grants.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/sql/show-grants.rst) were formatted such that the pair of SQL function links in each page's "See Also" were strung together on a single line without commas. 

Given that function names can contain spaces themselves, it was confusing to understand if (for example) "GRANT SHOW GRANTS" was one, two, or three separate links to other SQL function doc pages. 

Reformatted the three pairs of links to add commas between the links to aid usability, and to improve consistency with the formatting of the other pages in /sql/. 

## Motivation and Context
Minor improvement in formatting to reduce confusion of the reader. 

## Impact
Documentation. 

## Test Plan
Local docs build to verify the edits look as intended, and that the links still worked as original. Also, CI. 

Screenshots, before and current: 

<img width="153" alt="Screenshot 2024-05-21 at 2 00 24 PM" src="https://github.com/prestodb/presto/assets/7013443/f63e1964-d8b2-48be-8721-16987998671e">
<img width="223" alt="Screenshot 2024-05-21 at 2 01 38 PM" src="https://github.com/prestodb/presto/assets/7013443/8d2f6830-a667-4b25-b9b6-93d2e98c3f72">
<img width="207" alt="Screenshot 2024-05-21 at 1 48 58 PM" src="https://github.com/prestodb/presto/assets/7013443/1ba1bb8e-f66b-4a0f-829d-f8591cdf0fb4">


Screenshots, after:

<img width="178" alt="Screenshot 2024-05-21 at 1 48 29 PM" src="https://github.com/prestodb/presto/assets/7013443/c2696530-f937-4da9-b9c5-c5f4e615ca17">
<img width="246" alt="Screenshot 2024-05-21 at 2 02 32 PM" src="https://github.com/prestodb/presto/assets/7013443/149bbc37-3a9f-42dc-8c84-9d547bf69ab9">
<img width="235" alt="Screenshot 2024-05-21 at 1 48 23 PM" src="https://github.com/prestodb/presto/assets/7013443/fbc346b1-01a5-4e5e-83ad-6b0199dc4ea3">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

