### PR TITLE
Add release notes for 0.288

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.288
     Release-0.287 [2024-04-16] <release/release-0.287>
     Release-0.286 [2024-02-12] <release/release-0.286>
     Release-0.285.1 [2023-12-30] <release/release-0.285.1>

--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,7 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
-    release/release-0.288
+    Release-0.288 [2024-06-13] <release/release-0.288>
     Release-0.287 [2024-04-16] <release/release-0.287>
     Release-0.286 [2024-02-12] <release/release-0.286>
     Release-0.285.1 [2023-12-30] <release/release-0.285.1>

--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -1,0 +1,85 @@
+=============
+Release 0.288
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix CAST of REAL values outside of BIGINT range to return an exception with an INVALID_CAST_ARGUMENT error code. Previously they would silently overflow.
+* Fix HBO to skip tracking of stats for plan nodes affected by dynamic filter pushdown in presto cpp :pr:`22853 `.
+* Fix a bug where map_top_n could return wrong results if there is any NaN input.
+* Fix a bug with array_min/array_max where it would return NaN rather than null when there was both NaN and null input.
+* Fix an error for some queries using a mix of joins and semi-joins when grouped execution is enabled.
+* Fix array_join to not add a trailing delimeter when the last element in the array is NULL. :pr:`22652`.
+* Fix cast of NaN and Infinity from DOUBLE or REAL to  BIGINT, INTEGER, SMALLINT, and TINYINT. It will now return an exception with the INVALID_CAST_ARGUMENT error code. Previously it would return zero.
+* Fix compilation error for queries with lambda in aggregation function.
+* Fix incorrect behaviors when defining duplicate field names in RowType and throw exception uniformly.
+* Fix regr_r2 result incorrect.
+* Fix the latency regression for queries with large IN clause.
+* Fix wrong results when queries using materialized CTEs have multiple common filters pushed into the CTE :pr:`22700 `.
+* Improve :doc:`/sql/explain-analyze` statement to support a ``format`` argument with values of ``<TEXT|JSON>`` :pr:`22733`.
+* Improve README.md and CONTRIBUTING.md :pr:`22918`.
+* Improve configuring worker threads relative to core count by setting the ``task.max-worker-threads`` configuration property to ``<multiplier>C``. For example, setting the property to ``2C`` configures the worker thread pool to create up to twice as many threads as there are cores available on a machine. :pr:`22809`.
+* Improve logging for RowExpressionRewriteRuleSet and StatsRecordingPlanOptimizer optimizers to include more information :pr:`22765`.
+* Improve session property ``property-use_broadcast_when_buildsize_small_probeside_unknown`` to do broadcast join when probe side size is unknown and build side estimation from HBO is small.
+* Improve the estimation stats recorded during query optimization :pr:`22769 `.
+* Add :doc:`/presto_cpp/properties` documentation :pr:`22885`.
+* Add PR number to the release note entry examples in pull_request_template.md :pr:`22665`.
+* Add Prestissimo Properties Reference page to the Prestissimo Developer Guide documentation :pr:`22620`.
+* Add `http-server.authentication.allow-forwarded-https` configuration property to recognize X-Forwarded-Proto header, :pr:`22492`.
+* Add `node-scheduler.max-preferred-nodes` configuration property to allow changing number of preferred nodes when soft affinity scheduling is enabled. :pr:`22562`.
+* Add documentation for :func:`noisy_approx_set_sfm_from_index_and_zeros`.
+* Add documentation for noisy aggregate functions at :doc:`/functions/noisy`, including :func:`noisy_approx_distinct_sfm` and :func:`noisy_approx_set_sfm` (:pr:`21290`, :pr:`22715`).
+* Add support for memoizing in resource group state info endpoint. This can be enabled by setting `cluster-resource-group-state-info-expiration-duration` to a non-zero duration. :pr:`22764`.
+* Add support for non default keystore and truststore type.
+* Add support for querying system.runtime.tasks table in native clusters.
+* Remove deprecated feature and configuration property ``deprecated.group-by-uses-equal``, which allowed group by to use equal to rather than distinct semantics.
+* ... Improve C++ based Presto documentation :pr:`22717`.
+* Change error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from ``NUMERIC_VALUE_OUT_OF_RANGE`` to ``INVALID_CAST_ARGUMENT``.
+* Change handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself.  It also changes the handling of positive and negative zero to always be considered equal to each other.  Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property ``use-new-nan-definition`` to ``false``. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release.
+* Enable HBO for CTE materialized query :pr:`22606`.
+* Prestissimo support for CTAS into bucketed (but not partitioned) tables pr:`22737`.
+* Update CI pipeline to build and publish native worker docker image :pr:`22806`.
+* Upgrade Alluxio to 313.
+* Upgrade io.jsonwebtoken artifacts to 0.11.5 :pr:`22762`.
+* Upgrades fasterxml.jackson artifacts to 2.11 :pr:`22417`.
+
+Hive Connector Changes
+______________________
+* Improve affinity scheduling granularity from a file to a section of a file by adding a `hive.affinity-scheduling-file-section-size` configuration property and `affinity_scheduling_file_section_size` session property. The default file size is 256MB. :pr:`22563`.
+
+Iceberg Connector Changes
+_________________________
+* Improve the partition specs that must be checked to determine if the partition supports metadata deletion or predicate thoroughly pushdown :pr:`22753`.
+* Improve time travel ``TIMESTAMP (SYSTEM_TIME)`` syntax to include timestamp-with-time-zone data type :pr:`22851`.
+* Improve time travel ``VERSION (SYSTEM_VERSION)`` syntax to include snapshot id using bigint data type :pr:`22851`.
+* Add procedure `expire_snapshots` to remove old snapshots in Iceberg. :pr:`22609`.
+* Add support for Iceberg REST catalog :pr:`22417`.
+* Add time travel ``BEFORE`` syntax for Iceberg tables to return historical data :pr:`22851`.
+* Disable timestamp with time zone in create, alter and insert statements :pr:`22926`.
+
+Verifier Changes
+________________
+* Support function call substitution based on the specified substitution pattern passed by the parameter --function-substitutes.
+
+SPI Changes
+___________
+* Add runtime stats as parameter to `ConnectorPageSourceProvider`.
+
+Hive Changes
+____________
+* Introduce AWS Security Mapping which will allow flexible mapping of Presto Users to AWS Credentials or IAM Roles for different AWS Services.
+
+Iceberg Changes
+_______________
+* Support metadata delete with predicate on non-identity partition columns when they align with partitioning boundaries.
+
+**Credits**
+===========
+
+8dukongjian, Abhisek Saikia, Ajay Gupte, Amit Dutta, Andrii Rosa, Beinan Wang, Christian Zentgraf, Deepak Majeti, Denodo Research Labs, Elliotte Rusty Harold, Emanuel F, Emanuel F., Fazal Majid, Feilong Liu, Ge Gao, Jalpreet Singh Nanda (:imjalpreet), Jialiang Tan, Jimmy Lu, Jonathan Hehir, Karteekmurthys, Ke, Kevin Wilfong, Konjac Huang, Linsong Wang, Michael Shang, Neerad Somanchi, Nidhin Varghese, Nikhil Collooru, Pranjal Shankhdhar, Rebecca Schlussel, Reetika Agrawal, Rohit Jain, Sean Yeh, Sergey Pershin, Sergii Druzkin, Sreeni Viswanadha, Steve Burnett, Swapnil Tailor, Tishyaa Chaudhry, Vivek, Vivian Hsu, Wills Feng, Yedidya Feldblum, Yihao Zhou, Yihong Wang, Ying, Zac Blanco, Zac Wen, abhinavmuk04, aditi-pandit, deepthydavis, jackychen718, jaystarshot, kiersten-stokes, wangd, wypb, xiaoxmeng, ymmarissa

--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -31,8 +31,10 @@ _______________
 * Improve Presto C++ documentation. :pr:`22717`
 * Improve error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from NUMERIC_VALUE_OUT_OF_RANGE to INVALID_CAST_ARGUMENT. :pr:`22917`
 * Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
+* Improve the performance of reading common table expressions (CTE). :pr:`22478`
 * Add HBO for CTE materialized query. :pr:`22606`
 * Add Prestissimo support for CTAS into bucketed (but not partitioned) tables. :pr:`22737`
+* Add support for ``NOT NULL`` column constraints in the CREATE TABLE and ALTER TABLE statements. This only takes effect for Hive connector now. :pr:`22064`
 * Add :doc:`/presto_cpp/properties` documentation. :pr:`22885`
 * Add PR number to the release note entry examples in pull_request_template.md. :pr:`22665`
 * Add ``http-server.authentication.allow-forwarded-https`` configuration property to recognize X-Forwarded-Proto header. :pr:`22492`
@@ -65,6 +67,7 @@ _________________________
 * Add time travel ``BEFORE`` syntax for Iceberg tables to return historical data. :pr:`22851`
 * Add support for metadata delete with predicate on non-identity partition columns when they align with partitioning boundaries. :pr:`22554`
 * Remove timestamp with time zone in ``CREATE``, ``ALTER``, and ``INSERT`` statements. :pr:`22926`
+* Add configuration of Iceberg split manager threads using the iceberg.split-manager-threads configuration property. :pr:`22754`
 
 Verifier Changes
 ________________

--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -4,6 +4,9 @@ Release 0.288
 
 **Highlights**
 ==============
+* Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
+* Add procedure `expire_snapshots` to remove old snapshots in Iceberg. :pr:`22609`
+* Add support for Iceberg REST catalog. :pr:`22417`
 
 **Details**
 ===========

--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -7,6 +7,7 @@ Release 0.288
 * Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. For more information, see `RFC-0001-nan-definition.md <https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md>`_. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
 * Add procedure `expire_snapshots` to remove old snapshots in Iceberg. :pr:`22609`
 * Add support for Iceberg REST catalog. :pr:`22417`
+* Add support for ``NOT NULL`` column constraints in the CREATE TABLE and ALTER TABLE statements. This only takes effect for Hive connector now. :pr:`22064`
 
 **Details**
 ===========
@@ -15,14 +16,14 @@ General Changes
 _______________
 * Fix CAST of REAL values outside of BIGINT range to return an exception with an INVALID_CAST_ARGUMENT error code. Previously they would silently overflow. :pr:`22917`
 * Fix HBO to skip tracking of stats for plan nodes affected by dynamic filter pushdown in presto cpp. :pr:`22853`
-* Fix a bug where :func:`map_top_n` could return wrong results if there is any NaN input. :pr:`22386`
+* Fix a bug where :func:`!map_top_n` could return wrong results if there is any NaN input. :pr:`22386`
 * Fix a bug with array_min/array_max where it would return NaN rather than null when there was both NaN and null input. :pr:`22386`
 * Fix an error for some queries using a mix of joins and semi-joins when grouped execution is enabled. :pr:`22538`
 * Fix :func:`!array_join` to not add a trailing delimeter when the last element in the array is NULL. :pr:`22652`
 * Fix cast of NaN and Infinity from DOUBLE or REAL to  BIGINT, INTEGER, SMALLINT, and TINYINT. It will now return an exception with the INVALID_CAST_ARGUMENT error code. Previously it would return zero. :pr:`22917`
 * Fix compilation error for queries with lambda in aggregation function. :pr:`22539`
 * Fix incorrect behaviors when defining duplicate field names in RowType and throw exception uniformly. :pr:`22618`
-* Fix regr_r2 result incorrect. :pr:`22611`
+* Fix wrong results for :func:`!regr_r2`. :pr:`22611`
 * Fix the latency regression for queries with large IN clause. :pr:`22661`
 * Fix wrong results when queries using materialized CTEs have multiple common filters pushed into the CTE. :pr:`22700`
 * Improve :doc:`/sql/explain-analyze` statement to support a ``format`` argument with values of ``<TEXT|JSON>``. :pr:`22733`
