### PR TITLE
Revert "Use File directly"

### DIFF
--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
@@ -227,7 +227,7 @@ public class InMemoryHiveMetastore
         if (deleteData && table.getTableType().equals(MANAGED_TABLE.name())) {
             for (String location : locations) {
                 if (location != null) {
-                    File directory = new File(location);
+                    File directory = new File(new Path(location).toUri());
                     checkArgument(isAncestor(directory, baseDirectory), format("Table directory %s must be inside of the metastore base directory %s", directory, baseDirectory));
                     deleteDirectory(directory);
                 }


### PR DESCRIPTION
## Description
This reverts commit 1f2325631512423e3381af8f018c2a65b5ba20d0. This commit is breaking Prism as location can be an URI. We are reverting the change to unblock the build
## Motivation and Context
To resolve prism test failure, we are reverting commit 1f2325631512423e3381af8f018c2a65b5ba20d0
## Impact
Resolve prism test failure
## Test Plan
Existing tests
## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

