### PR TITLE
Part 1: ImmutableList.of() --> Collections.emptyList()

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/BenchmarkThriftUdfPageSerDe.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BenchmarkThriftUdfPageSerDe.java
@@ -57,6 +57,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -138,7 +139,7 @@ public class BenchmarkThriftUdfPageSerDe
                     0.0f,
                     0.0f,
                     false,
-                    ImmutableList.of());
+                    Collections.emptyList());
             page = new Page(POSITIONS_PER_PAGE, block);
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRowBasedSerialization.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRowBasedSerialization.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -206,7 +207,7 @@ public class TestRowBasedSerialization
     public void testRandom(String typeSignature)
     {
         Type type = functionAndTypeManager.getType(parseTypeSignature(typeSignature));
-        testRandomBlocks(type, ImmutableList.of());
+        testRandomBlocks(type, Collections.emptyList());
     }
 
     @Test(dataProvider = "getTypeSignatures")
@@ -263,7 +264,7 @@ public class TestRowBasedSerialization
     private static List<Slice> serialize(List<Block> blocks)
     {
         if (blocks.isEmpty()) {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
         int positions = blocks.get(0).getPositionCount();
         for (Block block : blocks) {
@@ -280,7 +281,7 @@ public class TestRowBasedSerialization
     {
         if (types.isEmpty()) {
             assertTrue(rows.isEmpty());
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         List<BlockBuilder> blockBuilders = types.stream()

--- a/presto-main/src/test/java/com/facebook/presto/connector/MockConnectorFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/connector/MockConnectorFactory.java
@@ -39,9 +39,9 @@ import com.facebook.presto.tpch.TpchColumnHandle;
 import com.facebook.presto.tpch.TpchHandleResolver;
 import com.facebook.presto.tpch.TpchRecordSetProvider;
 import com.facebook.presto.tpch.TpchSplitManager;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -230,8 +230,8 @@ public class MockConnectorFactory
 
     public static final class Builder
     {
-        private Function<ConnectorSession, List<String>> listSchemaNames = (session) -> ImmutableList.of();
-        private BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables = (session, schemaName) -> ImmutableList.of();
+        private Function<ConnectorSession, List<String>> listSchemaNames = (session) -> Collections.emptyList();
+        private BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables = (session, schemaName) -> Collections.emptyList();
         private BiFunction<ConnectorSession, SchemaTablePrefix, Map<SchemaTableName, ConnectorViewDefinition>> getViews = (session, schemaTablePrefix) -> ImmutableMap.of();
         private BiFunction<ConnectorSession, ConnectorTableHandle, Map<String, TpchColumnHandle>> getColumnHandles = (session, tableHandle) -> notSupported();
         private Supplier<TableStatistics> getTableStatistics = TableStatistics::empty;

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -78,6 +78,7 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -925,7 +926,7 @@ public class TestCostCalculator
                 source,
                 ImmutableMap.of(new VariableReferenceExpression(Optional.empty(), "count", BIGINT), aggregation),
                 singleGroupingSet(source.getOutputVariables()),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestHistoricalPlanStatistics.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.statistics.TableWriterNodeStatistics;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,10 +38,10 @@ public class TestHistoricalPlanStatistics
     public void testWithNoTables()
     {
         HistoricalPlanStatistics stats = HistoricalPlanStatistics.empty();
-        stats = updatePlanStatistics(stats, ImmutableList.of(), stats(10, 10));
-        assertEquals(getPredictedPlanStatistics(stats, ImmutableList.of()), stats(10, 10));
-        stats = updatePlanStatistics(stats, ImmutableList.of(), stats(12, 13));
-        assertEquals(getPredictedPlanStatistics(stats, ImmutableList.of()), stats(12, 13));
+        stats = updatePlanStatistics(stats, Collections.emptyList(), stats(10, 10));
+        assertEquals(getPredictedPlanStatistics(stats, Collections.emptyList()), stats(10, 10));
+        stats = updatePlanStatistics(stats, Collections.emptyList(), stats(12, 13));
+        assertEquals(getPredictedPlanStatistics(stats, Collections.emptyList()), stats(12, 13));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
@@ -25,6 +25,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.getDefaultJoinSelectivityCoefficient;
@@ -237,7 +238,7 @@ public class TestJoinStatsRule
         PlanNodeStatsEstimate expected = NORMALIZER.normalize(LEFT_STATS.mapOutputRowCount(rowCount -> 0.0));
         PlanNodeStatsEstimate actual = JOIN_STATS_RULE.calculateJoinComplementStats(
                 Optional.empty(),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 LEFT_STATS,
                 RIGHT_STATS);
         assertEquals(actual, expected);

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestValuesNodeStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestValuesNodeStats.java
@@ -18,6 +18,7 @@ import com.facebook.presto.sql.relational.FunctionResolution;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -132,7 +133,7 @@ public class TestValuesNodeStats
         tester().assertStatsFor(pb -> pb
                 .values(
                         ImmutableList.of(pb.variable("a", BIGINT)),
-                        ImmutableList.of()))
+                        Collections.emptyList()))
                 .check(outputStats -> outputStats.equalTo(
                         PlanNodeStatsEstimate.builder()
                                 .setOutputRowCount(0)

--- a/presto-main/src/test/java/com/facebook/presto/geospatial/TestBingTile.java
+++ b/presto-main/src/test/java/com/facebook/presto/geospatial/TestBingTile.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -155,9 +156,9 @@ public class TestBingTile
     @Test
     public void testFindDissolvedTileCovering()
     {
-        assertTileCovering("POINT EMPTY", 0, ImmutableList.of());
-        assertTileCovering("POINT EMPTY", 10, ImmutableList.of());
-        assertTileCovering("POINT EMPTY", 20, ImmutableList.of());
+        assertTileCovering("POINT EMPTY", 0, Collections.emptyList());
+        assertTileCovering("POINT EMPTY", 10, Collections.emptyList());
+        assertTileCovering("POINT EMPTY", 20, Collections.emptyList());
 
         assertSmallSquareCovering(2);
         assertSmallSquareCovering(5);

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestHighMemoryTaskKiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestHighMemoryTaskKiller.java
@@ -44,6 +44,7 @@ import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
@@ -125,7 +126,7 @@ public class TestHighMemoryTaskKiller
     {
         TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
                 Optional.of(PLAN_FRAGMENT),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 createInitialEmptyOutputBuffers(PARTITIONED)
                         .withNoMoreBufferIds(),
                 Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -43,6 +43,7 @@ import io.airlift.units.DataSize;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -133,7 +134,7 @@ public class TestMemoryPools
                     TableScanOperator.class.getSimpleName());
 
             OutputFactory outputFactory = new PageConsumerOutputFactory(types -> (page -> {}));
-            Operator outputOperator = outputFactory.createOutputOperator(2, new PlanNodeId("output"), ImmutableList.of(), Function.identity(), Optional.empty(), new TestingPagesSerdeFactory())
+            Operator outputOperator = outputFactory.createOutputOperator(2, new PlanNodeId("output"), Collections.emptyList(), Function.identity(), Optional.empty(), new TestingPagesSerdeFactory())
                     .createOperator(driverContext);
             RevocableMemoryOperator revocableMemoryOperator = new RevocableMemoryOperator(revokableOperatorContext, reservedPerPage, numberOfPages);
             createOperator.set(revocableMemoryOperator);

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
@@ -45,6 +45,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -115,7 +116,7 @@ public class TestSystemMemoryBlocking
                         new ConnectorTableHandle() {},
                         new ConnectorTransactionHandle() {},
                         Optional.empty()),
-                ImmutableList.of());
+                Collections.emptyList());
         PageConsumerOperator sink = createSinkOperator(types);
         Driver driver = Driver.createDriver(driverContext, source, sink);
         assertSame(driver.getDriverContext(), driverContext);
@@ -168,7 +169,7 @@ public class TestSystemMemoryBlocking
         @Override
         public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -326,7 +327,7 @@ public class TestDiscoveryNodeManager
             implements ServiceSelector
     {
         @GuardedBy("this")
-        private List<ServiceDescriptor> descriptors = ImmutableList.of();
+        private List<ServiceDescriptor> descriptors = Collections.emptyList();
 
         private synchronized void announceNodes(Set<InternalNode> activeNodes, Set<InternalNode> inactiveNodes)
         {

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionAndTypeManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionAndTypeManager.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -403,7 +404,7 @@ public class TestFunctionAndTypeManager
 
     private static SignatureBuilder functionSignature(List<String> arguments, String returnType)
     {
-        return functionSignature(arguments, returnType, ImmutableList.of());
+        return functionSignature(arguments, returnType, Collections.emptyList());
     }
 
     private static SignatureBuilder functionSignature(List<String> arguments, String returnType, List<TypeVariableConstraint> typeVariableConstraints)
@@ -428,8 +429,8 @@ public class TestFunctionAndTypeManager
     {
         private static final String TEST_FUNCTION_NAME = "TEST_FUNCTION_NAME";
 
-        private List<SignatureBuilder> functionSignatures = ImmutableList.of();
-        private List<TypeSignature> parameterTypes = ImmutableList.of();
+        private List<SignatureBuilder> functionSignatures = Collections.emptyList();
+        private List<TypeSignature> parameterTypes = Collections.emptyList();
 
         public ResolveFunctionAssertion among(SignatureBuilder... functionSignatures)
         {

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestInformationSchemaMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestInformationSchemaMetadata.java
@@ -43,6 +43,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -70,7 +71,7 @@ public class TestInformationSchemaMetadata
                                 new SchemaTableName("test_schema", "test_view"),
                                 new SchemaTableName("test_schema", "another_table")))
                 .withGetViews((connectorSession, prefix) -> {
-                    String viewJson = VIEW_DEFINITION_JSON_CODEC.toJson(new ViewDefinition("select 1", Optional.of("test_catalog"), Optional.of("test_schema"), ImmutableList.of(), Optional.empty(), false));
+                    String viewJson = VIEW_DEFINITION_JSON_CODEC.toJson(new ViewDefinition("select 1", Optional.of("test_catalog"), Optional.of("test_schema"), Collections.emptyList(), Optional.empty(), false));
                     SchemaTableName viewName = new SchemaTableName("test_schema", "test_view");
                     return ImmutableMap.of(viewName, new ConnectorViewDefinition(viewName, Optional.empty(), viewJson));
                 }).build();

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndSegmentedAggregationOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndSegmentedAggregationOperators.java
@@ -44,6 +44,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -85,7 +86,7 @@ public class BenchmarkHashAndSegmentedAggregationOperators
     private static final JavaAggregationFunctionImplementation LONG_SUM = FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
             FUNCTION_AND_TYPE_MANAGER.lookupFunction("sum", fromTypes(BIGINT)));
     private static final JavaAggregationFunctionImplementation COUNT = FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
-            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", ImmutableList.of()));
+            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", Collections.emptyList()));
 
     @State(Thread)
     public static class Context
@@ -138,8 +139,8 @@ public class BenchmarkHashAndSegmentedAggregationOperators
                     new PlanNodeId("test"),
                     ImmutableList.of(VARCHAR, BIGINT),
                     ImmutableList.of(0, 1),
-                    segmentedAggregation ? ImmutableList.of(0) : ImmutableList.of(),
-                    ImmutableList.of(),
+                    segmentedAggregation ? ImmutableList.of(0) : Collections.emptyList(),
+                    Collections.emptyList(),
                     AggregationNode.Step.SINGLE,
                     false,
                     ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(2), Optional.empty()),

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndStreamingAggregationOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndStreamingAggregationOperators.java
@@ -45,6 +45,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -86,7 +87,7 @@ public class BenchmarkHashAndStreamingAggregationOperators
     private static final JavaAggregationFunctionImplementation LONG_SUM = FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
             FUNCTION_AND_TYPE_MANAGER.lookupFunction("sum", fromTypes(BIGINT)));
     private static final JavaAggregationFunctionImplementation COUNT = FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
-            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", ImmutableList.of()));
+            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", Collections.emptyList()));
 
     @State(Thread)
     public static class Context
@@ -159,8 +160,8 @@ public class BenchmarkHashAndStreamingAggregationOperators
                     new PlanNodeId("test"),
                     ImmutableList.of(VARCHAR),
                     ImmutableList.of(0),
-                    ImmutableList.of(),
-                    ImmutableList.of(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
                     AggregationNode.Step.SINGLE,
                     false,
                     ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(0), Optional.empty()),

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -41,6 +41,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -304,7 +305,7 @@ public class BenchmarkHashBuildAndJoinOperators
                 buildContext.getHashChannel(),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 10_000,
                 new PagesIndex.TestingFactory(false),
                 false,

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkUnnestOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkUnnestOperator.java
@@ -42,6 +42,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -178,7 +179,7 @@ public class BenchmarkUnnestOperator
                         primitiveNullsRatio,
                         rowNullsRatio,
                         false,
-                        ImmutableList.of()));
+                        Collections.emptyList()));
             }
 
             operatorFactory = new UnnestOperator.UnnestOperatorFactory(

--- a/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
@@ -28,6 +28,7 @@ import io.airlift.units.Duration;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -173,7 +174,7 @@ public final class OperatorAssertion
 
     public static List<Page> toPages(OperatorFactory operatorFactory, DriverContext driverContext)
     {
-        return toPages(operatorFactory, driverContext, ImmutableList.of());
+        return toPages(operatorFactory, driverContext, Collections.emptyList());
     }
 
     public static MaterializedResult toMaterializedResult(Session session, List<Type> types, List<Page> pages)
@@ -221,7 +222,7 @@ public final class OperatorAssertion
             MaterializedResult expected,
             boolean revokeMemoryWhenAddingPages)
     {
-        assertOperatorEquals(operatorFactory, driverContext, input, expected, false, ImmutableList.of(), revokeMemoryWhenAddingPages);
+        assertOperatorEquals(operatorFactory, driverContext, input, expected, false, Collections.emptyList(), revokeMemoryWhenAddingPages);
     }
 
     public static void assertOperatorEquals(OperatorFactory operatorFactory, DriverContext driverContext, List<Page> input, MaterializedResult expected, boolean hashEnabled, List<Integer> hashChannels)

--- a/presto-main/src/test/java/com/facebook/presto/operator/PageAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/PageAssertions.java
@@ -22,6 +22,7 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.facebook.presto.block.BlockAssertions.Encoding.DICTIONARY;
@@ -52,7 +53,7 @@ public final class PageAssertions
 
     public static Page createPageWithRandomData(List<Type> types, int positionCount, float primitiveNullRate, float nestedNullRate)
     {
-        return createPageWithRandomData(types, positionCount, true, false, primitiveNullRate, nestedNullRate, false, ImmutableList.of());
+        return createPageWithRandomData(types, positionCount, true, false, primitiveNullRate, nestedNullRate, false, Collections.emptyList());
     }
 
     public static Page createDictionaryPageWithRandomData(List<Type> types, int positionCount, float primitiveNullRate, float nestedNullRate)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
@@ -38,6 +38,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -138,12 +139,12 @@ public class TestAggregationOperator
                 ImmutableList.of(0),
                 Optional.of(1),
                 ImmutableList.of(BIGINT, BOOLEAN),
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 null,
                 true, // distinct
                 new JoinCompiler(MetadataManager.createTestMetadataManager(), new FeaturesConfig()),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 false,
                 TEST_SESSION,
                 new TempStorageStandaloneSpillerFactory(new TestingTempStorageManager(), new BlockEncodingManager(), new NodeSpillConfig(), new FeaturesConfig(), new SpillerStats()));

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForAggregates.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForAggregates.java
@@ -60,6 +60,7 @@ import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
+import java.util.Collections;
 import java.util.List;
 
 import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
@@ -381,7 +382,7 @@ public class TestAnnotationEngineForAggregates
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "simple_generic_implementations"),
                 FunctionKind.AGGREGATE,
                 ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 parseTypeSignature("T"),
                 ImmutableList.of(parseTypeSignature("T")),
                 false);
@@ -540,7 +541,7 @@ public class TestAnnotationEngineForAggregates
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "implicit_specialized_aggregate"),
                 FunctionKind.AGGREGATE,
                 ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 parseTypeSignature("T"),
                 ImmutableList.of(new TypeSignature(ARRAY, TypeSignatureParameter.of(parseTypeSignature("T"))), parseTypeSignature("T")),
                 false);
@@ -632,7 +633,7 @@ public class TestAnnotationEngineForAggregates
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "explicit_specialized_aggregate"),
                 FunctionKind.AGGREGATE,
                 ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 parseTypeSignature("T"),
                 ImmutableList.of(new TypeSignature(ARRAY, TypeSignatureParameter.of(parseTypeSignature("T")))),
                 false);
@@ -871,7 +872,7 @@ public class TestAnnotationEngineForAggregates
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "inject_type_aggregate"),
                 FunctionKind.AGGREGATE,
                 ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 parseTypeSignature("T"),
                 ImmutableList.of(parseTypeSignature("T")),
                 false);
@@ -1023,7 +1024,7 @@ public class TestAnnotationEngineForAggregates
         Signature expectedSignature = new Signature(
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "parametric_aggregate_long_constraint"),
                 FunctionKind.AGGREGATE,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of(new LongVariableConstraint("z", "x + y")),
                 parseTypeSignature("varchar(z)", ImmutableSet.of("z")),
                 ImmutableList.of(parseTypeSignature("varchar(x)", ImmutableSet.of("x")),
@@ -1098,8 +1099,8 @@ public class TestAnnotationEngineForAggregates
         Signature expectedSignature = new Signature(
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "fixed_type_parameter_injection"),
                 FunctionKind.AGGREGATE,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 DoubleType.DOUBLE.getTypeSignature(),
                 ImmutableList.of(DoubleType.DOUBLE.getTypeSignature()),
                 false);
@@ -1165,7 +1166,7 @@ public class TestAnnotationEngineForAggregates
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "partially_fixed_type_parameter_injection"),
                 FunctionKind.AGGREGATE,
                 ImmutableList.of(typeVariable("T1"), typeVariable("T2")),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 DoubleType.DOUBLE.getTypeSignature(),
                 ImmutableList.of(DoubleType.DOUBLE.getTypeSignature()),
                 false);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForScalars.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForScalars.java
@@ -42,6 +42,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -378,7 +379,7 @@ public class TestAnnotationEngineForScalars
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "parametric_scalar"),
                 FunctionKind.SCALAR,
                 ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 parseTypeSignature("T"),
                 ImmutableList.of(parseTypeSignature("T")),
                 false);
@@ -418,8 +419,8 @@ public class TestAnnotationEngineForScalars
         Signature expectedSignature = new Signature(
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "with_exact_scalar"),
                 FunctionKind.SCALAR,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 BOOLEAN.getTypeSignature(),
                 ImmutableList.of(parseTypeSignature("array(varchar(x))", ImmutableSet.of("x"))),
                 false);
@@ -427,8 +428,8 @@ public class TestAnnotationEngineForScalars
         Signature exactSignature = new Signature(
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "with_exact_scalar"),
                 FunctionKind.SCALAR,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 BOOLEAN.getTypeSignature(),
                 ImmutableList.of(parseTypeSignature("array(varchar(17))")),
                 false);
@@ -465,8 +466,8 @@ public class TestAnnotationEngineForScalars
         Signature expectedSignature = new Signature(
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "parametric_scalar_inject"),
                 FunctionKind.SCALAR,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 BIGINT.getTypeSignature(),
                 ImmutableList.of(parseTypeSignature("varchar(x)", ImmutableSet.of("x"))),
                 false);
@@ -526,7 +527,7 @@ public class TestAnnotationEngineForScalars
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "parametric_scalar_inject_constructor"),
                 FunctionKind.SCALAR,
                 ImmutableList.of(typeVariable("T")),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 BIGINT.getTypeSignature(),
                 ImmutableList.of(parseTypeSignature("array(T)")),
                 false);
@@ -568,8 +569,8 @@ public class TestAnnotationEngineForScalars
         Signature expectedSignature = new Signature(
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "fixed_type_parameter_scalar_function"),
                 FunctionKind.SCALAR,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 BIGINT.getTypeSignature(),
                 ImmutableList.of(BIGINT.getTypeSignature()),
                 false);
