### PR TITLE
[docs] Fix doc build errors in /rest/

### DIFF
--- a/presto-docs/src/main/sphinx/rest/query.rst
+++ b/presto-docs/src/main/sphinx/rest/query.rst
@@ -3,9 +3,9 @@ Query Resource
 ==============
 
 The Query REST service is the most complex of the rest services. It
-contains detailed information about nodes, and other
-details that capture the state and history of a query being executed
-on a Presto installation.
+contains detailed information about nodes, and other details that 
+capture the state and history of a query being executed on a Presto 
+installation.
 
 .. function:: GET /v1/query
 
@@ -69,6 +69,6 @@ on a Presto installation.
     	   "outputDataSize" : "32B",
     	   "outputPositions" : 1
        },
-       "outputStage" : ...
+       "outputStage" : { }
      }
 

--- a/presto-docs/src/main/sphinx/rest/task.rst
+++ b/presto-docs/src/main/sphinx/rest/task.rst
@@ -24,7 +24,7 @@ execution of queries on a Presto installation.
 
    **Example response**:
 
-   .. sourcecode:: http
+   .. sourcecode:: json
 
       [ {
         "taskId" : "20131222_183944_00011_dk5x2.1.0",
@@ -89,7 +89,7 @@ execution of queries on a Presto installation.
 
    **Example response**:
 
-   .. sourcecode:: http
+   .. sourcecode:: json
 
       {
 	"taskId" : "20140115_170528_00004_dk5x2.0.0",


### PR DESCRIPTION
## Description
Fix the three similar doc build errors in [presto-docs/src/main/sphinx/rest/query.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/rest/query.rst) and [presto-docs/src/main/sphinx/rest/task.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/rest/task.rst). 

```
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/rest/query.rst:29: WARNING: Lexing literal_block '{\n  "queryId" : "20131229_211533_00017_dk5x2",\n  "session" : {\n      "user" : "tobrien",\n      "source" : "presto-cli",\n      "catalog" : "jmx",\n      "schema" : "jmx",\n      "remoteUserAddress" : "173.15.79.89",\n      "userAgent" : "StatementClient/0.55-SNAPSHOT",\n      "startTime" : 1388351852026\n  },\n  "state" : "FINISHED",\n  "self" : "http://10.193.207.128:8080/v1/query/20131229_211533_00017_dk5x2",\n  "fieldNames" : [ "name" ],\n  "query" : "select name from \\"java.lang:type=runtime\\"",\n  "queryStats" : {\n      "createTime" : "2013-12-29T16:17:32.027-05:00",\n      "executionStartTime" : "2013-12-29T16:17:32.086-05:00",\n      "lastHeartbeat" : "2013-12-29T16:17:44.561-05:00",\n      "endTime" : "2013-12-29T16:17:32.152-05:00",\n      "elapsedTime" : "125.00ms",\n      "queuedTime" : "1.31ms",\n      "analysisTime" : "4.84ms",\n      "totalTasks" : 2,\n      "runningTasks" : 0,\n      "completedTasks" : 2,\n      "totalDrivers" : 2,\n      "queuedDrivers" : 0,\n      "runningDrivers" : 0,\n      "completedDrivers" : 2,\n      "totalMemoryReservation" : "0B",\n      "totalScheduledTime" : "5.84ms",\n      "totalCpuTime" : "710.49us",\n      "totalBlockedTime" : "27.38ms",\n      "rawInputDataSize" : "27B",\n      "rawInputPositions" : 1,\n      "processedInputDataSize" : "32B",\n      "processedInputPositions" : 1,\n      "outputDataSize" : "32B",\n      "outputPositions" : 1\n  },\n  "outputStage" : ...\n}' as "json" resulted in an error at token: '.'. Retrying in relaxed mode.

/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/rest/task.rst:27: WARNING: Lexing literal_block '[ {\n  "taskId" : "20131222_183944_00011_dk5x2.1.0",\n  "version" : 9223372036854775807,\n  "state" : "CANCELED",\n  "self" : "unknown",\n  "lastHeartbeat" : "2013-12-22T13:54:46.566-05:00",\n  "outputBuffers" : {\n    "state" : "FINISHED",\n    "masterSequenceId" : 0,\n    "pagesAdded" : 0,\n    "buffers" : [ ]\n  },\n  "noMoreSplits" : [ ],\n  "stats" : {\n    "createTime" : "2013-12-22T13:54:46.566-05:00",\n    "elapsedTime" : "0.00ns",\n    "queuedTime" : "92.00us",\n    "totalDrivers" : 0,\n    "queuedDrivers" : 0,\n    "runningDrivers" : 0,\n    "completedDrivers" : 0,\n    "memoryReservation" : "0B",\n    "totalScheduledTime" : "0.00ns",\n    "totalCpuTime" : "0.00ns",\n    "totalBlockedTime" : "0.00ns",\n    "rawInputDataSize" : "0B",\n    "rawInputPositions" : 0,\n    "processedInputDataSize" : "0B",\n    "processedInputPositions" : 0,\n    "outputDataSize" : "0B",\n    "outputPositions" : 0,\n    "pipelines" : [ ]\n  },\n  "failures" : [ ],\n  "outputs" : { }\n}]' as "http" resulted in an error at token: '['. Retrying in relaxed mode.

/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/rest/task.rst:92: WARNING: Lexing literal_block '{\n  "taskId" : "20140115_170528_00004_dk5x2.0.0",\n  "version" : 42,\n  "state" : "FINISHED",\n  "self" : "http://10.193.207.128:8080/v1/task/20140115_170528_00004_dk5x2.0.0",\n  "lastHeartbeat" : "2014-01-15T12:12:12.518-05:00",\n  "outputBuffers" : {\n    "state" : "FINISHED",\n    "masterSequenceId" : 0,\n    "pagesAdded" : 1,\n    "buffers" : [ {\n      "bufferId" : "out",\n      "finished" : true,\n      "bufferedPages" : 0,\n      "pagesSent" : 1\n    } ]\n  },\n  "noMoreSplits" : [ "8" ],\n  "stats" : {\n    "createTime" : "2014-01-15T12:12:08.520-05:00",\n    "startTime" : "2014-01-15T12:12:08.526-05:00",\n    "endTime" : "2014-01-15T12:12:12.518-05:00",\n    "elapsedTime" : "4.00s",\n    "queuedTime" : "6.39ms",\n    "totalDrivers" : 1,\n    "queuedDrivers" : 0,\n    "runningDrivers" : 0,\n    "completedDrivers" : 1,\n    "memoryReservation" : "174.76kB",\n    "totalScheduledTime" : "4.19ms",\n    "totalCpuTime" : "4.09ms",\n    "totalBlockedTime" : "29.50ms",\n    "rawInputDataSize" : "10.90kB",\n    "rawInputPositions" : 154,\n    "processedInputDataSize" : "10.90kB",\n    "processedInputPositions" : 154,\n    "outputDataSize" : "10.90kB",\n    "outputPositions" : 154,\n    "pipelines" : [ {\n      "inputPipeline" : true,\n      "outputPipeline" : true,\n      "totalDrivers" : 1,\n      "queuedDrivers" : 0,\n      "runningDrivers" : 0,\n      "completedDrivers" : 1,\n      "memoryReservation" : "0B",\n      "queuedTime" : {\n        "maxError" : 0.0,\n        "count" : 1.0,\n        "total" : 5857000.0,\n        "p01" : 5857000,\n        "p05" : 5857000,\n        "p10" : 5857000,\n        "p25" : 5857000,\n        "p50" : 5857000,\n        "p75" : 5857000,\n        "p90" : 5857000,\n        "p95" : 5857000,\n        "p99" : 5857000,\n        "min" : 5857000,\n        "max" : 5857000\n      },\n      "elapsedTime" : {\n        "maxError" : 0.0,\n        "count" : 1.0,\n        "total" : 4.1812E7,\n        "p01" : 41812000,\n        "p05" : 41812000,\n        "p10" : 41812000,\n        "p25" : 41812000,\n        "p50" : 41812000,\n        "p75" : 41812000,\n        "p90" : 41812000,\n        "p95" : 41812000,\n        "p99" : 41812000,\n        "min" : 41812000,\n        "max" : 41812000\n      },\n      "totalScheduledTime" : "4.19ms",\n      "totalCpuTime" : "4.09ms",\n      "totalBlockedTime" : "29.50ms",\n      "rawInputDataSize" : "10.90kB",\n      "rawInputPositions" : 154,\n      "processedInputDataSize" : "10.90kB",\n      "processedInputPositions" : 154,\n      "outputDataSize" : "10.90kB",\n      "outputPositions" : 154,\n      "operatorSummaries" : [ {\n        "operatorId" : 0,\n        "operatorType" : "ExchangeOperator",\n        "addInputCalls" : 0,\n        "addInputWall" : "0.00ns",\n        "addInputCpu" : "0.00ns",\n        "addInputUser" : "0.00ns",\n        "inputDataSize" : "10.90kB",\n        "inputPositions" : 154,\n        "getOutputCalls" : 1,\n        "getOutputWall" : "146.00us",\n        "getOutputCpu" : "137.90us",\n        "getOutputUser" : "0.00ns",\n        "outputDataSize" : "10.90kB",\n        "outputPositions" : 154,\n        "blockedWall" : "29.50ms",\n        "finishCalls" : 0,\n        "finishWall" : "0.00ns",\n        "finishCpu" : "0.00ns",\n        "finishUser" : "0.00ns",\n        "memoryReservation" : "0B",\n        "info" : {\n          "bufferedBytes" : 0,\n          "averageBytesPerRequest" : 11158,\n          "bufferedPages" : 0,\n          "pageBufferClientStatuses" : [ {\n            "uri" : "http://10.193.207.128:8080/v1/task/20140115_170528_00004_dk5x2.1.0/results/ab68e201-3878-4b21-b6b9-f6658ddc408b",\n            "state" : "closed",\n            "lastUpdate" : "2014-01-15T12:12:08.562-05:00",\n            "pagesReceived" : 1,\n            "requestsScheduled" : 3,\n            "requestsCompleted" : 3,\n            "httpRequestState" : "queued"\n          } ]\n        }\n      }, {\n        "operatorId" : 1,\n        "operatorType" : "FilterAndProjectOperator",\n        "addInputCalls" : 1,\n        "addInputWall" : "919.00us",\n        "addInputCpu" : "919.38us",\n        "addInputUser" : "0.00ns",\n        "inputDataSize" : "10.90kB",\n        "inputPositions" : 154,\n        "getOutputCalls" : 2,\n        "getOutputWall" : "128.00us",\n        "getOutputCpu" : "128.64us",\n        "getOutputUser" : "0.00ns",\n        "outputDataSize" : "10.45kB",\n        "outputPositions" : 154,\n        "blockedWall" : "0.00ns",\n        "finishCalls" : 5,\n        "finishWall" : "258.00us",\n        "finishCpu" : "253.19us",\n        "finishUser" : "0.00ns",\n        "memoryReservation" : "0B"\n      }, {\n        "operatorId" : 2,\n        "operatorType" : "OrderByOperator",\n        "addInputCalls" : 1,\n        "addInputWall" : "438.00us",\n        "addInputCpu" : "439.18us",\n        "addInputUser" : "0.00ns",\n        "inputDataSize" : "10.45kB",\n        "inputPositions" : 154,\n        "getOutputCalls" : 4,\n        "getOutputWall" : "869.00us",\n        "getOutputCpu" : "831.85us",\n        "getOutputUser" : "0.00ns",\n        "outputDataSize" : "10.45kB",\n        "outputPositions" : 154,\n        "blockedWall" : "0.00ns",\n        "finishCalls" : 4,\n        "finishWall" : "808.00us",\n        "finishCpu" : "810.18us",\n        "finishUser" : "0.00ns",\n        "memoryReservation" : "174.76kB"\n      }, {\n        "operatorId" : 3,\n        "operatorType" : "FilterAndProjectOperator",\n        "addInputCalls" : 1,\n        "addInputWall" : "166.00us",\n        "addInputCpu" : "166.66us",\n        "addInputUser" : "0.00ns",\n        "inputDataSize" : "10.45kB",\n        "inputPositions" : 154,\n        "getOutputCalls" : 5,\n        "getOutputWall" : "305.00us",\n        "getOutputCpu" : "241.14us",\n        "getOutputUser" : "0.00ns",\n        "outputDataSize" : "10.90kB",\n        "outputPositions" : 154,\n        "blockedWall" : "0.00ns",\n        "finishCalls" : 2,\n        "finishWall" : "70.00us",\n        "finishCpu" : "71.02us",\n        "finishUser" : "0.00ns",\n        "memoryReservation" : "0B"\n      }, {\n        "operatorId" : 4,\n        "operatorType" : "TaskOutputOperator",\n        "addInputCalls" : 1,\n        "addInputWall" : "50.00us",\n        "addInputCpu" : "51.03us",\n        "addInputUser" : "0.00ns",\n        "inputDataSize" : "10.90kB",\n        "inputPositions" : 154,\n        "getOutputCalls" : 0,\n        "getOutputWall" : "0.00ns",\n        "getOutputCpu" : "0.00ns",\n        "getOutputUser" : "0.00ns",\n        "outputDataSize" : "10.90kB",\n        "outputPositions" : 154,\n        "blockedWall" : "0.00ns",\n        "finishCalls" : 1,\n        "finishWall" : "35.00us",\n        "finishCpu" : "35.39us",\n        "finishUser" : "0.00ns",\n        "memoryReservation" : "0B"\n      } ],\n      "drivers" : [ ]\n    } ]\n  },\n  "failures" : [ ],\n  "outputs" : { }\n}' as "http" resulted in an error at token: '{'. Retrying in relaxed mode.
```
Searching for this error, I found in [Could not lex literal_block as “…”.](https://www.tarantool.io/en/doc/latest/contributing/docs/sphinx-warnings/#could-not-lex-literal-block-as-highlighting-skipped), which suggested:

_However, sometimes there’s no appropriate lexer or the code snippet can’t be lexed properly. In that case, use `code-block:: text`._

Changed the three code blocks to `code-block:: text` and the errors do not appear in the local docs build. 

Like #23023, I limited the scope of this PR to fixing only errors of this one type to simplify the work of the reviewer.

## Motivation and Context
Builds on the doc build errors fixes in #23023, #22876, and #22985, these errors don't stop the build but they're annoying, and these are easy and low-risk fixes.

## Impact
Documentation.

## Test Plan
Local doc builds. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

