### PR TITLE
[native]Update Prestissimo to report the actual used task memory

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1128,7 +1128,7 @@ void PrestoServer::populateMemAndCPUInfo() {
   size_t numContexts{0};
   queryCtxMgr->visitAllContexts([&](const protocol::QueryId& queryId,
                                     const velox::core::QueryCtx* queryCtx) {
-    const protocol::Long bytes = queryCtx->pool()->currentBytes();
+    const protocol::Long bytes = queryCtx->pool()->usedBytes();
     poolInfo.queryMemoryReservations.insert({queryId, bytes});
     // TODO(spershin): Might want to see what Java exports and export similar
     // info (like child memory pools).
@@ -1199,7 +1199,7 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       (int)std::thread::hardware_concurrency(),
       cpuLoadPct,
       cpuLoadPct,
-      pool_ ? pool_->currentBytes() : 0,
+      pool_ ? pool_->usedBytes() : 0,
       nodeMemoryGb * 1024 * 1024 * 1024,
       nonHeapUsed};
 

--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -547,7 +547,8 @@ void PrestoTask::updateMemoryInfoLocked(
   protocol::TaskStats& prestoTaskStats = info.stats;
 
   const auto veloxTaskMemStats = task->pool()->stats();
-  prestoTaskStats.userMemoryReservationInBytes = veloxTaskMemStats.currentBytes;
+  const auto currentBytes = task->pool()->usedBytes();
+  prestoTaskStats.userMemoryReservationInBytes = currentBytes;
   prestoTaskStats.systemMemoryReservationInBytes = 0;
   prestoTaskStats.peakUserMemoryInBytes = veloxTaskMemStats.peakBytes;
   prestoTaskStats.peakTotalMemoryInBytes = veloxTaskMemStats.peakBytes;
@@ -555,7 +556,6 @@ void PrestoTask::updateMemoryInfoLocked(
   // TODO(venkatra): Populate these memory stats as well.
   prestoTaskStats.revocableMemoryReservationInBytes = {};
 
-  const int64_t currentBytes = veloxTaskMemStats.currentBytes;
   const int64_t averageMemoryForLastPeriod =
       (currentBytes + lastMemoryReservation) / 2;
   const double sinceLastPeriodMs = currentTimeMs - lastTaskStatsUpdateMs;

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTestBase.h
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTestBase.h
@@ -145,7 +145,7 @@ std::string bodyAsString(http::HttpResponse& response, MemoryPool* pool) {
     oss << std::string((const char*)body->data(), body->length());
     pool->free(body->writableData(), body->capacity());
   }
-  EXPECT_EQ(pool->currentBytes(), 0);
+  EXPECT_EQ(pool->usedBytes(), 0);
   return oss.str();
 }
 

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -1369,7 +1369,7 @@ TEST_F(TaskManagerTest, testCumulativeMemory) {
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
-  const auto memoryUsage = veloxTask->queryCtx()->pool()->currentBytes();
+  const auto memoryUsage = veloxTask->queryCtx()->pool()->usedBytes();
   ASSERT_GT(memoryUsage, 0);
 
   const uint64_t lastTimeMs = velox::getCurrentTimeMs();


### PR DESCRIPTION
Changes to report the cumulative bytes using usedBytes from non-leaf pool instead of
reserved bytes so as to track the actual memory usage better.