### PR TITLE
Remove unnecessary use of final on private and static methods

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
@@ -448,7 +448,7 @@ public class BenchmarkParquetPageSource
             }
         }
 
-        private final Object createValue(Type type, float filterRate)
+        private Object createValue(Type type, float filterRate)
         {
             if (BOOLEAN.equals(type)) {
                 switch (withNulls) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
@@ -205,7 +205,7 @@ public class BenchmarkPageProcessor
             return pageBuilder.build();
         }
 
-        private final RowExpression createFilterExpression(FunctionAndTypeManager functionAndTypeManager)
+        private RowExpression createFilterExpression(FunctionAndTypeManager functionAndTypeManager)
         {
             if (filterFails.equals("never")) {
                 return new ConstantExpression(true, BOOLEAN);
@@ -265,7 +265,7 @@ public class BenchmarkPageProcessor
             }
         }
 
-        private final RowExpression createProjectExpression(FunctionAndTypeManager functionAndTypeManager)
+        private RowExpression createProjectExpression(FunctionAndTypeManager functionAndTypeManager)
         {
             switch (projectionDataType) {
                 case "BIGINT":

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -388,7 +388,7 @@ public class BenchmarkSelectiveStreamReaders
             }
         }
 
-        private final Object createValue(Type type, float filterRate)
+        private Object createValue(Type type, float filterRate)
         {
             if (type == BOOLEAN) {
                 // We need to specialize BOOLEAN case because we can't specify filterRate by manipulating the filter value in getFilter.

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BytesUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BytesUtils.java
@@ -19,7 +19,7 @@ public class BytesUtils
     {
     }
 
-    public static final int getInt(byte[] byteBuffer, int offset)
+    public static int getInt(byte[] byteBuffer, int offset)
     {
         int ch0 = byteBuffer[offset + 0] & 255;
         int ch1 = byteBuffer[offset + 1] & 255;
@@ -29,7 +29,7 @@ public class BytesUtils
         return (ch3 << 24) + (ch2 << 16) + (ch1 << 8) + ch0;
     }
 
-    public static final long getLong(byte[] byteBuffer, int offset)
+    public static long getLong(byte[] byteBuffer, int offset)
     {
         int ch0 = byteBuffer[offset + 0];
         int ch1 = byteBuffer[offset + 1];

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
@@ -88,7 +88,7 @@ public class Decoders
         }
     }
 
-    private static final ValuesDecoder createValuesDecoder(ColumnDescriptor columnDescriptor, Dictionary dictionary, int valueCount, ParquetEncoding encoding, byte[] buffer, int offset, int length)
+    private static ValuesDecoder createValuesDecoder(ColumnDescriptor columnDescriptor, Dictionary dictionary, int valueCount, ParquetEncoding encoding, byte[] buffer, int offset, int length)
             throws IOException
     {
         final PrimitiveTypeName type = columnDescriptor.getPrimitiveType().getPrimitiveTypeName();
@@ -268,7 +268,7 @@ public class Decoders
                 createValuesDecoderV2(pageV2, columnDescriptor, dictionary));
     }
 
-    private static final RepetitionLevelDecoder createRepetitionLevelDecoderV2(int valueCount, RichColumnDescriptor columnDescriptor, Slice repetitionLevelBuffer)
+    private static RepetitionLevelDecoder createRepetitionLevelDecoderV2(int valueCount, RichColumnDescriptor columnDescriptor, Slice repetitionLevelBuffer)
     {
         final int maxRepetitionLevel = columnDescriptor.getMaxRepetitionLevel();
         final int repetitionLevelBitWidth = getWidthFromMaxInt(maxRepetitionLevel);
@@ -278,7 +278,7 @@ public class Decoders
         return new RepetitionLevelDecoder(valueCount, repetitionLevelBitWidth, new ByteArrayInputStream(repetitionLevelBuffer.getBytes()));
     }
 
-    private static final DefinitionLevelDecoder createDefinitionLevelDecoderV2(int valueCount, RichColumnDescriptor columnDescriptor, Slice definitionLevelBuffer)
+    private static DefinitionLevelDecoder createDefinitionLevelDecoderV2(int valueCount, RichColumnDescriptor columnDescriptor, Slice definitionLevelBuffer)
     {
         final int maxDefinitionLevel = columnDescriptor.getMaxDefinitionLevel();
         final int definitionLevelBitWidth = getWidthFromMaxInt(maxDefinitionLevel);
@@ -288,14 +288,14 @@ public class Decoders
         return new DefinitionLevelDecoder(valueCount, definitionLevelBitWidth, new ByteArrayInputStream(definitionLevelBuffer.getBytes()));
     }
 
-    private static final ValuesDecoder createValuesDecoderV2(DataPageV2 pageV2, RichColumnDescriptor columnDescriptor, Dictionary dictionary)
+    private static ValuesDecoder createValuesDecoderV2(DataPageV2 pageV2, RichColumnDescriptor columnDescriptor, Dictionary dictionary)
             throws IOException
     {
         final byte[] valueBuffer = pageV2.getSlice().getBytes();
         return createValuesDecoder(columnDescriptor, dictionary, pageV2.getValueCount(), pageV2.getDataEncoding(), valueBuffer, 0, valueBuffer.length);
     }
 
-    private static final FlatDefinitionLevelDecoder createFlatDefinitionLevelDecoder(ParquetEncoding encoding, boolean isRequired, int maxLevelValue, int valueCount, ByteBuffer buffer)
+    private static FlatDefinitionLevelDecoder createFlatDefinitionLevelDecoder(ParquetEncoding encoding, boolean isRequired, int maxLevelValue, int valueCount, ByteBuffer buffer)
             throws IOException
     {
         if (isRequired) {
@@ -320,7 +320,7 @@ public class Decoders
         return definitionLevelDecoder;
     }
 
-    public static final RepetitionLevelDecoder createRepetitionLevelDecoder(ParquetEncoding encoding, int maxLevelValue, int valueCount, ByteBuffer buffer)
+    public static RepetitionLevelDecoder createRepetitionLevelDecoder(ParquetEncoding encoding, int maxLevelValue, int valueCount, ByteBuffer buffer)
             throws IOException
     {
         final int bitWidth = getWidthFromMaxInt(maxLevelValue);
@@ -337,7 +337,7 @@ public class Decoders
         return repetitionLevelDecoder;
     }
 
-    public static final DefinitionLevelDecoder createDefinitionLevelDecoder(ParquetEncoding encoding, int maxLevelValue, int valueCount, ByteBuffer buffer)
+    public static DefinitionLevelDecoder createDefinitionLevelDecoder(ParquetEncoding encoding, int maxLevelValue, int valueCount, ByteBuffer buffer)
             throws IOException
     {
         final int bitWidth = getWidthFromMaxInt(maxLevelValue);

--- a/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusMetricResult.java
+++ b/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusMetricResult.java
@@ -38,7 +38,7 @@ public class PrometheusMetricResult
     }
 
     @JsonSetter("value")
-    private final void setTimeSeriesValues(PrometheusTimeSeriesValue timeSeriesValue)
+    private void setTimeSeriesValues(PrometheusTimeSeriesValue timeSeriesValue)
     {
         this.timeSeriesValues = new PrometheusTimeSeriesValueArray(Arrays.asList(timeSeriesValue));
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/QueryId.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/QueryId.java
@@ -82,7 +82,7 @@ public final class QueryId
     //
 
     // Check if the string matches [_a-z0-9]+ , but without the overhead of regex
-    private static final boolean isIdMatchPattern(String id)
+    private static boolean isIdMatchPattern(String id)
     {
         if (id.length() == 0) {
             return false;


### PR DESCRIPTION
## Description
Remove unnecessary use of final on private and static methods

## Motivation and Context
Shorten code

## Impact
None

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

