### PR TITLE
Make TestNodeMemoryConfig success independent of running heap size

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
@@ -25,20 +25,33 @@ import static com.facebook.presto.memory.LocalMemoryManager.validateHeapHeadroom
 import static com.facebook.presto.memory.NodeMemoryConfig.AVAILABLE_HEAP_MEMORY;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestNodeMemoryConfig
 {
+    private static final DataSize DEFAULT_MAX_QUERY_BROADCAST_MEMORY = new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE);
+    private static final DataSize DEFAULT_MAX_QUERY_MEMORY_PER_NODE = new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE);
+    private static final DataSize DEFAULT_SOFT_MAX_QUERY_MEMORY_PER_NODE = new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE);
+    private static final DataSize DEFAULT_MAX_QUERY_TOTAL_MEMORY_PER_NODE = new DataSize(AVAILABLE_HEAP_MEMORY * 0.2, BYTE);
+    private static final DataSize DEFAULT_SOFT_MAX_QUERY_TOTAL_MEMORY_PER_NODE = new DataSize(AVAILABLE_HEAP_MEMORY * 0.2, BYTE);
+    private static final DataSize DEFAULT_HEAP_HEADROOM = new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE);
+
+    private static final DataSize OVERRIDE_MAX_QUERY_BROADCAST_MEMORY = new DataSize(DEFAULT_MAX_QUERY_BROADCAST_MEMORY.toBytes() * 2, BYTE);
+    private static final DataSize OVERRIDE_MAX_QUERY_MEMORY_PER_NODE = new DataSize(DEFAULT_MAX_QUERY_MEMORY_PER_NODE.toBytes() * 2, BYTE);
+    private static final DataSize OVERRIDE_SOFT_MAX_QUERY_MEMORY_PER_NODE = new DataSize(DEFAULT_SOFT_MAX_QUERY_MEMORY_PER_NODE.toBytes() * 2, BYTE);
+    private static final DataSize OVERRIDE_MAX_QUERY_TOTAL_MEMORY_PER_NODE = new DataSize(DEFAULT_MAX_QUERY_TOTAL_MEMORY_PER_NODE.toBytes() * 2, BYTE);
+    private static final DataSize OVERRIDE_SOFT_MAX_QUERY_TOTAL_MEMORY_PER_NODE = new DataSize(DEFAULT_SOFT_MAX_QUERY_TOTAL_MEMORY_PER_NODE.toBytes() * 2, BYTE);
+    private static final DataSize OVERRIDE_HEAP_HEADROOM = new DataSize(DEFAULT_HEAP_HEADROOM.toBytes() * 0.5, BYTE);
+
     @Test
     public void testDefaults()
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(NodeMemoryConfig.class)
-                .setMaxQueryBroadcastMemory(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
-                .setMaxQueryMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
-                .setSoftMaxQueryMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
-                .setMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.2, BYTE))
-                .setSoftMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.2, BYTE))
-                .setHeapHeadroom(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
+                .setMaxQueryBroadcastMemory(DEFAULT_MAX_QUERY_BROADCAST_MEMORY)
+                .setMaxQueryMemoryPerNode(DEFAULT_MAX_QUERY_MEMORY_PER_NODE)
+                .setSoftMaxQueryMemoryPerNode(DEFAULT_SOFT_MAX_QUERY_MEMORY_PER_NODE)
+                .setMaxQueryTotalMemoryPerNode(DEFAULT_MAX_QUERY_TOTAL_MEMORY_PER_NODE)
+                .setSoftMaxQueryTotalMemoryPerNode(DEFAULT_SOFT_MAX_QUERY_TOTAL_MEMORY_PER_NODE)
+                .setHeapHeadroom(DEFAULT_HEAP_HEADROOM)
                 .setReservedPoolEnabled(true)
                 .setVerboseExceededMemoryLimitErrorsEnabled(true));
     }