@@ -35,8 +36,9 @@ _______________
 * Improve error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from NUMERIC_VALUE_OUT_OF_RANGE to INVALID_CAST_ARGUMENT. :pr:`22917`
 * Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
 * Improve the performance of reading common table expressions (CTE). :pr:`22478`
+* Improve join performance by prefiltering the build side with distinct keys from the probe side. This can be enabled with the ``join_prefilter_build_side `` session property. :pr:`22667`
 * Add HBO for CTE materialized query. :pr:`22606`
-* Add Prestissimo support for CTAS into bucketed (but not partitioned) tables. :pr:`22737`
+* Add support for CTAS on bucketed (but not partitioned) tables for Presto C++ clusters. :pr:`22737`
 * Add support for ``NOT NULL`` column constraints in the CREATE TABLE and ALTER TABLE statements. This only takes effect for Hive connector now. :pr:`22064`
 * Add :doc:`/presto_cpp/properties` documentation. :pr:`22885`
 * Add PR number to the release note entry examples in pull_request_template.md. :pr:`22665`
@@ -46,9 +48,11 @@ _______________
 * Add documentation for noisy aggregate functions at :doc:`/functions/noisy`, including :func:`!noisy_approx_distinct_sfm` and :func:`!noisy_approx_set_sfm`. :pr:`22715`
 * Add support for memoizing in resource group state info endpoint. This can be enabled by setting ``cluster-resource-group-state-info-expiration-duration`` to a non-zero duration. :pr:`22764`
 * Add support for non default keystore and truststore type in presto CLI and JDBC. :pr:`22556`
-* Add support for querying system.runtime.tasks table in native clusters. :pr:`21416`
+* Add support for querying system.runtime.tasks table in Presto C++ clusters. :pr:`21416`
+* Add two system configuration properties to specify the reserved query memory capacity on Presto C++ clusters: ``query-reserved-memory-gb`` is the total amount of memory in GB reserved for the queries on a worker node. ``memory-pool-reserved-capacity`` is the amount of memory in bytes reserved for each query. :pr:`22593`
+* Replace the Presto native stats definition and reporting for the memory allocator, in-memory cache and ssd cache metrics from Presto repo to Velox repo, with the metrics names changing from presto_cpp.<metrics_name> to velox.<metrics_name>. :pr:`22751`
 * Remove deprecated feature and configuration property ``deprecated.group-by-uses-equal``, which allowed group by to use equal to rather than distinct semantics. :pr:`22888`
-* Upgrade CI pipeline to build and publish native worker docker image. :pr:`22806`
+* Upgrade CI pipeline to build and publish Presto C++ worker docker image. :pr:`22806`
 * Upgrade Alluxio to 313. :pr:`22958`
 * Upgrade io.jsonwebtoken artifacts to 0.11.5. :pr:`22762`
 * Upgrade fasterxml.jackson artifacts to 2.11. :pr:`22417`
@@ -59,6 +63,7 @@ ______________________
 * Improve affinity scheduling granularity from a file to a section of a file by adding a ``hive.affinity-scheduling-file-section-size`` configuration property and ``affinity_scheduling_file_section_size`` session property. The default file size is 256MB. :pr:`22563`
 * Add AWS Security Mapping to allow flexible mapping of Presto Users to AWS Credentials or IAM Roles for different AWS Services. :pr:`21622`
 * Add config property ``hive.legacy-timestamp-bucketing`` and session property ``hive.legacy_timestamp_bucketing`` to use the original hash function for Timestamp column, which is not hive compatible. :pr:`22980`
+* Add support for ``NOT NULL`` column constraints in the CREATE TABLE and ALTER TABLE statements for the Hive connector. :pr:`22064`
 
 Iceberg Connector Changes
 _________________________
@@ -83,4 +88,4 @@ ___________
 **Credits**
 ===========
 
-8dukongjian, Abhisek Saikia, Ajay Gupte, Amit Dutta, Andrii Rosa, Beinan Wang, Christian Zentgraf, Deepak Majeti, Denodo Research Labs, Elliotte Rusty Harold, Emanuel F, Emanuel F., Fazal Majid, Feilong Liu, Ge Gao, Jalpreet Singh Nanda (:imjalpreet), Jialiang Tan, Jimmy Lu, Jonathan Hehir, Karteekmurthys, Ke, Kevin Wilfong, Konjac Huang, Linsong Wang, Michael Shang, Neerad Somanchi, Nidhin Varghese, Nikhil Collooru, Pranjal Shankhdhar, Rebecca Schlussel, Reetika Agrawal, Rohit Jain, Sean Yeh, Sergey Pershin, Sergii Druzkin, Sreeni Viswanadha, Steve Burnett, Swapnil Tailor, Tishyaa Chaudhry, Vivek, Vivian Hsu, Wills Feng, Yedidya Feldblum, Yihao Zhou, Yihong Wang, Ying, Zac Blanco, Zac Wen, abhinavmuk04, aditi-pandit, deepthydavis, jackychen718, jaystarshot, kiersten-stokes, wangd, wypb, xiaoxmeng, ymmarissa
+8dukongjian, Abhisek Saikia, Ajay Gupte, Amit Dutta, Andrii Rosa, Beinan Wang, Christian Zentgraf, Deepak Majeti, Denodo Research Labs, Elliotte Rusty Harold, Emanuel F, Fazal Majid, Feilong Liu, Ge Gao, Jalpreet Singh Nanda (:imjalpreet), Jialiang Tan, Jimmy Lu, Jonathan Hehir, Karteekmurthys, Ke, Kevin Wilfong, Konjac Huang, Linsong Wang, Michael Shang, Neerad Somanchi, Nidhin Varghese, Nikhil Collooru, Pranjal Shankhdhar, Rebecca Schlussel, Reetika Agrawal, Rohit Jain, Sean Yeh, Sergey Pershin, Sergii Druzkin, Sreeni Viswanadha, Steve Burnett, Swapnil Tailor, Tishyaa Chaudhry, Vivek, Vivian Hsu, Wills Feng, Yedidya Feldblum, Yihao Zhou, Yihong Wang, Ying Su, Zac Blanco, Zac Wen, abhinavmuk04, aditi-pandit, deepthydavis, jackychen718, jaystarshot, kiersten-stokes, wangd, wypb, xiaoxmeng, ymmarissa

--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -28,6 +28,11 @@ _______________
 * Improve logging for RowExpressionRewriteRuleSet and StatsRecordingPlanOptimizer optimizers to include more information. :pr:`22765`
 * Improve session property ``property-use_broadcast_when_buildsize_small_probeside_unknown`` to do broadcast join when probe side size is unknown and build side estimation from HBO is small. :pr:`22681`
 * Improve the estimation stats recorded during query optimization. :pr:`22769`
+* Improve Presto C++ documentation. :pr:`22717`
+* Improve error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from NUMERIC_VALUE_OUT_OF_RANGE to INVALID_CAST_ARGUMENT. :pr:`22917`
+* Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
+* Add HBO for CTE materialized query. :pr:`22606`
+* Add Prestissimo support for CTAS into bucketed (but not partitioned) tables. :pr:`22737`
 * Add :doc:`/presto_cpp/properties` documentation. :pr:`22885`
 * Add PR number to the release note entry examples in pull_request_template.md. :pr:`22665`
 * Add ``http-server.authentication.allow-forwarded-https`` configuration property to recognize X-Forwarded-Proto header. :pr:`22492`
@@ -38,19 +43,17 @@ _______________
 * Add support for non default keystore and truststore type in presto CLI and JDBC. :pr:`22556`
 * Add support for querying system.runtime.tasks table in native clusters. :pr:`21416`
 * Remove deprecated feature and configuration property ``deprecated.group-by-uses-equal``, which allowed group by to use equal to rather than distinct semantics. :pr:`22888`
-* ... Improve :doc:`/presto-cpp` documentation. :pr:`22717`
-* Change error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from ``NUMERIC_VALUE_OUT_OF_RANGE`` to ``INVALID_CAST_ARGUMENT``. :pr:`22917`
-* Change handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself.  It also changes the handling of positive and negative zero to always be considered equal to each other.  Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property ``use-new-nan-definition`` to ``false``. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
-* Enable HBO for CTE materialized query. :pr:`22606`
-* Prestissimo support for CTAS into bucketed (but not partitioned) tables. pr:`22737`
-* Update CI pipeline to build and publish native worker docker image. :pr:`22806`
+* Upgrade CI pipeline to build and publish native worker docker image. :pr:`22806`
 * Upgrade Alluxio to 313. :pr:`22958`
 * Upgrade io.jsonwebtoken artifacts to 0.11.5. :pr:`22762`
 * Upgrade fasterxml.jackson artifacts to 2.11. :pr:`22417`
 
 Hive Connector Changes
 ______________________
+* Fix hash calculation for Timestamp column to be hive compatible when writing to a table bucketed by Timestamp. :pr:`22980`
 * Improve affinity scheduling granularity from a file to a section of a file by adding a ``hive.affinity-scheduling-file-section-size`` configuration property and ``affinity_scheduling_file_section_size`` session property. The default file size is 256MB. :pr:`22563`
+* Add AWS Security Mapping to allow flexible mapping of Presto Users to AWS Credentials or IAM Roles for different AWS Services. :pr:`21622`
+* Add config property ``hive.legacy-timestamp-bucketing`` and session property ``hive.legacy_timestamp_bucketing`` to use the original hash function for Timestamp column, which is not hive compatible. :pr:`22980`
 
 Iceberg Connector Changes
 _________________________
@@ -60,25 +63,16 @@ _________________________
 * Add procedure `expire_snapshots` to remove old snapshots in Iceberg. :pr:`22609`
 * Add support for Iceberg REST catalog. :pr:`22417`
 * Add time travel ``BEFORE`` syntax for Iceberg tables to return historical data. :pr:`22851`
-* Disable timestamp with time zone in ``CREATE``, ``ALTER``, and ``INSERT`` statements. :pr:`22926`
+* Add support for metadata delete with predicate on non-identity partition columns when they align with partitioning boundaries. :pr:`22554`
+* Remove timestamp with time zone in ``CREATE``, ``ALTER``, and ``INSERT`` statements. :pr:`22926`
 
 Verifier Changes
 ________________
-* Support function call substitution based on the specified substitution pattern passed by the parameter --function-substitutes. :pr:`22783`
+* Add support for function call substitution based on the specified substitution pattern passed by the parameter --function-substitutes. :pr:`22783`
 
 SPI Changes
 ___________
 * Add runtime stats as parameter to ``ConnectorPageSourceProvider``. :pr:`22960`
-
-Hive Changes
-____________
-* Introduce AWS Security Mapping to allow flexible mapping of Presto Users to AWS Credentials or IAM Roles for different AWS Services. :pr:`21622`
-* Fix hash calculation for Timestamp column to be hive compatible when writing to a table bucketed by Timestamp. :pr:`22890`
-* Add config `hive.legacy-timestamp-bucketing` and session property ``hive.legacy_timestamp_bucketing`` to use the original hash function for Timestamp column, which is not hive compatible. :pr:`22890`
-
-Iceberg Changes
-_______________
-* Support metadata delete with predicate on non-identity partition columns when they align with partitioning boundaries. :pr:`22554`
 
 **Credits**
 ===========

--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -4,7 +4,7 @@ Release 0.288
 
 **Highlights**
 ==============
-* Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
+* Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. For more information, see `RFC-0001-nan-definition.md <https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md>`_. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
 * Add procedure `expire_snapshots` to remove old snapshots in Iceberg. :pr:`22609`
 * Add support for Iceberg REST catalog. :pr:`22417`
 

