### PR TITLE
Fix for previous correctness issue with TableScan Confidence

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
@@ -81,6 +81,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.isStatisticsEnabled
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getMetastoreHeaders;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.isUserDefinedTypeEncodingEnabled;
 import static com.facebook.presto.hive.metastore.PartitionStatistics.empty;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.HIGH;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -212,7 +213,7 @@ public class MetastoreHiveStatisticsProvider
             }
             result.setColumnStatistics(columnHandle, columnStatistics.build());
         });
-        return result.build();
+        return result.setConfidenceLevel(HIGH).build();
     }
 
     @VisibleForTesting
@@ -469,7 +470,7 @@ public class MetastoreHiveStatisticsProvider
             }
             result.setColumnStatistics(columnHandle, columnStatistics);
         }
-        return result.build();
+        return result.setConfidenceLevel(HIGH).build();
     }
 
     @VisibleForTesting

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -130,6 +130,7 @@ import static com.facebook.presto.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.LOW;
 import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -474,7 +475,7 @@ public class IcebergHiveMetadata
                 }
             }
             return filterStatsCalculatorService.filterStats(
-                    calculateAndSetTableSize(filteredStatsBuilder).build(),
+                    calculateAndSetTableSize(filteredStatsBuilder).setConfidenceLevel(LOW).build(),
                     translatedPredicate,
                     session,
                     columnHandles.stream().map(IcebergColumnHandle.class::cast).collect(toImmutableMap(

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
@@ -90,6 +90,7 @@ import static com.facebook.presto.iceberg.Partition.toMap;
 import static com.facebook.presto.iceberg.util.StatisticsUtil.calculateAndSetTableSize;
 import static com.facebook.presto.spi.statistics.ColumnStatisticType.NUMBER_OF_DISTINCT_VALUES;
 import static com.facebook.presto.spi.statistics.ColumnStatisticType.TOTAL_SIZE_IN_BYTES;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.HIGH;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.Long.parseLong;
@@ -149,6 +150,7 @@ public class TableStatisticsMaker
         if (intersection.isNone()) {
             return TableStatistics.builder()
                     .setRowCount(Estimate.of(0))
+                    .setConfidenceLevel(HIGH)
                     .build();
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/StatisticsUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/StatisticsUtil.java
@@ -89,7 +89,7 @@ public final class StatisticsUtil
             }
             statsBuilder.setColumnStatistics(columnHandle, mergedStats.build());
         });
-        return calculateAndSetTableSize(statsBuilder).build();
+        return calculateAndSetTableSize(statsBuilder).setConfidenceLevel(icebergStatistics.getConfidence()).build();
     }
 
     public static EnumSet<ColumnStatisticType> decodeMergeFlags(String input)

--- a/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.cost.FilterStatsCalculator.UNKNOWN_FILTER_COEFFICIENT;
 import static com.facebook.presto.cost.StatsUtil.toVariableStatsEstimate;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.LOW;
 import static java.util.Objects.requireNonNull;
 
 public class ConnectorFilterStatsCalculatorService
@@ -80,7 +81,7 @@ public class ConnectorFilterStatsCalculatorService
             double totalSizeAfterFilter = filteredStatistics.getRowCount().getValue() / tableStatistics.getRowCount().getValue() * tableStatistics.getTotalSize().getValue();
             filteredStatsWithSize.setTotalSize(Estimate.of(totalSizeAfterFilter));
         }
-        return filteredStatsWithSize.build();
+        return filteredStatsWithSize.setConfidenceLevel(LOW).build();
     }
 
     private static PlanNodeStatsEstimate toPlanNodeStats(
@@ -112,7 +113,7 @@ public class ConnectorFilterStatsCalculatorService
         for (Map.Entry<VariableReferenceExpression, VariableStatsEstimate> entry : planNodeStats.getVariableStatistics().entrySet()) {
             builder.setColumnStatistics(columnByName.get(entry.getKey().getName()), toColumnStatistics(entry.getValue(), rowCount));
         }
-        return builder.build();
+        return builder.setConfidenceLevel(planNodeStats.confidenceLevel()).build();
     }
 
     private static ColumnStatistics toColumnStatistics(VariableStatsEstimate variableStatsEstimate, double rowCount)

--- a/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.FACT;
 import static com.facebook.presto.sql.planner.plan.Patterns.tableScan;
 import static java.util.Objects.requireNonNull;
 
@@ -70,9 +69,7 @@ public class TableScanStatsRule
         return Optional.of(PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(tableStatistics.getRowCount().getValue())
                 .setTotalSize(tableStatistics.getTotalSize().getValue())
-
-                // TODO Handle the confidence level properly when filters are pushed into the tablescan
-                .setConfidence(FACT)
+                .setConfidence(tableStatistics.getConfidence())
                 .addVariableStatistics(outputVariableStats)
                 .build());
     }

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.common.type.Decimals.isShortDecimal;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimeType.TIME;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.HIGH;
 import static java.lang.Double.parseDouble;
 
 public class TpcdsTableStatisticsFactory
@@ -67,7 +68,7 @@ public class TpcdsTableStatisticsFactory
             }
         }
 
-        return tableStatistics.build();
+        return tableStatistics.setConfidenceLevel(HIGH).build();
     }
 
     private ColumnStatistics toColumnStatistics(ColumnStatisticsData columnStatisticsData, Type type, long rowCount)

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
@@ -208,7 +208,8 @@ public class TestTpcdsMetadataStatistics
                 "        \"max\" : 30.0\n" +
                 "      }\n" +
                 "    }\n" +
-                "  }\n" +
+                "  },\n" +
+                "  \"confidence\" : \"HIGH\"\n" +
                 "}");
     }
 

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -76,6 +76,7 @@ import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.HIGH;
 import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.facebook.presto.tpch.util.PredicateUtils.convertToPredicate;
 import static com.facebook.presto.tpch.util.PredicateUtils.filterOutColumnFromPredicate;
@@ -392,7 +393,7 @@ public class TpchMetadata
                 builder.setColumnStatistics(columnHandle, toColumnStatistics(stats, columnHandle.getType()));
             }
         });
-        return builder.build();
+        return builder.setConfidenceLevel(HIGH).build();
     }
 
     private ColumnStatistics toColumnStatistics(ColumnStatisticsData stats, Type columnType)


### PR DESCRIPTION
## Description
Fix for previous correctness issue with TableScan Confidence as there are a few cases where TableScan should be a low confidence

## Motivation and Context
TableScan Confidence should be set on whether or not there is filtering. If there is filtering it can be considered low and if not it can be considered high

## Test Plan
With amended code, all existing tests pass, ensuring that previous behavior is preserved.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

== NO RELEASE NOTE ==