@@ -47,23 +60,23 @@ public class TestNodeMemoryConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("query.max-memory-per-node", "1GB")
-                .put("query.max-broadcast-memory", "512MB")
-                .put("query.soft-max-memory-per-node", "512MB")
-                .put("query.max-total-memory-per-node", "3GB")
-                .put("query.soft-max-total-memory-per-node", "2GB")
-                .put("memory.heap-headroom-per-node", "1GB")
+                .put("query.max-memory-per-node", OVERRIDE_MAX_QUERY_MEMORY_PER_NODE.toString())
+                .put("query.max-broadcast-memory", OVERRIDE_MAX_QUERY_BROADCAST_MEMORY.toString())
+                .put("query.soft-max-memory-per-node", OVERRIDE_SOFT_MAX_QUERY_MEMORY_PER_NODE.toString())
+                .put("query.max-total-memory-per-node", OVERRIDE_MAX_QUERY_TOTAL_MEMORY_PER_NODE.toString())
+                .put("query.soft-max-total-memory-per-node", OVERRIDE_SOFT_MAX_QUERY_TOTAL_MEMORY_PER_NODE.toString())
+                .put("memory.heap-headroom-per-node", OVERRIDE_HEAP_HEADROOM.toString())
                 .put("experimental.reserved-pool-enabled", "false")
                 .put("memory.verbose-exceeded-memory-limit-errors-enabled", "false")
                 .build();
 
         NodeMemoryConfig expected = new NodeMemoryConfig()
-                .setMaxQueryBroadcastMemory(new DataSize(512, MEGABYTE))
-                .setMaxQueryMemoryPerNode(new DataSize(1, GIGABYTE))
-                .setSoftMaxQueryMemoryPerNode(new DataSize(512, MEGABYTE))
-                .setMaxQueryTotalMemoryPerNode(new DataSize(3, GIGABYTE))
-                .setSoftMaxQueryTotalMemoryPerNode(new DataSize(2, GIGABYTE))
-                .setHeapHeadroom(new DataSize(1, GIGABYTE))
+                .setMaxQueryBroadcastMemory(OVERRIDE_MAX_QUERY_BROADCAST_MEMORY)
+                .setMaxQueryMemoryPerNode(OVERRIDE_MAX_QUERY_MEMORY_PER_NODE)
+                .setSoftMaxQueryMemoryPerNode(OVERRIDE_SOFT_MAX_QUERY_MEMORY_PER_NODE)
+                .setMaxQueryTotalMemoryPerNode(OVERRIDE_MAX_QUERY_TOTAL_MEMORY_PER_NODE)
+                .setSoftMaxQueryTotalMemoryPerNode(OVERRIDE_SOFT_MAX_QUERY_TOTAL_MEMORY_PER_NODE)
+                .setHeapHeadroom(OVERRIDE_HEAP_HEADROOM)
                 .setReservedPoolEnabled(false)
                 .setVerboseExceededMemoryLimitErrorsEnabled(false);
 
