### PR TITLE
Remove unused VersionOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -208,7 +208,6 @@ import static com.facebook.presto.spi.StandardWarningCode.REDUNDANT_ORDER_BY;
 import static com.facebook.presto.spi.analyzer.AccessControlRole.TABLE_CREATE;
 import static com.facebook.presto.spi.analyzer.AccessControlRole.TABLE_DELETE;
 import static com.facebook.presto.spi.analyzer.AccessControlRole.TABLE_INSERT;
-import static com.facebook.presto.spi.connector.ConnectorTableVersion.VersionOperator;
 import static com.facebook.presto.spi.connector.ConnectorTableVersion.VersionType;
 import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
 import static com.facebook.presto.spi.function.FunctionKind.WINDOW;
@@ -280,7 +279,6 @@ import static com.facebook.presto.sql.tree.FrameBound.Type.PRECEDING;
 import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
 import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
 import static com.facebook.presto.sql.tree.TableVersionExpression.TableVersionOperator;
-import static com.facebook.presto.sql.tree.TableVersionExpression.TableVersionOperator.EQUAL;
 import static com.facebook.presto.sql.tree.TableVersionExpression.TableVersionOperator.LESS_THAN;
 import static com.facebook.presto.sql.tree.TableVersionExpression.TableVersionType;
 import static com.facebook.presto.sql.tree.TableVersionExpression.TableVersionType.TIMESTAMP;
@@ -1368,17 +1366,6 @@ class StatementAnalyzer
             }
         }
 
-        private VersionOperator toVersionOperator(TableVersionOperator operator)
-        {
-            switch (operator) {
-                case EQUAL:
-                    return VersionOperator.EQUAL;
-                case LESS_THAN:
-                    return VersionOperator.LESS_THAN;
-            }
-            throw new SemanticException(NOT_SUPPORTED, "Table version operator %s not supported." + operator);
-        }
-
         private VersionType toVersionType(TableVersionType type)
         {
             switch (type) {
@@ -1419,7 +1406,7 @@ class StatementAnalyzer
                 }
             }
 
-            ConnectorTableVersion tableVersion = new ConnectorTableVersion(toVersionType(tableVersionType), toVersionOperator(tableVersionOperator), stateExprType, evalStateExpr);
+            ConnectorTableVersion tableVersion = new ConnectorTableVersion(toVersionType(tableVersionType), stateExprType, evalStateExpr);
             return metadata.getHandleVersion(session, name, Optional.of(tableVersion));
         }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorTableVersion.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorTableVersion.java
@@ -24,24 +24,17 @@ public class ConnectorTableVersion
         TIMESTAMP,
         VERSION
     }
-    public enum VersionOperator
-    {
-        EQUAL,
-        LESS_THAN
-    }
+
     private final VersionType versionType;
-    private final VersionOperator versionOperator;
     private final Type versionExpressionType;
     private final Object tableVersion;
 
-    public ConnectorTableVersion(VersionType versionType, VersionOperator versionOperator, Type versionExpressionType, Object tableVersion)
+    public ConnectorTableVersion(VersionType versionType, Type versionExpressionType, Object tableVersion)
     {
         requireNonNull(versionType, "versionType is null");
-        requireNonNull(versionOperator, "versionOperator is null");
         requireNonNull(versionExpressionType, "versionExpressionType is null");
         requireNonNull(tableVersion, "tableVersion is null");
         this.versionType = versionType;
-        this.versionOperator = versionOperator;
         this.versionExpressionType = versionExpressionType;
         this.tableVersion = tableVersion;
     }


### PR DESCRIPTION
## Description
Remove unused VersionOperator

## Motivation and Context
Either this isn't needed, or there's a more serious bug here if it should be used.

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

