### PR TITLE
Update Joda-Time to 2.12.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dep.drift.version>1.38</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
-        <dep.joda.version>2.12.5</dep.joda.version>
+        <dep.joda.version>2.12.7</dep.joda.version>
         <dep.tempto.version>1.53</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>


### PR DESCRIPTION
## Description
Update Joda-Time from from 2.12.5 to 2.12.7. The tzdata version is upgraded from 2023c to 2024a and the changes are:

- Enhance DateTimeZone.forID() to better match java.time.
- Better error message in DateTimeFormat.
- Updating the tzdata fixes the correctness issue discussed in https://github.com/prestodb/presto/issues/22981

## Motivation and Context
fix https://github.com/prestodb/presto/issues/22981

## Impact
Fixes existing bug discussed in https://github.com/prestodb/presto/issues/22981

## Test Plan
Wrote an unit test in previous commit that shows correct result for the issue discussed in https://github.com/prestodb/presto/issues/22981. Can't commit here because the CI system jvm needs to be updated with the new tzdata.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Update Joda-Time to 2.12.7 to use 2024a tzdata. 
  Note: a corresponding update to the Java runtime should also be made to ensure consistent timezone data.
  For example, Oracle JDK 8u381, tzdata2024a rpm for OpenJDK, or use Timezone Updater Tool to apply
  2024a tzdata to existing JVM. :pr:`23027`
```
