### PR TITLE
[native]Support no shuffle data copy to speedup query execution

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -250,6 +250,16 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   const std::string host_;
   const uint16_t port_;
   const folly::SSLContextPtr sslContext_;
+  // If true, we copy the iobufs allocated by proxygen to velox memory pool.
+  // Otherwise, we build serialized presto page from the proxygen iobufs
+  // directly.
+  const bool enableBufferCopy_;
+  // If true, copy proxygen iobufs to velox memory pool in http response handler
+  // immediately. This is to track the shuffle memory usage under velox memory
+  // control to prevent server OOM from the unexpected spiky shuffle memory
+  // usage from jemalloc. If false, does the copy later in driver executor
+  // context after the http client receives the whole response. This only
+  // applies if 'enableBufferCopy_' is true
   const bool immediateBufferTransfer_;
 
   folly::CPUThreadPoolExecutor* const driverExecutor_;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -214,6 +214,7 @@ SystemConfig::SystemConfig() {
           STR_PROP(kExchangeRequestTimeout, "10s"),
           STR_PROP(kExchangeConnectTimeout, "20s"),
           BOOL_PROP(kExchangeEnableConnectionPool, true),
+          BOOL_PROP(kExchangeEnableBufferCopy, true),
           BOOL_PROP(kExchangeImmediateBufferTransfer, true),
           NUM_PROP(kTaskRunTimeSliceMicros, 50'000),
           BOOL_PROP(kIncludeNodeInSpillPath, false),
@@ -581,6 +582,10 @@ std::chrono::duration<double> SystemConfig::exchangeConnectTimeoutMs() const {
 
 bool SystemConfig::exchangeEnableConnectionPool() const {
   return optionalProperty<bool>(kExchangeEnableConnectionPool).value();
+}
+
+bool SystemConfig::exchangeEnableBufferCopy() const {
+  return optionalProperty<bool>(kExchangeEnableBufferCopy).value();
 }
 
 bool SystemConfig::exchangeImmediateBufferTransfer() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -441,9 +441,17 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kExchangeMaxErrorDuration{
       "exchange.max-error-duration"};
 
+  /// If true, copy proxygen iobufs to velox memory pool, otherwise not. The
+  /// presto exchange source builds the serialized presto page from proxygen
+  /// iobufs directly.
+  static constexpr std::string_view kExchangeEnableBufferCopy{
+      "exchange.enable-buffer-copy"};
+
   /// Enable to make immediate buffer memory transfer in the handling IO threads
   /// as soon as exchange gets its response back. Otherwise the memory transfer
   /// will happen later in driver thread pool.
+  ///
+  /// NOTE: this only applies if 'exchange.no-buffer-copy' is false.
   static constexpr std::string_view kExchangeImmediateBufferTransfer{
       "exchange.immediate-buffer-transfer"};
 
@@ -696,6 +704,8 @@ class SystemConfig : public ConfigBase {
   std::chrono::duration<double> exchangeConnectTimeoutMs() const;
 
   bool exchangeEnableConnectionPool() const;
+
+  bool exchangeEnableBufferCopy() const;
 
   bool exchangeImmediateBufferTransfer() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -45,16 +45,6 @@ void registerPrestoMetrics() {
       100);
   DEFINE_METRIC(
       kCounterHttpClientNumConnectionsCreated, facebook::velox::StatType::SUM);
-  DEFINE_HISTOGRAM_METRIC(
-      kCounterPrestoExchangeSerializedPageSize,
-      10000,
-      0,
-      10000000,
-      50,
-      90,
-      95,
-      99,
-      100);
   DEFINE_METRIC(kCounterNumQueryContexts, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasks, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasksRunning, facebook::velox::StatType::AVG);
@@ -114,6 +104,10 @@ void registerPrestoMetrics() {
       1l * 1024 * 1024 * 1024,
       0,
       62l * 1024 * 1024 * 1024, // max bucket value: 62GB
+      50,
+      90,
+      95,
+      99,
       100);
 
   // NOTE: Metrics type exporting for file handle cache counters are in

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -48,9 +48,6 @@ constexpr folly::StringPiece kCounterHttpClientPrestoExchangeOnBodyBytes{
     "presto_cpp.http.client.presto_exchange_source.on_body_bytes"};
 constexpr folly::StringPiece kCounterHttpClientNumConnectionsCreated{
     "presto_cpp.http.client.num_connections_created"};
-/// SerializedPage size in bytes from PrestoExchangeSource.
-constexpr folly::StringPiece kCounterPrestoExchangeSerializedPageSize{
-    "presto_cpp.presto_exchange_source.serialized_page_size"};
 /// Peak number of bytes queued in PrestoExchangeSource waiting for consume.
 constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
     "presto_cpp.exchange_source_peak_queued_bytes"};


### PR DESCRIPTION
Avoids the data buffer copy from iobufs allocated from proxygen in http response to velox
memory pool. The copy is to prevent server OOM in case of unexpected spiky http shuffle
memory usage from jemalloc. The copy transfers the memory usage to velox memory pool,
and the latter is capped by velox memory management. Velox have improved the shuffle flow
control in past and have better control on the shuffle memory usage for presto batch workloads.
This PR makes a config option to disable the data copy to accelerate query execution. For
Meta internal 1hr stress test, the overall query execution time has been reduced by ~15% and
the walltime has been reduced by ~30%. The improvement comes from the reduced tail shuffle
exchange latency. Both data exchange and data size exchange tail latency (P100) has been
dropped from 2mins to 2s.

```
== NO RELEASE NOTE ==
```

