### PR TITLE
[docs] remove method toc icons

### DIFF
--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -119,6 +119,9 @@ html_add_permalinks = '#'
 html_show_copyright = True
 html_show_sphinx = False
 
+object_description_options = [
+    ("js:.*", dict(toc_icon_class=None, include_fields_in_toc=False)),
+]
 
 html_theme_options = {
 


### PR DESCRIPTION
## Description

Removes TOC icons from function definitions

## Motivation and Context

See https://github.com/prestodb/presto/pull/22887#issuecomment-2166580796

## Impact

Slight visual adjustment to page-level table of contents

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

