### PR TITLE
Track file read count in RuntimeStats

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -60,4 +60,5 @@ public class RuntimeMetricName
     public static final String HISTORY_OPTIMIZER_QUERY_REGISTRATION_GET_STATISTICS = "historyOptimizerQueryRegistrationGetStatistics";
     public static final String DIRECTORY_LISTING_CACHE_HIT = "directoryListingCacheHit";
     public static final String DIRECTORY_LISTING_CACHE_MISS = "directoryListingCacheMiss";
+    public static final String FILES_READ_COUNT = "filesReadCount";
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add support for tracking the number of file reads via runtime stats.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Help identify small file issue that can cause slow performance in certain queries.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
N/A

## Test Plan
<!---Please fill in how you tested your change-->
Verifier test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

