### PR TITLE
[edge release hotfix] Fix hash for double and real types when new nan is disabled

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
@@ -86,8 +86,12 @@ public final class DoubleType
     @Override
     public long hash(Block block, int position)
     {
-        // convert to canonical NaN if necessary
-        return doubleHashCode(longBitsToDouble(block.getLong(position)));
+        Double doubleValue = longBitsToDouble(block.getLong(position));
+        if (!useNewNanDefintion) {
+            // convert to canonical NaN if necessary
+            return AbstractLongType.hash(doubleToLongBits(doubleValue));
+        }
+        return doubleHashCode(doubleValue);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
@@ -22,6 +22,7 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.TypeUtils.realCompare;
 import static com.facebook.presto.common.type.TypeUtils.realEquals;
 import static com.facebook.presto.common.type.TypeUtils.realHashCode;
+import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -64,7 +65,12 @@ public final class RealType
     @Override
     public long hash(Block block, int position)
     {
-        return realHashCode(intBitsToFloat(block.getInt(position)));
+        float value = intBitsToFloat(block.getInt(position));
+        if (!useNewNanDefinition) {
+            // convert to canonical NaN if necessary
+            return AbstractIntType.hash(floatToIntBits(value));
+        }
+        return realHashCode(value);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
@@ -274,7 +274,7 @@ public final class TypeUtils
         // canonicalize +0 and -0 to a single value
         value = value == -0 ? 0 : value;
         // floatToIntBits converts all NaNs to the same representation
-        return AbstractLongType.hash(floatToIntBits(value));
+        return AbstractIntType.hash(floatToIntBits(value));
     }
 
     public static int realCompare(float a, float b)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDoubleType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDoubleType.java
@@ -19,9 +19,12 @@ import com.facebook.presto.common.block.LongArrayBlockBuilder;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.DoubleType.OLD_NAN_DOUBLE;
+import static com.facebook.presto.common.type.RealType.OLD_NAN_REAL;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.doubleToRawLongBits;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestDoubleType
         extends AbstractTestType
@@ -67,5 +70,23 @@ public class TestDoubleType
         assertEquals(DOUBLE.hash(blockBuilder, 0), DOUBLE.hash(blockBuilder, 1));
         assertEquals(DOUBLE.hash(blockBuilder, 0), DOUBLE.hash(blockBuilder, 2));
         assertEquals(DOUBLE.hash(blockBuilder, 0), DOUBLE.hash(blockBuilder, 3));
+    }
+
+    @Test
+    public void testLegacyDoubleHash()
+    {
+        BlockBuilder blockBuilder = new LongArrayBlockBuilder(null, 4);
+        blockBuilder.writeLong(doubleToLongBits(Double.parseDouble("-0")));
+        blockBuilder.writeLong(doubleToLongBits(Double.parseDouble("0")));
+        assertNotEquals(OLD_NAN_DOUBLE.hash(blockBuilder, 0), OLD_NAN_REAL.hash(blockBuilder, 1));
+    }
+
+    @Test
+    public void testDoubleHash()
+    {
+        BlockBuilder blockBuilder = new LongArrayBlockBuilder(null, 4);
+        blockBuilder.writeLong(doubleToLongBits(Double.parseDouble("-0")));
+        blockBuilder.writeLong(doubleToLongBits(Double.parseDouble("0")));
+        assertEquals(DOUBLE.hash(blockBuilder, 0), DOUBLE.hash(blockBuilder, 1));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRealType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRealType.java
@@ -18,11 +18,13 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.IntArrayBlockBuilder;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.common.type.RealType.OLD_NAN_REAL;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestRealType
         extends AbstractTestType
@@ -70,5 +72,23 @@ public class TestRealType
         assertEquals(REAL.hash(blockBuilder, 0), REAL.hash(blockBuilder, 1));
         assertEquals(REAL.hash(blockBuilder, 0), REAL.hash(blockBuilder, 2));
         assertEquals(REAL.hash(blockBuilder, 0), REAL.hash(blockBuilder, 3));
+    }
+
+    @Test
+    public void testLegacyRealHash()
+    {
+        BlockBuilder blockBuilder = new IntArrayBlockBuilder(null, 4);
+        blockBuilder.writeInt(floatToIntBits(Float.parseFloat("-0")));
+        blockBuilder.writeInt(floatToIntBits(Float.parseFloat("0")));
+        assertNotEquals(OLD_NAN_REAL.hash(blockBuilder, 0), OLD_NAN_REAL.hash(blockBuilder, 1));
+    }
+
+    @Test
+    public void testRealHash()
+    {
+        BlockBuilder blockBuilder = new IntArrayBlockBuilder(null, 4);
+        blockBuilder.writeInt(floatToIntBits(Float.parseFloat("-0")));
+        blockBuilder.writeInt(floatToIntBits(Float.parseFloat("0")));
+        assertEquals(REAL.hash(blockBuilder, 0), REAL.hash(blockBuilder, 1));
     }
 }


### PR DESCRIPTION
The hash function wasn't gated by the use-new-nan-definition field, which meant it returned different results for -0 (which in the new definition is the same as +0, and in the old definition was not).

This also changes the method call for the real hash function with use-new-nan-definition enabled, but the two functions have the same implementation, so the change is purely for clarity/consistency.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

