### PR TITLE
Use buffered bytes in Parquet written bytes count

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
@@ -86,7 +86,7 @@ public class ParquetFileWriter
     @Override
     public long getWrittenBytes()
     {
-        return parquetWriter.getWrittenBytes();
+        return parquetWriter.getWrittenBytes() + parquetWriter.getBufferedBytes();
     }
 
     @Override


### PR DESCRIPTION
Bytes buffered in memory should be considered written for statistical bookkeeping. This fixes issues where writer scaling doesn't work when there are files smaller than the configured parquet row group size.

## Description

Adds buffered bytes in both the legacy and optimized parquet writers' count of written bytes.

## Motivation and Context

See #23063 

## Impact

No API impact

## Test Plan

Existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

