### PR TITLE
Throw exception for cast of nan and infinity to int types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -16,7 +16,6 @@ package com.facebook.presto.type;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.AbstractLongType;
 import com.facebook.presto.common.type.StandardTypes;
-import com.facebook.presto.operator.scalar.MathFunctions;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.BlockIndex;
 import com.facebook.presto.spi.function.BlockPosition;
@@ -53,12 +52,10 @@ import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Float.floatToRawIntBits;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.math.RoundingMode.FLOOR;
 import static java.math.RoundingMode.HALF_UP;
@@ -195,10 +192,10 @@ public final class DoubleOperators
     public static long castToInteger(@SqlType(StandardTypes.DOUBLE) double value)
     {
         try {
-            return toIntExact((long) MathFunctions.round(value));
+            return DoubleMath.roundToInt(value, HALF_UP);
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for integer: " + value, e);
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to integer", value), e);
         }
     }
 
@@ -207,10 +204,10 @@ public final class DoubleOperators
     public static long castToSmallint(@SqlType(StandardTypes.DOUBLE) double value)
     {
         try {
-            return Shorts.checkedCast((long) MathFunctions.round(value));
+            return Shorts.checkedCast(DoubleMath.roundToInt(value, HALF_UP));
         }
-        catch (IllegalArgumentException e) {
-            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for smallint: " + value, e);
+        catch (ArithmeticException | IllegalArgumentException e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to smallint", value), e);
         }
     }
 
@@ -219,10 +216,10 @@ public final class DoubleOperators
     public static long castToTinyint(@SqlType(StandardTypes.DOUBLE) double value)
     {
         try {
-            return SignedBytes.checkedCast((long) MathFunctions.round(value));
+            return SignedBytes.checkedCast(DoubleMath.roundToInt(value, HALF_UP));
         }
-        catch (IllegalArgumentException e) {
-            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for tinyint: " + value, e);
+        catch (ArithmeticException | IllegalArgumentException e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to tinyint", value), e);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -406,7 +406,7 @@ public class TestArrayOperators
         assertInvalidCast("CAST(unchecked_to_json('[1, 2, 3') AS ARRAY<BIGINT>)", "Cannot cast to array(bigint).\n[1, 2, 3");
 
         assertInvalidCast("CAST(JSON '[\"a\", \"b\"]' AS ARRAY<BIGINT>)", "Cannot cast to array(bigint). Cannot cast 'a' to BIGINT\n[\"a\",\"b\"]");
-        assertInvalidCast("CAST(JSON '[1234567890123.456]' AS ARRAY<INTEGER>)", "Cannot cast to array(integer). Out of range for integer: 1.234567890123456E12\n[1.234567890123456E12]");
+        assertInvalidCast("CAST(JSON '[1234567890123.456]' AS ARRAY<INTEGER>)", "Cannot cast to array(integer). Unable to cast 1.234567890123456E12 to integer\n[1.234567890123456E12]");
 
         assertFunction("CAST(JSON '[1, 2.0, 3]' AS ARRAY(DECIMAL(10,5)))", new ArrayType(createDecimalType(10, 5)), ImmutableList.of(decimal("1.00000"), decimal("2.00000"), decimal("3.00000")));
         assertFunction("CAST(CAST(ARRAY [1, 2.0, 3] as JSON) AS ARRAY(DECIMAL(10,5)))", new ArrayType(createDecimalType(10, 5)), ImmutableList.of(decimal("1.00000"), decimal("2.00000"), decimal("3.00000")));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDoubleOperators.java
@@ -20,7 +20,10 @@ import static com.facebook.presto.common.function.OperatorType.INDETERMINATE;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static java.lang.Double.doubleToLongBits;
@@ -207,6 +210,59 @@ public class TestDoubleOperators
         assertInvalidFunction("cast(infinity() as bigint)", INVALID_CAST_ARGUMENT);
         assertInvalidFunction("cast(-infinity() as bigint)", INVALID_CAST_ARGUMENT);
         assertInvalidFunction("cast(nan() as bigint)", INVALID_CAST_ARGUMENT);
+    }
+
+    @Test
+    public void testCastToInteger()
+    {
+        assertFunction("cast(37.7E0 as integer)", INTEGER, 38);
+        assertFunction("cast(-37.7E0 as integer)", INTEGER, -38);
+        assertFunction("cast(17.1E0 as integer)", INTEGER, 17);
+        assertFunction("cast(-17.1E0 as integer)", INTEGER, -17);
+        assertFunction("cast(9.2E8 as integer)", INTEGER, 920000000);
+        assertFunction("cast(-9.2E8 as integer)", INTEGER, -920000000);
+        assertFunction("cast(2.21E8 as integer)", INTEGER, 221000000);
+        assertFunction("cast(-2.21E8 as integer)", INTEGER, -221000000);
+        assertFunction("cast(17.5E0 as integer)", INTEGER, 18);
+        assertFunction("cast(-17.5E0 as integer)", INTEGER, -18);
+
+        assertFunction("cast(" + Math.nextDown(0x1.0p31f) + " as integer)", INTEGER, (int) Math.nextDown(0x1.0p31f));
+        assertInvalidFunction("cast(" + 0x1.0p31 + " as integer)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(" + Math.nextUp(0x1.0p31f) + " as integer)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(" + Math.nextDown(-0x1.0p31f) + " as integer)", INVALID_CAST_ARGUMENT);
+        assertFunction("cast(" + -0x1.0p31 + " as integer)", INTEGER, (int) -0x1.0p31);
+        assertFunction("cast(" + Math.nextUp(-0x1.0p31f) + " as integer)", INTEGER, (int) Math.nextUp(-0x1.0p31f));
+
+        assertInvalidFunction("cast(9.3E9 as integer)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(-9.3E9 as integer)", INVALID_CAST_ARGUMENT);
+
+        assertInvalidFunction("cast(infinity() as integer)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(-infinity() as integer)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(nan() as integer)", INVALID_CAST_ARGUMENT);
+    }
+
+    @Test
+    public void testCastToSmallInt()
+    {
+        assertFunction("cast(" + (0x1.0p15 - 0.6) + " as smallint)", SMALLINT, Short.MAX_VALUE);
+        assertInvalidFunction("cast(DOUBLE '" + 0x1.0p15 + "' as smallint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(9.2E9 as smallint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(-9.2E9 as smallint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(infinity() as smallint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(-infinity() as smallint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(nan() as smallint)", INVALID_CAST_ARGUMENT);
+    }
+
+    @Test
+    public void testCastToTinyInt()
+    {
+        assertFunction("cast(" + (0x1.0p7 - 0.6) + " as tinyint)", TINYINT, Byte.MAX_VALUE);
+        assertInvalidFunction("cast(DOUBLE '" + 0x1.0p7 + "' as tinyint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(9.2E9 as tinyint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(-9.2E9 as tinyint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(infinity() as tinyint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(-infinity() as tinyint)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(nan() as tinyint)", INVALID_CAST_ARGUMENT);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -593,7 +593,7 @@ public class TestMapOperators
         assertInvalidCast("CAST(unchecked_to_json('{\"a\": 1') AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar,bigint).\n{\"a\": 1");
 
         assertInvalidCast("CAST(JSON '{\"a\": \"b\"}' AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar,bigint). Cannot cast 'b' to BIGINT\n{\"a\":\"b\"}");
-        assertInvalidCast("CAST(JSON '{\"a\": 1234567890123.456}' AS MAP<VARCHAR, INTEGER>)", "Cannot cast to map(varchar,integer). Out of range for integer: 1.234567890123456E12\n{\"a\":1.234567890123456E12}");
+        assertInvalidCast("CAST(JSON '{\"a\": 1234567890123.456}' AS MAP<VARCHAR, INTEGER>)", "Cannot cast to map(varchar,integer). Unable to cast 1.234567890123456E12 to integer\n{\"a\":1.234567890123456E12}");
 
         assertInvalidCast("CAST(JSON '{\"1\":1, \"01\": 2}' AS MAP<BIGINT, BIGINT>)", "Cannot cast to map(bigint,bigint). Duplicate keys are not allowed\n{\"01\":2,\"1\":1}");
         assertInvalidCast("CAST(JSON '[{\"1\":1, \"01\": 2}]' AS ARRAY<MAP<BIGINT, BIGINT>>)", "Cannot cast to array(map(bigint,bigint)). Duplicate keys are not allowed\n[{\"01\":2,\"1\":1}]");

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRealOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRealOperators.java
@@ -25,6 +25,7 @@ import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Float.isNaN;
@@ -183,6 +184,11 @@ public class TestRealOperators
         assertFunction("CAST(REAL'-754.2008' as BIGINT)", BIGINT, -754L);
         assertFunction("CAST(REAL'1.98' as BIGINT)", BIGINT, 2L);
         assertFunction("CAST(REAL'-0.0' as BIGINT)", BIGINT, 0L);
+
+        assertInvalidFunction("CAST(cast(nan() AS REAL) as BIGINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(infinity() AS REAL) as BIGINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as BIGINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(REAL '" + Float.MAX_VALUE + "' as BIGINT)", INVALID_CAST_ARGUMENT);
     }
 
     @Test
@@ -192,6 +198,20 @@ public class TestRealOperators
         assertFunction("CAST(REAL'-754.1985' AS INTEGER)", INTEGER, -754);
         assertFunction("CAST(REAL'9.99' AS INTEGER)", INTEGER, 10);
         assertFunction("CAST(REAL'-0.0' AS INTEGER)", INTEGER, 0);
+
+        assertFunction("cast(REAL '" + Math.nextDown(0x1.0p31f) + "' as integer)", INTEGER, (int) Math.nextDown(0x1.0p31f));
+        assertInvalidFunction("cast(REAL '" + 0x1.0p31 + "' as integer)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(REAL '" + Math.nextUp(0x1.0p31f) + "' as integer)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(REAL '" + Math.nextDown(-0x1.0p31f) + "' as integer)", INVALID_CAST_ARGUMENT);
+        assertFunction("cast(REAL '" + -0x1.0p31 + "' as integer)", INTEGER, (int) -0x1.0p31);
+        assertFunction("cast(REAL '" + Math.nextUp(-0x1.0p31f) + "' as integer)", INTEGER, (int) Math.nextUp(-0x1.0p31f));
+
+        assertInvalidFunction("cast(9.3E9 as integer)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(-9.3E9 as integer)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(nan() AS REAL) as INTEGER)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(infinity() AS REAL) as INTEGER)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as INTEGER)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(REAL '" + (Integer.MAX_VALUE + 0.6) + "' as INTEGER)", INVALID_CAST_ARGUMENT);
     }
 
     @Test
@@ -201,6 +221,10 @@ public class TestRealOperators
         assertFunction("CAST(REAL'-754.1985' AS SMALLINT)", SMALLINT, (short) -754);
         assertFunction("CAST(REAL'9.99' AS SMALLINT)", SMALLINT, (short) 10);
         assertFunction("CAST(REAL'-0.0' AS SMALLINT)", SMALLINT, (short) 0);
+        assertInvalidFunction("CAST(cast(nan() AS REAL) as SMALLINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(infinity() AS REAL) as SMALLINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as SMALLINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(REAL '" + (Short.MAX_VALUE + 0.6) + "' as SMALLINT)", INVALID_CAST_ARGUMENT);
     }
 
     @Test
@@ -210,6 +234,10 @@ public class TestRealOperators
         assertFunction("CAST(REAL'-128.234' AS TINYINT)", TINYINT, (byte) -128);
         assertFunction("CAST(REAL'9.99' AS TINYINT)", TINYINT, (byte) 10);
         assertFunction("CAST(REAL'-0.0' AS TINYINT)", TINYINT, (byte) 0);
+        assertInvalidFunction("CAST(cast(nan() AS REAL) as TINYINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(infinity() AS REAL) as TINYINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as TINYINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(REAL '" + (Byte.MAX_VALUE + 0.6) + "' as TINYINT)", INVALID_CAST_ARGUMENT);
     }
 
     @Test


