### PR TITLE
Fix hash calculation for Timestamp in HiveBucketing to be Hive Compatible

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BucketAdaptation.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BucketAdaptation.java
@@ -22,14 +22,22 @@ public class BucketAdaptation
     private final int tableBucketCount;
     private final int partitionBucketCount;
     private final int bucketToKeep;
+    private final boolean useLegacyTimestampBucketing;
 
-    public BucketAdaptation(int[] bucketColumnIndices, List<HiveType> bucketColumnHiveTypes, int tableBucketCount, int partitionBucketCount, int bucketToKeep)
+    public BucketAdaptation(
+            int[] bucketColumnIndices,
+            List<HiveType> bucketColumnHiveTypes,
+            int tableBucketCount,
+            int partitionBucketCount,
+            int bucketToKeep,
+            boolean useLegacyTimestampBucketing)
     {
         this.bucketColumnIndices = bucketColumnIndices;
         this.bucketColumnHiveTypes = bucketColumnHiveTypes;
         this.tableBucketCount = tableBucketCount;
         this.partitionBucketCount = partitionBucketCount;
         this.bucketToKeep = bucketToKeep;
+        this.useLegacyTimestampBucketing = useLegacyTimestampBucketing;
     }
 
     public int[] getBucketColumnIndices()
@@ -55,5 +63,10 @@ public class BucketAdaptation
     public int getBucketToKeep()
     {
         return bucketToKeep;
+    }
+
+    public boolean useLegacyTimestampBucketing()
+    {
+        return useLegacyTimestampBucketing;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketAdapterRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketAdapterRecordCursor.java
@@ -41,6 +41,7 @@ public class HiveBucketAdapterRecordCursor
     private final int bucketToKeep;
 
     private final Object[] scratch;
+    private final boolean useLegacyTimestampBucketing;
 
     public HiveBucketAdapterRecordCursor(
             int[] bucketColumnIndices,
@@ -49,7 +50,8 @@ public class HiveBucketAdapterRecordCursor
             int partitionBucketCount,
             int bucketToKeep,
             TypeManager typeManager,
-            RecordCursor delegate)
+            RecordCursor delegate,
+            boolean useLegacyTimestampBucketing)
     {
         this.bucketColumnIndices = requireNonNull(bucketColumnIndices, "bucketColumnIndices is null");
         this.delegate = requireNonNull(delegate, "delegate is null");
@@ -67,6 +69,7 @@ public class HiveBucketAdapterRecordCursor
         this.bucketToKeep = bucketToKeep;
 
         this.scratch = new Object[bucketColumnHiveTypes.size()];
+        this.useLegacyTimestampBucketing = useLegacyTimestampBucketing;
     }
 
     @Override
@@ -121,7 +124,7 @@ public class HiveBucketAdapterRecordCursor
                     throw new UnsupportedOperationException("unknown java type");
                 }
             }
