### PR TITLE
[Verifier] Wrap checksum queries with partition predicate for reused output table

### DIFF
--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -31,7 +31,23 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.facebook.presto</groupId>
+                    <artifactId>presto-cache</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-hive-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive-metastore</artifactId>
         </dependency>
 
         <dependency>
@@ -196,6 +212,11 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
         </dependency>
 
         <!-- for testing -->

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -108,7 +108,7 @@ public class DataVerification
             ChecksumQueryContext testChecksumQueryContext)
     {
         List<Column> testColumns = getColumns(getHelperAction(), typeManager, test.getObjectName());
-        Query testChecksumQuery = checksumValidator.generateChecksumQuery(test.getObjectName(), testColumns);
+        Query testChecksumQuery = checksumValidator.generateChecksumQuery(test.getObjectName(), testColumns, test.getPartitionsPredicate());
         testChecksumQueryContext.setChecksumQuery(formatSql(testChecksumQuery));
 
         List<Column> controlColumns = null;
@@ -116,7 +116,7 @@ public class DataVerification
 
         if (isControlEnabled()) {
             controlColumns = getColumns(getHelperAction(), typeManager, control.getObjectName());
-            Query controlChecksumQuery = checksumValidator.generateChecksumQuery(control.getObjectName(), controlColumns);
+            Query controlChecksumQuery = checksumValidator.generateChecksumQuery(control.getObjectName(), controlColumns, control.getPartitionsPredicate());
             controlChecksumQueryContext.setChecksumQuery(formatSql(controlChecksumQuery));
 
             QueryResult<ChecksumResult> controlChecksum = callAndConsume(

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
@@ -144,7 +144,7 @@ public class DeterminismAnalyzer
                         stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(run::setQueryId));
 
                 // Run checksum query
-                Query checksumQuery = checksumValidator.generateChecksumQuery(queryBundle.getObjectName(), columns);
+                Query checksumQuery = checksumValidator.generateChecksumQuery(queryBundle.getObjectName(), columns, Optional.empty());
                 ChecksumResult testChecksum = getOnlyElement(callAndConsume(
                         () -> prestoAction.execute(checksumQuery, DETERMINISM_ANALYSIS_CHECKSUM, ChecksumResult::fromResultSet),
                         stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(run::setChecksumQueryId)).getResults());

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExtendedVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExtendedVerification.java
@@ -273,7 +273,7 @@ public class ExtendedVerification
             ChecksumQueryContext checksumQueryContext,
             QueryStage queryStage)
     {
-        Query partitionChecksumQuery = checksumValidator.generatePartitionChecksumQuery(bundle.getObjectName(), dataColumns, partitionColumns);
+        Query partitionChecksumQuery = checksumValidator.generatePartitionChecksumQuery(bundle.getObjectName(), dataColumns, partitionColumns, bundle.getPartitionsPredicate());
         checksumQueryContext.setPartitionChecksumQuery(formatSql(partitionChecksumQuery));
         return callAndConsume(
                 () -> getHelperAction().execute(partitionChecksumQuery, queryStage, ChecksumResult::fromResultSet),
@@ -287,7 +287,7 @@ public class ExtendedVerification
             ChecksumQueryContext checksumQueryContext,
             QueryStage queryStage)
     {
-        Query bucketChecksumQuery = checksumValidator.generateBucketChecksumQuery(bundle.getObjectName(), partitionColumns, dataColumns);
+        Query bucketChecksumQuery = checksumValidator.generateBucketChecksumQuery(bundle.getObjectName(), partitionColumns, dataColumns, bundle.getPartitionsPredicate());
         List<ChecksumResult> checksumResults = callAndConsume(
                 () -> getHelperAction().execute(bucketChecksumQuery, queryStage, ChecksumResult::fromResultSet),
                 stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(checksumQueryContext::setBucketChecksumQueryId)).getResults();

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfiguration.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfiguration.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
@@ -37,6 +38,7 @@ public class QueryConfiguration
     private final Optional<String> password;
     private final Map<String, String> sessionProperties;
     private final boolean isReusableTable;
+    private final List<String> partitions;
 
     @JdbiConstructor
     public QueryConfiguration(
@@ -45,9 +47,10 @@ public class QueryConfiguration
             @ColumnName("username") Optional<String> username,
             @ColumnName("password") Optional<String> password,
             @ColumnName("session_properties") Optional<Map<String, String>> sessionProperties,
-            @ColumnName("client_tags") Optional<List<String>> clientTags)
+            @ColumnName("client_tags") Optional<List<String>> clientTags,
+            @ColumnName("partitions") Optional<List<String>> partitions)
     {
-        this(catalog, schema, username, password, sessionProperties, clientTags.filter(tags -> tags.contains(CLIENT_TAG_OUTPUT_RETAINED)).isPresent());
+        this(catalog, schema, username, password, sessionProperties, clientTags.filter(tags -> tags.contains(CLIENT_TAG_OUTPUT_RETAINED)).isPresent(), partitions);
     }
 
     public QueryConfiguration(
@@ -56,7 +59,8 @@ public class QueryConfiguration
             Optional<String> username,
             Optional<String> password,
             Optional<Map<String, String>> sessionProperties,
-            boolean isReusableTable)
+            boolean isReusableTable,
+            Optional<List<String>> partitions)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -64,6 +68,7 @@ public class QueryConfiguration
         this.password = requireNonNull(password, "password is null");
         this.sessionProperties = ImmutableMap.copyOf(sessionProperties.orElse(ImmutableMap.of()));
         this.isReusableTable = isReusableTable;
+        this.partitions = ImmutableList.copyOf(partitions.orElse(ImmutableList.of()));
     }
 
     public QueryConfiguration applyOverrides(QueryConfigurationOverrides overrides)
