### PR TITLE
[native] Error out on StreamingAggregation

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -989,7 +989,11 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   bool streamable = !node->preGroupedVariables.empty() &&
       node->groupingSets.groupingSetCount == 1 &&
       node->groupingSets.globalGroupingSets.empty();
-
+  // TODO karteekmurthys@ Re-enable after
+  // fixing:https://github.com/prestodb/presto/issues/22585
+  if (streamable) {
+    VELOX_UNSUPPORTED("StreamingAggregation is not supported");
+  }
   // groupIdField and globalGroupingSets are required for producing default
   // output rows for global grouping sets when there are no input rows.
   // Global grouping sets can be present without groupIdField in Final


### PR DESCRIPTION
## Description
This change disables StreamingAggregation by default. Refer this issue https://github.com/prestodb/presto/issues/22585. Prestissimo creates a StreamingAgg when there are pregrouped keys in the AggregationNode. This assumption breaks when the source to the Aggregation is a NestedLoopJoin.

## Test Plan
<!---Please fill in how you tested your change-->
Migrated the Presto tests related correlated subqueries under presto-native.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

