### PR TITLE
Remove cross join if one side of input is single row constant

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -324,6 +324,7 @@ public final class SystemSessionProperties
     public static final String GENERATE_DOMAIN_FILTERS = "generate_domain_filters";
     public static final String REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION = "rewrite_expression_with_constant_expression";
     public static final String PRINT_ESTIMATED_STATS_FROM_CACHE = "print_estimated_stats_from_cache";
+    public static final String REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT = "remove_cross_join_with_constant_single_row_input";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -1917,6 +1918,11 @@ public final class SystemSessionProperties
                                 "get stats from a cache that was populated during query optimization rather than recalculating the stats on the final plan.",
                         featuresConfig.isPrintEstimatedStatsFromCache(),
                         false),
+                booleanProperty(
+                        REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT,
+                        "If one input of the cross join is a single row with constant value, remove this cross join and replace with a project node",
+                        featuresConfig.isRemoveCrossJoinWithSingleConstantRow(),
+                        false),
                 new PropertyMetadata<>(
                         DEFAULT_VIEW_SECURITY_MODE,
                         format("Set default view security mode. Options are: %s",
@@ -3223,6 +3229,11 @@ public final class SystemSessionProperties
     public static boolean isPrintEstimatedStatsFromCacheEnabled(Session session)
     {
         return session.getSystemProperty(PRINT_ESTIMATED_STATS_FROM_CACHE, Boolean.class);
+    }
+
+    public static boolean isRemoveCrossJoinWithConstantSingleRowInputEnabled(Session session)
+    {
+        return session.getSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, Boolean.class);
     }
 
     public static boolean shouldOptimizerUseHistograms(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -308,6 +308,7 @@ public class FeaturesConfig
     private boolean limitNumberOfGroupsForKHyperLogLogAggregations = true;
     private boolean generateDomainFilters;
     private boolean printEstimatedStatsFromCache;
+    private boolean removeCrossJoinWithSingleConstantRow = true;
     private CreateView.Security defaultViewSecurityMode = DEFINER;
     private boolean useHistograms;
 
@@ -3104,6 +3105,19 @@ public class FeaturesConfig
     public FeaturesConfig setPrintEstimatedStatsFromCache(boolean printEstimatedStatsFromCache)
     {
         this.printEstimatedStatsFromCache = printEstimatedStatsFromCache;
+        return this;
+    }
+
+    public boolean isRemoveCrossJoinWithSingleConstantRow()
+    {
+        return this.removeCrossJoinWithSingleConstantRow;
+    }
+
+    @Config("optimizer.remove-cross-join-with-single-constant-row")
+    @ConfigDescription("If one input of the cross join is a single row with constant value, remove this cross join and replace with a project node")
+    public FeaturesConfig setRemoveCrossJoinWithSingleConstantRow(boolean removeCrossJoinWithSingleConstantRow)
+    {
+        this.removeCrossJoinWithSingleConstantRow = removeCrossJoinWithSingleConstantRow;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -97,6 +97,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PushRemoteExchangeThroughA
 import com.facebook.presto.sql.planner.iterative.rule.PushRemoteExchangeThroughGroupId;
 import com.facebook.presto.sql.planner.iterative.rule.PushTableWriteThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.PushTopNThroughUnion;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveCrossJoinWithConstantInput;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveIdentityProjectionsBelowProjection;
@@ -504,6 +505,13 @@ public class PlanOptimizers
                         estimatedExchangesCostCalculator,
                         ImmutableSet.<Rule<?>>builder().add(new RemoveRedundantCastToVarcharInJoinClause(metadata.getFunctionAndTypeManager()))
                                 .addAll(new RemoveMapCastRule(metadata.getFunctionAndTypeManager()).rules()).build()));
+
+        builder.add(new IterativeOptimizer(
+                metadata,
+                ruleStats,
+                statsCalculator,
+                estimatedExchangesCostCalculator,
+                ImmutableSet.of(new RemoveCrossJoinWithConstantInput(metadata.getFunctionAndTypeManager()))));
 
         builder.add(new IterativeOptimizer(
                 metadata,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveCrossJoinWithConstantInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveCrossJoinWithConstantInput.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.SystemSessionProperties.isRemoveCrossJoinWithConstantSingleRowInputEnabled;
+import static com.facebook.presto.sql.planner.PlannerUtils.addProjections;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+/**
+ * When one side of a cross join is one single row of constant, we can remove the cross join and replace it with a project.
+ * <pre>
+ * - Cross Join
+ *      - table scan
+ *          left_field
+ *      - values // only one row
+ *          right_field := 1
+ * </pre>
+ * into
+ * <pre>
+ * - project
+ *      left_field := left_field
+ *      right_field := 1
+ *      - table scan
+ *          left_field
+ * </pre>
+ */
+public class RemoveCrossJoinWithConstantInput
+        implements Rule<JoinNode>
+{
+    private final RowExpressionDeterminismEvaluator rowExpressionDeterminismEvaluator;
+
+    public RemoveCrossJoinWithConstantInput(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.rowExpressionDeterminismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
+    }
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return join().matching(x -> x.getType().equals(JoinType.INNER) && x.getCriteria().isEmpty());
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isRemoveCrossJoinWithConstantSingleRowInputEnabled(session);
+    }
+
+    @Override
+    public Result apply(JoinNode node, Captures captures, Context context)
+    {
+        PlanNode singleValueInput;
+        PlanNode joinInput;
+        PlanNode leftInput = context.getLookup().resolve(node.getLeft());
+        PlanNode rightInput = context.getLookup().resolve(node.getRight());
+        if (isOutputSingleConstantRow(rightInput, context)) {
+            singleValueInput = rightInput;
+            joinInput = leftInput;
+        }
+        else if (isOutputSingleConstantRow(leftInput, context)) {
+            singleValueInput = leftInput;
+            joinInput = rightInput;
+        }
+        else {
+            return Result.empty();
+        }
+        Optional<Map<VariableReferenceExpression, RowExpression>> mapping = getConstantAssignments(singleValueInput, context);
+        if (!mapping.isPresent()) {
+            return Result.empty();
+        }
+        PlanNode resultNode = addProjections(joinInput, context.getIdAllocator(), mapping.get());
+        if (node.getFilter().isPresent()) {
+            resultNode = new FilterNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), resultNode, node.getFilter().get());
+        }
+        return Result.ofPlanNode(resultNode);
+    }
+
+    private boolean isOutputSingleConstantRow(PlanNode planNode, Context context)
+    {
+        while (planNode instanceof ProjectNode) {
+            planNode = context.getLookup().resolve(((ProjectNode) planNode).getSource());
+        }
+        if (planNode instanceof ValuesNode) {
+            return ((ValuesNode) planNode).getRows().size() == 1;
+        }
+        return false;
+    }
+
+    private Optional<Map<VariableReferenceExpression, RowExpression>> getConstantAssignments(PlanNode planNode, Context context)
+    {
+        List<VariableReferenceExpression> outputVariables = planNode.getOutputVariables();
+        Map<VariableReferenceExpression, RowExpression> mapping = outputVariables.stream().collect(toImmutableMap(Function.identity(), Function.identity()));
+        while (planNode instanceof ProjectNode) {
+            Map<VariableReferenceExpression, RowExpression> assignments = ((ProjectNode) planNode).getAssignments().getMap();
+            mapping = updateAssignments(mapping, assignments);
+            planNode = context.getLookup().resolve(((ProjectNode) planNode).getSource());
+        }
+
+        checkState(planNode instanceof ValuesNode);
+        ValuesNode valuesNode = (ValuesNode) planNode;
+        if (!valuesNode.getOutputVariables().isEmpty()) {
+            Map<VariableReferenceExpression, RowExpression> assignments = IntStream.range(0, valuesNode.getOutputVariables().size()).boxed()
+                    .collect(toImmutableMap(idx -> valuesNode.getOutputVariables().get(idx), idx -> valuesNode.getRows().get(0).get(idx)));
+            mapping = updateAssignments(mapping, assignments);
+        }
+        boolean allDeterministic = mapping.values().stream().allMatch(rowExpressionDeterminismEvaluator::isDeterministic);
+        if (allDeterministic) {
+            return Optional.of(mapping);
+        }
+        return Optional.empty();
+    }
+
+    private static Map<VariableReferenceExpression, RowExpression> updateAssignments(Map<VariableReferenceExpression, RowExpression> mapping, Map<VariableReferenceExpression, RowExpression> newAssignments)
+    {
+        return mapping.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue() instanceof VariableReferenceExpression ? newAssignments.get(entry.getValue()) : entry.getValue()));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -271,6 +271,7 @@ public class TestFeaturesConfig
                 .setCteHeuristicReplicationThreshold(4)
                 .setLegacyJsonCast(true)
                 .setPrintEstimatedStatsFromCache(false)
