### PR TITLE
Reduce log cruft

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -395,12 +395,9 @@ public final class QueryAssertions
             boolean ifNotExists,
             boolean bucketed)
     {
-        log.info("Loading data from %s.%s...", sourceCatalog, sourceSchema);
-        long startTime = System.nanoTime();
         for (String table : tables) {
             copyTable(queryRunner, sourceCatalog, sourceSchema, session, table, ifNotExists, bucketed);
         }
-        log.info("Loading from %s.%s complete in %s", sourceCatalog, sourceSchema, nanosSince(startTime).toString(SECONDS));
     }
 
     public static void copyTable(
@@ -414,13 +411,8 @@ public final class QueryAssertions
     {
         QualifiedObjectName table = new QualifiedObjectName(sourceCatalog, sourceSchema, sourceTable);
 
-        long start = System.nanoTime();
-        log.info("Running import for %s", table.getObjectName());
-
         @Language("SQL") String sql = getCopyTableSql(sourceCatalog, table, ifNotExists, bucketed);
         long rows = (Long) queryRunner.execute(session, sql).getMaterializedRows().get(0).getField(0);
-
-        log.info("Imported %s rows for %s in %s", rows, table.getObjectName(), nanosSince(start).convertToMostSuccinctTimeUnit());
     }
 
     private static String getCopyTableSql(String sourceCatalog, QualifiedObjectName table, boolean ifNotExists, boolean bucketed)


### PR DESCRIPTION
## Description
Remove a few pages of log junk that make it harder to find the failing test

```
2024-06-11T13:50:18.7058126Z 2024-06-11T07:50:18.694-0600	INFO	TestNG-test=Surefire test-2	com.facebook.presto.tests.QueryAssertions	Running import for nation
2024-06-11T13:50:18.9056511Z 2024-06-11T07:50:18.892-0600	INFO	TestNG-test=Surefire test-2	com.facebook.presto.tests.QueryAssertions	Imported 25 rows for nation in 197.53ms
2024-06-11T13:50:18.9059218Z 2024-06-11T07:50:18.892-0600	INFO	TestNG-test=Surefire test-2	com.facebook.presto.tests.QueryAssertions	Running import for region
2024-06-11T13:50:19.1083707Z 2024-06-11T07:50:19.105-0600	INFO	TestNG-test=Surefire test-2	com.facebook.presto.tests.QueryAssertions	Imported 5 rows for region in 213.24ms
2024-06-11T13:50:19.1087245Z 2024-06-11T07:50:19.105-0600	INFO	TestNG-test=Surefire test-2	com.facebook.presto.tests.QueryAssertions	Loading from tpch.tiny complete in 3.50s
2024-06-11T13:50:19.1090350Z 2024-06-11T07:50:19.107-0600	INFO	TestNG-test=Surefire test-2	com.facebook.presto.tests.QueryAssertions	Loading data from tpcds.tiny...
2024-06-11T13:50:19.1093364Z 2024-06-11T07:50:19.107-0600	INFO	TestNG-test=Surefire test-2	com.facebook.presto.tests.QueryAssertions	Loading from tpcds.tiny complete in 0.00s
...
```

## Motivation and Context
General principle: passing tests generate no output

## Impact
None

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

