### PR TITLE
IcebergQueryRunner data directory fix

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -39,8 +39,7 @@ import static com.facebook.presto.SystemSessionProperties.LEGACY_TIMESTAMP;
 import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.TEST_CATALOG_DIRECTORY;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.TEST_DATA_DIRECTORY;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.iceberg.IcebergUtil.MIN_FORMAT_VERSION_FOR_DELETE;
 import static com.facebook.presto.iceberg.procedure.RegisterTableProcedure.METADATA_FOLDER_NAME;
 import static com.facebook.presto.iceberg.procedure.TestIcebergRegisterProcedure.getMetadataFileLocation;
@@ -1110,8 +1109,8 @@ public class IcebergDistributedSmokeTestBase
 
     protected Path getCatalogDirectory()
     {
-        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory().resolve(TEST_DATA_DIRECTORY);
-        return dataDirectory.getParent().resolve(TEST_CATALOG_DIRECTORY);
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        return getIcebergDataDirectoryPath(dataDirectory, catalogType.name(), new IcebergConfig().getFileFormat(), false);
     }
 
     protected Table getIcebergTable(ConnectorSession session, String namespace, String tableName)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -105,8 +105,7 @@ import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.SYNTHESIZ
 import static com.facebook.presto.iceberg.FileContent.EQUALITY_DELETES;
 import static com.facebook.presto.iceberg.FileContent.POSITION_DELETES;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.TEST_CATALOG_DIRECTORY;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.TEST_DATA_DIRECTORY;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.DELETE_AS_JOIN_REWRITE_ENABLED;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.STATISTIC_SNAPSHOT_RECORD_DIFFERENCE_WEIGHT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -1595,7 +1594,8 @@ public abstract class IcebergDistributedTestBase
     private void writePositionDeleteToNationTable(Table icebergTable, String dataFilePath, long deletePos)
             throws IOException
     {
-        File metastoreDir = getDistributedQueryRunner().getCoordinator().getDataDirectory().toFile();
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        File metastoreDir = getIcebergDataDirectoryPath(dataDirectory, catalogType.name(), new IcebergConfig().getFileFormat(), false).toFile();
         org.apache.hadoop.fs.Path metadataDir = new org.apache.hadoop.fs.Path(metastoreDir.toURI());
         String deleteFileName = "delete_file_" + UUID.randomUUID();
         FileSystem fs = getHdfsEnvironment().getFileSystem(new HdfsContext(SESSION), metadataDir);
@@ -1626,7 +1626,8 @@ public abstract class IcebergDistributedTestBase
     private void writeEqualityDeleteToNationTable(Table icebergTable, Map<String, Object> overwriteValues, Map<String, Object> partitionValues)
             throws Exception
     {
-        File metastoreDir = getDistributedQueryRunner().getCoordinator().getDataDirectory().toFile();
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        File metastoreDir = getIcebergDataDirectoryPath(dataDirectory, catalogType.name(), new IcebergConfig().getFileFormat(), false).toFile();
         org.apache.hadoop.fs.Path metadataDir = new org.apache.hadoop.fs.Path(metastoreDir.toURI());
         String deleteFileName = "delete_file_" + UUID.randomUUID();
         FileSystem fs = getHdfsEnvironment().getFileSystem(new HdfsContext(SESSION), metadataDir);
@@ -1689,14 +1690,9 @@ public abstract class IcebergDistributedTestBase
         Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
         switch (catalogType) {
             case HIVE:
-                return dataDirectory
-                        .resolve(TEST_DATA_DIRECTORY)
-                        .getParent()
-                        .resolve(TEST_CATALOG_DIRECTORY)
-                        .toFile();
             case HADOOP:
             case NESSIE:
-                return dataDirectory.toFile();
+                return getIcebergDataDirectoryPath(dataDirectory, catalogType.name(), new IcebergConfig().getFileFormat(), false).toFile();
         }
 
         throw new PrestoException(NOT_SUPPORTED, "Unsupported Presto Iceberg catalog type " + catalogType);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -201,7 +201,7 @@ public final class IcebergQueryRunner
         }
 
         if (createTpchTables) {
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables(), true);
         }
 
         return queryRunner;

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
@@ -30,7 +30,9 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.spi.security.SelectedRole.Type.ROLE;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 
@@ -53,7 +55,7 @@ public class TestIcebergMetadataListing
                 .build();
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
-        Path catalogDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data").resolve("catalog");
+        Path catalogDirectory = getIcebergDataDirectoryPath(queryRunner.getCoordinator().getDataDirectory(), HIVE.name(), new IcebergConfig().getFileFormat(), false);
 
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
@@ -125,7 +127,9 @@ public class TestIcebergMetadataListing
         assertQuerySucceeds("CREATE TABLE iceberg.test_metadata_schema.iceberg_table2 (_string VARCHAR, _integer INTEGER)");
         assertQuery("SHOW TABLES FROM iceberg.test_metadata_schema", "VALUES 'iceberg_table1', 'iceberg_table2'");
 
