### PR TITLE
Skip hbo stats recording for nodes with dynamic filter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/HashCollisionPlanNodeStats.java
@@ -13,11 +13,13 @@
  */
 package com.facebook.presto.sql.planner.planPrinter;
 
+import com.facebook.presto.operator.DynamicFilterStats;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.max;
@@ -45,10 +47,12 @@ public class HashCollisionPlanNodeStats
             long planNodeJoinBuildKeyCount,
             long planNodeNullJoinProbeKeyCount,
             long planNodeJoinProbeKeyCount,
+            Optional<DynamicFilterStats> dynamicFilterStats,
             Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats)
     {
         super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize,
-                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount, planNodeJoinProbeKeyCount);
+                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount,
+                planNodeJoinProbeKeyCount, dynamicFilterStats);
         this.operatorHashCollisionsStats = requireNonNull(operatorHashCollisionsStats, "operatorHashCollisionsStats is null");
     }
 
@@ -108,6 +112,7 @@ public class HashCollisionPlanNodeStats
                 merged.getPlanNodeJoinBuildKeyCount(),
                 merged.getPlanNodeNullJoinProbeKeyCount(),
                 merged.getPlanNodeJoinProbeKeyCount(),
+                merged.getDynamicFilterStats(),
                 operatorHashCollisionsStats);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.planPrinter;
 
 import com.facebook.presto.execution.StageInfo;
 import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.operator.DynamicFilterStats;
 import com.facebook.presto.operator.HashCollisionsInfo;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PipelineStats;
@@ -29,6 +30,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.util.MoreMaps.mergeMaps;
@@ -84,6 +86,7 @@ public class PlanNodeStatsSummarizer
         Map<PlanNodeId, Long> planNodeJoinBuildKeyCount = new HashMap<>();
         Map<PlanNodeId, Long> planNodeNullJoinProbeKeyCount = new HashMap<>();
         Map<PlanNodeId, Long> planNodeJoinProbeKeyCount = new HashMap<>();
+        Map<PlanNodeId, Optional<DynamicFilterStats>> planNodeIdDynamicFilterStatsMap = new HashMap<>();
 
         Map<PlanNodeId, Map<String, OperatorInputStats>> operatorInputStats = new HashMap<>();
         Map<PlanNodeId, Map<String, OperatorHashCollisionsStats>> operatorHashCollisionsStats = new HashMap<>();
@@ -158,6 +161,8 @@ public class PlanNodeStatsSummarizer
                 planNodeNullJoinProbeKeyCount.merge(planNodeId, operatorStats.getNullJoinProbeKeyCount(), Long::sum);
                 planNodeJoinProbeKeyCount.merge(planNodeId, operatorStats.getJoinProbeKeyCount(), Long::sum);
 
+                planNodeIdDynamicFilterStatsMap.merge(planNodeId, Optional.of(operatorStats.getDynamicFilterStats()), PlanNodeStats::mergeDynamicFilterStats);
+
                 processedNodes.add(planNodeId);
             }
 
@@ -218,6 +223,7 @@ public class PlanNodeStatsSummarizer
                         planNodeJoinBuildKeyCount.get(planNodeId),
                         planNodeNullJoinProbeKeyCount.get(planNodeId),
                         planNodeJoinProbeKeyCount.get(planNodeId),
+                        planNodeIdDynamicFilterStatsMap.get(planNodeId),
                         operatorHashCollisionsStats.get(planNodeId));
             }
             else if (windowNodeStats.containsKey(planNodeId)) {
@@ -236,6 +242,7 @@ public class PlanNodeStatsSummarizer
                         planNodeJoinBuildKeyCount.get(planNodeId),
                         planNodeNullJoinProbeKeyCount.get(planNodeId),
                         planNodeJoinProbeKeyCount.get(planNodeId),
+                        planNodeIdDynamicFilterStatsMap.get(planNodeId),
                         windowNodeStats.get(planNodeId));
             }
             else {
@@ -253,7 +260,8 @@ public class PlanNodeStatsSummarizer
                         planNodeNullJoinBuildKeyCount.get(planNodeId),
                         planNodeJoinBuildKeyCount.get(planNodeId),
                         planNodeNullJoinProbeKeyCount.get(planNodeId),
-                        planNodeJoinProbeKeyCount.get(planNodeId));
+                        planNodeJoinProbeKeyCount.get(planNodeId),
+                        planNodeIdDynamicFilterStatsMap.get(planNodeId));
             }
 
             stats.add(nodeStats);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowPlanNodeStats.java
@@ -13,11 +13,13 @@
  */
 package com.facebook.presto.sql.planner.planPrinter;
 
