### PR TITLE
Remove json serialization annotation for `TableWriterNode.UpdateTarget`

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
@@ -443,12 +443,11 @@ public class TableWriterNode
         private final List<String> updatedColumns;
         private final List<ColumnHandle> updatedColumnHandles;
 
-        @JsonCreator
         public UpdateTarget(
-                @JsonProperty("handle") TableHandle handle,
-                @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
-                @JsonProperty("updatedColumns") List<String> updatedColumns,
-                @JsonProperty("updatedColumnHandles") List<ColumnHandle> updatedColumnHandles)
+                TableHandle handle,
+                SchemaTableName schemaTableName,
+                List<String> updatedColumns,
+                List<ColumnHandle> updatedColumnHandles)
         {
             this.handle = requireNonNull(handle, "handle is null");
             this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
@@ -457,31 +456,26 @@ public class TableWriterNode
             this.updatedColumnHandles = requireNonNull(updatedColumnHandles, "updatedColumnHandles is null");
         }
 
-        @JsonProperty
         public TableHandle getHandle()
         {
             return handle;
         }
 
-        @Override
         public ConnectorId getConnectorId()
         {
             return handle.getConnectorId();
         }
 
-        @JsonProperty
         public SchemaTableName getSchemaTableName()
         {
             return schemaTableName;
         }
 
-        @JsonProperty
         public List<String> getUpdatedColumns()
         {
             return updatedColumns;
         }
 
-        @JsonProperty
         public List<ColumnHandle> getUpdatedColumnHandles()
         {
             return updatedColumnHandles;


### PR DESCRIPTION
## Description

`UpdateTarget` is a subclass of `WriterTarget` which is used coordinator-only. So there is no need to support serialization for it, referring to `CreateName`, `InsertReference` and `DeleteHandle` etc.

## Motivation and Context

Remove unnecessary json serialization annotation

## Impact

N/A

## Test Plan

 - Make sure the change do not affect existing test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

