### PR TITLE
Fix array_least_frequent docs and formatting

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -82,12 +82,16 @@ Array Functions
 
 .. function:: array_least_frequent(array(T)) -> array(T)
 
-    Returns the least frequent element of an array. If there are multiple elements with same frequency, the function returns the largest element.
+    Returns the least frequent element of an array. If there are multiple elements with same frequency, the function returns the smallest element. ::
+
+        SELECT array_least_frequent(ARRAY[1, 0 , 5])  -- ARRAY[0]
 
 .. function:: array_least_frequent(array(T), n) -> array(T)
 
-    Returns n least frequent elements of an array. The elements are based on increasing order of their frequencies.
-    If two elements have same frequency then element with higher value will appear before lower value.
+    Returns ``n`` least frequent elements of an array. The elements are ordered in increasing order of their frequencies.
+    If two elements have same frequency, smaller elements will appear first. ::
+
+        SELECT array_least_frequent(ARRAY[3, 2, 2, 6, 6, 1, 1], 3) -- ARRAY[3, 1, 2]
 
 .. function:: array_max(x) -> x
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -96,7 +96,7 @@ public class ArraySqlFunctions
     @TypeParameter("T")
     @SqlParameter(name = "input", type = "array(T)")
     @SqlType("array<T>")
-    public static String array_least_frequent()
+    public static String arrayLeastFrequent()
     {
         return "RETURN IF(COALESCE(CARDINALITY(REMOVE_NULLS(input)), 0) = 0, NULL, TRANSFORM(SLICE(ARRAY_SORT(TRANSFORM(MAP_ENTRIES(ARRAY_FREQUENCY(REMOVE_NULLS(input))), x -> ROW(x[2], x[1]))), 1, 1), x -> x[2]))";
     }
@@ -106,7 +106,7 @@ public class ArraySqlFunctions
     @TypeParameter("T")
     @SqlParameters({@SqlParameter(name = "input", type = "array(T)"), @SqlParameter(name = "n", type = "bigint")})
     @SqlType("array<T>")
-    public static String array_n_least_frequent()
+    public static String arrayNLeastFrequent()
     {
         return "RETURN IF(n < 0, fail('n must be greater than or equal to 0'), IF(COALESCE(CARDINALITY(REMOVE_NULLS(input)), 0) = 0, NULL, TRANSFORM(SLICE(ARRAY_SORT(TRANSFORM(MAP_ENTRIES(ARRAY_FREQUENCY(REMOVE_NULLS(input))), x -> ROW(x[2], x[1]))), 1, n), x -> x[2])))";
     }


### PR DESCRIPTION
array_least_frequent orders the smallest value first

## Description
Fix array_least_frequent docs to indicate that smallest values will be ordered first. Also fix formatting of the method name.

## Motivation and Context
clean up/ doc improvement

## Impact
doc improvement

## Test Plan
CI
## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