--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -15,7 +15,7 @@ _______________
 * Fix a bug where :func:`map_top_n` could return wrong results if there is any NaN input. :pr:`22386`
 * Fix a bug with array_min/array_max where it would return NaN rather than null when there was both NaN and null input. :pr:`22386`
 * Fix an error for some queries using a mix of joins and semi-joins when grouped execution is enabled. :pr:`22538`
-* Fix :func:`array_join` to not add a trailing delimeter when the last element in the array is NULL. :pr:`22652`
+* Fix :func:`!array_join` to not add a trailing delimeter when the last element in the array is NULL. :pr:`22652`
 * Fix cast of NaN and Infinity from DOUBLE or REAL to  BIGINT, INTEGER, SMALLINT, and TINYINT. It will now return an exception with the INVALID_CAST_ARGUMENT error code. Previously it would return zero. :pr:`22917`
 * Fix compilation error for queries with lambda in aggregation function. :pr:`22539`
 * Fix incorrect behaviors when defining duplicate field names in RowType and throw exception uniformly. :pr:`22618`
@@ -37,8 +37,8 @@ _______________
 * Add PR number to the release note entry examples in pull_request_template.md. :pr:`22665`
 * Add ``http-server.authentication.allow-forwarded-https`` configuration property to recognize X-Forwarded-Proto header. :pr:`22492`
 * Add ``node-scheduler.max-preferred-nodes`` configuration property to allow changing number of preferred nodes when soft affinity scheduling is enabled. :pr:`22562`
-* Add documentation for :func:`noisy_approx_set_sfm_from_index_and_zeros`. :pr:`22799`
-* Add documentation for noisy aggregate functions at :doc:`/functions/noisy`, including :func:`noisy_approx_distinct_sfm` and :func:`noisy_approx_set_sfm`. :pr:`22715`
+* Add documentation for :func:`!noisy_approx_set_sfm_from_index_and_zeros`. :pr:`22799`
+* Add documentation for noisy aggregate functions at :doc:`/functions/noisy`, including :func:`!noisy_approx_distinct_sfm` and :func:`!noisy_approx_set_sfm`. :pr:`22715`
 * Add support for memoizing in resource group state info endpoint. This can be enabled by setting ``cluster-resource-group-state-info-expiration-duration`` to a non-zero duration. :pr:`22764`
 * Add support for non default keystore and truststore type in presto CLI and JDBC. :pr:`22556`
 * Add support for querying system.runtime.tasks table in native clusters. :pr:`21416`

--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -73,6 +73,8 @@ ___________
 Hive Changes
 ____________
 * Introduce AWS Security Mapping to allow flexible mapping of Presto Users to AWS Credentials or IAM Roles for different AWS Services. :pr:`21622`
+* Fix hash calculation for Timestamp column to be hive compatible when writing to a table bucketed by Timestamp. :pr:`22890`
+* Add config `hive.legacy-timestamp-bucketing` and session property ``hive.legacy_timestamp_bucketing`` to use the original hash function for Timestamp column, which is not hive compatible. :pr:`22890`
 
 Iceberg Changes
 _______________

--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -10,74 +10,73 @@ Release 0.288
 
 General Changes
 _______________
-* Fix CAST of REAL values outside of BIGINT range to return an exception with an INVALID_CAST_ARGUMENT error code. Previously they would silently overflow.
-* Fix HBO to skip tracking of stats for plan nodes affected by dynamic filter pushdown in presto cpp :pr:`22853 `.
-* Fix a bug where map_top_n could return wrong results if there is any NaN input.
-* Fix a bug with array_min/array_max where it would return NaN rather than null when there was both NaN and null input.
-* Fix an error for some queries using a mix of joins and semi-joins when grouped execution is enabled.
-* Fix array_join to not add a trailing delimeter when the last element in the array is NULL. :pr:`22652`.
-* Fix cast of NaN and Infinity from DOUBLE or REAL to  BIGINT, INTEGER, SMALLINT, and TINYINT. It will now return an exception with the INVALID_CAST_ARGUMENT error code. Previously it would return zero.
-* Fix compilation error for queries with lambda in aggregation function.
-* Fix incorrect behaviors when defining duplicate field names in RowType and throw exception uniformly.
-* Fix regr_r2 result incorrect.
-* Fix the latency regression for queries with large IN clause.
-* Fix wrong results when queries using materialized CTEs have multiple common filters pushed into the CTE :pr:`22700 `.
-* Improve :doc:`/sql/explain-analyze` statement to support a ``format`` argument with values of ``<TEXT|JSON>`` :pr:`22733`.
-* Improve README.md and CONTRIBUTING.md :pr:`22918`.
-* Improve configuring worker threads relative to core count by setting the ``task.max-worker-threads`` configuration property to ``<multiplier>C``. For example, setting the property to ``2C`` configures the worker thread pool to create up to twice as many threads as there are cores available on a machine. :pr:`22809`.
-* Improve logging for RowExpressionRewriteRuleSet and StatsRecordingPlanOptimizer optimizers to include more information :pr:`22765`.
-* Improve session property ``property-use_broadcast_when_buildsize_small_probeside_unknown`` to do broadcast join when probe side size is unknown and build side estimation from HBO is small.
-* Improve the estimation stats recorded during query optimization :pr:`22769 `.
-* Add :doc:`/presto_cpp/properties` documentation :pr:`22885`.
-* Add PR number to the release note entry examples in pull_request_template.md :pr:`22665`.
-* Add Prestissimo Properties Reference page to the Prestissimo Developer Guide documentation :pr:`22620`.
-* Add `http-server.authentication.allow-forwarded-https` configuration property to recognize X-Forwarded-Proto header, :pr:`22492`.
-* Add `node-scheduler.max-preferred-nodes` configuration property to allow changing number of preferred nodes when soft affinity scheduling is enabled. :pr:`22562`.
-* Add documentation for :func:`noisy_approx_set_sfm_from_index_and_zeros`.
-* Add documentation for noisy aggregate functions at :doc:`/functions/noisy`, including :func:`noisy_approx_distinct_sfm` and :func:`noisy_approx_set_sfm` (:pr:`21290`, :pr:`22715`).
-* Add support for memoizing in resource group state info endpoint. This can be enabled by setting `cluster-resource-group-state-info-expiration-duration` to a non-zero duration. :pr:`22764`.
-* Add support for non default keystore and truststore type.
-* Add support for querying system.runtime.tasks table in native clusters.
-* Remove deprecated feature and configuration property ``deprecated.group-by-uses-equal``, which allowed group by to use equal to rather than distinct semantics.
-* ... Improve C++ based Presto documentation :pr:`22717`.
-* Change error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from ``NUMERIC_VALUE_OUT_OF_RANGE`` to ``INVALID_CAST_ARGUMENT``.
-* Change handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself.  It also changes the handling of positive and negative zero to always be considered equal to each other.  Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property ``use-new-nan-definition`` to ``false``. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release.
-* Enable HBO for CTE materialized query :pr:`22606`.
-* Prestissimo support for CTAS into bucketed (but not partitioned) tables pr:`22737`.
-* Update CI pipeline to build and publish native worker docker image :pr:`22806`.
-* Upgrade Alluxio to 313.
-* Upgrade io.jsonwebtoken artifacts to 0.11.5 :pr:`22762`.
-* Upgrades fasterxml.jackson artifacts to 2.11 :pr:`22417`.
+* Fix CAST of REAL values outside of BIGINT range to return an exception with an INVALID_CAST_ARGUMENT error code. Previously they would silently overflow. :pr:`22917`
+* Fix HBO to skip tracking of stats for plan nodes affected by dynamic filter pushdown in presto cpp. :pr:`22853`
+* Fix a bug where :func:`map_top_n` could return wrong results if there is any NaN input. :pr:`22386`
+* Fix a bug with array_min/array_max where it would return NaN rather than null when there was both NaN and null input. :pr:`22386`
+* Fix an error for some queries using a mix of joins and semi-joins when grouped execution is enabled. :pr:`22538`
+* Fix :func:`array_join` to not add a trailing delimeter when the last element in the array is NULL. :pr:`22652`
+* Fix cast of NaN and Infinity from DOUBLE or REAL to  BIGINT, INTEGER, SMALLINT, and TINYINT. It will now return an exception with the INVALID_CAST_ARGUMENT error code. Previously it would return zero. :pr:`22917`
+* Fix compilation error for queries with lambda in aggregation function. :pr:`22539`
+* Fix incorrect behaviors when defining duplicate field names in RowType and throw exception uniformly. :pr:`22618`
+* Fix regr_r2 result incorrect. :pr:`22611`
+* Fix the latency regression for queries with large IN clause. :pr:`22661`
+* Fix wrong results when queries using materialized CTEs have multiple common filters pushed into the CTE. :pr:`22700`
+* Improve :doc:`/sql/explain-analyze` statement to support a ``format`` argument with values of ``<TEXT|JSON>``. :pr:`22733`
+* Improve README.md and CONTRIBUTING.md. :pr:`22918`
+* Improve configuring worker threads relative to core count by setting the ``task.max-worker-threads`` configuration property to ``<multiplier>C``. For example, setting the property to ``2C`` configures the worker thread pool to create up to twice as many threads as there are cores available on a machine. :pr:`22809`
+* Improve logging for RowExpressionRewriteRuleSet and StatsRecordingPlanOptimizer optimizers to include more information. :pr:`22765`
+* Improve session property ``property-use_broadcast_when_buildsize_small_probeside_unknown`` to do broadcast join when probe side size is unknown and build side estimation from HBO is small. :pr:`22681`
+* Improve the estimation stats recorded during query optimization. :pr:`22769`
+* Add :doc:`/presto_cpp/properties` documentation. :pr:`22885`
+* Add PR number to the release note entry examples in pull_request_template.md. :pr:`22665`
+* Add ``http-server.authentication.allow-forwarded-https`` configuration property to recognize X-Forwarded-Proto header. :pr:`22492`
+* Add ``node-scheduler.max-preferred-nodes`` configuration property to allow changing number of preferred nodes when soft affinity scheduling is enabled. :pr:`22562`
+* Add documentation for :func:`noisy_approx_set_sfm_from_index_and_zeros`. :pr:`22799`
+* Add documentation for noisy aggregate functions at :doc:`/functions/noisy`, including :func:`noisy_approx_distinct_sfm` and :func:`noisy_approx_set_sfm`. :pr:`22715`
+* Add support for memoizing in resource group state info endpoint. This can be enabled by setting ``cluster-resource-group-state-info-expiration-duration`` to a non-zero duration. :pr:`22764`
+* Add support for non default keystore and truststore type in presto CLI and JDBC. :pr:`22556`
+* Add support for querying system.runtime.tasks table in native clusters. :pr:`21416`
+* Remove deprecated feature and configuration property ``deprecated.group-by-uses-equal``, which allowed group by to use equal to rather than distinct semantics. :pr:`22888`
+* ... Improve :doc:`/presto-cpp` documentation. :pr:`22717`
+* Change error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from ``NUMERIC_VALUE_OUT_OF_RANGE`` to ``INVALID_CAST_ARGUMENT``. :pr:`22917`
+* Change handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself.  It also changes the handling of positive and negative zero to always be considered equal to each other.  Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property ``use-new-nan-definition`` to ``false``. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
+* Enable HBO for CTE materialized query. :pr:`22606`
+* Prestissimo support for CTAS into bucketed (but not partitioned) tables. pr:`22737`
+* Update CI pipeline to build and publish native worker docker image. :pr:`22806`
+* Upgrade Alluxio to 313. :pr:`22958`
+* Upgrade io.jsonwebtoken artifacts to 0.11.5. :pr:`22762`
+* Upgrade fasterxml.jackson artifacts to 2.11. :pr:`22417`
 
 Hive Connector Changes
 ______________________
