### PR TITLE
Add analyzer warning for common NaN pitfalls

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
@@ -36,6 +36,7 @@ public class SqlFunctionProperties
     private final boolean fieldNamesInJsonCastEnabled;
     private final boolean legacyJsonCast;
     private final Map<String, String> extraCredentials;
+    private final boolean warnOnCommonNanPatterns;
 
     private SqlFunctionProperties(
             boolean parseDecimalLiteralAsDouble,
@@ -48,7 +49,8 @@ public class SqlFunctionProperties
             String sessionUser,
             boolean fieldNamesInJsonCastEnabled,
             boolean legacyJsonCast,
-            Map<String, String> extraCredentials)
+            Map<String, String> extraCredentials,
+            boolean warnOnCommonNanPatterns)
     {
         this.parseDecimalLiteralAsDouble = parseDecimalLiteralAsDouble;
         this.legacyRowFieldOrdinalAccessEnabled = legacyRowFieldOrdinalAccessEnabled;
@@ -61,6 +63,7 @@ public class SqlFunctionProperties
         this.fieldNamesInJsonCastEnabled = fieldNamesInJsonCastEnabled;
         this.legacyJsonCast = legacyJsonCast;
         this.extraCredentials = requireNonNull(extraCredentials, "extraCredentials is null");
+        this.warnOnCommonNanPatterns = warnOnCommonNanPatterns;
     }
 
     public boolean isParseDecimalLiteralAsDouble()
@@ -119,6 +122,11 @@ public class SqlFunctionProperties
         return legacyJsonCast;
     }
 
+    public boolean shouldWarnOnCommonNanPatterns()
+    {
+        return warnOnCommonNanPatterns;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -167,6 +175,7 @@ public class SqlFunctionProperties
         private boolean fieldNamesInJsonCastEnabled;
         private boolean legacyJsonCast;
         private Map<String, String> extraCredentials = emptyMap();
+        private boolean warnOnCommonNanPatterns;
 
         private Builder() {}
 
@@ -236,6 +245,12 @@ public class SqlFunctionProperties
             return this;
         }
 
+        public Builder setWarnOnCommonNanPatterns(boolean warnOnCommonNanPatterns)
+        {
+            this.warnOnCommonNanPatterns = warnOnCommonNanPatterns;
+            return this;
+        }
+
         public SqlFunctionProperties build()
         {
             return new SqlFunctionProperties(
@@ -249,7 +264,8 @@ public class SqlFunctionProperties
                     sessionUser,
                     fieldNamesInJsonCastEnabled,
                     legacyJsonCast,
-                    extraCredentials);
+                    extraCredentials,
+                    warnOnCommonNanPatterns);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -61,6 +61,7 @@ import static com.facebook.presto.SystemSessionProperties.isLegacyMapSubscript;
 import static com.facebook.presto.SystemSessionProperties.isLegacyRowFieldOrdinalAccessEnabled;
 import static com.facebook.presto.SystemSessionProperties.isLegacyTimestamp;
 import static com.facebook.presto.SystemSessionProperties.isParseDecimalLiteralsAsDouble;
+import static com.facebook.presto.SystemSessionProperties.warnOnCommonNanPatterns;
 import static com.facebook.presto.spi.ConnectorId.createInformationSchemaConnectorId;
 import static com.facebook.presto.spi.ConnectorId.createSystemTablesConnectorId;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
@@ -525,6 +526,7 @@ public final class Session
                 .setFieldNamesInJsonCastEnabled(isFieldNameInJsonCastEnabled(this))
                 .setLegacyJsonCast(legacyJsonCast)
                 .setExtraCredentials(identity.getExtraCredentials())
+                .setWarnOnCommonNanPatterns(warnOnCommonNanPatterns(this))
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -347,6 +347,7 @@ public final class SystemSessionProperties
     public static final String DEFAULT_VIEW_SECURITY_MODE = "default_view_security_mode";
     public static final String JOIN_PREFILTER_BUILD_SIDE = "join_prefilter_build_side";
     public static final String OPTIMIZER_USE_HISTOGRAMS = "optimizer_use_histograms";
