### PR TITLE
[docs] Add CODEOWNERS suggestion to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,6 @@ Thanks for your interest in Presto. Our goal is to build a fast, scalable, and r
 | Supporting Users | Reply to questions on the [Slack channel](https://join.slack.com/t/prestodb/shared_invite/enQtNTQ3NjU2MTYyNDA2LTYyOTg3MzUyMWE1YTI3Njc5YjgxZjNiYTgxODAzYjI5YWMwYWE0MTZjYWFhNGMwNjczYjI3N2JhM2ExMGJlMWM), check Presto's [open issues](https://github.com/prestodb/presto/issues) for user questions, or help with [code reviews](#codereviews). 
 | Need help?       | For community support, [ask for help in Slack](https://join.slack.com/t/prestodb/shared_invite/enQtNTQ3NjU2MTYyNDA2LTYyOTg3MzUyMWE1YTI3Njc5YjgxZjNiYTgxODAzYjI5YWMwYWE0MTZjYWFhNGMwNjczYjI3N2JhM2ExMGJlMWM).                                                                                                                                   |
 
-## <a id="requirements">Requirements</a>
-
 ## Presto Community
 
 The Presto community values:
@@ -359,6 +357,8 @@ Details for each point and good commit message examples can be found on https://
 ## Committers
 
 Presto committers are defined as [code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) and documented in the project's [`CODEOWNERS`](CODEOWNERS) file.  Each line in the `CODEOWNERS` file defines a module or submodule that the committer has the rights to approve.  New modules and submodules for CODEOWNERS may be added as needed.
+
+See [`CODEOWNERS`](CODEOWNERS) for modules, connectors, and libraries that lack active codeownership. If you have interest in contributing to one of these, work toward becoming a codeowner for that area.
 
 New committers are approved by majority vote of the TSC ([see TSC charter](https://github.com/prestodb/tsc/blob/master/CHARTER.md)).  To become a committer, reach out to an [existing TSC member](https://github.com/prestodb/tsc#members) and ask for their feedback on your eligibility (see: [How to become a Presto Committer?](https://github.com/prestodb/presto/wiki/How-to-become-a-Presto-committer%3F)).  Note: to expedite the process, consider creating a document that outlines your Github stats, such as the number of reviews, lines of code added, number of PRs, and outlines particularly outstanding code and review contributions.  If the TSC member believes you are eligible, they will submit your nomination to a vote by the TSC, typically in the form of a PR that adds your handle to the `CODEOWNERS` file.  The process is complete once the PR is merged.
 


### PR DESCRIPTION
## Description
* Add to [Committers](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#committers) in CONTRIBUTING.md a suggestion encouraging readers to volunteer as codeowners for areas of Presto lacking active codeownership.
* Delete an empty Requirements heading (the Presto [Requirements](https://github.com/prestodb/presto/blob/master/README.md#requirements) have been moved to README.md) in CONTRIBUTING.md that was overlooked in #22930. 

## Motivation and Context
The first addresses [a suggestion](https://github.com/prestodb/presto/pull/22641#issuecomment-2125106114) that I made in #22641. The second fixes a text error. 

## Impact
Documentation.

## Test Plan
Pushed branch to my fork of the repo and View File to see the file as it will be displayed in GitHub. Also, CI. 

* Screenshot of new Committers topic, showing the added text in the two sentences beginning with "See `CODEOWNERS` for modules, connectors, [...]". 

<img width="985" alt="Screenshot 2024-06-06 at 10 44 52 AM" src="https://github.com/prestodb/presto/assets/7013443/8e41c589-7a14-46d2-822e-2cf6804eb552">

-------------------------------------

* Screenshot of current CONTRIBUTING.md, showing the empty Requirements heading that this PR deletes.

<img width="599" alt="Screenshot 2024-06-06 at 11 01 34 AM" src="https://github.com/prestodb/presto/assets/7013443/4171bdbc-8149-429f-9be2-0b86fa93d68e">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

