### PR TITLE
Exclude presto-ui from shaded jar

### DIFF
--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -245,6 +245,11 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>com.facebook.presto:presto-ui</exclude>
+                                </excludes>
+                            </artifactSet>
                             <createSourcesJar>true</createSourcesJar>
                             <shadeSourcesContent>true</shadeSourcesContent>
                             <dependencyReducedPomLocation>${project.build.directory}/pom.xml</dependencyReducedPomLocation>


### PR DESCRIPTION
## Description
Keeps the ui out of the test jar

## Motivation and Context
Avoids duplicate finder errors.

## Impact
None

## Test Plan
```
mvn -pl presto-jdbc  install -DskipTests -T1C
jar tvf /Users/elharo/.m2/repository/com/facebook/presto/presto-jdbc/0.289-SNAPSHOT/presto-jdbc-0.289-SNAPSHOT.jar| grep webapp
```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