-        File tableMetadataDir = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDataDirectory().resolve("iceberg_data").resolve("catalog").resolve("test_metadata_schema").resolve("iceberg_table1").resolve("metadata").toFile();
+        Path dataDirectory = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDataDirectory();
+        Path icebergDataDirectory = getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false);
+        File tableMetadataDir = icebergDataDirectory.resolve("test_metadata_schema").resolve("iceberg_table1").resolve("metadata").toFile();
         for (File file : tableMetadataDir.listFiles()) {
             file.delete();
         }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergOrcMetricsCollection.java
@@ -29,8 +29,10 @@ import java.util.Map;
 import static com.facebook.presto.SystemSessionProperties.MAX_DRIVERS_PER_TASK;
 import static com.facebook.presto.SystemSessionProperties.TASK_CONCURRENCY;
 import static com.facebook.presto.SystemSessionProperties.TASK_WRITER_COUNT;
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.iceberg.FileContent.DATA;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.iceberg.TestIcebergOrcMetricsCollection.DataFileRecord.toDataFileRecord;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static org.testng.Assert.assertEquals;
@@ -58,7 +60,8 @@ public class TestIcebergOrcMetricsCollection
         queryRunner.installPlugin(new TpchPlugin());
         queryRunner.createCatalog("tpch", "tpch");
 
-        Path catalogDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data").resolve("catalog");
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false);
 
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -30,7 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,7 +52,8 @@ public class TestIcebergSystemTables
                 .build();
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
-        Path catalogDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data").resolve("catalog");
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false);
 
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableVersion.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableVersion.java
@@ -25,7 +25,9 @@ import org.testng.annotations.Test;
 import java.nio.file.Path;
 import java.util.Map;
 
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 
 public class TestIcebergTableVersion
@@ -72,7 +74,8 @@ public class TestIcebergTableVersion
                 .build();
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
-        Path catalogDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data").resolve("catalog");
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false);
 
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeHadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeHadoop.java
@@ -24,7 +24,6 @@ import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.tests.DistributedQueryRunner;
 import org.apache.iceberg.Table;
 import org.testng.annotations.Test;
 
@@ -33,6 +32,7 @@ import java.nio.file.Path;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static java.lang.String.format;
 
 @Test
