### PR TITLE
[UI] Preserve inlined JS scripts

### DIFF
--- a/presto-ui/src/webpack.config.js
+++ b/presto-ui/src/webpack.config.js
@@ -50,6 +50,9 @@ module.exports = (env) => {
                     }),
                     new HtmlInlineScriptPlugin({
                         htmlMatchPattern: [/query_viewer_spa.html$/],
+                        assetPreservePattern: [
+                            /.*.js$/,
+                        ]
                     }),
                 ],
         mode,


### PR DESCRIPTION
## Description

Prevents scripts inlined in SPA from being omitted from the UI build.

Previously, this broke the dev/index.html page as the query_viewer.js file
was not correctly generated.

## Motivation and Context

See above.

## Impact

Fix dev/index.html page

## Test Plan

Local testing to ensure query_viewer.js file is generated.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