@@ -85,7 +90,8 @@ public class QueryConfiguration
                 Optional.ofNullable(overrides.getUsernameOverride().orElse(username.orElse(null))),
                 Optional.ofNullable(overrides.getPasswordOverride().orElse(password.orElse(null))),
                 Optional.of(sessionProperties),
-                isReusableTable);
+                isReusableTable,
+                Optional.of(partitions));
     }
 
     public String getCatalog()
@@ -118,6 +124,11 @@ public class QueryConfiguration
         return isReusableTable;
     }
 
+    public List<String> getPartitions()
+    {
+        return partitions;
+    }
+
     @Override
     public boolean equals(Object obj)
     {
@@ -133,13 +144,14 @@ public class QueryConfiguration
                 Objects.equals(username, o.username) &&
                 Objects.equals(password, o.password) &&
                 Objects.equals(sessionProperties, o.sessionProperties) &&
-                isReusableTable == o.isReusableTable;
+                isReusableTable == o.isReusableTable &&
+                Objects.equals(partitions, partitions);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(catalog, schema, username, password, sessionProperties, isReusableTable);
+        return Objects.hash(catalog, schema, username, password, sessionProperties, isReusableTable, partitions);
     }
 
     @Override
@@ -152,6 +164,7 @@ public class QueryConfiguration
                 .add("password", password)
                 .add("sessionProperties", sessionProperties)
                 .add("isReusableTable", isReusableTable)
+                .add("partitions", partitions)
                 .toString();
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryObjectBundle.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryObjectBundle.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Statement;
 
@@ -25,6 +26,7 @@ public class QueryObjectBundle
         extends QueryBundle
 {
     private final QualifiedName objectName;
+    private final Optional<Expression> partitionsPredicate;
     private final boolean reuseTable;
     private final Optional<String> rewrittenFunctionCalls;
 
@@ -35,11 +37,13 @@ public class QueryObjectBundle
             List<Statement> teardownQueries,
             ClusterType cluster,
             Optional<String> rewrittenFunctionCalls,
+            Optional<Expression> partitionsPredicate,
             boolean reuseTable)
     {
         super(setupQueries, query, teardownQueries, cluster);
         this.objectName = requireNonNull(objectName, "objectName is null");
         this.rewrittenFunctionCalls = requireNonNull(rewrittenFunctionCalls, "rewrittenFunctionCalls is null");
+        this.partitionsPredicate = partitionsPredicate;
         this.reuseTable = reuseTable;
     }
 
