### PR TITLE
[docs] Fix error in 0.287 release notes

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.287.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.287.rst
@@ -82,7 +82,7 @@ _________________________
 * Add year/month/day/hour transforms both on legacy and non-legacy TimestampType column. :pr:`21959`
 * Fix error encountered when attempting to execute an ``INSERT INTO`` statement where column names contain white spaces. :pr:`21827`
 * Add support for row-level deletes on Iceberg V2 tables. The delete mode can be changed from ``merge-on-read`` to ``copy-on-write`` by setting table property ``delete_mode``. :pr:`21571`
-* Add support for Iceberg V1 tables in Prestissimo. :pr:`22013`
+* Add support for Iceberg V1 tables in Prestissimo. :pr:`21584`
 * Add support to read Iceberg V2 tables with Position Deletes in Prestissimo. :pr:`21980`
 * Add support for Iceberg concurrent insertions. :pr:`21250`
 


### PR DESCRIPTION
## Description
@yingsu00 noticed the release note entry 

`Add support for Iceberg V1 tables in Prestissimo. [#22013](https://github.com/prestodb/presto/pull/22013)`

in [release/release-0.287.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/release/release-0.287.rst) links to the wrong PR. Found the correct PR by reviewing #22647 and fixed the link. 

## Motivation and Context
Fix an error in the doc. 

## Impact
Documentation. 

## Test Plan
Local doc build, verified the updated link works. Also, CI. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