@@ -47,14 +47,16 @@ public class TestIcebergSmokeHadoop
     @Override
     protected String getLocation(String schema, String table)
     {
-        File tempLocation = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDataDirectory().toFile();
+        File tempLocation = getCatalogDirectory().toFile();
         return format("%s%s/%s", tempLocation.toURI(), schema, table);
     }
 
     @Override
     protected Path getCatalogDirectory()
     {
-        return getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(dataDirectory, HADOOP.name(), new IcebergConfig().getFileFormat(), false);
+        return catalogDirectory;
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
@@ -22,6 +22,7 @@ import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
+import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.spi.ConnectorSession;
@@ -31,9 +32,11 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.Table;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import static com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore.memoizeMetastore;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static java.lang.String.format;
 
 public class TestIcebergSmokeHive
@@ -47,8 +50,9 @@ public class TestIcebergSmokeHive
     @Override
     protected String getLocation(String schema, String table)
     {
-        File tempLocation = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDataDirectory().toFile();
-        return format("%scatalog/%s/%s", tempLocation.toURI(), schema, table);
+        Path dataDirectory = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDataDirectory();
+        File tempLocation = getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false).toFile();
+        return format("%s%s/%s", tempLocation.toURI(), schema, table);
     }
 
     protected static HdfsEnvironment getHdfsEnvironment()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg.nessie;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergPlugin;
 import com.facebook.presto.iceberg.TestIcebergSystemTables;
 import com.facebook.presto.testing.MaterializedResult;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,7 +70,8 @@ public class TestIcebergSystemTablesNessie
                 .build();
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
-        Path catalogDirectory = queryRunner.getCoordinator().getDataDirectory().resolve("iceberg_data").resolve("catalog");
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(dataDirectory, "NESSIE", new IcebergConfig().getFileFormat(), false);
 
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestExpireSnapshotProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestExpireSnapshotProcedure.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg.procedure;
 import com.facebook.presto.Session;
 import com.facebook.presto.Session.SessionBuilder;
 import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
@@ -41,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.SystemSessionProperties.LEGACY_TIMESTAMP;
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -259,7 +261,8 @@ public class TestExpireSnapshotProcedure
     private File getCatalogDirectory()
     {
         Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
-        return dataDirectory.toFile();
+        Path catalogDirectory = getIcebergDataDirectoryPath(dataDirectory, HADOOP.name(), new IcebergConfig().getFileFormat(), false);
+        return catalogDirectory.toFile();
     }
 
     private long waitUntilAfter(long snapshotTimeMillis)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestIcebergRegisterProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestIcebergRegisterProcedure.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import static com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore.memoizeMetastore;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getMetastoreHeaders;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.isUserDefinedTypeEncodingEnabled;
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.iceberg.procedure.RegisterTableProcedure.METADATA_FOLDER_NAME;
 import static com.facebook.presto.iceberg.procedure.RegisterTableProcedure.getFileSystem;
 import static com.facebook.presto.iceberg.procedure.RegisterTableProcedure.parseMetadataVersionFromFileName;
@@ -80,7 +82,8 @@ public class TestIcebergRegisterProcedure
 
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
-        File metastoreDir = queryRunner.getCoordinator().getDataDirectory().resolve(TEST_DATA_DIRECTORY).resolve(TEST_CATALOG_DIRECTORY).toFile();
+        Path dataDirectory = queryRunner.getCoordinator().getDataDirectory();
+        File metastoreDir = getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false).toFile();
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
                 .put("iceberg.file-format", new IcebergConfig().getFileFormat().name())
@@ -467,8 +470,8 @@ public class TestIcebergRegisterProcedure
 
     protected Path getCatalogDirectory()
     {
-        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory().resolve(TEST_DATA_DIRECTORY);
-        return dataDirectory.resolve(TEST_CATALOG_DIRECTORY);
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        return getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false);
     }
 
     private String getMetadataLocation(String schema, String table)

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -125,7 +125,7 @@ From the Presto repo run the commands below:
 * `mvn clean install -DskipTests -T1C -pl -presto-docs`
 
 Run IntelliJ IDEA:
-* Edit/Create `HiveQueryRunnerExternal` Application Run/Debug Configuration (alter paths accordingly).
+* Edit/Create `HiveExternalWorkerQueryRunner` Application Run/Debug Configuration (alter paths accordingly).
   * Main class: `com.facebook.presto.nativeworker.HiveExternalWorkerQueryRunner`.
   * VM options: `-ea -Xmx5G -XX:+ExitOnOutOfMemoryError -Duser.timezone=America/Bahia_Banderas -Dhive.security=legacy`.
   * Working directory: `$MODULE_DIR$`