+import com.facebook.presto.operator.DynamicFilterStats;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -41,10 +43,12 @@ public class WindowPlanNodeStats
             long planNodeJoinBuildKeyCount,
             long planNodeNullJoinProbeKeyCount,
             long planNodeJoinProbeKeyCount,
+            Optional<DynamicFilterStats> dynamicFilterStats,
             WindowOperatorStats windowOperatorStats)
     {
         super(planNodeId, planNodeScheduledTime, planNodeCpuTime, planNodeInputPositions, planNodeInputDataSize, planNodeRawInputPositions, planNodeRawInputDataSize,
-                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount, planNodeJoinProbeKeyCount);
+                planNodeOutputPositions, planNodeOutputDataSize, operatorInputStats, planNodeNullJoinBuildKeyCount, planNodeJoinBuildKeyCount, planNodeNullJoinProbeKeyCount,
+                planNodeJoinProbeKeyCount, dynamicFilterStats);
         this.windowOperatorStats = windowOperatorStats;
     }
 
@@ -74,6 +78,7 @@ public class WindowPlanNodeStats
                 merged.getPlanNodeJoinBuildKeyCount(),
                 merged.getPlanNodeNullJoinProbeKeyCount(),
                 merged.getPlanNodeJoinProbeKeyCount(),
+                merged.getDynamicFilterStats(),
                 windowOperatorStats);
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestNativeHistoryBasedStatsTracking.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestNativeHistoryBasedStatsTracking.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.SqlQueryManager;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.testing.InMemoryHistoryBasedPlanStatisticsProvider;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static java.lang.Double.NaN;
+
+@Test(singleThreaded = true)
+public class TestNativeHistoryBasedStatsTracking
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp()
+    {
+        getHistoryProvider().clearCache();
+    }
+
+    @Test
+    public void testDynamicFilterEnabled()
+    {
+        Session broadcastSession = Session.builder(getQueryRunner().getDefaultSession()).setSystemProperty(JOIN_DISTRIBUTION_TYPE, "BROADCAST").build();
+        String sql = "select s.name, s.acctbal, sum(l.quantity) from lineitem l join supplier s on l.suppkey=s.suppkey where acctbal < 0 and length(l.comment) > 2 group by 1, 2";
+        // CBO Statistics
+        assertPlan(
+                broadcastSession,
+                sql,
+                anyTree(
+                        node(ProjectNode.class, anyTree(any())).withOutputRowCount(NaN),
+                        anyTree(any())));
+
+        // HBO Statistics
+        executeAndTrackHistory(sql, broadcastSession);
+        assertPlan(
+                broadcastSession,
+                sql,
+                anyTree(
+                        node(ProjectNode.class, anyTree(any())).withOutputRowCount(NaN),
+                        anyTree(any())));
+    }
+
+    private void executeAndTrackHistory(String sql, Session session)
+    {
+        getQueryRunner().execute(session, sql);
+        getHistoryProvider().waitProcessQueryEvents();
+    }
+
+    private InMemoryHistoryBasedPlanStatisticsProvider getHistoryProvider()
+    {
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
+        SqlQueryManager sqlQueryManager = (SqlQueryManager) queryRunner.getCoordinator().getQueryManager();
+        return (InMemoryHistoryBasedPlanStatisticsProvider) sqlQueryManager.getHistoryBasedPlanStatisticsTracker().getHistoryBasedPlanStatisticsProvider();
+    }
+}


### PR DESCRIPTION
## Description
Presto CPP enable dynamic filter pushdown from join build to join probe side. When this is enabled, the number of output rows reported in the probe side will be less than the number of rows without dynamic filter pushdown.
This can be a problem if we still record the number of output rows in HBO. For example, for join T1 Join T2, after dynamic filter pushdown, it's possible that the probe side outputs 0 rows, and HBO will record 0 rows for probe side. Next time, we ran this query, HBO will use T1 as build side, as it's smaller. However now build side does not have dynamic filter pushdown, the build side may OOM due to no dynamic filter pushdown on build side.

In this PR, I will skip the HBO stats recording if it's affected by dynamic filter pushdown. It includes all plan nodes between the node where filter was pushed to (scan node in above example) and before the join node.

## Motivation and Context
Described above

## Impact
Avoid potential OOM due to inaccurate statistics caused by dynamic filter

## Test Plan
End to end test
[Control](https://fburl.com/scuba/presto_query_plan_stats_inc_archive/1omwpu32) vs. [Test](https://fburl.com/scuba/presto_query_plan_stats_inc_archive/v2o0vqpz)
and unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix HBO to skip tracking of stats for plan nodes affected by dynamic filter pushdown in presto cpp :pr:`22853 `
```


