### PR TITLE
[docs] Fix errors in doc build

### DIFF
--- a/presto-docs/src/main/sphinx/cache/local.rst
+++ b/presto-docs/src/main/sphinx/cache/local.rst
@@ -50,8 +50,9 @@ In the above example configuration,
 
 When affinity scheduling is enabled, a set of preferred nodes is assigned to a certain file section. The default file section size is ``256MB``.
 For example, if the file size is 512MB, two different affinity preferences will be assigned:
-    - ``[0MB..256MB] -> NodeA, NodeB``
-    - ``[256MB+1B..512MB] -> NodeC, NodeD``
+
+- ``[0MB..256MB] -> NodeA, NodeB``
+- ``[256MB+1B..512MB] -> NodeC, NodeD``
 
 The section is selected based on the split start offset.
 A split that has its first byte in the first section is preferred to be scheduled on ``NodeA`` or ``NodeB``.

--- a/presto-docs/src/main/sphinx/connector/hudi.rst
+++ b/presto-docs/src/main/sphinx/connector/hudi.rst
@@ -18,8 +18,8 @@ To use Hudi, we need:
 
 * Network access from the Presto coordinator and workers to the distributed object storage.
 * Access to a Hive metastore service (HMS).
-* Network access from the Presto coordinator to the HMS. Hive metastore access with the Thrift
-protocol defaults to using port 9083.
+* Network access from the Presto coordinator to the HMS. Hive metastore access with the Thrift 
+  protocol defaults to using port 9083.
 
 Configuration
 -------------

--- a/presto-docs/src/main/sphinx/connector/sqlserver.rst
+++ b/presto-docs/src/main/sphinx/connector/sqlserver.rst
@@ -61,6 +61,7 @@ A connection string using a truststore would be similar to the following example
 .. code-block:: none
 
     connection-url=jdbc:sqlserver://<host>:<port>;databaseName=<databaseName>;encrypt=true;trustServerCertificate=false;trustStoreType=PEM;hostNameInCertificate=hostname;trustStore=path/to/truststore.pem;trustStorePassword=password
+
 Multiple SQL Server Databases or Servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/functions.rst
+++ b/presto-docs/src/main/sphinx/functions.rst
@@ -37,3 +37,4 @@ Functions and Operators
     functions/internationalization
     functions/setdigest
     functions/sketch
+    functions/pinot

--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -139,7 +139,7 @@ Array Functions
 .. function:: array_sort(x) -> array
 
     Sorts and returns the array ``x``. The elements of ``x`` must be orderable.
-    Null elements will be placed at the end of the returned array.::
+    Null elements will be placed at the end of the returned array.
 
 .. function:: array_sort(array(T), function(T,T,int)) -> array(T)
 

--- a/presto-docs/src/main/sphinx/functions/comparison.rst
+++ b/presto-docs/src/main/sphinx/functions/comparison.rst
@@ -160,9 +160,9 @@ The LIKE operator is used to match a specified character pattern in a string. Pa
 regular characters as well as wildcards. Wildcard characters can be escaped using the single character
 specified for the ESCAPE parameter. Matching is case sensitive.
 
-Syntax::
+Syntax:
 
-expression LIKE pattern [ ESCAPE 'escape_character' ]
+    expression LIKE pattern [ ESCAPE 'escape_character' ]
 
 if ``pattern`` or ``escape_character`` is null, the expression evaluates to null.
 

--- a/presto-docs/src/main/sphinx/functions/window.rst
+++ b/presto-docs/src/main/sphinx/functions/window.rst
@@ -13,9 +13,9 @@ clause to specify the window as follows::
         [frame]
     )
 
-A ``frame`` is one of::
+A ``frame`` is one of:
 
-    {RANGE|ROWS|GROUPS} frame_start
+    {RANGE|ROWS|GROUPS} frame_start 
     {RANGE|ROWS|GROUPS} BETWEEN frame_start AND frame_end
 
 ``frame_start`` and ``frame_end`` can be any of::

