### PR TITLE
[native] Make node.id optional

### DIFF
--- a/presto-native-execution/etc/node.properties
+++ b/presto-native-execution/etc/node.properties
@@ -1,4 +1,3 @@
 node.environment=testing
-node.id=e4901aae-a1c9-4ff7-97a9-5687835ad54c
 node.internal-address=127.0.0.1
 node.location=testing-location

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -17,6 +17,9 @@
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/core/QueryConfig.h"
 
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #if __has_include("filesystem")
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -648,7 +651,14 @@ std::string NodeConfig::nodeEnvironment() const {
 }
 
 std::string NodeConfig::nodeId() const {
-  return requiredProperty(kNodeId);
+  auto resultOpt = optionalProperty(kNodeId);
+  if (resultOpt.hasValue()) {
+    return resultOpt.value();
+  }
+  // Generate the nodeId which must be a UUID. nodeId must be a singleton.
+  static auto nodeId =
+      boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+  return nodeId;
 }
 
 std::string NodeConfig::nodeLocation() const {

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(
   presto_server_test
   AnnouncerTest.cpp
   CoordinatorDiscovererTest.cpp
+  ConfigsTest.cpp
   HttpServerWrapper.cpp
   MutableConfigs.cpp
   PeriodicMemoryCheckerTest.cpp

--- a/presto-native-execution/presto_cpp/main/tests/ConfigsTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ConfigsTest.cpp
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/common/Configs.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::presto {
+namespace {
+
+TEST(NodeConfig, optionalNodeId) {
+  NodeConfig config;
+  auto nodeId = config.nodeId();
+  // Same value must be returned.
+  EXPECT_EQ(nodeId, config.nodeId());
+  EXPECT_EQ(nodeId, config.nodeId());
+}
+
+} // namespace
+} // namespace facebook::presto


### PR DESCRIPTION
## Description
Make node.id optional in line with the Java implementation.
Auto-generate node.id if missing.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution)
* Make nodeid optional :pr:`22815`

```