@@ -56,5 +60,10 @@ public class QueryObjectBundle
     public boolean isReuseTable()
     {
         return reuseTable;
+    }
+
+    public Optional<Expression> getPartitionsPredicate()
+    {
+        return partitionsPredicate;
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.rewrite;
 
+import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.BooleanLiteral;
@@ -48,6 +49,7 @@ public class VerificationQueryRewriterFactory
 {
     private final SqlParser sqlParser;
     private final TypeManager typeManager;
+    private final BlockEncodingSerde blockEncodingSerde;
     private final QualifiedName controlTablePrefix;
     private final QualifiedName testTablePrefix;
     private final List<Property> controlTableProperties;
@@ -61,12 +63,14 @@ public class VerificationQueryRewriterFactory
     public VerificationQueryRewriterFactory(
             SqlParser sqlParser,
             TypeManager typeManager,
+            BlockEncodingSerde blockEncodingSerde,
             @ForControl QueryRewriteConfig controlConfig,
             @ForTest QueryRewriteConfig testConfig,
             VerifierConfig verifierConfig)
     {
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerge is null");
         this.controlTablePrefix = requireNonNull(controlConfig.getTablePrefix(), "controlTablePrefix is null");
         this.testTablePrefix = requireNonNull(testConfig.getTablePrefix(), "testTablePrefix is null");
         this.controlTableProperties = constructProperties(controlConfig.getTableProperties());
@@ -82,6 +86,7 @@ public class VerificationQueryRewriterFactory
         return new QueryRewriter(
                 sqlParser,
                 typeManager,
+                blockEncodingSerde,
                 prestoAction,
                 ImmutableMap.of(CONTROL, controlTablePrefix, TEST, testTablePrefix),
                 ImmutableMap.of(CONTROL, controlTableProperties, TEST, testTableProperties),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/PrestoQuerySourceQuerySupplier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/PrestoQuerySourceQuerySupplier.java
@@ -51,6 +51,8 @@ public class PrestoQuerySourceQuerySupplier
                             Optional.ofNullable(resultSet.getString("control_session_properties"))
                                     .map(StringToStringMapColumnMapper.CODEC::fromJson),
                             Optional.ofNullable(resultSet.getString("control_client_tags"))
+                                    .map(StringListColumnMapper.CODEC::fromJson),
+                            Optional.ofNullable(resultSet.getString("control_partitions"))
                                     .map(StringListColumnMapper.CODEC::fromJson)),
                     new QueryConfiguration(
                             resultSet.getString("test_catalog"),
@@ -60,6 +62,8 @@ public class PrestoQuerySourceQuerySupplier
                             Optional.ofNullable(resultSet.getString("test_session_properties"))
                                     .map(StringToStringMapColumnMapper.CODEC::fromJson),
                             Optional.ofNullable(resultSet.getString("test_client_tags"))
+                                    .map(StringListColumnMapper.CODEC::fromJson),
+                            Optional.ofNullable(resultSet.getString("test_partitions"))
                                     .map(StringListColumnMapper.CODEC::fromJson))));
 
     private final PrestoAction helperAction;
@@ -73,7 +77,14 @@ public class PrestoQuerySourceQuerySupplier
             PrestoQuerySourceQueryConfig config)
     {
         this.helperAction = helperActionFactory.create(
-                new QueryConfiguration(config.getCatalog(), config.getSchema(), config.getUsername(), config.getPassword(), Optional.empty(), Optional.empty()),
+                new QueryConfiguration(
+                        config.getCatalog(),
+                        config.getSchema(),
+                        config.getUsername(),
+                        config.getPassword(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
                 VerificationContext.create("", ""));
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.query = requireNonNull(config.getQuery(), "query is null");

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/VerifierDao.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/VerifierDao.java
@@ -40,6 +40,7 @@ public interface VerifierDao
             "  control_password varchar(256) DEFAULT NULL,\n" +
             "  control_session_properties text DEFAULT NULL,\n" +
             "  control_client_tags text DEFAULT NULL,\n" +
+            "  control_partitions text DEFAULT NULL,\n" +
             "  test_catalog varchar(256) NOT NULL,\n" +
             "  test_schema varchar(256) NOT NULL,\n" +
             "  test_query text NOT NULL,\n" +
@@ -47,7 +48,8 @@ public interface VerifierDao
             "  test_username varchar(256) DEFAULT NULL,\n" +
             "  test_password varchar(256) DEFAULT NULL,\n" +
             "  test_session_properties text DEFAULT NULL,\n" +
-            "  test_client_tags text DEFAULT NULL)")
+            "  test_client_tags text DEFAULT NULL,\n" +
+            "  test_partitions text DEFAULT NULL)")
     void createVerifierQueriesTable(@Define("table_name") String tableName);
 
     @SqlQuery("SELECT\n" +
@@ -61,6 +63,7 @@ public interface VerifierDao
             "  control_password,\n" +
             "  control_session_properties,\n" +
             "  control_client_tags,\n" +
+            "  control_partitions,\n" +
             "  test_query,\n" +
             "  test_query_id,\n" +
             "  test_catalog,\n" +
@@ -68,7 +71,8 @@ public interface VerifierDao
             "  test_username,\n" +
             "  test_password,\n" +
             "  test_session_properties,\n" +
-            "  test_client_tags\n" +
+            "  test_client_tags,\n" +
+            "  test_partitions\n" +
             "FROM\n" +
             "  <table_name>\n" +
             "WHERE\n" +

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
@@ -72,6 +72,7 @@ public class VerifierTestUtil
             ImmutableList.of(),
             CONTROL,
             Optional.empty(),
+            Optional.empty(),
             false);
 
     private static final MySqlOptions MY_SQL_OPTIONS = MySqlOptions.builder()

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
@@ -123,7 +123,8 @@ public class TestChecksumValidator
                         MAP_COLUMN,
                         MAP_FLOAT_NON_FLOAT_COLUMN,
                         MAP_NON_ORDERABLE_COLUMN,
-                        ROW_COLUMN));
+                        ROW_COLUMN),
+                Optional.empty());
         Statement expectedChecksumQuery = sqlParser.createStatement(
                 "SELECT\n" +
                         "  \"count\"(*)\n" +

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -18,6 +18,7 @@ import com.facebook.presto.verifier.event.QueryInfo;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
 import com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
@@ -226,9 +227,13 @@ public class TestDataVerification
         getQueryRunner().execute(controlQuery);
         String controlQueryId = "control_query_id";
 
-        Optional<VerifierQueryEvent> event = runVerification(testQuery, controlQuery, controlQueryId, testQueryId, reuseTableSettings);
+        Optional<VerifierQueryEvent> event = runVerification(testQuery, controlQuery, controlQueryId, testQueryId,
+                new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(),
+                        Optional.empty(), true, Optional.of(ImmutableList.of("test_column=1"))),
+                new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(),
+                        Optional.empty(), true, Optional.empty()), reuseTableSettings);
         assertTrue(event.get().getControlQueryInfo().getIsReuseTable());