@@ -161,7 +161,7 @@ Run CLion:
 
 ### Run Presto Coordinator + Worker
 * Note that everything below can be done w/o using IDEs by running command line commands (not in this readme).
-* Run 'HiveQueryRunnerExternal' from IntelliJ and wait until it started (`======== SERVER STARTED ========` in the log output).
+* Run `HiveExternalWorkerQueryRunner` from IntelliJ and wait until it starts (`======== SERVER STARTED ========` is displayed in the log output).
 * Scroll up the log output and find `Discovery URL http://127.0.0.1:50555`. The port is 'random' with every start.
 * Copy that port (or the whole URL) to the `discovery.uri` field in `presto/presto-native-execution/etc/config.properties` for the worker to discover the Coordinator.
 * In CLion run "presto_server" module. Connection success will be indicated by `Announcement succeeded: 202` line in the log output.

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -125,22 +125,30 @@ From the Presto repo run the commands below:
 * `mvn clean install -DskipTests -T1C -pl -presto-docs`
 
 Run IntelliJ IDEA:
+
+Run HiveExternalWorkerQueryRunner,
 * Edit/Create `HiveExternalWorkerQueryRunner` Application Run/Debug Configuration (alter paths accordingly).
   * Main class: `com.facebook.presto.nativeworker.HiveExternalWorkerQueryRunner`.
   * VM options: `-ea -Xmx5G -XX:+ExitOnOutOfMemoryError -Duser.timezone=America/Bahia_Banderas -Dhive.security=legacy`.
   * Working directory: `$MODULE_DIR$`
   * Environment variables: `PRESTO_SERVER=/Users/<user>/git/presto/presto-native-execution/cmake-build-debug/presto_cpp/main/presto_server;DATA_DIR=/Users/<user>/Desktop/data;WORKER_COUNT=0`
   * Use classpath of module: choose `presto-native-execution` module.
-* Edit/Create `TestPrestoNativeGeneralQueriesJSON` Test Run/Debug Configuration (alter paths accordingly).
-  * Class: `com.facebook.presto.nativeworker.TestPrestoNativeGeneralQueriesJSON`
-  * VM Options: `-ea -DPRESTO_SERVER=/Users/<user>/git/presto_cpp/cmake-build-debug/presto_cpp/main/presto_server -DDATA_DIR=/Users/<user>/Desktop/data`
-  * Working directory: `$MODULE_WORKING_DIR$`
-  * On Apple Silicon
-    * Environment Variables: `DYLD_LIBRARY_PATH=/usr/local/lib`
-* Edit/Create `Presto Client` Application Run/Debug Configuration (alter paths accordingly).
-  * Main class: `com.facebook.presto.cli.Presto`
-  * Program arguments: `--catalog hive --schema tpch`
-  * Use classpath of module: choose `presto-cli` module.
+
+Run IcebergExternalWorkerQueryRunner,
+* Edit/Create `IcebergExternalWorkerQueryRunner` Application Run/Debug Configuration (alter paths accordingly).
+  * Main class: `com.facebook.presto.nativeworker.IcebergExternalWorkerQueryRunner`.
+  * VM options: `-ea -Xmx5G -XX:+ExitOnOutOfMemoryError -Duser.timezone=America/Bahia_Banderas -Dhive.security=legacy`.
+  * Working directory: `$MODULE_DIR$`
+  * Environment variables: `PRESTO_SERVER=/Users/<user>/git/presto/presto-native-execution/cmake-build-debug/presto_cpp/main/presto_server;DATA_DIR=/Users/<user>/Desktop/data;WORKER_COUNT=0`
+    * When `addStorageFormatToPath = false` **(Default)**,
+    
+      `$DATA_DIR/iceberg_data/<catalog_type>`. Here `catalog_type` could be `HIVE | HADOOP | NESSIE | REST`.
+    
+      `addStorageFormatToPath` is `false` by default because Java `HiveQueryRunner` and `IcebergQueryRunner` do not add the file format to the path.
+    * When `addStorageFormatToPath = true`,
+
+      `$DATA_DIR/iceberg_data/<file_format>/<catalog_type>`. Here `file_format` could be `PARQUET | ORC | AVRO` and `catalog_type` could be `HIVE | HADOOP | NESSIE | REST`.
+  * Use classpath of module: choose `presto-native-execution` module.
 
 Run CLion:
 * File->Close Project if any is open.
