### PR TITLE
Add config metrics-reporting-enabled and report metrics by default

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -158,8 +158,9 @@ void PrestoServer::run() {
     baseVeloxQueryConfig->initialize(
         fmt::format("{}/velox.properties", configDirectoryPath_), true);
 
-    if (systemConfig->enableRuntimeMetricsCollection()) {
-      enableRuntimeMetricReporting();
+    if (systemConfig->enableMetricsReporting() ||
+        systemConfig->enableRuntimeMetricsCollection()) {
+      enableMetricsReporting();
     }
 
     httpPort = systemConfig->httpServerHttpPort();
@@ -1104,7 +1105,7 @@ std::string PrestoServer::getBaseSpillDirectory() const {
   return SystemConfig::instance()->spillerSpillPath().value_or("");
 }
 
-void PrestoServer::enableRuntimeMetricReporting() {
+void PrestoServer::enableMetricsReporting() {
   // This flag must be set to register the counters.
   facebook::velox::BaseStatsReporter::registered = true;
   registerStatsCounters();

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -170,7 +170,7 @@ class PrestoServer {
   virtual std::string getBaseSpillDirectory() const;
 
   /// Invoked to enable stats reporting and register counters.
-  virtual void enableRuntimeMetricReporting();
+  virtual void enableMetricsReporting();
 
   /// Invoked to get the list of filters passed to the http server.
   std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -227,6 +227,7 @@ SystemConfig::SystemConfig() {
           STR_PROP(kCacheVeloxTtlThreshold, "2d"),
           STR_PROP(kCacheVeloxTtlCheckInterval, "1h"),
           BOOL_PROP(kEnableRuntimeMetricsCollection, false),
+          BOOL_PROP(kEnableMetricsReporting, true),
       };
 }
 
@@ -628,6 +629,10 @@ std::chrono::duration<double> SystemConfig::cacheVeloxTtlCheckInterval() const {
 
 bool SystemConfig::enableRuntimeMetricsCollection() const {
   return optionalProperty<bool>(kEnableRuntimeMetricsCollection).value();
+}
+
+bool SystemConfig::enableMetricsReporting() const {
+  return optionalProperty<bool>(kEnableMetricsReporting).value();
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -335,8 +335,12 @@ class SystemConfig : public ConfigBase {
       "cache.velox.ttl-check-interval"};
   static constexpr std::string_view kUseMmapAllocator{"use-mmap-allocator"};
 
+  /// TODO: Deprecate. Please use metrics-reporting-enabled instead.
   static constexpr std::string_view kEnableRuntimeMetricsCollection{
       "runtime-metrics-collection-enabled"};
+
+  static constexpr std::string_view kEnableMetricsReporting{
+      "metrics-reporting-enabled"};
 
   /// Specifies the memory arbitrator kind. If it is empty, then there is no
   /// memory arbitration.
@@ -710,6 +714,8 @@ class SystemConfig : public ConfigBase {
   std::chrono::duration<double> cacheVeloxTtlCheckInterval() const;
 
   bool enableRuntimeMetricsCollection() const;
+
+  bool enableMetricsReporting() const;
 };
 
 /// Provides access to node properties defined in node.properties file.


### PR DESCRIPTION
Add a new config metrics-reporting-enabled with default true. It will then
registerStatsCounters() by default.

[#22699](https://github.com/prestodb/presto/pull/22699) removes the call of registerStatsCounters() in PrestoServer.cpp.
To restore the behavior, we should enable registerStatsCounters()
by default. We have an existing config runtime-metrics-collection-enabled
for registerStatsCounters(), with default false.
This change adds a new config name to be more accurate.

```
== NO RELEASE NOTE ==
```

