### PR TITLE
[verifier] Filter out limit-without-order-by queries only when not skipping control & checksum

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
@@ -112,6 +112,7 @@ public class VerificationManager
     private final int verificationResubmissionLimit;
     private final boolean explain;
     private final boolean skipControl;
+    private final boolean skipChecksum;
     private final String runningMode;
 
     private final ExecutorService executor;
@@ -151,6 +152,7 @@ public class VerificationManager
         this.queryRepetitions = config.getQueryRepetitions();
         this.verificationResubmissionLimit = config.getVerificationResubmissionLimit();
         this.skipControl = config.isSkipControl();
+        this.skipChecksum = config.isSkipChecksum();
         this.explain = config.isExplain();
 
         this.executor = newFixedThreadPool(maxConcurrency);
@@ -267,7 +269,7 @@ public class VerificationManager
                 else if (controlQueryType != testQueryType) {
                     postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, MISMATCHED_QUERY_TYPE, skipControl));
                 }
-                else if (isLimitWithoutOrderBy(controlStatement, sourceQuery.getName())) {
+                else if (!skipControl && !skipChecksum && isLimitWithoutOrderBy(controlStatement, sourceQuery.getName())) {
                     log.debug("LimitWithoutOrderByChecker Skipped %s", sourceQuery.getName());
                     postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, NON_DETERMINISTIC, skipControl));
                 }


### PR DESCRIPTION
## Description
Current verifier will filter out all queries with limit but no order because of their non-deterministic nature. This PR changes the behavior not to filter such queries when control or checksum are skipped where determinism does not matter.

## Motivation and Context
There are cases that we don't care about correctness like skipping the control run and ignore checksum comparison. In such cases, we only collect non-functional metrics like CPU time, wall time etc.

## Impact
N/A

## Test Plan
Run the verifier with a query that's having limit clause but no 'order by' and enable skip checksum flag. 
Make sure the query is not filtered out.


```
== NO RELEASE NOTE ==
```

