### PR TITLE
Inline single use constructor

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -72,6 +72,7 @@ import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 
 public class OrcBatchPageSourceFactory
@@ -242,6 +243,9 @@ public class OrcBatchPageSourceFactory
 
             byte[] partitionID = rowIDPartitionComponent.orElse(new byte[0]);
             String rowGroupID = path.getName();
+
+            // none of the columns are row numbers
+            List<Boolean> isRowNumberList = nCopies(physicalColumns.size(), false);
             return new OrcBatchPageSource(
                     recordReader,
                     reader.getOrcDataSource(),
@@ -250,6 +254,7 @@ public class OrcBatchPageSourceFactory
                     systemMemoryUsage,
                     stats,
                     hiveFileContext.getStats(),
+                    isRowNumberList,
                     partitionID,
                     rowGroupID);
         }


### PR DESCRIPTION
## Description
Standardize on "row number" as the term for location of rows within a group instead of "row position" and introduce other local variables as needed for clarity.

## Motivation and Context
Clarify and simplify code while searching for bug. In particular, standardize on "row number" as the term for location of rows within a group instead of "row position". Previously these terms were used interchangeably in different classes. I found this a tad confusing, especially given that we also have "row IDs" which are not the same thing.

## Impact
None

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