--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -14,6 +14,7 @@ Release Notes
     release/release-0.282
     release/release-0.281
     release/release-0.280
+    release/release-0.279.2
     release/release-0.279
     release/release-0.278.1
     release/release-0.278
@@ -58,6 +59,7 @@ Release Notes
     release/release-0.249.2
     release/release-0.249.1
     release/release-0.249
+    release/release-0.248.1
     release/release-0.248
     release/release-0.247
     release/release-0.246

--- a/presto-docs/src/main/sphinx/release/release-0.258.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.258.rst
@@ -13,21 +13,21 @@ _______________
 * Add additional details to memory exceeded error messages to simplify debugging. Disabled by default. Can be enabled by setting the ``verbose_exceeded_memory_limit_errors_enabled`` session property to ``true``.
 * Support dynamic filtering with comparison operators. Can be enabled by setting the ``enable-dynamic-filtering`` property to ``true``. Disabled by default.
 
-Cassandra Changes
-________________
+Cassandra Connector Changes
+___________________________
 * Improve query performance by caching metadata to avoid extra remote calls to the Cassandra server.
 
-Elasticsearch Changes
-_____________________
+Elasticsearch Connector Changes
+_______________________________
 * Fix incorrect pushdown of ``IS NULL`` predicate in Elasticsearch.
 
-Hive Changes
-____________
+Hive Connector Changes
+______________________
 * Fix a bug in Parquet dereference pushdown that caused inconsistent query results in certain cases.
 * Add support for allowing to match columns between table and partition schemas by names for HUDI tables. This is enabled when configuration property ``hive.parquet.use-column-names`` or the hive catalog session property ``parquet_use_column_names`` is set to ``true``. By default they are mapped by index.
 
-Iceberg Changes
-_______________
+Iceberg Connector Changes
+_________________________
 * Add support for ORC files.
 
 SPI Changes

--- a/presto-docs/src/main/sphinx/release/release-0.259.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.259.rst
@@ -3,7 +3,8 @@ Release 0.259
 =============
 
 .. warning::
-This release includes a regression on jdbc connector.
+
+   This release includes a regression on jdbc connector.
 
 **Details**
 ===========

--- a/presto-docs/src/main/sphinx/release/release-0.271.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.271.rst
@@ -9,10 +9,11 @@ General Changes
 _______________
 * Fix a bug where cache performance might be affected when ``CONSISTENT_HASHING`` is used as the scheduling strategy.
 * Fix cast from bigint to varchar. Casting a number to a bounded varchar smaller than needed to hold the result will now fail.
-  Example for presto CLI
-    select cast(1234500000000000000 as varchar(3));
+  Example for presto CLI:
 
-    Query ... failed: Value 1234500000000000000 cannot be represented as varchar(3)
+  ``select cast(1234500000000000000 as varchar(3));``
+
+  ``Query ... failed: Value 1234500000000000000 cannot be represented as varchar(3)``
 
 * Fix reorder joins optimization where plan might not be optimal when original build side is larger than configured ``join-max-broadcast-table-size``.
 * Add a new configuration property ``experimental.distinct-aggregation-large-block-size-threshold`` to define the threshold size beyond which the block will be spilled into a separate spill file.  This can be overridden by ``distinct_aggregation_large_block_size_threshold`` session property.
@@ -20,13 +21,13 @@ _______________
 * Add support for viewing expanded prepared query in Web UI.
 * Generate a warning when creating a map with double/real as keys.
 
-Hive Changes
-____________
+Hive Connector Changes
+______________________
 * Fix ANALYZE TABLE for partitioned Hive tables with complex columns (array, map, struct).
 * Improve performance of ANALYZE TABLE on hive tables with complex columns.
 
-Iceberg Changes
-_______________
+Iceberg Connector Changes
+_________________________
 * Remove the iceberg.catalog.uri config. Use hive.metastore.uri instead.
 * Add support for ORC format caching module for iceberg connector.
 * Add support for basic timestamp in the iceberg connector.