+    public static final String WARN_ON_COMMON_NAN_PATTERNS = "warn_on_common_nan_patterns";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1937,6 +1938,10 @@ public final class SystemSessionProperties
                 booleanProperty(OPTIMIZER_USE_HISTOGRAMS,
                         "whether or not to use histograms in the CBO",
                         featuresConfig.isUseHistograms(),
+                        false),
+                booleanProperty(WARN_ON_COMMON_NAN_PATTERNS,
+                        "Whether to give a warning for some common issues relating to NaNs",
+                        featuresConfig.getWarnOnCommonNanPatterns(),
                         false));
     }
 
@@ -3228,5 +3233,10 @@ public final class SystemSessionProperties
     public static boolean shouldOptimizerUseHistograms(Session session)
     {
         return session.getSystemProperty(OPTIMIZER_USE_HISTOGRAMS, Boolean.class);
+    }
+
+    public static boolean warnOnCommonNanPatterns(Session session)
+    {
+        return session.getSystemProperty(WARN_ON_COMMON_NAN_PATTERNS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -312,6 +312,7 @@ public class FeaturesConfig
     private boolean useHistograms;
 
     private boolean useNewNanDefinition = true;
+    private boolean warnOnPossibleNans;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -3130,6 +3131,19 @@ public class FeaturesConfig
     public FeaturesConfig setUseNewNanDefinition(boolean useNewNanDefinition)
     {
         this.useNewNanDefinition = useNewNanDefinition;
+        return this;
+    }
+
+    public boolean getWarnOnCommonNanPatterns()
+    {
+        return warnOnPossibleNans;
+    }
+
+    @Config("warn-on-common-nan-patterns")
+    @ConfigDescription("Give warnings for operations on DOUBLE/REAL types where NaN issues are common")
+    public FeaturesConfig setWarnOnCommonNanPatterns(boolean warnOnPossibleNans)
+    {
+        this.warnOnPossibleNans = warnOnPossibleNans;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -272,7 +272,8 @@ public class TestFeaturesConfig
                 .setLegacyJsonCast(true)
                 .setPrintEstimatedStatsFromCache(false)
                 .setUseHistograms(false)
-                .setUseNewNanDefinition(true));
+                .setUseNewNanDefinition(true)
+                .setWarnOnCommonNanPatterns(false));
     }
 
     @Test
@@ -489,6 +490,7 @@ public class TestFeaturesConfig
                 .put("optimizer.print-estimated-stats-from-cache", "true")
                 .put("optimizer.use-histograms", "true")
                 .put("use-new-nan-definition", "false")
+                .put("warn-on-common-nan-patterns", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -702,7 +704,8 @@ public class TestFeaturesConfig
                 .setLegacyJsonCast(false)
                 .setPrintEstimatedStatsFromCache(true)
                 .setUseHistograms(true)
-                .setUseNewNanDefinition(false);
+                .setUseNewNanDefinition(false)
+                .setWarnOnCommonNanPatterns(true);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
## Description
Add an analyzer warning for division that can produce nans and for comparison operations involving doubles.  The warning will be returned regardless of whether the query is actually affected by nans, as we are unable to know the actual input until runtime. This feature is gated by the configuration property `warn-on-possible-nans` and session property `warn_on_possible_nans`

## Motivation and Context
Division of real and double type is a common accidental source of nans.  Comparison operations are the most significant of the semantic changes for the new nan semantic. Warn for both of these cases to help users adjust to the new nan semantics.

## Impact
Warning for division or comparison operators involving double or real types when warn_on_possible_nans is true.

## Test Plan
new unit tests, also ran a few queries and saw the warnings.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add configuration property ``warn-on-possible-nans`` and session property ``warn_on_possible_nans`` to produce a warning on division operations or comparison operations involving double or real types. Division operations are common causes of accidental creation of nans, and the semantics of comparison operations involving nans changed considerably in the most recent Presto release. 
```

