### PR TITLE
Prioritize Facts over HBO stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsCalculator.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.common.RuntimeMetricName.HISTORY_OPTIMIZER_QUE
 import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.cost.HistoricalPlanStatisticsUtil.getSelectedHistoricalPlanStatisticsEntry;
 import static com.facebook.presto.cost.HistoryBasedPlanStatisticsManager.historyBasedPlanCanonicalizationStrategyList;
+import static com.facebook.presto.spi.statistics.PlanStatistics.toConfidenceLevel;
 import static com.facebook.presto.sql.planner.iterative.Plans.resolveGroupReferences;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.graph.Traverser.forTree;
@@ -201,7 +202,7 @@ public class HistoryBasedPlanStatisticsCalculator
                         Optional<HistoricalPlanStatisticsEntry> historicalPlanStatisticsEntry = getSelectedHistoricalPlanStatisticsEntry(entry.getValue(), inputTableStatistics.get(), historyMatchingThreshold);
                         if (historicalPlanStatisticsEntry.isPresent()) {
                             PlanStatistics predictedPlanStatistics = historicalPlanStatisticsEntry.get().getPlanStatistics();
-                            if (predictedPlanStatistics.getConfidence() > 0) {
+                            if ((toConfidenceLevel(predictedPlanStatistics.getConfidence()).getConfidenceOrdinal() >= delegateStats.confidenceLevel().getConfidenceOrdinal())) {
                                 return delegateStats.combineStats(
                                         predictedPlanStatistics,
                                         new HistoryBasedSourceInfo(entry.getKey().getHash(), inputTableStatistics, Optional.ofNullable(historicalPlanStatisticsEntry.get().getHistoricalPlanStatisticsEntryInfo())));

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestPlanStatistics.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestPlanStatistics.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.JoinNodeStatistics;
+import com.facebook.presto.spi.statistics.PartialAggregationStatistics;
+import com.facebook.presto.spi.statistics.PlanStatistics;
+import com.facebook.presto.spi.statistics.TableWriterNodeStatistics;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.statistics.PlanStatistics.toConfidenceLevel;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.HIGH;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.LOW;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+
+public class TestPlanStatistics
+{
+    @Test
+    public void testGetEnumConfidenceHigh()
+    {
+        PlanStatistics planStatistics1 = new PlanStatistics(Estimate.of(100), Estimate.of(1000), 1, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty(), PartialAggregationStatistics.empty());
+        PlanStatistics planStatistics2 = new PlanStatistics(Estimate.of(100), Estimate.of(1000), .5, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty(), PartialAggregationStatistics.empty());
+
+        assertEquals(toConfidenceLevel(planStatistics1.getConfidence()), HIGH);
+        assertEquals(toConfidenceLevel(planStatistics2.getConfidence()), HIGH);
+    }
+
+    @Test
+    public void testGetEnumConfidenceLow()
+    {
+        PlanStatistics planStatistics1 = new PlanStatistics(Estimate.of(100), Estimate.of(1000), 0, JoinNodeStatistics.empty(), TableWriterNodeStatistics.empty(), PartialAggregationStatistics.empty());
+
+        assertEquals(toConfidenceLevel(planStatistics1.getConfidence()), LOW);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -38,6 +38,8 @@ import com.facebook.presto.spi.plan.SortNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.statistics.SourceInfo;
+import com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -781,6 +783,18 @@ public final class PlanMatchPattern
     public PlanMatchPattern withOutputRowCount(double expectedOutputRowCount)
     {
         matchers.add(new StatsOutputRowCountMatcher(expectedOutputRowCount));
+        return this;
+    }
+
+    public PlanMatchPattern withSourceInfo(SourceInfo sourceInfo)
+    {
+        matchers.add(new StatsSourceInfoMatcher(sourceInfo));
+        return this;
+    }
+
+    public PlanMatchPattern withConfidenceLevel(ConfidenceLevel confidenceLevel)
+    {
+        matchers.add(new StatsConfidenceLevelMatcher(confidenceLevel));
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsConfidenceLevelMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsConfidenceLevelMatcher.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel;
+
+public class StatsConfidenceLevelMatcher
+        implements Matcher
+{
+    private final ConfidenceLevel expectedConfidenceLevel;
+
+    StatsConfidenceLevelMatcher(ConfidenceLevel expectedConfidenceLevel)
+    {
+        this.expectedConfidenceLevel = expectedConfidenceLevel;
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return true;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        return new MatchResult(stats.getStats(node).confidenceLevel() == expectedConfidenceLevel);
+    }
+
+    public String toString()
+    {
+        return "expectedConfidenceLevel(" + expectedConfidenceLevel + ")";
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsSourceInfoMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/StatsSourceInfoMatcher.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.statistics.SourceInfo;
+
+public class StatsSourceInfoMatcher
+        implements Matcher
+{
+    private final SourceInfo expectedSourceInfo;
+
+    StatsSourceInfoMatcher(SourceInfo expectedSourceInfo)
+    {
+        this.expectedSourceInfo = expectedSourceInfo;
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return true;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        return new MatchResult(stats.getStats(node).getSourceInfo().equals(expectedSourceInfo));
+    }
+
+    public String toString()
+    {
+        return "expectedSourceInfo(" + expectedSourceInfo + ")";
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/PlanStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/PlanStatistics.java
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 import static com.facebook.drift.annotations.ThriftField.Requiredness.OPTIONAL;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.HIGH;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.LOW;
 import static java.util.Objects.requireNonNull;
 
 @ThriftStruct
@@ -125,6 +128,14 @@ public class PlanStatistics
                 getJoinNodeStatistics(),
                 getTableWriterNodeStatistics(),
                 partialAggregationStatistics);
+    }
+
+    public static ConfidenceLevel toConfidenceLevel(double confidence)
+    {
+        if (confidence > 0) {
+            return HIGH;
+        }
+        return LOW;
     }
 
     private static void checkArgument(boolean condition, String message)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/SourceInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/SourceInfo.java
@@ -21,7 +21,21 @@ public abstract class SourceInfo
 {
     public enum ConfidenceLevel
     {
-        LOW, HIGH, FACT;
+        LOW(0),
+        HIGH(1),
+        FACT(2);
+
+        private final int confidenceOrdinal;
+
+        ConfidenceLevel(int confidenceOrdinal)
+        {
+            this.confidenceOrdinal = confidenceOrdinal;
+        }
+
+        public int getConfidenceOrdinal()
+        {
+            return confidenceOrdinal;
+        }
     }
 
     public abstract ConfidenceLevel confidenceLevel();

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestHistoryBasedStatsTracking.java
@@ -27,10 +27,12 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.SortNode;
 import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.statistics.CostBasedSourceInfo;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.sql.planner.assertions.MatchResult;
 import com.facebook.presto.sql.planner.assertions.Matcher;
 import com.facebook.presto.sql.planner.assertions.SymbolAliases;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
@@ -55,6 +57,7 @@ import static com.facebook.presto.SystemSessionProperties.TRACK_HISTORY_BASED_PL
 import static com.facebook.presto.SystemSessionProperties.TRACK_HISTORY_STATS_FROM_FAILED_QUERIES;
 import static com.facebook.presto.SystemSessionProperties.USE_HISTORY_BASED_PLAN_STATISTICS;
 import static com.facebook.presto.SystemSessionProperties.USE_PERFECTLY_CONSISTENT_HISTORIES;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.FACT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
@@ -469,6 +472,25 @@ public class TestHistoryBasedStatsTracking
                 anyTree(
                         node(ProjectNode.class, anyTree(any())).withOutputRowCount(60175.0),
                         anyTree(any())));
+    }
+
+    @Test
+    public void testFactPrioritization()
+    {
+        String query1 = "SELECT (SELECT nationkey FROM nation WHERE name = 'UNITED STATES') AS us_nationkey";
+        executeAndTrackHistory(query1);
+        assertPlan(query1, anyTree(node(EnforceSingleRowNode.class, anyTree(any()))
+                .withOutputRowCount(1)
+                .withSourceInfo(new CostBasedSourceInfo(FACT)))
+                .withConfidenceLevel(FACT));
+
+        Session session = Session.builder(createSession()).setSystemProperty("prefer_partial_aggregation", "false").build();
+        String query2 = "SELECT COUNT(*) FROM orders";
+        executeAndTrackHistory(query2);
+        assertPlan(session, query2, anyTree(node(AggregationNode.class, anyTree(any())))
+                .withOutputRowCount(1)
+                .withSourceInfo(new CostBasedSourceInfo(FACT))
+                .withConfidenceLevel(FACT));
     }
 
     private void executeAndTrackHistory(String sql)


### PR DESCRIPTION
## Description
Create logic where CBO Facts will be chosen over HBO and other high confidence statistics

## Motivation and Context
Currently, we always prioritize HBO, however with the new Enum change we can work to return the statistics with the highest confidence level.

## Impact
When there are both HBO and CBO stats available, only return the statistics with the highest confidence. This will help improve optimizer.

## Test Plan
Created new tests where both HBO and Fact CBO were available ensuring that FACT is chosen in its respective cases.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
== NO RELEASE NOTE ==


