### PR TITLE
Use semantic asserts

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -4308,7 +4308,7 @@ public abstract class AbstractTestHiveClient
             // verify all temp files start with the unique prefix
             stagingPathRoot = getStagingPathRoot(insertTableHandle);
             Set<String> tempFiles = listAllDataFiles(context, stagingPathRoot);
-            assertTrue(!tempFiles.isEmpty());
+            assertFalse(tempFiles.isEmpty());
             for (String filePath : tempFiles) {
                 assertTrue(new Path(filePath).getName().startsWith(session.getQueryId()));
             }
@@ -4535,7 +4535,7 @@ public abstract class AbstractTestHiveClient
                     insertTableHandle.getLocationHandle().getTargetPath().toString(),
                     false);
             Set<String> tempFiles = listAllDataFiles(context, getStagingPathRoot(insertTableHandle));
-            assertTrue(!tempFiles.isEmpty());
+            assertFalse(tempFiles.isEmpty());
             for (String filePath : tempFiles) {
                 assertTrue(new Path(filePath).getName().startsWith(session.getQueryId()));
             }
@@ -4663,7 +4663,7 @@ public abstract class AbstractTestHiveClient
                     insertTableHandle.getLocationHandle().getTargetPath().toString(),
                     false);
             Set<String> tempFiles = listAllDataFiles(context, getStagingPathRoot(insertTableHandle));
-            assertTrue(!tempFiles.isEmpty());
+            assertFalse(tempFiles.isEmpty());
             for (String filePath : tempFiles) {
                 assertTrue(new Path(filePath).getName().startsWith(session.getQueryId()));
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -148,6 +148,7 @@ import static io.airlift.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -2126,7 +2127,7 @@ public class TestHiveLogicalPlanner
         for (ColumnHandle columnHandle : tableScan.getAssignments().values()) {
             assertTrue(columnHandle instanceof HiveColumnHandle);
             HiveColumnHandle hiveColumnHandle = (HiveColumnHandle) columnHandle;
-            assertFalse(hiveColumnHandle.getColumnType() == HiveColumnHandle.ColumnType.AGGREGATED);
+            assertNotSame(hiveColumnHandle.getColumnType(), HiveColumnHandle.ColumnType.AGGREGATED);
             assertFalse(hiveColumnHandle.getPartialAggregation().isPresent());
         }
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -87,7 +87,7 @@ import static io.airlift.tpch.TpchTable.SUPPLIER;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -812,7 +812,7 @@ public class TestHiveMaterializedViewLogicalPlanner
             // from sampled table and full table
             String viewHalfQuery = format("SELECT * from %s ORDER BY nationkey", viewHalf);
             MaterializedResult viewHalfTable = computeActual(viewHalfQuery);
-            assertFalse(viewFullTable.equals(viewHalfTable));
+            assertNotEquals(viewFullTable, viewHalfTable);
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + viewFull);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveNativeLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveNativeLogicalPlanner.java
@@ -33,6 +33,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTre
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static io.airlift.tpch.TpchTable.ORDERS;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -74,7 +75,7 @@ public class TestHiveNativeLogicalPlanner
         for (ColumnHandle columnHandle : tableScan.getAssignments().values()) {
             assertTrue(columnHandle instanceof HiveColumnHandle);
             HiveColumnHandle hiveColumnHandle = (HiveColumnHandle) columnHandle;
-            assertFalse(hiveColumnHandle.getColumnType() == HiveColumnHandle.ColumnType.AGGREGATED);
+            assertNotSame(hiveColumnHandle.getColumnType(), HiveColumnHandle.ColumnType.AGGREGATED);
             assertFalse(hiveColumnHandle.getPartialAggregation().isPresent());
         }
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitScheduling.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitScheduling.java
@@ -65,9 +65,6 @@ public class TestHiveSplitScheduling
                 assertTrue(numberOfSplitsWithDynamicSplitScheduling < numberOfSplitsWithoutDynamicSplitScheduling, "Expected less splits with dynamic split scheduling");
             });
         }
-        catch (Exception e) {
-            assertTrue(false, e.getMessage());
-        }
         finally {
             getQueryRunner().execute("DROP TABLE IF EXISTS test_orders");
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -327,7 +327,7 @@ public class TestHiveSplitSource
 
             // sleep for a bit, and assure the thread is blocked
             MILLISECONDS.sleep(200);
-            assertTrue(!splits.isDone());
+            assertFalse(splits.isDone());
 
             // add a split
             hiveSplitSource.addToQueue(new TestSplit(33));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestJsonHiveHandles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestJsonHiveHandles.java
@@ -98,7 +98,7 @@ public class TestJsonHiveHandles
         assertEquals(columnHandle.getTypeSignature(), DOUBLE.getTypeSignature());
         assertEquals(columnHandle.getHiveType(), HiveType.HIVE_FLOAT);
         assertEquals(columnHandle.getHiveColumnIndex(), -1);
-        assertEquals(columnHandle.isPartitionKey(), true);
+        assertTrue(columnHandle.isPartitionKey());
     }
 
     private void testJsonEquals(String json, Map<String, Object> expectedMap)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
@@ -95,6 +95,7 @@ import static org.apache.hadoop.hive.common.FileUtils.makePartName;
 import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestHiveClientGlueMetastore
@@ -356,7 +357,7 @@ public class TestHiveClientGlueMetastore
                     tableName.getTableName(),
                     predicates);
 
-            assertTrue(!partitionNames.isEmpty());
+            assertFalse(partitionNames.isEmpty());
             assertEquals(partitionNames, ImmutableList.of("key=value2/int_partition=2"));
 
             // KEY is a reserved keyword in the grammar of the SQL parser used internally by Glue API
@@ -370,7 +371,7 @@ public class TestHiveClientGlueMetastore
                     tableName.getSchemaName(),
                     tableName.getTableName(),
                     predicates);
-            assertTrue(!partitionNames.isEmpty());
+            assertFalse(partitionNames.isEmpty());
             assertEquals(partitionNames, ImmutableList.of("key=value1/int_partition=1", "key=value2/int_partition=2"));
         }
         finally {


### PR DESCRIPTION
## Description
Most precise assertion method.
assertTrue(! --> assertFalse
assertTrue(x == y) ---> assertSame(x, y)


## Motivation and Context
Better test failure messages

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