--- a/presto-docs/src/main/sphinx/release/release-0.273.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.273.rst
@@ -40,12 +40,12 @@ _______________
 * Upgrade zstandard compression to version 1.5.2.2. This improves the cpu used for data compressed with zstandard by about 2%.
 * Upgrade postgresql driver to 42.3.3.
 
-Clickhouse Changes
-____________
+Clickhouse Connector Changes
+____________________________
 * Add a Presto connector for Clickhouse with support of username/password authentication.
 
-Hive Changes
-____________
+Hive Connector Changes
+______________________
 * Add a limit that prevents caching partitions with column counts greater than a configured threshold. This threshold can be set using the ``hive.partition-cache-column-count-limit`` configuration property.
 * Add metastore configuration property ``hive.metastore.thrift.delete-files-on-table-drop`` to delete files on drop table.
 * Add support for overwriting existing partitions with a Hive configuration property ``hive.insert-existing-partitions-behavior``. This configuration property supersedes the legacy one ``hive.insert-overwrite-immutable-partitions-enabled``. The new configuration property adds capability of overwriting new partitions for S3.
@@ -53,19 +53,19 @@ ____________
 * Replace Hive session property ``streaming_aggregation_enabled`` with ``order_based_execution_enabled``.
 * Replace Hive configuration property ``hive.streaming-aggregation-enabled`` with ``hive.order-based-execution-enabled``.
 
-Iceberg Changes
-_______________
+Iceberg Connector Changes
+_________________________
 * Fix Iceberg ``$files`` table in case of column dropping.
 * Add ``$properties`` system table.
 * Add support for storing column comments for Iceberg tables.
 * Upgrade Iceberg to 0.13.1.
 
-Mongodb Changes
-_______________
+Mongodb Connector Changes
+_________________________
 * Add :func:`CAST(ObjectId() as STRING)`.
 
-Pinot Changes
-_____________
+Pinot Connector Changes
+_______________________
 * Improve query performance by enabling pushdown of topn broker queries by default.
 * Add double-quotes to Pinot generated queries to ensure that reserved keywords are escaped.
 * Add TLS support in Pinot gRPC connection.

--- a/presto-docs/src/main/sphinx/release/release-0.280.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.280.rst
@@ -27,8 +27,8 @@ Resource Groups Changes
 _______________________
 * Fix blocking resource group lock when query queue is full (``QUERY_QUEUE_FULL`` error)
 
-Hive Changes
-____________
+Hive Connector Changes
+______________________
 * Add Amazon S3 Select pushdown for JSON files.
 
 **Credits**

--- a/presto-docs/src/main/sphinx/release/release-0.281.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.281.rst
@@ -31,20 +31,20 @@ ___________
 * Add ``MetadataResolver`` in the ``AnalyzerContext``, which is passed in the pluggable analyzer interface.
 
 
-Hive Changes
-____________
+Hive Connector Changes
+______________________
 * Fix a bug where the filter on a ``CHAR(n)`` column is not evaluated correctly for ORC/DWRF files when filter pushdown is enabled.
 * Fix issue while accessing HUDI Merge-on-Read Realtime tables (:issue:`18911`).
 * Enable Hive splits for uncompressed inputs in S3 Select connector by leveraging the scan range feature of the service.
 
-Apache Hudi Changes
-___________________
+Apache Hudi Connector Changes
+_____________________________
 * Add the asynchronous split generation in Hudi connector to speed up the query execution and reduce overall query finishing time. ``hudi.max-outstanding-splits`` session property controls the maximum outstanding splits in a batch enqueued for processing.  ``hudi.split-generator-parallelism`` session property controls the number of threads to generate splits from partitions.
 * Upgrade Apache Hudi version to 0.12.1.
 
 