### PR DESCRIPTION
## Description
Fix cast of nan and infinity from DOUBLE/REAL to
BIGINT/INT/SMALLINT/TINYTINT.  Previously all except double -> bigint would return zero.  Now they will all throw an INVALID_CAST_ARGUMENT exception.

Fix silent overflow for casting from REAL to BIGINT type. We now throw
an INVALID_CAST_ARGUMENT if the value is out of the BIGINT range.

Change error code from NUMERIC_VALUE_OUT_OF_RANGE to
INVALID_CAST_ARGUMENT for out of range values in casts from floating
point to integer types.  With the library we now use for the
implementaiton for these casts, we can't always tell by the exception
type that the value is out of range, so we return the more generic, but
still relevant INVALID_CAST_ARGUMENT instead.

## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/22910.  
Nan and infinity can't be represented as an integer, so casting to an int type should throw an error.

This also brings Presto and velox behavior in alignment. We are choosing to modify Presto in this case because velox behavior is correct here (we would want to change Presto regardless of the native worker migration)

## Impact

CAST of nan and infinity to BIGINT, INTEGER, SMALLINT, and TINYINT types will now return an exception with the INVALID_CAST_ARGUMENT error code

Cast of out of range values for DOUBLE or FLOAT to BIGINT, INTEGER, SMALLINT, or TINYINT will now return an INVALID_CAST_ARGUMENT error code rather than NUMERIC_VALUE_OUT_OF_RANGE error code

CAST of real values outside of BIGINT range will now return a NUMERIC_VALUE_OUT_OF_RANGE error. Previously they would silently overflow.


## Test Plan
unit tests
## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix cast of NaN and Infinity from DOUBLE or REAL to  BIGINT, INTEGER, SMALLINT, and TINYINT. It will now return an exception with the INVALID_CAST_ARGUMENT error code. Previously it would return zero.
* Fix CAST of REAL values outside of BIGINT range to return an exception with an INVALID_CAST_ARGUMENT error code. Previously they would silently overflow.
* Change error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from ``NUMERIC_VALUE_OUT_OF_RANGE`` to ``INVALID_CAST_ARGUMENT``.

```