@@ -607,7 +608,7 @@ public class TestAnnotationEngineForScalars
                 QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "partially_fixed_type_parameter_scalar_function"),
                 FunctionKind.SCALAR,
                 ImmutableList.of(typeVariable("T1"), typeVariable("T2")),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 BIGINT.getTypeSignature(),
                 ImmutableList.of(BIGINT.getTypeSignature()),
                 false);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -54,6 +54,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.Closeable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,18 +111,18 @@ public class TestDriver
                             Optional.empty(),
                             new PlanNodeId("test-scan"),
                             TESTING_TABLE_HANDLE,
-                            ImmutableList.of(),
+                            Collections.emptyList(),
                             ImmutableMap.of(),
                             TupleDomain.all(),
                             TupleDomain.all()),
                     ImmutableMap.of(),
-                    singleGroupingSet(ImmutableList.of()),
-                    ImmutableList.of(),
+                    singleGroupingSet(Collections.emptyList()),
+                    Collections.emptyList(),
                     AggregationNode.Step.PARTIAL,
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty()),
-            new PartitioningScheme(Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.of()), ImmutableList.of()),
+            new PartitioningScheme(Partitioning.create(FIXED_HASH_DISTRIBUTION, Collections.emptyList()), Collections.emptyList()),
             testSessionBuilder().setSystemProperty(FRAGMENT_RESULT_CACHING_ENABLED, "true").build(),
             new ObjectMapper()).get();
 
@@ -253,7 +254,7 @@ public class TestDriver
                         .addSequencePage(10, 20, 30, 40)
                         .build()),
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of());
+                Collections.emptyList());
 
         PageConsumerOperator sink = createSinkOperator(driverContext, types);
         Driver driver = Driver.createDriver(driverContext, source, sink);
@@ -286,7 +287,7 @@ public class TestDriver
             throws Exception
     {
         BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, new PlanNodeId("test"), "source"), false);
-        final Driver driver = Driver.createDriver(driverContext, brokenOperator, createSinkOperator(driverContext, ImmutableList.of()));
+        final Driver driver = Driver.createDriver(driverContext, brokenOperator, createSinkOperator(driverContext, Collections.emptyList()));
 
         assertSame(driver.getDriverContext(), driverContext);
 
@@ -318,7 +319,7 @@ public class TestDriver
             throws Exception
     {
         BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, new PlanNodeId("test"), "source"), true);
-        final Driver driver = Driver.createDriver(driverContext, brokenOperator, createSinkOperator(driverContext, ImmutableList.of()));
+        final Driver driver = Driver.createDriver(driverContext, brokenOperator, createSinkOperator(driverContext, Collections.emptyList()));
 
         assertSame(driver.getDriverContext(), driverContext);
 
@@ -353,7 +354,7 @@ public class TestDriver
                         .addSequencePage(10, 20, 30, 40)
                         .build()),
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of());
+                Collections.emptyList());
 
         Driver driver = Driver.createDriver(driverContext, source, createSinkOperator(driverContext, types));
         // the table scan operator will request memory revocation with requestMemoryRevoking()
@@ -382,7 +383,7 @@ public class TestDriver
                         .addSequencePage(10, 20, 30, 40)
                         .build()),
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of());
+                Collections.emptyList());
 
         BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, new PlanNodeId("test"), "source"));
         final Driver driver = Driver.createDriver(driverContext, source, brokenOperator);
@@ -439,7 +440,7 @@ public class TestDriver
                         .addSequencePage(10, 20, 30, 40)
                         .build()),
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of());
+                Collections.emptyList());
 
         PageConsumerOperator sink = createSinkOperator(driverContext, types);
         Driver driver = Driver.createDriver(driverContext, source, sink);
@@ -652,7 +653,7 @@ public class TestDriver
         @Override
         public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheManager.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -111,7 +112,7 @@ public class TestFileFragmentResultCacheManager
         assertEquals(stats.getCacheSizeInBytes(), 0);
 
         // Test empty page. Current cache status: empty
-        cacheManager.put(SERIALIZED_PLAN_FRAGMENT_1, SPLIT_1, ImmutableList.of(), INPUT_DATA_SIZE_1).get();
+        cacheManager.put(SERIALIZED_PLAN_FRAGMENT_1, SPLIT_1, Collections.emptyList(), INPUT_DATA_SIZE_1).get();
         fragmentCacheResult = cacheManager.get(SERIALIZED_PLAN_FRAGMENT_1, SPLIT_1);
         Optional<Iterator<Page>> result = fragmentCacheResult.getPages();
         assertTrue(result.isPresent());
@@ -193,7 +194,7 @@ public class TestFileFragmentResultCacheManager
         assertEquals(stats.getCacheSizeInBytes(), getCachePhysicalSize(cacheDirectory));
 
         // Adding an empty page is fine.
-        cacheManager.put(SERIALIZED_PLAN_FRAGMENT_2, SPLIT_1, ImmutableList.of(), 0).get();
+        cacheManager.put(SERIALIZED_PLAN_FRAGMENT_2, SPLIT_1, Collections.emptyList(), 0).get();
         fragmentCacheResult = cacheManager.get(SERIALIZED_PLAN_FRAGMENT_2, SPLIT_1);
         result = fragmentCacheResult.getPages();
         assertTrue(result.isPresent());
@@ -316,7 +317,7 @@ public class TestFileFragmentResultCacheManager
         @Override
         public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestGroupIdOperator.java
@@ -24,6 +24,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -67,7 +68,7 @@ public class TestGroupIdOperator
 
     public void testGroupId()
     {
-        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(false, ImmutableList.of(), BIGINT, VARCHAR, BOOLEAN, BIGINT);
+        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(false, Collections.emptyList(), BIGINT, VARCHAR, BOOLEAN, BIGINT);
         List<Page> input = rowPagesBuilder
                 .addSequencePage(3, 100, 400, 0, 1000)
                 .addSequencePage(3, 200, 500, 0, 1100)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -51,6 +51,7 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -108,7 +109,7 @@ public class TestHashAggregationOperator
     private static final JavaAggregationFunctionImplementation LONG_AVERAGE = getAggregation("avg", BIGINT);
     private static final JavaAggregationFunctionImplementation LONG_SUM = getAggregation("sum", BIGINT);
     private static final JavaAggregationFunctionImplementation COUNT = FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
-            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", ImmutableList.of()));
+            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", Collections.emptyList()));
 
     private static final int MAX_BLOCK_SIZE_IN_BYTES = 64 * 1024;
 
@@ -181,8 +182,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(VARCHAR),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 false,
                 ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(0), Optional.empty()),
@@ -236,7 +237,7 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(VARCHAR, BIGINT),
                 groupByChannels,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 globalAggregationGroupIds,
                 Step.SINGLE,
                 true,
@@ -289,8 +290,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 true,
                 ImmutableList.of(generateAccumulatorFactory(arrayAggColumn, ImmutableList.of(0), Optional.empty())),
@@ -333,8 +334,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(0), Optional.empty()),
                         generateAccumulatorFactory(LONG_SUM, ImmutableList.of(3), Optional.empty()),
@@ -372,8 +373,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(VARCHAR),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 false,
                 ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(0), Optional.empty())),
@@ -401,8 +402,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(type),
                 ImmutableList.of(0),
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(0), Optional.empty())),
                 Optional.of(1),
@@ -454,8 +455,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(VARCHAR),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(0), Optional.empty())),
                 rowPagesBuilder.getHashChannel(),
@@ -488,8 +489,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(0), Optional.empty()),
                         generateAccumulatorFactory(LONG_AVERAGE, ImmutableList.of(1), Optional.empty())),
@@ -521,8 +522,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.PARTIAL,
                 ImmutableList.of(generateAccumulatorFactory(LONG_SUM, ImmutableList.of(0), Optional.empty())),
                 rowPagesBuilder.getHashChannel(),
@@ -603,8 +604,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 ImmutableList.of(0),
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 false,
                 ImmutableList.of(generateAccumulatorFactory(LONG_SUM, ImmutableList.of(0), Optional.empty())),
@@ -649,8 +650,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 ImmutableList.of(0),
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 false,
                 ImmutableList.of(generateAccumulatorFactory(LONG_SUM, ImmutableList.of(0), Optional.empty())),
@@ -705,8 +706,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 false,
                 ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(0), Optional.empty()),
@@ -750,8 +751,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 ImmutableList.of(0),
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 false,
                 ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(1), Optional.of(2))),
@@ -796,8 +797,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.SINGLE,
                 ImmutableList.of(generateAccumulatorFactory(LONG_SUM, ImmutableList.of(0), Optional.empty())),
                 rowPagesBuilder.getHashChannel(),
@@ -840,8 +841,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.PARTIAL,
                 false,
                 ImmutableList.of(generateAccumulatorFactory(LONG_SUM, ImmutableList.of(0), Optional.empty())),
@@ -914,8 +915,8 @@ public class TestHashAggregationOperator
                 new PlanNodeId("test"),
                 ImmutableList.of(BIGINT),
                 hashChannels,
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Step.PARTIAL,
                 false,
                 ImmutableList.of(generateAccumulatorFactory(LONG_SUM, ImmutableList.of(0), Optional.empty())),
@@ -951,7 +952,7 @@ public class TestHashAggregationOperator
         MaterializedResult expected = MaterializedResult.resultBuilder(driverContext.getSession(), BIGINT, BIGINT)
                 .pages(expectedPages)
                 .build();
-        OperatorAssertion.assertOperatorEquals(operatorFactory, driverContext, inputPages, expected, false, ImmutableList.of(), false);
+        OperatorAssertion.assertOperatorEquals(operatorFactory, driverContext, inputPages, expected, false, Collections.emptyList(), false);
     }
 
     private DriverContext createDriverContext()
@@ -1001,7 +1002,7 @@ public class TestHashAggregationOperator
                 @Override
                 public List<Iterator<Page>> getSpills()
                 {
-                    return ImmutableList.of();
+                    return Collections.emptyList();
                 }
 
                 @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperatorInSegmentedAggregationMode.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperatorInSegmentedAggregationMode.java
@@ -32,6 +32,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -56,7 +57,7 @@ public class TestHashAggregationOperatorInSegmentedAggregationMode
     private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
 
     private static final JavaAggregationFunctionImplementation COUNT = FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
-            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", ImmutableList.of()));
+            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", Collections.emptyList()));
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
@@ -68,7 +69,7 @@ public class TestHashAggregationOperatorInSegmentedAggregationMode
             ImmutableList.of(BIGINT, BIGINT),
             ImmutableList.of(0, 1),
             ImmutableList.of(0),
-            ImmutableList.of(),
+            Collections.emptyList(),
             Step.SINGLE,
             false,
             ImmutableList.of(generateAccumulatorFactory(COUNT, ImmutableList.of(2), Optional.empty())),

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -55,6 +55,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -563,7 +564,7 @@ public class TestHashJoinOperator
 
         ValuesOperatorFactory valuesOperatorFactory1 = new ValuesOperatorFactory(17, new PlanNodeId("values1"), probe1Pages.build());
         ValuesOperatorFactory valuesOperatorFactory2 = new ValuesOperatorFactory(18, new PlanNodeId("values2"), probe2Pages.build());
-        ValuesOperatorFactory valuesOperatorFactory3 = new ValuesOperatorFactory(18, new PlanNodeId("values3"), ImmutableList.of());
+        ValuesOperatorFactory valuesOperatorFactory3 = new ValuesOperatorFactory(18, new PlanNodeId("values3"), Collections.emptyList());
         PageBuffer pageBuffer = new PageBuffer(10);
         PageBufferOperatorFactory pageBufferOperatorFactory = new PageBufferOperatorFactory(19, new PlanNodeId(PAGE_BUFFER), pageBuffer, PAGE_BUFFER);
 
@@ -1599,7 +1600,7 @@ public class TestHashJoinOperator
                         .map(OptionalInt::of).orElse(OptionalInt.empty()),
                 filterFunctionFactory,
                 Optional.empty(),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 100,
                 new PagesIndex.TestingFactory(false),
                 spillEnabled,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestInMemoryGroupedTopNBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestInMemoryGroupedTopNBuilder.java
@@ -117,7 +117,7 @@ public class TestInMemoryGroupedTopNBuilder
                 produceRowNumbers,
                 new TestingMemoryContext(100L),
                 groupByHash);
-        assertBuilderSize(groupByHash, types, ImmutableList.of(), ImmutableList.of(), groupedTopNBuilder.getEstimatedSizeInBytes());
+        assertBuilderSize(groupByHash, types, Collections.emptyList(), Collections.emptyList(), groupedTopNBuilder.getEstimatedSizeInBytes());
 
         // add 4 rows for the first page and created three heaps with 1, 1, 2 rows respectively
         assertTrue(groupedTopNBuilder.processPage(input.get(0)).process());
@@ -192,7 +192,7 @@ public class TestInMemoryGroupedTopNBuilder
                 new NoChannelGroupByHash());
 
         GroupByHash groupByHash = groupedTopNBuilder.getGroupByHash();
-        assertBuilderSize(groupByHash, types, ImmutableList.of(), ImmutableList.of(), groupedTopNBuilder.getEstimatedSizeInBytes());
+        assertBuilderSize(groupByHash, types, Collections.emptyList(), Collections.emptyList(), groupedTopNBuilder.getEstimatedSizeInBytes());
 
         // add 4 rows for the first page and created a single heap with 4 rows
         assertTrue(groupedTopNBuilder.processPage(input.get(0)).process());
@@ -253,7 +253,7 @@ public class TestInMemoryGroupedTopNBuilder
                 false,
                 new TestingMemoryContext(100L),
                 groupByHash);
-        assertBuilderSize(groupByHash, types, ImmutableList.of(), ImmutableList.of(), groupedTopNBuilder.getEstimatedSizeInBytes());
+        assertBuilderSize(groupByHash, types, Collections.emptyList(), Collections.emptyList(), groupedTopNBuilder.getEstimatedSizeInBytes());
 
         Work<?> work = groupedTopNBuilder.processPage(input);
         assertFalse(work.process());
@@ -271,7 +271,7 @@ public class TestInMemoryGroupedTopNBuilder
                 .build()
                 .get(0);
         assertPageEquals(types, output.get(0), expected);
-        assertBuilderSize(groupByHash, types, ImmutableList.of(0), ImmutableList.of(), groupedTopNBuilder.getEstimatedSizeInBytes());
+        assertBuilderSize(groupByHash, types, ImmutableList.of(0), Collections.emptyList(), groupedTopNBuilder.getEstimatedSizeInBytes());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestLookupJoinPageBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestLookupJoinPageBuilder.java
@@ -23,6 +23,7 @@ import com.facebook.presto.operator.JoinProbe.JoinProbeFactory;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.OptionalInt;
 
@@ -163,7 +164,7 @@ public class TestLookupJoinPageBuilder
         Page page = new Page(blockBuilder.build());
 
         // nothing on the build side so we don't append anything
-        LookupSource lookupSource = new TestLookupSource(ImmutableList.of(), page);
+        LookupSource lookupSource = new TestLookupSource(Collections.emptyList(), page);
         JoinProbe probe = (new JoinProbeFactory(new int[] {0}, ImmutableList.of(0), OptionalInt.empty())).createJoinProbe(page);
         LookupJoinPageBuilder lookupJoinPageBuilder = new LookupJoinPageBuilder(ImmutableList.of(BIGINT));
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopBuildOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopBuildOperator.java
@@ -25,6 +25,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -101,7 +102,7 @@ public class TestNestedLoopBuildOperator
             throws Exception
     {
         TaskContext taskContext = createTaskContext();
-        List<Type> buildTypes = ImmutableList.of();
+        List<Type> buildTypes = Collections.emptyList();
         JoinBridgeManager<NestedLoopJoinBridge> nestedLoopJoinBridgeManager = new JoinBridgeManager<>(
                 false,
                 PipelineExecutionStrategy.UNGROUPED_EXECUTION,
@@ -137,7 +138,7 @@ public class TestNestedLoopBuildOperator
             throws Exception
     {
         TaskContext taskContext = createTaskContext();
-        List<Type> buildTypes = ImmutableList.of();
+        List<Type> buildTypes = Collections.emptyList();
         JoinBridgeManager<NestedLoopJoinBridge> nestedLoopJoinBridgeManager = new JoinBridgeManager<>(
                 false,
                 PipelineExecutionStrategy.UNGROUPED_EXECUTION,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorAssertion.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.common.Page;
 import com.facebook.presto.testing.assertions.Assert;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.Duration;
@@ -23,6 +22,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -52,7 +52,7 @@ public class TestOperatorAssertion
     {
         Operator operator = new BlockedOperator(Duration.valueOf("15 ms"));
         List<Page> pages = OperatorAssertion.toPages(operator, emptyIterator());
-        Assert.assertEquals(pages, ImmutableList.of());
+        Assert.assertEquals(pages, Collections.emptyList());
     }
 
     private class BlockedOperator

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -45,7 +46,7 @@ public class TestPositionLinks
         assertEquals(factoryBuilder.link(11, 10), 11);
         assertEquals(factoryBuilder.link(12, 11), 12);
 
-        PositionLinks positionLinks = factoryBuilder.build().create(ImmutableList.of());
+        PositionLinks positionLinks = factoryBuilder.build().create(Collections.emptyList());
 
         assertEquals(positionLinks.start(3, 0, TEST_PAGE), 3);
         assertEquals(positionLinks.next(3, 0, TEST_PAGE), 2);
@@ -310,9 +311,9 @@ public class TestPositionLinks
     {
         return new SimplePagesHashStrategy(
                 ImmutableList.of(BIGINT),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of(ImmutableList.of(TEST_PAGE.getBlock(0))),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 OptionalInt.empty(),
                 Optional.of(0),
                 MetadataManager.createTestMetadataManager().getFunctionAndTypeManager(),

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
@@ -32,6 +32,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -122,7 +123,7 @@ public class TestRowNumberOperator
                 ImmutableList.of(BIGINT, DOUBLE),
                 Ints.asList(1, 0),
                 Ints.asList(),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty(),
                 Optional.empty(),
                 10,
@@ -344,7 +345,7 @@ public class TestRowNumberOperator
                 ImmutableList.of(BIGINT, DOUBLE),
                 Ints.asList(1, 0),
                 Ints.asList(),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.of(3),
                 Optional.empty(),
                 10,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -51,6 +51,7 @@ import com.google.common.collect.Iterators;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -125,7 +126,7 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of(VARCHAR),
                 Optional.empty(),
                 new DataSize(0, BYTE),
@@ -174,7 +175,7 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(64, KILOBYTE),
@@ -224,7 +225,7 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 () -> pageProcessor,
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(0, BYTE),
@@ -267,7 +268,7 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(0, BYTE),
@@ -316,7 +317,7 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of(VARCHAR),
                 Optional.empty(),
                 new DataSize(0, BYTE),
@@ -374,7 +375,7 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(0, BYTE),
@@ -447,7 +448,7 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 TESTING_TABLE_HANDLE,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(0, BYTE),

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestStreamingAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestStreamingAggregationOperator.java
@@ -29,6 +29,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -56,7 +57,7 @@ public class TestStreamingAggregationOperator
     private static final JavaAggregationFunctionImplementation LONG_SUM = FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
             FUNCTION_AND_TYPE_MANAGER.lookupFunction("sum", fromTypes(BIGINT)));
     private static final JavaAggregationFunctionImplementation COUNT = FUNCTION_AND_TYPE_MANAGER.getJavaAggregateFunctionImplementation(
-            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", ImmutableList.of()));
+            FUNCTION_AND_TYPE_MANAGER.lookupFunction("count", Collections.emptyList()));
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTableWriterOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTableWriterOperator.java
@@ -52,6 +52,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -395,7 +396,7 @@ public class TestTableWriterOperator
         void complete()
         {
             future.complete(null);
-            finishFuture.complete(ImmutableList.of());
+            finishFuture.complete(Collections.emptyList());
         }
     }
 
@@ -414,7 +415,7 @@ public class TestTableWriterOperator
         @Override
         public CompletableFuture<Collection<Slice>> finish()
         {
-            return completedFuture(ImmutableList.of());
+            return completedFuture(Collections.emptyList());
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
@@ -31,6 +31,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -171,7 +172,7 @@ public class TestTopNRowNumberOperator
                 ImmutableList.of(BIGINT, DOUBLE),
                 Ints.asList(1, 0),
                 Ints.asList(),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Ints.asList(1),
                 ImmutableList.of(SortOrder.ASC_NULLS_LAST),
                 3,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
@@ -40,6 +40,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -76,7 +77,7 @@ public class TestWindowOperator
     private static final FrameInfo UNBOUNDED_FRAME = new FrameInfo(RANGE, UNBOUNDED_PRECEDING, Optional.empty(), Optional.empty(), UNBOUNDED_FOLLOWING, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
 
     public static final List<WindowFunctionDefinition> ROW_NUMBER = ImmutableList.of(
-            window(new ReflectionWindowFunctionSupplier<>("row_number", BIGINT, ImmutableList.of(), RowNumberFunction.class), BIGINT, UNBOUNDED_FRAME));
+            window(new ReflectionWindowFunctionSupplier<>("row_number", BIGINT, Collections.emptyList(), RowNumberFunction.class), BIGINT, UNBOUNDED_FRAME));
 
     private static final List<WindowFunctionDefinition> FIRST_VALUE = ImmutableList.of(
             window(new ReflectionWindowFunctionSupplier<>("first_value", VARCHAR, ImmutableList.<Type>of(VARCHAR), FirstValueFunction.class), VARCHAR, UNBOUNDED_FRAME, 1));
@@ -746,7 +747,7 @@ public class TestWindowOperator
                 outputChannels,
                 functions,
                 partitionChannels,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 sortChannels,
                 sortOrder,
                 0,

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateCountDistinct.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateCountDistinct.java
@@ -67,7 +67,7 @@ public abstract class AbstractTestApproximateCountDistinct
     @Test(dataProvider = "provideStandardErrors")
     public void testNoPositions(double maxStandardError)
     {
-        assertCount(ImmutableList.of(), maxStandardError, 0);
+        assertCount(Collections.emptyList(), maxStandardError, 0);
     }
 
     @Test(dataProvider = "provideStandardErrors")

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctBoolean.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctBoolean.java
@@ -15,12 +15,12 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Booleans;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -73,7 +73,7 @@ public class TestApproximateCountDistinctBoolean
     @Test
     public void testNoInput()
     {
-        assertCount(ImmutableList.of(), 0, 0);
+        assertCount(Collections.emptyList(), 0, 0);
     }
 
     private long distinctCount(List<Boolean> inputSequence)

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountAggregation.java
@@ -15,8 +15,8 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -55,6 +55,6 @@ public class TestCountAggregation
     @Override
     protected List<String> getFunctionParameterTypes()
     {
-        return ImmutableList.of();
+        return Collections.emptyList();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/exchange/TestLocalExchange.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/exchange/TestLocalExchange.java
@@ -44,6 +44,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -110,7 +111,7 @@ public class TestLocalExchange
                 SINGLE_DISTRIBUTION,
                 8,
                 TYPES,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty(),
                 executionStrategy,
                 new DataSize(retainedSizeOfPages(99), BYTE));
@@ -184,7 +185,7 @@ public class TestLocalExchange
                 FIXED_BROADCAST_DISTRIBUTION,
                 2,
                 TYPES,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty(),
                 executionStrategy,
                 LOCAL_EXCHANGE_MAX_BUFFERED_BYTES);
@@ -273,7 +274,7 @@ public class TestLocalExchange
                 FIXED_ARBITRARY_DISTRIBUTION,
                 2,
                 TYPES,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty(),
                 executionStrategy,
                 LOCAL_EXCHANGE_MAX_BUFFERED_BYTES);
@@ -323,7 +324,7 @@ public class TestLocalExchange
                 FIXED_PASSTHROUGH_DISTRIBUTION,
                 2,
                 TYPES,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty(),
                 executionStrategy,
                 new DataSize(retainedSizeOfPages(1), BYTE));
@@ -500,7 +501,7 @@ public class TestLocalExchange
                 }),
                 new ConnectorPartitioningHandle() {
                 });