-            int bucket = HiveBucketing.getHiveBucket(tableBucketCount, typeInfoList, scratch);
+            int bucket = HiveBucketing.getHiveBucket(tableBucketCount, typeInfoList, scratch, useLegacyTimestampBucketing);
             if ((bucket - bucketToKeep) % partitionBucketCount != 0) {
                 throw new PrestoException(HIVE_INVALID_BUCKET_FILES, format(
                         "A row that is supposed to be in bucket %s is encountered. Only rows in bucket %s (modulo %s) are expected",

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -221,6 +221,7 @@ public class HiveClientConfig
     private int parquetQuickStatsMaxConcurrentCalls = 500;
     private int quickStatsMaxConcurrentCalls = 100;
     private DataSize affinitySchedulingFileSectionSize = new DataSize(256, MEGABYTE);
+    private boolean legacyTimestampBucketing;
 
     @Min(0)
     public int getMaxInitialSplits()
@@ -1846,5 +1847,18 @@ public class HiveClientConfig
     public boolean isSkipEmptyFilesEnabled()
     {
         return this.skipEmptyFiles;
+    }
+
+    public boolean isLegacyTimestampBucketing()
+    {
+        return legacyTimestampBucketing;
+    }
+
+    @Config("hive.legacy-timestamp-bucketing")
+    @ConfigDescription("Use legacy timestamp bucketing algorithm (which is not Hive compatible) for table bucketed by timestamp type.")
+    public HiveClientConfig setLegacyTimestampBucketing(boolean legacyTimestampBucketing)
+    {
+        this.legacyTimestampBucketing = legacyTimestampBucketing;
+        return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import static com.facebook.presto.hive.HiveBucketFunction.createHiveCompatibleBucketFunction;
 import static com.facebook.presto.hive.HiveBucketFunction.createPrestoNativeBucketFunction;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getNodeSelectionStrategy;
+import static com.facebook.presto.hive.HiveSessionProperties.isLegacyTimestampBucketing;
 import static com.facebook.presto.spi.StandardErrorCode.NODE_SELECTION_NOT_SUPPORTED;
 import static com.facebook.presto.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -54,9 +55,9 @@ public class HiveNodePartitioningProvider
         BucketFunctionType bucketFunctionType = handle.getBucketFunctionType();
         switch (bucketFunctionType) {
             case HIVE_COMPATIBLE:
-                return createHiveCompatibleBucketFunction(bucketCount, handle.getHiveTypes().get());
+                return createHiveCompatibleBucketFunction(bucketCount, handle.getHiveTypes().get(), isLegacyTimestampBucketing(session));
             case PRESTO_NATIVE:
-                return createPrestoNativeBucketFunction(bucketCount, handle.getTypes().get());
+                return createPrestoNativeBucketFunction(bucketCount, handle.getTypes().get(), isLegacyTimestampBucketing(session));
             default:
                 throw new IllegalArgumentException("Unsupported bucket function type " + bucketFunctionType);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
@@ -61,6 +61,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TOO_MANY_OPEN_PARTITIONS;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static com.facebook.presto.hive.HiveSessionProperties.isFileRenamingEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isLegacyTimestampBucketing;
 import static com.facebook.presto.hive.HiveSessionProperties.isOptimizedPartitionUpdateSerializationEnabled;
 import static com.facebook.presto.hive.HiveUtil.serializeZstdCompressed;
 import static com.facebook.presto.hive.PartitionUpdate.FileWriteInfo;
@@ -183,10 +184,10 @@ public class HivePageSink
                     List<HiveType> bucketColumnHiveTypes = bucketProperty.get().getBucketedBy().stream()
                             .map(dataColumnNameToHiveTypeMap::get)
                             .collect(toImmutableList());
-                    bucketFunction = createHiveCompatibleBucketFunction(bucketCount, bucketColumnHiveTypes);
+                    bucketFunction = createHiveCompatibleBucketFunction(bucketCount, bucketColumnHiveTypes, isLegacyTimestampBucketing(session));
                     break;
                 case PRESTO_NATIVE:
-                    bucketFunction = createPrestoNativeBucketFunction(bucketCount, bucketProperty.get().getTypes().get());
+                    bucketFunction = createPrestoNativeBucketFunction(bucketCount, bucketProperty.get().getTypes().get(), isLegacyTimestampBucketing(session));
                     break;
                 default:
                     throw new IllegalArgumentException("Unsupported bucket function type " + bucketFunctionType);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -299,6 +299,7 @@ public class HivePageSource
         public final int tableBucketCount;
         public final int partitionBucketCount; // for sanity check only
         private final List<TypeInfo> typeInfoList;
+        private final boolean useLegacyTimestampBucketing;
 
         public BucketAdapter(BucketAdaptation bucketAdaptation)
         {
@@ -309,6 +310,7 @@ public class HivePageSource
                     .collect(toImmutableList());
             this.tableBucketCount = bucketAdaptation.getTableBucketCount();
             this.partitionBucketCount = bucketAdaptation.getPartitionBucketCount();
+            this.useLegacyTimestampBucketing = bucketAdaptation.useLegacyTimestampBucketing();
         }
 
         @Nullable
@@ -317,7 +319,7 @@ public class HivePageSource
             IntArrayList ids = new IntArrayList(page.getPositionCount());
             Page bucketColumnsPage = page.extractChannels(bucketColumns);
             for (int position = 0; position < page.getPositionCount(); position++) {
-                int bucket = getHiveBucket(tableBucketCount, typeInfoList, bucketColumnsPage, position);
+                int bucket = getHiveBucket(tableBucketCount, typeInfoList, bucketColumnsPage, position, useLegacyTimestampBucketing);
                 if ((bucket - bucketToKeep) % partitionBucketCount != 0) {
                     throw new PrestoException(HIVE_INVALID_BUCKET_FILES, format(
                             "A row that is supposed to be in bucket %s is encountered. Only rows in bucket %s (modulo %s) are expected",

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -73,6 +73,7 @@ import static com.facebook.presto.hive.HiveColumnHandle.isRowIdColumnHandle;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 import static com.facebook.presto.hive.HivePageSourceProvider.ColumnMapping.toColumnHandles;
+import static com.facebook.presto.hive.HiveSessionProperties.isLegacyTimestampBucketing;
 import static com.facebook.presto.hive.HiveSessionProperties.isUseRecordPageSourceForCustomSplit;
 import static com.facebook.presto.hive.HiveUtil.getPrefilledColumnValue;
 import static com.facebook.presto.hive.HiveUtil.parsePartitionValue;
@@ -208,7 +209,7 @@ public class HivePageSourceProvider
                 .transform(Subfield::getRootName)
                 .transform(hiveLayout.getPredicateColumns()::get);
 
-        if (shouldSkipBucket(hiveLayout, hiveSplit, splitContext)) {
+        if (shouldSkipBucket(hiveLayout, hiveSplit, splitContext, isLegacyTimestampBucketing(session))) {
             return new HiveEmptySplitPageSource();
         }
 
@@ -343,7 +344,7 @@ public class HivePageSourceProvider
                 split.getFileSplit(),
                 split.getTableBucketNumber());
 
-        Optional<BucketAdaptation> bucketAdaptation = split.getBucketConversion().map(conversion -> toBucketAdaptation(conversion, columnMappings, split.getTableBucketNumber(), mapping -> mapping.getHiveColumnHandle().getHiveColumnIndex()));
+        Optional<BucketAdaptation> bucketAdaptation = split.getBucketConversion().map(conversion -> toBucketAdaptation(conversion, columnMappings, split.getTableBucketNumber(), mapping -> mapping.getHiveColumnHandle().getHiveColumnIndex(), isLegacyTimestampBucketing(session)));
 
         Map<Integer, String> prefilledValues = columnMappings.stream()
                 .filter(mapping -> mapping.getKind() == ColumnMappingKind.PREFILLED)
@@ -361,7 +362,7 @@ public class HivePageSourceProvider
 
         RowExpression optimizedRemainingPredicate = rowExpressionCache.getUnchecked(new RowExpressionCacheKey(layout.getRemainingPredicate(), session));
 
-        if (shouldSkipBucket(layout, split, splitContext)) {
+        if (shouldSkipBucket(layout, split, splitContext, isLegacyTimestampBucketing(session))) {
             return Optional.of(new HiveEmptySplitPageSource());
         }
 
@@ -462,7 +463,12 @@ public class HivePageSourceProvider
         // Finds the non-synthetic columns.
         List<ColumnMapping> regularAndInterimColumnMappings = ColumnMapping.extractRegularAndInterimColumnMappings(columnMappings);
 
-        Optional<BucketAdaptation> bucketAdaptation = bucketConversion.map(conversion -> toBucketAdaptation(conversion, regularAndInterimColumnMappings, tableBucketNumber, ColumnMapping::getIndex));
+        Optional<BucketAdaptation> bucketAdaptation = bucketConversion.map(conversion -> toBucketAdaptation(
+                conversion,
+                regularAndInterimColumnMappings,
+                tableBucketNumber,
+                ColumnMapping::getIndex,
+                isLegacyTimestampBucketing(session)));
 
         if (isUseRecordPageSourceForCustomSplit(session) && shouldUseRecordReaderFromInputFormat(configuration, storage, fileSplit.getCustomSplitInfo())) {
             return getPageSourceFromCursorProvider(
@@ -623,7 +629,8 @@ public class HivePageSourceProvider
                             bucketAdaptation.get().getPartitionBucketCount(),
                             bucketAdaptation.get().getBucketToKeep(),
                             typeManager,
-                            delegate);
+                            delegate,
+                            isLegacyTimestampBucketing(session));
                 }
 
                 // Need to wrap RcText and RcBinary into a wrapper, which will do the coercion for mismatch columns
@@ -659,7 +666,7 @@ public class HivePageSourceProvider
         return Optional.empty();
     }
 
-    private static boolean shouldSkipBucket(HiveTableLayoutHandle hiveLayout, HiveSplit hiveSplit, SplitContext splitContext)
+    private static boolean shouldSkipBucket(HiveTableLayoutHandle hiveLayout, HiveSplit hiveSplit, SplitContext splitContext, boolean useLegacyTimestampBucketing)
     {
         if (!splitContext.getDynamicFilterPredicate().isPresent()
                 || !hiveSplit.getReadBucketNumber().isPresent()
@@ -668,7 +675,7 @@ public class HivePageSourceProvider
         }
 
         TupleDomain<ColumnHandle> dynamicFilter = splitContext.getDynamicFilterPredicate().get();
-        Optional<HiveBucketing.HiveBucketFilter> hiveBucketFilter = getHiveBucketFilter(hiveSplit.getStorage().getBucketProperty(), hiveLayout.getDataColumns(), dynamicFilter);
+        Optional<HiveBucketing.HiveBucketFilter> hiveBucketFilter = getHiveBucketFilter(hiveSplit.getStorage().getBucketProperty(), hiveLayout.getDataColumns(), dynamicFilter, useLegacyTimestampBucketing);
 
         return hiveBucketFilter.map(filter -> !filter.getBucketsToKeep().contains(hiveSplit.getReadBucketNumber().getAsInt())).orElse(false);
     }
@@ -705,7 +712,12 @@ public class HivePageSourceProvider
         return false;
     }
 
-    private static BucketAdaptation toBucketAdaptation(BucketConversion conversion, List<ColumnMapping> columnMappings, OptionalInt tableBucketNumber, Function<ColumnMapping, Integer> bucketColumnIndexProducer)
+    private static BucketAdaptation toBucketAdaptation(
+            BucketConversion conversion,
+            List<ColumnMapping> columnMappings,
+            OptionalInt tableBucketNumber,
+            Function<ColumnMapping, Integer> bucketColumnIndexProducer,
+            boolean useLegacyTimestamp)
     {
         Map<Integer, ColumnMapping> hiveIndexToBlockIndex = uniqueIndex(columnMappings, columnMapping -> columnMapping.getHiveColumnHandle().getHiveColumnIndex());
         int[] bucketColumnIndices = conversion.getBucketColumnHandles().stream()
@@ -720,7 +732,13 @@ public class HivePageSourceProvider
                 .map(ColumnMapping::getHiveColumnHandle)
                 .map(HiveColumnHandle::getHiveType)
                 .collect(toImmutableList());
-        return new BucketAdaptation(bucketColumnIndices, bucketColumnHiveTypes, conversion.getTableBucketCount(), conversion.getPartitionBucketCount(), tableBucketNumber.getAsInt());
+        return new BucketAdaptation(
+                bucketColumnIndices,
+                bucketColumnHiveTypes,
+                conversion.getTableBucketCount(),
+                conversion.getPartitionBucketCount(),
+                tableBucketNumber.getAsInt(),
+                useLegacyTimestamp);
     }
 
     public static class ColumnMapping

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -69,6 +69,7 @@ import static com.facebook.presto.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_EXCEEDED_PARTITION_LIMIT;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxBucketsForGroupedExecution;
 import static com.facebook.presto.hive.HiveSessionProperties.getMinBucketCountToNotIgnoreTableBucketing;
+import static com.facebook.presto.hive.HiveSessionProperties.isLegacyTimestampBucketing;
 import static com.facebook.presto.hive.HiveSessionProperties.isOfflineDataDebugModeEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isParallelParsingOfPartitionValuesEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.shouldIgnoreTableBucketing;
@@ -270,7 +271,7 @@ public class HivePartitionManager
         }
 
         Optional<HiveBucketHandle> hiveBucketHandle = getBucketHandle(table, session, effectivePredicate);
-        Optional<HiveBucketFilter> bucketFilter = hiveBucketHandle.flatMap(value -> getHiveBucketFilter(table, effectivePredicate));
+        Optional<HiveBucketFilter> bucketFilter = hiveBucketHandle.flatMap(value -> getHiveBucketFilter(table, effectivePredicate, isLegacyTimestampBucketing(session)));
 
         if (!queryUsesHiveBucketColumn(effectivePredicate)
                 && hiveBucketHandle.isPresent()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -133,6 +133,7 @@ public final class HiveSessionProperties
     public static final String DYNAMIC_SPLIT_SIZES_ENABLED = "dynamic_split_sizes_enabled";
     public static final String AFFINITY_SCHEDULING_FILE_SECTION_SIZE = "affinity_scheduling_file_section_size";
     public static final String SKIP_EMPTY_FILES = "skip_empty_files";
+    public static final String LEGACY_TIMESTAMP_BUCKETING = "legacy_timestamp_bucketing";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -647,6 +648,11 @@ public final class HiveSessionProperties
                         SKIP_EMPTY_FILES,
                         "If it is required empty files will be skipped",
                         hiveClientConfig.isSkipEmptyFilesEnabled(),
+                        false),
+                booleanProperty(
+                        LEGACY_TIMESTAMP_BUCKETING,
+                        "Use legacy timestamp bucketing algorithm (which is not Hive compatible) for table bucketed by timestamp type.",
+                        hiveClientConfig.isLegacyTimestampBucketing(),
                         false));
     }
 
@@ -1128,5 +1134,10 @@ public final class HiveSessionProperties
     public static boolean isSkipEmptyFilesEnabled(ConnectorSession session)
     {
         return session.getProperty(SKIP_EMPTY_FILES, Boolean.class);
+    }
+
+    public static boolean isLegacyTimestampBucketing(ConnectorSession session)
+    {
+        return session.getProperty(LEGACY_TIMESTAMP_BUCKETING, Boolean.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
@@ -104,11 +104,6 @@ public class TestHiveBucketing
         assertBucketEquals("date", new DateWritable(toIntExact(LocalDate.of(1970, 1, 1).toEpochDay())).get());
         assertBucketEquals("date", new DateWritable(toIntExact(LocalDate.of(2015, 11, 19).toEpochDay())).get());
         assertBucketEquals("date", new DateWritable(toIntExact(LocalDate.of(1950, 11, 19).toEpochDay())).get());
-        assertBucketEquals("timestamp", null);
-        assertBucketEquals("timestamp", new Timestamp(1000 * LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0).toEpochSecond(ZoneOffset.UTC)));
-        assertBucketEquals("timestamp", new Timestamp(1000 * LocalDateTime.of(1969, 12, 31, 23, 59, 59, 999_000_000).toEpochSecond(ZoneOffset.UTC)));
-        assertBucketEquals("timestamp", new Timestamp(1000 * LocalDateTime.of(1950, 11, 19, 12, 34, 56, 789_000_000).toEpochSecond(ZoneOffset.UTC)));
-        assertBucketEquals("timestamp", new Timestamp(1000 * LocalDateTime.of(2015, 11, 19, 7, 6, 5, 432_000_000).toEpochSecond(ZoneOffset.UTC)));
         assertBucketEquals("array<double>", null);
         assertBucketEquals("array<boolean>", ImmutableList.of());
         assertBucketEquals("array<smallint>", ImmutableList.of((short) 5, (short) 8, (short) 13));
@@ -126,6 +121,23 @@ public class TestHiveBucketing
         assertBucketEquals(
                 ImmutableList.of("double", "array<smallint>", "boolean", "map<string,bigint>", "tinyint"),
                 asList(null, ImmutableList.of((short) 5, (short) 8, (short) 13), null, ImmutableMap.of("key", 123L), null));
+    }
+
+    @Test
+    public void testTimestamp()
+            throws Exception
+    {
+        // Test seconds
+        assertBucketEquals("timestamp", null);
+        assertBucketEquals("timestamp", new Timestamp(1000 * LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0).toEpochSecond(ZoneOffset.UTC)));
+        assertBucketEquals("timestamp", new Timestamp(1000 * LocalDateTime.of(1969, 12, 31, 23, 59, 59, 999_000_000).toEpochSecond(ZoneOffset.UTC)));
+        assertBucketEquals("timestamp", new Timestamp(1000 * LocalDateTime.of(1950, 11, 19, 12, 34, 56, 789_000_000).toEpochSecond(ZoneOffset.UTC)));
+        assertBucketEquals("timestamp", new Timestamp(1000 * LocalDateTime.of(2015, 11, 19, 7, 6, 5, 432_000_000).toEpochSecond(ZoneOffset.UTC)));
+        // Test milliseconds
+        assertBucketEquals("timestamp", new Timestamp(10 + 1000 * LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0).toEpochSecond(ZoneOffset.UTC)));
+        assertBucketEquals("timestamp", new Timestamp(22 + 1000 * LocalDateTime.of(1969, 12, 31, 23, 59, 59, 999_000_000).toEpochSecond(ZoneOffset.UTC)));
+        assertBucketEquals("timestamp", new Timestamp(100 + 1000 * LocalDateTime.of(1950, 11, 19, 12, 34, 56, 789_000_000).toEpochSecond(ZoneOffset.UTC)));
+        assertBucketEquals("timestamp", new Timestamp(250 + 1000 * LocalDateTime.of(2015, 11, 19, 7, 6, 5, 432_000_000).toEpochSecond(ZoneOffset.UTC)));
     }
 
     private static void assertBucketEquals(String hiveTypeStrings, Object hiveValues)
@@ -185,8 +197,8 @@ public class TestHiveBucketing
             nativeContainerValues[i] = toNativeContainerValue(type, hiveValue);
         }
         ImmutableList<Block> blockList = blockListBuilder.build();
-        int result1 = HiveBucketing.getHiveBucket(bucketCount, hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2);
-        int result2 = HiveBucketing.getHiveBucket(bucketCount, hiveTypeInfos, nativeContainerValues);
+        int result1 = HiveBucketing.getHiveBucket(bucketCount, hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2, false);
+        int result2 = HiveBucketing.getHiveBucket(bucketCount, hiveTypeInfos, nativeContainerValues, false);
         assertEquals(result1, result2, "Overloads of getHiveBucket produced different result");
         return result1;
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -166,7 +166,8 @@ public class TestHiveClientConfig
                 .setMaxConcurrentParquetQuickStatsCalls(500)
                 .setCteVirtualBucketCount(128)
                 .setSkipEmptyFilesEnabled(false)
-                .setAffinitySchedulingFileSectionSize(new DataSize(256, MEGABYTE)));
+                .setAffinitySchedulingFileSectionSize(new DataSize(256, MEGABYTE))
+                .setLegacyTimestampBucketing(false));
     }
 
     @Test