-Apache Iceberg Changes
-______________________
+Apache Iceberg Connector Changes
+________________________________
 * Upgrade Apache Iceberg version from 1.1.0 to 1.2.0.
 
 JDBC Changes

--- a/presto-docs/src/main/sphinx/release/release-0.282.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.282.rst
@@ -22,13 +22,13 @@ _______________
 * Upgrade Joda version to 2.12.2. Note: a corresponding update to the Java runtime should also be made to ensure consistent timezone data.
 * Upgrade AWS SDK version to 1.12.261.
 
-Hive Changes
-____________
+Hive Connector Changes
+______________________
 * Remove the implementation of Alluxio's metadata store because this feature won't be supported in Alluxio 3.0.0.
 * Upgrade Alluxio version from 2.8.1 to 2.9.3.
 
-Apache Iceberg Changes
-______________________
+Iceberg Connector Changes
+_________________________
 * Add parquet metadata caching in Apache Iceberg.
 
 Presto on Spark Changes
@@ -37,8 +37,8 @@ _______________________
 * Add an additional field  ``attemptNumber`` in ``TaskId`` which is used to capture task retries in Presto on Spark. For presto classic this field will be set to ``0`` by default.
 * Remove :doc:`/sql/create-function` and :doc:`/sql/drop-function` support from Presto on Spark.
 
-JDBC Changes
-____________
+JDBC Connector Changes
+______________________
 * Fix ``TRUNCATE TABLE`` for JDBC connector.
 
 Resource Group Changes

--- a/presto-docs/src/main/sphinx/release/release-0.283.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.283.rst
@@ -31,8 +31,8 @@ _______________
 * Remove ``Experimental`` prefix from Dynamic Filtering.
 * Add support for Hive S3 configuration to Iceberg Hadoop and Nessie catalogs.
 
-Hive Changes
-____________
+Hive Connector Changes
+______________________
 * Fix a bug where the ParquetWriter throws "Size is greater than maximum int value" error when the table is large.
 * Add Prestissimo support to write Parquet table storage format.
 * Add support for the TTL of Alluxio SDK cache.
@@ -41,8 +41,8 @@ JDBC Changes
 ____________
 * Add cache support for JDBC metadata calls. This can be enabled by configuring parameter ``metadata-cache-ttl``, ``metadata-cache-refresh-interval`` and ``metadata-cache-size``.
 
-Native Changes
-______________
+Native Connector Changes
+________________________
 * Add TPC-DS tests for native execution based on Parquet files.
 
 Presto on Spark Changes

--- a/presto-docs/src/main/sphinx/release/release-0.285.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.285.rst
@@ -24,7 +24,7 @@ _______________
 * Add task killer which is triggered when a worker is running out of memory and the garbage collector cannot reclaim sufficient memory. Two strategies are provided: full garbage collection, and frequent full garbage collection. :pr:`21254`
 * Add support to remove redundant `cast to varchar` expressions in a join condition. This feature is configurable by the session property ``remove_redundant_cast_to_varchar_in_join`` (enabled by default). :pr:`21050`
 * Add support to use HBO for scaled writers. This feature is configurable by the session property ``enable_hbo_for_scaled_writer`` (disabled by default).
-* Add support to split aggregates into partial and final based on partial aggregation statistics. This feature is configurable by the session property ``use_partial_aggregation_history``(disabled by default). :pr:`21160`
+* Add support to split aggregates into partial and final based on partial aggregation statistics. This feature is configurable by the session property ``use_partial_aggregation_history`` (disabled by default). :pr:`21160`
 * Add optimization where values node followed by an always false filter is converted to an empty values node.
 * Add information about cost-based optimizers and the source of stats they use (CBO/HBO) in explain plans when session property ``verbose_optimizer_info_enabled=true``. :pr:`20990`
 * Upgrade Joda-Time to 2.12.5 to use 2023c tzdata. The JVM should also be updated to ensure the timezone data is consistent. :pr:`21329`

