### PR TITLE
Privatize getExpectedOrdersTableDescription

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -121,7 +121,7 @@ public abstract class AbstractTestIntegrationSmokeTest
     public void testDescribeTable()
     {
         MaterializedResult actualColumns = computeActual("DESC orders").toTestTypes();
-        assertEquals(actualColumns, getExpectedOrdersTableDescription(isDateTypeSupported(), isParameterizedVarcharSupported()));
+        assertEquals(actualColumns, getExpectedOrdersTableDescription());
     }
 
     @Test
@@ -185,16 +185,16 @@ public abstract class AbstractTestIntegrationSmokeTest
                 "line 1:49: Column name 'orderkey' specified more than once");
     }
 
-    protected MaterializedResult getExpectedOrdersTableDescription(boolean dateSupported, boolean parametrizedVarchar)
+    private MaterializedResult getExpectedOrdersTableDescription()
     {
         String orderDateType;
-        if (dateSupported) {
+        if (isDateTypeSupported()) {
             orderDateType = "date";
         }
         else {
             orderDateType = "varchar";
         }
-        if (parametrizedVarchar) {
+        if (isParameterizedVarcharSupported()) {
             return MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                     .row("orderkey", "bigint", "", "")
                     .row("custkey", "bigint", "", "")


### PR DESCRIPTION
## Description
Privatize getExpectedOrdersTableDescription

## Motivation and Context
Reduce public API surface

## Impact
This will break & require changes in TestXdbIntegrationSmokeTest in Prism, but this will help us uncouple that class from presto-hive. 

## Test Plan
ci

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

