### PR TITLE
Add noisy_approx_percentile_qtree.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/MergeQuantileTreeAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/MergeQuantileTreeAggregation.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.type.QuantileTreeType;
+import io.airlift.slice.Slice;
+
+import java.util.Collections;
+
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+
+/**
+ * Merge a set of QuantileTree sketches together to produce a QuantileTree of the set union.
+ * This aggregator essentially reduces the trees into a single QuantileTree object, using
+ * QuantileTree.merge(). There is no noise added in this aggregator, but any noise from the
+ * existing trees will add in the merging process. The merged sketch is equivalent to
+ * having produced a single sketch (though possibly with a different privacy budget, which
+ * is reflected in the rho property of the final merged sketch).
+ */
+@AggregationFunction(value = "merge")
+public final class MergeQuantileTreeAggregation
+{
+    private MergeQuantileTreeAggregation() {}
+
+    @InputFunction
+    public static void input(@AggregationState QuantileTreeState state, @SqlType(QuantileTreeType.NAME) Slice treeSlice)
+    {
+        QuantileTree tree;
+        try {
+            tree = QuantileTree.deserialize(treeSlice);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
+        if (state.getQuantileTree() == null) {
+            // If nothing in state, set this as the QuantileTree in state.
+            state.setQuantileTree(tree);
+            state.addMemoryUsage(tree.estimatedSizeInBytes()); // all (compatible) trees will be of the same size
+            // The remaining parameters are unused.
+            state.setEpsilon(0);
+            state.setDelta(0);
+            state.setProbabilities(Collections.singletonList(0.0));
+        }
+        else {
+            // If there is a tree in state, merge them together (throw errors gracefully if not compatible).
+            try {
+                state.getQuantileTree().merge(tree);
+            }
+            catch (IllegalArgumentException e) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+            }
+        }
+    }
+
+    @CombineFunction
+    public static void combineStates(@AggregationState QuantileTreeState state, @AggregationState QuantileTreeState otherState)
+    {
+        QuantileTreeAggregationUtils.combineStates(state, otherState);
+    }
+
+    @OutputFunction(QuantileTreeType.NAME)
+    public static void evaluateFinal(@AggregationState QuantileTreeState state, BlockBuilder out)
+    {
+        if (state.getQuantileTree() == null) {
+            out.appendNull();
+        }
+        else {
+            VARBINARY.writeSlice(out, state.getQuantileTree().serialize());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyApproxPercentileQuantileTreeAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyApproxPercentileQuantileTreeAggregation.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BIN_COUNT;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BRANCHING_FACTOR;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_DEPTH;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_WIDTH;
+
+/**
+ * noisy_approx_percentile_qtree returns noisy estimates of percentiles from a multiset of values.
+ * Like all noisy aggregations, it does not achieve a true DP guarantee,
+ * as it returns NULL in the absence of data. Its DP-like privacy guarantee holds at the row-level under
+ * unbounded-neighbors (add/remove) semantics. This corresponds to user-level privacy in the case when a user
+ * contributes at most one row. To achieve user-level privacy when users contribute more than one row, divide
+ * the privacy budget accordingly.
+ */
+@AggregationFunction(value = "noisy_approx_percentile_qtree")
+public final class NoisyApproxPercentileQuantileTreeAggregation
+{
+    private NoisyApproxPercentileQuantileTreeAggregation() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState QuantileTreeState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.DOUBLE) double probability,
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.DOUBLE) double delta,
+            @SqlType(StandardTypes.DOUBLE) double lower,
+            @SqlType(StandardTypes.DOUBLE) double upper)
+    {
+        QuantileTreeAggregationUtils.inputValue(state, value, probability, epsilon, delta, lower, upper,
+                DEFAULT_BIN_COUNT, DEFAULT_BRANCHING_FACTOR, DEFAULT_SKETCH_DEPTH, DEFAULT_SKETCH_WIDTH);
+    }
+
+    @CombineFunction
+    public static void combineStates(@AggregationState QuantileTreeState state, @AggregationState QuantileTreeState otherState)
+    {
+        QuantileTreeAggregationUtils.combineStates(state, otherState);
+    }
+
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void evaluateFinal(@AggregationState QuantileTreeState state, BlockBuilder out)
+    {
+        if (state.getQuantileTree() == null) {
+            out.appendNull();
+        }
+        else {
+            QuantileTreeAggregationUtils.enablePrivacy(state);
+            double probability = state.getProbabilities().get(0);
+            double quantile = state.getQuantileTree().quantile(probability);
+            DoubleType.DOUBLE.writeDouble(out, quantile);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyApproxPercentileQuantileTreeArrayAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyApproxPercentileQuantileTreeArrayAggregation.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BIN_COUNT;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BRANCHING_FACTOR;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_DEPTH;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_WIDTH;
+
+/**
+ * noisy_approx_percentile_qtree returns noisy estimates of percentiles from a multiset of values.
+ * Like all noisy aggregations, it does not achieve a true DP guarantee,
+ * as it returns NULL in the absence of data. Its DP-like privacy guarantee holds at the row-level under
+ * unbounded-neighbors (add/remove) semantics. This corresponds to user-level privacy in the case when a user
+ * contributes at most one row. To achieve user-level privacy when users contribute more than one row, divide
+ * the privacy budget accordingly.
+ */
+@AggregationFunction(value = "noisy_approx_percentile_qtree")
+public final class NoisyApproxPercentileQuantileTreeArrayAggregation
+{
+    private NoisyApproxPercentileQuantileTreeArrayAggregation() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState QuantileTreeState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType("array(double)") Block probabilities,
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.DOUBLE) double delta,
+            @SqlType(StandardTypes.DOUBLE) double lower,
+            @SqlType(StandardTypes.DOUBLE) double upper)
+    {
+        QuantileTreeAggregationUtils.inputValue(state, value, probabilities, epsilon, delta, lower, upper,
+                DEFAULT_BIN_COUNT, DEFAULT_BRANCHING_FACTOR, DEFAULT_SKETCH_DEPTH, DEFAULT_SKETCH_WIDTH);
+    }
+
+    @CombineFunction
+    public static void combineStates(@AggregationState QuantileTreeState state, @AggregationState QuantileTreeState otherState)
+    {
+        QuantileTreeAggregationUtils.combineStates(state, otherState);
+    }
+
+    @OutputFunction("array(double)")
+    public static void evaluateFinal(@AggregationState QuantileTreeState state, BlockBuilder out)
+    {
+        QuantileTree quantileTree = state.getQuantileTree();
+        List<Double> probabilities = state.getProbabilities();
+
+        if (state.getQuantileTree() == null || probabilities == null) {
+            out.appendNull();
+            return;
+        }
+
+        QuantileTreeAggregationUtils.enablePrivacy(state);
+        BlockBuilder blockBuilder = out.beginBlockEntry();
+        for (Double probability : probabilities) {
+            double quantile = quantileTree.quantile(probability);
+            DOUBLE.writeDouble(blockBuilder, quantile);
+        }
+        out.closeEntry();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyQuantileTreeAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/NoisyQuantileTreeAggregation.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.type.QuantileTreeType;
+
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BIN_COUNT;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BRANCHING_FACTOR;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_DEPTH;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_WIDTH;
+import static java.lang.Math.toIntExact;
+
+/**
+ * noisy_qtree_agg creates a QuantileTree object representing a multiset of values. This can be used to
+ * obtain noisy estimates of percentiles. Like all noisy aggregations, it does not achieve a true DP guarantee,
+ * as it returns NULL in the absence of data. Its DP-like privacy guarantee holds at the row-level under
+ * unbounded-neighbors (add/remove) semantics. This corresponds to user-level privacy in the case when a user
+ * contributes at most one row. To achieve user-level privacy when users contribute more than one row, divide
+ * the privacy budget accordingly.
+ * <p>
+ * This agg function takes many parameters, of which several are optional. The function signature is:
+ * <p>
+ * <code>noisy_qtree_agg(value, epsilon, delta, lower, upper[, bin_count[,
+ * branching_factor[, sketch_depth, sketch_width]]])</code>
+ */
+@AggregationFunction(value = "noisy_qtree_agg")
+public final class NoisyQuantileTreeAggregation
+{
+    private NoisyQuantileTreeAggregation() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState QuantileTreeState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.DOUBLE) double delta,
+            @SqlType(StandardTypes.DOUBLE) double lower,
+            @SqlType(StandardTypes.DOUBLE) double upper,
+            @SqlType(StandardTypes.INTEGER) long binCount,
+            @SqlType(StandardTypes.INTEGER) long branchingFactor,
+            @SqlType(StandardTypes.INTEGER) long sketchDepth,
+            @SqlType(StandardTypes.INTEGER) long sketchWidth)
+    {
+        QuantileTreeAggregationUtils.inputValue(state, value, 0, epsilon, delta, lower, upper,
+                toIntExact(binCount), toIntExact(branchingFactor), toIntExact(sketchDepth), toIntExact(sketchWidth));
+    }
+
+    @InputFunction
+    public static void input(
+            @AggregationState QuantileTreeState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.DOUBLE) double delta,
+            @SqlType(StandardTypes.DOUBLE) double lower,
+            @SqlType(StandardTypes.DOUBLE) double upper,
+            @SqlType(StandardTypes.INTEGER) long binCount,
+            @SqlType(StandardTypes.INTEGER) long branchingFactor)
+    {
+        QuantileTreeAggregationUtils.inputValue(state, value, 0, epsilon, delta, lower, upper,
+                toIntExact(binCount), toIntExact(branchingFactor), DEFAULT_SKETCH_DEPTH, DEFAULT_SKETCH_WIDTH);
+    }
+
+    @InputFunction
+    public static void input(
+            @AggregationState QuantileTreeState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.DOUBLE) double delta,
+            @SqlType(StandardTypes.DOUBLE) double lower,
+            @SqlType(StandardTypes.DOUBLE) double upper,
+            @SqlType(StandardTypes.INTEGER) long binCount)
+    {
+        QuantileTreeAggregationUtils.inputValue(state, value, 0, epsilon, delta, lower, upper,
+                toIntExact(binCount), DEFAULT_BRANCHING_FACTOR, DEFAULT_SKETCH_DEPTH, DEFAULT_SKETCH_WIDTH);
+    }
+
+    @InputFunction
+    public static void input(
+            @AggregationState QuantileTreeState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.DOUBLE) double delta,
+            @SqlType(StandardTypes.DOUBLE) double lower,
+            @SqlType(StandardTypes.DOUBLE) double upper)
+    {
+        QuantileTreeAggregationUtils.inputValue(state, value, 0, epsilon, delta, lower, upper,
+                DEFAULT_BIN_COUNT, DEFAULT_BRANCHING_FACTOR, DEFAULT_SKETCH_DEPTH, DEFAULT_SKETCH_WIDTH);
+    }
+
+    @CombineFunction
+    public static void combineStates(@AggregationState QuantileTreeState state, @AggregationState QuantileTreeState otherState)
+    {
+        QuantileTreeAggregationUtils.combineStates(state, otherState);
+    }
+
+    @OutputFunction(QuantileTreeType.NAME)
+    public static void evaluateFinal(@AggregationState QuantileTreeState state, BlockBuilder out)
+    {
+        QuantileTreeAggregationUtils.writeSketch(state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/QuantileTreeAggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/QuantileTreeAggregationUtils.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.SecureRandomizationStrategy;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.spi.PrestoException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+
+public class QuantileTreeAggregationUtils
+{
+    // These parameters were chosen in N5336227.
+    public static final int DEFAULT_BIN_COUNT = 65_536; // 2^16
+    public static final int DEFAULT_BRANCHING_FACTOR = 4;
+    public static final int DEFAULT_SKETCH_DEPTH = 3;
+    public static final int DEFAULT_SKETCH_WIDTH = 400;
+
+    private QuantileTreeAggregationUtils() {}
+
+    public static void initializeState(QuantileTreeState state, Block probabilities, double epsilon, double delta,
+            double lower, double upper, int binCount, int branchingFactor, int sketchDepth, int sketchWidth)
+    {
+        if (epsilon <= 0 || delta <= 0) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "epsilon and delta must be positive");
+        }
+
+        List<Double> probabilitiesArray = new ArrayList<>();
+        for (int i = 0; i < probabilities.getPositionCount(); i++) {
+            if (probabilities.isNull(i)) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "probability cannot be null");
+            }
+
+            double probability = DOUBLE.getDouble(probabilities, i);
+            if (probability < 0 || probability > 1) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "cumulative probability must be between 0 and 1");
+            }
+            probabilitiesArray.add(probability);
+        }
+
+        if (probabilitiesArray.isEmpty()) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "must pass in at least 1 probability");
+        }
+
+        QuantileTree quantileTree = state.getQuantileTree();
+        if (quantileTree == null) {
+            try {
+                quantileTree = new QuantileTree(lower, upper, binCount, branchingFactor, sketchDepth, sketchWidth);
+            }
+            catch (IllegalArgumentException e) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+            }
+            state.setProbabilities(probabilitiesArray);
+            state.setEpsilon(epsilon);
+            state.setDelta(delta);
+            state.setQuantileTree(quantileTree);
+            state.addMemoryUsage(quantileTree.estimatedSizeInBytes());
+        }
+    }
+
+    public static void inputValue(QuantileTreeState state, double value, Block probabilities, double epsilon, double delta,
+            double lower, double upper, int binCount, int branchingFactor, int sketchDepth, int sketchWidth)
+    {
+        initializeState(state, probabilities, epsilon, delta, lower, upper, binCount, branchingFactor, sketchDepth, sketchWidth);
+        state.getQuantileTree().add(value);
+    }
+
+    public static void inputValue(QuantileTreeState state, double value, double probability, double epsilon, double delta,
+            double lower, double upper, int binCount, int branchingFactor, int sketchDepth, int sketchWidth)
+    {
+        BlockBuilder probabilityBlockBuilder = DOUBLE.createFixedSizeBlockBuilder(1);
+        DOUBLE.writeDouble(probabilityBlockBuilder, probability);
+        Block singleProbabilityBlock = probabilityBlockBuilder.build();
+        inputValue(state, value, singleProbabilityBlock, epsilon, delta, lower, upper, binCount, branchingFactor, sketchDepth, sketchWidth);
+    }
+
+    public static void combineStates(QuantileTreeState state, QuantileTreeState otherState)
+    {
+        QuantileTree tree = state.getQuantileTree();
+        QuantileTree otherTree = otherState.getQuantileTree();
+        if (tree == null) {
+            // If no tree in state, take values from otherState.
+            state.setQuantileTree(otherTree);
+            state.setEpsilon(otherState.getEpsilon());
+            state.setDelta(otherState.getDelta());
+            state.setProbabilities(otherState.getProbabilities());
+            state.addMemoryUsage(otherTree.estimatedSizeInBytes());
+        }
+        else {
+            try {
+                tree.merge(otherTree);
+            }
+            catch (IllegalArgumentException e) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Enables privacy in the QuantileTree stored in state, if any
+     * <p>
+     * Note: If epsilon is infinite or delta >= 1, this is a no-op, since those parameters yield no privacy.
+     */
+    public static void enablePrivacy(QuantileTreeState state)
+    {
+        if (state.getQuantileTree() == null) {
+            return;
+        }
+        double rho = QuantileTree.getRhoForEpsilonDelta(state.getEpsilon(), state.getDelta());
+        if (rho != QuantileTree.NON_PRIVATE_RHO) {
+            state.getQuantileTree().enablePrivacy(rho, new SecureRandomizationStrategy());
+        }
+    }
+
+    public static void writeSketch(QuantileTreeState state, BlockBuilder out)
+    {
+        if (state.getQuantileTree() == null) {
+            out.appendNull();
+        }
+        else {
+            QuantileTreeAggregationUtils.enablePrivacy(state);
+            VARBINARY.writeSlice(out, state.getQuantileTree().serialize());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/QuantileTreeState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/QuantileTreeState.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+import java.util.List;
+
+@AccumulatorStateMetadata(stateSerializerClass = QuantileTreeStateSerializer.class, stateFactoryClass = QuantileTreeStateFactory.class)
+public interface QuantileTreeState
+        extends AccumulatorState
+{
+    double getDelta();
+
+    double getEpsilon();
+
+    List<Double> getProbabilities();
+
+    QuantileTree getQuantileTree();
+
+    void setDelta(double delta);
+
+    void setEpsilon(double epsilon);
+
+    void setProbabilities(List<Double> probabilities);
+
+    void setQuantileTree(QuantileTree tree);
+
+    void addMemoryUsage(long value);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/QuantileTreeStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/QuantileTreeStateFactory.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.array.ObjectBigArray;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.spi.function.GroupedAccumulatorState;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class QuantileTreeStateFactory
+        implements AccumulatorStateFactory<QuantileTreeState>
+{
+    @Override
+    public QuantileTreeState createSingleState()
+    {
+        return new SingleQuantileTreeState();
+    }
+
+    @Override
+    public Class<? extends QuantileTreeState> getSingleStateClass()
+    {
+        return SingleQuantileTreeState.class;
+    }
+
+    @Override
+    public QuantileTreeState createGroupedState()
+    {
+        return new GroupedQuantileTreeState();
+    }
+
+    @Override
+    public Class<? extends QuantileTreeState> getGroupedStateClass()
+    {
+        return GroupedQuantileTreeState.class;
+    }
+
+    public static class GroupedQuantileTreeState
+            implements QuantileTreeState, GroupedAccumulatorState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedQuantileTreeState.class).instanceSize();
+
+        private final ObjectBigArray<Double> deltas = new ObjectBigArray<>();
+        private final ObjectBigArray<Double> epsilons = new ObjectBigArray<>();
+        private final ObjectBigArray<List<Double>> probabilities = new ObjectBigArray<>();
+        private final ObjectBigArray<QuantileTree> quantileTrees = new ObjectBigArray<>();
+
+        private long retainedBytes;
+        private long groupId;
+
+        @Override
+        public final void setGroupId(long groupId)
+        {
+            this.groupId = groupId;
+        }
+
+        protected final long getGroupId()
+        {
+            return groupId;
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            deltas.ensureCapacity(size);
+            epsilons.ensureCapacity(size);
+            probabilities.ensureCapacity(size);
+            quantileTrees.ensureCapacity(size);
+        }
+
+        @Override
+        public QuantileTree getQuantileTree()
+        {
+            return quantileTrees.get(getGroupId());
+        }
+
+        @Override
+        public double getDelta()
+        {
+            return deltas.get(getGroupId());
+        }
+
+        @Override
+        public double getEpsilon()
+        {
+            return epsilons.get(getGroupId());
+        }
+
+        @Override
+        public List<Double> getProbabilities()
+        {
+            return probabilities.get(getGroupId());
+        }
+
+        @Override
+        public void setDelta(double value)
+        {
+            deltas.set(getGroupId(), value);
+        }
+
+        @Override
+        public void setEpsilon(double value)
+        {
+            epsilons.set(getGroupId(), value);
+        }
+
+        @Override
+        public void setProbabilities(List<Double> values)
+        {
+            probabilities.set(getGroupId(), values);
+        }
+
+        @Override
+        public void setQuantileTree(QuantileTree tree)
+        {
+            requireNonNull(tree, "quantile tree is null");
+            quantileTrees.set(getGroupId(), tree);
+        }
+
+        @Override
+        public void addMemoryUsage(long value)
+        {
+            retainedBytes += value;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return INSTANCE_SIZE + retainedBytes + quantileTrees.sizeOf() + deltas.sizeOf() + epsilons.sizeOf() + probabilities.sizeOf();
+        }
+    }
+
+    public static class SingleQuantileTreeState
+            implements QuantileTreeState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleQuantileTreeState.class).instanceSize();
+
+        private double delta;
+        private double epsilon;
+        private List<Double> probabilities;
+        private QuantileTree quantileTree;
+
+        @Override
+        public double getDelta()
+        {
+            return delta;
+        }
+
+        @Override
+        public double getEpsilon()
+        {
+            return epsilon;
+        }
+
+        @Override
+        public List<Double> getProbabilities()
+        {
+            return probabilities;
+        }
+
+        @Override
+        public QuantileTree getQuantileTree()
+        {
+            return quantileTree;
+        }
+
+        @Override
+        public void setDelta(double value)
+        {
+            delta = value;
+        }
+
+        @Override
+        public void setEpsilon(double value)
+        {
+            epsilon = value;
+        }
+
+        @Override
+        public void setProbabilities(List<Double> values)
+        {
+            probabilities = new ArrayList<>(values);
+        }
+
+        @Override
+        public void setQuantileTree(QuantileTree tree)
+        {
+            quantileTree = tree;
+        }
+
+        @Override
+        public void addMemoryUsage(long value)
+        {
+            // noop
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            long estimatedSize = INSTANCE_SIZE;
+            if (quantileTree != null) {
+                estimatedSize += quantileTree.estimatedSizeInBytes();
+            }
+            return estimatedSize;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/QuantileTreeStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/QuantileTreeStateSerializer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+
+public class QuantileTreeStateSerializer
+        implements AccumulatorStateSerializer<QuantileTreeState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(QuantileTreeState state, BlockBuilder out)
+    {
+        if (state.getQuantileTree() == null) {
+            out.appendNull();
+        }
+        else {
+            Slice treeSlice = state.getQuantileTree().serialize();
+            int sizeInBytes = 2 * SIZE_OF_DOUBLE + // epsilon, delta
+                    SIZE_OF_INT + // probability array size
+                    state.getProbabilities().size() * SIZE_OF_DOUBLE + // probabilities
+                    treeSlice.length();
+            DynamicSliceOutput output = new DynamicSliceOutput(sizeInBytes);
+            output.appendDouble(state.getEpsilon());
+            output.appendDouble(state.getDelta());
+
+            // write probabilities
+            List<Double> probabilities = state.getProbabilities();
+            output.appendInt(probabilities.size());
+            for (Double probability : probabilities) {
+                output.appendDouble(probability);
+            }
+
+            output.appendBytes(treeSlice);
+            VARBINARY.writeSlice(out, output.slice());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, QuantileTreeState state)
+    {
+        Slice stateSlice = VARBINARY.getSlice(block, index);
+        BasicSliceInput input = stateSlice.getInput();
+        state.setEpsilon(input.readDouble());
+        state.setDelta(input.readDouble());
+
+        // read probabilities
+        List<Double> probabilities = new ArrayList<>();
+        int numProbabilities = input.readInt();
+        for (int i = 0; i < numProbabilities; i++) {
+            probabilities.add(input.readDouble());
+        }
+        state.setProbabilities(probabilities);
+        Slice treeSlice = input.slice();
+        state.setQuantileTree(QuantileTree.deserialize(treeSlice));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/RandomizationStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/RandomizationStrategy.java
@@ -20,5 +20,9 @@ public abstract class RandomizationStrategy
         return nextDouble() <= probability;
     }
 
-    abstract double nextDouble();
+    public abstract double nextDouble();
+
+    public abstract double nextGaussian();
+
+    public abstract int nextInt(int max);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/SecureRandomizationStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/SecureRandomizationStrategy.java
@@ -37,4 +37,14 @@ public class SecureRandomizationStrategy
     {
         return random.nextDouble();
     }
+
+    public double nextGaussian()
+    {
+        return random.nextGaussian();
+    }
+
+    public int nextInt(int max)
+    {
+        return random.nextInt(max);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/ThreadLocalRandomizationStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/ThreadLocalRandomizationStrategy.java
@@ -28,4 +28,16 @@ public class ThreadLocalRandomizationStrategy
     {
         return ThreadLocalRandom.current().nextDouble();
     }
+
+    @Override
+    public double nextGaussian()
+    {
+        return ThreadLocalRandom.current().nextGaussian();
+    }
+
+    @Override
+    public int nextInt(int max)
+    {
+        return ThreadLocalRandom.current().nextInt(max);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/CountSketch.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/CountSketch.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Murmur3Hash128;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+
+/**
+ * An approximate multiset structure, allowing for compact approximation of counts of longs
+ */
+public class CountSketch
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(CountSketch.class).instanceSize();
+    private static final long PRIME_FIELD_SIZE = (1L << 31) - 1;
+
+    private final int depth;
+    private final int width;
+
+    private final float[][] table;
+
+    /**
+     * Create a new CountSketch with fixed dimensions
+     */
+    public CountSketch(int depth, int width)
+    {
+        if (depth <= 0 || width <= 0) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "sketch dimensions (depth and width) must be positive");
+        }
+
+        this.width = width;
+        this.depth = depth;
+        this.table = new float[depth][width];
+    }
+
+    /**
+     * Deserialize an existing CountSketch
+     */
+    public CountSketch(SliceInput s)
+    {
+        depth = s.readInt();
+        width = s.readInt();
+        table = new float[depth][width];
+        for (int i = 0; i < depth; ++i) {
+            for (int j = 0; j < width; ++j) {
+                table[i][j] = s.readFloat();
+            }
+        }
+    }
+
+    /**
+     * Adds noise to the counters (table) to enable privacy
+     * @param rho zCDP privacy budget
+     * @param insertionCount number of items potentially inserted into the sketch between neighbors
+     */
+    public void addNoise(double rho, int insertionCount, RandomizationStrategy randomizationStrategy)
+    {
+        if (rho <= 0) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "rho must be greater than zero");
+        }
+
+        // Assuming unbounded neighbors, the squared L2 sensitivity is depth * insertionCount^2,
+        // as (without loss of generality) the worst-case object adds +1 to exactly D = depth
+        // buckets I = insertionCount times, yielding a difference between neighbors of:
+        // I, 0, 0, 0...
+        // I, 0, 0, 0...
+        // ...
+        // (repeated D times)
+        //
+        // To achieve rho-zCDP, we add noise with variance depth * insertionCount^2 / (2 * rho),
+        // i.e., with standard deviation insertionCount * sqrt(0.5 * depth / rho).
+        for (int i = 0; i < depth; i++) {
+            for (int j = 0; j < width; j++) {
+                table[i][j] += randomizationStrategy.nextGaussian() * insertionCount * Math.sqrt(0.5 * depth / rho);
+            }
+        }
+    }
+
+    public int getDepth()
+    {
+        return depth;
+    }
+
+    public int getWidth()
+    {
+        return width;
+    }
+
+    public void add(long item, float count)
+    {
+        long baseHash = getBaseHash(item);
+        for (int i = 0; i < depth; ++i) {
+            long iteratedHash = getIteratedHash(baseHash, i);
+            table[i][getBucket(iteratedHash)] += count * getSign(iteratedHash);
+        }
+    }
+
+    public void add(long item)
+    {
+        add(item, 1);
+    }
+
+    public long estimateCount(long item)
+    {
+        long baseHash = getBaseHash(item);
+        float[] values = new float[depth];
+        for (int i = 0; i < depth; ++i) {
+            long iteratedHash = getIteratedHash(baseHash, i);
+            values[i] = getSign(iteratedHash) * table[i][getBucket(iteratedHash)];
+        }
+        Arrays.sort(values);
+        int mid = Math.floorDiv(depth, 2);
+        return Math.round(values[mid]);
+    }
+
+    /**
+     * A 64-bit hash used to derive further hashes (see getIteratedHash)
+     */
+    @VisibleForTesting
+    static long getBaseHash(long item)
+    {
+        return Murmur3Hash128.hash64(item);
+    }
+
+    /**
+     * Following the style of Kirsch and Mitzenmacher's "Less Hashing, Same Performance"
+     * (https://www.eecs.harvard.edu/~michaelm/postscripts/rsa2008.pdf),
+     * we compute multiple hashes for the sketch by mutating two base sketches, h1 and h2,
+     * which we take to be the two halves of a 64-bit base sketch.
+     * @returns a new hash derived from baseHash over the field of size 2 * width
+     */
+    @VisibleForTesting
+    long getIteratedHash(long baseHash, int i)
+    {
+        // Partition baseHash into left and right halves
+        long h1 = baseHash >> 32;
+        long h2 = baseHash & Integer.MAX_VALUE;
+
+        // Derive a new hash over a prime field
+        long primeHash = Math.abs(h1 + i * h2) % PRIME_FIELD_SIZE;
+
+        // Return a hash in the field of size 2 * width
+        return primeHash % (2 * width);
+    }
+
+    /**
+     * Calculate the bucket index from an iterated hash.
+     * Since the iteratedHash is modulo 2 * width, we can drop the least significant bit (used for sign) to
+     * obtain a bucket index modulo width.
+     */
+    @VisibleForTesting
+    static int getBucket(long iteratedHash)
+    {
+        return (int) (iteratedHash >> 1);
+    }
+
+    /**
+     * Calculate the sign from an iterated hash. We use the least significant bit to determine sign, and leave
+     * the rest of the hash to calculate bucket.
+     */
+    @VisibleForTesting
+    static int getSign(long iteratedHash)
+    {
+        long sign = iteratedHash & 1L;
+        return sign == 1 ? 1 : -1;
+    }
+
+    public CountSketch merge(CountSketch... otherSketches)
+            throws IllegalArgumentException
+    {
+        for (CountSketch other : otherSketches) {
+            if (other.depth != depth || other.width != width) {
+                throw new IllegalArgumentException("Cannot merge CountSketch of different shapes (depth, width):" +
+                        "(" + depth + "," + width + ") vs. (" + other.depth + "," + other.width + ")");
+            }
+
+            for (int i = 0; i < table.length; i++) {
+                for (int j = 0; j < table[i].length; j++) {
+                    table[i][j] += other.table[i][j];
+                }
+            }
+        }
+
+        return this;
+    }
+
+    public int estimatedSerializedSizeInBytes()
+    {
+        return 2 * SIZE_OF_INT +    //depth, width
+                depth * width * SIZE_OF_FLOAT; // float[][] table
+    }
+
+    public Slice serialize()
+    {
+        int requiredBytes = estimatedSerializedSizeInBytes();
+
+        SliceOutput s = new DynamicSliceOutput(requiredBytes);
+        s.writeInt(depth);
+        s.writeInt(width);
+        for (int i = 0; i < depth; ++i) {
+            for (int j = 0; j < width; ++j) {
+                s.writeFloat(table[i][j]);
+            }
+        }
+        return s.slice();
+    }
+
+    public long estimatedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                SizeOf.sizeOf(table) + depth * SizeOf.sizeOfFloatArray(width); // float[depth][width] table
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/HistogramLevel.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/HistogramLevel.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+
+public class HistogramLevel
+        implements QuantileTreeLevel
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(HistogramLevel.class).instanceSize();
+    private final float[] bins;
+
+    public HistogramLevel(int length)
+    {
+        this.bins = new float[length];
+    }
+
+    public HistogramLevel(SliceInput s)
+    {
+        int size = s.readInt();
+        this.bins = new float[size];
+
+        for (int i = 0; i < size; i++) {
+            bins[i] = s.readFloat();
+        }
+    }
+
+    public QuantileTreeLevelFormat getFormat()
+    {
+        return QuantileTreeLevelFormat.HISTOGRAM;
+    }
+
+    public void merge(QuantileTreeLevel other)
+    {
+        checkArgument(getFormat() == other.getFormat(), "Cannot merge levels of different format");
+        HistogramLevel otherHistogram = (HistogramLevel) other;
+        checkArgument(bins.length == otherHistogram.bins.length, "Cannot merge histogramLevel with different size");
+        for (int i = 0; i < bins.length; i++) {
+            bins[i] += otherHistogram.bins[i];
+        }
+    }
+
+    public void add(long item)
+    {
+        bins[itemIndex(item)] += 1;
+    }
+
+    public float query(long item)
+    {
+        return bins[itemIndex(item)];
+    }
+
+    public void addNoise(double rho, RandomizationStrategy randomizationStrategy)
+    {
+        checkArgument(rho > 0, "rho must be positive");
+
+        // Under unbounded-neighbors semantics (add/remove), we have a squared L2 sensitivity of 1.
+        // To achieve rho-zCDP, we add Gaussian noise with:
+        // variance = 1 / (2 * rho), i.e., standard deviation = sqrt(0.5 / rho)
+        for (int i = 0; i < bins.length; i++) {
+            bins[i] += randomizationStrategy.nextGaussian() * Math.sqrt(0.5 / rho);
+        }
+    }
+
+    private static int itemIndex(long item)
+    {
+        checkArgument(item <= Integer.MAX_VALUE, "Cannot insert items greater than Integer.MAX_VALUE");
+        return (int) item;
+    }
+
+    public int size()
+    {
+        return bins.length;
+    }
+
+    public int estimatedSerializedSizeInBytes()
+    {
+        return SIZE_OF_INT + bins.length * SIZE_OF_FLOAT;
+    }
+
+    public Slice serialize()
+    {
+        int requiredBytes = estimatedSerializedSizeInBytes();
+
+        SliceOutput s = new DynamicSliceOutput(requiredBytes);
+        s.writeInt(bins.length);
+        for (float bin : bins) {
+            s.writeFloat(bin);
+        }
+
+        return s.slice();
+    }
+
+    public long estimatedSizeInBytes()
+    {
+        return INSTANCE_SIZE + SizeOf.sizeOf(bins);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/QuantileTree.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/QuantileTree.java
@@ -1,0 +1,379 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+
+/**
+ * The QuantileTree represents a hierarchical histogram over the floating-point range [rangeLowerBound, rangeUpperBound].
+ * This hierarchy is represented with a tree structure. The bottom level of the tree holds the canonical histogram bins.
+ * Each level up in the hierarchy, a node reflects the sum of its descendants.
+ * This seemingly redundant structure is a common structure used to handle range queries under differential privacy.
+ * See <a href="https://fb.workplace.com/notes/147894314581680">this Workplace note</a> for background.
+ * <p>
+ * To save space, some histogram levels may be stored verbatim, while others may be sketched using the PrivateCountMedianSketch.
+ * Privacy is obtained by adding Gaussian noise to the nodes of the tree (or their sketched values), and privacy is parameterized
+ * by rho, according to zero-concentrated DP. The privacy guarantee holds under unbounded-neighbors (add/remove) semantics,
+ * for multisets differing by one item.
+ */
+public class QuantileTree
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(QuantileTree.class).instanceSize();
+    private static final int MIN_BRANCHING_FACTOR = 2;
+    public static final double NON_PRIVATE_RHO = Double.POSITIVE_INFINITY;
+    private final double rangeLowerBound;
+    private final double rangeUpperBound;
+    private final int binCount;
+    private final int branchingFactor;
+    private final QuantileTreeLevel[] levels;
+    private double rho = NON_PRIVATE_RHO;
+
+    public QuantileTree(double rangeLowerBound, double rangeUpperBound, int binCount, int branchingFactor, int sketchDepth, int sketchWidth)
+    {
+        checkArgument(rangeLowerBound < rangeUpperBound, "rangeLowerBound must be less than rangeUpperBound");
+        checkArgument(binCount >= MIN_BRANCHING_FACTOR, "bin count must be at least %s", MIN_BRANCHING_FACTOR);
+        checkArgument(branchingFactor >= MIN_BRANCHING_FACTOR && branchingFactor <= binCount,
+                "branching factor must be between %s and %s", MIN_BRANCHING_FACTOR, binCount);
+        checkArgument(sketchDepth > 0 && sketchWidth > 0, "sketchDepth and sketchWidth must be positive");
+
+        this.rangeLowerBound = rangeLowerBound;
+        this.rangeUpperBound = rangeUpperBound;
+        this.branchingFactor = branchingFactor;
+
+        // Build the tree!
+        // We force the tree to be a complete tree, stopping when the bin count is at least the requested binCount.
+        // (In other words, the actual bin count will be rounded up the next power of branchingFactor.)
+        // Each level of the tree will be represented by an exact histogram if the histogram is smaller than the
+        // requested sketch dimensions. Otherwise, we represent the level with a SketchedLevel (CountSketch).
+        int actualBinCount = 1; // The first level is the root node.
+        int totalLevels = 1;
+        while (actualBinCount < binCount) {
+            actualBinCount *= this.branchingFactor;
+            totalLevels++;
+        }
+        this.binCount = actualBinCount;
+
+        levels = new QuantileTreeLevel[totalLevels];
+        long hypotheticalSketchSize = sketchDepth * sketchWidth;
+        int binCountAtCurrentLevel = 1;
+        for (int i = 0; i < totalLevels; i++) {
+            // add the smaller of the two options: a HistogramLevel or a SketchedLevel
+            if (binCountAtCurrentLevel <= hypotheticalSketchSize) {
+                levels[i] = new HistogramLevel(binCountAtCurrentLevel);
+            }
+            else {
+                levels[i] = new SketchedLevel(sketchDepth, sketchWidth);
+            }
+            binCountAtCurrentLevel *= this.branchingFactor;
+        }
+    }
+
+    public QuantileTree(double rangeLowerBound, double rangeUpperBound, int binCount, int branchingFactor, double rho, QuantileTreeLevel[] levels)
+    {
+        checkArgument(rangeLowerBound < rangeUpperBound, "rangeLowerBound must be less than rangeUpperBound");
+        checkArgument(branchingFactor >= MIN_BRANCHING_FACTOR && branchingFactor <= binCount,
+                "branching factor must be between %s and %s", MIN_BRANCHING_FACTOR, binCount);
+        checkArgument(rho > 0, "rho must be positive");
+        checkArgument(levels.length > 0, "levels can not be empty");
+
+        this.rangeLowerBound = rangeLowerBound;
+        this.rangeUpperBound = rangeUpperBound;
+        this.binCount = binCount;
+        this.branchingFactor = branchingFactor;
+        this.rho = rho;
+
+        int totalLevels = levels.length;
+        this.levels = new QuantileTreeLevel[totalLevels];
+        System.arraycopy(levels, 0, this.levels, 0, totalLevels);
+    }
+
+    public static QuantileTree deserialize(Slice serialized)
+    {
+        SliceInput s = new BasicSliceInput(serialized);
+        double rangeLowerBound = s.readDouble();
+        double rangeUpperBound = s.readDouble();
+        double rho = s.readDouble();
+        int binCount = s.readInt();
+        int branchingFactor = s.readInt();
+        int totalLevels = s.readByte();
+        QuantileTreeLevel[] levels = new QuantileTreeLevel[totalLevels];
+
+        // deserialize tree levels
+        for (int i = 0; i < totalLevels; i++) {
+            int levelFormat = s.readByte();
+
+            if (levelFormat == QuantileTreeLevelFormat.SKETCHED.getTag()) {
+                levels[i] = new SketchedLevel(s);
+            }
+            else if (levelFormat == QuantileTreeLevelFormat.HISTOGRAM.getTag()) {
+                levels[i] = new HistogramLevel(s);
+            }
+        }
+
+        return new QuantileTree(rangeLowerBound, rangeUpperBound, binCount, branchingFactor, rho, levels);
+    }
+
+    public void merge(QuantileTree other)
+    {
+        checkArgument(rangeLowerBound == other.rangeLowerBound && rangeUpperBound == other.rangeUpperBound,
+                "Cannot merge quantiletree due to range mismatch");
+        checkArgument(binCount == other.binCount,
+                "Cannot merge quantiletree due to bin count mismatch");
+        checkArgument(totalLevels() == other.totalLevels(), "Cannot merge quantiletree with different level structure");
+
+        rho = mergedRho(rho, other.rho);
+        for (int i = 0; i < levels.length; i++) {
+            levels[i].merge(other.levels[i]);
+        }
+    }
+
+    /**
+     * The effective value of rho after merging two trees.
+     * Note: this captures the noise level of the trees, not the privacy leakage.
+     * In other words, the level of noise in the merged tree is the same as if everything
+     * had been inserted into one tree with mergedRho(rho1, rho2).
+     * <p>
+     * Every counter in the quantiletree (whether a histogram bin or a sketched counter)
+     * is given noise with variance proportional to 1 / rho. When merging trees, we sum
+     * these counters, so the variances add. This gives an effective "merged rho" of
+     * 1 / (1 / rho_1 + 1 / rho_2).
+     */
+    @VisibleForTesting
+    static double mergedRho(double rho1, double rho2)
+    {
+        // Merging with a non-private tree? Take the other tree's rho value, as we're not adding any noise.
+        if (rho1 == NON_PRIVATE_RHO) {
+            return rho2;
+        }
+        if (rho2 == NON_PRIVATE_RHO) {
+            return rho1;
+        }
+
+        // Merging two noisy trees returns something noisier.
+        // This calculation comes from the addition of variances that are inversely proportional to rho1, rho2.
+        return 1 / (1 / rho1 + 1 / rho2);
+    }
+
+    public Slice serialize()
+    {
+        SliceOutput res = new DynamicSliceOutput(estimatedSerializedSizeInBytes());
+        res.appendDouble(this.rangeLowerBound); // 8
+        res.appendDouble(this.rangeUpperBound); // 8
+        res.appendDouble(this.rho); // 8
+        res.appendInt(this.binCount); // 4
+        res.appendInt(this.branchingFactor); // 4
+        res.appendByte(this.totalLevels()); // 1
+
+        for (QuantileTreeLevel level : levels) {
+            res.appendByte(level.getFormat().getTag());
+            res.appendBytes(level.serialize());
+        }
+
+        return res.slice();
+    }
+
+    public int getBranchingFactor()
+    {
+        return branchingFactor;
+    }
+
+    /**
+     * The QuantileTree represents a hierarchical histogram over the range [rangeLowerBound, rangeUpperBound].
+     * At the bottom level of the tree, each bin is equally sized over this range.
+     * This function returns those bottom-level bin widths.
+     * (Higher levels simply reflect the unions of these bottom-level bins.)
+     */
+    @VisibleForTesting
+    double getBinWidth()
+    {
+        return (rangeUpperBound - rangeLowerBound) / binCount;
+    }
+
+    /**
+     * Assigns a given value to one of the bins of the (hierarchical) histogram.
+     * Specifically, this maps double values from the range [rangeLowerBound, rangeUpperBound]
+     * to the discrete set { 0, 1, 2, ... binCount - 1 }.
+     */
+    @VisibleForTesting
+    long toBin(double x)
+    {
+        long y = (long) Math.floor((x - rangeLowerBound) / getBinWidth());
+        return Math.max(0, Math.min(binCount - 1, y));
+    }
+
+    /**
+     * Maps values from discrete bins back to the original data range.
+     * Due to discretization, we don't know where in a bin a given value falls.
+     * We assume the midpoint of each bin.
+     */
+    @VisibleForTesting
+    double fromBin(long y)
+    {
+        return rangeLowerBound + (y + 0.5) * getBinWidth();
+    }
+
+    public void add(double value)
+    {
+        long item = toBin(value);
+        for (int i = totalLevels() - 1; i >= 0; i--) {
+            levels[i].add(item);
+            item = Math.floorDiv(item, Long.valueOf(branchingFactor));
+        }
+    }
+
+    /**
+     * Returns the (approximate) number of items in the QuantileTree
+     */
+    public double cardinality()
+    {
+        return new QuantileTreeSearch(this).cardinality();
+    }
+
+    /**
+     * Find a value that corresponds to the p-th quantile
+     * Uses a tree-traversal search algorithm with some inverse-variance weighting
+     * for fast but not quite optimal estimation.
+     */
+    public double quantile(double p)
+    {
+        checkArgument(p >= 0 && p <= 1, "cumulative probability (p) must be between 0 and 1");
+        long bin = new QuantileTreeSearch(this).findQuantile(p);
+        return fromBin(bin);
+    }
+
+    public boolean isPrivacyEnabled()
+    {
+        return rho < NON_PRIVATE_RHO;
+    }
+
+    /**
+     * Adds noise to the sketch to bring rho to the requested level
+     */
+    public void enablePrivacy(double targetRho, RandomizationStrategy randomizationStrategy)
+    {
+        // find the amount of noise needed to bring rho up to targetRho
+        double rhoToAdd = findRho2(getRho(), targetRho);
+
+        if (rhoToAdd == NON_PRIVATE_RHO) {
+            // no additional noise needed
+            return;
+        }
+
+        // divide rhoToAdd over the levels of the sketch
+        for (QuantileTreeLevel level : levels) {
+            level.addNoise(rhoToAdd / levels.length, randomizationStrategy);
+        }
+
+        this.rho = targetRho;
+    }
+
+    /**
+     * Noise is added to every counter in the sketch with variance proportional to 1 / rho.
+     * To raise the noise level, we re-add noise. Since the variance adds, the amount of noise
+     * to add can be determined using the same math as in mergedRho(rho1, rho2). In this case,
+     * however, we know rho1 and the final noise level (mergedRho), and we're solving for rho2.
+     */
+    @VisibleForTesting
+    static double findRho2(double rho1, double targetRho)
+    {
+        checkArgument(rho1 >= targetRho, "existing rho is stricter than targetRho: %s < %s", rho1, targetRho);
+        checkArgument(targetRho > 0, "targetRho must be positive");
+
+        if (rho1 == NON_PRIVATE_RHO) {
+            // if there is no noise in the existing sketch, just use the requested rho
+            // (this includes the case when targetRho == NON_PRIVATE_RHO)
+            return targetRho;
+        }
+        else {
+            // targetRho = 1 / (1 / rho1 + 1 / rho2) -- see mergedRho(rho1, rho2)
+            double rho2 = 1 / (1 / targetRho - 1 / rho1);
+            return Math.max(0, rho2);
+        }
+    }
+
+    /**
+     * Returns a given tree level, indexed from the top of the tree.
+     * Note: this "tree" has no root node, so the 0-th level will have two nodes, 1-st will have four, and so on.
+     * This is in contrast with the QuantileTreeSearch class, which considers a virtual root node and indexes levels
+     * starting with 0 for the (nonexistent) root node.
+     */
+    public QuantileTreeLevel getLevel(int index)
+    {
+        return this.levels[index];
+    }
+
+    public int totalLevels()
+    {
+        return levels.length;
+    }
+
+    public double getRho()
+    {
+        return this.rho;
+    }
+
+    /**
+     * A mechanism satisfying rho-zCDP satisfies (rho + 2 sqrt(rho*log(1/delta)), delta)-DP for any delta > 0,
+     * per <a href="https://arxiv.org/pdf/1605.02065.pdf">Bun and Steinke</a>.
+     * <p>
+     * Thus to satisfy (epsilon, delta)-DP for our choice of epsilon and delta, we obtain:
+     * <p>
+     * rho = epsilon - 2 * log(delta) - 2 * sqrt(log^2(delta) - epsilon * log(delta))
+     */
+    public static double getRhoForEpsilonDelta(double epsilon, double delta)
+    {
+        checkArgument(epsilon > 0, "epsilon must be positive");
+        checkArgument(delta > 0, "delta must be positive");
+
+        // An epsilon of infinity or a delta >= 1 indicates no privacy guarantee at all.
+        if (epsilon == Double.POSITIVE_INFINITY || delta >= 1) {
+            return NON_PRIVATE_RHO;
+        }
+
+        return epsilon - 2 * Math.log(delta) - 2 * Math.sqrt(Math.pow(Math.log(delta), 2) - epsilon * Math.log(delta));
+    }
+
+    public int estimatedSerializedSizeInBytes()
+    {
+        int size = 3 * SIZE_OF_DOUBLE + 2 * SIZE_OF_INT + SIZE_OF_BYTE; // lower, upper, rho, binCount, branchingFactor, totalLevels
+        for (QuantileTreeLevel level : levels) {
+            size += SIZE_OF_BYTE; // format tag of level
+            size += level.estimatedSerializedSizeInBytes(); // level serialization
+        }
+        return size;
+    }
+
+    // optimize the loop calculation: TODO T139787526
+    public long estimatedSizeInBytes()
+    {
+        long treeLevelsSize = 0;
+        for (QuantileTreeLevel level : levels) {
+            treeLevelsSize += level.estimatedSizeInBytes();
+        }
+        return INSTANCE_SIZE + SizeOf.sizeOf(levels) + treeLevelsSize;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/QuantileTreeLevel.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/QuantileTreeLevel.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import io.airlift.slice.Slice;
+
+public interface QuantileTreeLevel
+{
+    void add(long item);
+
+    void addNoise(double rho, RandomizationStrategy randomizationStrategy);
+
+    QuantileTreeLevelFormat getFormat();
+
+    float query(long item);
+
+    int size();
+
+    void merge(QuantileTreeLevel other);
+
+    int estimatedSerializedSizeInBytes();
+
+    long estimatedSizeInBytes();
+
+    Slice serialize();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/QuantileTreeLevelFormat.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/QuantileTreeLevelFormat.java
@@ -11,30 +11,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.operator.aggregation.noisyaggregation.sketch;
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
 
-/**
- * Non-random numbers for testing
- */
-public class TestingDeterministicRandomizationStrategy
-        extends RandomizationStrategy
+public enum QuantileTreeLevelFormat
 {
-    public TestingDeterministicRandomizationStrategy() {}
+    HISTOGRAM(0),
+    SKETCHED(1),
+    OFFSET(2);
 
-    public double nextDouble()
+    private final byte tag;
+
+    QuantileTreeLevelFormat(int tag)
     {
-        return 0.5;
+        this.tag = (byte) tag;
     }
 
-    @Override
-    public double nextGaussian()
+    public byte getTag()
     {
-        return 0.5;
-    }
-
-    @Override
-    public int nextInt(int max)
-    {
-        return 1;
+        return tag;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/QuantileTreeSearch.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/QuantileTreeSearch.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.math.IntMath;
+
+import java.util.Arrays;
+
+/**
+ * A class used for traversing and querying QuantileTrees, including denoising and quantile estimation
+ */
+public class QuantileTreeSearch
+{
+    /**
+     * Largest number of leaf nodes of subtree to traverse to denoise any single node's value
+     */
+    private static final int MAX_DENOISING_LEAVES = 64;
+
+    private final QuantileTree tree;
+    private final int maxDenoisingTraversalDepth;
+
+    public QuantileTreeSearch(QuantileTree tree)
+    {
+        this.tree = tree;
+        maxDenoisingTraversalDepth = findMaxTraversalDepth(tree.getBranchingFactor());
+    }
+
+    @VisibleForTesting
+    static int findMaxTraversalDepth(int branchingFactor)
+    {
+        int depth = 1;
+        int nodes = branchingFactor;
+        while (nodes <= MAX_DENOISING_LEAVES) {
+            depth++;
+            nodes *= branchingFactor;
+        }
+        return depth - 1;
+    }
+
+    /**
+     * Returns an estimate of the total number of items in the tree, using the denoised root node value
+     */
+    public double cardinality()
+    {
+        return query(rootNode());
+    }
+
+    @VisibleForTesting
+    int getBranchingFactor()
+    {
+        return tree.getBranchingFactor();
+    }
+
+    /**
+     * Return the raw estimate from the node (no denoising)
+     */
+    @VisibleForTesting
+    double queryDirect(NodeAddress node)
+    {
+        return tree.getLevel(node.level()).query(node.position());
+    }
+
+    /**
+     * Estimate node value, traversing through some descendants to apply inverse-variance weighting.
+     * The inverse-variance weighting is performed as described in "Understanding Hierarchical
+     * Methods for Differentially Private Histograms" by Qardaji et al.
+     * (https://www.vldb.org/pvldb/vol6/p1954-qardaji.pdf).
+     * @return a pair of floats: estimate and relative variance
+     */
+    @VisibleForTesting
+    double[] queryDown(NodeAddress node, int depth)
+    {
+        double localEst = queryDirect(node);
+
+        // Return the node value with a relative variance of 1 if depth == 0 or if we're on the bottom level.
+        if (depth == 0 || node.isLeaf()) {
+            return new double[] {localEst, 1};
+        }
+
+        // Else return a weighted average of the node value and the estimates derived from its children.
+        double estimateSum = 0;
+        double childVariance = 0;
+        for (NodeAddress child : node.children()) {
+            double[] est = queryDown(child, depth - 1);
+            estimateSum += est[0];
+            childVariance = est[1];
+        }
+        double variance = tree.getBranchingFactor() * childVariance / (tree.getBranchingFactor() * childVariance + 1);
+        double weight = 1 / (tree.getBranchingFactor() * childVariance);
+        double estimate = (localEst + weight * estimateSum) / (1 + weight);
+        return new double[] {estimate, variance};
+    }
+
+    /**
+     * Return a denoised estimate of the node value based on the node and some of its descendants
+     */
+    @VisibleForTesting
+    double query(NodeAddress node)
+    {
+        return queryDown(node, maxDenoisingTraversalDepth)[0];
+    }
+
+    /**
+     * Traverse the tree to find the leaf node corresponding to the p-th quantile
+     * @return Canonical bin corresponding to the p-th quantile
+     */
+    public long findQuantile(double p)
+    {
+        // Start at root, where the left bound is the p=0-th quantile,
+        // and the right bound is the p=1-th (100%-th) quantile.
+        NodeAddress node = rootNode();
+        double left = 0;
+        double right = 1;
+        double nodeCount = cardinality();
+
+        while (!node.isLeaf()) {
+            NodeAddress[] children = node.children();
+            double[] splits = findSplits(children, left, right, nodeCount);
+
+            boolean foundSplit = false;
+            for (int j = 0; j < splits.length; j++) {
+                // find first split for which p < split, traverse down that node
+                if (p < splits[j]) {
+                    node = children[j];
+                    if (j > 0) {
+                        left = splits[j - 1];
+                    }
+                    right = splits[j];
+                    foundSplit = true;
+                    break;
+                }
+            }
+
+            // if no split is < p, take the right-most child
+            if (!foundSplit) {
+                node = children[children.length - 1];
+                left = splits[splits.length - 1];
+            }
+        }
+
+        return node.position();
+    }
+
+    /**
+     * Given a set of nodes representing an interval of cumulative frequencies
+     * from leftBound to rightBound, find the values that separate the child nodes.
+     * In other words, picturing the interval [leftBound, rightBound] on a number line,
+     * find the points that separate the subintervals corresponding to each node.
+     * Note: Because nodes have noisy values, the results returned here could be non-monotonic.
+     */
+    private double[] findSplits(NodeAddress[] children, double leftBound, double rightBound, double totalCardinality)
+    {
+        // Finding the splits boils down to finding the cumulative sum over the nodes.
+        // In other words, we have to answer (nodes.length - 1) range queries, finding
+        // the sum from the start to each node. Because nodes are noisy, there
+        // are several approaches to doing this, differing most notably in their variance
+        // and potential bias. The approach taken here is that of "mean consistency" as described
+        // in "Understanding Hierarchical Methods for Differentially Private Histograms" by
+        // Qardaji et al. (https://www.vldb.org/pvldb/vol6/p1954-qardaji.pdf).
+        // Essentially, we add up the values of the children, and compare that sum to the parent.
+        // (Since we're working with subsets of the unit interval here, we'll be doing all these
+        // calculations normalized relative to totalCardinality.)
+        // We divide the difference equally over the children so that in place of each child node's
+        // value, we use a modified value that incorporates a share of this difference.
+
+        // Store normalized but unadjusted child values in childValues.
+        // At the end of the for loop, residual will equal the (normalized) difference between parent and child-sum.
+        double[] childValues = new double[children.length];
+        double residual = rightBound - leftBound;
+        for (int i = 0; i < children.length; i++) {
+            childValues[i] = query(children[i]) / totalCardinality;
+            residual -= childValues[i];
+        }
+
+        // Find the points that separate the subintervals
+        // split[i] is the point separating the i-th child branch from the (i+1)-th child branch
+        double[] splits = new double[children.length - 1];
+
+        // To calculate split[i], we can either:
+        // - add the adjusted childValues from 0 through i to leftBound
+        // - subtract the adjusted childValues from i+i through (end) from rightBound
+        // The way that produces the least noisy estimates is to go from the left when we're closer to the left
+        // or from the right when we're closer to the right.
+        // Starting from the left, we'll calculate splits 0 through floor(children.length / 2) - 1
+        // Letting C = children.length, w = rightBound - leftBound,
+        // the formula for these is:
+        // leftBound + sum(childValues[0:i]) + (i+1)/C * residual
+        double leftSum = 0;
+        for (int i = 0; i < Math.floorDiv(children.length, 2); i++) {
+            leftSum += childValues[i];
+            double fraction = (i + 1.0) / children.length;
+            splits[i] = leftBound + leftSum + fraction * residual;
+        }
+
+        // We're left to calculate the remaining splits from the right.
+        // We'll iterate from children.length - 1 through floor(children.length / 2), and calculate
+        // rightBound - sum(childValues[i+1:]) + (1 - (i+1)/C) * residual
+        double rightSum = 0;
+        for (int i = children.length - 2; i >= Math.floorDiv(children.length, 2); i--) {
+            rightSum += childValues[i + 1];
+            double fraction = (i + 1.0) / children.length;
+            splits[i] = rightBound - rightSum + (1 - fraction) * residual;
+        }
+
+        return splits;
+    }
+
+    @VisibleForTesting
+    NodeAddress rootNode()
+    {
+        return new NodeAddress();
+    }
+
+    /**
+     * We reference any node in the tree by the index at each level. For example, in the following tree:
+     * <pre>
+     *             (0)
+     *         1         2
+     *       3   4     5   6
+     * </pre>
+     * node 4 can be addressed as (0, 1) (0-th child in first level, 1-th child in second level),
+     * node 5 can be address as (1, 0),
+     * and so on...
+     */
+    @VisibleForTesting
+    class NodeAddress
+    {
+        @VisibleForTesting
+        int[] indices;
+
+        public NodeAddress(int... indices)
+        {
+            this.indices = indices;
+        }
+
+        public NodeAddress[] children()
+        {
+            NodeAddress[] children = new NodeAddress[tree.getBranchingFactor()];
+            for (int i = 0; i < tree.getBranchingFactor(); i++) {
+                int[] child = Arrays.copyOf(indices, indices.length + 1);
+                child[indices.length] = i;
+                children[i] = new NodeAddress(child);
+            }
+            return children;
+        }
+
+        public boolean isLeaf()
+        {
+            return level() >= tree.totalLevels() - 1;
+        }
+
+        public int level()
+        {
+            return indices.length;
+        }
+
+        public int position()
+        {
+            int position = 0;
+            for (int i = 0; i < indices.length; i++) {
+                position += indices[indices.length - i - 1] * IntMath.pow(tree.getBranchingFactor(), i);
+            }
+            return position;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/SketchedLevel.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/SketchedLevel.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class SketchedLevel
+        implements QuantileTreeLevel
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(SketchedLevel.class).instanceSize();
+
+    private final CountSketch sketch;
+
+    public SketchedLevel(int depth, int width)
+    {
+        sketch = new CountSketch(depth, width);
+    }
+
+    public SketchedLevel(SliceInput s)
+    {
+        sketch = new CountSketch(s);
+    }
+
+    public QuantileTreeLevelFormat getFormat()
+    {
+        return QuantileTreeLevelFormat.SKETCHED;
+    }
+
+    public void merge(QuantileTreeLevel other)
+    {
+        checkArgument(getFormat() == other.getFormat(), "Cannot merge levels of different format");
+        CountSketch otherSketch = ((SketchedLevel) other).sketch;
+        sketch.merge(otherSketch);
+    }
+
+    public void add(long item)
+    {
+        sketch.add(item);
+    }
+
+    public void addNoise(double rho, RandomizationStrategy randomizationStrategy)
+    {
+        sketch.addNoise(rho, 1, randomizationStrategy);
+    }
+
+    public float query(long item)
+    {
+        return sketch.estimateCount(item);
+    }
+
+    @Override
+    public int size()
+    {
+        return sketch.getDepth() * sketch.getWidth();
+    }
+
+    public Slice serialize()
+    {
+        return sketch.serialize();
+    }
+
+    public int estimatedSerializedSizeInBytes()
+    {
+        return sketch.estimatedSerializedSizeInBytes();
+    }
+
+    public long estimatedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sketch.estimatedSizeInBytes();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/QuantileTreeScalarFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/QuantileTreeScalarFunctions.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.SecureRandomizationStrategy;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.type.QuantileTreeType;
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+
+public final class QuantileTreeScalarFunctions
+{
+    private QuantileTreeScalarFunctions() {}
+
+    @ScalarFunction(value = "cardinality")
+    @Description("Returns the approximate number of items in a QuantileTree sketch")
+    @SqlType(StandardTypes.BIGINT)
+    public static long cardinality(@SqlType(QuantileTreeType.NAME) Slice serializedSketch)
+    {
+        double cardinality = QuantileTree.deserialize(serializedSketch).cardinality();
+        return Math.max(0, Math.round(cardinality));
+    }
+
+    @ScalarFunction(value = "noisy_empty_qtree", deterministic = false)
+    @Description("Creates an empty QuantileTree sketch object")
+    @SqlType(QuantileTreeType.NAME)
+    public static Slice emptyQuantileTree(
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.DOUBLE) double delta,
+            @SqlType(StandardTypes.DOUBLE) double lower,
+            @SqlType(StandardTypes.DOUBLE) double upper)
+    {
+        return emptyQuantileTree(epsilon, delta, lower, upper, new SecureRandomizationStrategy());
+    }
+
+    /**
+     * For mocking purposes, expose a version of the emptyQuantileTree function that accepts a RandomizationStrategy
+     */
+    @VisibleForTesting
+    static Slice emptyQuantileTree(double epsilon, double delta, double lower, double upper, RandomizationStrategy randomizationStrategy)
+    {
+        QuantileTree tree = new QuantileTree(lower, upper,
+                QuantileTreeAggregationUtils.DEFAULT_BIN_COUNT,
+                QuantileTreeAggregationUtils.DEFAULT_BRANCHING_FACTOR,
+                QuantileTreeAggregationUtils.DEFAULT_SKETCH_WIDTH,
+                QuantileTreeAggregationUtils.DEFAULT_SKETCH_DEPTH);
+        tree.enablePrivacy(QuantileTree.getRhoForEpsilonDelta(epsilon, delta), randomizationStrategy);
+
+        return tree.serialize();
+    }
+
+    @ScalarFunction(value = "ensure_noise_qtree", deterministic = false)
+    @Description("Adds noise to a QuantileTree sketch to ensure a given level of noise")
+    @SqlType(QuantileTreeType.NAME)
+    public static Slice ensureNoise(
+            @SqlType(QuantileTreeType.NAME) Slice serializedSketch,
+            @SqlType(StandardTypes.DOUBLE) double epsilon,
+            @SqlType(StandardTypes.DOUBLE) double delta)
+    {
+        QuantileTree tree = QuantileTree.deserialize(serializedSketch);
+        tree.enablePrivacy(QuantileTree.getRhoForEpsilonDelta(epsilon, delta), new SecureRandomizationStrategy());
+        return tree.serialize();
+    }
+
+    @ScalarFunction(value = "value_at_quantile")
+    @Description("Returns the approximate value from the quantile tree corresponding to a cumulative probability between 0 and 1")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double valueAtQuantile(@SqlType(QuantileTreeType.NAME) Slice serializedSketch, @SqlType(StandardTypes.DOUBLE) double probability)
+    {
+        return QuantileTree.deserialize(serializedSketch).quantile(probability);
+    }
+
+    @ScalarFunction(value = "values_at_quantiles")
+    @Description("Returns the approximate values from the quantile tree corresponding to cumulative probabilities between 0 and 1")
+    @SqlType("array(double)")
+    public static Block valuesAtQuantiles(@SqlType(QuantileTreeType.NAME) Slice serializedSketch, @SqlType("array(double)") Block probabilityArrayBlock)
+    {
+        QuantileTree deserializedQuantileTree = QuantileTree.deserialize(serializedSketch);
+        BlockBuilder output = DOUBLE.createBlockBuilder(null, probabilityArrayBlock.getPositionCount());
+        for (int i = 0; i < probabilityArrayBlock.getPositionCount(); i++) {
+            double probability = DOUBLE.getDouble(probabilityArrayBlock, i);
+            DOUBLE.writeDouble(output, deserializedQuantileTree.quantile(probability));
+        }
+        return output.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/QuantileTreeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/QuantileTreeOperators.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlType;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.common.function.OperatorType.CAST;
+
+public final class QuantileTreeOperators
+{
+    private QuantileTreeOperators() {}
+
+    @ScalarOperator(CAST)
+    @SqlType(QuantileTreeType.NAME)
+    public static Slice castFromVarbinary(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return slice;
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice castToBinary(@SqlType(QuantileTreeType.NAME) Slice slice)
+    {
+        return slice;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/QuantileTreeType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/QuantileTreeType.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.common.type.AbstractVariableWidthType;
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+
+public class QuantileTreeType
+        extends AbstractVariableWidthType
+{
+    public static final QuantileTreeType QUANTILE_TREE_TYPE = new QuantileTreeType();
+    public static final String NAME = "QuantileTree";
+
+    @JsonCreator
+    public QuantileTreeType()
+    {
+        super(parseTypeSignature(NAME), Slice.class);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else {
+            block.writeBytesTo(position, 0, block.getSliceLength(position), blockBuilder);
+            blockBuilder.closeEntry();
+        }
+    }
+
+    @Override
+    public Slice getSlice(Block block, int position)
+    {
+        return block.getSlice(position, 0, block.getSliceLength(position));
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value)
+    {
+        writeSlice(blockBuilder, value, 0, value.length());
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        blockBuilder.writeBytes(value, offset, length).closeEntry();
+    }
+
+    @Override
+    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+
+        return new SqlVarbinary(block.getSlice(position, 0, block.getSliceLength(position)).getBytes());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/AbstractTestQuantileTreeAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/AbstractTestQuantileTreeAggregation.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.airlift.slice.Slices.wrappedBuffer;
+
+/**
+ * For tests of QuantileTree-related aggregators (noisy_approx_percentile_qtree, noisy_qtree_agg, merge)
+ */
+public abstract class AbstractTestQuantileTreeAggregation
+        extends AbstractTestFunctions
+{
+    protected static boolean quantileTreesMatch(Object input, Object refObj, double tolerance)
+    {
+        QuantileTree inputTree = parseQuantileTree(input);
+        QuantileTree refTree = parseQuantileTree(refObj);
+        for (double p : new double[] {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9}) {
+            if (Math.abs(inputTree.quantile(p) - refTree.quantile(p)) > tolerance) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected static BiFunction<Object, Object, Boolean> getQuantileComparator(double tolerance)
+    {
+        return (x, y) -> quantileTreesMatch(x, y, tolerance);
+    }
+
+    protected static QuantileTree parseQuantileTree(Object serialized)
+    {
+        return QuantileTree.deserialize(wrappedBuffer(((SqlVarbinary) serialized).getBytes()));
+    }
+
+    protected static Double[] generateNormal(int n, double mean, double standardDeviation, RandomizationStrategy randomizationStrategy)
+    {
+        Double[] values = new Double[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = mean + standardDeviation * randomizationStrategy.nextGaussian();
+        }
+        return values;
+    }
+
+    protected static Double[] generateSequence(int n)
+    {
+        Double[] values = new Double[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = (double) i;
+        }
+        return values;
+    }
+
+    protected JavaAggregationFunctionImplementation getFunction(String name, Type... type)
+    {
+        FunctionAndTypeManager functionAndTypeManager = functionAssertions.getMetadata().getFunctionAndTypeManager();
+        return functionAssertions.getMetadata().getFunctionAndTypeManager().getJavaAggregateFunctionImplementation(
+                functionAndTypeManager.lookupFunction(name, fromTypes(type)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestMergeQuantileTreeAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestMergeQuantileTreeAggregation.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.TestingSeededRandomizationStrategy;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.facebook.presto.type.QuantileTreeType;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BIN_COUNT;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BRANCHING_FACTOR;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_DEPTH;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_WIDTH;
+import static org.testng.Assert.assertThrows;
+
+public class TestMergeQuantileTreeAggregation
+        extends AbstractTestQuantileTreeAggregation
+{
+    @Test
+    public void testMergeOne()
+    {
+        JavaAggregationFunctionImplementation mergeAgg = getFunction("merge", QuantileTreeType.QUANTILE_TREE_TYPE);
+
+        int n = 1_000;
+        double mean = 100;
+        double standardDeviation = 10;
+        double rho = 0.5;
+        double lower = 50;
+        double upper = 150;
+        QuantileTree tree = generateNormalSketch(n, mean, standardDeviation, lower, upper, rho, new TestingSeededRandomizationStrategy(1));
+
+        assertAggregation(
+                mergeAgg,
+                getQuantileComparator(0), // quantiles should match exactly (merge is deterministic)
+                "quantiles of merged tree = quantiles of original tree (single tree)",
+                getPage(tree),
+                new SqlVarbinary(tree.serialize().getBytes()));
+    }
+
+    @Test
+    public void testMergeSeveral()
+    {
+        JavaAggregationFunctionImplementation mergeAgg = getFunction("merge", QuantileTreeType.QUANTILE_TREE_TYPE);
+
+        int numSketches = 20;
+        int nPerSketch = 1_000;
+        double mean = 0;
+        double standardDeviation = 1;
+        double rho = 0.5;
+        double lower = -10;
+        double upper = 10;
+
+        QuantileTree[] trees = new QuantileTree[numSketches];
+        for (int i = 0; i < numSketches; i++) {
+            trees[i] = generateNormalSketch(nPerSketch, mean, standardDeviation, lower, upper, rho, new TestingSeededRandomizationStrategy(i));
+        }
+
+        assertAggregation(
+                mergeAgg,
+                getQuantileComparator(0), // quantiles should match exactly (merge is deterministic)
+                "quantiles of merged tree = quantiles of manually merged tree",
+                getPage(trees),
+                buildMergedSketch(trees));
+    }
+
+    @Test
+    public void testMergeIncompatible()
+    {
+        JavaAggregationFunctionImplementation mergeAgg = getFunction("merge", QuantileTreeType.QUANTILE_TREE_TYPE);
+
+        QuantileTree[] trees = new QuantileTree[2];
+        // Note: These trees are incompatible because their bounds are different (0-123 vs. 123-456).
+        trees[0] = generateNormalSketch(100, 100, 10, 0, 123, 0.5, new TestingSeededRandomizationStrategy(1));
+        trees[1] = generateNormalSketch(100, 200, 10, 123, 456, 0.5, new TestingSeededRandomizationStrategy(2));
+
+        assertThrows(PrestoException.class, () -> {
+            assertAggregation(
+                    mergeAgg,
+                    getQuantileComparator(Double.POSITIVE_INFINITY), // doesn't matter
+                    null,
+                    getPage(trees),
+                    null);
+        });
+    }
+
+    private static QuantileTree generateNormalSketch(int n, double mean, double standardDeviation, double lower, double upper, double rho, RandomizationStrategy randomizationStrategy)
+    {
+        QuantileTree tree = new QuantileTree(lower, upper,
+                DEFAULT_BIN_COUNT, DEFAULT_BRANCHING_FACTOR, DEFAULT_SKETCH_DEPTH, DEFAULT_SKETCH_WIDTH);
+        for (double number : generateNormal(n, mean, standardDeviation, randomizationStrategy)) {
+            tree.add(number);
+        }
+        if (rho != QuantileTree.NON_PRIVATE_RHO) {
+            tree.enablePrivacy(rho, randomizationStrategy);
+        }
+        return tree;
+    }
+
+    private static Page getPage(QuantileTree... trees)
+    {
+        BlockBuilder builder = QuantileTreeType.QUANTILE_TREE_TYPE.createBlockBuilder(null, trees.length);
+        for (QuantileTree tree : trees) {
+            QuantileTreeType.QUANTILE_TREE_TYPE.writeSlice(builder, tree.serialize());
+        }
+        return new Page(builder.build());
+    }
+
+    private static SqlVarbinary buildMergedSketch(QuantileTree... trees)
+    {
+        if (trees.length == 0) {
+            return null;
+        }
+
+        QuantileTree merged = QuantileTree.deserialize(trees[0].serialize()); // roundabout clone
+        for (int i = 1; i < trees.length; i++) {
+            merged.merge(trees[i]);
+        }
+
+        return new SqlVarbinary(merged.serialize().getBytes());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyApproxPercentileQuantileTreeAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyApproxPercentileQuantileTreeAggregation.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.TestingSeededRandomizationStrategy;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import org.testng.annotations.Test;
+
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+
+public class TestNoisyApproxPercentileQuantileTreeAggregation
+        extends AbstractTestQuantileTreeAggregation
+{
+    @Test
+    public void testPrivateMedian()
+    {
+        JavaAggregationFunctionImplementation percentileAgg = getFunction("noisy_approx_percentile_qtree", DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double p = 0.5;
+        double epsilon = 5;
+        double delta = 1e-6;
+        double lower = 50;
+        double upper = 150;
+
+        assertAggregation(
+                percentileAgg,
+                getComparator(15), // since this test is random, we allow 15 standard deviations in error
+                "private median is within 15 SD of expectation",
+                getPage(numbers, p, epsilon, delta, lower, upper),
+                100.0);
+    }
+
+    @Test
+    public void testNonPrivateMedian()
+    {
+        JavaAggregationFunctionImplementation percentileAgg = getFunction("noisy_approx_percentile_qtree", DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double p = 0.5;
+        double epsilon = Double.POSITIVE_INFINITY;
+        double delta = 1;
+        double lower = 50;
+        double upper = 150;
+
+        assertAggregation(
+                percentileAgg,
+                getComparator(0.1), // this test is seeded, so it should always return the same value
+                "non-private median is accurate to within 0.1 SD",
+                getPage(numbers, p, epsilon, delta, lower, upper),
+                100.0);
+    }
+
+    @Test
+    public void testNonPrivateFirstQuartile()
+    {
+        JavaAggregationFunctionImplementation percentileAgg = getFunction("noisy_approx_percentile_qtree", DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double p = 0.25;
+        double epsilon = Double.POSITIVE_INFINITY;
+        double delta = 1;
+        double lower = 50;
+        double upper = 150;
+
+        assertAggregation(
+                percentileAgg,
+                getComparator(0.1), // this test is seeded, so it should always return the same value
+                "non-private 0.25-th quantile is accurate to within 0.1 SD",
+                getPage(numbers, p, epsilon, delta, lower, upper),
+                100.0 - 0.6745);
+    }
+
+    private static Page getPage(Double[] values, double p, double epsilon, double delta, double lower, double upper)
+    {
+        return new Page(
+                createDoublesBlock(values),
+                createRLEBlock(p, values.length),
+                createRLEBlock(epsilon, values.length),
+                createRLEBlock(delta, values.length),
+                createRLEBlock(lower, values.length),
+                createRLEBlock(upper, values.length));
+    }
+
+    public static BiFunction<Object, Object, Boolean> getComparator(double tolerance)
+    {
+        return (x, y) -> Math.abs(new Double(x.toString()) - new Double(y.toString())) <= tolerance;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyApproxPercentileQuantileTreeArrayAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyApproxPercentileQuantileTreeArrayAggregation.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.RunLengthEncodedBlock;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.TestingSeededRandomizationStrategy;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+
+public class TestNoisyApproxPercentileQuantileTreeArrayAggregation
+        extends AbstractTestQuantileTreeAggregation
+{
+    @Test
+    public void testPrivateMedian()
+    {
+        JavaAggregationFunctionImplementation percentileAgg = getFunction("noisy_approx_percentile_qtree", DOUBLE, new ArrayType(DOUBLE), DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        List<Double> probabilities = ImmutableList.of(0.5);
+        double epsilon = 5;
+        double delta = 1e-6;
+        double lower = 50;
+        double upper = 150;
+        List<Double> expected = ImmutableList.of(100.0);
+
+        assertAggregation(
+                percentileAgg,
+                getComparator(15), // since this test is random, we allow 15 standard deviations in error
+                "private median is within 15 SD of expectation",
+                getPage(numbers, probabilities, epsilon, delta, lower, upper),
+                expected);
+    }
+
+    /**
+     * T181507692
+     */
+    @Test(enabled = false)
+    public void testPrivateMultipleQuantiles()
+    {
+        JavaAggregationFunctionImplementation percentileAgg = getFunction("noisy_approx_percentile_qtree", DOUBLE, new ArrayType(DOUBLE), DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        Double[] numbers = generateNormal(10000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        List<Double> probabilities = ImmutableList.of(0.25, 0.5, 0.75);
+        double epsilon = 5;
+        double delta = 1e-6;
+        double lower = 50;
+        double upper = 150;
+        List<Double> expected = ImmutableList.of(99.3255, 100.0, 100.6745);
+
+        assertAggregation(
+                percentileAgg,
+                getComparator(15), // since this test is random, we allow 15 standard deviations in error
+                "private multiple quantiles are within 15 SD of expectation",
+                getPage(numbers, probabilities, epsilon, delta, lower, upper),
+                expected);
+    }
+
+    @Test
+    public void testNonPrivateMedian()
+    {
+        JavaAggregationFunctionImplementation percentileAgg = getFunction("noisy_approx_percentile_qtree", DOUBLE, new ArrayType(DOUBLE), DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        List<Double> probabilities = ImmutableList.of(0.5);
+        double epsilon = Double.POSITIVE_INFINITY;
+        double delta = 1;
+        double lower = 50;
+        double upper = 150;
+        List<Double> expected = ImmutableList.of(100.0);
+
+        assertAggregation(
+                percentileAgg,
+                getComparator(0.1), // this test is seeded, so it should always return the same value
+                "non-private median is accurate to within 0.1 SD",
+                getPage(numbers, probabilities, epsilon, delta, lower, upper),
+                expected);
+    }
+
+    @Test
+    public void testNonPrivateFirstQuartile()
+    {
+        JavaAggregationFunctionImplementation percentileAgg = getFunction("noisy_approx_percentile_qtree", DOUBLE, new ArrayType(DOUBLE), DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        List<Double> probabilities = ImmutableList.of(0.25);
+        double epsilon = Double.POSITIVE_INFINITY;
+        double delta = 1;
+        double lower = 50;
+        double upper = 150;
+        List<Double> expected = ImmutableList.of(100.0 - 0.6745);
+
+        assertAggregation(
+                percentileAgg,
+                getComparator(0.1), // this test is seeded, so it should always return the same value
+                "non-private 0.25-th quantile is accurate to within 0.1 SD",
+                getPage(numbers, probabilities, epsilon, delta, lower, upper),
+                expected);
+    }
+
+    private static Page getPage(Double[] values, List<Double> probabilities, double epsilon, double delta, double lower, double upper)
+    {
+        return new Page(
+                createDoublesBlock(values),
+                createRLEProbabilityBlock(probabilities, values.length),
+                createRLEBlock(epsilon, values.length),
+                createRLEBlock(delta, values.length),
+                createRLEBlock(lower, values.length),
+                createRLEBlock(upper, values.length));
+    }
+
+    public static BiFunction<Object, Object, Boolean> getComparator(double tolerance)
+    {
+        return (x, y) -> {
+            List<Double> xArray = Collections.unmodifiableList((List<? extends Double>) x);
+            List<Double> yArray = Collections.unmodifiableList((List<? extends Double>) y);
+            for (int i = 0; i < xArray.size(); i++) {
+                double difference = Math.abs(xArray.get(i) - yArray.get(i));
+                if (difference > tolerance) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
+
+    public static RunLengthEncodedBlock createRLEProbabilityBlock(Iterable<Double> values, int positionCount)
+    {
+        BlockBuilder rleBlockBuilder = new ArrayType(DOUBLE).createBlockBuilder(null, 1);
+        BlockBuilder arrayBlockBuilder = rleBlockBuilder.beginBlockEntry();
+        for (double value : values) {
+            DOUBLE.writeDouble(arrayBlockBuilder, value);
+        }
+        rleBlockBuilder.closeEntry();
+
+        return new RunLengthEncodedBlock(rleBlockBuilder.build(), positionCount);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyQuantileTreeAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestNoisyQuantileTreeAggregation.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.TestingSeededRandomizationStrategy;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.spi.function.JavaAggregationFunctionImplementation;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BIN_COUNT;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_BRANCHING_FACTOR;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_DEPTH;
+import static com.facebook.presto.operator.aggregation.noisyaggregation.QuantileTreeAggregationUtils.DEFAULT_SKETCH_WIDTH;
+
+public class TestNoisyQuantileTreeAggregation
+        extends AbstractTestQuantileTreeAggregation
+{
+    @Test
+    public void testNonPrivate()
+    {
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double epsilon = Double.POSITIVE_INFINITY;
+        double delta = 1;
+        double lower = 50;
+        double upper = 150;
+        int binCount = 16384; // 2^14 = 4^7
+        int branchingFactor = 2;
+        int sketchDepth = 5;
+        int sketchWidth = 500;
+
+        assertAggregation(
+                getAggFunction(),
+                getQuantileComparator(0), // without privacy, the quantiles should match exactly
+                "non-private tree matches quantiles",
+                getPage(numbers, epsilon, delta, lower, upper, binCount, branchingFactor, sketchDepth, sketchWidth),
+                buildReferenceTree(numbers, lower, upper, binCount, branchingFactor, sketchDepth, sketchWidth));
+    }
+
+    @Test
+    public void testNonPrivateDefaultSketch()
+    {
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double epsilon = Double.POSITIVE_INFINITY;
+        double delta = 1;
+        double lower = 50;
+        double upper = 150;
+        int binCount = 16384; // 2^14 = 4^7
+        int branchingFactor = 2;
+
+        assertAggregation(
+                getAggFunctionDefaultSketch(),
+                getQuantileComparator(0), // without privacy, the quantiles should match exactly
+                "non-private tree matches quantiles",
+                getPage(numbers, epsilon, delta, lower, upper, binCount, branchingFactor),
+                buildReferenceTree(numbers, lower, upper, binCount, branchingFactor));
+    }
+
+    @Test
+    public void testNonPrivateDefaultSketchBranchingFactor()
+    {
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double epsilon = Double.POSITIVE_INFINITY;
+        double delta = 1;
+        double lower = 50;
+        double upper = 150;
+        int binCount = 16384; // 2^14
+
+        assertAggregation(
+                getAggFunctionDefaultSketchBranchingFactor(),
+                getQuantileComparator(0), // without privacy, the quantiles should match exactly
+                "non-private tree matches quantiles",
+                getPage(numbers, epsilon, delta, lower, upper, binCount),
+                buildReferenceTree(numbers, lower, upper, binCount));
+    }
+
+    @Test
+    public void testNonPrivateDefaultSketchBranchingFactorBinCount()
+    {
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double epsilon = Double.POSITIVE_INFINITY;
+        double delta = 1;
+        double lower = 50;
+        double upper = 150;
+
+        assertAggregation(
+                getAggFunctionDefaultSketchBranchingFactorBinCount(),
+                getQuantileComparator(0), // without privacy, the quantiles should match exactly
+                "non-private tree matches quantiles",
+                getPage(numbers, epsilon, delta, lower, upper),
+                buildReferenceTree(numbers, lower, upper));
+    }
+
+    @Test
+    public void testPrivate()
+    {
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double epsilon = 8; // low privacy = low noise
+        double delta = 0.001;
+        double lower = 50;
+        double upper = 150;
+        int binCount = 1024; // 2^10 = 4^5
+        int branchingFactor = 2;
+        int sketchDepth = 1;
+        int sketchWidth = 10_000; // do not sketch
+
+        // With privacy, the quantiles won't match exactly but should be close.
+        // The tolerance is set wide here, since the test is random.
+        assertAggregation(
+                getAggFunction(),
+                getQuantileComparator(25),
+                "private tree quantiles match (to within 25 SD)",
+                getPage(numbers, epsilon, delta, lower, upper, binCount, branchingFactor, sketchDepth, sketchWidth),
+                buildReferenceTree(numbers, lower, upper, binCount, branchingFactor, sketchDepth, sketchWidth));
+    }
+
+    @Test
+    public void testPrivateDefaultSketch()
+    {
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double epsilon = 8; // low privacy = low noise
+        double delta = 0.001;
+        double lower = 50;
+        double upper = 150;
+        int binCount = 1024; // 2^10 = 4^5
+        int branchingFactor = 2;
+
+        // With privacy, the quantiles won't match exactly but should be close.
+        // The tolerance is set wide here, since the test is random.
+        assertAggregation(
+                getAggFunctionDefaultSketch(),
+                getQuantileComparator(25),
+                "private tree quantiles match (to within 25 SD)",
+                getPage(numbers, epsilon, delta, lower, upper, binCount, branchingFactor),
+                buildReferenceTree(numbers, lower, upper, binCount, branchingFactor));
+    }
+
+    @Test
+    public void testPrivateDefaultSketchBranchingFactor()
+    {
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double epsilon = 8; // low privacy = low noise
+        double delta = 0.001;
+        double lower = 50;
+        double upper = 150;
+        int binCount = 1024; // 2^10
+
+        // With privacy, the quantiles won't match exactly but should be close.
+        // The tolerance is set wide here, since the test is random.
+        assertAggregation(
+                getAggFunctionDefaultSketchBranchingFactor(),
+                getQuantileComparator(25),
+                "private tree quantiles match (to within 25 SD)",
+                getPage(numbers, epsilon, delta, lower, upper, binCount),
+                buildReferenceTree(numbers, lower, upper, binCount));
+    }
+
+    @Test
+    public void testPrivateDefaultSketchBranchingFactorBinCount()
+    {
+        Double[] numbers = generateNormal(1000, 100, 1, new TestingSeededRandomizationStrategy(1));
+        double epsilon = 8; // low privacy = low noise
+        double delta = 0.001;
+        double lower = 50;
+        double upper = 150;
+
+        // With privacy, the quantiles won't match exactly but should be close.
+        // The tolerance is set wide here, since the test is random.
+        assertAggregation(
+                getAggFunctionDefaultSketchBranchingFactorBinCount(),
+                getQuantileComparator(25),
+                "private tree quantiles match (to within 25 SD)",
+                getPage(numbers, epsilon, delta, lower, upper),
+                buildReferenceTree(numbers, lower, upper));
+    }
+
+    private JavaAggregationFunctionImplementation getAggFunction()
+    {
+        return getFunction("noisy_qtree_agg", DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, INTEGER, INTEGER, INTEGER, INTEGER);
+    }
+
+    private JavaAggregationFunctionImplementation getAggFunctionDefaultSketch()
+    {
+        return getFunction("noisy_qtree_agg", DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, INTEGER, INTEGER);
+    }
+
+    private JavaAggregationFunctionImplementation getAggFunctionDefaultSketchBranchingFactor()
+    {
+        return getFunction("noisy_qtree_agg", DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE, INTEGER);
+    }
+
+    private JavaAggregationFunctionImplementation getAggFunctionDefaultSketchBranchingFactorBinCount()
+    {
+        return getFunction("noisy_qtree_agg", DOUBLE, DOUBLE, DOUBLE, DOUBLE, DOUBLE);
+    }
+
+    private static Page getPage(Double[] values, double epsilon, double delta, double lower, double upper)
+    {
+        return new Page(
+                createDoublesBlock(values),
+                createRLEBlock(epsilon, values.length),
+                createRLEBlock(delta, values.length),
+                createRLEBlock(lower, values.length),
+                createRLEBlock(upper, values.length));
+    }
+
+    private static Page getPage(Double[] values, double epsilon, double delta, double lower, double upper, long binCount)
+    {
+        return new Page(
+                createDoublesBlock(values),
+                createRLEBlock(epsilon, values.length),
+                createRLEBlock(delta, values.length),
+                createRLEBlock(lower, values.length),
+                createRLEBlock(upper, values.length),
+                createRLEBlock(binCount, values.length));
+    }
+
+    private static Page getPage(Double[] values, double epsilon, double delta, double lower, double upper, long binCount, long branchingFactor)
+    {
+        return new Page(
+                createDoublesBlock(values),
+                createRLEBlock(epsilon, values.length),
+                createRLEBlock(delta, values.length),
+                createRLEBlock(lower, values.length),
+                createRLEBlock(upper, values.length),
+                createRLEBlock(binCount, values.length),
+                createRLEBlock(branchingFactor, values.length));
+    }
+
+    private static Page getPage(Double[] values, double epsilon, double delta, double lower, double upper, long binCount, long branchingFactor, long sketchDepth, long sketchWidth)
+    {
+        return new Page(
+                createDoublesBlock(values),
+                createRLEBlock(epsilon, values.length),
+                createRLEBlock(delta, values.length),
+                createRLEBlock(lower, values.length),
+                createRLEBlock(upper, values.length),
+                createRLEBlock(binCount, values.length),
+                createRLEBlock(branchingFactor, values.length),
+                createRLEBlock(sketchDepth, values.length),
+                createRLEBlock(sketchWidth, values.length));
+    }
+
+    private static SqlVarbinary buildReferenceTree(Double[] numbers, double lower, double upper)
+    {
+        return buildReferenceTree(numbers, lower, upper, DEFAULT_BIN_COUNT, DEFAULT_BRANCHING_FACTOR, DEFAULT_SKETCH_DEPTH, DEFAULT_SKETCH_WIDTH);
+    }
+
+    private static SqlVarbinary buildReferenceTree(Double[] numbers, double lower, double upper, int binCount)
+    {
+        return buildReferenceTree(numbers, lower, upper, binCount, DEFAULT_BRANCHING_FACTOR, DEFAULT_SKETCH_DEPTH, DEFAULT_SKETCH_WIDTH);
+    }
+
+    private static SqlVarbinary buildReferenceTree(Double[] numbers, double lower, double upper, int binCount, int branchingFactor)
+    {
+        return buildReferenceTree(numbers, lower, upper, binCount, branchingFactor, DEFAULT_SKETCH_DEPTH, DEFAULT_SKETCH_WIDTH);
+    }
+
+    private static SqlVarbinary buildReferenceTree(Double[] numbers, double lower, double upper, int binCount, int branchingFactor, int sketchDepth, int sketchWidth)
+    {
+        QuantileTree tree = new QuantileTree(lower, upper, binCount, branchingFactor, sketchDepth, sketchWidth);
+
+        for (double number : numbers) {
+            tree.add(number);
+        }
+
+        return new SqlVarbinary(tree.serialize().getBytes());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestQuantileTreeStateFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestQuantileTreeStateFactory.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestQuantileTreeStateFactory
+{
+    private final QuantileTreeStateFactory factory = new QuantileTreeStateFactory();
+
+    @Test
+    public void testCreateSingleStateEmpty()
+    {
+        QuantileTreeState state = factory.createSingleState();
+        assertNull(state.getQuantileTree());
+        assertNull(state.getProbabilities());
+        assertEquals(state.getEstimatedSize(), ClassLayout.parseClass(QuantileTreeStateFactory.SingleQuantileTreeState.class).instanceSize());
+    }
+
+    @Test
+    public void testCreateSingleStatePresent()
+    {
+        QuantileTreeState state = factory.createSingleState();
+        QuantileTree tree = new QuantileTree(0, 123.45, 1024, 2, 5, 272);
+        state.setQuantileTree(tree);
+        state.setDelta(0.1);
+        state.setEpsilon(2);
+        state.setProbabilities(Collections.singletonList(0.3));
+        assertEquals(state.getQuantileTree(), tree);
+        assertEquals(state.getDelta(), 0.1);
+        assertEquals(state.getEpsilon(), 2);
+        assertEquals(state.getProbabilities().get(0), 0.3);
+    }
+
+    @Test
+    public void testCreateGroupedStateEmpty()
+    {
+        QuantileTreeState state = factory.createGroupedState();
+        assertNull(state.getQuantileTree());
+        assertNull(state.getProbabilities());
+    }
+
+    @Test
+    public void testCreateGroupedStatePresent()
+    {
+        QuantileTreeState state = factory.createGroupedState();
+        assertTrue(state instanceof QuantileTreeStateFactory.GroupedQuantileTreeState);
+        QuantileTreeStateFactory.GroupedQuantileTreeState groupedState = (QuantileTreeStateFactory.GroupedQuantileTreeState) state;
+
+        groupedState.setGroupId(1);
+        assertNull(state.getQuantileTree());
+        QuantileTree tree1 = new QuantileTree(0, 16, 16, 2, 5, 272);
+        tree1.add(0);
+        groupedState.setQuantileTree(tree1);
+        groupedState.setDelta(0.1);
+        groupedState.setEpsilon(2);
+        groupedState.setProbabilities(Collections.singletonList(0.3));
+        assertEquals(state.getQuantileTree(), tree1);
+        assertEquals(state.getDelta(), 0.1);
+        assertEquals(state.getEpsilon(), 2);
+        assertEquals(state.getProbabilities().get(0), 0.3);
+
+        groupedState.setGroupId(2);
+        assertNull(state.getQuantileTree());
+        QuantileTree tree2 = new QuantileTree(0, 123.45, 1024, 2, 5, 272);
+        tree2.add(1);
+        tree2.add(2);
+        groupedState.setQuantileTree(tree2);
+        groupedState.setDelta(0.1);
+        groupedState.setEpsilon(2);
+        groupedState.setProbabilities(Collections.singletonList(0.3));
+        assertEquals(state.getQuantileTree(), tree2);
+        assertEquals(state.getDelta(), 0.1);
+        assertEquals(state.getEpsilon(), 2);
+        assertEquals(state.getProbabilities().get(0), 0.3);
+
+        groupedState.setGroupId(1);
+        assertNotNull(state.getQuantileTree());
+        assertEquals(state.getQuantileTree().cardinality(), 1); // we inserted one item into this group
+
+        groupedState.setGroupId(2);
+        assertNotNull(state.getQuantileTree());
+        assertEquals(state.getQuantileTree().cardinality(), 2); // we inserted two items into this group
+
+        groupedState.setGroupId(3);
+        assertNull(state.getQuantileTree()); // this group doesn't exist
+    }
+
+    @Test
+    public void testMemoryAccounting()
+    {
+        QuantileTreeState state = factory.createGroupedState();
+        long oldSize = state.getEstimatedSize();
+        QuantileTree tree = new QuantileTree(0, 123.45, 1024, 2, 5, 272);
+        state.setQuantileTree(tree);
+        state.addMemoryUsage(tree.estimatedSizeInBytes());
+        state.setEpsilon(5);
+        state.setDelta(0.001);
+        state.setProbabilities(Collections.singletonList(0.5));
+        assertEquals(
+                state.getEstimatedSize(),
+                oldSize + tree.estimatedSizeInBytes(),
+                format(
+                        "Expected size %s before adding tree and %s after",
+                        oldSize,
+                        state.getEstimatedSize()));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestQuantileTreeStateSerializer.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/TestQuantileTreeStateSerializer.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.operator.aggregation.state.StateCompiler;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.type.QuantileTreeType;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+public class TestQuantileTreeStateSerializer
+{
+    private static QuantileTree generateQuantileTree()
+    {
+        QuantileTree tree = new QuantileTree(0, 123.45, 1024, 2, 5, 272);
+        for (int i = 0; i < 50; i++) {
+            tree.add(i);
+        }
+        return tree;
+    }
+
+    @Test
+    public void testQuantileTreeStateSerializeDeserialize()
+    {
+        AccumulatorStateFactory<QuantileTreeState> factory = StateCompiler.generateStateFactory(QuantileTreeState.class);
+        AccumulatorStateSerializer<QuantileTreeState> serializer = StateCompiler.generateStateSerializer(QuantileTreeState.class);
+        QuantileTreeState state = factory.createSingleState();
+        state.setQuantileTree(generateQuantileTree());
+
+        state.setDelta(0.1);
+        state.setEpsilon(2.3);
+        state.setProbabilities(Collections.singletonList(0.4));
+
+        BlockBuilder builder = QuantileTreeType.QUANTILE_TREE_TYPE.createBlockBuilder(null, 1);
+        serializer.serialize(state, builder);
+        Block block = builder.build();
+
+        state.setQuantileTree(null);
+        state.setProbabilities(Collections.singletonList(0.0));
+        state.setEpsilon(0);
+        state.setDelta(0);
+        serializer.deserialize(block, 0, state);
+
+        assertEquals(state.getDelta(), 0.1);
+        assertEquals(state.getEpsilon(), 2.3);
+        assertEquals(state.getProbabilities().get(0), 0.4);
+
+        QuantileTree refTree = generateQuantileTree();
+
+        assertEquals(state.getQuantileTree().quantile(0.5), refTree.quantile(0.5));
+        assertEquals(state.getQuantileTree().quantile(0.95), refTree.quantile(0.95));
+    }
+
+    @Test
+    public void testQuantileTreeStateSerializeDeserializeGrouped()
+    {
+        AccumulatorStateFactory<QuantileTreeState> factory = StateCompiler.generateStateFactory(QuantileTreeState.class);
+        AccumulatorStateSerializer<QuantileTreeState> serializer = StateCompiler.generateStateSerializer(QuantileTreeState.class);
+        QuantileTreeStateFactory.GroupedQuantileTreeState groupedState = (QuantileTreeStateFactory.GroupedQuantileTreeState) factory.createGroupedState();
+        QuantileTree tree1 = generateQuantileTree();
+        QuantileTree tree2 = generateQuantileTree();
+        for (int i = 0; i < 100; i++) {
+            tree2.add(0); // add a spike to the histogram in tree2 (this makes quantiles in the two trees unequal)
+        }
+
+        // Add state to group 1
+        groupedState.setGroupId(1);
+        groupedState.setQuantileTree(tree1);
+        groupedState.setEpsilon(1);
+        groupedState.setDelta(0.001);
+        groupedState.setProbabilities(Collections.singletonList(0.1));
+        // Add another state to group 2, the following test will show it does not affect the group 1
+        groupedState.setGroupId(2);
+        groupedState.setQuantileTree(tree2);
+        groupedState.setEpsilon(1);
+        groupedState.setDelta(0.001);
+        groupedState.setProbabilities(Collections.singletonList(0.1));
+        // Return to group 1
+        groupedState.setGroupId(1);
+
+        BlockBuilder builder = QuantileTreeType.QUANTILE_TREE_TYPE.createBlockBuilder(null, 1);
+        serializer.serialize(groupedState, builder);
+        Block block = builder.build();
+
+        // check on group 1
+        serializer.deserialize(block, 0, groupedState);
+        double valueFromStateGroup1 = groupedState.getQuantileTree().quantile(0.9);
+        double valueFromOriginalTree1 = tree1.quantile(0.9);
+        assertNotNull(groupedState.getQuantileTree());
+        assertEquals(valueFromStateGroup1, valueFromOriginalTree1);
+
+        // check on group 2
+        groupedState.setGroupId(2);
+        assertNotNull(groupedState.getQuantileTree());
+        assertEquals(groupedState.getQuantileTree().quantile(0.7), tree2.quantile(0.7));
+
+        // Groups we did not touch are null
+        groupedState.setGroupId(3);
+        assertNull(groupedState.getQuantileTree());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/TestingSeededRandomizationStrategy.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/TestingSeededRandomizationStrategy.java
@@ -32,4 +32,16 @@ public class TestingSeededRandomizationStrategy
     {
         return random.nextDouble();
     }
+
+    @Override
+    public double nextGaussian()
+    {
+        return random.nextGaussian();
+    }
+
+    @Override
+    public int nextInt(int max)
+    {
+        return random.nextInt(max);
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTree.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTree.java
@@ -1,0 +1,488 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.Slice;
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.airlift.slice.testing.SliceAssertions.assertSlicesEqual;
+import static java.util.Collections.sort;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestQuantileTree
+{
+    @Test
+    public void testBinningUnitInterval()
+    {
+        double lower = 0;
+        double upper = 1;
+        int totalBins = 4096;
+        double binWidth = 1.0 / 4096.0;
+        for (int branchingFactor : new int[] {2, 4, 8}) {
+            QuantileTree tree = new QuantileTree(lower, upper, totalBins, branchingFactor, 1, 10_000);
+
+            assertEquals(tree.getBinWidth(), binWidth);
+
+            for (double value : new double[] {0, 0.1, 0.25, 0.5, 0.99}) {
+                long bin = tree.toBin(value);
+                assertEquals(bin, Math.floor(value * totalBins));
+            }
+
+            // the maximum bin is totalBins - 1
+            assertEquals(tree.toBin(1), 4095);
+        }
+    }
+
+    @Test
+    public void testBinningOutOfBounds()
+    {
+        double lower = 10;
+        double upper = 20;
+        int totalBins = 1024;
+        QuantileTree tree = new QuantileTree(lower, upper, totalBins, 2, 3, 10_000);
+
+        assertEquals(tree.toBin(5), 0); // 5 is below rangeLowerBound, so it should be assigned minimum bin
+        assertEquals(tree.toBin(500), 1023); // 500 is above rangeUpperBound, so it should be assigned maximum bin
+    }
+
+    @Test
+    public void testBinningRoundTrip()
+    {
+        double lower = -5;
+        double upper = 5;
+        int totalBins = 1024;
+        double binWidth = 10.0 / 1024.0;
+        QuantileTree tree = new QuantileTree(lower, upper, totalBins, 2, 3, 10_000);
+
+        for (double value : new double[] {-5, -4, -3.14, -2.78, 0, 1, 1.23, 2, 3, 4.5}) {
+            // Going to bin and back should return a value within binWidth of the original value.
+            double roundTrip = tree.fromBin(tree.toBin(value));
+            assertTrue(roundTrip > value - binWidth && roundTrip < value + binWidth, "round-trip deviated too far from original value");
+        }
+    }
+
+    @Test
+    public void testBinCountRoundUpBinary()
+    {
+        double lower = 0;
+        double upper = 1;
+        int totalBins = 800; // not a power of 2!
+        double requestedBinWidth = 1.0 / 800.0; // not what we'll get
+
+        QuantileTree tree = new QuantileTree(lower, upper, totalBins, 2, 3, 10_000);
+
+        // Bin width should be smaller than requested because we will use 1024 bins (next power of 2)
+        assertTrue(tree.getBinWidth() < requestedBinWidth, "bin width should be smaller than requested");
+
+        // All 1024 bins should be used to cover [0, 1], not the original 800 requested.
+        // Consequently, the bin for 0.9 should be around 0.9 * 1024, not 0.9 * 800.
+        assertEquals(tree.toBin(0.9), Math.floor(0.9 * 1024), "binning should map range to all bins");
+    }
+
+    @Test
+    public void testBinCountRoundUpArbitraryBranching()
+    {
+        double lower = 0;
+        double upper = 1;
+        int totalBins = 70; // not a power of anything (except 70) :(
+
+        int[] branchingFactors = new int[] {2, 3, 4, 5, 8};
+        int[] expectedBinCounts = new int[] {128, 81, 256, 125, 512};
+
+        for (int i = 0; i < branchingFactors.length; i++) {
+            QuantileTree tree = new QuantileTree(lower, upper, totalBins, branchingFactors[i], 3, 10_000);
+            assertEquals(tree.getBinWidth(), 1.0 / expectedBinCounts[i], 0.0001);
+        }
+    }
+
+    @Test
+    public void testBinCountEqualToBranchingFactor()
+    {
+        // By setting branchingFactor equal to bin count, you essentially obtain a linear histogram (root node + histogram)
+        double lower = 0;
+        double upper = 1;
+        int totalBins = 700;
+        QuantileTree tree = new QuantileTree(lower, upper, totalBins, totalBins, 3, 10_000);
+
+        assertEquals(tree.totalLevels(), 2);
+        assertEquals(tree.getBinWidth(), 1.0 / 700);
+    }
+
+    @Test
+    public void testBranchingFactor()
+    {
+        int binCount = 4096; // 2^12 = 4^6 = 8^4 = 16^3
+        double lower = 0;
+        double upper = 1;
+        int sketchDepth = 5;
+        int sketchWidth = 300;
+
+        QuantileTree tree2 = new QuantileTree(lower, upper, binCount, 2, sketchDepth, sketchWidth);
+        assertEquals(tree2.getBranchingFactor(), 2);
+        assertEquals(tree2.totalLevels(), 12 + 1);
+        assertEquals(tree2.getBinWidth(), 1.0 / binCount);
+
+        QuantileTree tree4 = new QuantileTree(lower, upper, binCount, 4, sketchDepth, sketchWidth);
+        assertEquals(tree4.getBranchingFactor(), 4);
+        assertEquals(tree4.totalLevels(), 6 + 1);
+        assertEquals(tree4.getBinWidth(), 1.0 / binCount);
+
+        QuantileTree tree8 = new QuantileTree(lower, upper, binCount, 8, sketchDepth, sketchWidth);
+        assertEquals(tree8.getBranchingFactor(), 8);
+        assertEquals(tree8.totalLevels(), 4 + 1);
+        assertEquals(tree8.getBinWidth(), 1.0 / binCount);
+
+        QuantileTree tree16 = new QuantileTree(lower, upper, binCount, 16, sketchDepth, sketchWidth);
+        assertEquals(tree16.getBranchingFactor(), 16);
+        assertEquals(tree16.totalLevels(), 3 + 1);
+        assertEquals(tree16.getBinWidth(), 1.0 / binCount);
+    }
+
+    @Test
+    public void testCardinality()
+    {
+        for (int branchingFactor : new int[] {2, 4, 8}) {
+            QuantileTree tree = new QuantileTree(0, 10, 4096, branchingFactor, 1, 10_000);
+            assertEquals(tree.cardinality(), 0);
+
+            int n = 123;
+            for (int i = 0; i < n; i++) {
+                tree.add(i % 10); // add n values to the tree
+            }
+
+            // check non-noisy cardinality
+            assertEquals(tree.cardinality(), n);
+
+            // now add noise and check again
+            tree.enablePrivacy(0.5, new TestQuantileTreeSeededRandomizationStrategy(1));
+            assertEquals(tree.cardinality(), n, 10.0);
+        }
+    }
+
+    @Test
+    public void testQuantileTreeQueries()
+    {
+        double lower = -12.34;
+        double upper = 12.34;
+        double binWidth = 0.001;
+        int sketchDepth = 5;
+        int sketchWidth = 1000;
+        int totalLeafNodes = (int) Math.round((upper - lower) / binWidth);
+        RandomizationStrategy randomizationStrategy = new TestQuantileTreeSeededRandomizationStrategy(1);
+
+        int n = 10_000;
+        List<Double> numbers = new ArrayList<>();
+
+        for (int i = 0; i < n; i++) {
+            double x = randomizationStrategy.nextGaussian();
+            numbers.add(x);
+        }
+
+        sort(numbers);
+
+        for (int branchingFactor : new int[] {2, 3, 4, 5}) {
+            QuantileTree tree = new QuantileTree(lower, upper, totalLeafNodes, branchingFactor, sketchDepth, sketchWidth);
+            for (double num : numbers) {
+                tree.add(num);
+            }
+            tree.enablePrivacy(0.1, randomizationStrategy);
+
+            double tolerance = 0.01;
+            for (double p : new double[] {0.01, 0.05, 0.1, 0.5, 0.9, 0.95, 0.99}) {
+                double lowerBound = p - tolerance;
+                double upperBound = p + tolerance;
+
+                if (lowerBound < 0) {
+                    lowerBound = numbers.get(0);
+                }
+                else {
+                    lowerBound = numbers.get((int) (n * lowerBound));
+                }
+
+                if (upperBound >= 1) {
+                    upperBound = numbers.get(n - 1);
+                }
+                else {
+                    upperBound = numbers.get((int) (n * upperBound));
+                }
+
+                double res = tree.quantile(p);
+                assertTrue(res >= lowerBound && res <= upperBound, "estimated quantile is outside of tolerated range");
+            }
+        }
+    }
+
+    @Test
+    public void testNonPrivateQuantileTreeQuery()
+    {
+        QuantileTree tree = new QuantileTree(0, 1024, 1024, 2, 1, 10_000);
+        List<Integer> numbers = new ArrayList<>();
+        int n = 100;
+        for (int i = 1; i <= n; i++) {
+            tree.add(i);
+            numbers.add(i);
+        }
+        double quantile = 0.9;
+        int x = numbers.get((int) (n * quantile));
+        double res = tree.quantile(quantile);
+
+        // Note: bins are discretized to [0, 1), [1, 2), ... [1023, 1024].
+        // Since we return the midpoint of the bin containing the quantile, we'll be off by 0.5 here.
+        assertEquals(res, x + 0.5);
+    }
+
+    @Test
+    public void testNonPrivateQuantileTreeMerge()
+    {
+        double[] quantiles = {0.1, 0.5, 0.9};
+        QuantileTree tree1 = new QuantileTree(0, 1024, 1024, 2, 5, 300);
+        QuantileTree tree2 = new QuantileTree(0, 1024, 1024, 2, 5, 300);
+        QuantileTree tree = new QuantileTree(0, 1024, 1024, 2, 5, 300);
+
+        for (int i = 1; i <= 50; i++) {
+            tree1.add(i);
+            tree.add(i);
+        }
+        for (int i = 51; i <= 100; i++) {
+            tree2.add(i);
+            tree.add(i);
+        }
+        tree1.merge(tree2);
+        assertFalse(tree1.isPrivacyEnabled());
+        for (int i = 0; i < quantiles.length; i++) {
+            assertEquals(tree1.quantile(quantiles[i]), tree.quantile(quantiles[i]));
+        }
+    }
+
+    @Test
+    public void testQuantileTreeMerge()
+    {
+        double lower = -10;
+        double upper = 10;
+        double binWidth = 0.001;
+        int totalLeafNodes = (int) Math.round((upper - lower) / binWidth);
+        double rho1 = 0.4;
+        double rho2 = 0.5;
+        RandomizationStrategy randomizationStrategy1 = new TestQuantileTreeSeededRandomizationStrategy(1);
+        RandomizationStrategy randomizationStrategy2 = new TestQuantileTreeSeededRandomizationStrategy(2);
+        QuantileTree tree1 = new QuantileTree(lower, upper, totalLeafNodes, 2, 5, 300);
+        QuantileTree tree2 = new QuantileTree(lower, upper, totalLeafNodes, 2, 5, 300);
+        tree1.enablePrivacy(rho1, randomizationStrategy1);
+        tree2.enablePrivacy(rho2, randomizationStrategy2);
+
+        List<Double> numbers = new ArrayList<>();
+
+        int n = 10_000;
+        for (int i = 1; i <= 5000; i++) {
+            double x = randomizationStrategy1.nextGaussian();
+            tree1.add(x);
+            numbers.add(x);
+        }
+        for (int i = 5001; i <= n; i++) {
+            double x = randomizationStrategy2.nextGaussian();
+            tree2.add(x);
+            numbers.add(x);
+        }
+        tree1.merge(tree2);
+        sort(numbers);
+
+        assertTrue(tree1.isPrivacyEnabled(), "tree should be marked private");
+        assertTrue(tree1.getRho() < Math.min(rho1, rho2), "rho should be less than before merging");
+
+        double tolerance = 0.01;
+        for (double p : new double[] {0.05, 0.1, 0.5, 0.9, 0.95}) {
+            double lowerBound = p - tolerance;
+            double upperBound = p + tolerance;
+
+            if (lowerBound < 0) {
+                lowerBound = numbers.get(0);
+            }
+            else {
+                lowerBound = numbers.get((int) (n * lowerBound));
+            }
+
+            if (upperBound >= 1) {
+                upperBound = numbers.get(n - 1);
+            }
+            else {
+                upperBound = numbers.get((int) (n * upperBound));
+            }
+
+            double res = tree1.quantile(p);
+            assertTrue(res >= lowerBound && res <= upperBound, "estimated quantile is outside of tolerated range");
+        }
+    }
+
+    @Test
+    public void testMergedRho()
+    {
+        // merging x with NON_PRIVATE_RHO should return x
+        assertEquals(QuantileTree.mergedRho(QuantileTree.NON_PRIVATE_RHO, 0.123), 0.123);
+        assertEquals(QuantileTree.mergedRho(0.123, QuantileTree.NON_PRIVATE_RHO), 0.123);
+
+        // merging rho should be symmetric
+        assertEquals(QuantileTree.mergedRho(0.1, 0.2), QuantileTree.mergedRho(0.2, 0.1));
+
+        // merging two finite values should return 1 / (1 / rho1 + 1 / rho2)
+        // 1 / 0.5 = 2, 1 / 0.25 = 4
+        assertEquals(QuantileTree.mergedRho(0.5, 0.25), 1.0 / 6, 1e-6);
+        // 1 / 0.1 = 10
+        assertEquals(QuantileTree.mergedRho(0.1, 0.1), 1.0 / 20, 1e-6);
+    }
+
+    @Test
+    public void testFindRho2()
+    {
+        // findRho2 solves the mergedRho equation for a different variable, i.e.,
+        // given rho1 and targetRho, findRho2 returns the rho2 value that would satisfy
+        // mergedRho(rho1, rho2) = targetRho
+        double[] rho1 = new double[]{0.5, 0.6, 0.7};
+        double[] targetRho = new double[]{0.1, 0.2, 0.3};
+
+        for (int i = 0; i < rho1.length; i++) {
+            double rho2 = QuantileTree.findRho2(rho1[i], targetRho[i]);
+            assertEquals(QuantileTree.mergedRho(rho1[i], rho2), targetRho[i], 1e-6);
+        }
+    }
+
+    @Test
+    public void testEnablePrivacy()
+    {
+        QuantileTree tree = new QuantileTree(0, 1024, 1024, 2, 5, 300);
+        int n = 100;
+        for (int i = 1; i <= n; i++) {
+            tree.add(i);
+        }
+
+        assertFalse(tree.isPrivacyEnabled());
+
+        double p = 0.5;
+        double nonPrivateQuantile = tree.quantile(p);
+
+        tree.enablePrivacy(0.3, new TestQuantileTreeSeededRandomizationStrategy(1));
+        assertTrue(tree.isPrivacyEnabled());
+
+        double privateQuantile = tree.quantile(p);
+
+        assertNotEquals(nonPrivateQuantile, privateQuantile, 0.0, "quantile should be noisy after enabling privacy");
+        assertEquals(privateQuantile, n * p, 5.0, "quantile should be around true value");
+    }
+
+    @Test
+    public void testEnableAdditionalPrivacy()
+    {
+        RandomizationStrategy randomizationStrategy = new TestQuantileTreeSeededRandomizationStrategy(1);
+        QuantileTree tree = new QuantileTree(0, 1024, 1024, 2, 5, 300);
+        int n = 1000;
+        for (int i = 1; i <= n; i++) {
+            tree.add(i);
+        }
+
+        tree.enablePrivacy(0.8, randomizationStrategy);
+        assertTrue(tree.isPrivacyEnabled());
+        assertEquals(tree.getRho(), 0.8);
+        double originalMedian = tree.quantile(0.5);
+        double originalCardinality = tree.cardinality();
+
+        // this should be a no-op
+        tree.enablePrivacy(0.8, randomizationStrategy);
+        assertTrue(tree.isPrivacyEnabled());
+        assertEquals(tree.getRho(), 0.8);
+        assertEquals(tree.quantile(0.5), originalMedian);
+        assertEquals(tree.cardinality(), originalCardinality);
+
+        // now we add a little more noise
+        tree.enablePrivacy(0.6, randomizationStrategy);
+        assertTrue(tree.isPrivacyEnabled());
+        assertEquals(tree.getRho(), 0.6);
+        assertNotEquals(tree.cardinality(), originalCardinality, "cardinality should no longer match exactly");
+        assertEquals(tree.cardinality(), originalCardinality, 5.0, "cardinality should be close to original cardinality");
+        assertEquals(tree.quantile(0.5), originalMedian, 5.0, "median should be close to original median");
+    }
+
+    @Test
+    public void testRhoForEpsilonDelta()
+    {
+        // See math in N2273303
+        assertEquals(QuantileTree.getRhoForEpsilonDelta(4, 0.001), 0.4548534, 0.00001);
+        assertEquals(QuantileTree.getRhoForEpsilonDelta(4, 0.0001), 0.3596987, 0.00001);
+        assertEquals(QuantileTree.getRhoForEpsilonDelta(4, 0.00001), 0.2976519, 0.00001);
+        assertEquals(QuantileTree.getRhoForEpsilonDelta(1, 0.001), 0.0337869, 0.00001);
+        assertEquals(QuantileTree.getRhoForEpsilonDelta(1, 0.0001), 0.0257628, 0.00001);
+        assertEquals(QuantileTree.getRhoForEpsilonDelta(1, 0.00001), 0.0208199, 0.00001);
+    }
+
+    @Test
+    public void testQuantileTreeSerializeRoundTrip()
+    {
+        double lower = -9.9;
+        double upper = 9.9;
+        double binWidth = 0.001;
+        int totalLeafNodes = (int) Math.round((upper - lower) / binWidth);
+        RandomizationStrategy randomizationStrategy = new TestQuantileTreeSeededRandomizationStrategy(1);
+
+        // Build a tree
+        QuantileTree tree = new QuantileTree(lower, upper, totalLeafNodes, 3, 5, 1000);
+        tree.enablePrivacy(0.5, randomizationStrategy);
+        int n = 10_000;
+        for (int i = 0; i < n; i++) {
+            double x = randomizationStrategy.nextGaussian();
+            tree.add(x);
+        }
+
+        Slice serialized = tree.serialize();
+        QuantileTree rebuildTree = QuantileTree.deserialize(serialized);
+
+        assertSlicesEqual(serialized, rebuildTree.serialize());
+        assertEquals(tree.quantile(0.5), rebuildTree.quantile(0.5), "quantile does not match in round-trip tree");
+    }
+
+    @Test
+    public void testMemoryUsage()
+    {
+        // This tree will have a mix of histogram, sketched, and offset levels.
+        QuantileTree tree = new QuantileTree(0, 10, 65536, 2, 3, 100);
+
+        long expectedLevelsMemoryUsage = 0;
+        for (int i = 0; i < tree.totalLevels(); i++) {
+            expectedLevelsMemoryUsage += tree.getLevel(i).estimatedSizeInBytes();
+        }
+        long expectedMemoryUsage = ClassLayout.parseClass(QuantileTree.class).instanceSize() + SizeOf.sizeOfObjectArray(tree.totalLevels()) + expectedLevelsMemoryUsage;
+
+        assertEquals(tree.estimatedSizeInBytes(), expectedMemoryUsage);
+    }
+
+    @Test
+    public void testSerializedSize()
+    {
+        // This tree will have a mix of histogram, sketched, and offset levels.
+        QuantileTree tree = new QuantileTree(0, 10, 65536, 2, 3, 100);
+
+        // insert some values (doesn't really make an effect on size)
+        for (int i = 0; i < 500; i++) {
+            tree.add(i);
+        }
+
+        assertEquals(tree.estimatedSerializedSizeInBytes(), tree.serialize().length());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTreeCountSketch.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTreeCountSketch.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestQuantileTreeCountSketch
+{
+    @Test
+    public void testEstimatedSerializedSize()
+    {
+        CountSketch sketch = new CountSketch(5, 272);
+        int res = sketch.estimatedSerializedSizeInBytes();
+        assertEquals(sketch.getWidth(), 272); // check the table's width
+        assertEquals(sketch.getDepth(), 5);  // check the table's depth
+        assertEquals(res, 5448);
+    }
+
+    @Test
+    public void testMemoryUsage()
+    {
+        float[][] expectedTable = new float[5][272];
+        CountSketch sketch = new CountSketch(5, 272);
+
+        long expectedMemoryUsage = ClassLayout.parseClass(CountSketch.class).instanceSize() +
+                SizeOf.sizeOf(expectedTable) + 5 * SizeOf.sizeOfFloatArray(272);
+
+        assertEquals(sketch.getWidth(), 272); // check the table's width
+        assertEquals(sketch.getDepth(), 5); // check the table's depth
+        assertEquals(sketch.estimatedSizeInBytes(), expectedMemoryUsage);
+    }
+
+    @Test
+    public void testSerializeAndDeserialize()
+    {
+        CountSketch sketch = new CountSketch(5, 272);
+
+        sketch.addNoise(0.5, 5, new TestQuantileTreeSeededRandomizationStrategy(1));
+        for (int i = 0; i < 100; i++) {
+            sketch.add(1);
+        }
+
+        // take a few random noisy estimates from our sketch
+        double[] counts = new double[]{sketch.estimateCount(1), sketch.estimateCount(2), sketch.estimateCount(3)};
+
+        Slice sketchSlice = sketch.serialize();
+        SliceInput sliceInput = new BasicSliceInput(sketchSlice);
+        CountSketch deserializedSketch = new CountSketch(sliceInput);
+        assertEquals(deserializedSketch.getDepth(), sketch.getDepth());
+        assertEquals(deserializedSketch.getWidth(), sketch.getWidth());
+
+        // take the same estimates from the deserialized sketch
+        double[] deserializedCounts = new double[]{deserializedSketch.estimateCount(1), deserializedSketch.estimateCount(2), deserializedSketch.estimateCount(3)};
+        assertEquals(deserializedCounts, counts);
+    }
+
+    @Test
+    public void testCountsSparse()
+    {
+        CountSketch sketch = new CountSketch(5, 272);
+
+        // if we only add a few items to the sketch, we should be able to return those without error
+        sketch.add(123, 50);
+        sketch.add(1234, 200);
+        sketch.add(999, 1000);
+
+        // these should match what we inserted (approximately)
+        assertEquals(sketch.estimateCount(123), 50);
+        assertEquals(sketch.estimateCount(1234), 200);
+        assertEquals(sketch.estimateCount(999), 1000);
+
+        // this was never inserted
+        assertEquals(sketch.estimateCount(7), 0);
+    }
+
+    @Test
+    public void testCountsSaturated()
+    {
+        CountSketch sketch = new CountSketch(5, 272);
+
+        // first, we add many small counts over the range 1xxxx
+        addCountsToSketch(sketch, 10000, 19999, 10);
+
+        // then we add some special counts that we really care about
+        sketch.add(123, 500);
+        sketch.add(1234, 2000);
+        sketch.add(999, 10000);
+
+        // We've now added roughly 10000 * 5.5 + 500 + 2000 + 10000 = 67,500 items to the sketch (10,003 unique items)
+        // Our estimates will be approximate this time.
+        double tolerance = 50;
+        assertEquals(sketch.estimateCount(123), 500, tolerance);
+        assertEquals(sketch.estimateCount(1234), 2000, tolerance);
+        assertEquals(sketch.estimateCount(999), 10000, tolerance);
+    }
+
+    @Test
+    public void testCountsPrivate()
+    {
+        CountSketch sketch = new CountSketch(5, 272);
+
+        // we only add a few items to the sketch
+        sketch.add(123, 50);
+        sketch.add(1234, 200);
+        sketch.add(999, 1000);
+
+        // but then we add noise to the sketch
+        sketch.addNoise(0.5, 1, new TestQuantileTreeSeededRandomizationStrategy(1));
+
+        // these should match what we inserted (approximately)
+        double tolerance = 10;
+        assertEquals(sketch.estimateCount(123), 50, tolerance);
+        assertEquals(sketch.estimateCount(1234), 200, tolerance);
+        assertEquals(sketch.estimateCount(999), 1000, tolerance);
+
+        // this was never inserted
+        assertEquals(sketch.estimateCount(7), 0, tolerance);
+    }
+
+    @Test
+    public void testHashingUniformity()
+    {
+        // This is an impractically small sketch, but the point is to test the uniformity of getBucket() and getSign() on the iterated hashes
+        int width = 12;
+        CountSketch sketch = new CountSketch(1, width);
+
+        int n = 1000;
+        long[] testItems = new long[]{-1, 0, 1, 2, 3, 4, 1234, 987654321, Long.MAX_VALUE};
+        for (long item : testItems) {
+            long baseHash = CountSketch.getBaseHash(item);
+
+            // try n hashes, compute distribution of buckets and signs
+            int[] bucketCounts = new int[width];
+            int positiveSigns = 0;
+            for (int i = 0; i < n; i++) {
+                long iteratedHash = sketch.getIteratedHash(baseHash, i);
+                bucketCounts[CountSketch.getBucket(iteratedHash)]++;
+                if (CountSketch.getSign(iteratedHash) > 0) {
+                    positiveSigns++;
+                }
+            }
+
+            // sign should be positive about half the time
+            assertEquals((float) positiveSigns / n, 0.5, 0.02);
+
+            // each bucket should get about equal allocation (1 / width)
+            for (int i = 0; i < width; i++) {
+                assertEquals((float) bucketCounts[i] / n, 1.0 / width, 0.02);
+            }
+        }
+    }
+
+    /**
+     * Deterministically fill sketch with counts covering a range of keys from lowerKey to upperKey, up to a given maximum count.
+     * The counts are a simple cyclic sequence from 1 to maximum.
+     */
+    private static void addCountsToSketch(CountSketch sketch, int lowerKey, int upperKey, int maximum)
+    {
+        for (int i = lowerKey; i <= upperKey; i++) {
+            sketch.add(i, 1 + i % maximum);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTreeHistogramLevel.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTreeHistogramLevel.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+public class TestQuantileTreeHistogramLevel
+{
+    @Test
+    public void testEstimatedSerializedSize()
+    {
+        HistogramLevel sketch = new HistogramLevel(10);
+        assertEquals(sketch.estimatedSerializedSizeInBytes(), sketch.serialize().length());
+    }
+
+    @Test
+    public void testMemoryUsage()
+    {
+        HistogramLevel sketch = new HistogramLevel(10);
+
+        long expectedMemoryUsage = ClassLayout.parseClass(HistogramLevel.class).instanceSize() +
+                SizeOf.sizeOfFloatArray(10);
+
+        assertEquals(sketch.estimatedSizeInBytes(), expectedMemoryUsage);
+    }
+
+    @Test
+    public void testSerializeAndDeserialize()
+    {
+        int bins = 10;
+        RandomizationStrategy randomizationStrategy = new TestQuantileTreeSeededRandomizationStrategy(1);
+        HistogramLevel sketch = new HistogramLevel(bins);
+
+        // populate bins with 100 random items
+        for (int i = 0; i < 100; i++) {
+            sketch.add(randomizationStrategy.nextInt(bins));
+        }
+
+        // enable privacy
+        sketch.addNoise(0.5, randomizationStrategy);
+
+        Slice sketchSlice = sketch.serialize();
+        SliceInput sliceInput = new BasicSliceInput(sketchSlice);
+        HistogramLevel deserializedSketch = new HistogramLevel(sliceInput);
+
+        for (int i = 0; i < bins; i++) {
+            assertEquals(deserializedSketch.query(i), sketch.query(i));
+        }
+    }
+
+    @Test
+    public void testAddOperation()
+    {
+        HistogramLevel sketch = new HistogramLevel(10);
+        assertEquals(sketch.query(3), 0); // no items added yet
+        for (int i = 1; i < 20; i++) {
+            sketch.add(3);
+            assertEquals(sketch.query(3), i); // i items added
+        }
+    }
+
+    @Test
+    public void testAddNoise()
+    {
+        int bins = 10;
+        HistogramLevel sketch = new HistogramLevel(bins);
+        sketch.addNoise(0.5, new TestQuantileTreeSeededRandomizationStrategy(1));
+        for (int i = 1; i < bins; i++) {
+            assertNotEquals(sketch.query(i), 0.0); // should have noise added
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTreeSearch.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTreeSearch.java
@@ -1,0 +1,430 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.google.common.math.IntMath;
+import org.testng.annotations.Test;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestQuantileTreeSearch
+{
+    @Test
+    public void testAddressingBinary()
+    {
+        // A binary tree is indexed like this:
+        //                  (root)
+        //          0                   1
+        //   00          01      10            11
+        // 000 001    010 011  100 101       110  111
+        //                   ...
+        QuantileTree tree = new QuantileTree(0, 1, 128, 2, 1, 100_000);
+        QuantileTreeSearch search = new QuantileTreeSearch(tree);
+        QuantileTreeSearch.NodeAddress root = search.rootNode();
+
+        // first level
+        QuantileTreeSearch.NodeAddress node0 = root.children()[0];
+        assertEquals(node0.indices, new int[]{0});
+        assertEquals(node0.level(), 1);
+        assertEquals(node0.position(), 0);
+
+        QuantileTreeSearch.NodeAddress node1 = root.children()[1];
+        assertEquals(node1.indices, new int[]{1});
+        assertEquals(node1.level(), 1);
+        assertEquals(node1.position(), 1);
+
+        // second level
+        QuantileTreeSearch.NodeAddress node00 = node0.children()[0];
+        assertEquals(node00.indices, new int[]{0, 0});
+        assertEquals(node00.level(), 2);
+        assertEquals(node00.position(), 0);
+
+        QuantileTreeSearch.NodeAddress node01 = node0.children()[1];
+        assertEquals(node01.indices, new int[]{0, 1});
+        assertEquals(node01.level(), 2);
+        assertEquals(node01.position(), 1);
+
+        QuantileTreeSearch.NodeAddress node10 = node1.children()[0];
+        assertEquals(node10.indices, new int[]{1, 0});
+        assertEquals(node10.level(), 2);
+        assertEquals(node10.position(), 2);
+
+        QuantileTreeSearch.NodeAddress node11 = node1.children()[1];
+        assertEquals(node11.indices, new int[]{1, 1});
+        assertEquals(node11.level(), 2);
+        assertEquals(node11.position(), 3);
+
+        // third level
+        QuantileTreeSearch.NodeAddress node000 = node00.children()[0];
+        assertEquals(node000.indices, new int[]{0, 0, 0});
+        assertEquals(node000.level(), 3);
+        assertEquals(node000.position(), 0);
+
+        QuantileTreeSearch.NodeAddress node011 = node01.children()[1];
+        assertEquals(node011.indices, new int[]{0, 1, 1});
+        assertEquals(node011.level(), 3);
+        assertEquals(node011.position(), 0b11);
+
+        QuantileTreeSearch.NodeAddress node100 = node10.children()[0];
+        assertEquals(node100.indices, new int[]{1, 0, 0});
+        assertEquals(node100.level(), 3);
+        assertEquals(node100.position(), 0b100);
+
+        QuantileTreeSearch.NodeAddress node111 = node11.children()[1];
+        assertEquals(node111.indices, new int[]{1, 1, 1});
+        assertEquals(node111.level(), 3);
+        assertEquals(node111.position(), 0b111);
+
+        // fourth level
+        QuantileTreeSearch.NodeAddress node1001 = node100.children()[1];
+        assertEquals(node1001.indices, new int[]{1, 0, 0, 1});
+        assertEquals(node1001.level(), 4);
+        assertEquals(node1001.position(), 0b1001);
+
+        QuantileTreeSearch.NodeAddress node1110 = node111.children()[0];
+        assertEquals(node1110.indices, new int[]{1, 1, 1, 0});
+        assertEquals(node1110.level(), 4);
+        assertEquals(node1110.position(), 0b1110);
+
+        // ...seventh level
+        QuantileTreeSearch.NodeAddress node0101010 = root.children()[0]
+                .children()[1]
+                .children()[0]
+                .children()[1]
+                .children()[0]
+                .children()[1]
+                .children()[0];
+        assertEquals(node0101010.indices, new int[]{0, 1, 0, 1, 0, 1, 0});
+        assertEquals(node0101010.level(), 7);
+        assertEquals(node0101010.position(), 0b0101010);
+    }
+
+    @Test
+    public void testAddressingTernary()
+    {
+        // A ternary tree is indexed like this:
+        //                            (root)
+        //          0                   1                   2
+        //   00     01     02    10    11     12     20    21     22
+        //                             ...
+        QuantileTree tree = new QuantileTree(0, 1, 81, 3, 1, 100_000);
+        QuantileTreeSearch search = new QuantileTreeSearch(tree);
+        QuantileTreeSearch.NodeAddress root = search.rootNode();
+
+        // first level
+        QuantileTreeSearch.NodeAddress node0 = root.children()[0];
+        assertEquals(node0.indices, new int[]{0});
+        assertEquals(node0.level(), 1);
+        assertEquals(node0.position(), 0);
+
+        QuantileTreeSearch.NodeAddress node1 = root.children()[1];
+        assertEquals(node1.indices, new int[]{1});
+        assertEquals(node1.level(), 1);
+        assertEquals(node1.position(), 1);
+
+        QuantileTreeSearch.NodeAddress node2 = root.children()[2];
+        assertEquals(node2.indices, new int[]{2});
+        assertEquals(node2.level(), 1);
+        assertEquals(node2.position(), 2);
+
+        // second level
+        QuantileTreeSearch.NodeAddress node00 = node0.children()[0];
+        assertEquals(node00.indices, new int[]{0, 0});
+        assertEquals(node00.level(), 2);
+        assertEquals(node00.position(), 0);
+
+        QuantileTreeSearch.NodeAddress node01 = node0.children()[1];
+        assertEquals(node01.indices, new int[]{0, 1});
+        assertEquals(node01.level(), 2);
+        assertEquals(node01.position(), 1);
+
+        QuantileTreeSearch.NodeAddress node02 = node0.children()[2];
+        assertEquals(node02.indices, new int[]{0, 2});
+        assertEquals(node02.level(), 2);
+        assertEquals(node02.position(), 2);
+
+        QuantileTreeSearch.NodeAddress node10 = node1.children()[0];
+        assertEquals(node10.indices, new int[]{1, 0});
+        assertEquals(node10.level(), 2);
+        assertEquals(node10.position(), 3);
+
+        QuantileTreeSearch.NodeAddress node11 = node1.children()[1];
+        assertEquals(node11.indices, new int[]{1, 1});
+        assertEquals(node11.level(), 2);
+        assertEquals(node11.position(), 4);
+
+        QuantileTreeSearch.NodeAddress node12 = node1.children()[2];
+        assertEquals(node12.indices, new int[]{1, 2});
+        assertEquals(node12.level(), 2);
+        assertEquals(node12.position(), 5);
+
+        QuantileTreeSearch.NodeAddress node20 = node2.children()[0];
+        assertEquals(node20.indices, new int[]{2, 0});
+        assertEquals(node20.level(), 2);
+        assertEquals(node20.position(), 6);
+
+        QuantileTreeSearch.NodeAddress node21 = node2.children()[1];
+        assertEquals(node21.indices, new int[]{2, 1});
+        assertEquals(node21.level(), 2);
+        assertEquals(node21.position(), 7);
+
+        QuantileTreeSearch.NodeAddress node22 = node2.children()[2];
+        assertEquals(node22.indices, new int[]{2, 2});
+        assertEquals(node22.level(), 2);
+        assertEquals(node22.position(), 8);
+
+        // third level
+        QuantileTreeSearch.NodeAddress node210 = node21.children()[0];
+        assertEquals(node210.indices, new int[]{2, 1, 0});
+        assertEquals(node210.level(), 3);
+        assertEquals(node210.position(), 2 * 9 + 1 * 3 + 0);
+
+        // fourth level
+        QuantileTreeSearch.NodeAddress node2101 = node210.children()[1];
+        assertEquals(node2101.indices, new int[]{2, 1, 0, 1});
+        assertEquals(node2101.level(), 4);
+        assertEquals(node2101.position(), 2 * 27 + 1 * 9 + 0 * 3 + 1);
+    }
+
+    @Test
+    public void testAddressingBase10()
+    {
+        // It's no longer practical to draw out the tree. :)
+        QuantileTree tree = new QuantileTree(0, 1, 10_000, 10, 1, 100_000);
+        QuantileTreeSearch search = new QuantileTreeSearch(tree);
+        QuantileTreeSearch.NodeAddress root = search.rootNode();
+
+        // first level
+        QuantileTreeSearch.NodeAddress node5 = root.children()[5];
+        assertEquals(node5.indices, new int[]{5});
+        assertEquals(node5.level(), 1);
+        assertEquals(node5.position(), 5);
+
+        // second level
+        QuantileTreeSearch.NodeAddress node54 = node5.children()[4];
+        assertEquals(node54.indices, new int[]{5, 4});
+        assertEquals(node54.level(), 2);
+        assertEquals(node54.position(), 54);
+
+        // third level
+        QuantileTreeSearch.NodeAddress node543 = node54.children()[3];
+        assertEquals(node543.indices, new int[]{5, 4, 3});
+        assertEquals(node543.level(), 3);
+        assertEquals(node543.position(), 543);
+
+        // fourth level
+        QuantileTreeSearch.NodeAddress node5432 = node543.children()[2];
+        assertEquals(node5432.indices, new int[]{5, 4, 3, 2});
+        assertEquals(node5432.level(), 4);
+        assertEquals(node5432.position(), 5432);
+
+        // fifth level
+        QuantileTreeSearch.NodeAddress node54321 = node5432.children()[1];
+        assertEquals(node54321.indices, new int[]{5, 4, 3, 2, 1});
+        assertEquals(node54321.level(), 5);
+        assertEquals(node54321.position(), 54321);
+    }
+
+    @Test
+    public void testQueryDirect()
+    {
+        int bins = 3 * 3 * 3; // a tree with branching factor = 3 and three levels
+        QuantileTree tree = generateQuantileTree(bins, 3);
+        QuantileTreeSearch search = new QuantileTreeSearch(tree);
+
+        eachNode(search, node -> {
+            if (node.isLeaf()) {
+                // leaf nodes should be the exact bin value, which is equal to one plus their position (by definition of generateQuantileTree)
+                assertEquals(search.queryDirect(node), node.position() + 1);
+            }
+            else {
+                // non-leaf nodes should exactly equal the sum of their children (since this tree has no noise)
+                assertEquals(search.queryDirect(node), Arrays.stream(node.children()).mapToDouble(search::queryDirect).sum(), 0.0001);
+            }
+        });
+    }
+
+    @Test
+    public void testQueryDownBinary()
+    {
+        for (int branchingFactor : new int[] {2, 3, 4}) {
+            // this will create a complete tree with at least 200 bins
+            // for branchingFactor = 2, that's 2^6 = 256 bins
+            // for                 = 3, that's 3^5 = 243 bins
+            // for                 = 4, that's 4^4 = 256 bins
+            QuantileTree refTree = generateQuantileTree(200, branchingFactor);
+            QuantileTreeSearch refSearch = new QuantileTreeSearch(refTree);
+
+            // Make a noisy copy of the tree (refTree will be our "ground truth" tree)
+            QuantileTree noisyTree = QuantileTree.deserialize(refTree.serialize());
+            noisyTree.enablePrivacy(1.0, new TestQuantileTreeSeededRandomizationStrategy(1));
+            QuantileTreeSearch noisySearch = new QuantileTreeSearch(noisyTree);
+
+            QuantileTreeSearch.NodeAddress refNode0 = refSearch.rootNode().children()[0];
+            QuantileTreeSearch.NodeAddress noisyNode0 = noisySearch.rootNode().children()[0];
+
+            assertEquals(refSearch.queryDirect(refNode0), noisySearch.queryDirect(noisyNode0), 10.0, "noisyTree counts should vary slightly from refTree");
+            double[] denoise1 = noisySearch.queryDown(noisyNode0, 1);
+            assertEquals(denoise1[0], noisySearch.queryDirect(noisyNode0), 10.0, "de-noising one level should change estimate slightly");
+            assertTrue(denoise1[1] < 1, "de-noising one level should reduce variance");
+            double relativeVariance1 = (branchingFactor - 1) / (branchingFactor - Math.pow(branchingFactor, -1));
+            assertEquals(denoise1[1], relativeVariance1, 0.001, "de-noising one level yield relative variance of relativeVariance1");
+
+            double[] denoise2 = noisySearch.queryDown(noisyNode0, 2);
+            assertEquals(denoise2[0], noisySearch.queryDirect(noisyNode0), 10.0, "de-noising two levels should change estimate slightly");
+            assertTrue(denoise2[1] < denoise1[1], "de-noising two level should reduce variance more than de-noising one level");
+            double relativeVariance2 = (branchingFactor - 1) / (branchingFactor - Math.pow(branchingFactor, -2));
+            assertEquals(denoise2[1], relativeVariance2, 0.001, "de-noising one level yield relative variance of relativeVariance2");
+        }
+    }
+
+    @Test
+    public void testQueryDownZeroLevels()
+    {
+        QuantileTree tree = generateQuantileTree(1296, 6); // 6^4
+        tree.enablePrivacy(1.0, new TestQuantileTreeSeededRandomizationStrategy(1));
+        QuantileTreeSearch search = new QuantileTreeSearch(tree);
+        // Picking a non-leaf node at random, queryDown(x, 0) is equivalent to queryDirect(x)
+        QuantileTreeSearch.NodeAddress arbitraryNode = search.rootNode().children()[2].children()[3];
+        assertEquals(search.queryDown(arbitraryNode, 0), new double[] {search.queryDirect(arbitraryNode), 1});
+    }
+
+    @Test
+    public void testMaxTraversalDepth()
+    {
+        assertEquals(QuantileTreeSearch.findMaxTraversalDepth(2), 6);
+        assertEquals(QuantileTreeSearch.findMaxTraversalDepth(3), 3);
+        assertEquals(QuantileTreeSearch.findMaxTraversalDepth(4), 3);
+        assertEquals(QuantileTreeSearch.findMaxTraversalDepth(5), 2);
+        assertEquals(QuantileTreeSearch.findMaxTraversalDepth(6), 2);
+        assertEquals(QuantileTreeSearch.findMaxTraversalDepth(7), 2);
+        assertEquals(QuantileTreeSearch.findMaxTraversalDepth(8), 2);
+
+        // branching factors 9 through 64 may traverse one level
+        for (int i = 9; i <= 64; i++) {
+            assertEquals(QuantileTreeSearch.findMaxTraversalDepth(i), 1);
+        }
+
+        // >64 should not traverse down at all (queryDirect only)
+        for (int i = 65; i < 1000; i++) {
+            assertEquals(QuantileTreeSearch.findMaxTraversalDepth(i), 0);
+        }
+    }
+
+    @Test
+    public void testIsLeaf()
+    {
+        for (int branchingFactor : new int[] {2, 3, 4}) {
+            int depth = 4;
+            int bins = IntMath.pow(branchingFactor, depth);
+            QuantileTree tree = new QuantileTree(0, 1, bins, branchingFactor, 1, 100_000);
+            QuantileTreeSearch search = new QuantileTreeSearch(tree);
+
+            eachNode(search, node -> {
+                assertEquals(node.isLeaf(), node.level() == depth);
+            });
+        }
+    }
+
+    @Test
+    public void testQuery()
+    {
+        for (int branchingFactor : new int[] {2, 3, 4}) {
+            int depth = 4;
+            int bins = IntMath.pow(branchingFactor, depth);
+            QuantileTree tree = generateQuantileTree(bins, branchingFactor);
+            tree.enablePrivacy(1.0, new TestQuantileTreeSeededRandomizationStrategy(1));
+            QuantileTreeSearch search = new QuantileTreeSearch(tree);
+
+            eachNode(search, node -> {
+                // Leaf nodes:
+                // Their values should approximately equal the number of items in the bin.
+                // query() and queryDirect() should return the same value here, since there are no children to use for variance-reduction.
+                if (node.isLeaf()) {
+                    double directValue = search.queryDirect(node);
+                    double queryValue = search.query(node);
+                    assertEquals(directValue, node.position() + 1, 10.0);
+                    assertEquals(queryValue, node.position() + 1, 10.0);
+                    assertEquals(directValue, queryValue);
+                }
+                // Non-leaf nodes:
+                // Since this tree is noisy, their values should approximately equal the sum of their children.
+                // Both query() and queryDirect() should return similar estimates, but we should get different estimates
+                // using query() vs. queryDirect(), since query() performs a variance-reduction step.
+                else {
+                    QuantileTreeSearch.NodeAddress[] children = node.children();
+                    double directValue = search.queryDirect(node);
+                    double queryValue = search.query(node);
+                    double childSum = Arrays.stream(children).mapToDouble(search::queryDirect).sum();
+                    assertEquals(directValue, childSum, 10.0);
+                    assertEquals(queryValue, childSum, 10.0);
+                    assertNotEquals(directValue, queryValue);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testFindQuantile()
+    {
+        for (int branchingFactor : new int[] {2, 3, 4, 5}) {
+            for (int depth : new int[] {1, 3, 5}) {
+                int bins = IntMath.pow(branchingFactor, depth);
+                QuantileTree tree = generateQuantileTree(bins, branchingFactor);
+                QuantileTreeSearch search = new QuantileTreeSearch(tree);
+                int total = IntStream.rangeClosed(1, bins).sum();
+                int cumulativeSum = 0;
+                for (int i = 1; i < bins; i++) {
+                    // findQuantile() returns 0-indexed bins
+                    // look for the bin with slightly less weight than the cumulativeSum
+                    cumulativeSum += i;
+                    assertEquals(search.findQuantile((cumulativeSum - 0.1) / total), i - 1);
+                }
+            }
+        }
+    }
+
+    private static QuantileTree generateQuantileTree(int bins, int branchingFactor)
+    {
+        // Create a tree with B bins, corresponding to the ranges [0, 1), [1, 2), ..., [B-2, B-1), [B-1, B]
+        // Using enormous sketch dimensions ensures we will only use non-sketched levels.
+        QuantileTree tree = new QuantileTree(0, bins, bins, branchingFactor, 100_000_000, 1);
+
+        // in each bin, i (1-indexed)
+        for (int i = 1; i <= bins; i++) {
+            // insert i items
+            for (int j = 0; j < i; j++) {
+                tree.add(i - 0.5);
+            }
+        }
+
+        return tree;
+    }
+
+    private static void eachNode(QuantileTreeSearch search, Consumer<QuantileTreeSearch.NodeAddress> assertion)
+    {
+        ArrayDeque<QuantileTreeSearch.NodeAddress> nodes = new ArrayDeque<QuantileTreeSearch.NodeAddress>(Arrays.asList(search.rootNode().children()));
+        while (!nodes.isEmpty()) {
+            QuantileTreeSearch.NodeAddress node = nodes.pop();
+            assertion.accept(node);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTreeSeededRandomizationStrategy.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/noisyaggregation/sketch/quantiletree/TestQuantileTreeSeededRandomizationStrategy.java
@@ -11,30 +11,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.operator.aggregation.noisyaggregation.sketch;
+package com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree;
+
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+
+import java.util.Random;
 
 /**
- * Non-random numbers for testing
+ * Seeded random numbers for testing
  */
-public class TestingDeterministicRandomizationStrategy
+public class TestQuantileTreeSeededRandomizationStrategy
         extends RandomizationStrategy
 {
-    public TestingDeterministicRandomizationStrategy() {}
+    private final Random random;
+
+    public TestQuantileTreeSeededRandomizationStrategy(long seed)
+    {
+        this.random = new Random(seed);
+    }
+
+    public boolean nextBoolean(double probability)
+    {
+        return random.nextDouble() <= probability;
+    }
 
     public double nextDouble()
     {
-        return 0.5;
+        return random.nextDouble();
     }
 
-    @Override
     public double nextGaussian()
     {
-        return 0.5;
+        return random.nextGaussian();
     }
 
-    @Override
     public int nextInt(int max)
     {
-        return 1;
+        return random.nextInt(max);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestQuantileTreeScalarFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestQuantileTreeScalarFunctions.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.RandomizationStrategy;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.QuantileTree;
+import com.facebook.presto.operator.aggregation.noisyaggregation.sketch.quantiletree.TestQuantileTreeSeededRandomizationStrategy;
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.scalar.QuantileTreeScalarFunctions.cardinality;
+import static com.facebook.presto.operator.scalar.QuantileTreeScalarFunctions.emptyQuantileTree;
+import static com.facebook.presto.operator.scalar.QuantileTreeScalarFunctions.ensureNoise;
+import static com.facebook.presto.operator.scalar.QuantileTreeScalarFunctions.valueAtQuantile;
+import static com.facebook.presto.operator.scalar.QuantileTreeScalarFunctions.valuesAtQuantiles;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestQuantileTreeScalarFunctions
+{
+    @Test
+    public void testCardinality()
+    {
+        QuantileTree tree = new QuantileTree(0, 10000, 1024, 2, 5, 272);
+        int n = 123;
+        for (int i = 0; i < n; i++) {
+            tree.add(i); // add n values
+        }
+
+        assertEquals(cardinality(tree.serialize()), n);
+    }
+
+    @Test
+    public void testEmptyQuantileTreeNonPrivate()
+    {
+        QuantileTree nonPrivateTree = QuantileTree.deserialize(emptyQuantileTree(Double.POSITIVE_INFINITY, 1, -50, 50));
+        assertFalse(nonPrivateTree.isPrivacyEnabled());
+        assertEquals(nonPrivateTree.cardinality(), 0);
+    }
+
+    @Test
+    public void testEmptyQuantileTreePrivateDeterministic()
+    {
+        QuantileTree privateTree = QuantileTree.deserialize(emptyQuantileTree(2, 1e-6, -50, 50, new TestQuantileTreeSeededRandomizationStrategy(10)));
+        assertTrue(privateTree.isPrivacyEnabled());
+        assertEquals(privateTree.cardinality(), 0, 20.0);
+    }
+
+    @Test
+    public void testEmptyQuantileTreePrivateRandom()
+    {
+        // This test uses the SecureRandomizationStrategy, so we check the privacy but not the cardinality.
+        QuantileTree privateTree = QuantileTree.deserialize(emptyQuantileTree(2, 1e-6, -50, 50));
+        assertTrue(privateTree.isPrivacyEnabled());
+    }
+
+    @Test
+    public void testEnsureNoiseOnNoiselessTree()
+    {
+        QuantileTree tree = new QuantileTree(-10, 10, 1024, 2, 5, 272);
+        for (int i = 0; i < 5; i++) {
+            tree.add(i);
+        }
+
+        assertFalse(tree.isPrivacyEnabled());
+        double epsilon = 1;
+        double delta = 1e-6;
+
+        QuantileTree returnedTree = QuantileTree.deserialize(ensureNoise(tree.serialize(), epsilon, delta));
+
+        assertTrue(returnedTree.isPrivacyEnabled());
+        assertEquals(returnedTree.getRho(), QuantileTree.getRhoForEpsilonDelta(epsilon, delta));
+    }
+
+    @Test
+    public void testEnsureNoiseOnNoisyTree()
+    {
+        RandomizationStrategy randomizationStrategy = new TestQuantileTreeSeededRandomizationStrategy(1);
+        QuantileTree tree = new QuantileTree(-10, 10, 1024, 2, 5, 272);
+        for (int i = 0; i < 5; i++) {
+            tree.add(i);
+        }
+        tree.enablePrivacy(0.5, randomizationStrategy);
+
+        assertTrue(tree.isPrivacyEnabled());
+        assertEquals(tree.getRho(), 0.5);
+
+        double epsilon = 1;
+        double delta = 1e-6;
+
+        QuantileTree returnedTree = QuantileTree.deserialize(ensureNoise(tree.serialize(), epsilon, delta));
+
+        assertTrue(returnedTree.isPrivacyEnabled());
+        assertEquals(returnedTree.getRho(), QuantileTree.getRhoForEpsilonDelta(epsilon, delta));
+    }
+
+    @Test
+    public void testValueAtQuantile()
+    {
+        RandomizationStrategy randomizationStrategy = new TestQuantileTreeSeededRandomizationStrategy(1);
+        QuantileTree tree = new QuantileTree(-0.1, 1000.1, 1024, 2, 5, 272);
+        tree.enablePrivacy(0.2, randomizationStrategy);
+        for (int i = 0; i < 1_000; i++) {
+            tree.add(randomizationStrategy.nextInt(100));
+        }
+        Slice serialized = tree.serialize();
+        assertEquals(valueAtQuantile(serialized, 0.5), 50, 5.0);
+    }
+
+    @Test
+    public void testValuesAtQuantiles()
+    {
+        RandomizationStrategy randomizationStrategy = new TestQuantileTreeSeededRandomizationStrategy(1);
+        QuantileTree tree = new QuantileTree(-0.1, 1000.1, 1024, 2, 5, 272);
+        tree.enablePrivacy(0.2, randomizationStrategy);
+        for (int i = 0; i < 1_000; i++) {
+            tree.add(randomizationStrategy.nextInt(100));
+        }
+        Slice serialized = tree.serialize();
+
+        Block resultBlock = valuesAtQuantiles(serialized, createDoublesBlock(0.1, 0.25, 0.33, 0.5, 0.75, 0.9, 0.99));
+        double[] resultArray = new double[resultBlock.getPositionCount()];
+        for (int i = 0; i < resultBlock.getPositionCount(); i++) {
+            resultArray[i] = DOUBLE.getDouble(resultBlock, i);
+        }
+        double[] expected = {10, 25, 33, 50, 75, 90, 99};
+        assertEquals(resultArray, expected, 5.0);
+    }
+}


### PR DESCRIPTION
This commits adds several functions to support noisy approx_percentile functions using private sketch called QuantileTree which supports differentially private quantile estimates.

The main function is `noisy_approx_percentile_qtree` that returns noisy estimates of percentiles from a multiset of values using private sketches. Like all noisy aggregations, it does not achieve a true DP guarantee, as it returns NULL in the absence of data. Its DP-like privacy guarantee holds at the row-level under unbounded-neighbors (add/ remove) semantics. This corresponds to user-level privacy in the case when a user contributes at most one row. To achieve user-level privacy when users contribute more than one row, divide the privacy budget accordingly.

This is one of aggregations in our effort to add Presto UDF for noisy aggregations, used as building block for differential privacy in Presto. This new noisy function can be used to replace `approx_percentile(x, percentile)` with `noisy_approx_percentile_qtree(x, percentile, epsilon, delta, upper, lower)` where `epsilon` and `delta` are differential privacy parameters and `upper` and `lower` are estimates of upper and lower bounds of `x`.

Other supporting functions includes:
- `cardinality` returns the approximate number of items in a QuantileTree sketch
- `noisy_empty_qtree` creates an empty QuantileTree sketch object
- `ensure_noise_qtree` adds noise to a QuantileTree sketch to ensure a given level of noise
- `value_at_quantile` returns the approximate value from the quantile tree corresponding to a cumulative probability between 0 and 1
- `values_at_quantiles` returns the approximate values from the quantile tree corresponding to cumulative probabilities between 0 and 1
- `merge` merges multiple QuantileTree objects
- `noisy_qtree_agg` creates a QuantileTree object representing a multiset of values, which can be used later by functions above listed

Why we want these functions:
The purpose is to help build systems/tools/framework that provide differential privacy guarantees. Differential privacy has been used by multiple teams within Meta to develop privacy-preserving systems. Current implementation involves complicated SQL operation even for simplest aggregations, increasing development time, complexity, maintenance and sharing cost, and sometimes completely blocking development of new features.

While these functions on their own do not guarantee 100% differential privacy, they are the building blocks for other systems. That is also why we do not call these functions “differentially private aggregations” but only “noisy aggregations” to avoid a wrong impression of achieving differential privacy solely by using these functions.




## Description
This commits adds several functions to support noisy approx_percentile functions using private sketch called QuantileTree which supports differentially private quantile estimates.

The main function is `noisy_approx_percentile_qtree` that returns noisy estimates of percentiles from a multiset of values using private sketches. Like all noisy aggregations, it does not achieve a true DP guarantee, as it returns NULL in the absence of data. Its DP-like privacy guarantee holds at the row-level under unbounded-neighbors (add/ remove) semantics. This corresponds to user-level privacy in the case when a user contributes at most one row. To achieve user-level privacy when users contribute more than one row, divide the privacy budget accordingly.

This is one of aggregations in our effort to add Presto UDF for noisy aggregations, used as building block for differential privacy in Presto. This new noisy function can be used to replace `approx_percentile(x, percentile)` with `noisy_approx_percentile_qtree(x, percentile, epsilon, delta, upper, lower)` where `epsilon` and `delta` are differential privacy parameters and `upper` and `lower` are estimates of upper and lower bounds of `x`.

Why we want these functions:
The purpose is to help build systems/tools/framework that provide differential privacy guarantees. Differential privacy has been used by multiple teams within Meta to develop privacy-preserving systems. Current implementation involves complicated SQL operation even for simplest aggregations, increasing development time, complexity, maintenance and sharing cost, and sometimes completely blocking development of new features.

While these functions on their own do not guarantee 100% differential privacy, they are the building blocks for other systems. That is also why we do not call these functions “differentially private aggregations” but only “noisy aggregations” to avoid a wrong impression of achieving differential privacy solely by using these functions.

## Impact
This commit adds the following functions:
- `noisy_max_qtree` and `noisy_min_qtree` to replace `min` and `max` by using `noisy_approx_percentile_qtree` at very small (or large, respectively) percentile w.r.t. privacy budget and estimated cardinality.
- `noisy_empty_qtree` creates an empty QuantileTree sketch object
- `cardinality` returns the approximate number of items in a QuantileTree sketch
- `ensure_noise_qtree` adds noise to a QuantileTree sketch to ensure a given level of noise
- `value_at_quantile` returns the approximate value from the quantile tree corresponding to a cumulative probability between 0 and 1
- `values_at_quantiles` returns the approximate values from the quantile tree corresponding to cumulative probabilities between 0 and 1
- `merge` merges multiple QuantileTree objects
- `noisy_qtree_agg` creates a QuantileTree object representing a multiset of values, which can be used later by functions above listed


## Test Plan
- Unittest: 
  - Tested QuantileTree data structure itself, and its state objects
  - Tested `noisy_approx_percentile_qtree` with first quantile and median with both private and non-private versions, with 1 quantile and several quantiles
  - Tested `noisy_qtree_agg` with different input signature and with both private and non-private versions
  - Tested `merge` with one, several or imcompatible QuantileTree objects
  - Tested on tpch schema for `noisy_approx_percentile_qtree`, `noisy_max_qtree`, and `noisy_min_qtree` compared to normal `approx_percentile`, `max`, and `min`

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== RELEASE NOTES ==

General Changes
* Adds several functions to support noisy approx_percentile functions using private sketch called QuantileTree which supports differentially private (DP) quantile estimates.
  The main function is `noisy_approx_percentile_qtree` that returns noisy estimates of percentiles from a multiset of values using private sketches. Like all noisy aggregations, it does not achieve a true DP guarantee, as it returns NULL in the absence of data. Its DP-like privacy guarantee holds at the row-level under unbounded-neighbors (add/ remove) semantics. This corresponds to user-level privacy in the case when a user contributes at most one row. To achieve user-level privacy when users contribute more than one row, divide the privacy budget accordingly.

  Other supporting functions includes:
  - `cardinality` returns the approximate number of items in a QuantileTree sketch
  - `noisy_empty_qtree` creates an empty QuantileTree sketch object
  - `ensure_noise_qtree` adds noise to a QuantileTree sketch to ensure a given level of noise
  - `value_at_quantile` returns the approximate value from the quantile tree corresponding to a cumulative probability between 0 and 1
  - `values_at_quantiles` returns the approximate values from the quantile tree corresponding to cumulative probabilities between 0 and 1
  - `merge` merges multiple QuantileTree objects
  - `noisy_qtree_agg` creates a QuantileTree object representing a multiset of values, which can be used later by functions above listed