### PR TITLE
Change getExpectedOrdersTableDescription() back to protected

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIntegrationSmokeTest.java
@@ -185,7 +185,7 @@ public abstract class AbstractTestIntegrationSmokeTest
                 "line 1:49: Column name 'orderkey' specified more than once");
     }
 
-    private MaterializedResult getExpectedOrdersTableDescription()
+    protected MaterializedResult getExpectedOrdersTableDescription()
     {
         String orderDateType;
         if (isDateTypeSupported()) {


### PR DESCRIPTION
## Description
presto trunk recently changed the signature of this method getExpectedOrdersTableDescription() and scope it from protected to private. There are subclasses using this API in meta internal, hence changing its scope back to protected.

```
== NO RELEASE NOTE ==
```