-        assertTrue(event.get().getTestQueryInfo().getIsReuseTable());
+        assertFalse(event.get().getTestQueryInfo().getIsReuseTable());
         assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
@@ -377,7 +382,7 @@ public class TestDataVerification
     public void testExecutionTimeSessionProperty()
     {
         QueryConfiguration configuration = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of(QUERY_MAX_EXECUTION_TIME,
-                "20m")), Optional.empty());
+                "20m")), Optional.empty(), Optional.empty());
         SourceQuery sourceQuery = new SourceQuery(SUITE, NAME, "SELECT 1.0", "SELECT 1.00001", Optional.empty(), Optional.empty(), configuration, configuration);
         Optional<VerifierQueryEvent> event = verify(sourceQuery, false);
         assertTrue(event.isPresent());

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -50,6 +52,7 @@ public class TestDeterminismAnalyzer
     private static final String SUITE = "test-suite";
     private static final String NAME = "test-query";
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private static final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager();
 
     @Test
     public void testMutableCatalog()
@@ -66,7 +69,7 @@ public class TestDeterminismAnalyzer
 
     private static DeterminismAnalyzer createDeterminismAnalyzer(String mutableCatalogPattern)
     {
-        QueryConfiguration configuration = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty());
+        QueryConfiguration configuration = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         VerificationContext verificationContext = VerificationContext.create(SUITE, NAME);
         VerifierConfig verifierConfig = new VerifierConfig().setTestId("test-id");
         RetryConfig retryConfig = new RetryConfig();