+                .setRemoveCrossJoinWithSingleConstantRow(true)
                 .setUseHistograms(false)
                 .setUseNewNanDefinition(true));
     }
@@ -487,6 +488,7 @@ public class TestFeaturesConfig
                 .put("default-view-security-mode", INVOKER.name())
                 .put("cte-heuristic-replication-threshold", "2")
                 .put("optimizer.print-estimated-stats-from-cache", "true")
+                .put("optimizer.remove-cross-join-with-single-constant-row", "false")
                 .put("optimizer.use-histograms", "true")
                 .put("use-new-nan-definition", "false")
                 .build();
@@ -701,6 +703,7 @@ public class TestFeaturesConfig
                 .setCteHeuristicReplicationThreshold(2)
                 .setLegacyJsonCast(false)
                 .setPrintEstimatedStatsFromCache(true)
+                .setRemoveCrossJoinWithSingleConstantRow(false)
                 .setUseHistograms(true)
                 .setUseNewNanDefinition(false);
         assertFullMapping(properties, expected);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -68,6 +68,7 @@ import static com.facebook.presto.SystemSessionProperties.MAX_LEAF_NODES_IN_PLAN
 import static com.facebook.presto.SystemSessionProperties.OFFSET_CLAUSE_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_HASH_GENERATION;
 import static com.facebook.presto.SystemSessionProperties.PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID;
