### PR TITLE
Remove format() calls for constant strings with no arguments

### DIFF
--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplitManager.java
@@ -36,7 +36,6 @@ import java.util.OptionalInt;
 import static com.facebook.presto.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
 import static com.google.cloud.bigquery.storage.v1beta1.Storage.ReadSession;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
@@ -131,7 +130,7 @@ public class BigQuerySplitManager
             return splits;
         }
         catch (BigQueryException e) {
-            throw new PrestoException(BIGQUERY_FAILED_TO_EXECUTE_QUERY, format("Failed to compute empty projection"), e);
+            throw new PrestoException(BIGQUERY_FAILED_TO_EXECUTE_QUERY, "Failed to compute empty projection", e);
         }
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/segment/SmooshedColumnSource.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/segment/SmooshedColumnSource.java
@@ -82,7 +82,7 @@ public class SmooshedColumnSource
             BufferedReader in = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(metadata)));
             String line = in.readLine();
             if (line == null) {
-                throw new PrestoException(DRUID_SEGMENT_LOAD_ERROR, format("Malformed metadata file: first line should be version,maxChunkSize,numChunks, got null."));
+                throw new PrestoException(DRUID_SEGMENT_LOAD_ERROR, "Malformed metadata file: first line should be version,maxChunkSize,numChunks, got null.");
             }
 
             String[] splits = line.split(",");

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -331,7 +331,7 @@ public abstract class AbstractSqlInvokedFunctionNamespaceManager
                 throw new IllegalStateException(
                         format("SqlInvokedFunction %s has BUILTIN implementation type but %s cannot manage BUILTIN functions", function.getSignature().getName(), this.getClass()));
             case CPP:
-                throw new IllegalStateException(format("Presto coordinator can not resolve implementation of CPP UDF functions"));
+                throw new IllegalStateException("Presto coordinator can not resolve implementation of CPP UDF functions");
             default:
                 throw new IllegalStateException(format("Unknown function implementation type: %s", implementationType));
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -3509,7 +3509,7 @@ public class HiveMetadata
             }
 
             if (seenColumns.contains(columnWithSubfield.toString())) {
-                throw new PrestoException(INVALID_TABLE_PROPERTY, format("The same column/subfield cannot have 2 encryption keys"));
+                throw new PrestoException(INVALID_TABLE_PROPERTY, "The same column/subfield cannot have 2 encryption keys");
             }
 
             if (columnWithSubfield.getSubfieldPath().isPresent()) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -6369,7 +6369,7 @@ public class TestHiveIntegrationSmokeTest
 
         // Negative tests
         assertQueryFails(addPrimaryKeyStmt, format("Primary key already exists for: %s.%s", getSession().getSchema().get(), tableName));
-        assertQueryFails(addUniqueConstraintStmt, format("Constraint already exists: 'uq3'"));
+        assertQueryFails(addUniqueConstraintStmt, "Constraint already exists: 'uq3'");
         String dropNonExistentConstraint = format("ALTER TABLE %s.%s.%s DROP CONSTRAINT missingconstraint", getSession().getCatalog().get(), getSession().getSchema().get(), tableName);
         assertQueryFails(dropNonExistentConstraint, "Constraint 'missingconstraint' not found");
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -398,7 +398,7 @@ public class PrestoNativeQueryRunnerUtils
                         }
                         else {
                             Files.write(catalogDirectoryPath.resolve(format("%s.properties", catalogName)),
-                                    format("connector.name=hive").getBytes());
+                                    "connector.name=hive".getBytes());
                         }
                         // Add catalog with caching always enabled.
                         Files.write(catalogDirectoryPath.resolve(format("%scached.properties", catalogName)),

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSource.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSource.java
@@ -391,7 +391,7 @@ public class PinotBrokerPageSource
                 throw new PinotException(
                     PINOT_UNEXPECTED_RESPONSE,
                     Optional.of(sql),
-                    String.format("Expected data schema in the response"));
+                    "Expected data schema in the response");
             }
             JsonNode columnDataTypes = dataSchema.get("columnDataTypes");
             JsonNode columnNames = dataSchema.get("columnNames");

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -133,10 +133,10 @@ public class TestPrestoSparkQueryRunner
     {
         assertUpdate(
                 getSession(),
-                format("CREATE TABLE hive.hive_test.test_hive_orders_bucketed_join_zero_file WITH (bucketed_by=array['orderkey'], bucket_count=8) AS " +
+                "CREATE TABLE hive.hive_test.test_hive_orders_bucketed_join_zero_file WITH (bucketed_by=array['orderkey'], bucket_count=8) AS " +
                         "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
                         "FROM orders_bucketed " +
-                        "WHERE orderkey = 1"),
+                        "WHERE orderkey = 1",
                 1);
     }
 


### PR DESCRIPTION
## Description
Remove format() calls for constant strings with no arguments

## Motivation and Context
simpler code

## Impact
none

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

