### PR TITLE
Remove unnecessary toString() invocations

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/DwrfEncryptionMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/DwrfEncryptionMetadata.java
@@ -63,7 +63,7 @@ public class DwrfEncryptionMetadata
         this.encryptionProvider = requireNonNull(encryptionProvider, "encryptionProvider is null");
 
         if (this.fieldToKeyData.containsKey(TABLE_IDENTIFIER) && this.fieldToKeyData.size() != 1) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, format("Cannot have both table and column level settings. Given: %s", fieldToKeyData.keySet().toString()));
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, format("Cannot have both table and column level settings. Given: %s", fieldToKeyData.keySet()));
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
@@ -176,7 +176,7 @@ public final class HiveBucketing
                         long millisSinceEpoch = prestoType.getLong(block, position);
                         return getHashForTimestamp(millisSinceEpoch, useLegacyTimestampBucketing);
                     default:
-                        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory.toString() + ".");
+                        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory + ".");
                 }
             }
             case LIST: {
@@ -233,7 +233,7 @@ public final class HiveBucketing
                         long millisSinceEpoch = (long) value;
                         return getHashForTimestamp(millisSinceEpoch, useLegacyTimestampBucketing);
                     default:
-                        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory.toString() + ".");
+                        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory + ".");
                 }
             }
             case LIST: {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -3521,13 +3521,13 @@ public class HiveMetadata
                     if (!(columnType instanceof RowType)) {
                         throw new PrestoException(
                                 INVALID_TABLE_PROPERTY,
-                                format("In %s subfields declared in %s, but %s has type %s", ENCRYPT_COLUMNS, columnWithSubfield.toString(), column.getName(), column.getType().getDisplayName()));
+                                format("In %s subfields declared in %s, but %s has type %s", ENCRYPT_COLUMNS, columnWithSubfield, column.getName(), column.getType().getDisplayName()));
                     }
 
                     if (seenColumns.contains(parentPath)) {
                         throw new PrestoException(
                                 INVALID_TABLE_PROPERTY,
-                                format("For (%s) found a keyReference at a higher level field (%s)", columnWithSubfield.toString(), parentPath));
+                                format("For (%s) found a keyReference at a higher level field (%s)", columnWithSubfield, parentPath));
                     }
 
                     RowType row = (RowType) columnType;
@@ -3537,7 +3537,7 @@ public class HiveMetadata
                             .map(RowType.Field::getType)
                             .orElseThrow(() -> new PrestoException(
                                     INVALID_TABLE_PROPERTY,
-                                    format("In %s subfields declared in %s, but %s has type %s", ENCRYPT_COLUMNS, columnWithSubfield.toString(), column.getName(), column.getType().getDisplayName())));
+                                    format("In %s subfields declared in %s, but %s has type %s", ENCRYPT_COLUMNS, columnWithSubfield, column.getName(), column.getType().getDisplayName())));
 
                     parentPath = format("%s.%s", parentPath, pathFragment);
                 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
@@ -92,7 +92,7 @@ public class HiveSplitPartitionInfo
         // it's safe to add a trailing slash
         if (!path.getPath().endsWith("/")) {
             try {
-                path = new URI(path.toString() + "/");
+                path = new URI(path + "/");
             }
             catch (URISyntaxException e) {
                 throw new PrestoException(GENERIC_INTERNAL_ERROR, e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -923,12 +923,12 @@ public final class HiveUtil
             BigDecimal decimal = new BigDecimal(value);
             decimal = decimal.setScale(type.getScale(), ROUND_UNNECESSARY);
             if (decimal.precision() > type.getPrecision()) {
-                throw new PrestoException(HIVE_INVALID_PARTITION_VALUE, format("Invalid partition value '%s' for %s partition key: %s", value, type.toString(), name));
+                throw new PrestoException(HIVE_INVALID_PARTITION_VALUE, format("Invalid partition value '%s' for %s partition key: %s", value, type, name));
             }
             return decimal;
         }
         catch (NumberFormatException e) {
-            throw new PrestoException(HIVE_INVALID_PARTITION_VALUE, format("Invalid partition value '%s' for %s partition key: %s", value, type.toString(), name));
+            throw new PrestoException(HIVE_INVALID_PARTITION_VALUE, format("Invalid partition value '%s' for %s partition key: %s", value, type, name));
         }
     }
 
@@ -937,7 +937,7 @@ public final class HiveUtil
         Slice partitionKey = Slices.utf8Slice(value);
         VarcharType varcharType = (VarcharType) columnType;
         if (SliceUtf8.countCodePoints(partitionKey) > varcharType.getLength()) {
-            throw new PrestoException(HIVE_INVALID_PARTITION_VALUE, format("Invalid partition value '%s' for %s partition key: %s", value, columnType.toString(), name));
+            throw new PrestoException(HIVE_INVALID_PARTITION_VALUE, format("Invalid partition value '%s' for %s partition key: %s", value, columnType, name));
         }
         return partitionKey;
     }
@@ -947,7 +947,7 @@ public final class HiveUtil
         Slice partitionKey = trimTrailingSpaces(Slices.utf8Slice(value));
         CharType charType = (CharType) columnType;
         if (SliceUtf8.countCodePoints(partitionKey) > charType.getLength()) {
-            throw new PrestoException(HIVE_INVALID_PARTITION_VALUE, format("Invalid partition value '%s' for %s partition key: %s", value, columnType.toString(), name));
+            throw new PrestoException(HIVE_INVALID_PARTITION_VALUE, format("Invalid partition value '%s' for %s partition key: %s", value, columnType, name));
         }
         return partitionKey;
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveZeroRowFileCreator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveZeroRowFileCreator.java
@@ -106,7 +106,7 @@ public class HiveZeroRowFileCreator
             HiveCompressionCodec compressionCodec)
     {
         String tmpDirectoryPath = System.getProperty("java.io.tmpdir");
-        String tmpFileName = format("presto-hive-zero-row-file-creator-%s-%s", session.getQueryId(), randomUUID().toString());
+        String tmpFileName = format("presto-hive-zero-row-file-creator-%s-%s", session.getQueryId(), randomUUID());
         java.nio.file.Path tmpFilePath = Paths.get(tmpDirectoryPath, tmpFileName);
 
         try {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/AggregatedParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/AggregatedParquetPageSource.java
@@ -162,7 +162,7 @@ public class AggregatedParquetPageSource
     {
         org.apache.parquet.schema.Type parquetType = parquetMetadata.getFileMetaData().getSchema().getType(columnIndex);
         if (parquetType instanceof GroupType) {
-            throw new IllegalArgumentException("Unsupported type : " + parquetType.toString());
+            throw new IllegalArgumentException("Unsupported type : " + parquetType);
         }
 
         Object value = null;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -5703,7 +5703,7 @@ public abstract class AbstractTestHiveClient
                             testCase.getConflictTrigger());
                 }
                 catch (AssertionError e) {
-                    throw new AssertionError(format("Test case: %s", testCase.toString()), e);
+                    throw new AssertionError(format("Test case: %s", testCase), e);
                 }
             }
             finally {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2824,7 +2824,7 @@ public class TestHiveIntegrationSmokeTest
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
-                new Path(tempDir.toURI().toASCIIString()).toString());
+                new Path(tempDir.toURI().toASCIIString()));
 
         assertUpdate(createTableSql);
         MaterializedResult actual = computeActual("SHOW CREATE TABLE test_create_external");


### PR DESCRIPTION
## Description
Remove unnecessary toString() invocations

## Motivation and Context
Shorter lines are easier to read

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