+import static com.facebook.presto.SystemSessionProperties.REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT;
 import static com.facebook.presto.SystemSessionProperties.SIMPLIFY_PLAN_WITH_EMPTY_INPUT;
 import static com.facebook.presto.SystemSessionProperties.TASK_CONCURRENCY;
 import static com.facebook.presto.SystemSessionProperties.getMaxLeafNodesInPlan;
@@ -1080,6 +1081,14 @@ public class TestLogicalPlanner
                 .setSystemProperty(OPTIMIZE_HASH_GENERATION, Boolean.toString(false))
                 .build();
 
+        Session disableRemoveCrossJoin = Session.builder(broadcastJoin)
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "false")
+                .build();
+
+        Session enableRemoveCrossJoin = Session.builder(broadcastJoin)
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .build();
+
         // replicated join with naturally partitioned and distributed probe side is rewritten to partitioned join
         assertPlanWithSession(
                 "SELECT r1.regionkey FROM (SELECT regionkey FROM region GROUP BY regionkey) r1, region r2 WHERE r2.regionkey = r1.regionkey",
@@ -1106,7 +1115,7 @@ public class TestLogicalPlanner
         // replicated join is preserved if probe side is single node
         assertPlanWithSession(
                 "SELECT * FROM (SELECT * FROM (VALUES 1) t(a)) t, region r WHERE r.regionkey = t.a",
-                broadcastJoin,
+                disableRemoveCrossJoin,
                 false,
                 anyTree(
                         node(JoinNode.class,
@@ -1115,6 +1124,12 @@ public class TestLogicalPlanner
                                 anyTree(
                                         exchange(REMOTE_STREAMING, GATHER,
                                                 node(TableScanNode.class))))));
+
+        assertPlanWithSession(
+                "SELECT * FROM (SELECT * FROM (VALUES 1) t(a)) t, region r WHERE r.regionkey = t.a",
+                enableRemoveCrossJoin,
+                false,
+                anyTree(node(TableScanNode.class)));
 
         // replicated join is preserved if there are no equality criteria
         assertPlanWithSession(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveCrossJoinWithConstantInput.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveCrossJoinWithConstantInput.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.LongArrayBlock;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.spi.TestingColumnHandle;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT;
+import static com.facebook.presto.common.block.MapBlock.fromKeyValueBlock;
+import static com.facebook.presto.common.block.MethodHandleUtil.compose;
+import static com.facebook.presto.common.block.MethodHandleUtil.nativeValueGetter;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHandle;
+
+public class TestRemoveCrossJoinWithConstantInput
+        extends BaseRuleTest
+{
+    private static final MethodHandle KEY_NATIVE_EQUALS = getOperatorMethodHandle(OperatorType.EQUAL, BIGINT, BIGINT);
+    private static final MethodHandle KEY_BLOCK_EQUALS = compose(KEY_NATIVE_EQUALS, nativeValueGetter(BIGINT), nativeValueGetter(BIGINT));
+    private static final MethodHandle KEY_NATIVE_HASH_CODE = getOperatorMethodHandle(OperatorType.HASH_CODE, BIGINT);
+    private static final MethodHandle KEY_BLOCK_HASH_CODE = compose(KEY_NATIVE_HASH_CODE, nativeValueGetter(BIGINT));
+
+    @Test
+    public void testOneColumnValuesNode()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.values(ImmutableList.of(p.variable("right_k1")), ImmutableList.of(ImmutableList.of(constant(1L, BIGINT)))));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(TableScanNode.class)));
+    }
+
+    @Test
+    public void testOneColumnValuesNodeArray()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    VariableReferenceExpression rightKey = p.variable("right_k1", new ArrayType(BIGINT));
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.values(ImmutableList.of(rightKey), ImmutableList.of(ImmutableList.of(constant(new LongArrayBlock(2, Optional.empty(), new long[2]), new ArrayType(BIGINT))))));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(TableScanNode.class)));
+    }
+
+    @Test
+    public void testOneColumnValuesNodeMap()
+    {
+        long[] keys = {1, 2};
+        LongArrayBlock longArrayBlock = new LongArrayBlock(2, Optional.empty(), keys);
+        int[] offsets = {0, 2, 4, 6};
+        Block mapBlock = fromKeyValueBlock(2, Optional.ofNullable(null), offsets, longArrayBlock, longArrayBlock);
+
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    VariableReferenceExpression rightKey = p.variable("right_k1", new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE));
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.values(ImmutableList.of(rightKey), ImmutableList.of(ImmutableList.of(constant(mapBlock, new MapType(BIGINT, BIGINT, KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE))))));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(TableScanNode.class)));
+    }
+
+    @Test
+    public void testOneColumnValuesNodeNonDeterministic()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.values(ImmutableList.of(p.variable("right_k1")), ImmutableList.of(ImmutableList.of(p.rowExpression("random()")))));
+                }).doesNotFire();
+    }
+
+    @Test
+    public void testOneColumnValuesNodeWithJoinFilter()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", BIGINT);
+                    p.variable("right_k1", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.values(ImmutableList.of(p.variable("right_k1")), ImmutableList.of(ImmutableList.of(constant(1L, BIGINT)))),
+                            p.rowExpression("left_k1+right_k1 > 2"));
+                })
+                .matches(
+                        node(FilterNode.class,
+                                node(ProjectNode.class,
+                                        node(TableScanNode.class))));
+    }
+
+    @Test
+    public void testMultipleColumnsValuesNode()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    VariableReferenceExpression rightK1 = p.variable("right_k1", BIGINT);
+                    VariableReferenceExpression rightK2 = p.variable("right_k2", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.values(ImmutableList.of(rightK1, rightK2), ImmutableList.of(ImmutableList.of(constant(1L, BIGINT), constant(2L, BIGINT)))));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(TableScanNode.class)));
+    }
+
+    @Test
+    public void testMultipleRowsValuesNode()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.values(ImmutableList.of(p.variable("right_k1")), ImmutableList.of(ImmutableList.of(constant(1L, BIGINT)), ImmutableList.of(constant(2L, BIGINT)))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testEmptyValuesNode()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.values(p.variable("right_k1")));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testProjectConstant()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    VariableReferenceExpression rightKey = p.variable("right_k", new ArrayType(BIGINT));
+                    p.variable("right_k1", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.project(
+                                    assignment(rightKey, p.rowExpression("1")),
+                                    p.values(1)));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(TableScanNode.class)));
+    }
+
+    @Test
+    public void testProjectConstantMultipleRows()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    VariableReferenceExpression rightKey = p.variable("right_k", new ArrayType(BIGINT));
+                    p.variable("right_k1", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.project(
+                                    assignment(rightKey, p.rowExpression("1")),
+                                    p.values(2)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testMultipleProjects()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    VariableReferenceExpression rightKey = p.variable("right_k", new ArrayType(BIGINT));
+                    VariableReferenceExpression rightKey2 = p.variable("right_k2", new ArrayType(BIGINT));
+                    p.variable("right_k1", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))),
+                            p.project(
+                                    assignment(rightKey, rightKey2),
+                                    p.project(
+                                            assignment(rightKey2, p.rowExpression("1")),
+                                            p.values(1))));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(TableScanNode.class)));
+    }
+
+    @Test
+    public void testOneColumnValuesNodeOnLeft()
+    {
+        tester().assertThat(new RemoveCrossJoinWithConstantInput(getMetadata().getFunctionAndTypeManager()))
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .on(p ->
+                {
+                    VariableReferenceExpression leftKey = p.variable("left_k1", new ArrayType(BIGINT));
+                    p.variable("right_k1", BIGINT);
+                    return p.join(JoinType.INNER,
+                            p.values(ImmutableList.of(p.variable("right_k1")), ImmutableList.of(ImmutableList.of(constant(1L, BIGINT)))),
+                            p.tableScan(ImmutableList.of(leftKey), ImmutableMap.of(leftKey, new TestingColumnHandle("col"))));
+                })
+                .matches(
+                        node(ProjectNode.class,
+                                node(TableScanNode.class)));
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -76,6 +76,7 @@ import static com.facebook.presto.SystemSessionProperties.PUSH_REMOTE_EXCHANGE_T
 import static com.facebook.presto.SystemSessionProperties.QUICK_DISTINCT_LIMIT_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY;
 import static com.facebook.presto.SystemSessionProperties.RANDOMIZE_OUTER_JOIN_NULL_KEY_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT;
 import static com.facebook.presto.SystemSessionProperties.REMOVE_MAP_CAST;
 import static com.facebook.presto.SystemSessionProperties.REMOVE_REDUNDANT_CAST_TO_VARCHAR_IN_JOIN;
 import static com.facebook.presto.SystemSessionProperties.REWRITE_CASE_TO_MAP_ENABLED;
@@ -7584,6 +7585,23 @@ public abstract class AbstractTestQueries
         assertTrue(((String) result.getMaterializedRows().get(0).getField(0)).indexOf("SemiJoin") != -1);
         result = computeActual(session, testQuery);
         assertTrue(result.getRowCount() == 25);
+    }
+
+    @Test
+    public void testRemoveCrossJoinWithSingleRowConstantInput()
+    {
+        Session enableOptimization = Session.builder(getSession())
+                .setSystemProperty(REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT, "true")
+                .build();
+        assertQuery(enableOptimization, "SELECT * FROM (SELECT EXTRACT(DAY FROM DATE '2017-01-01')) t CROSS JOIN (VALUES 1)",
+                "values (1, 1)");
+        assertQuery(enableOptimization, "SELECT * FROM (SELECT * FROM (VALUES 1) t(a)) t, region r WHERE r.regionkey = t.a");
+        assertQuery(enableOptimization, "WITH t(msg) AS (SELECT * FROM (VALUES ROW(CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))))) SELECT b.msg.x FROM t a, t b WHERE a.msg.y = b.msg.y",
+                "values 1");
+        assertQuery(enableOptimization, "WITH t(msg) AS (SELECT * FROM (VALUES ROW(CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))))) SELECT a.msg.y, b.msg.x from t a cross join t b where a.msg.x = 7 or is_finite(b.msg.y)",
+                "values (2.0, 1)");
+        assertQuery(enableOptimization, "WITH t(msg) AS (SELECT * FROM (VALUES ROW(CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))))) SELECT b.msg.x FROM t a, t b WHERE a.msg.y = b.msg.y limit 100",
+                "values 1");
     }
 
     /**


### PR DESCRIPTION
## Description
Fix https://github.com/prestodb/presto/issues/23074

When one side of cross join inputs is single row with constant values, we can remove this cross join and replace it with a project node. This will simplify the plan, and enable more following optimizations, such as filter pushdown etc.

## Motivation and Context
We observed savings enabled by this optimization in our workload.

## Impact
We observed savings enabled by this optimization in our workload.

## Test Plan
Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add an optimization to remove cross join when one side of inputs is single row of constant values. The optimization is controlled by session property `remove_cross_join_with_constant_single_row_input` :pr:`23081`
```


