### PR TITLE
Fix boolean precedence

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
@@ -37,9 +37,9 @@ public interface TupleDomainFilter
     TupleDomainFilter IS_NOT_NULL = new IsNotNull();
 
     /**
-     * A filter becomes non-deterministic when applies to nested column,
+     * A filter becomes non-deterministic when applied to a nested column;
      * e.g. a[1] > 10 is non-deterministic because > 10 filter applies only to some
-     * positions, e.g. first entry in a set of entries that correspond to a single
+     * position, e.g. first entry in a set of entries that correspond to a single
      * top-level position.
      */
     boolean isDeterministic();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercer.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercer.java
@@ -81,10 +81,10 @@ public interface HiveCoercer
         else if (fromType instanceof VarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
             return new VarcharToIntegerNumberCoercer(fromType, toType);
         }
-        else if (fromHiveType.equals(HIVE_BYTE) && toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {
+        else if (fromHiveType.equals(HIVE_BYTE) && (toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
             return new IntegerNumberUpscaleCoercer(fromType, toType);
         }
-        else if (fromHiveType.equals(HIVE_SHORT) && toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {
+        else if (fromHiveType.equals(HIVE_SHORT) && (toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
             return new IntegerNumberUpscaleCoercer(fromType, toType);
         }
         else if (fromHiveType.equals(HIVE_INT) && toHiveType.equals(HIVE_LONG)) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionRecordCursor.java
@@ -288,10 +288,10 @@ public class HiveCoercionRecordCursor
         else if (fromType instanceof VarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
             return new VarcharToIntegerNumberCoercer(toHiveType);
         }
-        else if (fromHiveType.equals(HIVE_BYTE) && toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {
+        else if (fromHiveType.equals(HIVE_BYTE) && (toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
             return new IntegerNumberUpscaleCoercer();
         }
-        else if (fromHiveType.equals(HIVE_SHORT) && toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {
+        else if (fromHiveType.equals(HIVE_SHORT) && (toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
             return new IntegerNumberUpscaleCoercer();
         }
         else if (fromHiveType.equals(HIVE_INT) && toHiveType.equals(HIVE_LONG)) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCoercingFilters.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCoercingFilters.java
@@ -17,17 +17,31 @@ import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.predicate.TupleDomainFilter;
 import com.facebook.presto.common.predicate.TupleDomainFilter.BigintRange;
 import com.facebook.presto.common.predicate.TupleDomainFilter.BytesRange;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.HiveCoercer.IntegerNumberToVarcharCoercer;
 import com.facebook.presto.hive.HiveCoercer.VarcharToIntegerNumberCoercer;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.PrestoException;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.HiveType.HIVE_BYTE;
+import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
+import static com.facebook.presto.hive.HiveType.HIVE_FLOAT;
+import static com.facebook.presto.hive.HiveType.HIVE_INT;
+import static com.facebook.presto.hive.HiveType.HIVE_LONG;
+import static com.facebook.presto.hive.HiveType.HIVE_SHORT;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestCoercingFilters
 {
+    private final TypeManager typeManager = MetadataManager.createTestMetadataManager().getFunctionAndTypeManager();
+
     @Test
     public void testIntegerToVarchar()
     {
@@ -69,5 +83,76 @@ public class TestCoercingFilters
         assertFalse(coercingFilter.testBytes("2147483648".getBytes(), 0, 10));
 
         assertFalse(coercingFilter.testNull());
+    }
+
+    @Test
+    public void testShortToInteger()
+    {
+        HiveCoercer coercer = HiveCoercer.createCoercer(typeManager, HIVE_SHORT, HIVE_INT);
+        assertEquals(coercer.getToType(), INTEGER);
+    }
+
+    @Test
+    public void testShortToLong()
+    {
+        HiveCoercer coercer = HiveCoercer.createCoercer(typeManager, HIVE_SHORT, HIVE_LONG);
+        assertEquals(coercer.getToType(), BIGINT);
+    }
+
+    @Test
+    public void testByteToInteger()
+    {
+        HiveCoercer coercer = HiveCoercer.createCoercer(typeManager, HIVE_BYTE, HIVE_INT);
+        assertEquals(coercer.getToType(), INTEGER);
+    }
+
+    @Test
+    public void testByteToLong()
+    {
+        HiveCoercer coercer = HiveCoercer.createCoercer(typeManager, HIVE_BYTE, HIVE_LONG);
+        assertEquals(coercer.getToType(), BIGINT);
+    }
+
+    @Test
+    public void testByteToShort()
+    {
+        HiveCoercer coercer = HiveCoercer.createCoercer(typeManager, HIVE_BYTE, HIVE_SHORT);
+        assertEquals(coercer.getToType(), SMALLINT);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testDoubleToShort()
+    {
+        HiveCoercer.createCoercer(typeManager, HIVE_DOUBLE, HIVE_SHORT);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testDoubleToInt()
+    {
+        HiveCoercer.createCoercer(typeManager, HIVE_DOUBLE, HIVE_INT);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testDoubleToLong()
+    {
+        HiveCoercer.createCoercer(typeManager, HIVE_DOUBLE, HIVE_LONG);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testShortToDouble()
+    {
+        HiveCoercer.createCoercer(typeManager, HIVE_SHORT, HIVE_DOUBLE);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testIntToFloat()
+    {
+        HiveCoercer.createCoercer(typeManager, HIVE_INT, HIVE_FLOAT);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testLongToFloat()
+    {
+        HiveCoercer.createCoercer(typeManager, HIVE_LONG, HIVE_FLOAT);
     }
 }


### PR DESCRIPTION
## Description
&& is evaluated before ||. The opposite was needed, so use parentheses. 

## Motivation and Context
I'm not sure where this code is used, but it looks like a real bug. However, it probably didn't bite because we don't have any coercers from byte or short.

## Impact
??

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTES ==
```
