### PR TITLE
Remove outdated workaround for long fixed maven-shade-plugin bug

### DIFF
--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -196,28 +196,6 @@
 
     <build>
         <plugins>
-            <!-- workaround for MSHADE-195 -->
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <!-- disable the default execution -->
-                    <execution>
-                        <id>attach-sources</id>
-                        <configuration>
-                            <skipSource>true</skipSource>
-                        </configuration>
-                    </execution>
-                    <!-- enable only the test jar; the sources jar is attached by the shade plugin -->
-                    <execution>
-                        <id>test-only</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>test-jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.basepom.maven</groupId>
                 <artifactId>duplicate-finder-maven-plugin</artifactId>


### PR DESCRIPTION
[MSHADE-195](https://issues.apache.org/jira/browse/MSHADE-195) was fixed years ago.

## Description
Remove special config of maven-source-plugin

## Motivation and Context
Looking into some duplicate finder problems between presto-jdbc and presto-ui

## Impact
None

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

