### PR TITLE
update to build native docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,7 +221,7 @@ pipeline {
                             cd presto-native-execution/
                             make submodules
                             docker buildx build --load --platform "linux/amd64" \
-                                    -t "${PRESTO_NATIVE_DOCKER_IMAGE}" \
+                                    -t "${NATIVE_DOCKER_IMAGE}" \
                                     --build-arg BUILD_TYPE=Release \
                                     --build-arg DEPENDENCY_IMAGE=${AWS_ECR}/presto-native-dependency:latest \
                                     --build-arg "EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON" \

--- a/jenkins/agent-dind.yaml
+++ b/jenkins/agent-dind.yaml
@@ -16,8 +16,8 @@ spec:
       tty: true
       resources:
         requests:
-          memory: "4Gi"
-          cpu: "2000m"
+          memory: "29Gi"
+          cpu: "7500m"
         limits:
-          memory: "4Gi"
-          cpu: "2000m"
+          memory: "29Gi"
+          cpu: "7500m"


### PR DESCRIPTION
## Description
Update Jenkins pipeline to build native worker docker image

## Motivation and Context
To support the adoption of native worker

## Impact
Will publish both java and native docker images to a public registry

## Test Plan
Will deploy clusters with docker images, and run tpcds queries

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Update CI pipeline to build and publish native worker docker image :pr:`22806`
```