@@ -86,6 +89,7 @@ public class TestDeterminismAnalyzer
         QueryRewriter queryRewriter = new QueryRewriter(
                 sqlParser,
                 typeManager,
+                blockEncodingSerde,
                 prestoAction,
                 ImmutableMap.of(CONTROL, QualifiedName.of("tmp_verifier_c"), TEST, QualifiedName.of("tmp_verifier_t")),
                 ImmutableMap.of(),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfiguration.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfiguration.java
@@ -50,15 +50,17 @@ public class TestQueryConfiguration
     private static final List<String> CLIENT_TAGS = ImmutableList.of(QueryConfiguration.CLIENT_TAG_OUTPUT_RETAINED);
 
     private static final QueryConfiguration CONFIGURATION_1 = new QueryConfiguration(CATALOG, SCHEMA, Optional.of(USERNAME), Optional.of(PASSWORD),
-            Optional.of(SESSION_PROPERTIES), Optional.of(CLIENT_TAGS));
-    private static final QueryConfiguration CONFIGURATION_2 = new QueryConfiguration(CATALOG, SCHEMA, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+            Optional.of(SESSION_PROPERTIES), Optional.of(CLIENT_TAGS), Optional.empty());
+    private static final QueryConfiguration CONFIGURATION_2 = new QueryConfiguration(CATALOG, SCHEMA, Optional.empty(), Optional.empty(),
+            Optional.empty(), Optional.empty(), Optional.empty());
     private static final QueryConfiguration CONFIGURATION_FULL_OVERRIDE = new QueryConfiguration(
             CATALOG_OVERRIDE,
             SCHEMA_OVERRIDE,
             Optional.of(USERNAME_OVERRIDE),
             Optional.of(PASSWORD_OVERRIDE),
             Optional.of(SESSION_PROPERTIES_OVERRIDE),
-            Optional.of(CLIENT_TAGS));
+            Optional.of(CLIENT_TAGS),
+            Optional.empty());
 
     private QueryConfigurationOverridesConfig overrides;
 
@@ -91,13 +93,15 @@ public class TestQueryConfiguration
                         Optional.of(USERNAME_OVERRIDE),
                         Optional.of(PASSWORD_OVERRIDE),
                         Optional.of(SESSION_PROPERTIES),
-                        Optional.of(CLIENT_TAGS)));
+                        Optional.of(CLIENT_TAGS),
+                        Optional.empty()));
         assertEquals(CONFIGURATION_2.applyOverrides(overrides),
                 new QueryConfiguration(
                         CATALOG_OVERRIDE,
                         SCHEMA_OVERRIDE,
                         Optional.of(USERNAME_OVERRIDE),
                         Optional.of(PASSWORD_OVERRIDE),
+                        Optional.empty(),
                         Optional.empty(),
                         Optional.empty()));
     }
@@ -113,6 +117,7 @@ public class TestQueryConfiguration
                 Optional.of(USERNAME_OVERRIDE),
                 Optional.of(PASSWORD_OVERRIDE),
                 Optional.of(SESSION_PROPERTIES_OVERRIDE),
+                false,
                 Optional.empty());
         assertEquals(CONFIGURATION_2.applyOverrides(overrides), overridden);
     }
@@ -127,7 +132,8 @@ public class TestQueryConfiguration
                 Optional.of(USERNAME_OVERRIDE),
                 Optional.of(PASSWORD_OVERRIDE),
                 Optional.of(ImmutableMap.of("property_1", "value_x", "property_2", "value_2", "property_3", "value_3")),
-                Optional.of(CLIENT_TAGS));
+                Optional.of(CLIENT_TAGS),
+                Optional.empty());
 
         assertEquals(CONFIGURATION_1.applyOverrides(overrides), substituted1);
 
@@ -137,6 +143,7 @@ public class TestQueryConfiguration
                 Optional.of(USERNAME_OVERRIDE),
                 Optional.of(PASSWORD_OVERRIDE),
                 Optional.of(SESSION_PROPERTIES_OVERRIDE),
+                false,
                 Optional.empty());
         assertEquals(CONFIGURATION_2.applyOverrides(overrides), substituted2);
     }
@@ -153,7 +160,8 @@ public class TestQueryConfiguration
                 Optional.of(USERNAME_OVERRIDE),
                 Optional.of(PASSWORD_OVERRIDE),
                 Optional.of(ImmutableMap.of("property_3", "value_3")),