-* Improve affinity scheduling granularity from a file to a section of a file by adding a `hive.affinity-scheduling-file-section-size` configuration property and `affinity_scheduling_file_section_size` session property. The default file size is 256MB. :pr:`22563`.
+* Improve affinity scheduling granularity from a file to a section of a file by adding a ``hive.affinity-scheduling-file-section-size`` configuration property and ``affinity_scheduling_file_section_size`` session property. The default file size is 256MB. :pr:`22563`
 
 Iceberg Connector Changes
 _________________________
-* Improve the partition specs that must be checked to determine if the partition supports metadata deletion or predicate thoroughly pushdown :pr:`22753`.
-* Improve time travel ``TIMESTAMP (SYSTEM_TIME)`` syntax to include timestamp-with-time-zone data type :pr:`22851`.
-* Improve time travel ``VERSION (SYSTEM_VERSION)`` syntax to include snapshot id using bigint data type :pr:`22851`.
-* Add procedure `expire_snapshots` to remove old snapshots in Iceberg. :pr:`22609`.
-* Add support for Iceberg REST catalog :pr:`22417`.
-* Add time travel ``BEFORE`` syntax for Iceberg tables to return historical data :pr:`22851`.
-* Disable timestamp with time zone in create, alter and insert statements :pr:`22926`.
+* Improve the partition specs that must be checked to determine if the partition supports metadata deletion or predicate thoroughly pushdown. :pr:`22753`
+* Improve time travel ``TIMESTAMP (SYSTEM_TIME)`` syntax to include timestamp-with-time-zone data type. :pr:`22851`
+* Improve time travel ``VERSION (SYSTEM_VERSION)`` syntax to include snapshot id using `BIGINT` data type. :pr:`22851`
+* Add procedure `expire_snapshots` to remove old snapshots in Iceberg. :pr:`22609`
+* Add support for Iceberg REST catalog. :pr:`22417`
+* Add time travel ``BEFORE`` syntax for Iceberg tables to return historical data. :pr:`22851`
+* Disable timestamp with time zone in ``CREATE``, ``ALTER``, and ``INSERT`` statements. :pr:`22926`
 
 Verifier Changes
 ________________
-* Support function call substitution based on the specified substitution pattern passed by the parameter --function-substitutes.
+* Support function call substitution based on the specified substitution pattern passed by the parameter --function-substitutes. :pr:`22783`
 
 SPI Changes
 ___________
-* Add runtime stats as parameter to `ConnectorPageSourceProvider`.
+* Add runtime stats as parameter to ``ConnectorPageSourceProvider``. :pr:`22960`
 
 Hive Changes
 ____________
-* Introduce AWS Security Mapping which will allow flexible mapping of Presto Users to AWS Credentials or IAM Roles for different AWS Services.
+* Introduce AWS Security Mapping to allow flexible mapping of Presto Users to AWS Credentials or IAM Roles for different AWS Services. :pr:`21622`
 
 Iceberg Changes
 _______________
-* Support metadata delete with predicate on non-identity partition columns when they align with partitioning boundaries.
+* Support metadata delete with predicate on non-identity partition columns when they align with partitioning boundaries. :pr:`22554`
 
 **Credits**
 ===========


### PR DESCRIPTION
# Missing Release Notes
## Ajay Gupte
- [ ] https://github.com/prestodb/presto/pull/22631 BEFORE syntax support for presto engine. (Merged by: Ajay Gupte)

## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/22968 [native] Remove unused include. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22963 [native] Minor cosmetic fixes. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22767 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22692 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22662 [native] Move static functions from PrestoTask to Util. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/22578 [native] Advance velox and remove an unused variable. (Merged by: Amit Dutta)

## Christian Zentgraf
- [ ] d2b2a11f31d8e04ac108572659343242c13accb2 [native] Update dockerfiles to use Centos9
- [ ] 8374c2564cf913d362ed8561a3392ebc2108d373 [native] Advance Velox

## Deepak Majeti
- [ ] https://github.com/prestodb/presto/pull/22815 [native] Make node.id optional (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/21929 [native] Add dockerfiles for dependencies and runtime and remove existing dockerfiles (Merged by: Timothy Meehan)

## Emanuel F
- [ ] https://github.com/prestodb/presto/pull/22930 Add table for users to quickly navigate documentation (Merged by: Steve Burnett)

## Jialiang Tan
- [ ] https://github.com/prestodb/presto/pull/22751 [native] Remove spill stats reporting from presto native (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/22720 [native] Migrate away stats reporting for allocator and cache (Merged by: tanjialiang)

## Jimmy Lu
- [ ] https://github.com/prestodb/presto/pull/22922 [native] Transfer idle HTTPSession between IO threads in exchange source (Merged by: Xiaoxuan)

## Karteekmurthys
- [ ] https://github.com/prestodb/presto/pull/22969 [Native] Advance velox (Merged by: Deepak Majeti)
- [ ] https://github.com/prestodb/presto/pull/22857 [Native] Modify setup-adapters.sh to install prometheus-cpp (Merged by: Deepak Majeti)
- [ ] https://github.com/prestodb/presto/pull/22699 [Native] Remove duplicate call to registerStatsCounters (Merged by: Amit Dutta)

## Ke
- [ ] cfd99caffcd6b1fd403ec22d7597fe367ada7ccf Fix hash calculation for Timestamp in HiveBucketing to be Hive Compatible
- [ ] 4818d3ca8c74bfef35e75441a70cae238fad789d Fix comment for Timestamp in HiveBucketing

## Konjac Huang
- [ ] https://github.com/prestodb/presto/pull/22487 Fix Pre Process Metadata Call when facing CTE Issue (Merged by: Nikhil Collooru)

## Linsong Wang
- [ ] 8380fe3f6051dc9d3257e0ec97a130d5607a83a9 [native] add entrypoint script into native worker docker image
- [ ] fa3c606a426a86b381b80528d91244bfcbcf2324 Update Jenkins pipeline per dockerfile name update

## Sreeni Viswanadha
- [ ] https://github.com/prestodb/presto/pull/22667 Prefilter join build side when it's too large (Merged by: Sreeni Viswanadha)

## Vivek
- [ ] https://github.com/prestodb/presto/pull/22064 Support for NOT NULL column constraints (Merged by: Vivek)

## Zac Blanco
- [ ] https://github.com/prestodb/presto/pull/22887 Update docs theme to sphinx-immaterial (Merged by: Zac Blanco)

## jackychen718
- [ ] https://github.com/prestodb/presto/pull/22845 Move the description of Iceberg procedures to a dedicated subheading (Merged by: Timothy Meehan)

## wypb
- [ ] https://github.com/prestodb/presto/pull/22754 Make Iceberg split manager threads configurable (Merged by: dongwang)

## xiaoxmeng
- [ ] https://github.com/prestodb/presto/pull/22906 [native]Remove access to current bytes in memory pool stats (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22833 [native]Update Prestissimo to report the actual used task memory (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22773 [native]Advance velox and update query ctx init (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22734 [native] Add native dynamic filter stats to operator stats for hbo (Merged by: Nikhil Collooru)
- [ ] https://github.com/prestodb/presto/pull/22732 [native]Make prestissimo monitoring compatible for new blokblocking r… (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22655 [native] Advance velox version (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22593 [native] Add reserved memory capacity configs (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/22579 [native] Remove old legecy code of temp directory (Merged by: Xiaoxuan)

# Extracted Release Notes
- #21416 (Author: aditi-pandit):  [native] SystemConnector to query system.runtime.tasks table
  - Add support for querying system.runtime.tasks table in native clusters.
- #21622 (Author: Jalpreet Singh Nanda (:imjalpreet)): Introduce AWS Security Mapping
  - Introduce AWS Security Mapping which will allow flexible mapping of Presto Users to AWS Credentials or IAM Roles for different AWS Services.
- #22386 (Author: Rebecca Schlussel): Implement new NaN behavior
  - Change handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself.  It also changes the handling of positive and negative zero to always be considered equal to each other.  Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property ``use-new-nan-definition`` to ``false``. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release.
  - Fix a bug where map_top_n could return wrong results if there is any NaN input.
  - Fix a bug with array_min/array_max where it would return NaN rather than null when there was both NaN and null input.
- #22417 (Author: kiersten-stokes): Add support for REST catalog in Iceberg connector
  - Upgrades fasterxml.jackson artifacts to 2.11 :pr:`22417`.
  - Add support for Iceberg REST catalog :pr:`22417`.
- #22492 (Author: Wills Feng): Support forwarded https
  - Add `http-server.authentication.allow-forwarded-https` configuration property to recognize X-Forwarded-Proto header, :pr:`22492`.
- #22538 (Author: Rebecca Schlussel): Fix no value present scheduling failure with grouped execution
  - Fix an error for some queries using a mix of joins and semi-joins when grouped execution is enabled.
- #22539 (Author: Feilong Liu): Fix analyzer for lambda in aggregation
  - Fix compilation error for queries with lambda in aggregation function.
- #22554 (Author: wangd): [Iceberg]Support metadata delete with predicate on non-identity partition columns
  - Support metadata delete with predicate on non-identity partition columns when they align with partitioning boundaries.
- #22556 (Author: Nidhin Varghese): Add Support for non default keystore and truststore type in presto CLI and JDBC
  - Add support for non default keystore and truststore type.
- #22562 (Author: Andrii Rosa): Make number of preferred nodes configurable
  - Add `node-scheduler.max-preferred-nodes` configuration property to allow changing number of preferred nodes when soft affinity scheduling is enabled. :pr:`22562`.
- #22563 (Author: Andrii Rosa): Allow different scheduling affinity for different sections of a file
  - Improve affinity scheduling granularity from a file to a section of a file by adding a `hive.affinity-scheduling-file-section-size` configuration property and `affinity_scheduling_file_section_size` session property. The default file size is 256MB. :pr:`22563`.
- #22606 (Author: Feilong Liu): Add HBO support for CTE materialization
  - Enable HBO for CTE materialized query :pr:`22606`.
- #22609 (Author: wangd): Support procedure expire_snapshots for iceberg
  - Add procedure `expire_snapshots` to remove old snapshots in Iceberg. :pr:`22609`.
- #22611 (Author: 8dukongjian): Fix correctness issue in regr_r2
  - Fix regr_r2 result incorrect.
- #22618 (Author: wangd): Revert "Revert "Preserve case for RowType's field name and JSON content when ``CAST``""
  - Fix incorrect behaviors when defining duplicate field names in RowType and throw exception uniformly.
- #22620 (Author: Steve Burnett): [docs] Add prestissimo/prestissimo-properties.rst
  - Add Prestissimo Properties Reference page to the Prestissimo Developer Guide documentation :pr:`22620`.
- #22652 (Author: Kevin Wilfong): array_join adds an extra delimeter if the last element is null
  - Fix array_join to not add a trailing delimeter when the last element in the array is NULL. :pr:`22652`.
- #22661 (Author: Feilong Liu): Revert "Add histograms for optimizer cost calculation"
  - Fix the latency regression for queries with large IN clause.
- #22665 (Author: Steve Burnett): [docs] Add PR number to the release notes entry
  - Add PR number to the release note entry examples in pull_request_template.md :pr:`22665`.
- #22681 (Author: Feilong Liu): Broadcast join if build estimation is small and from HBO
  - Improve session property ``property-use_broadcast_when_buildsize_small_probeside_unknown`` to do broadcast join when probe side size is unknown and build side estimation from HBO is small.
- #22700 (Author: jaystarshot): Fix cte filter pushdown wrong results by splitting SpecialFormExpressions
  - Fix wrong results when queries using materialized CTEs have multiple common filters pushed into the CTE :pr:`22700 `.
