### PR TITLE
[docs] Fix DROP SCHEMA doc

### DIFF
--- a/presto-docs/src/main/sphinx/sql/drop-schema.rst
+++ b/presto-docs/src/main/sphinx/sql/drop-schema.rst
@@ -26,7 +26,7 @@ Drop the schema ``web``::
 
 Drop the schema ``sales`` if it exists::
 
-    DROP TABLE IF EXISTS sales
+    DROP SCHEMA IF EXISTS sales
 
 See Also
 --------


### PR DESCRIPTION
## Description
Correct an example in the [DROP SCHEMA](https://prestodb.io/docs/current/sql/drop-schema.html) documentation from 

`DROP TABLE IF EXISTS sales` 

to 

`DROP SCHEMA IF EXISTS sales`

## Motivation and Context
A bad code example in the documentation can confuse readers. 

## Impact
Documentation.

## Test Plan
Local docs build. Also, CI. 

Current doc: 
<img width="288" alt="Screenshot 2024-06-05 at 1 25 26 PM" src="https://github.com/prestodb/presto/assets/7013443/f76680ed-c03d-415d-8a82-633d1f418dec">

Fixed doc: 
<img width="307" alt="Screenshot 2024-06-05 at 1 25 34 PM" src="https://github.com/prestodb/presto/assets/7013443/7405728f-f54d-47f8-ade8-d2300bdab754">

Note: Second screenshot is different in appearance because of new Presto docs theme merged in #22887. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

