### PR TITLE
Improve query assertion message for mismatched types

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -224,11 +224,15 @@ public final class QueryAssertions
 
         if (ensureOrdering) {
             if (!actualRows.equals(expectedRows)) {
-                assertEquals(actualRows, expectedRows, "For query: \n " + actual + "\n:");
+                assertEquals(actualRows,
+                        expectedRows,
+                        "For query: \n " + actual + "\n actual column types:\n " + actualResults.getTypes() + "\nexpected column types:\n" + expectedResults.getTypes() + "\n");
             }
         }
         else {
-            assertEqualsIgnoreOrder(actualRows, expectedRows, "For query: \n " + actual);
+            assertEqualsIgnoreOrder(actualRows,
+                    expectedRows,
+                    "For query: \n " + actual + "\n actual column types:\n " + actualResults.getTypes() + "\nexpected column types:\n" + expectedResults.getTypes() + "\n");
         }
     }
 


### PR DESCRIPTION
## Description
Include column types in row mismatch errors to help with debugging failures where the columns display the same but are different types (e.g. float vs. double or bigint vs. int)

Example new message:
```
java.lang.AssertionError: For query:
 SELECT array_sort(array_union(simple_real_array, ARRAY[CAST(nan() AS DOUBLE)])) FROM array_nans_table
 actual column types:
 [array(double)]
expected column types:
[array(real)]

not equal
Actual rows (6 of 6 extra rows shown, 7 rows in total):
    [[-1.0, 0.0, 1.0, NaN]]
    [[-1.0, 0.0, 1.0, NaN]]
    [[-1.0, 0.0, 1.0, NaN]]
    [[-1.0, 0.0, 1.0, NaN]]
    [[200.0, NaN, null]]
    [[NaN]]
Expected rows (6 of 6 missing rows shown, 7 rows in total):
    [[-1.0, 0.0, 1.0, NaN]]
    [[-1.0, 0.0, 1.0, NaN]]
    [[-1.0, 0.0, 1.0, NaN]]
    [[-1.0, 0.0, 1.0, NaN]]
    [[200.0, NaN, null]]
    [[NaN]]
```
Note that we can't add an assertion that the types match because sometimes type mismatches are okay, as the values are really the same For example, if the expected result is a single null value, we might compare against a`SELECT null` query, so the expected type will be "UNKNOWN" type, but the actual query will return e.g. double type. In this case, there will be no result mismatch and we wouldn't want these queries to start to fail by requiring that the types are the same.


## Motivation and Context
This makes it easier to debug test failures where the rows look the same, but the failures are due to mismatched types.

## Impact
n/a

## Test Plan
CI
## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

