### PR TITLE
Fix wrong results bug with count over mixed aggregation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/QueryCardinalityUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/QueryCardinalityUtil.java
@@ -105,10 +105,12 @@ public final class QueryCardinalityUtil
         @Override
         public Range<Long> visitAggregation(AggregationNode node, Void context)
         {
-            if (node.hasEmptyGroupingSet()) {
-                return Range.singleton(1L);
+            if (!node.hasNonEmptyGroupingSet()) {
+                // if there are no non-empty grouping sets, then the number of rows returned will be the number of
+                // non-empty (i.e. global) grouping sets.
+                return Range.singleton((long) node.getGlobalGroupingSets().size());
             }
-            return Range.atLeast(0L);
+            return Range.atLeast((long) node.getGlobalGroupingSets().size());
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.AggregationNode.GroupingSetDescriptor;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.testing.TestingTransactionHandle;
@@ -23,13 +24,13 @@ import com.facebook.presto.tpch.TpchColumnHandle;
 import com.facebook.presto.tpch.TpchTableHandle;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
-import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.constantExpressions;
@@ -118,7 +119,8 @@ public class TestPruneCountAggregationOverScalar
                                 .source(
                                         p.aggregation(aggregationBuilder -> {
                                             aggregationBuilder
-                                                    .source(p.tableScan(ImmutableList.of(), ImmutableMap.of())).groupingSets(singleGroupingSet(ImmutableList.of(p.variable("orderkey"))));
+                                                    .source(p.tableScan(ImmutableList.of(), ImmutableMap.of())).groupingSets(
+                                                            new GroupingSetDescriptor(ImmutableList.of(p.variable("orderkey")), 2, ImmutableSet.of(1)));
                                             aggregationBuilder
                                                     .source(p.tableScan(ImmutableList.of(), ImmutableMap.of()));
                                         }))))

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1166,6 +1166,18 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testCountOverGlobalAggregation()
+    {
+        assertQuery("SELECT COUNT(*) FROM (SELECT COUNT(*) FROM nation)");
+    }
+
+    @Test
+    public void testCountOverGroupedAggregation()
+    {
+        assertQuery("SELECT COUNT(*) FROM (SELECT COUNT(*) FROM nation GROUP BY GROUPING SETS (nationkey, ()))", "SELECT 26");
+    }
+
+    @Test
     public void testWildcard()
     {
         assertQuery("SELECT * FROM orders");


### PR DESCRIPTION
## Description
Fix a wrong results bug with count over an aggregation that had a mix of global and non-global grouping sets.

We were not checking for single global aggregations correctly in QueryCardinalityUtil, so we would return that the plan was scalar if there were *any* empty grouping sets rather than if the empty grouping set was the only grouping set.  we have now fixed this to return that if all of the grouping sets are global, then the cardinality will be the number of grouping sets, and otherwise it is at least the number of global grouping sets.

This fixes queries like the following:
```
SELECT COUNT(*) FROM (SELECT count(*) FROM tpch.sf1.nation GROUP BY GROUPING SETS (nationkey, ()));
```

previously we would incorrectly return 1. And now we return 26.

This change may also fix bugs with correlated subqueries, as those also use the isScalar() utility function.

## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/22977

## Impact
Fixes wrong results for queries with counts over mixed global and grouped aggregations .e.g. `SELECT COUNT(*) FROM (SELECT count(*) FROM tpch.sf1.nation GROUP BY GROUPING SETS (nationkey, ()));`
## Test Plan
added unit tests
## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix a bug where count queries on top of aggregations with mixed global and grouped grouping sets could return wrong results.

```