@@ -160,8 +168,10 @@ Run CLion:
     ![ScreenShot](cl_clangformat_switcherenable.png)
 
 ### Run Presto Coordinator + Worker
-* Note that everything below can be done w/o using IDEs by running command line commands (not in this readme).
-* Run `HiveExternalWorkerQueryRunner` from IntelliJ and wait until it starts (`======== SERVER STARTED ========` is displayed in the log output).
+* Note that everything below can be done without using IDEs by running command line commands (not in this readme).
+* Run QueryRunner as per your choice,
+  * For Hive, Run `HiveExternalWorkerQueryRunner` from IntelliJ and wait until it starts (`======== SERVER STARTED ========` is displayed in the log output).
+  * For Iceberg, Run `IcebergExternalWorkerQueryRunner` from IntelliJ and wait until it starts (`======== SERVER STARTED ========` is displayed in the log output).
 * Scroll up the log output and find `Discovery URL http://127.0.0.1:50555`. The port is 'random' with every start.
 * Copy that port (or the whole URL) to the `discovery.uri` field in `presto/presto-native-execution/etc/config.properties` for the worker to discover the Coordinator.
 * In CLion run "presto_server" module. Connection success will be indicated by `Announcement succeeded: 202` line in the log output.

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/IcebergExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/IcebergExternalWorkerQueryRunner.java
@@ -29,12 +29,12 @@ public class IcebergExternalWorkerQueryRunner
         Logging.initialize();
 
         // Create tables before launching distributed runner.
-        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner(true);
+        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner(false);
         NativeQueryRunnerUtils.createAllIcebergTables(javaQueryRunner);
         javaQueryRunner.close();
 
         // Launch distributed runner.
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner(true);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner(true, false);
         Thread.sleep(10);
         Logger log = Logger.get(DistributedQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -156,7 +156,7 @@ public class PrestoNativeQueryRunnerUtils
     public static QueryRunner createJavaIcebergQueryRunner(String storageFormat)
             throws Exception
     {
-        return createJavaIcebergQueryRunner(Optional.of(getNativeQueryRunnerParameters().dataDirectory), storageFormat, true);
+        return createJavaIcebergQueryRunner(Optional.of(getNativeQueryRunnerParameters().dataDirectory), storageFormat, false);
     }
 
     public static QueryRunner createJavaIcebergQueryRunner(Optional<Path> baseDataDirectory, String storageFormat, boolean addStorageFormatToPath)
@@ -164,8 +164,6 @@ public class PrestoNativeQueryRunnerUtils
     {
         ImmutableMap.Builder<String, String> icebergPropertiesBuilder = new ImmutableMap.Builder<>();
         icebergPropertiesBuilder.put("hive.parquet.writer.version", "PARQUET_1_0");
-
-        Optional<Path> dataDirectory = addStorageFormatToPath ? baseDataDirectory.map(path -> Paths.get(path.toString() + '/' + storageFormat)) : baseDataDirectory;
 
         DistributedQueryRunner queryRunner = createIcebergQueryRunner(
                 ImmutableMap.of(
@@ -179,7 +177,8 @@ public class PrestoNativeQueryRunnerUtils
                 false,
                 OptionalInt.empty(),
                 Optional.empty(),
-                dataDirectory);
+                baseDataDirectory,
+                addStorageFormatToPath);
 
         return queryRunner;
     }
@@ -190,6 +189,12 @@ public class PrestoNativeQueryRunnerUtils
         return createNativeIcebergQueryRunner(useThrift, ICEBERG_DEFAULT_STORAGE_FORMAT, Optional.empty());
     }
 
