### PR TITLE
Fix bug when $row_id is last column in second page

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
@@ -191,6 +191,7 @@ public class OrcBatchPageSource
             completedPositions += batchSize;
 
             Block[] blocks = new Block[hiveColumnIndexes.length];
+            // todo less then aor equal?
             for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
                 if (isRowPositionColumn(fieldId)) {
                     blocks[fieldId] = getRowPosColumnBlock(recordReader.getFilePosition(), batchSize);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -242,6 +242,7 @@ public class OrcBatchPageSourceFactory
 
             byte[] partitionID = rowIDPartitionComponent.orElse(new byte[0]);
             String rowGroupID = path.getName();
+            // todo(elharo) this is effectively saying no row IDs
             return new OrcBatchPageSource(
                     recordReader,
                     reader.getOrcDataSource(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
@@ -146,7 +146,6 @@ public class OrcSelectivePageSource
 
         // figure out which block is the row ID and replace it
         page = page.replaceColumn(rowIDColumnIndex.getAsInt(), rowIDs);
-
         if (!appendRowNumberEnabled) {
             // remove the row number block now that the row IDs have been constructed unless it was also requested
             page = page.dropColumn(page.getChannelCount() - 1);


### PR DESCRIPTION
## Description
WIP, not fixed yet

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