- #22715 (Author: Jonathan Hehir): Documented noisy aggregate functions in new page
  - Add documentation for noisy aggregate functions at :doc:`/functions/noisy`, including :func:`noisy_approx_distinct_sfm` and :func:`noisy_approx_set_sfm` (:pr:`21290`, :pr:`22715`).
- #22717 (Author: Steve Burnett): [docs] Restructure and expand presto_cpp docs
  - ... Improve C++ based Presto documentation :pr:`22717`.
- #22733 (Author: Zac Blanco): Support format arguments in EXPLAIN ANALYZE
  - Improve :doc:`/sql/explain-analyze` statement to support a ``format`` argument with values of ``<TEXT|JSON>`` :pr:`22733`.
- #22737 (Author: aditi-pandit): [Native] Add support for bucketed (but not partitioned) tables
  - Prestissimo support for CTAS into bucketed (but not partitioned) tables pr:`22737`.
- #22753 (Author: wangd): [Iceberg] Refine the partition specs that really need to be checked
  - Improve the partition specs that must be checked to determine if the partition supports metadata deletion or predicate thoroughly pushdown :pr:`22753`.
- #22762 (Author: kiersten-stokes): Update `io.jsonwebtoken` artifacts for Java 11 compatibility
  - Upgrade io.jsonwebtoken artifacts to 0.11.5 :pr:`22762`.
- #22764 (Author: Swapnil Tailor): Add support for memoization to resource group state endpoint
  - Add support for memoizing in resource group state info endpoint. This can be enabled by setting `cluster-resource-group-state-info-expiration-duration` to a non-zero duration. :pr:`22764`.
- #22765 (Author: Feilong Liu): Log detail name for optimizers of RowExpressionRewriteRuleSet and StatsRecordingPlanOptimizer
  - Improve logging for RowExpressionRewriteRuleSet and StatsRecordingPlanOptimizer optimizers to include more information :pr:`22765`.
- #22769 (Author: Feilong Liu): Record estimation stats during query optimization
  - Improve the estimation stats recorded during query optimization :pr:`22769 `.
- #22783 (Author: Ge Gao): Support functionc call rewrite by Presto Verifier
  - Support function call substitution based on the specified substitution pattern passed by the parameter --function-substitutes.
- #22799 (Author: Fazal Majid): added docs for noisy_approx_set_sfm_from_index_and_zeros
  - Add documentation for :func:`noisy_approx_set_sfm_from_index_and_zeros`.
- #22806 (Author: Linsong Wang): update to build native docker image
  - Update CI pipeline to build and publish native worker docker image :pr:`22806`.
- #22809 (Author: Andrii Rosa): Allow configuring driver threads based on the number of cores
  - Improve configuring worker threads relative to core count by setting the ``task.max-worker-threads`` configuration property to ``<multiplier>C``. For example, setting the property to ``2C`` configures the worker thread pool to create up to twice as many threads as there are cores available on a machine. :pr:`22809`.
- #22851 (Author: Ajay Gupte): Connector changes for time travel BEFORE clause.
  - Add time travel ``BEFORE`` syntax for Iceberg tables to return historical data :pr:`22851`.
  - Improve time travel ``VERSION (SYSTEM_VERSION)`` syntax to include snapshot id using bigint data type :pr:`22851`.
  - Improve time travel ``TIMESTAMP (SYSTEM_TIME)`` syntax to include timestamp-with-time-zone data type :pr:`22851`.
- #22853 (Author: Feilong Liu): Skip hbo stats recording for nodes with dynamic filter
  - Fix HBO to skip tracking of stats for plan nodes affected by dynamic filter pushdown in presto cpp :pr:`22853 `.
- #22885 (Author: Steve Burnett): [docs] Add Presto C++ config properties doc
  - Add :doc:`/presto_cpp/properties` documentation :pr:`22885`.
- #22888 (Author: Rebecca Schlussel): Remove deprecated feature group-by-uses-equal
  - Remove deprecated feature and configuration property ``deprecated.group-by-uses-equal``, which allowed group by to use equal to rather than distinct semantics.
- #22917 (Author: Rebecca Schlussel): Throw exception for cast of nan and infinity to int types
  - Fix cast of NaN and Infinity from DOUBLE or REAL to  BIGINT, INTEGER, SMALLINT, and TINYINT. It will now return an exception with the INVALID_CAST_ARGUMENT error code. Previously it would return zero.
  - Fix CAST of REAL values outside of BIGINT range to return an exception with an INVALID_CAST_ARGUMENT error code. Previously they would silently overflow.
  - Change error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from ``NUMERIC_VALUE_OUT_OF_RANGE`` to ``INVALID_CAST_ARGUMENT``.
- #22918 (Author: Steve Burnett): [docs] Improve README.md and CONTRIBUTING.md
  - Improve README.md and CONTRIBUTING.md :pr:`22918`.
- #22926 (Author: Denodo Research Labs): Disable timestamp with time zone in create, alter and insert statements
  - Disable timestamp with time zone in create, alter and insert statements :pr:`22926`.
- #22958 (Author: Zac Wen): Upgrade Alluxio to 313
  - Upgrade Alluxio to 313.
- #22960 (Author: Nikhil Collooru): Propagate runtime stats to page source provider
  - Add runtime stats as parameter to `ConnectorPageSourceProvider`.

