### PR TITLE
Fix SingleStore tests. Add metrics.

### DIFF
--- a/presto-singlestore/pom.xml
+++ b/presto-singlestore/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <singlestore.license>${env.SINGLESTORE_LICENSE}</singlestore.license>
     </properties>
 
     <dependencies>
@@ -103,9 +104,25 @@
         </dependency>
 
         <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-testing-docker</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -163,6 +180,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <SINGLESTORE_LICENSE>${singlestore.license}</SINGLESTORE_LICENSE>
+                    </environmentVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -175,6 +197,11 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <environmentVariables>
+                                <SINGLESTORE_LICENSE>${singlestore.license}</SINGLESTORE_LICENSE>
+                            </environmentVariables>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/presto-singlestore/src/main/java/com/facebook/presto/plugin/singlestore/SingleStoreClient.java
+++ b/presto-singlestore/src/main/java/com/facebook/presto/plugin/singlestore/SingleStoreClient.java
@@ -37,6 +37,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Properties;
 
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
@@ -60,7 +61,17 @@ public class SingleStoreClient
     @Inject
     public SingleStoreClient(JdbcConnectorId connectorId, BaseJdbcConfig config)
     {
-        super(connectorId, config, "`", new DriverConnectionFactory(new Driver(), config));
+        super(connectorId, config, "`",
+                new DriverConnectionFactory(new Driver(), config.getConnectionUrl(), Optional.ofNullable(config.getUserCredentialName()),
+                        Optional.ofNullable(config.getPasswordCredentialName()), connectionProperties(config)));
+    }
+
+    private static Properties connectionProperties(BaseJdbcConfig config)
+    {
+        Properties connectionProperties = DriverConnectionFactory.basicConnectionProperties(config);
+        String connectionAttributes = String.format("_connector_name:%s", "SingleStore Presto Connector");
+        connectionProperties.setProperty("connectionAttributes", connectionAttributes);
+        return connectionProperties;
     }
 
     @Override

--- a/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/SingleStoreContainer.java
+++ b/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/SingleStoreContainer.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.plugin.singlestore;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class SingleStoreContainer
+        extends JdbcDatabaseContainer<SingleStoreContainer>
+{
+    private static final String DEFAULT_DOCKER_IMAGE_NAME = "ghcr.io/singlestore-labs/singlestoredb-dev";
+    private static final String DEFAULT_DOCKER_IMAGE_TAG = "0.2.25";
+    private static final String DEFAULT_ROOT_PASSWORD = "root";
+    private static final String DEFAULT_ROOT = "root";
+    private static final int PORT = 3306;
+
+    private final String license;
+    private final String rootPassword;
+
+    public SingleStoreContainer(String license)
+    {
+        this(DEFAULT_DOCKER_IMAGE_NAME, DEFAULT_DOCKER_IMAGE_TAG, license, DEFAULT_ROOT_PASSWORD);
+    }
+
+    public SingleStoreContainer(String license, String rootPassword)
+    {
+        this(DEFAULT_DOCKER_IMAGE_NAME, DEFAULT_DOCKER_IMAGE_TAG, license, rootPassword);
+    }
+
+    public SingleStoreContainer(String dockerImageName, String dockerImageTag, String license, String rootPassword)
+    {
+        super(DockerImageName.parse(dockerImageName).withTag(dockerImageTag));
+        this.license = license;
+        this.rootPassword = rootPassword;
+        this.preconfigure();
+    }
+
+    private void preconfigure()
+    {
+        this.withStartupTimeoutSeconds(240);
+        this.withConnectTimeoutSeconds(120);
+        this.addEnv("SINGLESTORE_LICENSE", license);
+        this.addEnv("ROOT_PASSWORD", rootPassword);
+        this.addExposedPorts(PORT);
+    }
+
+    @Override
+    public String getDriverClassName()
+    {
+        return "com.singlestore.jdbc.Driver";
+    }
+
+    @Override
+    public String getJdbcUrl()
+    {
+        return String.format("jdbc:singlestore://localhost:%s?user=%s&password=%s", getMappedPort(PORT), DEFAULT_ROOT, rootPassword);
+    }
+
+    @Override
+    public String getUsername()
+    {
+        return DEFAULT_ROOT;
+    }
+
+    @Override
+    public String getPassword()
+    {
+        return rootPassword;
+    }
+
+    @Override
+    protected String getTestQueryString()
+    {
+        return "SELECT 1";
+    }
+}

--- a/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/SingleStoreContainer.java
+++ b/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/SingleStoreContainer.java
@@ -21,7 +21,7 @@ public class SingleStoreContainer
         extends JdbcDatabaseContainer<SingleStoreContainer>
 {
     private static final String DEFAULT_DOCKER_IMAGE_NAME = "ghcr.io/singlestore-labs/singlestoredb-dev";
-    private static final String DEFAULT_DOCKER_IMAGE_TAG = "0.2.25";
+    private static final String DEFAULT_DOCKER_IMAGE_TAG = "0.2.24";
     private static final String DEFAULT_ROOT_PASSWORD = "root";
     private static final String DEFAULT_ROOT = "root";
     private static final int PORT = 3306;


### PR DESCRIPTION
## Description
Fix SingleStore unit tests and add connection attribute metrics.

Tests were failed because of unable to start test container using 'presto-testing-docker' (failed to parse metadata when calling list images api). Fixed by using org.testcontainers.containers instead of 'presto-testing-docker'. 

## Motivation and Context
Fix https://github.com/prestodb/presto/issues/23006


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