+    public static QueryRunner createNativeIcebergQueryRunner(boolean useThrift, boolean addStorageFormatToPath)
+            throws Exception
+    {
+        return createNativeIcebergQueryRunner(useThrift, ICEBERG_DEFAULT_STORAGE_FORMAT, Optional.empty(), addStorageFormatToPath);
+    }
+
     public static QueryRunner createNativeIcebergQueryRunner(boolean useThrift, String storageFormat)
             throws Exception
     {
@@ -197,6 +202,12 @@ public class PrestoNativeQueryRunnerUtils
     }
 
     public static QueryRunner createNativeIcebergQueryRunner(boolean useThrift, String storageFormat, Optional<String> remoteFunctionServerUds)
+            throws Exception
+    {
+        return createNativeIcebergQueryRunner(useThrift, storageFormat, remoteFunctionServerUds, false);
+    }
+
+    public static QueryRunner createNativeIcebergQueryRunner(boolean useThrift, String storageFormat, Optional<String> remoteFunctionServerUds, boolean addStorageFormatToPath)
             throws Exception
     {
         int cacheMaxSize = 0;
@@ -209,7 +220,7 @@ public class PrestoNativeQueryRunnerUtils
                 useThrift,
                 remoteFunctionServerUds,
                 storageFormat,
-                true);
+                addStorageFormatToPath);
     }
 
     public static QueryRunner createNativeIcebergQueryRunner(
@@ -241,7 +252,8 @@ public class PrestoNativeQueryRunnerUtils
                 false,
                 OptionalInt.of(workerCount.orElse(4)),
                 getExternalWorkerLauncher("iceberg", prestoServerPath, cacheMaxSize, remoteFunctionServerUds),
-                addStorageFormatToPath ? dataDirectory.map(path -> Paths.get(path.toString() + '/' + storageFormat)) : dataDirectory);
+                dataDirectory,
+                addStorageFormatToPath);
     }
 
     public static QueryRunner createNativeQueryRunner(

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -386,6 +386,24 @@ public final class QueryAssertions
                 false);
     }
 
+    public static void copyTpchTables(
+            QueryRunner queryRunner,
+            String sourceCatalog,
+            String sourceSchema,
+            Session session,
+            Iterable<TpchTable<?>> tables,
+            boolean ifNotExists)
+    {
+        copyTables(
+                queryRunner,
+                sourceCatalog,
+                sourceSchema,
+                session,
+                Iterables.transform(tables, table -> table.getTableName()),
+                ifNotExists,
+                false);
+    }
+
     public static void copyTables(
             QueryRunner queryRunner,
             String sourceCatalog,


### PR DESCRIPTION
## Description
- IcebergQueryRunner data directory fix
- presto-native-execution readme small fix
- Enable the **ifNotExists** flag while creating tpch tables using IcebergQueryRunner

## Motivation and Context
- IcebergQueryRunner data directory fix
- presto-native-execution readme small fix
- Enable the **ifNotExists** flag while creating tpch tables using IcebergQueryRunner

## Impact
1. Currently, IcebergQueryRunner & HiveQueryRunner create different data directory structures in the case of Java and Native Query Runner and in the Tests, leading to confusion. As part of this PR, I tried to make changes to the final data directory name for IcebergQueryRunner in the subsequent PR I will make a similar data directory structure for HiveQueryRunner in the case of Java & Native Query Runner.
As part of this change now catalog directory structure would be something like this -

- When **addStorageFormatToPath = false** (Default)
`$DATA_DIR/iceberg_data/<catalog_type>`
Here catalog_type could be HIVE | HADOOP | NESSIE | REST

- When **addStorageFormatToPath = true** 
`$DATA_DIR/iceberg_data/<file_format>/<catalog_type>`
Here file_format could be PARQUET | ORC | AVRO
And catalog_type could be HIVE | HADOOP | NESSIE | REST

2. Without ifNotExists flag IcebergQueryRunner throws an exception if $DATA_DIR is holding any exiting tpch data.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