-        PartitionFunction partitionFunction = createPartitionFunction(partitioningProviderManager, session, partitioningHandle, 600, ImmutableList.of(), false);
+        PartitionFunction partitionFunction = createPartitionFunction(partitioningProviderManager, session, partitioningHandle, 600, Collections.emptyList(), false);
 
         assertEquals(partitionFunction.getPartitionCount(), partitionCount);
     }
@@ -516,7 +517,7 @@ public class TestLocalExchange
                 FIXED_BROADCAST_DISTRIBUTION,
                 2,
                 types,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty(),
                 executionStrategy,
                 LOCAL_EXCHANGE_MAX_BUFFERED_BYTES);
@@ -564,7 +565,7 @@ public class TestLocalExchange
                 FIXED_BROADCAST_DISTRIBUTION,
                 2,
                 TYPES,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty(),
                 executionStrategy,
                 new DataSize(1, BYTE));

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestMergingPageOutput.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestMergingPageOutput.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -151,7 +152,7 @@ public class TestMergingPageOutput
     public void testPositionCountOnly()
     {
         int minRowCount = 256;
-        MergingPageOutput output = new MergingPageOutput(ImmutableList.of(), 1024 * 1024, minRowCount);
+        MergingPageOutput output = new MergingPageOutput(Collections.emptyList(), 1024 * 1024, minRowCount);
 
         Page bufferedPage = new Page(minRowCount - 1);
         output.addInput(createPagesIterator(bufferedPage));

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
@@ -94,7 +94,7 @@ public class TestPageProcessor
     @Test
     public void testProjectNoColumns()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), Collections.emptyList(), OptionalInt.of(MAX_BATCH_SIZE));
 
         Page inputPage = new Page(createLongSequenceBlock(0, 100));
 
@@ -110,7 +110,7 @@ public class TestPageProcessor
     @Test
     public void testFilterNoColumns()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new TestingPageFilter(positionsRange(0, 50))), ImmutableList.of());
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new TestingPageFilter(positionsRange(0, 50))), Collections.emptyList());
 
         Page inputPage = new Page(createLongSequenceBlock(0, 100));
 
@@ -147,27 +147,27 @@ public class TestPageProcessor
     {
         // Primitive types
 
-        testPartialFilterAsList(BOOLEAN, 100, 0.5f, 0.5f, false, ImmutableList.of());
-        testPartialFilterAsList(REAL, 100, 0.5f, 0.5f, false, ImmutableList.of());
-        testPartialFilterAsList(BIGINT, 100, 0.5f, 0.5f, false, ImmutableList.of());
-        testPartialFilterAsList(VARCHAR, 100, 0.5f, 0.5f, false, ImmutableList.of());
+        testPartialFilterAsList(BOOLEAN, 100, 0.5f, 0.5f, false, Collections.emptyList());
+        testPartialFilterAsList(REAL, 100, 0.5f, 0.5f, false, Collections.emptyList());
+        testPartialFilterAsList(BIGINT, 100, 0.5f, 0.5f, false, Collections.emptyList());
+        testPartialFilterAsList(VARCHAR, 100, 0.5f, 0.5f, false, Collections.emptyList());
 
-        testPartialFilterAsList(BOOLEAN, 100, 0.5f, 0.5f, true, ImmutableList.of());
-        testPartialFilterAsList(REAL, 100, 0.5f, 0.5f, true, ImmutableList.of());
-        testPartialFilterAsList(BIGINT, 100, 0.5f, 0.5f, true, ImmutableList.of());
-        testPartialFilterAsList(VARCHAR, 100, 0.5f, 0.5f, true, ImmutableList.of());
+        testPartialFilterAsList(BOOLEAN, 100, 0.5f, 0.5f, true, Collections.emptyList());
+        testPartialFilterAsList(REAL, 100, 0.5f, 0.5f, true, Collections.emptyList());
+        testPartialFilterAsList(BIGINT, 100, 0.5f, 0.5f, true, Collections.emptyList());
+        testPartialFilterAsList(VARCHAR, 100, 0.5f, 0.5f, true, Collections.emptyList());
 
         // Complex types
 
-        testPartialFilterAsList(new ArrayType(BIGINT), 100, 0.5f, 0.5f, false, ImmutableList.of());
-        testPartialFilterAsList(new ArrayType(VARCHAR), 100, 0.5f, 0.5f, false, ImmutableList.of());
-        testPartialFilterAsList(createMapType(BIGINT, VARCHAR), 100, 0.5f, 0.5f, false, ImmutableList.of());
-        testPartialFilterAsList(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BOOLEAN, VARCHAR)))), 100, 0.5f, 0.5f, false, ImmutableList.of());
+        testPartialFilterAsList(new ArrayType(BIGINT), 100, 0.5f, 0.5f, false, Collections.emptyList());
+        testPartialFilterAsList(new ArrayType(VARCHAR), 100, 0.5f, 0.5f, false, Collections.emptyList());
+        testPartialFilterAsList(createMapType(BIGINT, VARCHAR), 100, 0.5f, 0.5f, false, Collections.emptyList());
+        testPartialFilterAsList(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BOOLEAN, VARCHAR)))), 100, 0.5f, 0.5f, false, Collections.emptyList());
 
-        testPartialFilterAsList(new ArrayType(BIGINT), 100, 0.5f, 0.5f, true, ImmutableList.of());
-        testPartialFilterAsList(new ArrayType(VARCHAR), 100, 0.5f, 0.5f, true, ImmutableList.of());
-        testPartialFilterAsList(createMapType(BIGINT, VARCHAR), 100, 0.5f, 0.5f, true, ImmutableList.of());
-        testPartialFilterAsList(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BOOLEAN, VARCHAR)))), 100, 0.5f, 0.5f, true, ImmutableList.of());
+        testPartialFilterAsList(new ArrayType(BIGINT), 100, 0.5f, 0.5f, true, Collections.emptyList());
+        testPartialFilterAsList(new ArrayType(VARCHAR), 100, 0.5f, 0.5f, true, Collections.emptyList());
+        testPartialFilterAsList(createMapType(BIGINT, VARCHAR), 100, 0.5f, 0.5f, true, Collections.emptyList());
+        testPartialFilterAsList(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BOOLEAN, VARCHAR)))), 100, 0.5f, 0.5f, true, Collections.emptyList());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -417,7 +418,7 @@ public class TestBlockEncodingBuffers
 
         assertSerialized(type, createAllNullsBlock(type, POSITIONS_PER_BLOCK));
 
-        BlockStatus blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, ImmutableList.of());
+        BlockStatus blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, Collections.emptyList());
         assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
 
         blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, ImmutableList.of(DICTIONARY));
@@ -438,7 +439,7 @@ public class TestBlockEncodingBuffers
         blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, ImmutableList.of(RUN_LENGTH, DICTIONARY, RUN_LENGTH, DICTIONARY));
         assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
 
-        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, ImmutableList.of());
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, Collections.emptyList());
         assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
 
         blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, ImmutableList.of(DICTIONARY));

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
@@ -51,6 +51,7 @@ import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -564,7 +565,7 @@ public class TestOptimizedPartitionedOutputOperator
     public void testEmptyPage()
     {
         List<Type> types = updateBlockTypesWithHashBlockAndNullBlock(ImmutableList.of(BIGINT), true, false);
-        Page page = PageAssertions.createPageWithRandomData(ImmutableList.of(BIGINT), 0, true, false, 0.0f, 0.0f, false, ImmutableList.of());
+        Page page = PageAssertions.createPageWithRandomData(ImmutableList.of(BIGINT), 0, true, false, 0.0f, 0.0f, false, Collections.emptyList());
 
         testPartitioned(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
     }
@@ -572,8 +573,8 @@ public class TestOptimizedPartitionedOutputOperator
     @Test
     public void testPageWithNoBlocks()
     {
-        List<Type> types = updateBlockTypesWithHashBlockAndNullBlock(ImmutableList.of(), false, false);
-        Page page = PageAssertions.createPageWithRandomData(ImmutableList.of(), 1, false, false, 0.0f, 0.0f, false, ImmutableList.of());
+        List<Type> types = updateBlockTypesWithHashBlockAndNullBlock(Collections.emptyList(), false, false);
+        Page page = PageAssertions.createPageWithRandomData(Collections.emptyList(), 1, false, false, 0.0f, 0.0f, false, Collections.emptyList());
 
         testPartitionedForZeroBlocks(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
     }
@@ -625,7 +626,7 @@ public class TestOptimizedPartitionedOutputOperator
         List<Type> types = updateBlockTypesWithHashBlockAndNullBlock(targetTypes, true, false);
 
         // Test plain blocks: no block views, no Dictionary/RLE blocks
-        Page page = PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT, true, false, 0.2f, 0.2f, false, ImmutableList.of());
+        Page page = PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT, true, false, 0.2f, 0.2f, false, Collections.emptyList());
 
         // First test for the cases where the buffer can hold the whole page, then force flushing for every a few rows.
         testPartitioned(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
@@ -646,7 +647,7 @@ public class TestOptimizedPartitionedOutputOperator
         List<Type> types = updateBlockTypesWithHashBlockAndNullBlock(targetTypes, true, false);
         List<Page> pages = new ArrayList<>();
         for (int i = 0; i < PAGE_COUNT; i++) {
-            pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, false, 0.2f, 0.2f, false, ImmutableList.of()));
+            pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, false, 0.2f, 0.2f, false, Collections.emptyList()));
             pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, false, 0.2f, 0.2f, true, ImmutableList.of(DICTIONARY, DICTIONARY, RUN_LENGTH)));
             pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, false, 0.2f, 0.2f, true, ImmutableList.of(RUN_LENGTH, DICTIONARY, DICTIONARY)));
         }
@@ -656,7 +657,7 @@ public class TestOptimizedPartitionedOutputOperator
 
         pages.clear();
         for (int i = 0; i < PAGE_COUNT / 3; i++) {
-            pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, false, 0.2f, 0.2f, false, ImmutableList.of()));
+            pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, false, 0.2f, 0.2f, false, Collections.emptyList()));
             pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, false, 0.2f, 0.2f, true, ImmutableList.of(DICTIONARY, DICTIONARY, RUN_LENGTH)));
             pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, false, 0.2f, 0.2f, true, ImmutableList.of(RUN_LENGTH, DICTIONARY, DICTIONARY)));
         }
@@ -669,7 +670,7 @@ public class TestOptimizedPartitionedOutputOperator
     {
         // Add a block that only contain null as the last block to force replicating all rows.
         List<Type> types = updateBlockTypesWithHashBlockAndNullBlock(targetTypes, true, true);
-        Page page = PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT, true, true, 0.2f, 0.2f, false, ImmutableList.of());
+        Page page = PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT, true, true, 0.2f, 0.2f, false, Collections.emptyList());
         testReplicated(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
         testReplicated(types, ImmutableList.of(page), new DataSize(1, KILOBYTE));
     }
@@ -679,7 +680,7 @@ public class TestOptimizedPartitionedOutputOperator
         List<Type> types = updateBlockTypesWithHashBlockAndNullBlock(targetTypes, true, true);
         List<Page> pages = new ArrayList<>();
         for (int i = 0; i < PAGE_COUNT; i++) {
-            pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, true, 0.2f, 0.2f, false, ImmutableList.of()));
+            pages.add(PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT + RANDOM.nextInt(POSITION_COUNT), true, true, 0.2f, 0.2f, false, Collections.emptyList()));
         }
 
         testReplicated(types, pages, new DataSize(128, MEGABYTE));
@@ -688,7 +689,7 @@ public class TestOptimizedPartitionedOutputOperator
 
     private void testPartitionedForZeroBlocks(List<Type> types, List<Page> pages, DataSize maxMemory)
     {
-        testPartitioned(types, pages, maxMemory, ImmutableList.of(), new InterpretedHashGenerator(ImmutableList.of(), new int[0]));
+        testPartitioned(types, pages, maxMemory, Collections.emptyList(), new InterpretedHashGenerator(Collections.emptyList(), new int[0]));
     }
 
     private void testPartitioned(List<Type> types, List<Page> pages, DataSize maxMemory)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
@@ -56,6 +56,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
 import java.lang.invoke.MethodHandle;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -208,7 +209,7 @@ public class BenchmarkArrayFilter
                     QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "exact_filter"),
                     FunctionKind.SCALAR,
                     ImmutableList.of(typeVariable("T")),
-                    ImmutableList.of(),
+                    Collections.emptyList(),
                     parseTypeSignature("array(T)"),
                     ImmutableList.of(parseTypeSignature("array(T)"), parseTypeSignature("function(T,boolean)")),
                     false));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
@@ -47,6 +47,7 @@ import org.openjdk.jmh.runner.options.VerboseMode;
 import org.openjdk.jmh.runner.options.WarmupMode;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -115,16 +116,16 @@ public class BenchmarkMapConcat
             List<String> rightKeys;
             switch (mapConfig) {
                 case "left_empty":
-                    leftKeys = ImmutableList.of();
+                    leftKeys = Collections.emptyList();
                     rightKeys = keyList1;
                     break;
                 case "right_empty":
                     leftKeys = keyList1;
-                    rightKeys = ImmutableList.of();
+                    rightKeys = Collections.emptyList();
                     break;
                 case "both_empty":
-                    leftKeys = ImmutableList.of();
-                    rightKeys = ImmutableList.of();
+                    leftKeys = Collections.emptyList();
+                    rightKeys = Collections.emptyList();
                     break;
                 case "non_empty":
                     leftKeys = keyList1;

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -970,9 +970,9 @@ public final class FunctionAssertions
     private static OperatorFactory compileFilterWithNoInputColumns(SqlFunctionProperties sqlFunctionProperties, RowExpression filter, ExpressionCompiler compiler)
     {
         try {
-            Supplier<PageProcessor> processor = compiler.compilePageProcessor(sqlFunctionProperties, Optional.of(filter), ImmutableList.of());
+            Supplier<PageProcessor> processor = compiler.compilePageProcessor(sqlFunctionProperties, Optional.of(filter), Collections.emptyList());
 
-            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(), new DataSize(0, BYTE), 0);
+            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, Collections.emptyList(), new DataSize(0, BYTE), 0);
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {
@@ -1022,7 +1022,7 @@ public final class FunctionAssertions
                             new ConnectorTableHandle() {},
                             new ConnectorTransactionHandle() {},
                             Optional.empty()),
-                    ImmutableList.of(),
+                    Collections.emptyList(),
                     ImmutableList.of(projection.getType()),
                     Optional.empty(),
                     new DataSize(0, BYTE),
@@ -1198,7 +1198,7 @@ public final class FunctionAssertions
         @Override
         public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayCombinationsFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayCombinationsFunction.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -51,7 +53,7 @@ public class TestArrayCombinationsFunction
     @Test
     public void testBasic()
     {
-        assertFunction("combinations(ARRAY['bar', 'foo', 'baz', 'foo'], 0)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(ImmutableList.of()));
+        assertFunction("combinations(ARRAY['bar', 'foo', 'baz', 'foo'], 0)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(Collections.emptyList()));
         assertFunction("combinations(ARRAY['bar', 'foo', 'baz', 'foo'], 1)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
                 ImmutableList.of("bar"),
                 ImmutableList.of("foo"),
@@ -71,7 +73,7 @@ public class TestArrayCombinationsFunction
                 ImmutableList.of("foo", "baz", "foo")));
         assertFunction("combinations(ARRAY['bar', 'foo', 'baz', 'foo'], 4)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
                 ImmutableList.of("bar", "foo", "baz", "foo")));
-        assertFunction("combinations(ARRAY['bar', 'foo', 'baz', 'foo'], 5)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of());
+        assertFunction("combinations(ARRAY['bar', 'foo', 'baz', 'foo'], 5)", new ArrayType(new ArrayType(createVarcharType(3))), Collections.emptyList());
         assertFunction("combinations(ARRAY['a', 'bb', 'ccc', 'dddd'], 2)", new ArrayType(new ArrayType(createVarcharType(4))), ImmutableList.of(
                 ImmutableList.of("a", "bb"),
                 ImmutableList.of("a", "ccc"),
@@ -147,8 +149,8 @@ public class TestArrayCombinationsFunction
                 ImmutableList.of("\u4FE1\u5FF5\u7231", "\u671B"),
                 ImmutableList.of("\u5E0C\u671B", "\u671B")));
 
-        assertFunction("combinations(ARRAY[], 2)", new ArrayType(new ArrayType(UNKNOWN)), ImmutableList.of());
-        assertFunction("combinations(ARRAY[''], 2)", new ArrayType(new ArrayType(createVarcharType(0))), ImmutableList.of());
+        assertFunction("combinations(ARRAY[], 2)", new ArrayType(new ArrayType(UNKNOWN)), Collections.emptyList());
+        assertFunction("combinations(ARRAY[''], 2)", new ArrayType(new ArrayType(createVarcharType(0))), Collections.emptyList());
         assertFunction("combinations(ARRAY['', ''], 2)", new ArrayType(new ArrayType(createVarcharType(0))), ImmutableList.of(ImmutableList.of("", "")));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayCumulativeSumFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayCumulativeSumFunction.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
@@ -37,7 +38,7 @@ public class TestArrayCumulativeSumFunction
         assertFunction("array_cum_sum(ARRAY [cast(5 as INTEGER), 6, 0])", new ArrayType(INTEGER), ImmutableList.of(5, 11, 11));
         assertFunction("array_cum_sum(ARRAY [cast(5 as INTEGER), 6, null, null, 2, 1])", new ArrayType(INTEGER), Arrays.asList(5, 11, null, null, null, null));
         assertFunction("array_cum_sum(ARRAY [cast(null as INTEGER), 6, 2, 3, 2, 1])", new ArrayType(INTEGER), Arrays.asList(null, null, null, null, null, null));
-        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(integer)))", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(integer)))", new ArrayType(INTEGER), Collections.emptyList());
         assertFunction("array_cum_sum(CAST(NULL AS array(integer)))", new ArrayType(INTEGER), null);
         assertFunctionThrowsIncorrectly("array_cum_sum(ARRAY [cast(2147483647 as integer), 2147483647, 2147483647])", PrestoException.class, "integer addition overflow:.*");
     }