@@ -294,6 +295,7 @@ public class TestHiveClientConfig
                 .put("hive.cte-virtual-bucket-count", "256")
                 .put("hive.affinity-scheduling-file-section-size", "512MB")
                 .put("hive.skip-empty-files", "true")
+                .put("hive.legacy-timestamp-bucketing", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -417,7 +419,8 @@ public class TestHiveClientConfig
                 .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE))
                 .setSkipEmptyFilesEnabled(true)
                 .setCteVirtualBucketCount(256)
-                .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE));
+                .setAffinitySchedulingFileSectionSize(new DataSize(512, MEGABYTE))
+                .setLegacyTimestampBucketing(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
@@ -180,7 +180,7 @@ public class LocalExchange
 
         BucketFunction bucketFunction = partitioningProvider.getBucketFunction(
                 partitioning.getTransactionHandle().orElse(null),
-                session.toConnectorSession(),
+                session.toConnectorSession(partitioning.getConnectorId().get()),
                 partitioning.getConnectorHandle(),
                 partitioningChannelTypes,
                 bucketCount);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
@@ -93,7 +93,7 @@ public class NodePartitioningManager
 
             bucketFunction = partitioningProvider.getBucketFunction(
                     partitioningHandle.getTransactionHandle().orElse(null),
-                    session.toConnectorSession(),
+                    session.toConnectorSession(partitioningHandle.getConnectorId().get()),
                     partitioningHandle.getConnectorHandle(),
                     partitionChannelTypes,
                     bucketToPartition.get().length);


### PR DESCRIPTION
[Presto Java](https://github.com/prestodb/presto/blob/3d06a01ab54f287331975bd6a2f2cdf34aee9529/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java#L175-L179) calculates hash for Timestamp type using formula:
hash(seconds << 30 + **milliseconds**)
[Hive](https://github.com/apache/hive/blob/master/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritable.java#L393-L397): 
hash(seconds << 30 + nanoseconds)
[Spark](https://github.com/apache/spark/blob/5a2f374a208f9580ea8d0183d75df6cd2bee8e1f/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala#L966-L974): 
hash(seconds << 30 + nanoseconds)
[Velox](https://github.com/facebookincubator/velox/blob/102526b4444df4723448078141cf52034b339355/velox/connectors/hive/HivePartitionFunction.cpp#L44-L46): 
hash(seconds << 30 + nanoseconds)

To keep a consistent behavior with other engines, fix the hash calculation formula for Timestamp.

```
== RELEASE NOTES ==

Hive Connector Changes
* Fix hash calculation for Timestamp column to be hive compatible when writing to a table bucketed by Timestamp.  :pr:`22890`
* Add config `hive.legacy-timestamp-bucketing` and session property ``hive.legacy_timestamp_bucketing`` to use the original hash function for Timestamp column, which is not hive compatible. :pr:`22890`

```