### PR TITLE
Allow running Driver threads with SCHED_BATCH policy on Linux

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -215,7 +215,10 @@ class PrestoServer {
   std::unique_ptr<folly::IOThreadPoolExecutor> connectorIoExecutor_;
 
   // Executor for exchange data over http.
-  std::shared_ptr<folly::IOThreadPoolExecutor> exchangeHttpExecutor_;
+  std::shared_ptr<folly::IOThreadPoolExecutor> exchangeHttpIoExecutor_;
+
+  // Executor for exchange request processing.
+  std::shared_ptr<folly::CPUThreadPoolExecutor> exchangeHttpCpuExecutor_;
 
   // Executor for HTTP request dispatching
   std::shared_ptr<folly::IOThreadPoolExecutor> httpSrvIOExecutor_;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -166,6 +166,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kExchangeHttpClientNumCpuThreadsHwMultiplier, 1.0),
           NUM_PROP(kConnectorNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kDriverNumCpuThreadsHwMultiplier, 4.0),
+          BOOL_PROP(kDriverThreadsBatchSchedulingEnabled, false),
           NUM_PROP(kDriverStuckOperatorThresholdMs, 30 * 60 * 1000),
           NUM_PROP(kSpillerNumCpuThreadsHwMultiplier, 1.0),
           STR_PROP(kSpillerFileCreateConfig, ""),
@@ -368,6 +369,10 @@ double SystemConfig::connectorNumIoThreadsHwMultiplier() const {
 
 double SystemConfig::driverNumCpuThreadsHwMultiplier() const {
   return optionalProperty<double>(kDriverNumCpuThreadsHwMultiplier).value();
+}
+
+bool SystemConfig::driverThreadsBatchSchedulingEnabled() const {
+  return optionalProperty<bool>(kDriverThreadsBatchSchedulingEnabled).value();
 }
 
 size_t SystemConfig::driverStuckOperatorThresholdMs() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -163,6 +163,7 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kHttpsKeyPath),
           NONE_PROP(kHttpsClientCertAndKeyPath),
           NUM_PROP(kExchangeHttpClientNumIoThreadsHwMultiplier, 1.0),
+          NUM_PROP(kExchangeHttpClientNumCpuThreadsHwMultiplier, 1.0),
           NUM_PROP(kConnectorNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kDriverNumCpuThreadsHwMultiplier, 4.0),
           NUM_PROP(kDriverStuckOperatorThresholdMs, 30 * 60 * 1000),
@@ -353,6 +354,11 @@ double SystemConfig::httpServerNumCpuThreadsHwMultiplier() const {
 
 double SystemConfig::exchangeHttpClientNumIoThreadsHwMultiplier() const {
   return optionalProperty<double>(kExchangeHttpClientNumIoThreadsHwMultiplier)
+      .value();
+}
+
+double SystemConfig::exchangeHttpClientNumCpuThreadsHwMultiplier() const {
+  return optionalProperty<double>(kExchangeHttpClientNumCpuThreadsHwMultiplier)
       .value();
 }
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -488,6 +488,13 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kExchangeHttpClientNumIoThreadsHwMultiplier{
       "exchange.http-client.num-io-threads-hw-multiplier"};
 
+  /// Floating point number used in calculating how many threads we would use
+  /// for Exchange HTTP client CPU executor: hw_concurrency x multiplier.
+  /// 1.0 is default.
+  static constexpr std::string_view
+      kExchangeHttpClientNumCpuThreadsHwMultiplier{
+          "exchange.http-client.num-cpu-threads-hw-multiplier"};
+
   /// The maximum timeslice for a task on thread if there are threads queued.
   static constexpr std::string_view kTaskRunTimeSliceMicros{
       "task-run-timeslice-micros"};
@@ -609,6 +616,8 @@ class SystemConfig : public ConfigBase {
   double httpServerNumCpuThreadsHwMultiplier() const;
 
   double exchangeHttpClientNumIoThreadsHwMultiplier() const;
+
+  double exchangeHttpClientNumCpuThreadsHwMultiplier() const;
 
   double connectorNumIoThreadsHwMultiplier() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -222,6 +222,11 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kDriverNumCpuThreadsHwMultiplier{
       "driver.num-cpu-threads-hw-multiplier"};
 
+  /// Run driver threads with the SCHED_BATCH scheduling policy. Linux only.
+  /// https://man7.org/linux/man-pages/man7/sched.7.html
+  static constexpr std::string_view kDriverThreadsBatchSchedulingEnabled{
+      "driver.threads-batch-scheduling-enabled"};
+
   /// Time duration threshold used to detect if an operator call in driver is
   /// stuck or not.  If any of the driver thread is detected as stuck by this
   /// standard, we take the worker offline and further investigation on the
@@ -622,6 +627,8 @@ class SystemConfig : public ConfigBase {
   double connectorNumIoThreadsHwMultiplier() const;
 
   double driverNumCpuThreadsHwMultiplier() const;
+
+  bool driverThreadsBatchSchedulingEnabled() const;
 
   size_t driverStuckOperatorThresholdMs() const;
 


### PR DESCRIPTION
## Description

Use SCHED_BATCH scheduling policy for Driver thread pool

## Motivation and Context

With blocking IO used by connectors (such as Hive connector) often it is necessary to set the number of threads to the number higher than the number of available cores.

This is needed to avoid slowdowns for IO heavy workload.

However for CPU intensive queries it may create unnecessary thread contention and may cause stability problems when communication threads are delayed.

Threads scheduled with SCHED_BATCH policy are run with slightly lower priority giving a green light for communication threads. These can run for longer resulting in less cache flushes if only other batch threads are waiting for execution.

More information about different scheduling policies in Linux can be found here: https://man7.org/linux/man-pages/man7/sched.7.html

## Impact

Improves efficiency and stability for certain cluster configurations

## Test Plan

- Set `driver.threads-batch-scheduling-enabled=true`
- Find a `Driver`  thread
- Run `chrt -p <driver thread id>`

Result:

```
chrt -p 3238430
pid 3238430's current scheduling policy: SCHED_BATCH
pid 3238430's current scheduling priority: 0
```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