@@ -48,7 +49,7 @@ public class TestArrayCumulativeSumFunction
         assertFunction("array_cum_sum(ARRAY [cast(5 as bigint), 6, 0])", new ArrayType(BIGINT), ImmutableList.of(5L, 11L, 11L));
         assertFunction("array_cum_sum(ARRAY [cast(5 as bigint), 6, null, null, 2, 1])", new ArrayType(BIGINT), Arrays.asList(5L, 11L, null, null, null, null));
         assertFunction("array_cum_sum(ARRAY [cast(null as bigint), 6, 2, 3, 2, 1])", new ArrayType(BIGINT), Arrays.asList(null, null, null, null, null, null));
-        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(bigint)))", new ArrayType(BIGINT), ImmutableList.of());
+        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(bigint)))", new ArrayType(BIGINT), Collections.emptyList());
         assertFunction("array_cum_sum(CAST(NULL AS array(bigint)))", new ArrayType(BIGINT), null);
         assertFunction("array_cum_sum(ARRAY [cast(2147483647 as bigint), 2147483647, 2147483647])", new ArrayType(BIGINT), ImmutableList.of(2147483647L, 4294967294L, 6442450941L));
     }
@@ -59,7 +60,7 @@ public class TestArrayCumulativeSumFunction
         assertFunctionFloatArrayWithError("array_cum_sum(ARRAY [cast(5.1 as real), 6.1, 0.5])", new ArrayType(REAL), ImmutableList.of(5.1f, 11.2f, 11.7f), 1e-5f);
         assertFunction("array_cum_sum(ARRAY [cast(5.1 as real), 6, null, null, 2, 1.2])", new ArrayType(REAL), Arrays.asList(5.1f, 11.1f, null, null, null, null));
         assertFunction("array_cum_sum(ARRAY [cast(null as real), 6.2, 2, 3, 2, 1])", new ArrayType(REAL), Arrays.asList(null, null, null, null, null, null));
-        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(real)))", new ArrayType(REAL), ImmutableList.of());
+        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(real)))", new ArrayType(REAL), Collections.emptyList());
         assertFunction("array_cum_sum(CAST(NULL AS array(real)))", new ArrayType(REAL), null);
     }
 
@@ -69,7 +70,7 @@ public class TestArrayCumulativeSumFunction
         assertFunctionDoubleArrayWithError("array_cum_sum(ARRAY [cast(5.1 as double), 6.1, 0.5])", new ArrayType(DOUBLE), ImmutableList.of(5.1, 11.2, 11.7), 1e-5);
         assertFunction("array_cum_sum(ARRAY [cast(5.1 as double), 6, null, null, 2, 1.2])", new ArrayType(DOUBLE), Arrays.asList(5.1, 11.1, null, null, null, null));
         assertFunction("array_cum_sum(ARRAY [cast(null as double), 6.2, 2, 3, 2, 1])", new ArrayType(DOUBLE), Arrays.asList(null, null, null, null, null, null));
-        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(double)))", new ArrayType(DOUBLE), ImmutableList.of());
+        assertFunction("array_cum_sum(CAST(ARRAY[] AS array(double)))", new ArrayType(DOUBLE), Collections.emptyList());
         assertFunction("array_cum_sum(CAST(NULL AS array(double)))", new ArrayType(DOUBLE), null);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayExceptFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayExceptFunction.java
@@ -17,6 +17,8 @@ import com.facebook.presto.common.type.ArrayType;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -42,8 +44,8 @@ public class TestArrayExceptFunction
     @Test
     public void testEmpty()
     {
-        assertFunction("array_except(ARRAY[], ARRAY[])", new ArrayType(UNKNOWN), ImmutableList.of());
-        assertFunction("array_except(ARRAY[], ARRAY[1, 3])", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("array_except(ARRAY[], ARRAY[])", new ArrayType(UNKNOWN), Collections.emptyList());
+        assertFunction("array_except(ARRAY[], ARRAY[1, 3])", new ArrayType(INTEGER), Collections.emptyList());
         assertFunction("array_except(ARRAY[CAST('abc' as VARCHAR)], ARRAY[])", new ArrayType(VARCHAR), ImmutableList.of("abc"));
     }
 
@@ -53,8 +55,8 @@ public class TestArrayExceptFunction
         assertFunction("array_except(ARRAY[NULL], NULL)", new ArrayType(UNKNOWN), null);
         assertFunction("array_except(NULL, NULL)", new ArrayType(UNKNOWN), null);
         assertFunction("array_except(NULL, ARRAY[NULL])", new ArrayType(UNKNOWN), null);
-        assertFunction("array_except(ARRAY[NULL], ARRAY[NULL])", new ArrayType(UNKNOWN), ImmutableList.of());
-        assertFunction("array_except(ARRAY[], ARRAY[NULL])", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("array_except(ARRAY[NULL], ARRAY[NULL])", new ArrayType(UNKNOWN), Collections.emptyList());
+        assertFunction("array_except(ARRAY[], ARRAY[NULL])", new ArrayType(UNKNOWN), Collections.emptyList());
         assertFunction("array_except(ARRAY[NULL], ARRAY[])", new ArrayType(UNKNOWN), singletonList(null));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFilterFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFilterFunction.java
@@ -17,6 +17,8 @@ import com.facebook.presto.common.type.ArrayType;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
@@ -40,20 +42,20 @@ public class TestArrayFilterFunction
     @Test
     public void testEmpty()
     {
-        assertFunction("filter(ARRAY [], x -> true)", new ArrayType(UNKNOWN), ImmutableList.of());
-        assertFunction("filter(ARRAY [], x -> false)", new ArrayType(UNKNOWN), ImmutableList.of());
-        assertFunction("filter(ARRAY [], x -> CAST (null AS BOOLEAN))", new ArrayType(UNKNOWN), ImmutableList.of());
-        assertFunction("filter(CAST (ARRAY [] AS ARRAY(INTEGER)), x -> true)", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("filter(ARRAY [], x -> true)", new ArrayType(UNKNOWN), Collections.emptyList());
+        assertFunction("filter(ARRAY [], x -> false)", new ArrayType(UNKNOWN), Collections.emptyList());
+        assertFunction("filter(ARRAY [], x -> CAST (null AS BOOLEAN))", new ArrayType(UNKNOWN), Collections.emptyList());
+        assertFunction("filter(CAST (ARRAY [] AS ARRAY(INTEGER)), x -> true)", new ArrayType(INTEGER), Collections.emptyList());
     }
 
     @Test
     public void testNull()
     {
         assertFunction("filter(ARRAY [NULL], x -> x IS NULL)", new ArrayType(UNKNOWN), singletonList(null));
-        assertFunction("filter(ARRAY [NULL], x -> x IS NOT NULL)", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("filter(ARRAY [NULL], x -> x IS NOT NULL)", new ArrayType(UNKNOWN), Collections.emptyList());
         assertFunction("filter(ARRAY [CAST (NULL AS INTEGER)], x -> x IS NULL)", new ArrayType(INTEGER), singletonList(null));
         assertFunction("filter(ARRAY [NULL, NULL, NULL], x -> x IS NULL)", new ArrayType(UNKNOWN), asList(null, null, null));
-        assertFunction("filter(ARRAY [NULL, NULL, NULL], x -> x IS NOT NULL)", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("filter(ARRAY [NULL, NULL, NULL], x -> x IS NOT NULL)", new ArrayType(UNKNOWN), Collections.emptyList());
 
         assertFunction("filter(ARRAY [25, 26, NULL], x -> x % 2 = 1 OR x IS NULL)", new ArrayType(INTEGER), asList(25, null));
         assertFunction("filter(ARRAY [25.6E0, 37.3E0, NULL], x -> x < 30.0E0 OR x IS NULL)", new ArrayType(DOUBLE), asList(25.6, null));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayIntersectFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayIntersectFunction.java
@@ -18,6 +18,8 @@ import com.facebook.presto.common.type.RowType;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -42,9 +44,9 @@ public class TestArrayIntersectFunction
     @Test
     public void testEmpty()
     {
-        assertFunction("array_intersect(ARRAY[], ARRAY[])", new ArrayType(UNKNOWN), ImmutableList.of());
-        assertFunction("array_intersect(ARRAY[], ARRAY[1, 3])", new ArrayType(INTEGER), ImmutableList.of());
-        assertFunction("array_intersect(ARRAY[CAST('abc' as VARCHAR)], ARRAY[])", new ArrayType(VARCHAR), ImmutableList.of());
+        assertFunction("array_intersect(ARRAY[], ARRAY[])", new ArrayType(UNKNOWN), Collections.emptyList());
+        assertFunction("array_intersect(ARRAY[], ARRAY[1, 3])", new ArrayType(INTEGER), Collections.emptyList());
+        assertFunction("array_intersect(ARRAY[CAST('abc' as VARCHAR)], ARRAY[])", new ArrayType(VARCHAR), Collections.emptyList());
     }
 
     @Test
@@ -54,8 +56,8 @@ public class TestArrayIntersectFunction
         assertFunction("array_intersect(NULL, NULL)", new ArrayType(UNKNOWN), null);
         assertFunction("array_intersect(NULL, ARRAY[NULL])", new ArrayType(UNKNOWN), null);
         assertFunction("array_intersect(ARRAY[NULL], ARRAY[NULL])", new ArrayType(UNKNOWN), asList(false ? 1 : null));
-        assertFunction("array_intersect(ARRAY[], ARRAY[NULL])", new ArrayType(UNKNOWN), ImmutableList.of());
-        assertFunction("array_intersect(ARRAY[NULL], ARRAY[])", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("array_intersect(ARRAY[], ARRAY[NULL])", new ArrayType(UNKNOWN), Collections.emptyList());
+        assertFunction("array_intersect(ARRAY[NULL], ARRAY[])", new ArrayType(UNKNOWN), Collections.emptyList());
     }
 
     @Test
@@ -71,7 +73,7 @@ public class TestArrayIntersectFunction
     public void testSQLFunctions()
     {
         assertFunction("array_intersect(ARRAY[ARRAY[1, 3, 5], ARRAY[2, 3, 5], ARRAY[3, 3, 3, 6]])", new ArrayType(INTEGER), ImmutableList.of(3));
-        assertFunction("array_intersect(ARRAY[ARRAY[], ARRAY[1, 2, 3]])", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("array_intersect(ARRAY[ARRAY[], ARRAY[1, 2, 3]])", new ArrayType(INTEGER), Collections.emptyList());
         assertFunction("array_intersect(ARRAY[ARRAY[1, 2, 3], null])", new ArrayType(INTEGER), null);
         assertFunction("array_intersect(ARRAY[ARRAY[DOUBLE'1.1', DOUBLE'2.2', DOUBLE'3.3'], ARRAY[DOUBLE'1.1', DOUBLE'3.4'], ARRAY[DOUBLE'1.0', DOUBLE'1.1', DOUBLE'1.2']])", new ArrayType(DOUBLE), ImmutableList.of(1.1));
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayTrimFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayTrimFunction.java
@@ -17,6 +17,8 @@ import com.facebook.presto.common.type.ArrayType;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static java.util.Arrays.asList;
@@ -31,7 +33,7 @@ public class TestArrayTrimFunction
         assertFunction("trim_array(ARRAY[1, 2, 3, 4], 1)", new ArrayType(INTEGER), ImmutableList.of(1, 2, 3));
         assertFunction("trim_array(ARRAY[1, 2, 3, 4], 2)", new ArrayType(INTEGER), ImmutableList.of(1, 2));
         assertFunction("trim_array(ARRAY[1, 2, 3, 4], 3)", new ArrayType(INTEGER), ImmutableList.of(1));
-        assertFunction("trim_array(ARRAY[1, 2, 3, 4], 4)", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("trim_array(ARRAY[1, 2, 3, 4], 4)", new ArrayType(INTEGER), Collections.emptyList());
 
         assertFunction("trim_array(ARRAY['a', 'b', 'c', 'd'], 1)", new ArrayType(createVarcharType(1)), ImmutableList.of("a", "b", "c"));
         assertFunction("trim_array(ARRAY['a', 'b', null, 'd'], 1)", new ArrayType(createVarcharType(1)), asList("a", "b", null));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -48,6 +48,7 @@ import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -170,7 +171,7 @@ public abstract class TestDateTimeFunctionsBase
                         timeZoneKey,
                         US,
                         instant,
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         ImmutableMap.of(),
                         isLegacyTimestamp(session),
                         Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
@@ -21,6 +21,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -48,8 +49,8 @@ public class TestJsonExtract
     @Test
     public void testJsonTokenizer()
     {
-        assertEquals(tokenizePath("$"), ImmutableList.of());
-        assertEquals(tokenizePath("$"), ImmutableList.of());
+        assertEquals(tokenizePath("$"), Collections.emptyList());
+        assertEquals(tokenizePath("$"), Collections.emptyList());
         assertEquals(tokenizePath("$.foo"), ImmutableList.of("foo"));
         assertEquals(tokenizePath("$[\"foo\"]"), ImmutableList.of("foo"));
         assertEquals(tokenizePath("$[\"foo.bar\"]"), ImmutableList.of("foo.bar"));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMapFilterFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMapFilterFunction.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -177,22 +178,22 @@ public class TestMapFilterFunction
         assertFunction(
                 "map_filter(map(ARRAY [ARRAY [1, 2], ARRAY [3, 4], ARRAY []], ARRAY [25, 26, 27]), (k, v) -> k = ARRAY [1, 2] OR v = 27)",
                 mapType(new ArrayType(INTEGER), INTEGER),
-                ImmutableMap.of(ImmutableList.of(1, 2), 25, ImmutableList.of(), 27));
+                ImmutableMap.of(ImmutableList.of(1, 2), 25, Collections.emptyList(), 27));
         assertFunction(
                 "map_filter(map(ARRAY [ARRAY [1, 2], ARRAY [3, 4], ARRAY []], ARRAY [25.5E0, 26.5E0, 27.5E0]), (k, v) -> k = ARRAY [1, 2] OR v = 27.5E0)",
                 mapType(new ArrayType(INTEGER), DOUBLE),
-                ImmutableMap.of(ImmutableList.of(1, 2), 25.5, ImmutableList.of(), 27.5));
+                ImmutableMap.of(ImmutableList.of(1, 2), 25.5, Collections.emptyList(), 27.5));
         assertFunction(
                 "map_filter(map(ARRAY [ARRAY [1, 2], ARRAY [3, 4], ARRAY []], ARRAY [false, null, true]), (k, v) -> k = ARRAY [1, 2] OR v)",
                 mapType(new ArrayType(INTEGER), BOOLEAN),
-                ImmutableMap.of(ImmutableList.of(1, 2), false, ImmutableList.of(), true));
+                ImmutableMap.of(ImmutableList.of(1, 2), false, Collections.emptyList(), true));
         assertFunction(
                 "map_filter(map(ARRAY [ARRAY [1, 2], ARRAY [3, 4], ARRAY []], ARRAY ['abc', 'def', 'xyz']), (k, v) -> k = ARRAY [1, 2] OR v = 'xyz')",
                 mapType(new ArrayType(INTEGER), createVarcharType(3)),
-                ImmutableMap.of(ImmutableList.of(1, 2), "abc", ImmutableList.of(), "xyz"));
+                ImmutableMap.of(ImmutableList.of(1, 2), "abc", Collections.emptyList(), "xyz"));
         assertFunction(
                 "map_filter(map(ARRAY [ARRAY [1, 2], ARRAY [3, 4], ARRAY []], ARRAY [ARRAY ['a', 'b'], ARRAY ['a', 'b', 'c'], ARRAY ['a', 'c']]), (k, v) -> cardinality(k) = 0 OR cardinality(v) = 3)",
                 mapType(new ArrayType(INTEGER), new ArrayType(createVarcharType(1))),
-                ImmutableMap.of(ImmutableList.of(3, 4), ImmutableList.of("a", "b", "c"), ImmutableList.of(), ImmutableList.of("a", "c")));
+                ImmutableMap.of(ImmutableList.of(3, 4), ImmutableList.of("a", "b", "c"), Collections.emptyList(), ImmutableList.of("a", "c")));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMapTopNKeysComparatorFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMapTopNKeysComparatorFunction.java
@@ -20,6 +20,8 @@ import com.facebook.presto.sql.analyzer.SemanticErrorCode;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
@@ -61,15 +63,15 @@ public class TestMapTopNKeysComparatorFunction
     @Test
     public void testZeroN()
     {
-        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[4, 5, 6], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)))", new ArrayType(INTEGER), ImmutableList.of());
-        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[4, 5, 6], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1)))", new ArrayType(INTEGER), ImmutableList.of());
-        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY['x', 'y', 'z'], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1)))", new ArrayType(createVarcharType(1)), ImmutableList.of());
+        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[4, 5, 6], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)))", new ArrayType(INTEGER), Collections.emptyList());
+        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[4, 5, 6], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1)))", new ArrayType(INTEGER), Collections.emptyList());
+        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY['x', 'y', 'z'], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1)))", new ArrayType(createVarcharType(1)), Collections.emptyList());
     }
 
     @Test
     public void testEmpty()
     {
-        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[], ARRAY[]), 1, (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)))", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[], ARRAY[]), 1, (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)))", new ArrayType(UNKNOWN), Collections.emptyList());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMapTransformValueFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMapTransformValueFunction.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -206,10 +207,10 @@ public class TestMapTransformValueFunction
         assertFunction(
                 "transform_values(map(ARRAY [ARRAY [1, 2], ARRAY []], ARRAY ['a', 'ff']), (k, v) -> k || from_base(v, 16))",
                 mapType(new ArrayType(INTEGER), new ArrayType(BIGINT)),
-                ImmutableMap.of(ImmutableList.of(1, 2), ImmutableList.of(1L, 2L, 10L), ImmutableList.of(), ImmutableList.of(255L)));
+                ImmutableMap.of(ImmutableList.of(1, 2), ImmutableList.of(1L, 2L, 10L), Collections.emptyList(), ImmutableList.of(255L)));
         assertFunction(
                 "transform_values(map(ARRAY [ARRAY [3, 4], ARRAY []], ARRAY [ARRAY ['a', 'b', 'c'], ARRAY ['a', 'c']]), (k, v) -> transform(k, x -> CAST(x AS VARCHAR)) || v)",
                 mapType(new ArrayType(INTEGER), new ArrayType(VARCHAR)),
-                ImmutableMap.of(ImmutableList.of(3, 4), ImmutableList.of("3", "4", "a", "b", "c"), ImmutableList.of(), ImmutableList.of("a", "c")));
+                ImmutableMap.of(ImmutableList.of(3, 4), ImmutableList.of("3", "4", "a", "b", "c"), Collections.emptyList(), ImmutableList.of("a", "c")));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestProvidedBlockBuilderReturnPlaceConvention.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestProvidedBlockBuilderReturnPlaceConvention.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -158,7 +159,7 @@ public class TestProvidedBlockBuilderReturnPlaceConvention
                     QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "identity1"),
                     FunctionKind.SCALAR,
                     ImmutableList.of(typeVariable("T")),
