### PR TITLE
Relax assertions in TestNoisySumGaussianRealAggregation

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisySumGaussianRealAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisySumGaussianRealAggregation.java
@@ -147,7 +147,7 @@ public class TestNoisySumGaussianRealAggregation
         BiFunction<Object, Object, Boolean> withinSomeStdAssertion = (actual, expected) -> {
             double actualValue = new Double(actual.toString());
             double expectedValue = new Double(expected.toString());
-            return expectedValue - 50 <= actualValue && actualValue <= expectedValue + 50;
+            return expectedValue - 50 * DEFAULT_TEST_STANDARD_DEVIATION <= actualValue && actualValue <= expectedValue + 50 * DEFAULT_TEST_STANDARD_DEVIATION;
         };
 
         int numRows = 1000;
@@ -286,7 +286,7 @@ public class TestNoisySumGaussianRealAggregation
             double actualValue = new Double(actual.toString());
             double expectedValue = new Double(expected.toString());
             // TODO calculate how many standard deviations this is
-            return expectedValue - 6 <= actualValue && actualValue <= expectedValue + 6;
+            return expectedValue - 50 * DEFAULT_TEST_STANDARD_DEVIATION <= actualValue && actualValue <= expectedValue + 50 * DEFAULT_TEST_STANDARD_DEVIATION;
         };
 
         int numRows = 10;


### PR DESCRIPTION
## Description
Allow more slack in test of semi-random result. Fix an issue https://github.com/prestodb/presto/issues/22325  

## Motivation and Context
Fix issue https://github.com/prestodb/presto/issues/22325 by setting tolerance to be 50 * standard deviation as suggested in the issue comment

## Impact
None

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