-                Optional.of(CLIENT_TAGS));
+                Optional.of(CLIENT_TAGS),
+                Optional.empty());
 
         assertEquals(CONFIGURATION_1.applyOverrides(overrides), removed);
     }
@@ -169,7 +177,8 @@ public class TestQueryConfiguration
                 Optional.of(USERNAME_OVERRIDE),
                 Optional.of(PASSWORD_OVERRIDE),
                 Optional.of(SESSION_PROPERTIES_OVERRIDE),
-                Optional.of(CLIENT_TAGS));
+                Optional.of(CLIENT_TAGS),
+                Optional.empty());
 
         assertEquals(CONFIGURATION_1.applyOverrides(overrides), removed);
     }
@@ -185,7 +194,8 @@ public class TestQueryConfiguration
                 Optional.of(USERNAME_OVERRIDE),
                 Optional.of(PASSWORD_OVERRIDE),
                 Optional.of(ImmutableMap.of("property_1", "value_1")),
-                Optional.of(CLIENT_TAGS));
+                Optional.of(CLIENT_TAGS),
+                Optional.empty());
 
         assertEquals(CONFIGURATION_1.applyOverrides(overrides), removed);
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.verifier.framework;
 
 import com.facebook.airlift.event.client.AbstractEventClient;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
@@ -115,7 +117,8 @@ public class TestVerificationManager
     private static final String NAME = "test-query";
     private static final QualifiedName TABLE_PREFIX = QualifiedName.of("tmp_verifier");
     private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON));
-    private static final QueryConfiguration QUERY_CONFIGURATION = new QueryConfiguration("test", "di", Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty());
+    private static final BlockEncodingSerde BLOCK_ENCODING_SERDE = new BlockEncodingManager();
+    private static final QueryConfiguration QUERY_CONFIGURATION = new QueryConfiguration("test", "di", Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     private static final SourceQuery SOURCE_QUERY = new SourceQuery(
             SUITE,
             NAME,
@@ -218,7 +221,7 @@ public class TestVerificationManager
                 new VerificationFactory(
                         SQL_PARSER,
                         (sourceQuery, verificationContext) -> new QueryActions(prestoAction, prestoAction, prestoAction),
-                        presto -> new QueryRewriter(SQL_PARSER, createTypeManager(), presto, ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX),
+                        presto -> new QueryRewriter(SQL_PARSER, createTypeManager(), BLOCK_ENCODING_SERDE, presto, ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX),
                                 ImmutableMap.of(),
                                 ImmutableMap.of(CONTROL, false, TEST, false)),
                         new FailureResolverManagerFactory(ImmutableSet.of(), ImmutableSet.of()),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestJdbcPrestoAction.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestJdbcPrestoAction.java
@@ -56,7 +56,7 @@ public class TestJdbcPrestoAction
     private static final String SUITE = "test-suite";
     private static final String NAME = "test-query";
     private static final QueryStage QUERY_STAGE = CONTROL_MAIN;
-    private static final QueryConfiguration CONFIGURATION = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty());
+    private static final QueryConfiguration CONFIGURATION = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
     private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DECIMAL).build();
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
@@ -69,6 +69,7 @@ public class TestIgnoredFunctionsMismatchResolver
                 ImmutableList.of(),
                 CONTROL,
                 Optional.empty(),
+                Optional.empty(),
                 false);
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestTooManyOpenPartitionsFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestTooManyOpenPartitionsFailureResolver.java
@@ -89,6 +89,7 @@ public class TestTooManyOpenPartitionsFailureResolver
             ImmutableList.of(),
             TEST,
             Optional.empty(),