-                    ImmutableList.of(),
+                    Collections.emptyList(),
                     parseTypeSignature("T"),
                     ImmutableList.of(parseTypeSignature("T")),
                     false));
@@ -278,7 +279,7 @@ public class TestProvidedBlockBuilderReturnPlaceConvention
                     QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "identity2"),
                     FunctionKind.SCALAR,
                     ImmutableList.of(typeVariable("T")),
-                    ImmutableList.of(),
+                    Collections.emptyList(),
                     parseTypeSignature("T"),
                     ImmutableList.of(parseTypeSignature("T")),
                     false));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestZipWithFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestZipWithFunction.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
@@ -42,7 +44,7 @@ public class TestZipWithFunction
     {
         assertFunction("zip_with(ARRAY[], ARRAY[], (x, y) -> (y, x))",
                 new ArrayType(RowType.anonymous(ImmutableList.of(UNKNOWN, UNKNOWN))),
-                ImmutableList.of());
+                Collections.emptyList());
 
         assertFunction("zip_with(ARRAY[1, 2], ARRAY['a', 'b'], (x, y) -> (y, x))",
                 new ArrayType(RowType.anonymous(ImmutableList.of(createVarcharType(1), INTEGER))),

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/queryplan/TestJsonPrestoQueryPlanFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/queryplan/TestJsonPrestoQueryPlanFunctions.java
@@ -18,6 +18,8 @@ import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.JsonType.JSON;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 
@@ -41,7 +43,7 @@ public class TestJsonPrestoQueryPlanFunctions
         assertFunction("json_presto_query_plan_node_children(null, '1')", new ArrayType(VARCHAR), null);
 
         assertFunction("json_presto_query_plan_node_children(json '" + TestJsonPrestoQueryPlanFunctionUtils.joinPlan.replaceAll("'", "''") + "', '314')",
-                new ArrayType(VARCHAR), ImmutableList.of());
+                new ArrayType(VARCHAR), Collections.emptyList());
 
         assertFunction("json_presto_query_plan_node_children(json '" + TestJsonPrestoQueryPlanFunctionUtils.joinPlan.replaceAll("'", "''") + "', '230')",
                 new ArrayType(VARCHAR), ImmutableList.of("251", "284"));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.block.BlockAssertions.createMapType;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -162,27 +164,27 @@ public class TestArraySqlFunctions
     public void testArrayDuplicates()
     {
         assertFunction("array_duplicates(cast(null as array(varchar)))", new ArrayType(VARCHAR), null);
-        assertFunction("array_duplicates(cast(array[] as array(varchar)))", new ArrayType(VARCHAR), ImmutableList.of());
+        assertFunction("array_duplicates(cast(array[] as array(varchar)))", new ArrayType(VARCHAR), Collections.emptyList());
 
         assertFunction("array_duplicates(array[varchar 'a', varchar 'b', varchar 'a'])", new ArrayType(VARCHAR), ImmutableList.of("a"));
-        assertFunction("array_duplicates(array[varchar 'a', varchar 'b'])", new ArrayType(VARCHAR), ImmutableList.of());
+        assertFunction("array_duplicates(array[varchar 'a', varchar 'b'])", new ArrayType(VARCHAR), Collections.emptyList());
         assertFunction("array_duplicates(array[varchar 'a', varchar 'a'])", new ArrayType(VARCHAR), ImmutableList.of("a"));
 
         assertFunction("array_duplicates(array[1, 2, 1])", new ArrayType(INTEGER), ImmutableList.of(1));
-        assertFunction("array_duplicates(array[1, 2])", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("array_duplicates(array[1, 2])", new ArrayType(INTEGER), Collections.emptyList());
         assertFunction("array_duplicates(array[1, 1, 1])", new ArrayType(INTEGER), ImmutableList.of(1));
 
-        assertFunction("array_duplicates(array[0, null])", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("array_duplicates(array[0, null])", new ArrayType(INTEGER), Collections.emptyList());
         assertFunction("array_duplicates(array[0, null, null])", new ArrayType(INTEGER), singletonList(null));
 
         // Test legacy name.
         assertFunction("array_dupes(array[1, 2, 1])", new ArrayType(INTEGER), ImmutableList.of(1));
 
         RowType rowType = RowType.from(ImmutableList.of(RowType.field(INTEGER), RowType.field(INTEGER)));
-        assertFunction("array_duplicates(array[array[1], array[2], array[]])", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of());
+        assertFunction("array_duplicates(array[array[1], array[2], array[]])", new ArrayType(new ArrayType(INTEGER)), Collections.emptyList());
         assertFunction("array_duplicates(array[array[1], array[2], array[2]])", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(ImmutableList.of(2)));
         assertFunction("array_duplicates(array[(1, 2), (1, 2)])", new ArrayType(rowType), ImmutableList.of(ImmutableList.of(1, 2)));
-        assertFunction("array_duplicates(array[(1, 2), (2, 2)])", new ArrayType(rowType), ImmutableList.of());
+        assertFunction("array_duplicates(array[(1, 2), (2, 2)])", new ArrayType(rowType), Collections.emptyList());
         assertInvalidFunction("array_duplicates(array[(1, null), (null, 2), (null, 1)])", StandardErrorCode.NOT_SUPPORTED, "ROW comparison not supported for fields with null elements");
         assertInvalidFunction("array_duplicates(array[(1, null), (null, 2), (null, null)])", StandardErrorCode.NOT_SUPPORTED, "map key cannot be null or contain nulls");
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapKeysByTopNValuesFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapKeysByTopNValuesFunction.java
@@ -20,6 +20,8 @@ import com.facebook.presto.spi.StandardErrorCode;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
@@ -82,21 +84,21 @@ public class TestMapKeysByTopNValuesFunction
         assertFunction(
                 "MAP_KEYS_BY_TOP_N_VALUES(MAP(ARRAY[-1, -2, -3], ARRAY[4, 5, 6]), 0)",
                 new ArrayType(INTEGER),
-                ImmutableList.of());
+                Collections.emptyList());
         assertFunction(
                 "MAP_KEYS_BY_TOP_N_VALUES(MAP(ARRAY['ab', 'bc', 'cd'], ARRAY['x', 'y', 'z']), 0)",
                 new ArrayType(createVarcharType(2)),
-                ImmutableList.of());
+                Collections.emptyList());
         assertFunction(
                 "MAP_KEYS_BY_TOP_N_VALUES(MAP(ARRAY[123.0, 99.5, 1000.99], ARRAY['x', 'y', 'z']), 0)",
                 new ArrayType(createDecimalType(6, 2)),
-                ImmutableList.of());
+                Collections.emptyList());
     }
 
     @Test
     public void testEmpty()
     {
-        assertFunction("MAP_KEYS_BY_TOP_N_VALUES(MAP(ARRAY[], ARRAY[]), 5)", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("MAP_KEYS_BY_TOP_N_VALUES(MAP(ARRAY[], ARRAY[]), 5)", new ArrayType(UNKNOWN), Collections.emptyList());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapTopNKeysFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapTopNKeysFunction.java
@@ -20,6 +20,8 @@ import com.facebook.presto.spi.StandardErrorCode;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
@@ -48,15 +50,15 @@ public class TestMapTopNKeysFunction
     @Test
     public void testZeroN()
     {
-        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[-1, -2, -3], ARRAY[4, 5, 6]), 0)", new ArrayType(INTEGER), ImmutableList.of());
-        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY['ab', 'bc', 'cd'], ARRAY['x', 'y', 'z']), 0)", new ArrayType(createVarcharType(2)), ImmutableList.of());
-        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[123.0, 99.5, 1000.99], ARRAY['x', 'y', 'z']), 0)", new ArrayType(createDecimalType(6, 2)), ImmutableList.of());
+        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[-1, -2, -3], ARRAY[4, 5, 6]), 0)", new ArrayType(INTEGER), Collections.emptyList());
+        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY['ab', 'bc', 'cd'], ARRAY['x', 'y', 'z']), 0)", new ArrayType(createVarcharType(2)), Collections.emptyList());
+        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[123.0, 99.5, 1000.99], ARRAY['x', 'y', 'z']), 0)", new ArrayType(createDecimalType(6, 2)), Collections.emptyList());
     }
 
     @Test
     public void testEmpty()
     {
-        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[], ARRAY[]), 5)", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("MAP_TOP_N_KEYS(MAP(ARRAY[], ARRAY[]), 5)", new ArrayType(UNKNOWN), Collections.emptyList());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapTopNValuesComparatorFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapTopNValuesComparatorFunction.java
@@ -21,6 +21,8 @@ import com.facebook.presto.sql.analyzer.SemanticErrorCode;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
@@ -70,15 +72,15 @@ public class TestMapTopNValuesComparatorFunction
     @Test
     public void testZeroN()
     {
-        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[4, 5, 6], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)))", new ArrayType(INTEGER), ImmutableList.of());
-        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[4, 5, 6], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1)))", new ArrayType(INTEGER), ImmutableList.of());
-        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[1, 2, 3], ARRAY['x', 'y', 'z']), 0, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1)))", new ArrayType(createVarcharType(1)), ImmutableList.of());
+        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[4, 5, 6], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)))", new ArrayType(INTEGER), Collections.emptyList());
+        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[4, 5, 6], ARRAY[1, 2, 3]), 0, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1)))", new ArrayType(INTEGER), Collections.emptyList());
+        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[1, 2, 3], ARRAY['x', 'y', 'z']), 0, (x, y) -> IF(x > y, 1, IF(x = y, 0, -1)))", new ArrayType(createVarcharType(1)), Collections.emptyList());
     }
 
     @Test
     public void testEmpty()
     {
-        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[], ARRAY[]), 1, (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)))", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[], ARRAY[]), 1, (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)))", new ArrayType(UNKNOWN), Collections.emptyList());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapTopNValuesFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapTopNValuesFunction.java
@@ -20,6 +20,8 @@ import com.facebook.presto.spi.StandardErrorCode;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
@@ -57,14 +59,14 @@ public class TestMapTopNValuesFunction
     @Test
     public void testZeroN()
     {
-        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[4, 5, 6], ARRAY[1, null, 3]), 0)", new ArrayType(INTEGER), ImmutableList.of());
-        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[4, 5, 6], ARRAY['a', 'b', 'c']), 0)", new ArrayType(createVarcharType(1)), ImmutableList.of());
+        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[4, 5, 6], ARRAY[1, null, 3]), 0)", new ArrayType(INTEGER), Collections.emptyList());
+        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[4, 5, 6], ARRAY['a', 'b', 'c']), 0)", new ArrayType(createVarcharType(1)), Collections.emptyList());
     }
 
     @Test
     public void testEmpty()
     {
-        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[], ARRAY[]), 5)", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("MAP_TOP_N_VALUES(MAP(ARRAY[], ARRAY[]), 5)", new ArrayType(UNKNOWN), Collections.emptyList());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/unnest/BenchmarkCopyBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/unnest/BenchmarkCopyBlock.java
@@ -19,7 +19,6 @@ import com.facebook.presto.common.block.LongArrayBlockBuilder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.metadata.Metadata;
-import com.google.common.collect.ImmutableList;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -38,6 +37,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -144,7 +144,7 @@ public class BenchmarkCopyBlock
                         primitiveNullsRatio,
                         0.0f,
                         false,
-                        ImmutableList.of()));
+                        Collections.emptyList()));
             }
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/unnest/TestUnnestOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/unnest/TestUnnestOperator.java
@@ -33,6 +33,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -432,12 +433,12 @@ public class TestUnnestOperator
 
     protected void testUnnest(List<Type> replicatedTypes, List<Type> unnestTypes, List<Type> types)
     {
-        testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.0f, false, ImmutableList.of());
-        testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.2f, false, ImmutableList.of());
-        testUnnest(replicatedTypes, unnestTypes, types, 0.2f, 0.2f, false, ImmutableList.of());
-        testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.0f, true, ImmutableList.of());
-        testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.2f, true, ImmutableList.of());
-        testUnnest(replicatedTypes, unnestTypes, types, 0.2f, 0.2f, true, ImmutableList.of());
+        testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.0f, false, Collections.emptyList());
+        testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.2f, false, Collections.emptyList());
+        testUnnest(replicatedTypes, unnestTypes, types, 0.2f, 0.2f, false, Collections.emptyList());
+        testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.0f, true, Collections.emptyList());
+        testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.2f, true, Collections.emptyList());
+        testUnnest(replicatedTypes, unnestTypes, types, 0.2f, 0.2f, true, Collections.emptyList());
 
         testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.0f, false, ImmutableList.of(DICTIONARY));
         testUnnest(replicatedTypes, unnestTypes, types, 0.0f, 0.0f, false, ImmutableList.of(RUN_LENGTH));

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,7 +81,7 @@ public class TestResourceManagerClusterStateProvider
 
         ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), Duration.valueOf("4s"), true, newSingleThreadScheduledExecutor());
 
-        assertEquals(provider.getClusterQueries(), ImmutableList.of());
+        assertEquals(provider.getClusterQueries(), Collections.emptyList());
 
         long query1Sequence = 0;
         long query2Sequence = 0;
@@ -131,7 +132,7 @@ public class TestResourceManagerClusterStateProvider
 
         ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), Duration.valueOf("4s"), true, newSingleThreadScheduledExecutor());
 
-        assertEquals(provider.getClusterQueries(), ImmutableList.of());
+        assertEquals(provider.getClusterQueries(), Collections.emptyList());
 
         provider.registerQueryHeartbeat("node1", createQueryInfo("1", QUEUED), 1);
         provider.registerQueryHeartbeat("node1", createQueryInfo("2", FINISHED), 2);
@@ -163,7 +164,7 @@ public class TestResourceManagerClusterStateProvider
         provider.registerNodeHeartbeat(createCoordinatorNodeStatus("node2"));
         provider.registerNodeHeartbeat(createCoordinatorNodeStatus("node3"));
 
-        assertEquals(provider.getClusterQueries(), ImmutableList.of());
+        assertEquals(provider.getClusterQueries(), Collections.emptyList());
 
         long query1Sequence = 0;
         long query2Sequence = 0;
@@ -213,7 +214,7 @@ public class TestResourceManagerClusterStateProvider
         provider.registerNodeHeartbeat(createCoordinatorNodeStatus("node5"));
         provider.registerNodeHeartbeat(createCoordinatorNodeStatus("node6"));
 
-        assertEquals(provider.getClusterQueries(), ImmutableList.of());
+        assertEquals(provider.getClusterQueries(), Collections.emptyList());
 
         provider.registerQueryHeartbeat("node1", createQueryInfo("1", WAITING_FOR_PREREQUISITES, "rg4", GENERAL_POOL), 0);
         assertTrue(provider.getClusterResourceGroups("node1").isEmpty());
@@ -299,7 +300,7 @@ public class TestResourceManagerClusterStateProvider
         long query8Sequence = 0;
         long query9Sequence = 0;
 
-        assertEquals(provider.getClusterQueries(), ImmutableList.of());
+        assertEquals(provider.getClusterQueries(), Collections.emptyList());
 
         provider.registerQueryHeartbeat("node1", createQueryInfo("1", WAITING_FOR_PREREQUISITES, "root.rg4", GENERAL_POOL), query1Sequence++);
         assertTrue(provider.getClusterResourceGroups("node1").isEmpty());
@@ -517,7 +518,7 @@ public class TestResourceManagerClusterStateProvider
 
         ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), Duration.valueOf("4s"), true, newSingleThreadScheduledExecutor());
 
-        assertEquals(provider.getClusterQueries(), ImmutableList.of());
+        assertEquals(provider.getClusterQueries(), Collections.emptyList());
 
         long query1Sequence = 0;
         long query2Sequence = 0;
@@ -775,7 +776,7 @@ public class TestResourceManagerClusterStateProvider
                         OptionalDouble.of(20)),
                 null,
                 Optional.empty(),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestingResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestingResourceManagerClient.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,7 +35,7 @@ public class TestingResourceManagerClient
     private final AtomicInteger resourceGroupRuntimeHeartbeats = new AtomicInteger();
     private final Map<String, Integer> resourceGroupInfoCalls = new ConcurrentHashMap<>();
 
-    private volatile List<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos = ImmutableList.of();
+    private volatile List<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos = Collections.emptyList();
 
     private int runningTaskCount;
 

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -45,7 +45,6 @@ import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.testing.TestingConnectorContext;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
@@ -272,7 +271,7 @@ public class TestAccessControlManager
                 connectorId,
                 connector,
                 createInformationSchemaConnectorId(connectorId),
-                new InformationSchemaConnector(catalogName, nodeManager, metadata, accessControl, ImmutableList.of()),
+                new InformationSchemaConnector(catalogName, nodeManager, metadata, accessControl, Collections.emptyList()),
                 systemId,
                 new SystemConnector(
                         systemId,

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -32,6 +32,7 @@ import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
@@ -119,7 +120,7 @@ public class TestBasicQueryInfo
                                         105,
                                         106,
                                         107)),
-                                ImmutableList.of(),
+                                Collections.emptyList(),
                                 new RuntimeStats()),
                         Optional.empty(),
                         Optional.empty(),
@@ -134,7 +135,7 @@ public class TestBasicQueryInfo
                         Optional.empty(),
                         null,
                         StandardErrorCode.ABANDONED_QUERY.toErrorCode(),
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         ImmutableSet.of(),
                         Optional.empty(),
                         false,
@@ -145,12 +146,12 @@ public class TestBasicQueryInfo
                         ImmutableMap.of(),
                         ImmutableSet.of(),
                         StatsAndCosts.empty(),
-                        ImmutableList.of(),
-                        ImmutableList.of(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
                         ImmutableSet.of(),
                         ImmutableSet.of(),
                         ImmutableSet.of(),
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         ImmutableMap.of(),
                         Optional.empty()));
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -34,6 +34,7 @@ import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -270,8 +271,8 @@ public class TestQueryStateInfo
                         DataSize.valueOf("34GB"),
                         DataSize.valueOf("35GB"),
                         DataSize.valueOf("36GB"),
-                        ImmutableList.of(),
-                        ImmutableList.of(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
                         new RuntimeStats()),
                 Optional.empty(),
                 Optional.empty(),