@@ -73,24 +86,25 @@ public class TestNodeMemoryConfig
     @Test
     public void testOutOfRangeBroadcastMemoryLimit()
     {
+        DataSize invalidBroadcastMemory = new DataSize(OVERRIDE_MAX_QUERY_MEMORY_PER_NODE.toBytes() * 2, BYTE);
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("query.max-memory-per-node", "1GB")
-                .put("query.max-broadcast-memory", "5GB")
-                .put("query.soft-max-memory-per-node", "512MB")
-                .put("query.max-total-memory-per-node", "3GB")
-                .put("query.soft-max-total-memory-per-node", "2GB")
-                .put("memory.heap-headroom-per-node", "1GB")
+                .put("query.max-memory-per-node", OVERRIDE_MAX_QUERY_MEMORY_PER_NODE.toString())
+                .put("query.max-broadcast-memory", invalidBroadcastMemory.toString())
+                .put("query.soft-max-memory-per-node", OVERRIDE_SOFT_MAX_QUERY_MEMORY_PER_NODE.toString())
+                .put("query.max-total-memory-per-node", OVERRIDE_MAX_QUERY_TOTAL_MEMORY_PER_NODE.toString())
+                .put("query.soft-max-total-memory-per-node", OVERRIDE_SOFT_MAX_QUERY_TOTAL_MEMORY_PER_NODE.toString())
+                .put("memory.heap-headroom-per-node", OVERRIDE_HEAP_HEADROOM.toString())
                 .put("experimental.reserved-pool-enabled", "false")
                 .put("memory.verbose-exceeded-memory-limit-errors-enabled", "false")
                 .build();
 
         NodeMemoryConfig expected = new NodeMemoryConfig()
-                .setMaxQueryMemoryPerNode(new DataSize(1, GIGABYTE))
-                .setMaxQueryBroadcastMemory(new DataSize(1, GIGABYTE))
-                .setSoftMaxQueryMemoryPerNode(new DataSize(512, MEGABYTE))
-                .setMaxQueryTotalMemoryPerNode(new DataSize(3, GIGABYTE))
-                .setSoftMaxQueryTotalMemoryPerNode(new DataSize(2, GIGABYTE))
-                .setHeapHeadroom(new DataSize(1, GIGABYTE))
+                .setMaxQueryMemoryPerNode(OVERRIDE_MAX_QUERY_MEMORY_PER_NODE)
+                .setMaxQueryBroadcastMemory(OVERRIDE_MAX_QUERY_MEMORY_PER_NODE)  // broadcast memory not allowed to exceed this value
+                .setSoftMaxQueryMemoryPerNode(OVERRIDE_SOFT_MAX_QUERY_MEMORY_PER_NODE)
+                .setMaxQueryTotalMemoryPerNode(OVERRIDE_MAX_QUERY_TOTAL_MEMORY_PER_NODE)
+                .setSoftMaxQueryTotalMemoryPerNode(OVERRIDE_SOFT_MAX_QUERY_TOTAL_MEMORY_PER_NODE)
+                .setHeapHeadroom(OVERRIDE_HEAP_HEADROOM)
                 .setReservedPoolEnabled(false)
                 .setVerboseExceededMemoryLimitErrorsEnabled(false);
 


### PR DESCRIPTION
## Description
There is a mismatch between the default values in `com.facebook.presto.memory.NodeMemoryConfig`, which are a factor of the runtime heap size, and the test override values in `com.facebook.presto.memory.TestNodeMemoryConfig`, which are hard-coded.  This can cause the tests to fail when: (heap size) * (default factor) == (test override).

## Motivation and Context
When run with a 5GB heap, tests will fail due to the hard-coded values:
```
mvn test -Dtest=com.facebook.presto.memory.TestNodeMemoryConfig -Dsurefire.failIfNoSpecifiedTests=false -pl presto-main -am -Dair.test.jvmsize=5g

[ERROR] Tests run: 4, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 1.305 s <<< FAILURE! - in com.facebook.presto.memory.TestNodeMemoryConfig
[ERROR] com.facebook.presto.memory.TestNodeMemoryConfig.testOutOfRangeBroadcastMemoryLimit  Time elapsed: 0.381 s  <<< FAILURE!
java.lang.AssertionError: SoftMaxQueryMemoryPerNode did not expect [536870912B] but found [512MB]
	at org.testng.Assert.fail(Assert.java:110)
	at org.testng.Assert.failEquals(Assert.java:1417)
	at org.testng.Assert.assertNotEqualsImpl(Assert.java:156)
	at org.testng.Assert.assertNotEquals(Assert.java:1986)
	at com.facebook.airlift.configuration.testing.ConfigAssertions.assertAttributesNotEqual(ConfigAssertions.java:228)
	at com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping(ConfigAssertions.java:131)
	at com.facebook.presto.memory.TestNodeMemoryConfig.testOutOfRangeBroadcastMemoryLimit(TestNodeMemoryConfig.java:97)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:135)
	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:673)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:220)
	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:945)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:193)
	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)

[ERROR] com.facebook.presto.memory.TestNodeMemoryConfig.testExplicitPropertyMappings  Time elapsed: 0.382 s  <<< FAILURE!
java.lang.AssertionError: SoftMaxQueryMemoryPerNode did not expect [536870912B] but found [512MB]
	at org.testng.Assert.fail(Assert.java:110)
	at org.testng.Assert.failEquals(Assert.java:1417)
	at org.testng.Assert.assertNotEqualsImpl(Assert.java:156)
	at org.testng.Assert.assertNotEquals(Assert.java:1986)
	at com.facebook.airlift.configuration.testing.ConfigAssertions.assertAttributesNotEqual(ConfigAssertions.java:228)
	at com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping(ConfigAssertions.java:131)
	at com.facebook.presto.memory.TestNodeMemoryConfig.testExplicitPropertyMappings(TestNodeMemoryConfig.java:70)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:135)
	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:673)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:220)
	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:945)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:193)
	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

## Impact

## Test Plan
```
mvn test -Dtest=com.facebook.presto.memory.TestNodeMemoryConfig -Dsurefire.failIfNoSpecifiedTests=false -pl presto-main -am -Dair.test.jvmsize=5g
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