--- a/presto-docs/src/main/sphinx/release/release-0.286.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.286.rst
@@ -48,18 +48,18 @@ SPI Changes
 ___________
 * Add support for connectors to return joins in ``ConnectorPlanOptimizer.optimize``. :pr:`21605`
 
-Hive Changes
-____________
+Hive Connector Changes
+______________________
 * Fix parquet dereference pushdown which was not working unless the ``parquet_use_column_names`` session property was set. :pr:`21647`
 * Fix CTE materialization for unsupported Hive bucket types. :pr:`21549`
 * Remove hive config ``hive.s3.use-instance-credentials`` as deprecated. :pr:`21648`
 
-Hudi Changes
-____________
+Hudi Connector Changes
+______________________
 * Upgrade Hudi version to 0.14.0. :pr:`21012`
 
-Iceberg Changes
-_______________
+Iceberg Connector Changes
+_________________________
 * Upgrade Apache Iceberg to 1.4.3.  :pr:`21714`
 * Add Iceberg Filter Pushdown Optimizer Rule for execution with Velox. :pr:`20501`
 * Add ``iceberg.pushdown-filter-enabled`` config property to Iceberg Connector. This config property controls the behaviour of Filter Pushdown in the Iceberg connector. :pr:`20501`

--- a/presto-docs/src/main/sphinx/rest/query.rst
+++ b/presto-docs/src/main/sphinx/rest/query.rst
@@ -23,51 +23,52 @@ on a Presto installation.
    interface of a Presto coordinator you will see a list of current
    queries. Clicking on a query will reveal a link to this service.
 
-   **Example response**:
 
-      .. code-block:: json
+   **Example response:**
 
-         {
-  	    "queryId" : "20131229_211533_00017_dk5x2",
-  	    "session" : {
-    	       "user" : "tobrien",
-    	       "source" : "presto-cli",
-    	       "catalog" : "jmx",
-    	       "schema" : "jmx",
-    	       "remoteUserAddress" : "173.15.79.89",
-    	       "userAgent" : "StatementClient/0.55-SNAPSHOT",
-    	       "startTime" : 1388351852026
-  	    },
-  	    "state" : "FINISHED",
-  	    "self" : "http://10.193.207.128:8080/v1/query/20131229_211533_00017_dk5x2",
-  	    "fieldNames" : [ "name" ],
-  	    "query" : "select name from \"java.lang:type=runtime\"",
-  	    "queryStats" : {
-    	       "createTime" : "2013-12-29T16:17:32.027-05:00",
-    	       "executionStartTime" : "2013-12-29T16:17:32.086-05:00",
-    	       "lastHeartbeat" : "2013-12-29T16:17:44.561-05:00",
-    	       "endTime" : "2013-12-29T16:17:32.152-05:00",
-    	       "elapsedTime" : "125.00ms",
-    	       "queuedTime" : "1.31ms",
-    	       "analysisTime" : "4.84ms",
-    	       "totalTasks" : 2,
-    	       "runningTasks" : 0,
-    	       "completedTasks" : 2,
-    	       "totalDrivers" : 2,
-    	       "queuedDrivers" : 0,
-    	       "runningDrivers" : 0,
-    	       "completedDrivers" : 2,
-    	       "totalMemoryReservation" : "0B",
-    	       "totalScheduledTime" : "5.84ms",
-    	       "totalCpuTime" : "710.49us",
-    	       "totalBlockedTime" : "27.38ms",
-    	       "rawInputDataSize" : "27B",
-    	       "rawInputPositions" : 1,
-    	       "processedInputDataSize" : "32B",
-    	       "processedInputPositions" : 1,
-    	       "outputDataSize" : "32B",
-    	       "outputPositions" : 1
-  	    },
-  	    "outputStage" : ...
-         }
+   .. code-block:: json
+
+     {
+       "queryId" : "20131229_211533_00017_dk5x2",
+       "session" : {
+    	   "user" : "tobrien",
+    	   "source" : "presto-cli",
+           "catalog" : "jmx",
+           "schema" : "jmx",
+           "remoteUserAddress" : "173.15.79.89",
+    	   "userAgent" : "StatementClient/0.55-SNAPSHOT",
+           "startTime" : 1388351852026
+       },
+       "state" : "FINISHED",
+       "self" : "http://10.193.207.128:8080/v1/query/20131229_211533_00017_dk5x2",
+       "fieldNames" : [ "name" ],
+       "query" : "select name from \"java.lang:type=runtime\"",
+       "queryStats" : {
+    	   "createTime" : "2013-12-29T16:17:32.027-05:00",
+    	   "executionStartTime" : "2013-12-29T16:17:32.086-05:00",
+    	   "lastHeartbeat" : "2013-12-29T16:17:44.561-05:00",
+    	   "endTime" : "2013-12-29T16:17:32.152-05:00",
+    	   "elapsedTime" : "125.00ms",
+    	   "queuedTime" : "1.31ms",
+    	   "analysisTime" : "4.84ms",
+    	   "totalTasks" : 2,
+    	   "runningTasks" : 0,
+    	   "completedTasks" : 2,
+    	   "totalDrivers" : 2,
+    	   "queuedDrivers" : 0,
+    	   "runningDrivers" : 0,
+    	   "completedDrivers" : 2,
+    	   "totalMemoryReservation" : "0B",
+    	   "totalScheduledTime" : "5.84ms",
+    	   "totalCpuTime" : "710.49us",
+    	   "totalBlockedTime" : "27.38ms",
+    	   "rawInputDataSize" : "27B",
+    	   "rawInputPositions" : 1,
+    	   "processedInputDataSize" : "32B",
+    	   "processedInputPositions" : 1,
+    	   "outputDataSize" : "32B",
+    	   "outputPositions" : 1
+       },
+       "outputStage" : ...
+     }
 