+            Optional.empty(),
             false);
     private static final QueryException HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION = new PrestoQueryException(
             new RuntimeException(),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.verifier.rewrite;
 
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
@@ -76,6 +78,7 @@ public class TestQueryRewriter
             Optional.of("user"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build();
     private static final QueryRewriteConfig QUERY_REWRITE_CONFIG = new QueryRewriteConfig()
@@ -83,6 +86,7 @@ public class TestQueryRewriter
             .setTableProperties("{\"p_int\": 30, \"p_long\": 4294967297, \"p_double\": 1.5, \"p_varchar\": \"test\", \"p_bool\": true}");
     private static final VerifierConfig VERIFIER_CONFIG = new VerifierConfig();
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private static final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager();
 
     private static StandaloneQueryRunner queryRunner;
     private static PrestoAction prestoAction;
@@ -583,14 +587,11 @@ public class TestQueryRewriter
     @Test
     public void testReuseTableRewrite()
     {
-        String query = "INSERT INTO dest_table SELECT * FROM test_table";
+        String query = "CREATE TABLE dest_table AS SELECT a, b FROM test_table WHERE a = 1 AND b = 'xyz'";
+        queryRunner.execute(query);
+        List<String> partitions = ImmutableList.of("a=1", "b=xyz");
         QueryConfiguration configuration = new QueryConfiguration(
-                CATALOG,
-                SCHEMA,
-                Optional.of("user"),
-                Optional.empty(),
-                Optional.empty(),
-                true);
+                CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty(), true, Optional.of(partitions));
         assertShadowed(
                 getQueryRewriter(new QueryRewriteConfig().setReuseTable(true), VERIFIER_CONFIG),
                 query,
@@ -674,6 +675,6 @@ public class TestQueryRewriter
 
     private QueryRewriter getQueryRewriter(QueryRewriteConfig rewriteConfig, VerifierConfig verifierConfig)
     {
-        return new VerificationQueryRewriterFactory(sqlParser, createTypeManager(), rewriteConfig, rewriteConfig, verifierConfig).create(prestoAction);
+        return new VerificationQueryRewriterFactory(sqlParser, createTypeManager(), blockEncodingSerde, rewriteConfig, rewriteConfig, verifierConfig).create(prestoAction);
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestPrestoQuerySourceQuerySupplier.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestPrestoQuerySourceQuerySupplier.java
@@ -60,6 +60,7 @@ public class TestPrestoQuerySourceQuerySupplier
             "    'user' control_username,\n" +
             "    '{\"a\": \"b\"}' control_session_properties,\n" +
             "    '[\"x\"]' control_client_tags,\n" +
+            "    NULL control_partitions,\n" +
             "    query_id control_query_id,\n" +
             "    NULL control_password,\n" +
             "    query test_query,\n" +
@@ -69,6 +70,7 @@ public class TestPrestoQuerySourceQuerySupplier
             "    NULL test_password,\n" +
             "    '{\"c\": \"d\"}' test_session_properties,\n" +
             "    '[\"y\"]' test_client_tags,\n" +
+            "    NULL test_partitions,\n" +
             "    query_id test_query_id\n" +
             "FROM (\n" +
             "    VALUES\n" +
@@ -76,9 +78,9 @@ public class TestPrestoQuerySourceQuerySupplier
             "        ('Q2', 'INSERT INTO test_table SELECT 1', 'T2')\n" +
             ") queries(name, query, query_id)";
     private static final QueryConfiguration CONTROL_CONFIGURATION = new QueryConfiguration(
-            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("a", "b")), Optional.of(ImmutableList.of("x")));
+            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("a", "b")), Optional.of(ImmutableList.of("x")), Optional.empty());
     private static final QueryConfiguration TEST_CONFIGURATION = new QueryConfiguration(
-            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("c", "d")), Optional.of(ImmutableList.of("y")));
+            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("c", "d")), Optional.of(ImmutableList.of("y")), Optional.empty());
     private static final List<SourceQuery> SOURCE_QUERIES = ImmutableList.of(
             new SourceQuery("test", "Q1", "SELECT 1", "SELECT 1", Optional.of("T1"), Optional.of("T1"), CONTROL_CONFIGURATION, TEST_CONFIGURATION),
             new SourceQuery("test", "Q2", "INSERT INTO test_table SELECT 1", "INSERT INTO test_table SELECT 1", Optional.of("T2"), Optional.of("T2"), CONTROL_CONFIGURATION,


### PR DESCRIPTION
For Insert and CTAS queries, when output table reuse is on, build the partition
predicate and apply it when assembling the checksum queries.

```
== RELEASE NOTES ==

Verifier Changes
* Add `control.reuse-table` and `test.reuse-table` configuration properties for the Presto Verifier to reuse the output tables of the source query for control and test.

