### PR TITLE
Fix serialization of aggregation node for HBO

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.CachingPlanCanonicalInfoProvider;
 import com.facebook.presto.sql.planner.PlanCanonicalInfoProvider;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.inject.Inject;
@@ -51,7 +52,7 @@ public class HistoryBasedPlanStatisticsManager
         requireNonNull(objectMapper, "objectMapper is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.historyBasedStatisticsCacheManager = new HistoryBasedStatisticsCacheManager();
-        ObjectMapper newObjectMapper = objectMapper.copy().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        ObjectMapper newObjectMapper = objectMapper.copy().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(historyBasedStatisticsCacheManager, newObjectMapper, metadata);
         this.config = requireNonNull(config, "config is null");
         this.isNativeExecution = featuresConfig.isNativeExecutionEnabled();


### PR DESCRIPTION
## Description
When I was debugging why we see different hash for the same query when running Presto CPP and Presto Java, I found that the serialized Json string from Aggregation node is different between these two plans.
For Java, the "arguments" attribute is before "functionHandle".
For CPP, the "functionHandle" is before "arguments".

The order of attributes should respect the order defined in json constructor, however further debug shows that, this is due to the two get function which is annotated with JsonProperty but not present in the constructor.
https://github.com/prestodb/presto/blob/b67366892b06a3c9ba76730876178c85c6e9479a/presto-spi/src/main/java/com/facebook/presto/spi/plan/AggregationNode.java#L475,L485
Somehow this shows in different order in serialization of cpp and java plans.

I do not think these two get functions need to be annotated as Json property, so I removed them.
I also set the objectMapper used by HBO to use SORT_PROPERTIES_ALPHABETICALLY property, so that even we have other similar cases, we can still output consistent serialized string

## Motivation and Context
Described above

## Impact
It will bridge the gap between CPP and Java for HBO. And solve potential mismatch of HBO hash caused by this issue.

## Test Plan
Tested locally end to end in Java HiveQueryRunner, make sure 1) the two additional fields not appearing in serialized json string now 2) the new json string has fields sorted

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* * Fix serialization of aggregation node in HBO plan hash to output consistent hash :pr:`22949 `
```