--- a/presto-docs/src/main/sphinx/router.rst
+++ b/presto-docs/src/main/sphinx/router.rst
@@ -1,6 +1,6 @@
-*****
+******
 Router
-*****
+******
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
## Description
Fixes the following errors in the Presto documentation build (errors taken from a local doc build): 

* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/cache/local.rst:53: ERROR: Unexpected indentation.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/connector/sqlserver.rst:64: WARNING: Explicit markup ends without a blank line; unexpected unindent.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/router.rst:1: WARNING: Title overline too short.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/release/release-0.273.rst:44: WARNING: Title underline too short.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/release/release-0.285.rst:27: WARNING: Inline literal start-string without end-string.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/release/release-0.271.rst:13: ERROR: Unexpected indentation.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/release/release-0.258.rst:17: WARNING: Title underline too short.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/release/release-0.259.rst:5: ERROR: Content block expected for the "warning" directive; none found.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/release/release-0.259.rst:6: WARNING: Explicit markup ends without a blank line; unexpected unindent.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/connector/hudi.rst:22: WARNING: Bullet list ends without a blank line; unexpected unindent.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/release/release-0.248.1.rst: WARNING: document isn't included in any toctree
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/release/release-0.279.2.rst: WARNING: document isn't included in any toctree
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/functions/pinot.rst: WARNING: document isn't included in any toctree
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/functions/array.rst:143: WARNING: Literal block expected; none found.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/functions/comparison.rst:165: WARNING: Literal block expected; none found.
* /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/functions/window.rst:18: WARNING: Lexing literal_block '{RANGE|ROWS|GROUPS} frame_start\n{RANGE|ROWS|GROUPS} BETWEEN frame_start AND frame_end' as "sql" resulted in an error at token: '{'. Retrying in relaxed mode.


## Motivation and Context
Like the doc build errors I fixed in #22876, these errors don't stop the build but they're annoying, and these are easy and low-risk fixes.


## Impact
Fewer errors in the doc build. 

## Test Plan
Local doc builds. Also, CI. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