# All Commits
- 8380fe3f6051dc9d3257e0ec97a130d5607a83a9 [native] add entrypoint script into native worker docker image (Linsong Wang)
- cfd99caffcd6b1fd403ec22d7597fe367ada7ccf Fix hash calculation for Timestamp in HiveBucketing to be Hive Compatible (Ke)
- 4818d3ca8c74bfef35e75441a70cae238fad789d Fix comment for Timestamp in HiveBucketing (Ke)
- fa3c606a426a86b381b80528d91244bfcbcf2324 Update Jenkins pipeline per dockerfile name update (Linsong Wang)
- d2b2a11f31d8e04ac108572659343242c13accb2 [native] Update dockerfiles to use Centos9 (Christian Zentgraf)
- 8374c2564cf913d362ed8561a3392ebc2108d373 [native] Advance Velox (Christian Zentgraf)
- 664d682a976ddcc36f179b3773bdca9a1eef9882 [native] Add sidecar system property (deepthydavis)
- 10143be627beb2c61aba5b3d36af473d2a8ef65e Privatize getExpectedOrdersTableDescription (Elliotte Rusty Harold)
- d7a9b0da52623024255e4594c2ad58ba3fd00e6c [Native] Add tests for windows with k Range frames (aditi-pandit)
- 1137a1f005e602054437cb68d7f96047b1e61111 Change native spill compression kind to zstd (xiaoxmeng)
- ed650510e5041df542b57eea0417bd70da10b4d5 Fix errors in doc build (Steve Burnett)
- f876f179cf6fbd7f30a00db42efebed6308b3aa5 Change confidenceLevel from boolean to Enum (abhinavmuk04)
- e0dac35a549cd14c2fdba1c703cfcb29fe44c867 Format inside method (Elliotte Rusty Harold)
- 257914184c2d71d8ccfad679d267465f87ab8ed6 Propagate runtime stats to page source provider (Nikhil Collooru)
- a795025f3c63e49fa7f5ca101f3eb9cada234539 [Native] Fix comment in AbstractTestNativeGeneralQueries.java (aditi-pandit)
- 3d06a01ab54f287331975bd6a2f2cdf34aee9529 Fix comment for Timestamp in HiveBucketing (Ke)
- fb2a314d82547da27a6290f166d99560c50392ee Add Presto C++ config properties doc (Steve Burnett)
- d428575adaf5c5b447b4d974fe24df66f0fbe2cd Increase timeouts testLargeIn tests for TestIcebergDistributedNessie (Zac Blanco)
- 8a4bdc42dfbe8bb73c671889b0b44bfbbdbeafd3 [native] Add support for convert VARBINARY filter to velox filter (wypb)
- 0504500329d64b300d9b3318a26f82c62f74fc2f [native] Fix location of TREAT_WARNINGS_AS_ERRORS (Deepak Majeti)
- e7dc3a5cf92e4f537e1fd2ed7b2bd921d21d2091 [Native] Advance velox (Karteekmurthys)
- 42c7dbb9721815b809645ba53285950191050fb1 [native] Remove unused include. (Amit Dutta)
- ccde456e7638a37f0a883d509a6caf1f26240a08 Revert "Use File directly" (Abhisek Saikia)
- 46c6e3b2a9f635359a3b223a7b25adaaa002cec1 [native] Minor cosmetic fixes. (Amit Dutta)
- 6cfdf44f4eb90b2188611c5b3b6bed17a7695daa [native]Remove the unused spill config (xiaoxmeng)
- b66b25b22d51ad93fcde9a7979a0c28903750e50 Upgrade Alluxio to 313 (Zac Wen)
- f661a1ce171a58697030f09c870c013a252ff55a Add execution stats to JSON distributed plan (Zac Blanco)
- b05a670fd325492aaf2e4d0065f3fb8b7791a0c3 Remove redundant unreachable branch (Elliotte Rusty Harold)
- 592053764e33cb3fc76e8cac6c5be2cb84abb0fc Prefer isEmpty (Elliotte Rusty Harold)
- 8f8784983022613249785a0f9d7f3890bc24637c Fix flaky test TestHiveSplitScheduling (Abhisek Saikia)
- 49f6566012bc67d9c06e48e74e1d2d6b4029b6e1 [native] Update CI image to latest (Deepak Majeti)
- 68366e0b71b97cc6137e2f1dc20bcacaa894c070 [Native] Advance Velox (aditi-pandit)
- 8828bcbeaba2335d4520632f87bcd9d9c73d48f8 [native]Correct the cumulative memory usage calculation (xiaoxmeng)
- eca969ca972e4e6893c04df0a243d8248f0f9dcf Disable timestamp with time zone in create, alter and insert statements (Denodo Research Labs)
- b67366892b06a3c9ba76730876178c85c6e9479a Add documentation for handling of NaNs (Rebecca Schlussel)
- 8493792e1937742e783b83030ad48cd5349c9d42 Add tests for join and distinct with +/-0 (Rebecca Schlussel)
- 38b99f9138268bf01ad7c1cc3c53d3d2a898d64c Set use-new-nan-definition to true by default (Rebecca Schlussel)
- e64a504ec21a955fde97c1ed26d5e9a69d3d1771 Fix Greatest/Least for new NaN definition (Rebecca Schlussel)
- b17a91676b7ae0ff5f52555c3a95875d544acae1 Fix array_min/max function for nans (Rebecca Schlussel)
- 984749a0a84a8554fb255bbea11667da1caf96a5 Support new nan definition in dynamic filters (Rebecca Schlussel)
- 49d7d3cc9bdfd26fc2bdb9ba210ef81aada90cb3 Change equality defintion for double and real types (Rebecca Schlussel)
- 6ee846e0319ef869ca51348e00d8cc4ed13ec474 Add support for new nan defintion to tuple domains (Rebecca Schlussel)
- 554f1c2931708f0b473a57c7a5ba117eba2c126b Add real operator support for new nan definition (Rebecca Schlussel)
- aa5de0c3ffcbab531d95ed6409bc635681272831 Add double operator support for new NaN definition (Rebecca Schlussel)
- 0b48e00281e50006bc0e61a8e78739dbf9286336 Add nan definition field to DoubleType and RealType (Rebecca Schlussel)
- 8f122fc5613013bf0eed7bbf704d648759b87290 Add property for new nan behavior (Rebecca Schlussel)
- d19a9624cc96553271aa5952af8de2fc34b4ac7d Removing presto-ui dependency from presto-jdbc (Swapnil Tailor)
- 1280be0e7fb0878746aa7473c112342133daec43 Rename isParent to isAncestor and expand failure message (Elliotte Rusty Harold)
- 635335be41bb3570640be3acb97e8120c8a5771c [native] Add support for bucketed (but not partitioned) tables (aditi-pandit)
- d899bc022e3220db70c13fa039950e4b9eb4d21c Add table for users to quickly navigate documentation (Emanuel F)
- c254d194e5151d1b01ee276001372f0f229191f1 Remove fields from PlanFragment task serialization (Zac Blanco)
- b8f5d44bef25ef57c45602eae87226e4900d11a2 Treat buffer as completed if no more pages (Tim Meehan)
- b5b0dd8464fb10f8a31eab4a6814c49dc6cdad2e Throw exception for cast of nan and infinity to int types (Rebecca Schlussel)
- 7dfd981aecc90a89b14554b4156eeb0b8579739a [native] Add floating point aggregate tests with NaN (Christian Zentgraf)
- 12cdad5321a340da302796362c72f756b0020721 Add compression codec in Iceberg table metadata based on file format (Reetika Agrawal)
- b0832d2fd84939e3d11ab0c064493fcfeb7499a7 Fix DROP SCHEMA doc (Steve Burnett)
- ab3bda7ab21ab22da1dc60eee301fabaa12ae434 [presto_cpp] Transfer idle HTTPSession between IO threads in exchange source (#22903) (Jimmy Lu)
- 65224e80fbe81b89de55bc67847b57a5787282dd Improve ARCHITECTURE.md and CONTRIBUTING.md (Steve Burnett)
- bae05b8a29f370c6335dd68e1cd1b10f7c1ce823 Correct BuildIN to BuiltIn (Elliotte Rusty Harold)
- 4245844a1ae62a2fa6af84f40ee85663cef95b1c Connector changes for time travel BEFORE clause. (Ajay Gupte)
- 001342ae3e259e0d8525a949b375b032e124634f Add boundary tests for Page (ymmarissa)
- 944b67c759ac9a93e76b18f0a1154573708b4950 Remove redundant code (Elliotte Rusty Harold)
- 32c9f930d7ffa825f26da9f6915063fd98c86135 Skip hbo stats recording for nodes with dynamic filter (Feilong Liu)
- 09685c86be0c467923c362d73552a059c58dabb3 Improve README.md and CONTRIBUTING.md (Steve Burnett)
- 36f7d6211d54a4c7a688989dcf14a2bc81fdbcc2 [native]Advance velox version and update memory usage (xiaoxmeng)
- 7443f83a9ab9f6795b0664ca88ca13d4d5920e57 Improve Metastore Metric (Konjac Huang)
- e2ec28f6ebca39357bed856441f66aebce9b2667 track directory listing time (Vivian Hsu)
- cf900974ac14b553aecbabdf268961ef00214315 Remove redundant aray initializers (Elliotte Rusty Harold)
- 07c1b339ee66837fa2565708d5af1a87ea29d199 Add documentation for AWS Security Mapping (Jalpreet Singh Nanda (:imjalpreet))
- e5e6615b590ec2df255b1e61f587321ab536908b Implement DynamicConfigurationProvider for AWS S3 Security Mapping (Jalpreet Singh Nanda (:imjalpreet))
- 134c888a5c2e8edc678de521bd6c1406dc499fcf Introduce AWS Security Mapping (Jalpreet Singh Nanda (:imjalpreet))
- 3492b98a59d9579c87e9e8dae3a1f3245af03699 Add option to set identity when creating TestingConnectorSession (Jalpreet Singh Nanda (:imjalpreet))
- 39e11a50462794c0f63a5dce70faa033060b6f21 Gate histogram calcs by session property (Zac Blanco)
- f87af00a462bbe4cce5e72af9af980732c69ba43 Fix optimizer performance regression for large IN (Zac Blanco)
- 1e0648e4638775fb53b83c3e7782b4ac2d18a1f4 Add histograms for optimizer cost calculation (Zac Blanco)
- e6f5d08b8c12a641eb7f449b6cf6b6f72e5994c1 Add Presto community to ARCHITECTURE.md (Tim Meehan)
- 232bb3c6ca696d09eb85ad35e610c71d5398bd8a Use virtual bucketing for temporary tables (jaystarshot)
- 37c9f33278aa1dd97b599bed83d65f3c6995999b Remove partitioning flow for cte materialized tables (jaystarshot)
- 3e0fad05cc647403c011c095489ea65a265af857 Fix header formatting (Steve Burnett)
- 1b491ba2495ec65c33f3426b3530032b398cd3d7 Remove some vestigial warning suppressions that are no longer needed (Elliotte Rusty Harold)
- 36d289dde43015cb4f6885dfc917a6f13104badb Update Resource Group Documentation and remove erroneous information (Jalpreet Singh Nanda (:imjalpreet))
- 86b31361287f3e395f8639ee14cef05f3215607d Fix issue when initializing DB based resource group manager (Jalpreet Singh Nanda (:imjalpreet))
- c18caf92f5c2fba64366b1b10860c6388abcf312 upgrade based docker image to centos:stream9 (Linsong Wang)
- 56f22ce1546a1eba93e829f7d7c6bcf79399d5b6 Update docs theme to sphinx-immaterial (Zac Blanco)
- 6661c825a2f525f7d9f4479c87fdc90d1fbee067 [native]Remove access to current bytes in memory pool stats (xiaoxmeng)
- 726a428b2a3dbe777ac061e98dc734b770ed17c0 Fix CVE-2024-36114 about airlift/aircompressor (Linsong Wang)
- 9c57e73126420aeb7ec2cbeb0f25238599740eef Remove deprecated feature group-by-uses-equal (Rebecca Schlussel)
- c3600f77444d19245b5d635d8c1174c883d4118d [Native] Advance Velox (Karteekmurthys)
- db359e340efb620c618e385135c859aa3429ceac Improve MathFunctions error descriptions (abhinavmuk04)
- 1f2325631512423e3381af8f018c2a65b5ba20d0 Use File directly (Elliotte Rusty Harold)
- 4a52dc27e78d37c25b5fd72d9be04da4f02046f4 [native] Register ssd checksum configs with default values (Zac Wen)
- fea27e05f4712fce1a727f3de2caffe409a2133a [native] Adapt new async cache config (Zac Wen)
- 6514b46811c76681d25d7b57e8d6257553086a22 [native] Advance Velox version (Zac Wen)
- aa59cc129159451c69cbfdaa416dd9d154ee8dc8 Add file read count to runtimestats (Vivian Hsu)
- 72a9d58fecebe3953d694a31f5ed301afb35bd23 Update CONTRIBUTING.md for presto-ui module (Zac Blanco)
- 20feab7cbb9fbb82366329b8107e8366f3aa2f37 Allow disabling UI module dependency (Zac Blanco)
- 3cd2744c18a8c8edf8df745d19ed3baa0383b8d1 Remove Metadata from RowExpressionInterpreter (Tim Meehan)
- 7659fe4bccd4962e402796127254623b7415591c Fix CODEOWNERS (Tim Meehan)
- 33d94e8582e6fda4e934f2bfe97d5e154e269c77 Abstract client info for internal and external use (Yihao Zhou)
- ab51711bcb1d548a9e5d14a52ef9761fdf13c477 Remove unnecessary use of final on private and static methods (Elliotte Rusty Harold)
- 3cb1e6f2e6372b748498a36e2afec8777355edf7 Allow configuring driver threads based on the number of cores (Andrii Rosa)
- 93b44ae6f61bcbbd464ea2972bdf460d5229bcdb Remove redundant semicolons (Elliotte Rusty Harold)
- b465e70c352d4c9a474fbe19713a1a2d9e4b12b4 [Native] Modify setup-adapters.sh to install prometheus-cpp (Karteekmurthys)
- 6f0cdfadd40a0ba1e681dd45f8bad315b5780bb5 Prefer singletonList (Elliotte Rusty Harold)
- a734f4765cf213a3f91bab04dfe5fdb0ab167b1e Improve query assertion message for mismatched types (Rebecca Schlussel)
- 0a40a0b76a660413f8f68d4f856aed0b7a031e4e [native]Update Prestissimo to report the actual used task memory (xiaoxmeng)
- 853e56fea6fc6665de2d85710d3be4cdd70cc528 Fix array_least_frequent docs and formatting (Rebecca Schlussel)
- 1b33172d4b594d0720162ee9a65bd36732eb73ea [native] Install Prestissimo adapters in the dependency image (Deepak Majeti)
- 0a0ac8f8f305e42bf53369eb8199cd1187a6ee8c Access static members in static fashion (Elliotte Rusty Harold)
- 88bc1c38ae2c0809c99c2cd903f676288d220204 Remove unnecessary conversion methods (Elliotte Rusty Harold)
- 88e5c777460bb0d2bb14a603b58254313d76ac19 Move the description of Iceberg procedures to a dedicated subheading (jackychen718)
- 0ed56dad3e2a580a482540feee8b980942a08e59 Fix issue with missing encryption information (Abhisek Saikia)
- 10b83319d29615aa89f373546879d9f241553aba increase agent size (Linsong Wang)
- 9474cca9d75880034aaf21d33fb4f79a64429253 fix var name (Linsong Wang)
- 594351b9784205f90ff04904bca6d790e1c6224a Build native worker image (Linsong Wang)
- 9d21337508f51ba2bf3e3f4c73360ee62a7bd235 Inline single use constructor (Elliotte Rusty Harold)
- f3ac97fea1c7c96b2dff06cd7cf86be1842a4047 Support functionc call rewrite by Presto Verifier (Ge Gao)
- 831d5947b909fee0d5c0091a3246ddc5b31b2731 [native] Advance Velox (Deepak Majeti)
- 46405d0afc04360e56b1efbcef3444001bef5bd8 [native] update CI image (Deepak Majeti)
- bb51436f2f40fff1d69e8691b19c6d4604c4b00e [iceberg] Tag columns with partition info in DESCRIBE and SHOW COLUMNS (Jalpreet Singh Nanda (:imjalpreet))
- 262538007c6fe22e3c5576eba77d4a8f03e7e91e [native] Fix protocol::FileFormat::ORC mapping to use dwio::common::FileFormat::ORC (wypb)
- 56c61e4a3fda8f1dc5e0f5be9fd475fca2c27ffd Enhance FunctionCallRewriter (Ge Gao)
- f16032e9e395afc4576eea0337c74cbee3920569 [verifier] Avoid checksum of map values if possible. (Sergey Pershin)
- 98e941f5d81d4372e88dc166bb7e9c32b7220405 [native] Move optional node config test in existing ConfigTest. (Amit Dutta)
- e17d22de1b3238afc5dddf458d8181361f243bc5 [Iceberg] Refine the partition specs that really need to be checked (wangd)
- 887bc5bd214ed5a93d077eb741d30f23189ba64c Fix metadata delete/truncate on Iceberg table with delete files (wangd)
- fd2cd58560ee6ff02f5ee37cb2488d8540d1936e [native] Remove node.id from configuration (Deepak Majeti)
- cc0d1ef184fe1bfb3bffc6aa63f1b23887c4632e [native] Make node.id optional (Deepak Majeti)
- e7cf910fba71ba6d44485369eaeddc42ab19eecc Update drift version (Nikhil Collooru)
- 3582e9fa65d6c8ab61e4f1da20cc69ef46478165 Identify unowned parts of the repo (Elliotte Rusty Harold)
- ba8ce8504a2a0c0b07f3c4b8d3ed081d50e7b728 Re-factor Iceberg catalog implementation (kiersten-stokes)
- 7db640fe27055208f14715bd457bbce2d0280c5e Add support for REST catalog in Iceberg connector (kiersten-stokes)
- 865a6c9602b818dfe734e16b6895dd3b60a3baad Update CONTRIBUTING.md (Elliotte Rusty Harold)
- 9d5dab6478a2ee10f64aebf62d060966b1ef4b09 Upgrade gRPC and protoc version for aarch support (Zac Blanco)
- 154dcecf70576eb6f7d7b070d5499d80f0b295b3 Add .vscode to root gitignore (Zac Blanco)
- 69f8f1afec2c3412c7f55266e6c43d6ce8e2848c Record estimation stats during query optimization (feilong-liu)
- 584636f3f981ad64a116ac1faa43d3cae2e80b6e [verifier] Filter out limit-without-order queries only when not skipping control & checksum (Michael Shang)
- 968f9ad09e5115afc14552b5543ced74e046a883 Fix links in sql/revoke.rst grant.rst show-grants.rst (Steve Burnett)
- 4cd7bee84cf5c3a154273feb5eb37bc9b05d1800 Optimize NullIfCode (Sreeni Viswanadha)
- f365a2ca59ef93ab3396ac5022f80bb88bc751e9 Enable tests to fail (Elliotte Rusty Harold)
- faa3a55794b1c2b2b59e6299a9e8c2ccac8e0bc5 Add entry to parquet metadata cache on file modificationTime (Reetika Agrawal)
- cf0ac0733a940ff3fb36236fab73d14ba21686f2 Parallelize maven builds by default (Zac Blanco)
- b2585433eaf9eababa64f0f3ece76a8cc34f9b2a Improve modularity of presto-hive-common module (Abhisek Saikia)
- b4721ff1746f57204a93c81c7e2888aeeed83755 Rewrite sentence (Elliotte Rusty Harold)
- de8fb6693f969b2012791949b88c7395db931c4d Update io.jsonwebtoken dependency for Java 11 compatibility (kiersten-stokes)
- 29be8711ed6c06f56089723284ce1459d482b05d [UI] Preserve inlined JS scripts (Zac Blanco)
- a629a91b69f37646a63849218fd9cd6406a511b8 Optimize RowIDCoercer (Sergii Druzkin)
- 5f64ec833ed416de439bfbb08831e69636631bc6 Add support for memoization to resource group state endpoint (Swapnil Tailor)
- 27dc1878b4736e4bbffd3431a30595f50f235270 Fix links in admin/function-namespace-managers.rst (Steve Burnett)
- 614bb8389b34964bab7a62886bcd8b99c2eaa844 added docs for noisy_approx_set_sfm_from_index_and_zeros (Fazal Majid)
- 9d4c8053f30b607f011d9ca4f361eae2668de9d6 [native] Fix docker compose to allow debug builds and clarify README (Deepak Majeti)
- 99e10b447b1d717c82c0ed912e294c4c457d42af [native] Add description for supported architectures in README (Deepak Majeti)
- ddf6f39b8c9293b05864a01000d6bd8f26a71b2d Make Iceberg split manager threads configurable (wypb)
- e80152c74a5d2453116db2d173bafdd0db748c86 Recognize row IDs hidden in Hadoop partitions (Elliotte Rusty Harold)
- 83d3c2b678cf44c35cce6fc8cddf04ce2a85dc01 Move UI to a separate module (Zac Blanco)
- 665f62bbe906e14bf3453cff3b9cf9e3381b7040 Implement cache refresh logic after file changed (Beinan Wang)
- c6ffb83184cd2e81e7697ed3fae57b67b3b76982 Pull constant values out of loop and check  earlier (Elliotte Rusty Harold)
- 2ca805812c47c1296bef9c623391629e6cac76f9 Fix 0.287 release notes (Steve Burnett)
- d70fb90091ab4638e730e52eb6dab4faf1c19405 Update presto protocol for removing predicate in IcebergTableHandle (wangd)
- e73378b9babda6b0ef7995779c030781a2b5512b [native] Add spiller executor stats (Jialiang Tan)
- 6af662d92e5b0fa5b651db67dc00a747edb64bdf Add changes to HBO to work for CTE materialization (feilong-liu)
- 8aadabfea35e384885232bb4f1db405f7c068bbf Fix formatting in admin/properties.rst (Steve Burnett)
- eb135fce2a05dc694d65e463c675bfbf7ad36d3c Fix space errors in file (Steve Burnett)
- 568784e502c0573a185e714bf432db13be4cf3bb Log detail name for RowExpressionRewriteRuleSet and StatsRecordingPlanOptimizer (feilong-liu)
- 08eed5a00f4c4eabb2ad024552166f1e1bab0c53 Enrich MetastoreContext with clientTags (Konjac Huang)
- ea645633c11050bf673938e817b948c31486dbdc [native]Advance velox and update query ctx init (xiaoxmeng)
- a08f75c3fcb95bc80d52d3c10328a28bf053a773 Add data type limitations (Steve Burnett)
- f1f17de00eeede116b86f2ac19d551de2d4c48ad [native] Advance velox. (Amit Dutta)
- 5240412564458d1960d79a14139c58611dc686dc [native]Add native dynamic filter stats to operator stats for hbo (xiaoxmeng)
- fccc18014eed61aad8975d0edd110f463fa8d9b1 Restructure and expand presto_cpp docs (Steve Burnett)
- e3446354359b3446ad9c599955e0dbb58c043122 Denest if for simplification (Elliotte Rusty Harold)
- 2aa4d42de00d7bed4263cc88528fb04e650edc17 Add CTE Materialization documentation (jaystarshot)
- a1bc771c13b221054d23c005303513ae07eb4331 Fix installation/deploy-docker.rst header format (Steve Burnett)
- d86c011d24c5faf8ddda59af9fb7a4f63ba12fd3 [native] Improve build dockerfiles (Deepak Majeti)
- 941068b657f5fbe3d17005dc543b158a7ce249a8 [native] Cleanup Makefile CMAKE_FLAGS (Deepak Majeti)
- ae9b2b1559ae5c5d691cdd079729837a874ae192 Correct check for  column presence (Elliotte Rusty Harold)
- b64c64cb08601bb396ddb91082e6870da31c17d4 [native] Add dockerfiles for dependencies and runtime (Deepak Majeti)
- 760853dc131a38d394bef2a771c08d10e1f194c5 [native] Remove centos-container.dockfile (Deepak Majeti)
- 6784981d134016c45f3bdc9f48ac1e5537ddf9be [native] Remove release-centos-dockerfile (Deepak Majeti)
- d8376e1588d22d6fbb430709073c6d0c087ed5a9 Documented noisy aggregate functions in new page (Jonathan Hehir)
- 6c682f5183498334cada2de8979c4084719b77e9 [native] Remove spill stats reporting from presto native (Jialiang Tan)
- 20f6640230d1df37f8032f948a302c22ee40134b Optimize join when build side is large (Sreeni Viswanadha)
- 87e201c8700b8a7177782e9b6c2244e5ed837bc8 Optimize Metastore (Konjac Huang)
- 21e301c6a1f708209ecc7deb9f36ff38fcc2aa0e Support metadata delete with predicate on non-identity partition column (wangd)
- d8d60a9983635fe2a4e21064f81ec34002865e8b BEFORE syntax support for presto engine. (Ajay Gupte)
- e484062f3525be54d03290d23e10147e218c74c4 Fix ValuesWriterFactory in ParquetReader thread safety (wangd)
- 5f2afc97f8cdc39b93e4a3569afdf912bdc8a3c9 Remove predicate in IcebergTableHandle to clarify the responsibilities (wangd)
- 1863d80cea920a69d8222c58c6c0f991d8354c3a Download node binary in GH action (Yihong Wang)
- b15f0c50b38c03257b5831d6d362491a943c5f29 [native] Introduce lastCoordinatorHeartbeatMs to PrestoTask. (Sergey Pershin)
- 9b9a516f10a3691d8ba3f4f4f32d2f24c68c70cc [native] Enabled two temporarily disabled tests. (Sergey Pershin)
- fa62d71a515d4050cac22459dec86ca7cefd54fc [native]Make prestissimo monitoring compatible for new blokblocking reason (xiaoxmeng)
- ecd2afac8dfc99808c30fa92acd21a316da3afeb Remove unused import (Elliotte Rusty Harold)
- a9bc7c3e0a6f5abe74d6a55fc68e9b7e0a8a91e6 Prefer Java 8 StandardCharsets (Elliotte Rusty Harold)
- 81f67a9fda1da9bf3074a29ee28dd8561589cc97 Update connector/hive.rst for hidden metadata columns (Steve Burnett)
- 00655a05f7a28daa74285428ea9aa9a96a53f4aa [native] Remove memory related counters (Jialiang Tan)
- d9114d38bcc7f07e8e6471f686e71e278ab6ec8a [native] Migrate away stats reporting for allocator and cache (Jialiang Tan)
- 9c82b1e861f6fd882607ea8e87a1f51e2db65f80 Broadcast join if build estimation is small and from HBO (feilong-liu)
- bd3ff3b019bad8b40461872d686875d35151d388 [native] Register Velox hive connector factory for iceberg (Deepak Majeti)
- 34ea5550e98aa4b75923b31439dacea8333ecf37 Remove unnecessary multiplication by 1.0 (Elliotte Rusty Harold)
- 8e34250ac1e0a2f6fb5d08a2842a7d3b5cd95db3 Fix cte filter pushdown wrong results by splitting SpecialFormExpressions (jaystarshot)
- 6c2f50d86a44beb67d74b40d610be3f1f3d0c421 [Native] Remove duplicate call to registerStatsCounters (Karteekmurthys)
- e61f5af0c0aa229fa7c2578539ed44b08a07d82e Add configuration to set metadata optimization threshold for Iceberg (wangd)
- d43b6f81151849fac4f9d65e420accba945cd171 Fix TimestampType/TimeType values when get partitions for Iceberg table (wangd)
- c4e1d8a085908e41539951cfad332bc6bf17ea72 Support partition based metadata query optimization for Iceberg (wangd)
- fdb057268bbeeedd3133050cde93491cda171d7c Add client tags to directory context properties (Nikhil Collooru)
- cd3ef2b5887f8f85d0ae647243df2d86b4b94270 [native] Advance velox. (Amit Dutta)
- b53953f381939df1c8644b6c67538fcc91aee420 Remove buggy, unused code (Elliotte Rusty Harold)
- 185876fab2f8aa2ff5caf2a9da6284a9c227c9c4 Clear out some dead code in tests (Elliotte Rusty Harold)
- 8de66c49da83b483eb225363c9685c8fd6453f41 Correct format argument misalignment (Elliotte Rusty Harold)
- f78f6f1da1544a9b7178a08dcf6b049213d52ce4 Support procedure `expire_snapshots` for iceberg (wangd)
- 913537144b66d783c4300386c17bbae8b92041dc Move iceberg procedures and tests to package `...iceberg.procedure` (wangd)
- ea6375e53774e63bf2b8b589aee9b45c157161b6 Fix hashcode bug (Elliotte Rusty Harold)
- 152f962e11895d215ff4e184e2bcbd7ef15eaab0 Add Presto Mission and Architecture doc (Tim Meehan)
- 0f21fe560e0da5e5f275510b4b1e02e4cdf47ac4 [native] Remove arbitrator stats reporting (Jialiang Tan)
- bc29df761819ac03e6cb582a92ccb206f01e617a Delete CODENOTIFY (Timothy Meehan)
- e51d1b1cf931a75a17b54fcae62c1084b794beeb [Iceberg] Add predicate in layout without pushdown_filter_enabled (Zac Blanco)
- da86cbe73d12e96d1ffddb5cc99e8e88402a1861 Collect data size statistics for Iceberg tables (Zac Blanco)
- dde7abeaa55c74436b420ea7d6b091d37485cd55 Add functional-style methods to Estimate.java (Zac Blanco)
- 12a6e44f1104c96dcefabf5e1f7d8d02d3369379 Fix toString() and hashCode() in relevant parse nodes (Vivek)
- feac167bbe0c842bde410cb637b8ea3df67aacfd Add documentation for NOT NULL constraints (Vivek)
- 785ece64987d21d465ee66731e0d39282754e9bb Add DDL support for adding or dropping NOT NULL constraints (Vivek)
- 142a7045c7134ca0d03b052b1ec3d746ab67ee41 Support create table with not null constraints in the Hive connector (Vivek)
- 2da835f841b0a906e0557f2e406793eb7c693cf3 Remove ordering restriction on constraint specifications (Vivek)
- 80ac01654ca9cd6b9dbca6572f651832c21a45b3 [native] Remove velox.properties file from e2e tests. (Amit Dutta)
- 374bc4b800f7e1ccf791e15d75735729d42f9fbd [native] Move static functions from PrestoTask to Util. (Amit Dutta)
- be20d299ed0a45981eac78d652f4e783fc46f09d Add PR number to the release notes entry (Steve Burnett)
- a9790c36dee00230af82d42f1ca1c9bb317fe9d0 Fix testQuickStats in TestParquetDistributedQueries (feilong-liu)
- d3d28c05388f112022d931cf876b86f32c267c68 Revert "[Iceberg] Add predicate in layout without pushdown_filter_enabled" (feilong-liu)
- 30cb3156ca9f7f782c64f56c44d0cb72aa180413 Revert "Collect data size statistics for Iceberg tables" (feilong-liu)
- afded7303282c21a687b9f4cba65253e4a4bf098 Revert "Add histograms for optimizer cost calculation" (feilong-liu)
- 943db5141c15b9ddeb163a4ecaebc2baecaa33fa Add feilong-liu as optimizer codeowner (Rebecca Schlussel)
- ea97263e5730743d8e8b99ad2412780191b931cd Add prestissimo/prestissimo-properties.rst (Steve Burnett)
- 2381d19bdc0b59b2730503193ab00cd5fd0c203e Fix array_join adding extra delimeter if last element is null (Kevin Wilfong)
- cc0726ec171d641d5a9c334f8e08d4d5cd6dc8de Add Support for non default keystore and truststore type (Nidhin Varghese)
- 8081e0c29693c8c12543ded89c77bf21d1aede3d Add row IDs to batch reader (Elliotte Rusty Harold)
- b0c575e5902f5cf7571d0be6ea718abfbca65ba5 Add link to develop/presto-console from clients/presto-console (Steve Burnett)
- 7b4d906c805cca251e52acd8763cdb01a9e0318d [native] Report number of evicted ssd cache regions (Zac Wen)
- f32f310a641371e069ce122016d7ea993eafc2b2 [native] Advance velox version (xiaoxmeng)
- 9bf3e3a182cf8e6f0f254adb6008b7e3fce3415e Generate JS files using Maven (Yihong Wang)
- 12eb85df1d673af2c85338309d292e07945e4156 [native] Advance Velox version (Zac Wen)
- 902c4267330a51f345eb1eebbef0fa380f94c69d Manage j2objc-annotations 1.3 (Elliotte Rusty Harold)
- 48d7496979b6c6f3a3b771b539588f67a227a931 Make constrcutor package protected (Elliotte Rusty Harold)
- 0edb84cc8e2f825e257c558143edca1e154f8a72 Enable SqlServer product tests (Reetika Agrawal)
- 8de7541bf9c4f2c24a1df89c6bb17e9511254107 Remove '-b multithreaded' from .mvn/maven.config (Sergii Druzkin)
- e5316220db0aae034b03eb84b903da66c51268fb Remove more Maven dependency loading log cruft (Elliotte Rusty Harold)
- c209f5069461aba1f3e6fb527dcdbb9f193322f3 Improve KLL Sketch perf for non-grouped queries (Zac Blanco)
- b2d45321d62bcd8e19cefa131dacc82dcbe59a6a [Iceberg] Add predicate in layout without pushdown_filter_enabled (Zac Blanco)
- 12ff6d98903b11d8dd90b59d2f97f80cfcd37caa [native] Temporarily disable two unit tests. (Sergey Pershin)
- 83a135945ca49018a78da8e04a75246b378488bd Add a doc page for Web UI development (Yihong Wang)
- 16fe817055949e149db8bed824d8ac066255c118 [native] Switch from old Task::create() API to the new ones (Jialiang Tan)
- 2611ae97a24aa3e0394959581f02cc67bf852f95 [native] Update readme and centos script (Christian Zentgraf)
- affd83e66e35f3a1f93fd1b64440794d491eead4 [native] Add functionality to cancel abandoned tasks. (Sergey Pershin)
- b62e37fcfa1717a8e50414564a04257f177d83aa Correct precondition messages (Elliotte Rusty Harold)
- 775ef4d7f8452d884610d66305dc00dafb2b82f5 [native] Add reserved memory capacity configs (xiaoxmeng)
- fd6f819ee527ea590f73e4b41a252e013e185b4e Adjust split weights by actual data read (Pranjal Shankhdhar)
- c437ea4daa06c1e7cc73137e16b58bcbc22d68fd [native] Improve Zombie Tasks logging. (Sergey Pershin)
- 6b439240859a4f14506af45a3b6a9a6aea640da2 Create a single-page application for Query Viewer (Yihong Wang)
- 8b7463f7867a9c24b40a50e8a718e1a5723a74a8 [native] Advance Velox (Christian Zentgraf)
- 1d27c73acd1546718376281249f32b97bbc66abb Update error_prone_annotations to 2.3.4 (Elliotte Rusty Harold)
- 4bd198a34559d87b92f6dd0a1e366a6ec5367dc7 Fix regr_r2 result incorrect (8dukongjian)
- aeaa0b759cc6cc3c0c3c2093c0a197a88ed493f9 [native] SystemConnector to query system.runtime.tasks table (aditi-pandit)
- 9a20c79fffbb204c05e2894d86b27c6b39094b39 Revert "Revert "Preserve case for RowType's field name and JSON content when ``CAST``"" (wangd)
- fdc97c1b8b2b6a3d8226484191becdcd6e90b498 Casting strings to integer types allows leading and trailing spaces (Steve Burnett)
- b4af7c40696e797b4262dca4b41b1893bc65850e Update the plan viewer page (Yihong Wang)
- 12f1ae6e9a7b5edfe8f56d3d75b0f18b4563b1d3 Make number of preferred nodes configurable (Andrii Rosa)
- 62d9641d15f55306cb627c404c8383bd0bfdc509 Prefer more semantic assert methods (Elliotte Rusty Harold)
- 5cf685a714b71ac78602b50a866726c0e6cba518 Remove some unreachable code (Elliotte Rusty Harold)
- 522e095649344d02ffccebb7151f597f5ee5ed8d [native] Add position delete tests with native iceberg connector (Jalpreet Singh Nanda (:imjalpreet))
- 9c13a6a8526828efe69bc18bed5ae37b82372bee Revert "Preserve case for RowType's field name and JSON content when ``CAST``" (Neerad Somanchi)
- 369f9d32ccbe6c6005b8d839dbb43d447e9e918a Support authenfication when allowForwardedHttps is true (Wills Feng)
- 73334fa179d0519e8faf6722e85ec248fe4ec880 Update clients/presto-cli.rst with --runtime-stats (Steve Burnett)
- e1d2f220bc21e0862bb2043f34e215a4be3a3135 Add --runtime-stats option to CLI (Emanuel F.)
- ff5282e221b461d4e9f9662c0f264cba09211f84 Allow different scheduling affinity for different sections of a file (Andrii Rosa)
- e687113205634214172a70fb2673f1477c47aeda [native] Fix setup scripts to align with Velox setup scripts (Deepak Majeti)
- 656d95a848c52cb35d147b4d198d9ec97c6372dc Construct row ID block in OrcSelectivePageSource (Elliotte Rusty Harold)
- 3264bf13ed47bc1b55f7044fb47d2a55c24ca46b Remove unused copy pasta (Elliotte Rusty Harold)
- 17a6feb04aa8a21eb084d862f0dcc1b22845b794 Fix assertSorted (Elliotte Rusty Harold)
- 6d052a370de78d8e0be798453bbd5f606d2f956d Remove TestingHiveStorageFormat (Tishyaa Chaudhry)
- ef3d47af8a455ef4ee8a39862d0077b6daa678bb Replace deprecated and removed GUava immediateCheckedFuture (Elliotte Rusty Harold)
- 0c15315cf70aaa4dd30fa864a4adf1d97a013cb7 [native] Remove old legecy code of temp directory (xiaoxmeng)
- f697be7a5fd51b957598c979b10e7a51b0c3f6eb [native] Advance velox and remove an unused variable. (Amit Dutta)
- 65b0ecc0378baa214fcb30e501c95c1636e26511 migrate use-cases of makePromiseContract to structured bindings (Yedidya Feldblum)
- 343534e17a489f9aac344d9f76b4a6841f734a83 Report number of checkpoints read/write (Zac Wen)
- adc3503d076efc4e475b35c0d865209d03ad1361 [native] Advance Velox version (Zac Wen)
- 71ad56f82a07e30059c36404ba8a2fddb9e0ae74 Fix analyzer for lambda in aggregation (feilong-liu)
- d2b2ae9cf392b8ce1a2ccf0276a160e593e1aab0 Fix TestUnscaledDecimal128Arithmetic#testHash (Elliotte Rusty Harold)
- 45387f9956eb899a93b96eaccf73b239102ee3fe Fix pre process metadata call (Konjac Huang)
- 219196b8bf63654e3fcf97ffbc93ff24f2f659bd Remove methods that override identical methods in the superclass (Elliotte Rusty Harold)
- 7e03528af612ce7cdcaccc671c2b826c8653594e Remove duplicates from sets and map keys (Elliotte Rusty Harold)
- c92795c5366d31e7189000e3c1277eaf60482bc3 Write full metrics of Delete files (Reetika Agrawal)
- 0f443ef707503a6c6408db7e08b05c96d5f3963d [client] Add support for SphericalGeography type in the client. (Sergey Pershin)
- d5516a27b01115a6f735163d5c6c6c37920551bd Use murmur hash in ModularHashingNodeProvider (Andrii Rosa)
- a955a8e6aed93d1fdfd93ad8a2d2baaf75eb375f Add @jaystarshot as codeowner for presto-tests (Tim Meehan)
- b05771916b12f91c62162f8e2a27662c6e7f009b Add @sdruzkin as codeowner for Hive ORC readers (Tim Meehan)
- b398569c2f3f3f299aa6736b819a389582410c87 Don't use dynamic schedule if some scans are ungrouped (Rebecca Schlussel)
- 491243bd6eff77973ce4e538e29b9171a1278877 Add more debug information when node not present (Rebecca Schlussel)
- 486565f893cbb0ef2aa47f69103292e4620b4d4e [Iceberg] Use isIdentity to check field transform (Zac Blanco)
- 174cc2d0c0a2f967934b8c54a49f225b9393a6be PRESTODB-22502: Remover OrcSelectiveRecordReader.close (Sean Yeh)
- 19ea95b7dd07038aeeb10b2964d568a0c0a9ae51 PRESTODB-22494 (Sean Yeh)
- 3df4e8aa97c9126a5b6cfc3a5c96e6557d583014 PRESTO-22502: Removing close method (Sean Yeh)
- 8418e30c454d8a33928b94783f4e28d3363ce45b Remove unused private method (Elliotte Rusty Harold)