### PR TITLE
Remove some vestigial warning suppressions that are no longer needed

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1668,7 +1668,6 @@ public abstract class AbstractTestHiveClient
         }
     }
 
-    @SuppressWarnings({"ValueOfIncrementOrDecrementUsed", "UnusedAssignment"})
     @Test
     public void testGetTableSchemaPartitionFormat()
     {
@@ -2066,7 +2065,6 @@ public abstract class AbstractTestHiveClient
         }
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Test
     public void testBucketedTableBigintBoolean()
             throws Exception

--- a/presto-hive/src/test/java/com/facebook/presto/hive/util/TestSerDeUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/util/TestSerDeUtils.java
@@ -64,7 +64,6 @@ import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFacto
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getReflectionObjectInspector;
 import static org.testng.Assert.assertEquals;
 
-@SuppressWarnings("PackageVisibleField")
 public class TestSerDeUtils
 {
     private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager();

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestClientBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestClientBuffer.java
@@ -474,7 +474,6 @@ public class TestClientBuffer
         return createBufferResult(TASK_INSTANCE_ID, token, pages);
     }
 
-    @SuppressWarnings("ConstantConditions")
     private static void assertBufferDestroyed(ClientBuffer buffer, int pagesSent)
     {
         BufferInfo bufferInfo = buffer.getInfo();

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/groupByAggregations/AggregationTestInput.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/groupByAggregations/AggregationTestInput.java
@@ -37,7 +37,6 @@ public class AggregationTestInput
     private final int offset;
     private final boolean isReversed;
 
-    @SuppressWarnings("NumericCastThatLosesPrecision")
     public AggregationTestInput(JavaAggregationFunctionImplementation function, Page[] pages, int offset, boolean isReversed)
     {
         this.pages = pages;

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayJoin.java
@@ -80,7 +80,6 @@ public class BenchmarkArrayJoin
                         data.getPage()));
     }
 
-    @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class BenchmarkData
     {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayTransform.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayTransform.java
@@ -95,7 +95,6 @@ public class BenchmarkArrayTransform
                         data.getPage()));
     }
 
-    @SuppressWarnings("FieldMayBeFinal")
     @State(Scope.Thread)
     public static class BenchmarkData
     {

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
@@ -105,7 +105,6 @@ public class TestServer
         client = new JettyHttpClient();
     }
 
-    @SuppressWarnings("deprecation")
     @AfterMethod
     public void teardown()
     {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
@@ -259,7 +259,7 @@ public abstract class AbstractTestOrcReader
         TempFile file = new TempFile();
         RecordWriter writer = createOrcRecordWriter(file.getFile(), ORC_12, CompressionKind.NONE, BIGINT);
 
-        @SuppressWarnings("deprecation") Serializer serde = new OrcSerde();
+        Serializer serde = new OrcSerde();
         SettableStructObjectInspector objectInspector = createSettableStructObjectInspector("test", BIGINT);
         Object row = objectInspector.create();
         StructField field = objectInspector.getAllStructFieldRefs().get(0);

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisMetadata.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisMetadata.java
@@ -243,7 +243,6 @@ public class RedisMetadata
         return redisTableDescriptionSupplier.get();
     }
 
-    @SuppressWarnings("ValueOfIncrementOrDecrementUsed")
     private ConnectorTableMetadata getTableMetadata(SchemaTableName schemaTableName)
     {
         RedisTableDescription table = getDefinedTables().get(schemaTableName);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
@@ -254,7 +254,6 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT *, 1.0 * sum(x) OVER () FROM (VALUES 1) t(x)", "SELECT 1, 1.0");
     }
 
-    @SuppressWarnings("PointlessArithmeticExpression")
     @Test
     public void testWindowFunctionsExpressions()
     {


### PR DESCRIPTION
## Description
Remove some vestigial warning suppressions that are no longer needed

Clarity

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