@@ -300,12 +301,12 @@ public class TestQueryStateInfo
                 ImmutableMap.of(),
                 ImmutableSet.of(),
                 StatsAndCosts.empty(),
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 ImmutableSet.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableMap.of(),
                 Optional.empty());
     }

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -143,7 +144,7 @@ public class TestGenericPartitioningSpiller
             assertSpilledPages(
                     TYPES,
                     spiller,
-                    ImmutableList.of(ImmutableList.of(), secondPartition, thirdPartition, ImmutableList.of()));
+                    ImmutableList.of(Collections.emptyList(), secondPartition, thirdPartition, Collections.emptyList()));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
+++ b/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -108,7 +107,7 @@ public class MockSplitSource
                     nextBatchFuture.setException(new IllegalStateException("Mock failure"));
                     break;
                 case FINISH:
-                    nextBatchFuture.set(ImmutableList.of());
+                    nextBatchFuture.set(Collections.emptyList());
                     break;
                 case DO_NOTHING:
                     break;
@@ -174,7 +173,7 @@ public class MockSplitSource
         @Override
         public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
@@ -63,6 +63,7 @@ import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.BeforeClass;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -481,7 +482,7 @@ public class AbstractAnalyzerTest
                 connectorId,
                 connector,
                 createInformationSchemaConnectorId(connectorId),
-                new InformationSchemaConnector(catalogName, nodeManager, metadata, accessControl, ImmutableList.of()),
+                new InformationSchemaConnector(catalogName, nodeManager, metadata, accessControl, Collections.emptyList()),
                 systemId,
                 new SystemConnector(
                         systemId,

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -26,6 +26,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1581,8 +1582,8 @@ public class TestMaterializedViewQueryOptimizer
                 viewName,
                 baseTables,
                 Optional.empty(),
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 Optional.empty());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
@@ -31,6 +31,7 @@ import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -176,7 +177,7 @@ public class TestJoinCompiler
 
         OptionalInt hashChannel = OptionalInt.empty();
         ImmutableList<List<Block>> channels = ImmutableList.of(extraChannel, varcharChannel, longChannel, doubleChannel, booleanChannel, extraUnusedChannel);
-        List<Block> precomputedHash = ImmutableList.of();
+        List<Block> precomputedHash = Collections.emptyList();
         if (hashEnabled) {
             ImmutableList.Builder<Block> hashChannelBuilder = ImmutableList.builder();
             for (int i = 0; i < 3; i++) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
@@ -29,6 +29,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
+import java.util.Collections;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
@@ -79,8 +80,8 @@ public class TestVarArgsToArrayAdapterGenerator
             super(new Signature(
                     QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "var_args_sum"),
                     FunctionKind.SCALAR,
-                    ImmutableList.of(),
-                    ImmutableList.of(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
                     INTEGER.getTypeSignature(),
                     ImmutableList.of(INTEGER.getTypeSignature()),
                     true));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION;
@@ -56,7 +57,7 @@ public class TestCanonicalize
                         .setSystemProperty(REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION, "false")
                         .build(),
                 anyTree(
-                        join(INNER, ImmutableList.of(), Optional.empty(),
+                        join(INNER, Collections.emptyList(), Optional.empty(),
                                 project(
                                         ImmutableMap.of("X", expression("BIGINT '1'")),
                                         values(ImmutableMap.of())),
@@ -67,7 +68,7 @@ public class TestCanonicalize
     public void testDuplicatesInWindowOrderBy()
     {
         ExpectedValueProvider<WindowNode.Specification> specification = specification(
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableList.of("A"),
                 ImmutableMap.of("A", SortOrder.ASC_NULLS_LAST));
 
@@ -78,7 +79,7 @@ public class TestCanonicalize
                 anyTree(
                         window(windowMatcherBuilder -> windowMatcherBuilder
                                         .specification(specification)
-                                        .addFunction(functionCall("row_number", Optional.empty(), ImmutableList.of())),
+                                        .addFunction(functionCall("row_number", Optional.empty(), Collections.emptyList())),
                                 values("A"))),
                 ImmutableList.of(
                         new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDynamicFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDynamicFilter.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
@@ -105,7 +106,7 @@ public class TestDynamicFilter
                 "SELECT o.orderkey FROM orders o CROSS JOIN lineitem l",
                 anyTree(
                         join(
-                                INNER, ImmutableList.of(),
+                                INNER, Collections.emptyList(),
                                 tableScan("orders"),
                                 exchange(tableScan("lineitem")))));
     }
@@ -117,7 +118,7 @@ public class TestDynamicFilter
                 anyTree(filter("O_COMMENT < CAST(L_COMMENT AS varchar(79))",
                         join(
                                 INNER,
-                                ImmutableList.of(),
+                                Collections.emptyList(),
                                 tableScan("orders", ImmutableMap.of("O_COMMENT", "comment")),
                                 exchange(
                                         tableScan("lineitem", ImmutableMap.of("L_COMMENT", "comment")))))));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -59,6 +59,7 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -166,7 +167,7 @@ public class TestEffectivePredicateExtractor
                         CV, count(metadata.getFunctionAndTypeManager()),
                         DV, count(metadata.getFunctionAndTypeManager())),
                 singleGroupingSet(ImmutableList.of(AV, BV, CV)),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
                 Optional.empty(),
@@ -192,7 +193,7 @@ public class TestEffectivePredicateExtractor
                 filter(baseTableScan, FALSE_CONSTANT),
                 ImmutableMap.of(),
                 globalAggregation(),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
                 Optional.empty(),
@@ -208,7 +209,7 @@ public class TestEffectivePredicateExtractor
     {
         PlanNode node = filter(baseTableScan,
                 and(
-                        greaterThan(AV, call(metadata.getFunctionAndTypeManager(), "rand", DOUBLE, ImmutableList.of())),
+                        greaterThan(AV, call(metadata.getFunctionAndTypeManager(), "rand", DOUBLE, Collections.emptyList())),
                         lessThan(BV, bigintLiteral(10))));
 
         RowExpression effectivePredicate = effectivePredicateExtractor.extract(node);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestExpressionDomainTranslator.java
@@ -52,6 +52,7 @@ import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -1272,7 +1273,7 @@ public class TestExpressionDomainTranslator
 
     private static Expression randPredicate(String symbol, Type type)
     {
-        return comparison(GREATER_THAN, new SymbolReference(symbol), cast(new FunctionCall(QualifiedName.of("rand"), ImmutableList.of()), type));
+        return comparison(GREATER_THAN, new SymbolReference(symbol), cast(new FunctionCall(QualifiedName.of("rand"), Collections.emptyList()), type));
     }
 
     private static ComparisonExpression equal(String symbol, Expression expression)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
@@ -55,6 +55,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -187,7 +188,7 @@ public class TestLocalExecutionPlanner
                 ImmutableSet.of(),
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(new PlanNodeId("sourceId")),
-                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of()),
+                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, Collections.emptyList()), Collections.emptyList()),
                 StageExecutionDescriptor.ungroupedExecution(),
                 false,
                 StatsAndCosts.empty(),
@@ -262,7 +263,7 @@ public class TestLocalExecutionPlanner
         @Override
         public List<VariableReferenceExpression> getOutputVariables()
         {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -494,7 +495,7 @@ public class TestPredicatePushdown
                                 ImmutableMap.of("a1", expression("a1")),
                                 join(
                                         INNER,
-                                        ImmutableList.of(),
+                                        Collections.emptyList(),
                                         Optional.empty(),
                                         Optional.of(REPLICATED),
                                         project(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPushDownDereferences.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPushDownDereferences.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_DEREFERENCE_ENABLED;
@@ -95,7 +96,7 @@ public class TestPushDownDereferences
         assertPlan("WITH t(msg) AS (SELECT * FROM (VALUES ROW(CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))))) " +
                         "SELECT a.msg.y, b.msg.x from t a cross join t b where a.msg.x = 7 or is_finite(b.msg.y)",
                 anyTree(
-                        join(INNER, ImmutableList.of(),
+                        join(INNER, Collections.emptyList(),
                                 project(ImmutableMap.of("a_x", expression("msg.x"), "a_y", expression("msg.y")),
                                         values("msg")),
                                 project(ImmutableMap.of("b_x", expression("msg.x"), "b_y", expression("msg.y")),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestStreamingForPartialAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestStreamingForPartialAggregation.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED;
@@ -42,7 +43,7 @@ public class TestStreamingForPartialAggregation
         assertPlan("SELECT clerk, count(*) FROM orders GROUP BY 1",
                 anyTree(aggregation(
                         singleGroupingSet("clerk"),
-                        ImmutableMap.of(Optional.empty(), functionCall("count", ImmutableList.of())),
+                        ImmutableMap.of(Optional.empty(), functionCall("count", Collections.emptyList())),
                         ImmutableList.of("clerk"), // streaming
                         ImmutableMap.of(),
                         Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -49,6 +49,7 @@ import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -175,7 +176,7 @@ public class TestTypeValidator
 
         WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, DOUBLE, variableC), frame, false);
 
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
+        WindowNode.Specification specification = new WindowNode.Specification(Collections.emptyList(), Optional.empty());
 
         PlanNode node = new WindowNode(
                 Optional.empty(),
@@ -209,7 +210,7 @@ public class TestTypeValidator
                         false,
                         Optional.empty())),
                 singleGroupingSet(ImmutableList.of(variableA, variableB)),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 SINGLE,
                 Optional.empty(),
                 Optional.empty(),
@@ -236,8 +237,8 @@ public class TestTypeValidator
                         Optional.empty(),
                         false,
                         Optional.empty())),
-                singleGroupingSet(ImmutableList.of()),
-                ImmutableList.of(),
+                singleGroupingSet(Collections.emptyList()),
+                Collections.emptyList(),
                 INTERMEDIATE,
                 Optional.empty(),
                 Optional.empty(),
@@ -264,8 +265,8 @@ public class TestTypeValidator
                         Optional.empty(),
                         false,
                         Optional.empty())),
-                singleGroupingSet(ImmutableList.of()),
-                ImmutableList.of(),
+                singleGroupingSet(Collections.emptyList()),
+                Collections.emptyList(),
                 PARTIAL,
                 Optional.empty(),
                 Optional.empty(),
@@ -322,8 +323,8 @@ public class TestTypeValidator
                         Optional.empty(),
                         false,
                         Optional.empty())),
-                singleGroupingSet(ImmutableList.of()),
-                ImmutableList.of(),
+                singleGroupingSet(Collections.emptyList()),
+                Collections.emptyList(),
                 INTERMEDIATE,
                 Optional.empty(),
                 Optional.empty(),
@@ -350,8 +351,8 @@ public class TestTypeValidator
                         Optional.empty(),
                         false,
                         Optional.empty())),
-                singleGroupingSet(ImmutableList.of()),
-                ImmutableList.of(),
+                singleGroupingSet(Collections.emptyList()),
+                Collections.emptyList(),
                 PARTIAL,
                 Optional.empty(),
                 Optional.empty(),
@@ -380,7 +381,7 @@ public class TestTypeValidator
                         false,
                         Optional.empty())),
                 singleGroupingSet(ImmutableList.of(variableA, variableB)),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 SINGLE,
                 Optional.empty(),
                 Optional.empty(),
@@ -409,7 +410,7 @@ public class TestTypeValidator
                         false,
                         Optional.empty())),
                 singleGroupingSet(ImmutableList.of(variableA, variableB)),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 SINGLE,
                 Optional.empty(),
                 Optional.empty(),
@@ -437,7 +438,7 @@ public class TestTypeValidator
 
         WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, BIGINT, variableA), frame, false);
 
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
+        WindowNode.Specification specification = new WindowNode.Specification(Collections.emptyList(), Optional.empty());
 
         PlanNode node = new WindowNode(
                 Optional.empty(),
@@ -471,7 +472,7 @@ public class TestTypeValidator
 
         WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, BIGINT, variableC), frame, false);
 
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
+        WindowNode.Specification specification = new WindowNode.Specification(Collections.emptyList(), Optional.empty());
 
         PlanNode node = new WindowNode(
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestUseDefaultsforCorrelatedAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestUseDefaultsforCorrelatedAggregations.java
@@ -18,6 +18,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
@@ -58,7 +60,7 @@ public class TestUseDefaultsforCorrelatedAggregations
                                                 aggregation(ImmutableMap.of("count", functionCall("count", ImmutableList.of("count_6"))),
                                                         FINAL,
                                                         anyTree(
-                                                                aggregation(ImmutableMap.of("count_6", functionCall("count", ImmutableList.of())),
+                                                                aggregation(ImmutableMap.of("count_6", functionCall("count", Collections.emptyList())),
                                                                         PARTIAL,
                                                                         tableScan("customer", ImmutableMap.of("nationkey_1", "nationkey"))))))))));
 
@@ -148,7 +150,7 @@ public class TestUseDefaultsforCorrelatedAggregations
                 output(
                         anyTree(
                                 join(INNER,
-                                        ImmutableList.of(),
+                                        Collections.emptyList(),
                                         join(LEFT,
                                                 ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
                                                 anyTree(
@@ -163,7 +165,7 @@ public class TestUseDefaultsforCorrelatedAggregations
                 output(
                         anyTree(
                                 join(INNER,
-                                        ImmutableList.of(),
+                                        Collections.emptyList(),
                                         join(LEFT,
                                                 ImmutableList.of(equiJoinClause("nationkey", "nationkey_1")),
                                                 anyTree(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestWindowFrameRange.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestWindowFrameRange.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
@@ -66,7 +67,7 @@ public class TestWindowFrameRange
                         window(
                                 windowMatcherBuilder -> windowMatcherBuilder
                                         .specification(specification(
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 ImmutableList.of("key"),
                                                 ImmutableMap.of("key", SortOrder.ASC_NULLS_LAST)))
                                         .addFunction(
@@ -109,7 +110,7 @@ public class TestWindowFrameRange
                         window(
                                 windowMatcherBuilder -> windowMatcherBuilder
                                         .specification(specification(
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 ImmutableList.of("key"),
                                                 ImmutableMap.of("key", SortOrder.ASC_NULLS_LAST)))
                                         .addFunction(
@@ -152,7 +153,7 @@ public class TestWindowFrameRange
                         window(
                                 windowMatcherBuilder -> windowMatcherBuilder
                                         .specification(specification(
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 ImmutableList.of("key"),
                                                 ImmutableMap.of("key", SortOrder.ASC_NULLS_LAST)))
                                         .addFunction(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/FunctionCallProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/FunctionCallProvider.java
@@ -21,8 +21,8 @@ import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -54,12 +54,12 @@ class FunctionCallProvider
 
     FunctionCallProvider(QualifiedName name, Optional<WindowFrame> frame, boolean distinct, List<PlanTestSymbol> args)
     {
-        this(true, name, frame, distinct, args, ImmutableList.of());
+        this(true, name, frame, distinct, args, Collections.emptyList());
     }
 
     FunctionCallProvider(QualifiedName name, boolean distinct, List<PlanTestSymbol> args)
     {
-        this(false, name, Optional.empty(), distinct, args, ImmutableList.of());
+        this(false, name, Optional.empty(), distinct, args, Collections.emptyList());
     }
 
     FunctionCallProvider(QualifiedName name, List<PlanTestSymbol> args, List<PlanMatchPattern.Ordering> orderBy)
@@ -69,7 +69,7 @@ class FunctionCallProvider
 
     FunctionCallProvider(QualifiedName name, List<PlanTestSymbol> args)
     {
-        this(false, name, Optional.empty(), false, args, ImmutableList.of());
+        this(false, name, Optional.empty(), false, args, Collections.emptyList());
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -75,6 +75,7 @@ import com.google.common.collect.Maps;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -219,7 +220,7 @@ public final class PlanMatchPattern
             Step step,
             PlanMatchPattern source)
     {
-        return aggregation(groupingSets, aggregations, ImmutableList.of(), masks, groupId, step, source);
+        return aggregation(groupingSets, aggregations, Collections.emptyList(), masks, groupId, step, source);
     }
 
     public static PlanMatchPattern aggregation(
@@ -506,7 +507,7 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern exchange(ExchangeNode.Scope scope, ExchangeNode.Type type, PlanMatchPattern... sources)
     {
-        return exchange(scope, type, ImmutableList.of(), sources);
+        return exchange(scope, type, Collections.emptyList(), sources);
     }
 
     public static PlanMatchPattern exchange(ExchangeNode.Scope scope, ExchangeNode.Type type, List<Ordering> orderBy, PlanMatchPattern... sources)
@@ -676,7 +677,7 @@ public final class PlanMatchPattern
         }
         if (node instanceof GroupReference) {
             if (sourcePatterns.isEmpty() && shapeMatchesMatchers(node)) {
-                states.add(new PlanMatchingState(ImmutableList.of()));
+                states.add(new PlanMatchingState(Collections.emptyList()));
             }
         }
         else if (node.getSources().size() == sourcePatterns.size() && shapeMatchesMatchers(node)) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -302,7 +303,7 @@ public class TestMemo
         @Override
         public List<VariableReferenceExpression> getOutputVariables()
         {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestAddIntermediateAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestAddIntermediateAggregations.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.ENABLE_INTERMEDIATE_AGGREGATIONS;
@@ -106,7 +107,7 @@ public class TestAddIntermediateAggregations
     public void testNoInputCount()
     {
         // COUNT(*) is a special class of aggregation that doesn't take any input that should be tested
-        ExpectedValueProvider<FunctionCall> rawInputCount = PlanMatchPattern.functionCall("count", false, ImmutableList.of());
+        ExpectedValueProvider<FunctionCall> rawInputCount = PlanMatchPattern.functionCall("count", false, Collections.emptyList());
         ExpectedValueProvider<FunctionCall> partialInputCount = PlanMatchPattern.functionCall("count", false, ImmutableList.of(anySymbol()));
 
         tester().assertThat(new AddIntermediateAggregations())

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -40,6 +40,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
@@ -77,7 +78,7 @@ public class TestDetermineJoinDistributionType
     @BeforeClass
     public void setUp()
     {
-        tester = new RuleTester(ImmutableList.of(), ImmutableMap.of(), Optional.of(NODES_COUNT));
+        tester = new RuleTester(Collections.emptyList(), ImmutableMap.of(), Optional.of(NODES_COUNT));
     }
 
     @AfterClass(alwaysRun = true)
@@ -210,13 +211,13 @@ public class TestDetermineJoinDistributionType
                                 p.values(
                                         ImmutableList.of(p.variable("B1")),
                                         ImmutableList.of(constantExpressions(BIGINT, 50L), constantExpressions(BIGINT, 11L))),
-                                ImmutableList.of(),
+                                Collections.emptyList(),
                                 ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
                                 Optional.of(p.rowExpression("A1 * B1 > 100"))))
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
                 .matches(join(
                         joinType,
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         Optional.of("A1 * B1 > 100"),
                         Optional.of(com.facebook.presto.spi.plan.JoinDistributionType.REPLICATED),
                         values(ImmutableMap.of("A1", 0)),
@@ -662,12 +663,12 @@ public class TestDetermineJoinDistributionType
                                 RIGHT,
                                 p.values(new PlanNodeId("valuesA"), aRows, p.variable("A1", BIGINT)),
                                 p.values(new PlanNodeId("valuesB"), bRows, p.variable("B1", BIGINT)),
-                                ImmutableList.of(),
+                                Collections.emptyList(),
                                 ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
                                 Optional.empty()))
                 .matches(join(
                         LEFT,
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         Optional.empty(),
                         Optional.of(REPLICATED),
                         values(ImmutableMap.of("B1", 0)),
@@ -695,12 +696,12 @@ public class TestDetermineJoinDistributionType
                                 RIGHT,
                                 p.values(new PlanNodeId("valuesA"), aRows, p.variable("A1", BIGINT)),
                                 p.values(new PlanNodeId("valuesB"), bRows, p.variable("B1", BIGINT)),
-                                ImmutableList.of(),
+                                Collections.emptyList(),
                                 ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
                                 Optional.empty()))
                 .matches(join(
                         RIGHT,
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         Optional.empty(),
                         Optional.of(PARTITIONED),
                         values(ImmutableMap.of("B1", 0)),
@@ -1265,13 +1266,13 @@ public class TestDetermineJoinDistributionType
                                     TRUE_CONSTANT,
                                     p.values(new PlanNodeId("valuesB"), bRows, b1)),
                             p.values(new PlanNodeId("valuesA"), aRows, a1),
-                            ImmutableList.of(),
+                            Collections.emptyList(),
                             ImmutableList.of(b1, a1),
                             Optional.empty());
                 })
                 .matches(join(
                         INNER,
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         Optional.empty(),
                         Optional.of(REPLICATED),
                         filter("true", values(ImmutableMap.of("B1", 0))),
@@ -1377,7 +1378,7 @@ public class TestDetermineJoinDistributionType
                 getSourceTablesSizeInBytes(
                         planBuilder.unnest(
                                 planBuilder.values(sourceVariable1),
-                                ImmutableList.of(),
+                                Collections.emptyList(),
                                 ImmutableMap.of(sourceVariable1, ImmutableList.of(sourceVariable1)),
                                 Optional.empty()),
                         noLookup(),
@@ -1495,7 +1496,7 @@ public class TestDetermineJoinDistributionType
                                 ImmutableList.of(
                                         planBuilder.unnest(
                                                 planBuilder.values(sourceVariable1),
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 ImmutableMap.of(sourceVariable1, ImmutableList.of(sourceVariable1)),
                                                 Optional.empty()),
                                         planBuilder.values(sourceVariable2))),
@@ -1523,7 +1524,7 @@ public class TestDetermineJoinDistributionType
                                 ImmutableList.of(
                                         planBuilder.unnest(
                                                 planBuilder.values(sourceVariable1),
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 ImmutableMap.of(sourceVariable1, ImmutableList.of(sourceVariable1)),
                                                 Optional.empty()),
                                         planBuilder.values(sourceVariable2))),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
@@ -43,6 +43,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
@@ -68,7 +69,7 @@ public class TestDetermineSemiJoinDistributionType
     @BeforeClass
     public void setUp()
     {
-        tester = new RuleTester(ImmutableList.of(), ImmutableMap.of(), Optional.of(NODES_COUNT));
+        tester = new RuleTester(Collections.emptyList(), ImmutableMap.of(), Optional.of(NODES_COUNT));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -292,7 +293,7 @@ public class TestEliminateCrossJoins
                 Optional.empty(),
                 idAllocator.getNextId(),
                 Arrays.asList(variables),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestImplementOffset.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestImplementOffset.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.SystemSessionProperties.OFFSET_CLAUSE_ENABLED;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.rowNumber;
@@ -53,7 +55,7 @@ public class TestImplementOffset
                                         "row_num > BIGINT '2'",
                                         rowNumber(
                                                 pattern -> pattern
-                                                        .partitionBy(ImmutableList.of()),
+                                                        .partitionBy(Collections.emptyList()),
                                                 values("a", "b"))
                                                 .withAlias("row_num", new RowNumberSymbolMatcher()))));
     }
@@ -76,7 +78,7 @@ public class TestImplementOffset
                                         "row_num > BIGINT '2'",
                                         rowNumber(
                                                 pattern -> pattern
-                                                        .partitionBy(ImmutableList.of()),
+                                                        .partitionBy(Collections.emptyList()),
                                                 values("a", "b"))
                                                 .withAlias("row_num", new RowNumberSymbolMatcher()))));
     }
@@ -102,7 +104,7 @@ public class TestImplementOffset
                                         "row_num > BIGINT '2'",
                                         rowNumber(
                                                 pattern -> pattern
-                                                        .partitionBy(ImmutableList.of()),
+                                                        .partitionBy(Collections.emptyList()),
                                                 sort(
                                                         ImmutableList.of(sort("a", ASCENDING, FIRST)),
                                                         values("a", "b")))

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinNodeFlattener.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinNodeFlattener.java
@@ -36,6 +36,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 
@@ -423,7 +424,7 @@ public class TestJoinNodeFlattener
                 projectWithNonDeterministicAssignment,
                 valuesC,
                 ImmutableList.of(equiJoinClause(randomPlusSum, c1)),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty());
 
         MultiJoinNode expected = MultiJoinNode.builder()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -91,10 +92,10 @@ public class TestMergeAdjacentWindows
     private static final FunctionHandle SUM_FUNCTION_HANDLE = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("sum", fromTypes(DOUBLE));
     private static final FunctionHandle AVG_FUNCTION_HANDLE = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("avg", fromTypes(DOUBLE));
     private static final FunctionHandle LAG_FUNCTION_HANDLE = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("lag", fromTypes(DOUBLE));
-    private static final FunctionHandle RANK_FUNCTION_HANDLE = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("rank", ImmutableList.of());
+    private static final FunctionHandle RANK_FUNCTION_HANDLE = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("rank", Collections.emptyList());
     private static final String columnAAlias = "ALIAS_A";
     private static final ExpectedValueProvider<WindowNode.Specification> specificationA =
-            specification(ImmutableList.of(columnAAlias), ImmutableList.of(), ImmutableMap.of());
+            specification(ImmutableList.of(columnAAlias), Collections.emptyList(), ImmutableMap.of());
 
     @Test
     public void testPlanWithoutWindowNode()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
@@ -64,7 +65,7 @@ public class TestPlanRemoteProjections
 
     private static final SqlInvokedFunction FUNCTION_REMOTE_FOO_0 = new SqlInvokedFunction(
             REMOTE_FOO,
-            ImmutableList.of(),
+            Collections.emptyList(),
             parseTypeSignature(StandardTypes.INTEGER),
             "remote_foo()",
             RoutineCharacteristics.builder().setLanguage(JAVA).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
@@ -103,7 +104,7 @@ public class TestPlanRemoteProjections
     @BeforeClass
     public void setup()
     {
-        tester = new RuleTester(ImmutableList.of(), ImmutableMap.of("remote_functions_enabled", "true"));
+        tester = new RuleTester(Collections.emptyList(), ImmutableMap.of("remote_functions_enabled", "true"));
         FunctionAndTypeManager functionAndTypeManager = getFunctionAndTypeManager();
         functionAndTypeManager.addFunctionNamespace(
                 "unittest",
@@ -270,7 +271,7 @@ public class TestPlanRemoteProjections
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = ".*Remote functions are not enabled")
     public void testRemoteFunctionDisabled()
     {
-        RuleTester tester = new RuleTester(ImmutableList.of());
+        RuleTester tester = new RuleTester(Collections.emptyList());
         FunctionAndTypeManager functionAndTypeManager = tester.getMetadata().getFunctionAndTypeManager();
         functionAndTypeManager.addFunctionNamespace(
                 "unittest",

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneAggregationColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneAggregationColumns.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -50,7 +51,7 @@ public class TestPruneAggregationColumns
                                         singleGroupingSet("key"),
                                         ImmutableMap.of(
                                                 Optional.of("b"),
-                                                functionCall("count", false, ImmutableList.of())),
+                                                functionCall("count", false, Collections.emptyList())),
                                         ImmutableMap.of(),
                                         Optional.empty(),
                                         SINGLE,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneAggregationSourceColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneAggregationSourceColumns.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -89,6 +90,6 @@ public class TestPruneAggregationSourceColumns
                 .source(
                         planBuilder.values(
                                 filteredSourceVariables,
-                                ImmutableList.of())));
+                                Collections.emptyList())));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -49,7 +50,7 @@ public class TestPruneCountAggregationOverScalar
                                         p.variable("count_1", BIGINT),
                                         p.rowExpression("count()"))
                                 .source(
-                                        p.tableScan(ImmutableList.of(), ImmutableMap.of())))
+                                        p.tableScan(Collections.emptyList(), ImmutableMap.of())))
                 ).doesNotFire();
     }
 
