### PR TITLE
[native] Add support to convert VARBINARY filter to velox filter

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
@@ -235,6 +235,9 @@ std::string toString(
     const VeloxExprConverter& exprConverter,
     const TypePtr& type) {
   auto value = exprConverter.getConstantValue(type, *block);
+  if (type->isVarbinary()) {
+    return value.value<TypeKind::VARBINARY>();
+  }
   return value.value<std::string>();
 }
 
@@ -652,6 +655,7 @@ std::unique_ptr<common::Filter> toFilter(
     case TypeKind::DOUBLE:
       return doubleRangeToFilter(range, nullAllowed, exprConverter, type);
     case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
       return varcharRangeToFilter(range, nullAllowed, exprConverter, type);
     case TypeKind::BOOLEAN:
       return boolRangeToFilter(range, nullAllowed, exprConverter, type);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Currently, queries with VARBINARY filters will fail:
```
presto:velox> select id from parquet_date_binary_test where c = to_ieee754_64(1);

Query 20240604_074724_00001_83ier, FAILED, 1 node
Splits: 1 total, 0 done (0.00%)
0:04 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20240604_074724_00001_83ier failed:  Unsupported range type: VARBINARY
```

This PR converts Presto's VARBINARY filter to Velox's `common::BytesRange`.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

