### PR TITLE
Fix flaky test TestHiveSplitScheduling

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitScheduling.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitScheduling.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveSessionProperties.DYNAMIC_SPLIT_SIZES_ENABLED;
 import static io.airlift.tpch.TpchTable.ORDERS;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -58,11 +57,12 @@ public class TestHiveSplitScheduling
             executeExclusively(() -> {
                 eventListener.resetSplits();
                 getQueryRunner().execute("SELECT orderpriority FROM test_orders where ds = '2020-09-01' and substr(orderpriority, 1, 1) = '1'");
-                assertEquals(eventListener.getTotalSplits(), 9);
+                int numberOfSplitsWithoutDynamicSplitScheduling = eventListener.getTotalSplits();
                 eventListener.resetSplits();
                 getQueryRunner().execute(dynamicSplitsSession(), "SELECT orderpriority FROM test_orders where ds = '2020-09-01' and substr(orderpriority, 1, 1) = '1'");
                 // Less splits using dynamic number of splits.
-                assertEquals(eventListener.getTotalSplits(), 5);
+                int numberOfSplitsWithDynamicSplitScheduling = eventListener.getTotalSplits();
+                assertTrue(numberOfSplitsWithDynamicSplitScheduling < numberOfSplitsWithoutDynamicSplitScheduling, "Expected less splits with dynamic split scheduling");
             });
         }
         catch (Exception e) {


### PR DESCRIPTION
## Description
The test TestHiveSplitScheduling has been failing on some OS due to differences in split counts. As part of this PR, we are changing the test to compare the split count between dynamic and non-dynamic split scheduling instead of asserting on absolute count values.
## Motivation and Context
Fix flaky test

## Test Plan
Unit tests
## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