@@ -66,7 +67,7 @@ public class TestPruneCountAggregationOverScalar
                                 .step(AggregationNode.Step.SINGLE)
                                 .source(
                                         p.aggregation((aggregationBuilder) -> aggregationBuilder
-                                                .source(p.tableScan(ImmutableList.of(), ImmutableMap.of()))
+                                                .source(p.tableScan(Collections.emptyList(), ImmutableMap.of()))
                                                 .globalGrouping()
                                                 .step(AggregationNode.Step.SINGLE)))))
                 .matches(values(ImmutableMap.of("count_1", 0)));
@@ -100,7 +101,7 @@ public class TestPruneCountAggregationOverScalar
                                         p.rowExpression("count()"))
                                 .step(AggregationNode.Step.SINGLE)
                                 .globalGrouping()
-                                .source(p.enforceSingleRow(p.tableScan(ImmutableList.of(), ImmutableMap.of())))))
+                                .source(p.enforceSingleRow(p.tableScan(Collections.emptyList(), ImmutableMap.of())))))
                 .matches(values(ImmutableMap.of("count_1", 0)));
     }
 
@@ -118,9 +119,9 @@ public class TestPruneCountAggregationOverScalar
                                 .source(
                                         p.aggregation(aggregationBuilder -> {
                                             aggregationBuilder
-                                                    .source(p.tableScan(ImmutableList.of(), ImmutableMap.of())).groupingSets(singleGroupingSet(ImmutableList.of(p.variable("orderkey"))));
+                                                    .source(p.tableScan(Collections.emptyList(), ImmutableMap.of())).groupingSets(singleGroupingSet(ImmutableList.of(p.variable("orderkey"))));
                                             aggregationBuilder
-                                                    .source(p.tableScan(ImmutableList.of(), ImmutableMap.of()));
+                                                    .source(p.tableScan(Collections.emptyList(), ImmutableMap.of()));
                                         }))))
                 .doesNotFire();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneCrossJoinColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneCrossJoinColumns.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -47,7 +48,7 @@ public class TestPruneCrossJoinColumns
                                 ImmutableMap.of("rightValue", PlanMatchPattern.expression("rightValue")),
                                 join(
                                         JoinType.INNER,
-                                        ImmutableList.of(),
+                                        Collections.emptyList(),
                                         Optional.empty(),
                                         strictProject(
                                                 ImmutableMap.of(),
@@ -66,7 +67,7 @@ public class TestPruneCrossJoinColumns
                                 ImmutableMap.of("leftValue", PlanMatchPattern.expression("leftValue")),
                                 join(
                                         JoinType.INNER,
-                                        ImmutableList.of(),
+                                        Collections.emptyList(),
                                         Optional.empty(),
                                         values(ImmutableList.of("leftValue")),
                                         strictProject(
@@ -97,7 +98,7 @@ public class TestPruneCrossJoinColumns
                         JoinType.INNER,
                         p.values(leftValue),
                         p.values(rightValue),
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         outputs,
                         Optional.empty(),
                         Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneJoinChildrenColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneJoinChildrenColumns.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -75,7 +76,7 @@ public class TestPruneJoinChildrenColumns
                             JoinType.INNER,
                             p.values(leftValue),
                             p.values(rightValue),
-                            ImmutableList.of(),
+                            Collections.emptyList(),
                             ImmutableList.of(leftValue, rightValue),
                             Optional.empty(),
                             Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneJoinColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneJoinColumns.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -78,7 +79,7 @@ public class TestPruneJoinColumns
                                     JoinType.INNER,
                                     p.values(leftValue),
                                     p.values(rightValue),
-                                    ImmutableList.of(),
+                                    Collections.emptyList(),
                                     ImmutableList.of(leftValue, rightValue),
                                     Optional.empty(),
                                     Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneOrderByInAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneOrderByInAggregation.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -81,6 +82,6 @@ public class TestPruneOrderByInAggregation
                 .addAggregation(avg, planBuilder.rowExpression("avg(input order by input)"), Optional.empty(), Optional.of(orderingScheme), false, Optional.of(mask))
                 .addAggregation(arrayAgg, planBuilder.rowExpression("array_agg(input order by input)"), Optional.empty(), Optional.of(orderingScheme), false, Optional.of(mask))
                 .hashVariable(keyHash)
-                .source(planBuilder.values(sourceVariables, ImmutableList.of())));
+                .source(planBuilder.values(sourceVariables, Collections.emptyList())));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinFilteringSourceColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneSemiJoinFilteringSourceColumns.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -76,6 +77,6 @@ public class TestPruneSemiJoinFilteringSourceColumns
                 p.values(leftKey),
                 p.values(
                         filteredSourceVariables,
-                        ImmutableList.of()));
+                        Collections.emptyList()));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -330,6 +331,6 @@ public class TestPruneWindowColumns
                         hash,
                         p.values(
                                 filteredInputs,
-                                ImmutableList.of())));
+                                Collections.emptyList())));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantsAboveGroupBy.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantsAboveGroupBy.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -76,7 +77,7 @@ public class TestPullConstantsAboveGroupBy
     @Test
     public void testRuleDisabledDoesNotFire()
     {
-        RuleTester tester = new RuleTester(ImmutableList.of(), ImmutableMap.of("optimize_constant_grouping_keys", "false", "rewrite_expression_with_constant_expression", "false"));
+        RuleTester tester = new RuleTester(Collections.emptyList(), ImmutableMap.of("optimize_constant_grouping_keys", "false", "rewrite_expression_with_constant_expression", "false"));
 
         tester.assertThat(new PullConstantsAboveGroupBy())
             .on(p -> p.aggregation(ab -> ab

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.USE_DEFAULTS_FOR_CORRELATED_AGGREGATION_PUSHDOWN_THROUGH_OUTER_JOINS;
@@ -78,7 +79,7 @@ public class TestPushAggregationThroughOuterJoin
                         project(ImmutableMap.of(
                                 "COL1", expression("COL1"),
                                 "COALESCE", expression("coalesce(AVG, AVG_NULL)")),
-                                join(JoinType.INNER, ImmutableList.of(),
+                                join(JoinType.INNER, Collections.emptyList(),
                                         join(JoinType.LEFT, ImmutableList.of(equiJoinClause("COL1", "COL2")),
                                                 values(ImmutableMap.of("COL1", 0)),
                                                 aggregation(
@@ -127,7 +128,7 @@ public class TestPushAggregationThroughOuterJoin
                                 "COL1", expression("COL1"),
                                 "COL3", expression("COL3"),
                                 "COALESCE", expression("coalesce(AVG, AVG_NULL)")),
-                                join(JoinType.INNER, ImmutableList.of(),
+                                join(JoinType.INNER, Collections.emptyList(),
                                         join(JoinType.LEFT, ImmutableList.of(equiJoinClause("COL1", "COL2")),
                                                 values(ImmutableMap.of("COL1", 0, "COL3", 0)),
                                                 aggregation(
@@ -174,7 +175,7 @@ public class TestPushAggregationThroughOuterJoin
                         project(ImmutableMap.of(
                                 "COALESCE", expression("coalesce(AVG, AVG_NULL)"),
                                 "COL1", expression("COL1")),
-                                join(JoinType.INNER, ImmutableList.of(),
+                                join(JoinType.INNER, Collections.emptyList(),
                                         join(JoinType.RIGHT, ImmutableList.of(equiJoinClause("COL2", "COL1")),
                                                 aggregation(
                                                         singleGroupingSet("COL2"),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushDownFilterExpressionEvaluationThroughCrossJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushDownFilterExpressionEvaluationThroughCrossJoin.java
@@ -16,9 +16,10 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
+
+import java.util.Collections;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -54,7 +55,7 @@ public class TestPushDownFilterExpressionEvaluationThroughCrossJoin
                                         "add_1 = add_0",
                                         join(
                                                 JoinType.INNER,
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 project(
                                                         ImmutableMap.of("add_1", expression("left_k1+left_k2")),
                                                         values("left_k1", "left_k2")),
@@ -101,7 +102,7 @@ public class TestPushDownFilterExpressionEvaluationThroughCrossJoin
                                         "left_k1 = card",
                                         join(
                                                 JoinType.INNER,
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 values("left_k1"),
                                                 project(
                                                         ImmutableMap.of("card", expression("cardinality(right_k1)")),
@@ -130,7 +131,7 @@ public class TestPushDownFilterExpressionEvaluationThroughCrossJoin
                                         "left_k1 = right_k1 OR cast_1 = cast_0",
                                         join(
                                                 JoinType.INNER,
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 project(
                                                         ImmutableMap.of("cast_1", expression("CAST(left_k2 AS bigint)")),
                                                         values("left_k1", "left_k2")),
@@ -161,7 +162,7 @@ public class TestPushDownFilterExpressionEvaluationThroughCrossJoin
                                         "left_k1 = right_k1 OR cast_1 = expr",
                                         join(
                                                 JoinType.INNER,
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 project(
                                                         ImmutableMap.of("cast_1", expression("CAST(left_k1 AS varchar)")),
                                                         values("left_k1")),
@@ -190,7 +191,7 @@ public class TestPushDownFilterExpressionEvaluationThroughCrossJoin
                                         "contains(right_array_k1, cast_l)",
                                         join(
                                                 JoinType.INNER,
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 project(
                                                         ImmutableMap.of("cast_l", expression("CAST(left_k1 AS bigint)")),
                                                         values("left_k1")),
@@ -217,7 +218,7 @@ public class TestPushDownFilterExpressionEvaluationThroughCrossJoin
                                         "contains(cast_arr, left_k1)",
                                         join(
                                                 JoinType.INNER,
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 values("left_k1"),
                                                 project(
                                                         ImmutableMap.of("cast_arr", expression("cast(right_array_k1 as array<varchar>)")),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveEmptyDelete.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveEmptyDelete.java
@@ -19,10 +19,10 @@ import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.facebook.presto.tpch.TpchTableHandle;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -43,7 +43,7 @@ public class TestRemoveEmptyDelete
                                         new TpchTableHandle("nation", 1.0),
                                         TestingTransactionHandle.create(),
                                         Optional.empty()),
-                                ImmutableList.of(),
+                                Collections.emptyList(),
                                 ImmutableMap.of()),
                         p.variable("a", BIGINT)))
                 .doesNotFire();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveUnreferencedScalarApplyNodes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveUnreferencedScalarApplyNodes.java
@@ -17,9 +17,9 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.relation.InSubqueryExpression;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
-import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
@@ -34,7 +34,7 @@ public class TestRemoveUnreferencedScalarApplyNodes
         tester().assertThat(new RemoveUnreferencedScalarApplyNodes())
                 .on(p -> p.apply(
                         assignment(p.variable("z"), new InSubqueryExpression(Optional.empty(), p.variable("x"), p.variable("y"))),
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         p.values(p.variable("x")),
                         p.values(p.variable("y"))))
                 .doesNotFire();
@@ -46,7 +46,7 @@ public class TestRemoveUnreferencedScalarApplyNodes
         tester().assertThat(new RemoveUnreferencedScalarApplyNodes())
                 .on(p -> p.apply(
                         Assignments.of(),
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         p.values(p.variable("x")),
                         p.values(p.variable("y"))))
                 .matches(values("x"));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
@@ -37,6 +37,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,7 +75,7 @@ public class TestReorderJoins
     private FunctionResolution functionResolution;
 
     // TWO_ROWS are used to prevent node from being scalar
-    private static final ImmutableList<List<RowExpression>> TWO_ROWS = ImmutableList.of(ImmutableList.of(), ImmutableList.of());
+    private static final ImmutableList<List<RowExpression>> TWO_ROWS = ImmutableList.of(Collections.emptyList(), Collections.emptyList());
     private static final QualifiedName RANDOM = QualifiedName.of("random");
 
     @DataProvider
@@ -112,7 +113,7 @@ public class TestReorderJoins
     public void setUp()
     {
         tester = new RuleTester(
-                ImmutableList.of(),
+                Collections.emptyList(),
                 ImmutableMap.of(
                         JOIN_DISTRIBUTION_TYPE, JoinDistributionType.AUTOMATIC.name(),
                         JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.AUTOMATIC.name(),
@@ -338,7 +339,7 @@ public class TestReorderJoins
                                 INNER,
                                 p.values(new PlanNodeId("valuesA"), ImmutableList.of(p.variable("A1")), TWO_ROWS),
                                 p.values(new PlanNodeId("valuesB"), ImmutableList.of(p.variable("B1")), TWO_ROWS),
-                                ImmutableList.of(),
+                                Collections.emptyList(),
                                 ImmutableList.of(p.variable("A1"), p.variable("B1")),
                                 Optional.empty()))
                 .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
@@ -385,9 +386,9 @@ public class TestReorderJoins
                                                 Optional.empty(),
                                                 Optional.empty(),
                                                 qualifyObjectName(RANDOM),
-                                                ImmutableList.of()),
+                                                Collections.emptyList()),
                                         BIGINT,
-                                        ImmutableList.of())))))
+                                        Collections.emptyList())))))
                 .doesNotFire();
     }
 
@@ -402,7 +403,7 @@ public class TestReorderJoins
                                         INNER,
                                         p.values(new PlanNodeId("valuesA"), ImmutableList.of(p.variable("A1")), TWO_ROWS),
                                         p.values(new PlanNodeId("valuesB"), ImmutableList.of(p.variable("B1"), p.variable("B2")), TWO_ROWS),
-                                        ImmutableList.of(),
+                                        Collections.emptyList(),
                                         ImmutableList.of(p.variable("A1"), p.variable("B1"), p.variable("B2")),
                                         Optional.empty()),
                                 p.values(new PlanNodeId("valuesC"), ImmutableList.of(p.variable("C1")), TWO_ROWS),
@@ -641,7 +642,7 @@ public class TestReorderJoins
                                 anyTree(
                                         project(ImmutableMap.of("SUBTRACT", expression("S_ACCTBAL - C_ACCTBAL")),
                                                 join(INNER,
-                                                        ImmutableList.of(), //CrossJoin
+                                                        Collections.emptyList(), //CrossJoin
                                                         join(INNER,
                                                                 ImmutableList.of(equiJoinClause("PS_SUPPKEY", "S_SUPPKEY")),
                                                                 anyTree(tableScan("partsupp", ImmutableMap.of("PS_SUPPKEY", "suppkey"))),
@@ -663,7 +664,7 @@ public class TestReorderJoins
                                 anyTree(
                                         filter("O_TOTALPRICE = S_ACCTBAL - C_ACCTBAL",
                                                 join(INNER,
-                                                        ImmutableList.of(), //CrossJoin
+                                                        Collections.emptyList(), //CrossJoin
                                                         join(INNER,
                                                                 ImmutableList.of(equiJoinClause("O_CUSTKEY", "C_CUSTKEY")),
                                                                 anyTree(tableScan("orders", ImmutableMap.of("O_CUSTKEY", "custkey", "O_TOTALPRICE", "totalprice"))),
@@ -684,7 +685,7 @@ public class TestReorderJoins
                 anyTree(
                         filter("PS_PARTKEY - P_PARTKEY = 0",
                                 join(INNER,
-                                        ImmutableList.of(), // CrossJoin
+                                        Collections.emptyList(), // CrossJoin
                                         join(INNER,
                                                 ImmutableList.of(equiJoinClause("PS_SUPPKEY", "S_SUPPKEY")),
                                                 anyTree(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRuntimeReorderJoinSides.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRuntimeReorderJoinSides.java
@@ -37,6 +37,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -64,7 +65,7 @@ public class TestRuntimeReorderJoinSides
     @BeforeClass
     public void setUp()
     {
-        tester = new RuleTester(ImmutableList.of(), ImmutableMap.of(), Optional.of(NODES_COUNT));
+        tester = new RuleTester(Collections.emptyList(), ImmutableMap.of(), Optional.of(NODES_COUNT));
         connectorId = tester.getCurrentConnectorId();
 
         TpchTableHandle nationTpchTableHandle = new TpchTableHandle("nation", 1.0);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -83,7 +84,7 @@ public class TestSwapAdjacentWindowsBySpecifications
                                 ImmutableList.of(p.variable("a")),
                                 Optional.empty()),
                         ImmutableMap.of(p.variable("avg_1"),
-                                new WindowNode.Function(call("avg", functionHandle, DOUBLE, ImmutableList.of()), frame, false)),
+                                new WindowNode.Function(call("avg", functionHandle, DOUBLE, Collections.emptyList()), frame, false)),
                         p.values(p.variable("a"))))
                 .doesNotFire();
     }
@@ -94,8 +95,8 @@ public class TestSwapAdjacentWindowsBySpecifications
         String columnAAlias = "ALIAS_A";
         String columnBAlias = "ALIAS_B";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationA = specification(ImmutableList.of(columnAAlias), ImmutableList.of(), ImmutableMap.of());
-        ExpectedValueProvider<WindowNode.Specification> specificationAB = specification(ImmutableList.of(columnAAlias, columnBAlias), ImmutableList.of(), ImmutableMap.of());
+        ExpectedValueProvider<WindowNode.Specification> specificationA = specification(ImmutableList.of(columnAAlias), Collections.emptyList(), ImmutableMap.of());
+        ExpectedValueProvider<WindowNode.Specification> specificationAB = specification(ImmutableList.of(columnAAlias, columnBAlias), Collections.emptyList(), ImmutableMap.of());
 
         tester().assertThat(new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0))
                 .on(p ->
@@ -138,13 +139,13 @@ public class TestSwapAdjacentWindowsBySpecifications
     @Test
     public void dependentWindowsAreNotReorderedWithOffset()
     {
-        FunctionHandle rankFunction = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("rank", ImmutableList.of());
+        FunctionHandle rankFunction = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("rank", Collections.emptyList());
         WindowNode.Function windowFunction = new WindowNode.Function(
                 call(
                         "rank",
                         rankFunction,
                         BIGINT,
-                        ImmutableList.of()),
+                        Collections.emptyList()),
                 frame,
                 false);
         WindowNode.Frame frameWithRowOffset = new WindowNode.Frame(
@@ -183,13 +184,13 @@ public class TestSwapAdjacentWindowsBySpecifications
     @Test
     public void dependentWindowsWithRangeAreNotReordered()
     {
-        FunctionHandle rankFunction = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("rank", ImmutableList.of());
+        FunctionHandle rankFunction = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("rank", Collections.emptyList());
         WindowNode.Function windowFunction = new WindowNode.Function(
                 call(
                         "rank",
                         rankFunction,
                         BIGINT,
-                        ImmutableList.of()),
+                        Collections.emptyList()),
                 frame,
                 false);
         WindowNode.Frame frameWithRowOffset = new WindowNode.Frame(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarAggregationToJoin.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
@@ -55,7 +57,7 @@ public class TestTransformCorrelatedScalarAggregationToJoin
     {
         tester().assertThat(new TransformCorrelatedScalarAggregationToJoin(tester().getMetadata().getFunctionAndTypeManager()))
                 .on(p -> p.lateral(
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         p.values(p.variable("a")),
                         p.values(p.variable("b"))))
                 .doesNotFire();
@@ -90,7 +92,7 @@ public class TestTransformCorrelatedScalarAggregationToJoin
                         project(ImmutableMap.of("sum_1", expression("sum_1"), "corr", expression("corr")),
                                 aggregation(ImmutableMap.of("sum_1", functionCall("sum", ImmutableList.of("a"))),
                                         join(JoinType.LEFT,
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 assignUniqueId("unique",
                                                         values(ImmutableMap.of("corr", 0))),
                                                 project(ImmutableMap.of("non_null", expression("true")),
@@ -114,7 +116,7 @@ public class TestTransformCorrelatedScalarAggregationToJoin
                         project(ImmutableMap.of("corr", expression("corr"), "expr", expression("(\"sum_1\" + 1)")),
                                 aggregation(ImmutableMap.of("sum_1", functionCall("sum", ImmutableList.of("a"))),
                                         join(JoinType.LEFT,
-                                                ImmutableList.of(),
+                                                Collections.emptyList(),
                                                 assignUniqueId("unique",
                                                         values(ImmutableMap.of("corr", 0))),
                                                 project(ImmutableMap.of("non_null", expression("true")),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -88,7 +89,7 @@ public class TestTransformCorrelatedScalarSubquery
     {
         tester().assertThat(rule)
                 .on(p -> p.lateral(
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         p.values(p.variable("a")),
                         p.values(ImmutableList.of(p.variable("b")), ImmutableList.of(constantExpressions(BIGINT, 1L)))))
                 .doesNotFire();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -61,8 +62,8 @@ public class TestTransformCorrelatedSingleRowSubqueryToProject
                                 p.project(
                                         assignment(p.variable("l_expr2"), p.rowExpression("l_nationkey + 1")),
                                         p.values(
-                                                ImmutableList.of(),
-                                                ImmutableList.of(ImmutableList.of())))))
+                                                Collections.emptyList(),
+                                                ImmutableList.of(Collections.emptyList())))))
                 .matches(project(
                         ImmutableMap.of(
                                 ("l_expr2"), PlanMatchPattern.expression("l_nationkey + 1"),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformExistsApplyToLateralJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformExistsApplyToLateralJoin.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -64,15 +65,15 @@ public class TestTransformExistsApplyToLateralJoin
                 .on(p ->
                         p.apply(
                                 assignment(p.variable("b", BOOLEAN), new ExistsExpression(Optional.empty(), TRUE_CONSTANT)),
-                                ImmutableList.of(),
+                                Collections.emptyList(),
                                 p.values(),
                                 p.values()))
                 .matches(lateral(
-                        ImmutableList.of(),
+                        Collections.emptyList(),
                         values(ImmutableMap.of()),
                         project(
                                 ImmutableMap.of("b", PlanMatchPattern.expression("(\"count_expr\" > CAST(0 AS bigint))")),
-                                aggregation(ImmutableMap.of("count_expr", functionCall("count", ImmutableList.of())),
+                                aggregation(ImmutableMap.of("count_expr", functionCall("count", Collections.emptyList())),
                                         values()))));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -97,6 +97,7 @@ import com.google.common.collect.ListMultimap;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -196,7 +197,7 @@ public class PlanBuilder
 
     public ValuesNode values()
     {
-        return values(idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of());
+        return values(idAllocator.getNextId(), Collections.emptyList(), Collections.emptyList());
     }
 
     public ValuesNode values(VariableReferenceExpression... columns)
@@ -326,7 +327,7 @@ public class PlanBuilder
 
     public RemoteSourceNode remoteSource(List<PlanFragmentId> sourceFragmentIds)
     {
-        return remoteSource(idAllocator.getNextId(), sourceFragmentIds, ImmutableList.of());
+        return remoteSource(idAllocator.getNextId(), sourceFragmentIds, Collections.emptyList());
     }
 
     public RemoteSourceNode remoteSource(PlanNodeId planNodeId, List<PlanFragmentId> sourceFragmentIds, List<VariableReferenceExpression> outputVariables)
@@ -340,7 +341,7 @@ public class PlanBuilder
                 Optional.empty(),
                 idAllocator.getNextId(),
                 Optional.of(statsEquivalentPlanNode),
-                sourceFragmentIds, ImmutableList.of(),
+                sourceFragmentIds, Collections.emptyList(),
                 false,
                 Optional.empty(),
                 REPARTITION);
@@ -427,7 +428,7 @@ public class PlanBuilder
 
         public AggregationBuilder globalGrouping()
         {
-            groupingSets(AggregationNode.singleGroupingSet(ImmutableList.of()));
+            groupingSets(AggregationNode.singleGroupingSet(Collections.emptyList()));
             return this;
         }
 
@@ -540,7 +541,7 @@ public class PlanBuilder
                 tableHandle,
                 variables,
                 assignments,
-                ImmutableList.of(),
+                Collections.emptyList(),
                 currentConstraint,
                 enforcedConstraint);
     }
@@ -701,7 +702,7 @@ public class PlanBuilder
 
         public ExchangeBuilder singleDistributionPartitioningScheme(List<VariableReferenceExpression> outputVariables)
         {
-            return partitioningScheme(new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), outputVariables));
+            return partitioningScheme(new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, Collections.emptyList()), outputVariables));
         }
 
         public ExchangeBuilder fixedHashDistributionPartitioningScheme(List<VariableReferenceExpression> outputVariables, List<VariableReferenceExpression> partitioningVariables)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRuleTester.java
@@ -21,6 +21,8 @@ import com.facebook.presto.sql.planner.iterative.Rule;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
@@ -41,7 +43,7 @@ public class TestRuleTester
                                             ImmutableList.of(p.variable("x")),
                                             ImmutableList.of(constantExpressions(BIGINT, 1L)))))
                     .matches(
-                            values(ImmutableList.of("different"), ImmutableList.of()));
+                            values(ImmutableList.of("different"), Collections.emptyList()));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestStatisticsWriterNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestStatisticsWriterNode.java
@@ -40,6 +40,7 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -111,7 +112,7 @@ public class TestStatisticsWriterNode
         return new StatisticsWriterNode(
                 withSourceLocation ? Optional.of(new SourceLocation(1, 2)) : Optional.empty(),
                 newId(),
-                new ValuesNode(Optional.empty(), newId(), COLUMNS.stream().map(column -> new VariableReferenceExpression(Optional.empty(), column, BIGINT)).collect(toImmutableList()), ImmutableList.of(), Optional.empty()),
+                new ValuesNode(Optional.empty(), newId(), COLUMNS.stream().map(column -> new VariableReferenceExpression(Optional.empty(), column, BIGINT)).collect(toImmutableList()), Collections.emptyList(), Optional.empty()),
                 new TableHandle(new ConnectorId("test"), new TestingTableHandle(), TestingTransactionHandle.create(), Optional.empty()),
                 variableAllocator.newVariable("count", BIGINT),
                 true,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
@@ -47,6 +47,7 @@ import io.airlift.slice.Slice;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -94,7 +95,7 @@ public class TestWindowNode
                 Optional.empty(),
                 newId(),
                 ImmutableList.of(columnA, columnB, columnC),
-                ImmutableList.of(),
+                Collections.emptyList(),
                 Optional.empty());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestJsonRenderer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestJsonRenderer.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -88,9 +89,9 @@ public class TestJsonRenderer
                 TypeProvider.viewOf(VARIABLE_ALLOCATOR.getVariables()),
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableList.of(),
-                ImmutableList.of(),
-                ImmutableList.of());
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList());
     }
 
     private NodeRepresentation getNodeRepresentation(PlanNode root, List<PlanNodeId> planNodeIds)
@@ -103,11 +104,11 @@ public class TestJsonRenderer
                 "",
                 root.getOutputVariables(),
                 Optional.empty(),
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 planNodeIds,
-                ImmutableList.of(),
-                ImmutableList.of());
+                Collections.emptyList(),
+                Collections.emptyList());
     }
 
     private Map<PlanRepresentation, JsonRenderer.JsonRenderedNode> buildPlanResult(PlanNode root)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestPlanPrinter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestPlanPrinter.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
@@ -80,7 +81,7 @@ public class TestPlanPrinter
                 ImmutableSet.of(variable),
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(scanNode.getId()),
-                new PartitioningScheme(Partitioning.create(SOURCE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(variable)),
+                new PartitioningScheme(Partitioning.create(SOURCE_DISTRIBUTION, Collections.emptyList()), ImmutableList.of(variable)),
                 StageExecutionDescriptor.ungroupedExecution(),
                 false,
                 StatsAndCosts.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestDynamicFiltersChecker.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestDynamicFiltersChecker.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -123,8 +124,8 @@ public class TestDynamicFiltersChecker
     public void testUnmatchedDynamicFilter()
     {
         PlanNode root = builder.output(
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 builder.join(
                         INNER,
                         ordersTableScanNode,
@@ -146,8 +147,8 @@ public class TestDynamicFiltersChecker
     public void testUnmatchedNestedDynamicFilter()
     {
         PlanNode root = builder.output(
-                ImmutableList.of(),
-                ImmutableList.of(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 builder.join(
                         INNER,
                         ordersTableScanNode,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
@@ -22,9 +22,9 @@ import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
-import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -46,10 +46,10 @@ public class TestVerifyOnlyOneOutputNode
                                 new ValuesNode(
                                         Optional.empty(),
                                         idAllocator.getNextId(),
-                                        ImmutableList.of(), ImmutableList.of(),
+                                        Collections.emptyList(), Collections.emptyList(),
                                         Optional.empty()),
                                 Assignments.of()
-                        ), ImmutableList.of(), ImmutableList.of());
+                        ), Collections.emptyList(), Collections.emptyList());
         new VerifyOnlyOneOutputNode().validate(root, null, null, null, null, WarningCollector.NOOP);
     }
 
@@ -63,12 +63,12 @@ public class TestVerifyOnlyOneOutputNode
                                 new OutputNode(Optional.empty(), idAllocator.getNextId(),
                                         new ProjectNode(idAllocator.getNextId(),
                                                 new ValuesNode(Optional.empty(),
-                                                        idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of(), Optional.empty()),
+                                                        idAllocator.getNextId(), Collections.emptyList(), Collections.emptyList(), Optional.empty()),
                                                 Assignments.of()
-                                        ), ImmutableList.of(), ImmutableList.of()
+                                        ), Collections.emptyList(), Collections.emptyList()
                                 ), new VariableReferenceExpression(Optional.empty(), "a", BIGINT),
                                 false),
-                        ImmutableList.of(), ImmutableList.of());
+                        Collections.emptyList(), Collections.emptyList());
         new VerifyOnlyOneOutputNode().validate(root, null, null, null, null, WarningCollector.NOOP);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/transaction/TestTransactionManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/transaction/TestTransactionManager.java
@@ -35,6 +35,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.Closeable;
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -213,7 +214,7 @@ public class TestTransactionManager
                 connectorId,
                 connector,
                 createInformationSchemaConnectorId(connectorId),
-                new InformationSchemaConnector(catalogName, nodeManager, metadata, new AllowAllAccessControl(), ImmutableList.of()),
+                new InformationSchemaConnector(catalogName, nodeManager, metadata, new AllowAllAccessControl(), Collections.emptyList()),
                 systemId,
                 new SystemConnector(
                         systemId,

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -36,6 +36,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1071,7 +1072,7 @@ public class TestMapOperators
         assertFunction("map_entries(MAP(null, ARRAY[]))", unknownEntryType, null);
         assertFunction("map_entries(MAP(ARRAY[1, 2, 3], null))", entryType(INTEGER, UNKNOWN), null);
         assertFunction("map_entries(MAP(null, ARRAY[1, 2, 3]))", entryType(UNKNOWN, INTEGER), null);
-        assertFunction("map_entries(MAP(ARRAY[], ARRAY[]))", unknownEntryType, ImmutableList.of());
+        assertFunction("map_entries(MAP(ARRAY[], ARRAY[]))", unknownEntryType, Collections.emptyList());
         assertFunction("map_entries(MAP(ARRAY[1], ARRAY['x']))", entryType(INTEGER, createVarcharType(1)), ImmutableList.of(ImmutableList.of(1, "x")));
         assertFunction("map_entries(MAP(ARRAY[1, 2], ARRAY['x', 'y']))", entryType(INTEGER, createVarcharType(1)), ImmutableList.of(ImmutableList.of(1, "x"), ImmutableList.of(2, "y")));
 

--- a/presto-main/src/test/java/com/facebook/presto/util/TestMergeSortedPages.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestMergeSortedPages.java
@@ -25,6 +25,7 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
@@ -401,7 +402,7 @@ public class TestMergeSortedPages
         assertTrue(mergedPages.process());
 
         if (mergedPages.isFinished()) {
-            return toMaterializedResult(TEST_SESSION, types, ImmutableList.of());
+            return toMaterializedResult(TEST_SESSION, types, Collections.emptyList());
         }
 
         Page page = mergedPages.getResult();


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Original PR #22837 turned out to be too big for github to render, and thus we considered dividing it into 4 parts.
Current PR is Part 1 of 4.

Diffs in the tests are larger and as a result this part contains fewer files.

It touches: 
`presto-main/src/tests`
except:

`presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/`
`presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java`
`presto-main/src/test/java/com/facebook/presto/execution/`
`presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java`
`presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java`



Files in except will be addressed in another PR.

Changed ImmutableList.of() --> Collections.emptyList() in ~167 files.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
#22835 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
None,
There may be a performance benefit, but hard to measure.

## Test Plan
<!---Please fill in how you tested your change-->
Existing tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

