### PR TITLE
Disable timestamp with time zone in create, alter and insert statements

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java
@@ -126,10 +126,6 @@ public class ColumnIdentity
 
     public static ColumnIdentity createColumnIdentity(String name, int id, org.apache.iceberg.types.Type fieldType)
     {
-        if (fieldType.equals(Types.TimestampType.withZone())) {
-            throw new UnsupportedOperationException(format("Iceberg column type %s is not supported", fieldType));
-        }
-
         if (!fieldType.isNestedType()) {
             return new ColumnIdentity(id, name, PRIMITIVE, ImmutableList.of());
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -138,6 +138,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.tryGetLocation;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetSchema;
 import static com.facebook.presto.iceberg.IcebergUtil.validateTableMode;
+import static com.facebook.presto.iceberg.IcebergUtil.verifyTypeSupported;
 import static com.facebook.presto.iceberg.PartitionFields.getPartitionColumnName;
 import static com.facebook.presto.iceberg.PartitionFields.getTransformTerm;
 import static com.facebook.presto.iceberg.PartitionFields.toPartitionFields;
@@ -673,6 +674,8 @@ public abstract class IcebergAbstractMetadata
         verify(table.getIcebergTableName().getTableType() == DATA, "only the data table can have data inserted");
         Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
         validateTableMode(session, icebergTable);
+
+        verifyTypeSupported(icebergTable.schema());
 
         return beginIcebergTableInsert(table, icebergTable);
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -122,6 +122,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.isIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.populateTableProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetProperties;
+import static com.facebook.presto.iceberg.IcebergUtil.verifyTypeSupported;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
 import static com.facebook.presto.iceberg.util.StatisticsUtil.calculateAndSetTableSize;
 import static com.facebook.presto.iceberg.util.StatisticsUtil.mergeHiveStatistics;
@@ -267,6 +268,8 @@ public class IcebergHiveMetadata
         String tableName = schemaTableName.getTableName();
 
         Schema schema = toIcebergSchema(tableMetadata.getColumns());
+
+        verifyTypeSupported(schema);
 
         PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.iceberg.IcebergTableType.DATA;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.populateTableProperties;
+import static com.facebook.presto.iceberg.IcebergUtil.verifyTypeSupported;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergNamespace;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
@@ -163,6 +164,8 @@ public class IcebergNativeMetadata
         String tableName = schemaTableName.getTableName();
 
         Schema schema = toIcebergSchema(tableMetadata.getColumns());
+
+        verifyTypeSupported(schema);
 
         PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
         FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -417,6 +417,13 @@ public final class IcebergUtil
         }
     }
 
+    public static void verifyTypeSupported(Schema schema)
+    {
+        if (schema.columns().stream().anyMatch(column -> Types.TimestampType.withZone().equals(column.type()))) {
+            throw new PrestoException(NOT_SUPPORTED, format("Iceberg column type %s is not supported", Types.TimestampType.withZone()));
+        }
+    }
+
     public static Map<String, String> createIcebergViewProperties(ConnectorSession session, String prestoVersion)
     {
         return ImmutableMap.<String, String>builder()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -89,6 +89,7 @@ public class IcebergDistributedSmokeTestBase
     public void testTimestampWithTimeZone()
     {
         assertQueryFails("CREATE TABLE test_timestamp_with_timezone (x timestamp with time zone)", "Iceberg column type timestamptz is not supported");
+        assertQueryFails("CREATE TABLE test_timestamp_with_timezone (x) AS SELECT TIMESTAMP '1969-12-01 00:00:00.000000 UTC'", "Iceberg column type timestamptz is not supported");
         assertUpdate("CREATE TABLE test_timestamp_with_timezone (x timestamp)");
         assertQueryFails("ALTER TABLE test_timestamp_with_timezone ADD COLUMN y timestamp with time zone", "Iceberg column type timestamptz is not supported");
         dropTable(getSession(), "test_timestamp_with_timezone");


### PR DESCRIPTION
Timestamp with time zone is not allowed in DDL statements because inserts fail, but tables with timestamp with time zone can be registered and queried.

## Description
Presto issue #22794 

## Motivation and Context
When querying an Iceberg table in AWS Glue the following error is received: 'Iceberg column type timestamptz is not supported'. This worked before Presto 0.285. It is related to #21096 

## Impact
Create table, alter table and insert statements having "timestamp with time zone" will return error for Iceberg tables:
'Iceberg column type timestamptz is not supported'.
But existent Iceberg tables with timestamp with time zone can be registered and queried.

## Test Plan
Add a new test in IcebergDistributedSmokeTestBase

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Disable timestamp with time zone in create, alter and insert statements :pr:`22926`
