### PR TITLE
Use File directly

### DIFF
--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
@@ -226,7 +226,7 @@ public class InMemoryHiveMetastore
         if (deleteData && table.getTableType().equals(MANAGED_TABLE.name())) {
             for (String location : locations) {
                 if (location != null) {
-                    File directory = new File(new Path(location).toUri());
+                    File directory = new File(location);
                     checkArgument(isParentDir(directory, baseDirectory), "Table directory must be inside of the metastore base directory");
                     deleteDirectory(directory);
                 }


### PR DESCRIPTION
## Description
Avoid creating a Hadoop path before deleting.

## Motivation and Context
Had some issues here while debugging an integration test. Seeing if we can simplify it or provide more complete exception messages. 

```
	Suppressed: java.lang.IllegalArgumentException: URI is not absolute
		at java.base/java.io.File.<init>(File.java:418)
		at com.facebook.presto.hive.metastore.thrift.InMemoryHiveMetastore.dropTable(InMemoryHiveMetastore.java:229)
		at com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore.dropTable(BridgingHiveMetastore.java:208)
		at com.facebook.presto.hive.metastore.AbstractCachingHiveMetastore.dropTable(AbstractCachingHiveMetastore.java:104)
		at com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore$Committer.lambda$prepareDropTable$0(SemiTransactionalHiveMetastore.java:1343)
		at com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore$IrreversibleMetastoreOperation.run(SemiTransactionalHiveMetastore.java:2756)
		at com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore$Committer.executeMetastoreDeleteOperations(SemiTransactionalHiveMetastore.java:1750)
		... 14 more
```

Also, the less use we make of org.apache.hadoop the better.

## Impact
None

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

