### PR TITLE
Add entry to parquet metadata cache on file modificationTime

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -1701,8 +1701,8 @@ public abstract class AbstractTestParquetReader
                     parquetMetadataSource,
                     tempFile.getFile(),
                     tempFileModificationTime);
-            assertEquals(parquetFileMetadataCache.stats().missCount(), 3);
-            assertEquals(parquetFileMetadataCache.stats().hitCount(), 4);
+            assertEquals(parquetFileMetadataCache.stats().missCount(), 2);
+            assertEquals(parquetFileMetadataCache.stats().hitCount(), 5);
         }
     }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
@@ -54,12 +54,12 @@ public class CachingParquetMetadataSource
                 ParquetFileMetadata fileMetadataCache = cache.get(
                         parquetDataSource.getId(),
                         () -> delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable, modificationTime, fileDecryptor, readMaskedValue));
-                if (fileMetadataCache.getModificationTime() == modificationTime) {
-                    return fileMetadataCache;
-                }
-                else {
+                if (fileMetadataCache.getModificationTime() != modificationTime) {
                     cache.invalidate(parquetDataSource.getId());
+                    fileMetadataCache = delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable, modificationTime, fileDecryptor, readMaskedValue);
+                    cache.put(parquetDataSource.getId(), fileMetadataCache);
                 }
+                return fileMetadataCache;
             }
             return delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable, modificationTime, fileDecryptor, readMaskedValue);
         }


### PR DESCRIPTION
## Description
Add an entry to parquet metadata cache on file modification time

## Motivation and Context
Currently, if the modification time of the parquet file is different then we just return the new fileMetadataCache cache object, we can also add that newer entry in the same flow.

## Impact
NA

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

