### PR TITLE
[docs] Fix doc build errors

### DIFF
--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -181,7 +181,7 @@ queries.
        * Array checksum of the value set
 * **Row Columns**
     * Checksums row fields recursively according to the type of the fields.
-* For all other column types, generates a simple checksum using the :func:`checksum` function.
+* For all other column types, generates a simple checksum using the :func:`!checksum` function.
 
 Determinism
 -----------

--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -107,7 +107,7 @@ html_favicon = 'images/favicon.ico'
 # doesn't seem to do anything
 # html_baseurl = 'overview.html'
 
-html_static_path = ['static']
+html_static_path = ['.']
 
 templates_path = ['_templates']
 

--- a/presto-docs/src/main/sphinx/connector/clickhouse.rst
+++ b/presto-docs/src/main/sphinx/connector/clickhouse.rst
@@ -135,7 +135,7 @@ Pushdown
 
 The connector supports pushdown for a number of operations:
 
-* :ref:`limit-pushdown`
+* :ref:`!limit-pushdown`
 
 .. _clickhouse-sql-support:
 

--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -12,14 +12,14 @@ Overview
 
 Aggregate functions operate on a set of values to compute a single result.
 
-Except for :func:`count`, :func:`count_if`, :func:`max_by`, :func:`min_by` and
-:func:`approx_distinct`, all of these aggregate functions ignore null values
+Except for :func:`!count`, :func:`!count_if`, :func:`!max_by`, :func:`!min_by` and
+:func:`!approx_distinct`, all of these aggregate functions ignore null values
 and return null for no input rows or when all values are null. For example,
-:func:`sum` returns null rather than zero and :func:`avg` does not include null
+:func:`!sum` returns null rather than zero and :func:`!avg` does not include null
 values in the count. The ``coalesce`` function can be used to convert null into
 zero.
 
-Some aggregate functions such as :func:`array_agg` produce different results
+Some aggregate functions such as :func:`!array_agg` produce different results
 depending on the order of input values. This ordering can be specified by writing
 an :ref:`order-by-clause` within the aggregate function::
 
@@ -32,7 +32,7 @@ General Aggregate Functions
 
 .. function:: any_value(x) -> [same as input]
 
-    This is an alias for :func:`arbitrary`.
+    This is an alias for :func:`!arbitrary`.
 
 .. function:: arbitrary(x) -> [same as input]
 
@@ -77,7 +77,7 @@ General Aggregate Functions
 
 .. function:: every(boolean) -> boolean
 
-    This is an alias for :func:`bool_and`.
+    This is an alias for :func:`!bool_and`.
 
 .. function:: geometric_mean(bigint) -> double
               geometric_mean(double) -> double
@@ -385,7 +385,7 @@ Approximate Aggregate Functions
 
     Computes an approximate histogram with up to ``buckets`` number of buckets
     for all ``value``\ s. This function is equivalent to the variant of
-    :func:`numeric_histogram` that takes a ``weight``, with a per-item weight of ``1``.
+    :func:`!numeric_histogram` that takes a ``weight``, with a per-item weight of ``1``.
     In this case, the total weight in the returned map is the count of items in the bin.
 
 
@@ -479,7 +479,7 @@ Statistical Aggregate Functions
 
 .. function:: stddev(x) -> double
 
-    This is an alias for :func:`stddev_samp`.
+    This is an alias for :func:`!stddev_samp`.
 
 .. function:: stddev_pop(x) -> double
 
@@ -491,7 +491,7 @@ Statistical Aggregate Functions
 
 .. function:: variance(x) -> double
 
-    This is an alias for :func:`var_samp`.
+    This is an alias for :func:`!var_samp`.
 
 .. function:: var_pop(x) -> double
 
@@ -598,7 +598,7 @@ To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_charact
 .. function:: classification_miss_rate(buckets, y, x) -> array<double>
 
     This function is equivalent to the variant of
-    :func:`classification_miss_rate` that takes a ``weight``, with a per-item weight of ``1``.
+    :func:`!classification_miss_rate` that takes a ``weight``, with a per-item weight of ``1``.
 
 .. function:: classification_fall_out(buckets, y, x, weight) -> array<double>
 
@@ -627,7 +627,7 @@ To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_charact
 .. function:: classification_fall_out(buckets, y, x) -> array<double>
 
     This function is equivalent to the variant of
-    :func:`classification_fall_out` that takes a ``weight``, with a per-item weight of ``1``.
+    :func:`!classification_fall_out` that takes a ``weight``, with a per-item weight of ``1``.
 
 .. function:: classification_precision(buckets, y, x, weight) -> array<double>
 
@@ -656,7 +656,7 @@ To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_charact
 .. function:: classification_precision(buckets, y, x) -> array<double>
 
     This function is equivalent to the variant of
-    :func:`classification_precision` that takes a ``weight``, with a per-item weight of ``1``.
+    :func:`!classification_precision` that takes a ``weight``, with a per-item weight of ``1``.
 
 .. function:: classification_recall(buckets, y, x, weight) -> array<double>
 
@@ -685,7 +685,7 @@ To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_charact
 .. function:: classification_recall(buckets, y, x) -> array<double>
 
     This function is equivalent to the variant of
-    :func:`classification_recall` that takes a ``weight``, with a per-item weight of ``1``.
+    :func:`!classification_recall` that takes a ``weight``, with a per-item weight of ``1``.
 
 .. function:: classification_thresholds(buckets, y, x) -> array<double>
 

--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -78,7 +78,7 @@ Array Functions
 .. function:: array_has_duplicates(array(T)) -> boolean
 
     Returns a boolean: whether ``array`` has any elements that occur more than once.
-    Throws an exception if any of the elements are rows or arrays that contain nulls. ::
+    Throws an exception if any of the elements are rows or arrays that contain nulls. 
 
     SELECT array_has_duplicates(ARRAY[1, 2, null, 1, null, 3]) -- true
     SELECT array_has_duplicates(ARRAY[ROW(1, null), ROW(1, null)]) -- "map key cannot be null or contain nulls"
@@ -210,7 +210,7 @@ Array Functions
 .. function:: array_sum(array(T)) -> bigint/double
 
     Returns the sum of all non-null elements of the ``array``. If there is no non-null elements, returns ``0``.
-    The behavior is similar to aggregation function :func:`sum`.
+    The behavior is similar to aggregation function :func:`!sum`.
 
     ``T`` must be coercible to ``double``.
     Returns ``bigint`` if T is coercible to ``bigint``. Otherwise, returns ``double``.

--- a/presto-docs/src/main/sphinx/functions/binary.rst
+++ b/presto-docs/src/main/sphinx/functions/binary.rst
@@ -120,7 +120,7 @@ Binary Functions
 .. function:: crc32(binary) -> bigint
 
     Computes the CRC-32 of ``binary``. For general purpose hashing, use
-    :func:`xxhash64`, as it is much faster and produces a better quality hash.
+    :func:`!xxhash64`, as it is much faster and produces a better quality hash.
 
 .. function:: md5(binary) -> varbinary
 

--- a/presto-docs/src/main/sphinx/functions/bitwise.rst
+++ b/presto-docs/src/main/sphinx/functions/bitwise.rst
@@ -80,4 +80,4 @@ functions, the amount to shift is given by the bottom bits of the ``shift`` para
         SELECT bitwise_right_shift_arithmetic(BIGINT '-8', 2); -- -2
         SELECT bitwise_right_shift_arithmetic(SMALLINT '7', 2); -- 1
 
-See also :func:`bitwise_and_agg` and :func:`bitwise_or_agg`.
+See also :func:`!bitwise_and_agg` and :func:`!bitwise_or_agg` in `Bitwise Aggregate Functions <aggregate.html#bitwise-aggregate-functions>`_.

--- a/presto-docs/src/main/sphinx/functions/conversion.rst
+++ b/presto-docs/src/main/sphinx/functions/conversion.rst
@@ -20,7 +20,7 @@ Conversion Functions
 
 .. function:: try_cast(value AS type) -> type
 
-    Like :func:`cast`, but returns null if the cast fails.
+    Like :func:`!cast`, but returns null if the cast fails.
 
 .. note::
 

--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -241,7 +241,7 @@ Specifier Description
 
 .. [#f] Timestamp is truncated to milliseconds.
 .. [#y] When parsing, two-digit year format assumes range ``1970`` .. ``2069``, so "70" will result in year ``1970`` but "69" will produce ``2069``.
-.. [#w] This specifier is not supported yet. Consider using :func:`day_of_week` (it uses ``1-7`` instead of ``0-6``).
+.. [#w] This specifier is not supported yet. Consider using :func:`!day_of_week` (it uses ``1-7`` instead of ``0-6``).
 .. [#z] This specifier does not support ``0`` as a month or day.
 
 .. warning:: The following specifiers are not currently supported: ``%D %U %u %V %w %X``
@@ -278,23 +278,23 @@ The ``extract`` function supports the following fields:
 =================== ===========
 Field               Description
 =================== ===========
-``YEAR``            :func:`year`
-``QUARTER``         :func:`quarter`
-``MONTH``           :func:`month`
-``WEEK``            :func:`week`
-``DAY``             :func:`day`
-``DAY_OF_MONTH``    :func:`day`
-``DAY_OF_WEEK``     :func:`day_of_week`
-``DOW``             :func:`day_of_week`
-``DAY_OF_YEAR``     :func:`day_of_year`
-``DOY``             :func:`day_of_year`
-``YEAR_OF_WEEK``    :func:`year_of_week`
-``YOW``             :func:`year_of_week`
-``HOUR``            :func:`hour`
-``MINUTE``          :func:`minute`
-``SECOND``          :func:`second`
-``TIMEZONE_HOUR``   :func:`timezone_hour`
-``TIMEZONE_MINUTE`` :func:`timezone_minute`
+``YEAR``            :func:`!year`
+``QUARTER``         :func:`!quarter`
+``MONTH``           :func:`!month`
+``WEEK``            :func:`!week`
+``DAY``             :func:`!day`
+``DAY_OF_MONTH``    :func:`!day`
+``DAY_OF_WEEK``     :func:`!day_of_week`
+``DOW``             :func:`!day_of_week`
+``DAY_OF_YEAR``     :func:`!day_of_year`
+``DOY``             :func:`!day_of_year`
+``YEAR_OF_WEEK``    :func:`!year_of_week`
+``YOW``             :func:`!year_of_week`
+``HOUR``            :func:`!hour`
+``MINUTE``          :func:`!minute`
+``SECOND``          :func:`!second`
+``TIMEZONE_HOUR``   :func:`!timezone_hour`
+``TIMEZONE_MINUTE`` :func:`!timezone_minute`
 =================== ===========
 
 The types supported by the ``extract`` function vary depending on the
@@ -315,7 +315,7 @@ Convenience Extraction Functions
 
 .. function:: day_of_month(x) -> bigint
 
-    This is an alias for :func:`day`.
+    This is an alias for :func:`!day`.
 
 .. function:: day_of_week(x) -> bigint
 
@@ -329,11 +329,11 @@ Convenience Extraction Functions
 
 .. function:: dow(x) -> bigint
 
-    This is an alias for :func:`day_of_week`.
+    This is an alias for :func:`!day_of_week`.
 
 .. function:: doy(x) -> bigint
 
-    This is an alias for :func:`day_of_year`.
+    This is an alias for :func:`!day_of_year`.
 
 .. function:: hour(x) -> bigint
 
@@ -378,7 +378,7 @@ Convenience Extraction Functions
 
 .. function:: week_of_year(x) -> bigint
 
-    This is an alias for :func:`week`.
+    This is an alias for :func:`!week`.
 
 .. function:: year(x) -> bigint
 
@@ -390,4 +390,4 @@ Convenience Extraction Functions
 
 .. function:: yow(x) -> bigint
 
-    This is an alias for :func:`year_of_week`.
+    This is an alias for :func:`!year_of_week`.

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -175,8 +175,8 @@ Operations
 
     Returns a geometry that represents the point set union of the input
     geometries. Performance of this function, in conjunction with
-    :func:`array_agg` to first aggregate the input geometries, may be better
-    than :func:`geometry_union_agg`, at the expense of higher memory
+    :func:`!array_agg` to first aggregate the input geometries, may be better
+    than :func:`!geometry_union_agg`, at the expense of higher memory
     utilization.
 
 .. function:: ST_Boundary(Geometry) -> Geometry
@@ -231,7 +231,7 @@ Operations
     Returns a geometry that represents the point set union of the input
     geometries.
 
-    See also:  :func:`geometry_union`, :func:`geometry_union_agg`
+    See also:  :func:`!geometry_union`, :func:`!geometry_union_agg`
 
 
 Accessors
@@ -329,7 +329,7 @@ Accessors
 .. function:: ST_IsSimple(Geometry) -> boolean
 
     Returns ``true`` if this Geometry has no anomalous geometric points, such as self intersection or self tangency.
-    Use :func:`geometry_invalid_reason` to determine why the geometry is not simple.
+    Use :func:`!geometry_invalid_reason` to determine why the geometry is not simple.
 
 .. function:: ST_IsRing(Geometry) -> boolean
 
@@ -338,7 +338,7 @@ Accessors
 .. function:: ST_IsValid(Geometry) -> boolean
 
     Returns ``true`` if and only if the input geometry is well formed.
-    Use :func:`geometry_invalid_reason` to determine why the geometry is not well formed.
+    Use :func:`!geometry_invalid_reason` to determine why the geometry is not well formed.
 
 .. function:: ST_Length(Geometry) -> double
 

--- a/presto-docs/src/main/sphinx/functions/hyperloglog.rst
+++ b/presto-docs/src/main/sphinx/functions/hyperloglog.rst
@@ -2,7 +2,7 @@
 HyperLogLog Functions
 =====================
 
-Presto implements the :func:`approx_distinct` function using the
+Presto implements the :func:`!approx_distinct` function using the
 `HyperLogLog <https://en.wikipedia.org/wiki/HyperLogLog>`_ data structure.
 
 Data Structures
@@ -25,14 +25,14 @@ Serialization
 
 Data sketches can be serialized to and deserialized from ``varbinary``. This
 allows them to be stored for later use.  Combined with the ability to merge
-multiple sketches, this allows one to calculate :func:`approx_distinct` of the
+multiple sketches, this allows one to calculate :func:!approx_distinct` of the
 elements of a partition of a query, then for the entirety of a query with very
 little cost.
 
 For example, calculating the ``HyperLogLog`` for daily unique users will allow
 weekly or monthly unique users to be calculated incrementally by combining the
 dailies. This is similar to computing weekly revenue by summing daily revenue.
-Uses of :func:`approx_distinct` with ``GROUPING SETS`` can be converted to use
+Uses of :func:`!approx_distinct` with ``GROUPING SETS`` can be converted to use
 ``HyperLogLog``.  Examples::
 
     CREATE TABLE visit_summaries (
@@ -56,7 +56,7 @@ Functions
 
     Returns the ``HyperLogLog`` sketch of the input data set of ``x``.
     The value of the maximum standard error is defaulted to ``0.01625``.
-    This data sketch underlies :func:`approx_distinct` and can be stored and
+    This data sketch underlies :func:`!approx_distinct` and can be stored and
     used later by calling ``cardinality()``.
 
 .. function:: approx_set(x, e) -> HyperLogLog
@@ -64,13 +64,13 @@ Functions
     Returns the ``HyperLogLog`` sketch of the input data set of ``x``, with
     a maximum standard error of ``e``. The current implementation of this
     function requires that ``e`` be in the range of ``[0.0040625, 0.26000]``.
-    This data sketch underlies :func:`approx_distinct` and can be stored and
+    This data sketch underlies :func:`!approx_distinct` and can be stored and
     used later by calling ``cardinality()``.
 
 .. function:: cardinality(hll) -> bigint
     :noindex:
 
-    This will perform :func:`approx_distinct` on the data summarized by the
+    This will perform :func:`!approx_distinct` on the data summarized by the
     ``hll`` HyperLogLog data sketch.
 
 .. function:: empty_approx_set() -> HyperLogLog

--- a/presto-docs/src/main/sphinx/functions/json.rst
+++ b/presto-docs/src/main/sphinx/functions/json.rst
@@ -159,7 +159,7 @@ JSON Functions
 
 .. function:: json_extract_scalar(json, json_path) -> varchar
 
-    Like :func:`json_extract`, but returns the result value as a string (as opposed
+    Like :func:`!json_extract`, but returns the result value as a string (as opposed
     to being encoded as JSON). The value referenced by ``json_path`` must be a
     scalar (boolean, number or string)::
 
@@ -169,17 +169,17 @@ JSON Functions
 .. function:: json_format(json) -> varchar
 
     Returns the JSON text serialized from the input JSON value.
-    This is inverse function to :func:`json_parse`::
+    This is inverse function to :func:`!json_parse`::
 
         SELECT json_format(JSON '[1, 2, 3]'); -- '[1,2,3]'
         SELECT json_format(JSON '"a"'); -- '"a"'
 
 .. note::
 
-    :func:`json_format` and ``CAST(json AS VARCHAR)`` have completely
+    :func:`!json_format` and ``CAST(json AS VARCHAR)`` have completely
     different semantics.
 
-    :func:`json_format` serializes the input JSON value to JSON text conforming to
+    :func:`!json_format` serializes the input JSON value to JSON text conforming to
     :rfc:`7159`. The JSON value can be a JSON object, a JSON array, a JSON string,
     a JSON number, ``true``, ``false`` or ``null``::
 
@@ -205,17 +205,17 @@ JSON Functions
 .. function:: json_parse(string) -> json
 
     Returns the JSON value deserialized from the input JSON text.
-    This is inverse function to :func:`json_format`::
+    This is inverse function to :func:`!json_format`::
 
         SELECT json_parse('[1, 2, 3]'); -- JSON '[1,2,3]'
         SELECT json_parse('"abc"'); -- JSON '"abc"'
 
 .. note::
 
-    :func:`json_parse` and ``CAST(string AS JSON)`` have completely
+    :func:`!json_parse` and ``CAST(string AS JSON)`` have completely
     different semantics.
 
-    :func:`json_parse` expects a JSON text conforming to :rfc:`7159`, and returns
+    :func:`!json_parse` expects a JSON text conforming to :rfc:`7159`, and returns
     the JSON value deserialized from the JSON text.
     The JSON value can be a JSON object, a JSON array, a JSON string, a JSON number,
     ``true``, ``false`` or ``null``::
@@ -241,7 +241,7 @@ JSON Functions
 
 .. function:: json_size(json, json_path) -> bigint
 
-    Like :func:`json_extract`, but returns the size of the value.
+    Like :func:`!json_extract`, but returns the size of the value.
     For objects or arrays, the size is the number of members,
     and the size of a scalar value is zero::
 

--- a/presto-docs/src/main/sphinx/functions/khyperloglog.rst
+++ b/presto-docs/src/main/sphinx/functions/khyperloglog.rst
@@ -4,7 +4,7 @@ KHyperLogLog Functions
 
 Presto implements the `KHyperLogLog <https://research.google/pubs/pub47664/>`_
 algorithm and data structure. ``KHyperLogLog`` data structure can be created
-through :func:`khyperloglog_agg`.
+through :func:`!khyperloglog_agg`.
 
 
 Data Structures

--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -28,7 +28,7 @@ Mathematical Functions
 
 .. function:: ceil(x) -> [same as input]
 
-    This is an alias for :func:`ceiling`.
+    This is an alias for :func:`!ceiling`.
 
 .. function:: ceiling(x) -> [same as input]
 
@@ -82,7 +82,7 @@ Mathematical Functions
 
 .. function:: pow(x, p) -> double
 
-    This is an alias for :func:`power`.
+    This is an alias for :func:`!power`.
 
 .. function:: power(x, p) -> double
 
@@ -94,7 +94,7 @@ Mathematical Functions
 
 .. function:: rand() -> double
 
-    This is an alias for :func:`random()`.
+    This is an alias for :func:`!random()`.
 
 .. function:: random() -> double
 
@@ -106,7 +106,7 @@ Mathematical Functions
 
 .. function:: secure_rand() -> double
 
-    This is an alias for :func:`secure_random()`.
+    This is an alias for :func:`!secure_random()`.
 
 .. function:: secure_random() -> double
 
@@ -313,7 +313,7 @@ Trigonometric Functions
 -----------------------
 
 All trigonometric function arguments are expressed in radians.
-See unit conversion functions :func:`degrees` and :func:`radians`.
+See unit conversion functions :func:`!degrees` and :func:`!radians`.
 
 .. function:: acos(x) -> double
 

--- a/presto-docs/src/main/sphinx/functions/noisy.rst
+++ b/presto-docs/src/main/sphinx/functions/noisy.rst
@@ -11,8 +11,8 @@ Overview
 --------
 
 Noisy aggregate functions are functions that provide random, noisy
-approximations of common aggregations like :func:`sum`, :func:`count`, and
-:func:`approx_distinct` as well as sketches like :func:`approx_set`. By
+approximations of common aggregations like :func:`!sum`, :func:`!count`, and
+:func:`!approx_distinct` as well as sketches like :func:`!approx_set`. By
 injecting random noise into results, noisy aggregation functions make it more
 difficult to determine or confirm the exact data that was aggregated.
 
@@ -40,10 +40,10 @@ Counts, Sums, and Averages
 
     .. note::
 
-        Unlike :func:`count`, this function returns ``NULL`` when the (true) count of ``col`` is 0.
+        Unlike :func:`!count`, this function returns ``NULL`` when the (true) count of ``col`` is 0.
 
     Distinct counting can be performed using ``noisy_count_gaussian(DISTINCT col, ...)``, or with
-    :func:`noisy_approx_distinct_sfm`. Generally speaking, :func:`noisy_count_gaussian`
+    :func:`!noisy_approx_distinct_sfm`. Generally speaking, :func:`!noisy_count_gaussian`
     returns more accurate results but at a larger computational cost.
 
 .. function:: noisy_count_if_gaussian(col, noise_scale[, random_seed]) -> bigint
@@ -60,7 +60,7 @@ Counts, Sums, and Averages
 
     .. note::
 
-        Unlike :func:`count_if`, this function returns ``NULL`` when the (true) count is 0.
+        Unlike :func:`!count_if`, this function returns ``NULL`` when the (true) count is 0.
 
 .. function:: noisy_sum_gaussian(col, noise_scale, lower, upper[, random_seed]) -> double
 
@@ -108,7 +108,7 @@ is supported via the Sketch-Flip-Merge (SFM) data sketch [Hehir2023]_.
 .. function:: noisy_approx_set_sfm(col, epsilon[, buckets[, precision]]) -> SfmSketch
 
     Returns an SFM sketch of the input values in ``col``. This is analogous to the
-    :func:`approx_set` function, which returns a (deterministic) HyperLogLog sketch.
+    :func:`!approx_set` function, which returns a (deterministic) HyperLogLog sketch.
 
     - ``col`` supports many types, similar to ``HyperLogLog``.
     - ``epsilon`` (double) is a positive number that controls the level of noise in
@@ -120,14 +120,14 @@ is supported via the Sketch-Flip-Merge (SFM) data sketch [Hehir2023]_.
 
     .. note::
 
-        Unlike :func:`approx_set`, this function returns ``NULL`` when ``col`` is empty.
-        If this behavior is undesirable, use :func:`coalesce` with :func:`noisy_empty_approx_set_sfm`.
+        Unlike :func:`!approx_set`, this function returns ``NULL`` when ``col`` is empty.
+        If this behavior is undesirable, use :func:`!coalesce` with :func:`!noisy_empty_approx_set_sfm`.
 
 .. function:: noisy_approx_set_sfm_from_index_and_zeros(col_index, col_zeros, epsilon, buckets[, precision]) -> SfmSketch
 
     Returns an SFM sketch of the input values in ``col_index`` and ``col_zeros``.
 
-    This is similar to :func:`noisy_approx_set_sfm` except that function calculates a ``Murmur3Hash128.hash64()`` of ``col``,
+    This is similar to :func:`!noisy_approx_set_sfm` except that function calculates a ``Murmur3Hash128.hash64()`` of ``col``,
     and calculates the SFM PCSA bucket index and number of trailing zeros as described in
     [FlajoletMartin1985]_. In this function, the caller must explicitly calculate the hash bucket index
     and zeros themselves and pass them as arguments ``col_index`` and ``col_zeros``.
@@ -143,23 +143,23 @@ is supported via the Sketch-Flip-Merge (SFM) data sketch [Hehir2023]_.
 
     .. note::
 
-        Like  :func:`noisy_approx_set_sfm`, this function returns ``NULL`` when ``col_index``
+        Like  :func:`!noisy_approx_set_sfm`, this function returns ``NULL`` when ``col_index``
         or ``col_zeros`` is ``NULL``.
-        If this behavior is undesirable, use :func:`coalesce` with :func:`noisy_empty_approx_set_sfm`.
+        If this behavior is undesirable, use :func:`!coalesce` with :func:`!noisy_empty_approx_set_sfm`.
 
 .. function:: noisy_approx_distinct_sfm(col, epsilon[, buckets[, precision]]) -> bigint
 
     Equivalent to ``cardinality(noisy_approx_set_sfm(col, epsilon, buckets, precision))``,
     this returns the approximate cardinality (distinct count) of the column ``col``.
-    This is analogous to the (deterministic) :func:`approx_distinct` function.
+    This is analogous to the (deterministic) :func:`!approx_distinct` function.
 
     .. note::
 
-        Unlike :func:`approx_distinct`, this function returns ``NULL`` when ``col`` is empty.
+        Unlike :func:`!approx_distinct`, this function returns ``NULL`` when ``col`` is empty.
 
 .. function:: noisy_empty_approx_set_sfm(epsilon[, buckets[, precision]]) -> SfmSketch
 
-    Returns an SFM sketch with no items in it. This is analogous to the :func:`empty_approx_set`
+    Returns an SFM sketch with no items in it. This is analogous to the :func:`!empty_approx_set`
     function, which returns an empty (deterministic) HyperLogLog sketch.
 
     - ``epsilon`` (double) is a positive number that controls the level of noise in the sketch,
@@ -183,7 +183,7 @@ is supported via the Sketch-Flip-Merge (SFM) data sketch [Hehir2023]_.
 .. function:: merge_sfm(ARRAY[SfmSketch, ...]) -> SfmSketch
 
     A scalar function that returns a merged ``SfmSketch`` of the set union of an array
-    of ``SfmSketch`` objects, similar to :func:`merge_hll`. ::
+    of ``SfmSketch`` objects, similar to :func:`!merge_hll`. ::
 
         SELECT cardinality(merge_sfm(ARRAY[
             noisy_approx_set_sfm(col_1, 5.0),

--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -15,7 +15,7 @@ String Functions
     These functions assume that the input strings contain valid UTF-8 encoded
     Unicode code points.  There are no explicit checks for valid UTF-8 and
     the functions may return incorrect results on invalid UTF-8.
-    Invalid UTF-8 data can be corrected with :func:`from_utf8`.
+    Invalid UTF-8 data can be corrected with :func:`!from_utf8`.
 
     Additionally, the functions operate on Unicode code points and not user
     visible *characters* (or *grapheme clusters*).  Some languages combine
@@ -23,7 +23,7 @@ String Functions
     unit of a writing system for a language, but the functions will treat each
     code point as a separate unit.
 
-    The :func:`lower` and :func:`upper` functions do not perform
+    The :func:`!lower` and :func:`!upper` functions do not perform
     locale-sensitive, context-sensitive, or one-to-many mappings required for
     some languages. Specifically, this will return incorrect results for
     Lithuanian, Turkish and Azeri.
@@ -75,7 +75,7 @@ String Functions
 
 .. function:: ltrim(string) -> varchar
 
-    Removes leading whitespace from ``string``. See :func:`trim` for the set of
+    Removes leading whitespace from ``string``. See :func:`!trim` for the set of
     recognized whitespace characters.
 
 .. function:: ltrim(string, chars) -> varchar
@@ -115,7 +115,7 @@ String Functions
 
 .. function:: rtrim(string) -> varchar
 
-    Removes trailing whitespace from ``string``. See :func:`trim` for the set of
+    Removes trailing whitespace from ``string``. See :func:`!trim` for the set of
     recognized whitespace characters.
 
 .. function:: rtrim(string, chars) -> varchar

--- a/presto-docs/src/main/sphinx/functions/teradata.rst
+++ b/presto-docs/src/main/sphinx/functions/teradata.rst
@@ -13,15 +13,15 @@ String Functions
 
 .. function:: index(string, substring) -> bigint
 
-    Alias for :func:`strpos` function.
+    Alias for :func:`!strpos` function.
 
 .. function:: substring(string, start) -> varchar
 
-    Alias for :func:`substr` function.
+    Alias for :func:`!substr` function.
 
 .. function:: substring(string, start, length) -> varchar
 
-    Alias for :func:`substr` function.
+    Alias for :func:`!substr` function.
 
 Date Functions
 --------------

--- a/presto-docs/src/main/sphinx/functions/url.rst
+++ b/presto-docs/src/main/sphinx/functions/url.rst
@@ -64,4 +64,4 @@ Encoding Functions
 .. function:: url_decode(value) -> varchar
 
     Unescapes the URL encoded ``value``.
-    This function is the inverse of :func:`url_encode`.
+    This function is the inverse of :func:`!url_encode`.

--- a/presto-docs/src/main/sphinx/functions/window.rst
+++ b/presto-docs/src/main/sphinx/functions/window.rst
@@ -132,7 +132,7 @@ Ranking Functions
 .. function:: dense_rank() -> bigint
 
     Returns the rank of a value in a group of values. This is similar to
-    :func:`rank`, except that tie values do not produce gaps in the sequence.
+    :func:`!rank`, except that tie values do not produce gaps in the sequence.
 
 .. function:: ntile(n) -> bigint
 
@@ -148,7 +148,7 @@ Ranking Functions
 .. function:: percent_rank() -> double
 
     Returns the percentage ranking of a value in group of values. The result
-    is ``(r - 1) / (n - 1)`` where ``r`` is the :func:`rank` of the row and
+    is ``(r - 1) / (n - 1)`` where ``r`` is the :func:`!rank` of the row and
     ``n`` is the total number of rows in the window partition.
 
 .. function:: rank() -> bigint

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -310,14 +310,14 @@ HyperLogLog
 -----------
 
 Calculating the approximate distinct count can be done much more cheaply than an exact count using the
-`HyperLogLog <https://en.wikipedia.org/wiki/HyperLogLog>`_ data sketch. See :doc:`/functions/hyperloglog`.
+`HyperLogLog <https://en.wikipedia.org/wiki/HyperLogLog>`__ data sketch. See :doc:`/functions/hyperloglog`.
 
 .. _hyperloglog_type:
 
 ``HyperLogLog``
 ^^^^^^^^^^^^^^^
 
-A HyperLogLog sketch allows efficient computation of :func:`approx_distinct`. It starts as a
+A HyperLogLog sketch allows efficient computation of :func:`!approx_distinct`. It starts as a
 sparse representation, switching to a dense representation when it becomes more efficient.
 
 .. _p4hyperloglog_type:
@@ -373,7 +373,7 @@ SFM Sketch
 ^^^^^^^^^^^^^
 
 The Sketch-Flip-Merge (SFM) data sketch is a noisy, random distinct-counting
-sketch similar to :ref:`hyperloglog_type`. See :func:`noisy_approx_set_sfm`.
+sketch similar to :ref:`hyperloglog_type`. See :func:`!noisy_approx_set_sfm`.
 
 Quantile Digest
 ---------------

--- a/presto-docs/src/main/sphinx/release/release-0.100.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.100.rst
@@ -14,12 +14,12 @@ implementing the ``getSystemTables()`` method on the ``Connector`` interface.
 General Changes
 ---------------
 
-* Fix ``%f`` specifier in :func:`date_format` and :func:`date_parse`.
+* Fix ``%f`` specifier in :func:`!date_format` and :func:`!date_parse`.
 * Add ``WITH ORDINALITY`` support to ``UNNEST``.
-* Add :func:`array_distinct` function.
-* Add :func:`split` function.
-* Add :func:`degrees` and :func:`radians` functions.
-* Add :func:`to_base` and :func:`from_base` functions.
+* Add :func:`!array_distinct` function.
+* Add :func:`!split` function.
+* Add :func:`!degrees` and :func:`!radians` functions.
+* Add :func:`!to_base` and :func:`!from_base` functions.
 * Rename config property ``task.shard.max-threads`` to ``task.max-worker-threads``.
   This property sets the number of threads used to concurrently process splits.
   The old property name is deprecated and will be removed in a future release.

--- a/presto-docs/src/main/sphinx/release/release-0.101.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.101.rst
@@ -7,14 +7,14 @@ General Changes
 
 * Add support for :doc:`/sql/create-table` (in addition to :doc:`/sql/create-table-as`).
 * Add ``IF EXISTS`` support to :doc:`/sql/drop-table` and :doc:`/sql/drop-view`.
-* Add :func:`array_agg` function.
-* Add :func:`array_intersect` function.
-* Add :func:`array_position` function.
-* Add :func:`regexp_split` function.
-* Add support for ``millisecond`` to :func:`date_diff` and :func:`date_add`.
-* Fix excessive memory usage in :func:`map_agg`.
+* Add :func:`!array_agg` function.
+* Add :func:`!array_intersect` function.
+* Add :func:`!array_position` function.
+* Add :func:`!regexp_split` function.
+* Add support for ``millisecond`` to :func:`!date_diff` and :func:`!date_add`.
+* Fix excessive memory usage in :func:`!map_agg`.
 * Fix excessive memory usage in queries that perform partitioned top-N operations
-  with :func:`row_number`.
+  with :func:`!row_number`.
 * Optimize :ref:`array_type` comparison operators.
 * Fix analysis of ``UNION`` queries for tables with hidden columns.
 * Fix ``JOIN`` associativity to be left-associative instead of right-associative.

--- a/presto-docs/src/main/sphinx/release/release-0.102.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.102.rst
@@ -8,7 +8,7 @@ Unicode Support
 All string functions have been updated to support Unicode. The functions assume
 that the string contains valid UTF-8 encoded code points. There are no explicit
 checks for valid UTF-8, and the functions may return incorrect results on
-invalid UTF-8.  Invalid UTF-8 data can be corrected with :func:`from_utf8`.
+invalid UTF-8.  Invalid UTF-8 data can be corrected with :func:`!from_utf8`.
 
 Additionally, the functions operate on Unicode code points and not user visible
 *characters* (or *grapheme clusters*).  Some languages combine multiple code points
@@ -31,11 +31,11 @@ General Changes
   be joined on the inner side.
 * Add support for full outer joins.
 * Support returning booleans as numbers in JDBC driver
-* Fix :func:`contains` to return ``NULL`` if the value was not found, but a ``NULL`` was.
+* Fix :func:`!contains` to return ``NULL`` if the value was not found, but a ``NULL`` was.
 * Fix nested :ref:`row_type` rendering in ``DESCRIBE``.
-* Add :func:`array_join`.
+* Add :func:`!array_join`.
 * Optimize map subscript operator.
-* Add :func:`from_utf8` and :func:`to_utf8` functions.
+* Add :func:`!from_utf8` and :func:`!to_utf8` functions.
 * Add ``task_writer_count`` session property to set ``task.writer-count``.
 * Add cast from ``ARRAY(F)`` to ``ARRAY(T)``.
 * Extend implicit coercions to ``ARRAY`` element types.

--- a/presto-docs/src/main/sphinx/release/release-0.103.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.103.rst
@@ -46,9 +46,9 @@ Hive Changes
 General Changes
 ---------------
 
-* Add :func:`array_remove`.
-* Fix NPE in :func:`max_by` and :func:`min_by` caused when few rows were present in the aggregation.
-* Reduce memory usage of :func:`map_agg`.
+* Add :func:`!array_remove`.
+* Fix NPE in :func:`!max_by` and :func:`!min_by` caused when few rows were present in the aggregation.
+* Reduce memory usage of :func:`!map_agg`.
 * Change HTTP client defaults: 2 second idle timeout, 10 second request
   timeout and 250 connections per host.
 * Add SQL command autocompletion to CLI.

--- a/presto-docs/src/main/sphinx/release/release-0.104.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.104.rst
@@ -7,20 +7,20 @@ General Changes
 
 * Handle thread interruption in StatementClient.
 * Fix CLI hang when server becomes unreachable during a query.
-* Add :func:`covar_pop`, :func:`covar_samp`, :func:`corr`, :func:`regr_slope`,
-  and :func:`regr_intercept` functions.
+* Add :func:`!covar_pop`, :func:`!covar_samp`, :func:`!corr`, :func:`!regr_slope`,
+  and :func:`!regr_intercept` functions.
 * Fix potential deadlock in cluster memory manager.
 * Add a visualization of query execution timeline.
-* Allow mixed case in input to :func:`from_hex`.
+* Allow mixed case in input to :func:`!from_hex`.
 * Display "BLOCKED" state in web UI.
 * Reduce CPU usage in coordinator.
 * Fix excess object retention in workers due to long running queries.
-* Reduce memory usage of :func:`array_distinct`.
+* Reduce memory usage of :func:`!array_distinct`.
 * Add optimizer for projection push down which can
   improve the performance of certain query shapes.
 * Improve query performance by storing pre-partitioned pages.
-* Support ``TIMESTAMP`` for :func:`first_value`, :func:`last_value`,
-  :func:`nth_value`, :func:`lead` and :func:`lag`.
+* Support ``TIMESTAMP`` for :func:`!first_value`, :func:`!last_value`,
+  :func:`!nth_value`, :func:`!lead` and :func:`!lag`.
 
 Hive Changes
 ------------

--- a/presto-docs/src/main/sphinx/release/release-0.107.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.107.rst
@@ -12,5 +12,5 @@ General Changes
 * Added ``task.info-refresh-max-wait`` to configure task info freshness.
 * Add support for ``DELETE`` to language and connector SPI.
 * Reenable error classification code for syntax errors.
-* Fix out of bounds exception in :func:`lower` and :func:`upper`
+* Fix out of bounds exception in :func:`!lower` and :func:`!upper`
   when the string contains the code point ``U+10FFFF``.

--- a/presto-docs/src/main/sphinx/release/release-0.108.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.108.rst
@@ -5,18 +5,18 @@ Release 0.108
 General Changes
 ---------------
 
-* Fix incorrect query results when a window function follows a :func:`row_number`
+* Fix incorrect query results when a window function follows a :func:`!row_number`
   function and both are partitioned on the same column(s).
 * Fix planning issue where queries that apply a ``false`` predicate
   to the result of a non-grouped aggregation produce incorrect results.
 * Fix exception when ``ORDER BY`` clause contains duplicate columns.
 * Fix issue where a query (read or write) that should fail can instead
   complete successfully with zero rows.
-* Add :func:`normalize`, :func:`from_iso8601_timestamp`, :func:`from_iso8601_date`
-  and :func:`to_iso8601` functions.
-* Add support for :func:`position` syntax.
-* Add Teradata compatibility functions: :func:`index`, :func:`char2hexint`,
-  :func:`to_char`, :func:`to_date` and :func:`to_timestamp`.
+* Add :func:`!normalize`, :func:`!from_iso8601_timestamp`, :func:`!from_iso8601_date`
+  and :func:`!to_iso8601` functions.
+* Add support for :func:`!position` syntax.
+* Add Teradata compatibility functions: :func:`!index`, :func:`!char2hexint`,
+  :func:`!to_char`, :func:`!to_date` and :func:`!to_timestamp`.
 * Make ``ctrl-C`` in CLI cancel the query (rather than a partial cancel).
 * Allow calling ``Connection.setReadOnly(false)`` in the JDBC driver.
   The read-only status for the connection is currently ignored.
@@ -25,7 +25,7 @@ General Changes
   ``TIMESTAMP WITH TIME ZONE``.
 * Trim values when converting from ``VARCHAR`` to date/time types.
 * Add support for fixed time zones ``+00:00`` and ``-00:00``.
-* Properly account for query memory when using the :func:`row_number` function.
+* Properly account for query memory when using the :func:`!row_number` function.
 * Skip execution of inner join when the join target is empty.
 * Improve query detail UI page.
 * Fix printing of table layouts in :doc:`/sql/explain`.

--- a/presto-docs/src/main/sphinx/release/release-0.109.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.109.rst
@@ -5,7 +5,7 @@ Release 0.109
 General Changes
 ---------------
 
-* Add :func:`slice`, :func:`md5`, :func:`array_min` and :func:`array_max` functions.
+* Add :func:`!slice`, :func:`!md5`, :func:`!array_min` and :func:`!array_max` functions.
 * Fix bug that could cause queries submitted soon after startup to hang forever.
 * Fix bug that could cause ``JOIN`` queries to hang forever, if the right side of
   the ``JOIN`` had too little data or skewed data.

--- a/presto-docs/src/main/sphinx/release/release-0.110.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.110.rst
@@ -5,7 +5,7 @@ Release 0.110
 General Changes
 ---------------
 
-* Fix result truncation bug in window function :func:`row_number` when performing a
+* Fix result truncation bug in window function :func:`!row_number` when performing a
   partitioned top-N that chooses the maximum or minimum ``N`` rows. For example::
 
     SELECT * FROM (

--- a/presto-docs/src/main/sphinx/release/release-0.112.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.112.rst
@@ -5,7 +5,7 @@ Release 0.112
 General Changes
 ---------------
 
-* Fix incorrect handling of filters and limits in :func:`row_number` optimizer.
+* Fix incorrect handling of filters and limits in :func:`!row_number` optimizer.
   This caused certain query shapes to produce incorrect results.
 * Fix non-string object arrays in JMX connector.
 

--- a/presto-docs/src/main/sphinx/release/release-0.113.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.113.rst
@@ -39,11 +39,11 @@ can be validated and converted to any Java type using
 General Changes
 ---------------
 
-* Allow using any type with value window functions :func:`first_value`,
-  :func:`last_value`, :func:`nth_value`, :func:`lead` and :func:`lag`.
-* Add :func:`element_at` function.
-* Add :func:`url_encode` and :func:`url_decode` functions.
-* :func:`concat` now allows arbitrary number of arguments.
+* Allow using any type with value window functions :func:`!first_value`,
+  :func:`!last_value`, :func:`!nth_value`, :func:`!lead` and :func:`!lag`.
+* Add :func:`!element_at` function.
+* Add :func:`!url_encode` and :func:`!url_decode` functions.
+* :func:`!concat` now allows arbitrary number of arguments.
 * Fix JMX connector. In the previous release it always returned zero rows.
 * Fix handling of literal ``NULL`` in ``IS DISTINCT FROM``.
 * Fix an issue that caused some specific queries to fail in planning.

--- a/presto-docs/src/main/sphinx/release/release-0.114.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.114.rst
@@ -5,7 +5,7 @@ Release 0.114
 General Changes
 ---------------
 
-* Fix ``%k`` specifier for :func:`date_format` and :func:`date_parse`.
+* Fix ``%k`` specifier for :func:`!date_format` and :func:`!date_parse`.
   It previously used ``24`` rather than ``0`` for the midnight hour.
 
 Hive Changes

--- a/presto-docs/src/main/sphinx/release/release-0.115.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.115.rst
@@ -6,8 +6,8 @@ General Changes
 ---------------
 
 * Fix an issue with hierarchical queue rules where queries could be rejected after being accepted.
-* Add :func:`sha1`, :func:`sha256` and :func:`sha512` functions.
-* Add :func:`power` as an alias for :func:`pow`.
+* Add :func:`!sha1`, :func:`!sha256` and :func:`!sha512` functions.
+* Add :func:`!power` as an alias for :func:`!pow`.
 * Add support for ``LIMIT ALL`` syntax.
 
 Hive Changes

--- a/presto-docs/src/main/sphinx/release/release-0.116.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.116.rst
@@ -31,9 +31,9 @@ configured with the ``query.low-memory-killer.delay`` option.
 General Changes
 ---------------
 
-* Add :func:`multimap_agg` function.
-* Add :func:`checksum` function.
-* Add :func:`max` and :func:`min` that takes a second argument and produces
+* Add :func:`!multimap_agg` function.
+* Add :func:`!checksum` function.
+* Add :func:`!max` and :func:`!min` that takes a second argument and produces
   ``n`` largest or ``n`` smallest values.
 * Add ``query_max_run_time`` session property and ``query.max-run-time``
   config. Queries are failed after the specified duration.

--- a/presto-docs/src/main/sphinx/release/release-0.117.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.117.rst
@@ -6,7 +6,7 @@ General Changes
 ---------------
 
 * Add back casts between JSON and VARCHAR to provide an easier migration path
-  to :func:`json_parse` and :func:`json_format`. These will be removed in a
+  to :func:`!json_parse` and :func:`!json_format`. These will be removed in a
   future release.
 * Fix bug in semi joins and group bys on a single ``BIGINT`` column where
   0 could match ``NULL``.

--- a/presto-docs/src/main/sphinx/release/release-0.118.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.118.rst
@@ -6,7 +6,7 @@ General Changes
 ---------------
 
 * Fix planning error for ``UNION`` queries that require implicit coercions.
-* Fix null pointer exception when using :func:`checksum`.
+* Fix null pointer exception when using :func:`!checksum`.
 * Fix completion condition for ``SqlTask`` that can cause queries to be blocked.
 
 Authorization

--- a/presto-docs/src/main/sphinx/release/release-0.119.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.119.rst
@@ -6,7 +6,7 @@ General Changes
 ---------------
 
 * Add :doc:`/connector/redis`.
-* Add :func:`geometric_mean` function.
+* Add :func:`!geometric_mean` function.
 * Fix restoring interrupt status in ``StatementClient``.
 * Support getting server version in JDBC driver.
 * Improve correctness and compliance of JDBC ``DatabaseMetaData``.
@@ -19,7 +19,7 @@ General Changes
 * Replaced the ``task.http-notification-threads`` config option with two
   independent options: ``task.http-response-threads`` and ``task.http-timeout-threads``.
 * Improve handling of negated expressions in join criteria.
-* Fix :func:`arbitrary`, :func:`max_by` and :func:`min_by` functions when used
+* Fix :func:`!arbitrary`, :func:`!max_by` and :func:`!min_by` functions when used
   with an array, map or row type.
 * Fix union coercion when the same constant or column appears more than once on
   the same side.

--- a/presto-docs/src/main/sphinx/release/release-0.122.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.122.rst
@@ -16,7 +16,7 @@ General Changes
 * Fix ``NoSuchElementException`` when cross join is used inside ``IN`` query.
 * Fix ``GROUP BY`` to support maps of structural types.
 * The web interface now displays a lock icon next to authenticated users.
-* The :func:`min_by` and :func:`max_by` aggregations now have an additional form
+* The :func:`!min_by` and :func:`!max_by` aggregations now have an additional form
   that return multiple values.
 * Fix incorrect results when using ``IN`` lists of more than 1000 elements of
   ``timestamp with time zone``, ``time with time zone`` or structural types.

--- a/presto-docs/src/main/sphinx/release/release-0.124.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.124.rst
@@ -7,7 +7,7 @@ General Changes
 
 * Fix race in memory tracking of ``JOIN`` which could cause the cluster to become over
   committed and possibly crash.
-* The :func:`approx_percentile` aggregation now also accepts an array of percentages.
+* The :func:`!approx_percentile` aggregation now also accepts an array of percentages.
 * Allow nested row type references.
 * Fix correctness for some queries with ``IN`` lists. When all constants in the
   list are in the range of 32-bit signed integers but the test value can be

--- a/presto-docs/src/main/sphinx/release/release-0.126.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.126.rst
@@ -11,7 +11,7 @@ General Changes
 * Fix occasional query planning failure due to a bug in the projection
   push down optimizer.
 * Fix a parsing issue when expressions contain the form ``POSITION(x in (y))``.
-* Add a new version of :func:`approx_percentile` that takes an ``accuracy``
+* Add a new version of :func:`!approx_percentile` that takes an ``accuracy``
   parameter.
 * Allow specifying columns names in :doc:`/sql/insert` queries.
 * Add ``field_length`` table property to blackhole connector to control the

--- a/presto-docs/src/main/sphinx/release/release-0.129.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.129.rst
@@ -13,7 +13,7 @@ General Changes
 
 * Fix a planner issue that could cause queries involving ``OUTER JOIN`` to
   return incorrect results.
-* Some queries, particularly those using :func:`max_by` or :func:`min_by`, now
+* Some queries, particularly those using :func:`!max_by` or :func:`!min_by`, now
   accurately reflect their true memory usage and thus appear to use more memory
   than before.
 * Fix :doc:`/sql/show-session` to not show hidden session properties.

--- a/presto-docs/src/main/sphinx/release/release-0.130.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.130.rst
@@ -7,7 +7,7 @@ General Changes
 
 * Fix a performance regression in ``GROUP BY`` and ``JOIN`` queries when the
   length of the keys is between 16 and 31 bytes.
-* Add :func:`map_concat` function.
+* Add :func:`!map_concat` function.
 * Performance improvements for filters, projections and dictionary encoded data.
   This optimization is turned off by default. It can be configured via the
   ``optimizer.columnar-processing-dictionary`` config property or the

--- a/presto-docs/src/main/sphinx/release/release-0.132.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.132.rst
@@ -4,7 +4,7 @@ Release 0.132
 
 .. warning::
 
-   :func:`concat` on :ref:`array_type`, or enabling ``columnar_processing_dictionary``
+   :func:`!concat` on :ref:`array_type`, or enabling ``columnar_processing_dictionary``
    may cause queries to fail in this release. This is fixed in :doc:`/release/release-0.133`.
 
 General Changes
@@ -23,10 +23,10 @@ General Changes
 * Add support for transactional connectors.
 * Add support for non-correlated scalar sub-queries.
 * Add support for SQL binary literals.
-* Add variant of :func:`random` that produces an integer number between 0 and a
+* Add variant of :func:`!random` that produces an integer number between 0 and a
   specified upper bound.
-* Perform bounds checks when evaluating :func:`abs`.
-* Improve accuracy of memory accounting for :func:`map_agg` and :func:`array_agg`.
+* Perform bounds checks when evaluating :func:`!abs`.
+* Improve accuracy of memory accounting for :func:`!map_agg` and :func:`!array_agg`.
   These functions will now appear to use more memory than before.
 * Various performance optimizations for functions operating on :ref:`array_type`.
 * Add server version to web UI.

--- a/presto-docs/src/main/sphinx/release/release-0.133.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.133.rst
@@ -14,7 +14,7 @@ General Changes
   This optimization is turned off by default. It can be configured via the
   ``optimizer.dictionary-aggregation`` config property or the
   ``dictionary_aggregation`` session property.
-* Fix race which could cause queries to fail when using :func:`concat` on
+* Fix race which could cause queries to fail when using :func:`!concat` on
   :ref:`array_type`, or when enabling ``columnar_processing_dictionary``.
 * Add sticky headers and the ability to sort the tasks table on the query page
   in the web interface.

--- a/presto-docs/src/main/sphinx/release/release-0.135.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.135.rst
@@ -8,6 +8,6 @@ General Changes
 * Add summary of change in CPU usage to verifier output.
 * Add cast between JSON and VARCHAR, BOOLEAN, DOUBLE, BIGINT. For the old
   behavior of cast between JSON and VARCHAR (pre-:doc:`/release/release-0.122`),
-  use :func:`json_parse` and :func:`json_format`.
+  use :func:`!json_parse` and :func:`!json_format`.
 * Fix bug in 0.134 that prevented query page in web UI from displaying in
   Safari.

--- a/presto-docs/src/main/sphinx/release/release-0.137.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.137.rst
@@ -9,13 +9,13 @@ General Changes
 * Fix invalid plans when scalar subqueries use ``GROUP BY``, ``DISTINCT`` or ``JOIN``.
 * Do not allow creating views with a column type of ``UNKNOWN``.
 * Improve expression optimizer to remove some redundant operations.
-* Add :func:`bit_count`, :func:`bitwise_not`, :func:`bitwise_and`,
-  :func:`bitwise_or`, and :func:`bitwise_xor` functions.
-* Add :func:`approx_distinct` aggregation support for ``VARBINARY`` input.
+* Add :func:`!bit_count`, :func:`!bitwise_not`, :func:`!bitwise_and`,
+  :func:`!bitwise_or`, and :func:`!bitwise_xor` functions.
+* Add :func:`!approx_distinct` aggregation support for ``VARBINARY`` input.
 * Add create time to query detail page in UI.
 * Add support for ``VARCHAR(length)`` type.
 * Track per-stage peak memory usage.
-* Allow using double input for :func:`approx_percentile` with an array of
+* Allow using double input for :func:`!approx_percentile` with an array of
   percentiles.
 * Add API to JDBC driver to track query progress.
 

--- a/presto-docs/src/main/sphinx/release/release-0.140.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.140.rst
@@ -12,7 +12,7 @@ General Changes
 * Fix logging of ``failure_host`` and ``failure_task`` fields in
   ``QueryCompletionEvent``.
 * Fix race which can cause queries to fail with a ``REMOTE_TASK_ERROR``.
-* Optimize :func:`array_distinct` for ``array(bigint)``.
+* Optimize :func:`!array_distinct` for ``array(bigint)``.
 * Optimize ``>`` operator for :ref:`array_type`.
 * Fix an optimization issue that could result in non-deterministic functions
   being evaluated more than once producing unexpected results.

--- a/presto-docs/src/main/sphinx/release/release-0.142.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.142.rst
@@ -12,13 +12,13 @@ General Changes
 * Add support for :ref:`complex grouping operations<complex_grouping_operations>`
   - ``CUBE``, ``ROLLUP`` and ``GROUPING SETS``.
 * Add support for ``IF NOT EXISTS`` in ``CREATE TABLE AS`` queries.
-* Add :func:`substring` function.
+* Add :func:`!substring` function.
 * Add ``http.server.authentication.krb5.keytab`` config option to set the location of the Kerberos
   keytab file explicitly.
 * Add ``optimize_metadata_queries`` session property to enable the metadata-only query optimization.
 * Improve support for non-equality predicates in ``JOIN`` criteria.
 * Add support for non-correlated subqueries in aggregation queries.
-* Improve performance of :func:`json_extract`.
+* Improve performance of :func:`!json_extract`.
 
 Hive Changes
 ------------

--- a/presto-docs/src/main/sphinx/release/release-0.143.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.143.rst
@@ -13,11 +13,11 @@ General Changes
 * Add config option ``query.max-cpu-time`` to limit CPU time used by a query.
 * Add loading indicator and error message to query detail page in UI.
 * Add query teardown to query timeline visualizer.
-* Add string padding functions :func:`lpad` and :func:`rpad`.
-* Add :func:`width_bucket` function.
-* Add :func:`truncate` function.
+* Add string padding functions :func:`!lpad` and :func:`!rpad`.
+* Add :func:`!width_bucket` function.
+* Add :func:`!truncate` function.
 * Improve query startup time in large clusters.
-* Improve error messages for ``CAST`` and :func:`slice`.
+* Improve error messages for ``CAST`` and :func:`!slice`.
 
 Hive Changes
 ------------

--- a/presto-docs/src/main/sphinx/release/release-0.144.7.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.144.7.rst
@@ -7,4 +7,4 @@ General Changes
 
 * Fail queries with non-equi conjuncts in ``OUTER JOIN``\s, instead of silently
   dropping such conjuncts from the query and producing incorrect results.
-* Add :func:`cosine_similarity` function.
+* Add :func:`!cosine_similarity` function.

--- a/presto-docs/src/main/sphinx/release/release-0.146.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.146.rst
@@ -5,7 +5,7 @@ Release 0.146
 General Changes
 ---------------
 
-* Fix error in :func:`map_concat` when the second map is empty.
+* Fix error in :func:`!map_concat` when the second map is empty.
 * Require at least 4096 file descriptors to run Presto.
 * Support casting between map types.
 * Add :doc:`/connector/mongodb`.

--- a/presto-docs/src/main/sphinx/release/release-0.147.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.147.rst
@@ -17,15 +17,15 @@ General Changes
 * Support ``LIKE`` clause for :doc:`/sql/show-catalogs` and :doc:`/sql/show-schemas`.
 * Add support for ``INTERSECT``.
 * Add support for casting row types.
-* Add :func:`sequence` function.
-* Add :func:`sign` function.
-* Add :func:`flatten` function.
+* Add :func:`!sequence` function.
+* Add :func:`!sign` function.
+* Add :func:`!flatten` function.
 * Add experimental implementation of :doc:`resource groups </admin/resource-groups>`.
 * Add :doc:`/connector/localfile`.
 * Remove experimental intermediate aggregation optimizer. The ``optimizer.use-intermediate-aggregations``
   config option and ``task_intermediate_aggregation`` session property are no longer supported.
 * Add support for colocated joins for connectors that expose node-partitioned data.
-* Improve the performance of :func:`array_intersect`.
+* Improve the performance of :func:`!array_intersect`.
 * Generalize the intra-node parallel execution system to work with all query stages.
   The ``task.concurrency`` configuration property replaces the old ``task.join-concurrency``
   and ``task.default-concurrency`` options. Similarly, the ``task_concurrency`` session

--- a/presto-docs/src/main/sphinx/release/release-0.148.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.148.rst
@@ -23,10 +23,10 @@ General Changes
 * Add ``colocated-joins-enabled`` to enable colocated joins by default for
   connectors that expose node-partitioned data.
 * Add support for colocated unions.
-* Reduce initial memory usage of :func:`array_agg` function.
+* Reduce initial memory usage of :func:`!array_agg` function.
 * Improve planning of co-partitioned ``JOIN`` and ``UNION``.
 * Improve planning of aggregations over partitioned data.
-* Improve the performance of the :func:`array_sort` function.
+* Improve the performance of the :func:`!array_sort` function.
 * Improve outer join predicate push down.
 * Increase default value for ``query.initial-hash-partitions`` to ``100``.
 * Change default value of ``query.max-memory-per-node`` to ``10%`` of the Java heap.
@@ -62,10 +62,10 @@ This release fixes several problems with large and negative intervals.
 Functions and Language Features
 -------------------------------
 
-* Add :func:`element_at` function for map type.
-* Add :func:`split_to_map` function.
-* Add :func:`zip` function.
-* Add :func:`map_union` aggregation function.
+* Add :func:`!element_at` function for map type.
+* Add :func:`!split_to_map` function.
+* Add :func:`!zip` function.
+* Add :func:`!map_union` aggregation function.
 * Add ``ROW`` syntax for constructing row types.
 * Add support for ``REVOKE`` permission syntax.
 * Add support for ``SMALLINT`` and ``TINYINT`` types.

--- a/presto-docs/src/main/sphinx/release/release-0.149.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.149.rst
@@ -6,13 +6,13 @@ General Changes
 ---------------
 
 * Fix runtime failure for queries that use grouping sets over unions.
-* Do not ignore null values in :func:`array_agg`.
+* Do not ignore null values in :func:`!array_agg`.
 * Fix failure when casting row values that contain null fields.
 * Fix failure when using complex types as map keys.
 * Fix potential memory tracking leak when queries are cancelled.
 * Fix rejection of queries that do not match any queue/resource group rules.
   Previously, a 500 error was returned to the client.
-* Fix :func:`trim` and :func:`rtrim` functions to produce more intuitive results
+* Fix :func:`!trim` and :func:`!rtrim` functions to produce more intuitive results
   when the argument contains invalid ``UTF-8`` sequences.
 * Add a new web interface with cluster overview, realtime stats, and improved sorting
   and filtering of queries.
@@ -24,7 +24,7 @@ General Changes
 * ``columnar_processing`` and ``columnar_processing_dictionary`` session
   properties were merged to ``processing_optimization`` with possible values
   ``disabled``, ``columnar`` and ``columnar_dictionary``
-* Change ``%y`` (2-digit year) in :func:`date_parse` to evaluate to a year between
+* Change ``%y`` (2-digit year) in :func:`!date_parse` to evaluate to a year between
   1970 and 2069 inclusive.
 * Add ``queued`` flag to ``StatementStats`` in REST API.
 * Improve error messages for math operations.

--- a/presto-docs/src/main/sphinx/release/release-0.150.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.150.rst
@@ -12,9 +12,9 @@ General Changes
 ---------------
 
 * Fix web UI bug that caused rendering to fail when a stage has no tasks.
-* Fix failure due to ambiguity when calling :func:`round` on ``tinyint`` arguments.
+* Fix failure due to ambiguity when calling :func:`!round` on ``tinyint`` arguments.
 * Fix race in exchange HTTP endpoint, which could cause queries to fail randomly.
-* Add support for parsing timestamps with nanosecond precision in :func:`date_parse`.
+* Add support for parsing timestamps with nanosecond precision in :func:`!date_parse`.
 * Add CPU quotas to resource groups.
 
 Hive Changes

--- a/presto-docs/src/main/sphinx/release/release-0.151.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.151.rst
@@ -8,12 +8,12 @@ General Changes
 * Fix issue where aggregations may produce the wrong result when ``task.concurrency`` is set to ``1``.
 * Fix query failure when ``array``, ``map``, or ``row`` type is used in non-equi ``JOIN``.
 * Fix performance regression for queries using ``OUTER JOIN``.
-* Fix query failure when using the :func:`arbitrary` aggregation function on ``integer`` type.
+* Fix query failure when using the :func:`!arbitrary` aggregation function on ``integer`` type.
 * Add various math functions that operate directly on ``float`` type.
-* Add flag ``deprecated.legacy-array-agg`` to restore legacy :func:`array_agg`
+* Add flag ``deprecated.legacy-array-agg`` to restore legacy :func:`!array_agg`
   behavior (ignore ``NULL`` input). This flag will be removed in a future release.
 * Add support for uncorrelated ``EXISTS`` clause.
-* Add :func:`cosine_similarity` function.
+* Add :func:`!cosine_similarity` function.
 * Allow :doc:`/installation/tableau` to use catalogs other than ``hive``.
 
 Verifier Changes

--- a/presto-docs/src/main/sphinx/release/release-0.152.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.152.rst
@@ -5,10 +5,10 @@ Release 0.152
 General Changes
 ---------------
 
-* Add :func:`array_union` function.
-* Add :func:`reverse` function for arrays.
+* Add :func:`!array_union` function.
+* Add :func:`!reverse` function for arrays.
 * Fix issue that could cause queries with ``varchar`` literals to fail.
-* Fix categorization of errors from :func:`url_decode`, allowing it to be used with ``TRY``.
+* Fix categorization of errors from :func:`!url_decode`, allowing it to be used with ``TRY``.
 * Fix error reporting for invalid JSON paths provided to JSON functions.
 * Fix view creation for queries containing ``GROUPING SETS``.
 * Fix query failure when referencing a field of a ``NULL`` row.

--- a/presto-docs/src/main/sphinx/release/release-0.153.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.153.rst
@@ -8,8 +8,8 @@ General Changes
 * Fix incorrect results for grouping sets when ``task.concurrency`` is greater than one.
 * Fix silent numeric overflow when casting ``INTEGER`` to large ``DECIMAL`` types.
 * Fix issue where ``GROUP BY ()`` would produce no results if the input had no rows.
-* Fix null handling in :func:`array_distinct` when applied to the ``array(bigint)`` type.
-* Fix handling of ``-2^63`` as the element index for :func:`json_array_get`.
+* Fix null handling in :func:`!array_distinct` when applied to the ``array(bigint)`` type.
+* Fix handling of ``-2^63`` as the element index for :func:`!json_array_get`.
 * Fix correctness issue when the input to ``TRY_CAST`` evaluates to null.
   For types such as booleans, numbers, dates, timestamps, etc., rather than
   returning null, a default value specific to the type such as
@@ -27,11 +27,11 @@ General Changes
 * Fix query stats to not include queued time in planning time.
 * Fix query completion event to log final stats for the query.
 * Fix spurious log messages when queries are torn down.
-* Remove broken ``%w`` specifier for :func:`date_format` and :func:`date_parse`.
+* Remove broken ``%w`` specifier for :func:`!date_format` and :func:`!date_parse`.
 * Improve performance of :ref:`array_type` when underlying data is dictionary encoded.
 * Improve performance of outer joins with non-equality criteria.
 * Require task concurrency and task writer count to be a power of two.
-* Use nulls-last ordering for :func:`array_sort`.
+* Use nulls-last ordering for :func:`!array_sort`.
 * Validate that ``TRY`` is used with exactly one argument.
 * Allow running Presto with early-access Java versions.
 * Add :doc:`/connector/accumulo`.
@@ -45,10 +45,10 @@ Functions and Language Features
 * Add initial support for correlated subqueries.
 * Add execution support for prepared statements.
 * Add ``DOUBLE PRECISION`` as an alias for the ``DOUBLE`` type.
-* Add :func:`typeof` for discovering expression types.
-* Add decimal support to :func:`avg`, :func:`ceil`, :func:`floor`, :func:`round`,
-  :func:`truncate`, :func:`abs`, :func:`mod` and :func:`sign`.
-* Add :func:`shuffle` function for arrays.
+* Add :func:`!typeof` for discovering expression types.
+* Add decimal support to :func:`!avg`, :func:`!ceil`, :func:`!floor`, :func:`!round`,
+  :func:`!truncate`, :func:`!abs`, :func:`!mod` and :func:`!sign`.
+* Add :func:`!shuffle` function for arrays.
 
 Pluggable Resource Groups
 -------------------------

--- a/presto-docs/src/main/sphinx/release/release-0.155.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.155.rst
@@ -12,8 +12,8 @@ General Changes
 * Fix error messages for failures during commit.
 * Fix memory accounting for simple aggregation, top N and distinct queries.
   These queries may now report higher memory usage than before.
-* Reduce unnecessary memory usage of :func:`map_agg`, :func:`multimap_agg`
-  and :func:`map_union`.
+* Reduce unnecessary memory usage of :func:`!map_agg`, :func:`!multimap_agg`
+  and :func:`!map_union`.
 * Make ``INCLUDING``, ``EXCLUDING`` and ``PROPERTIES`` non-reserved keywords.
 * Remove support for the experimental feature to compute approximate queries
   based on sampled tables.

--- a/presto-docs/src/main/sphinx/release/release-0.156.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.156.rst
@@ -15,9 +15,9 @@ General Changes
 * Fix query failure when using ``AT TIME ZONE`` in ``VALUES`` list.
 * Add support for quantified comparison predicates: ``ALL``, ``ANY``, and ``SOME``.
 * Add support for :ref:`array_type` and :ref:`row_type` that contain ``NULL``
-  in :func:`checksum` aggregation.
+  in :func:`!checksum` aggregation.
 * Add support for filtered aggregations. Example: ``SELECT sum(a) FILTER (WHERE b > 0) FROM ...``
-* Add a variant of :func:`from_unixtime` function that takes a timezone argument.
+* Add a variant of :func:`!from_unixtime` function that takes a timezone argument.
 * Improve performance of ``GROUP BY`` queries that compute a mix of distinct
   and non-distinct aggregations. This optimization can be turned on by setting
   the ``optimizer.optimize-mixed-distinct-aggregations`` configuration option or

--- a/presto-docs/src/main/sphinx/release/release-0.157.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.157.rst
@@ -9,7 +9,7 @@ General Changes
   during planning.
 * Reduce CPU usage of coordinator in large, heavily loaded clusters.
 * Add support for ``DESCRIBE OUTPUT``.
-* Add :func:`bitwise_and_agg` and :func:`bitwise_or_agg` aggregation functions.
+* Add :func:`!bitwise_and_agg` and :func:`!bitwise_or_agg` aggregation functions.
 * Add JMX stats for the scheduler.
 * Add ``query.min-schedule-split-batch-size`` config flag to set the minimum number of
   splits to consider for scheduling per batch.

--- a/presto-docs/src/main/sphinx/release/release-0.158.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.158.rst
@@ -13,7 +13,7 @@ General Changes
 * Fix non-linear performance issue when parsing certain SQL expressions.
 * Fix case-sensitivity issues when operating on columns of ``ROW`` data type.
 * Fix failure when creating views for tables names that need quoting.
-* Return ``NULL`` from :func:`element_at` for out-of-range indices instead of failing.
+* Return ``NULL`` from :func:`!element_at` for out-of-range indices instead of failing.
 * Remove redundancies in query plans, which can reduce data transfers over the network and reduce CPU requirements.
 * Validate resource groups configuration file on startup to ensure that all
   selectors reference a configured resource group.

--- a/presto-docs/src/main/sphinx/release/release-0.161.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.161.rst
@@ -19,11 +19,11 @@ General Changes
 * Improve error message when coordinator responds with ``403 FORBIDDEN``.
 * Improve performance for queries containing expressions in the join criteria
   that reference columns on one side of the join.
-* Improve performance of :func:`map_concat` when one argument is empty.
+* Improve performance of :func:`!map_concat` when one argument is empty.
 * Remove ``/v1/execute`` resource.
 * Add new column to :doc:`/sql/show-columns` (and :doc:`/sql/describe`)
   to show extra information from connectors.
-* Add :func:`map` to construct an empty :ref:`map_type`.
+* Add :func:`!map` to construct an empty :ref:`map_type`.
 
 Hive Connector
 --------------

--- a/presto-docs/src/main/sphinx/release/release-0.162.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.162.rst
@@ -4,7 +4,7 @@ Release 0.162
 
 .. warning::
 
-    The :func:`xxhash64` function introduced in this release will return a
+    The :func:`!xxhash64` function introduced in this release will return a
     varbinary instead of a bigint in the next release.
 
 General Changes
@@ -22,7 +22,7 @@ General Changes
 * Improve performance of certain multi-way JOINs by automatically choosing the
   best evaluation order. This feature is turned off by default and can be enabled
   via the ``reorder-joins`` config option or ``reorder_joins`` session property.
-* Add :func:`xxhash64` and :func:`to_big_endian_64` functions.
+* Add :func:`!xxhash64` and :func:`!to_big_endian_64` functions.
 * Add aggregated operator statistics to final query statistics.
 * Allow specifying column comments for :doc:`/sql/create-table`.
 

--- a/presto-docs/src/main/sphinx/release/release-0.163.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.163.rst
@@ -11,8 +11,8 @@ General Changes
 * Improve exchange performance by reading from buffers in parallel.
 * Improve performance when only a subset of the columns resulting from a ``JOIN`` are referenced.
 * Make ``ALL``, ``SOME`` and ``ANY`` non-reserved keywords.
-* Add :func:`from_big_endian_64` function.
-* Change :func:`xxhash64` return type from ``BIGINT`` to ``VARBINARY``.
+* Add :func:`!from_big_endian_64` function.
+* Change :func:`!xxhash64` return type from ``BIGINT`` to ``VARBINARY``.
 * Change subscript operator for map types to fail if the key is not present in the map. The former
   behavior (returning ``NULL``) can be restored by setting the ``deprecated.legacy-map-subscript``
   config option.

--- a/presto-docs/src/main/sphinx/release/release-0.164.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.164.rst
@@ -7,14 +7,14 @@ General Changes
 
 * Fix correctness issue for queries that perform ``DISTINCT`` and ``LIMIT`` on the results of a ``JOIN``.
 * Fix correctness issue when casting between maps where the key or value is the ``REAL`` type.
-* Fix correctness issue in :func:`min_by` and :func:`max_by` when nulls are present in the comparison column.
+* Fix correctness issue in :func:`!min_by` and :func:`!max_by` when nulls are present in the comparison column.
 * Fail queries when ``FILTER`` clause is specified for scalar functions.
 * Fix planning failure for certain correlated subqueries that contain aggregations.
 * Fix planning failure when arguments to selective aggregates are derived from other selective aggregates.
 * Fix boolean expression optimization bug that can cause long planning times, planning failures and coordinator instability.
 * Fix query failure when ``TRY`` or lambda expression with the exact same body is repeated in an expression.
 * Fix split source resource leak in coordinator that can occur when a query fails.
-* Improve :func:`array_join` performance.
+* Improve :func:`!array_join` performance.
 * Improve error message for map subscript operator when key is not present in the map.
 * Improve client error message for invalid session.
 * Add ``VALIDATE`` mode for :doc:`/sql/explain`.

--- a/presto-docs/src/main/sphinx/release/release-0.165.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.165.rst
@@ -6,7 +6,7 @@ General Changes
 ---------------
 
 * Make ``AT`` a non-reserved keyword.
-* Improve performance of :func:`transform`.
+* Improve performance of :func:`!transform`.
 * Improve exchange performance by deserializing in parallel.
 * Add support for compressed exchanges. This can be enabled with the ``exchange.compression-enabled``
   config option.

--- a/presto-docs/src/main/sphinx/release/release-0.166.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.166.rst
@@ -9,7 +9,7 @@ General Changes
   certain combinations of data types (e.g., ``double`` and ``decimal``).
 * Add ``query.max-length`` config flag to set the maximum length of a SQL query.
   The default maximum length is 1MB.
-* Improve performance of :func:`approx_percentile`.
+* Improve performance of :func:`!approx_percentile`.
 
 Hive Changes
 ------------

--- a/presto-docs/src/main/sphinx/release/release-0.167.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.167.rst
@@ -14,9 +14,9 @@ General Changes
 * Short-circuit inner and right join when right side is empty.
 * Optimize constant patterns for ``LIKE`` predicates that use an escape character.
 * Validate escape sequences in ``LIKE`` predicates per the SQL standard.
-* Reduce memory usage of :func:`min_by` and :func:`max_by`.
-* Add :func:`transform_keys`, :func:`transform_values` and :func:`zip_with` lambda functions.
-* Add :func:`levenshtein_distance` function.
+* Reduce memory usage of :func:`!min_by` and :func:`!max_by`.
+* Add :func:`!transform_keys`, :func:`!transform_values` and :func:`!zip_with` lambda functions.
+* Add :func:`!levenshtein_distance` function.
 * Add JMX stat for the elapsed time of the longest currently active split.
 * Add JMX stats for compiler caches.
 * Raise required Java version to 8u92.

--- a/presto-docs/src/main/sphinx/release/release-0.168.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.168.rst
@@ -12,19 +12,19 @@ General Changes
 * Temporarily revert empty join short-circuit optimization due to issue with hanging queries.
 * Improve performance of ``DECIMAL`` type and operators.
 * Optimize window frame computation for empty frames.
-* :func:`json_extract` and :func:`json_extract_scalar` now support escaping double
+* :func:`!json_extract` and :func:`!json_extract_scalar` now support escaping double
   quotes or backslashes using a backslash with a JSON path subscript. This changes
   the semantics of any invocation using a backslash, as backslashes were previously
   treated as normal characters.
-* Improve performance of :func:`filter` and :func:`map_filter` lambda functions.
+* Improve performance of :func:`!filter` and :func:`!map_filter` lambda functions.
 * Add :doc:`/connector/memory`.
-* Add :func:`arrays_overlap` and :func:`array_except` functions.
-* Allow concatenating more than two arrays with ``concat()`` or maps with :func:`map_concat`.
+* Add :func:`!arrays_overlap` and :func:`!array_except` functions.
+* Allow concatenating more than two arrays with ``concat()`` or maps with :func:`!map_concat`.
 * Add a time limit for the iterative optimizer. It can be adjusted via the ``iterative_optimizer_timeout``
   session property or ``experimental.iterative-optimizer-timeout`` configuration option.
 * ``ROW`` types are now orderable if all of the field types are orderable.
   This allows using them in comparison expressions, ``ORDER BY`` and
-  functions that require orderable types (e.g., :func:`max`).
+  functions that require orderable types (e.g., :func:`!max`).
 
 JDBC Driver Changes
 -------------------

--- a/presto-docs/src/main/sphinx/release/release-0.169.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.169.rst
@@ -7,8 +7,8 @@ General Changes
 
 * Fix regression that could cause queries involving ``JOIN`` and certain language features
   such as ``current_date``, ``current_time`` or ``extract`` to fail during planning.
-* Limit the maximum allowed input size to :func:`levenshtein_distance`.
-* Improve performance of :func:`map_agg` and :func:`multimap_agg`.
+* Limit the maximum allowed input size to :func:`!levenshtein_distance`.
+* Improve performance of :func:`!map_agg` and :func:`!multimap_agg`.
 * Improve memory accounting when grouping on a single ``BIGINT`` column.
 
 JDBC Driver Changes

--- a/presto-docs/src/main/sphinx/release/release-0.171.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.171.rst
@@ -10,9 +10,9 @@ General Changes
 * Fix issue for data definition queries that prevented firing completion events or purging them from
   the coordinator's memory.
 * Add support for capture in lambda expressions.
-* Add support for ``ARRAY`` and ``ROW`` type as the compared value in :func:`min_by` and :func:`max_by`.
+* Add support for ``ARRAY`` and ``ROW`` type as the compared value in :func:`!min_by` and :func:`!max_by`.
 * Add support for ``CHAR(n)`` data type to common string functions.
-* Add :func:`codepoint`, :func:`skewness` and :func:`kurtosis` functions.
+* Add :func:`!codepoint`, :func:`!skewness` and :func:`!kurtosis` functions.
 * Improve validation of resource group configuration.
 * Fail queries when casting unsupported types to JSON; see :doc:`/functions/json` for supported types.
 

--- a/presto-docs/src/main/sphinx/release/release-0.172.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.172.rst
@@ -10,5 +10,5 @@ General Changes
 * Fix planning failure when left side of ``IN`` expression contains subqueries.
 * Fix incorrect permissions check for ``SHOW TABLES``.
 * Fix planning failure when ``JOIN`` clause contains lambda expressions that reference columns or variables from the enclosing scope.
-* Reduce memory usage of :func:`map_agg` and :func:`map_union`.
+* Reduce memory usage of :func:`!map_agg` and :func:`!map_union`.
 * Reduce memory usage of ``GROUP BY`` queries.

--- a/presto-docs/src/main/sphinx/release/release-0.173.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.173.rst
@@ -5,5 +5,5 @@ Release 0.173
 General Changes
 ---------------
 
-* Fix issue where ``FILTER`` was ignored for :func:`count` with a constant argument.
+* Fix issue where ``FILTER`` was ignored for :func:`!count` with a constant argument.
 * Support table comments for :doc:`/sql/create-table` and :doc:`/sql/create-table-as`.

--- a/presto-docs/src/main/sphinx/release/release-0.174.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.174.rst
@@ -6,11 +6,11 @@ General Changes
 ---------------
 
 * Fix correctness issue for correlated subqueries containing a ``LIMIT`` clause.
-* Fix query failure when :func:`reduce` function is used with lambda expressions
-  containing :func:`array_sort`, :func:`shuffle`, :func:`reverse`, :func:`array_intersect`,
-  :func:`arrays_overlap`, :func:`concat` (for arrays) or :func:`map_concat`.
-* Fix a bug that causes underestimation of the amount of memory used by :func:`max_by`,
-  :func:`min_by`, :func:`max`, :func:`min`, and :func:`arbitrary` aggregations over
+* Fix query failure when :func:`!reduce` function is used with lambda expressions
+  containing :func:`!array_sort`, :func:`!shuffle`, :func:`!reverse`, :func:`!array_intersect`,
+  :func:`!arrays_overlap`, :func:`!concat` (for arrays) or :func:`!map_concat`.
+* Fix a bug that causes underestimation of the amount of memory used by :func:`!max_by`,
+  :func:`!min_by`, :func:`!max`, :func:`!min`, and :func:`!arbitrary` aggregations over
   varchar/varbinary columns.
 * Fix a memory leak in the coordinator that causes long-running queries in highly loaded
   clusters to consume unnecessary memory.

--- a/presto-docs/src/main/sphinx/release/release-0.175.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.175.rst
@@ -20,7 +20,7 @@ General Changes
   operations will take advantage of this in future releases.
 * Add ``enable_intermediate_aggregations`` session property to enable the
   use of intermediate aggregations within un-grouped aggregations.
-* Add support for ``INTERVAL`` data type to :func:`avg` and :func:`sum` aggregation functions.
+* Add support for ``INTERVAL`` data type to :func:`!avg` and :func:`!sum` aggregation functions.
 * Add support for ``INT`` as an alias for the ``INTEGER`` data type.
 * Add resource group information to query events.
 

--- a/presto-docs/src/main/sphinx/release/release-0.176.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.176.rst
@@ -9,9 +9,9 @@ General Changes
   consume CPU/memory on the coordinator and workers after the query fails.
 * Fix a regression that cause the GC overhead and pauses to increase significantly when processing maps.
 * Fix a memory tracking bug that causes the memory to be overestimated for ``GROUP BY`` queries on ``bigint`` columns.
-* Improve the performance of the :func:`transform_values` function.
+* Improve the performance of the :func:`!transform_values` function.
 * Add support for casting from ``JSON`` to ``REAL`` type.
-* Add :func:`parse_duration` function.
+* Add :func:`!parse_duration` function.
 
 MySQL Changes
 -------------

--- a/presto-docs/src/main/sphinx/release/release-0.177.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.177.rst
@@ -24,7 +24,7 @@ General Changes
   with subqueries).
 * Add ``SHOW STATS`` to display table and query statistics.
 * Improve implicit coercion support for functions involving lambda. Specifically, this makes
-  it easier to use the :func:`reduce` function.
+  it easier to use the :func:`!reduce` function.
 * Improve plans for queries involving ``ORDER BY`` and ``LIMIT`` by avoiding unnecessary
   data exchanges.
 * Improve performance of queries containing window functions with identical ``PARTITION BY``

--- a/presto-docs/src/main/sphinx/release/release-0.178.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.178.rst
@@ -11,7 +11,7 @@ General Changes
 * Add ability to cast to ``JSON`` from ``REAL``, ``TINYINT`` or ``SMALLINT``.
 * Add support for ``GROUPING`` operation to :ref:`complex grouping operations<complex_grouping_operations>`.
 * Add support for correlated subqueries in ``IN`` predicates.
-* Add :func:`to_ieee754_32` and :func:`to_ieee754_64` functions.
+* Add :func:`!to_ieee754_32` and :func:`!to_ieee754_64` functions.
 
 Hive Changes
 ------------

--- a/presto-docs/src/main/sphinx/release/release-0.179.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.179.rst
@@ -17,8 +17,8 @@ General Changes
 * Reduce the memory usage of map/array aggregation functions.
 * Redact sensitive config property values in the server log.
 * Update timezone database to version 2017b.
-* Add :func:`repeat` function.
-* Add :func:`crc32` function.
+* Add :func:`!repeat` function.
+* Add :func:`!crc32` function.
 * Add file based global security, which can be configured with the ``etc/access-control.properties``
   and ``security.config-file`` config properties. See :doc:`/security/built-in-system-access-control`
   for more details.

--- a/presto-docs/src/main/sphinx/release/release-0.180.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.180.rst
@@ -12,7 +12,7 @@ General Changes
 * Fix incorrect results when performing comparisons between values of approximate
   data types (``REAL``, ``DOUBLE``) and columns of certain exact numeric types
   (``INTEGER``, ``BIGINT``, ``DECIMAL``).
-* Fix memory accounting for :func:`min_by` and :func:`max_by` on complex types.
+* Fix memory accounting for :func:`!min_by` and :func:`!max_by` on complex types.
 * Fix query failure due to ``NoClassDefFoundError`` when scalar functions declared
   in plugins are implemented with instance methods.
 * Improve performance of map subscript from O(n) to O(1) in all cases. Previously, only maps

--- a/presto-docs/src/main/sphinx/release/release-0.181.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.181.rst
@@ -6,7 +6,7 @@ General Changes
 ---------------
 
 * Fix query failure and memory usage tracking when query contains
-  :func:`transform_keys` or :func:`transform_values`.
+  :func:`!transform_keys` or :func:`!transform_values`.
 * Prevent ``CREATE TABLE IF NOT EXISTS`` queries from ever failing with *"Table already exists"*.
 * Fix query failure when ``ORDER BY`` expressions reference columns that are used in
   the ``GROUP BY`` clause by their fully-qualified name.

--- a/presto-docs/src/main/sphinx/release/release-0.182.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.182.rst
@@ -5,10 +5,10 @@ Release 0.182
 General Changes
 ---------------
 
-* Fix correctness issue that causes :func:`corr` to return positive numbers for inverse correlations.
+* Fix correctness issue that causes :func:`!corr` to return positive numbers for inverse correlations.
 * Fix the :doc:`/sql/explain` query plan for tables that are partitioned
   on ``TIMESTAMP`` or ``DATE`` columns.
-* Fix query failure when when using certain window functions that take arrays or maps as arguments (e.g., :func:`approx_percentile`).
+* Fix query failure when when using certain window functions that take arrays or maps as arguments (e.g., :func:`!approx_percentile`).
 * Implement subtraction for all ``TIME`` and ``TIMESTAMP`` types.
 * Improve planning performance for queries that join multiple tables with
   a large number columns.
@@ -16,7 +16,7 @@ General Changes
   a nested loops join instead of a hash join.
 * Improve the performance of casting from ``JSON`` to ``ARRAY`` or ``MAP`` types.
 * Add a new :ref:`ipaddress_type` type to represent IP addresses.
-* Add :func:`to_milliseconds` function to convert intervals (day to second) to milliseconds.
+* Add :func:`!to_milliseconds` function to convert intervals (day to second) to milliseconds.
 * Add support for column aliases in ``CREATE TABLE AS`` statements.
 * Add a config option to reject queries during cluster initialization.
   Queries are rejected if the active worker count is less than the

--- a/presto-docs/src/main/sphinx/release/release-0.183.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.183.rst
@@ -12,12 +12,12 @@ General Changes
 * Fix issue where a query may have a reported memory that is higher than actual usage when
   an aggregation is followed by other non-trivial work in the same stage. This can lead to failures
   due to query memory limit, or lower cluster throughput due to perceived insufficient memory.
-* Fix query failure for ``CHAR`` functions :func:`trim`, :func:`rtrim`, and :func:`substr` when
+* Fix query failure for ``CHAR`` functions :func:`!trim`, :func:`!rtrim`, and :func:`!substr` when
   the return value would have trailing spaces under ``VARCHAR`` semantics.
 * Fix formatting in ``EXPLAIN ANALYZE`` output.
 * Improve error message when a query contains an unsupported form of correlated subquery.
 * Improve performance of ``CAST(json_parse(...) AS ...)``.
-* Add :func:`map_from_entries` and :func:`map_entries` functions.
+* Add :func:`!map_from_entries` and :func:`!map_entries` functions.
 * Change spilling for aggregations to only occur when the cluster runs out of memory.
 * Remove the ``experimental.operator-memory-limit-before-spill`` config property
   and the ``operator_memory_limit_before_spill`` session property.

--- a/presto-docs/src/main/sphinx/release/release-0.184.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.184.rst
@@ -11,11 +11,11 @@ General Changes
 * Fix planning failure for some query shapes containing ``count(*)`` and a non-empty
   ``GROUP BY`` clause.
 * Fix communication failures caused by lock contention in the local scheduler.
-* Improve performance of :func:`element_at` for maps to be constant time rather than
+* Improve performance of :func:`!element_at` for maps to be constant time rather than
   proportional to the size of the map.
 * Improve performance of queries with gathering exchanges.
 * Require ``coalesce()`` to have at least two arguments, as mandated by the SQL standard.
-* Add :func:`hamming_distance` function.
+* Add :func:`!hamming_distance` function.
 
 JDBC Driver Changes
 -------------------

--- a/presto-docs/src/main/sphinx/release/release-0.185.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.185.rst
@@ -19,7 +19,7 @@ General Changes
 * Improve performance of joins where the condition is a range over a function.
   For example: ``a JOIN b ON b.x < f(a.x) AND b.x > g(a.x)``
 * Improve performance of certain window functions (e.g., ``LAG``) with similar specifications.
-* Extend :func:`substr` function to work on ``VARBINARY`` in addition to ``CHAR`` and ``VARCHAR``.
+* Extend :func:`!substr` function to work on ``VARBINARY`` in addition to ``CHAR`` and ``VARCHAR``.
 * Add cast from ``JSON`` to ``ROW``.
 * Allow usage of ``TRY`` within lambda expressions.
 

--- a/presto-docs/src/main/sphinx/release/release-0.186.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.186.rst
@@ -16,7 +16,7 @@ General Changes
 * Fix issue that may cause queries containing expensive functions, such as regular
   expressions, to continue using CPU resources even after they are killed.
 * Fix performance issue caused by redundant casts.
-* Fix :func:`json_parse` to not ignore trailing characters. Previously,
+* Fix :func:`!json_parse` to not ignore trailing characters. Previously,
   input such as ``[1,2]abc`` would successfully parse as ``[1,2]``.
 * Fix leak in running query counter for failed queries. The counter would
   increment but never decrement for queries that failed before starting.
@@ -26,7 +26,7 @@ General Changes
 * Add queued time and elapsed time to the client protocol.
 * Add ``query_max_execution_time`` session property and ``query.max-execution-time`` config
   property. Queries will be aborted after they execute for more than the specified duration.
-* Add :func:`inverse_normal_cdf` function.
+* Add :func:`!inverse_normal_cdf` function.
 * Add :doc:`/functions/geospatial` including functions for processing Bing tiles.
 * Add :doc:`/admin/spill` for joins.
 * Add :doc:`/connector/redshift`.

--- a/presto-docs/src/main/sphinx/release/release-0.188.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.188.rst
@@ -5,7 +5,7 @@ Release 0.188
 General Changes
 ---------------
 
-* Fix handling of negative start indexes in array :func:`slice` function.
+* Fix handling of negative start indexes in array :func:`!slice` function.
 * Fix inverted sign for time zones ``Etc/GMT-12``, ``Etc/GMT-11``, ..., ``Etc/GMT-1``,
   ``Etc/GMT+1``, ... ``Etc/GMT+12``.
 * Improve performance of server logging and HTTP request logging.

--- a/presto-docs/src/main/sphinx/release/release-0.189.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.189.rst
@@ -8,7 +8,7 @@ General Changes
 * Fix query failure while logging the query plan.
 * Fix a bug that causes clients to hang when executing ``LIMIT`` queries when
   ``optimizer.force-single-node-output`` is disabled.
-* Fix a bug in the :func:`bing_tile_at` and :func:`bing_tile_polygon` functions
+* Fix a bug in the :func:`!bing_tile_at` and :func:`!bing_tile_polygon` functions
   where incorrect results were produced for points close to tile edges.
 * Fix variable resolution when lambda argument has the same name as a table column.
 * Improve error message when running ``SHOW TABLES`` on a catalog that does not exist.

--- a/presto-docs/src/main/sphinx/release/release-0.190.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.190.rst
@@ -5,7 +5,7 @@ Release 0.190
 General Changes
 ---------------
 
-* Fix correctness issue for :func:`array_min` and :func:`array_max` when arrays contain ``NaN``.
+* Fix correctness issue for :func:`!array_min` and :func:`!array_max` when arrays contain ``NaN``.
 * Fix planning failure for queries involving ``GROUPING`` that require implicit coercions
   in expressions containing aggregate functions.
 * Fix potential workload imbalance when using topology-aware scheduling.
@@ -16,14 +16,14 @@ General Changes
   the same partition property as the data being written.
 * Ignore case when sorting the output of ``SHOW FUNCTIONS``.
 * Improve rendering of the ``BingTile`` type.
-* The :func:`approx_distinct` function now supports a standard error
+* The :func:`!approx_distinct` function now supports a standard error
   in the range of ``[0.0040625, 0.26000]``.
 * Add support for ``ORDER BY`` in aggregation functions.
 * Add dictionary processing for joins which can improve join performance up to 50%.
   This optimization can be disabled using the ``dictionary-processing-joins-enabled``
   config property or the ``dictionary_processing_join`` session property.
 * Add support for casting to ``INTERVAL`` types.
-* Add :func:`ST_Buffer` geospatial function.
+* Add :func:`!ST_Buffer` geospatial function.
 * Allow treating decimal literals as values of the ``DECIMAL`` type rather than ``DOUBLE``.
   This behavior can be enabled by setting the ``parse-decimal-literals-as-double``
   config property or the ``parse_decimal_literals_as_double`` session property to ``false``.

--- a/presto-docs/src/main/sphinx/release/release-0.191.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.191.rst
@@ -7,7 +7,7 @@ General Changes
 
 * Fix regression that could cause high CPU usage for join queries when dictionary
   processing for joins is enabled.
-* Fix :func:`bit_count` for bits between 33 and 63.
+* Fix :func:`!bit_count` for bits between 33 and 63.
 * The ``query.low-memory-killer.enabled`` config property has been replaced
   with ``query.low-memory-killer.policy``. Use ``total-reservation`` to continue
   using the previous policy of killing the largest query. There is also a new

--- a/presto-docs/src/main/sphinx/release/release-0.192.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.192.rst
@@ -8,7 +8,7 @@ General Changes
 * Fix performance regression in split scheduling introduced in 0.191. If a query
   scans a non-trivial number of splits (~1M splits in an hour), the coordinator
   CPU utilization can be very high, leading to elevated communication failures.
-* Fix correctness issue in the :func:`geometry_to_bing_tiles` function that causes
+* Fix correctness issue in the :func:`!geometry_to_bing_tiles` function that causes
   it to return irrelevant tiles when bottom or right side of the bounding box of the
   geometry is aligned with the tile border.
 * Fix handling of invalid WKT (well-known text) input in geospatial functions.
@@ -19,7 +19,7 @@ General Changes
 * Fix bug in validation of resource groups that prevented use of the ``WEIGHTED_FAIR`` policy.
 * Fail queries properly when the coordinator fails to fetch data from workers.
   Previously, it would return an HTTP 500 error to the client.
-* Improve memory tracking for queries involving ``DISTINCT`` or :func:`row_number` that could cause
+* Improve memory tracking for queries involving ``DISTINCT`` or :func:`!row_number` that could cause
   over-committing memory resources for short time periods.
 * Improve performance for queries involving ``grouping()``.
 * Improve buffer utilization calculation for writer scaling.

--- a/presto-docs/src/main/sphinx/release/release-0.193.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.193.rst
@@ -11,9 +11,9 @@ General Changes
 * Fix failure during query planning when lambda expressions are used in ``UNNEST`` or ``VALUES`` clauses.
 * Fix ``Tried to free more revocable memory than is reserved`` error for queries that have spilling enabled
   and run in the reserved memory pool.
-* Improve the performance of the :func:`ST_Contains` function.
-* Add :func:`map_zip_with` lambda function.
-* Add :func:`normal_cdf` function.
+* Improve the performance of the :func:`!ST_Contains` function.
+* Add :func:`!map_zip_with` lambda function.
+* Add :func:`!normal_cdf` function.
 * Add ``SET_DIGEST`` type and related functions.
 * Add query stat that tracks peak total memory.
 * Improve performance of queries that filter all data from a table up-front (e.g., due to partition pruning).

--- a/presto-docs/src/main/sphinx/release/release-0.194.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.194.rst
@@ -8,11 +8,11 @@ General Changes
 * Fix planning performance regression that can affect queries over Hive tables
   with many partitions.
 * Fix deadlock in memory management logic introduced in the previous release.
-* Add :func:`word_stem` function.
+* Add :func:`!word_stem` function.
 * Restrict ``n`` (number of result elements) to 10,000 or less for
   ``min(col, n)``, ``max(col, n)``, ``min_by(col1, col2, n)``, and ``max_by(col1, col2, n)``.
 * Improve error message when a session property references an invalid catalog.
-* Reduce memory usage of :func:`histogram` aggregation function.
+* Reduce memory usage of :func:`!histogram` aggregation function.
 * Improve coordinator CPU efficiency when discovering splits.
 * Include minimum and maximum values for columns in ``SHOW STATS``.
 

--- a/presto-docs/src/main/sphinx/release/release-0.195.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.195.rst
@@ -5,7 +5,7 @@ Release 0.195
 General Changes
 ---------------
 
-* Fix :func:`histogram` for map type when type coercion is required.
+* Fix :func:`!histogram` for map type when type coercion is required.
 * Fix ``nullif`` for map type when type coercion is required.
 * Fix incorrect termination of queries when the coordinator to worker communication is under high load.
 * Fix race condition that causes queries with a right or full outer join to fail.

--- a/presto-docs/src/main/sphinx/release/release-0.196.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.196.rst
@@ -17,13 +17,13 @@ General Changes
 * Fix returned value from ``round(x, d)`` when ``x`` is a ``DECIMAL`` with
   scale ``0`` and ``d`` is a negative integer. Previously, no rounding was done
   in this case.
-* Improve performance of the :func:`array_join` function.
-* Improve performance of the :func:`ST_Envelope` function.
-* Optimize :func:`min_by` and :func:`max_by` by avoiding unnecessary object
+* Improve performance of the :func:`!array_join` function.
+* Improve performance of the :func:`!ST_Envelope` function.
+* Optimize :func:`!min_by` and :func:`!max_by` by avoiding unnecessary object
   creation in order to reduce GC overhead.
 * Show join partitioning explicitly in ``EXPLAIN``.
-* Add :func:`is_json_scalar` function.
-* Add :func:`regexp_replace` function variant that executes a lambda for
+* Add :func:`!is_json_scalar` function.
+* Add :func:`!regexp_replace` function variant that executes a lambda for
   each replacement.
 
 Security

--- a/presto-docs/src/main/sphinx/release/release-0.197.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.197.rst
@@ -13,10 +13,10 @@ General Changes
 * Extend predicate inference and pushdown for queries using a ``<symbol> IN <subquery>`` predicate.
 * Support predicate pushdown for the ``<column> IN <values list>`` predicate
   where values in the ``values list`` require casting to match the type of ``column``.
-* Optimize :func:`min` and :func:`max` to avoid unnecessary object creation in order to reduce GC overhead.
-* Optimize the performance of :func:`ST_XMin`, :func:`ST_XMax`, :func:`ST_YMin`, and :func:`ST_YMax`.
-* Add ``DATE`` variant for :func:`sequence` function.
-* Add :func:`ST_IsSimple` geospatial function.
+* Optimize :func:`!min` and :func:`!max` to avoid unnecessary object creation in order to reduce GC overhead.
+* Optimize the performance of :func:`!ST_XMin`, :func:`!ST_XMax`, :func:`!ST_YMin`, and :func:`!ST_YMax`.
+* Add ``DATE`` variant for :func:`!sequence` function.
+* Add :func:`!ST_IsSimple` geospatial function.
 * Add support for broadcast spatial joins.
 
 Resource Groups Changes

--- a/presto-docs/src/main/sphinx/release/release-0.198.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.198.rst
@@ -13,11 +13,11 @@ General Changes
   the ``parse_decimal_literals_as_double`` session property.
 * Fix ``current_date`` failure when the session time zone has a "gap" at ``1970-01-01 00:00:00``.
   The time zone ``America/Bahia_Banderas`` is one such example.
-* Add variant of :func:`sequence` function for ``DATE`` with an implicit one-day step increment.
-* Increase the maximum number of arguments for the :func:`zip` function from 4 to 5.
-* Add :func:`ST_IsValid`, :func:`geometry_invalid_reason`, :func:`simplify_geometry`, and
-  :func:`great_circle_distance` functions.
-* Support :func:`min` and :func:`max` aggregation functions when the input type is unknown at query analysis time.
+* Add variant of :func:`!sequence` function for ``DATE`` with an implicit one-day step increment.
+* Increase the maximum number of arguments for the :func:`!zip` function from 4 to 5.
+* Add :func:`!ST_IsValid`, :func:`!geometry_invalid_reason`, :func:`!simplify_geometry`, and
+  :func:`!great_circle_distance` functions.
+* Support :func:`!min` and :func:`!max` aggregation functions when the input type is unknown at query analysis time.
   In particular, this allows using the functions with ``NULL`` literals.
 * Add configuration property ``task.max-local-exchange-buffer-size`` for setting local exchange buffer size.
 * Add trace token support to the scheduler and exchange HTTP clients. Each HTTP request sent
@@ -25,14 +25,14 @@ General Changes
   headers, which will be logged in the HTTP request logs. This information can be used to
   correlate the requests and responses during debugging.
 * Improve query performance when dynamic writer scaling is enabled.
-* Improve performance of :func:`ST_Intersects`.
+* Improve performance of :func:`!ST_Intersects`.
 * Improve query latency when tables are known to be empty during query planning.
-* Optimize :func:`array_agg` to avoid excessive object overhead and native memory usage with G1 GC.
+* Optimize :func:`!array_agg` to avoid excessive object overhead and native memory usage with G1 GC.
 * Improve performance for high-cardinality aggregations with ``DISTINCT`` argument qualifiers. This
   is an experimental optimization that can be activated by disabling the `use_mark_distinct` session
   property or the ``optimizer.use-mark-distinct`` config option.
 * Improve parallelism of queries that have an empty grouping set.
-* Improve performance of join queries involving the :func:`ST_Distance` function.
+* Improve performance of join queries involving the :func:`!ST_Distance` function.
 
 Resource Groups Changes
 -----------------------

--- a/presto-docs/src/main/sphinx/release/release-0.199.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.199.rst
@@ -10,9 +10,9 @@ General Changes
   creation permission is now only checked at query time, not at creation time,
   and the query time check is skipped if the user is the owner of the view.
 * Add support for spatial left join.
-* Add :func:`hmac_md5`, :func:`hmac_sha1`, :func:`hmac_sha256`, and :func:`hmac_sha512` functions.
-* Add :func:`array_sort` function that takes a lambda as a comparator.
-* Add :func:`line_locate_point` geospatial function.
+* Add :func:`!hmac_md5`, :func:`!hmac_sha1`, :func:`!hmac_sha256`, and :func:`!hmac_sha512` functions.
+* Add :func:`!array_sort` function that takes a lambda as a comparator.
+* Add :func:`!line_locate_point` geospatial function.
 * Add support for ``ORDER BY`` clause in aggregations for queries that use grouping sets.
 * Add support for yielding when unspilling an aggregation.
 * Expand grouped execution support to ``GROUP BY`` and ``UNION ALL``, making it possible
@@ -24,16 +24,16 @@ General Changes
 * Accessing anonymous row fields via ``.field0``, ``.field1``, etc., is no longer allowed.
   This behavior can be restored with the ``deprecated.legacy-row-field-ordinal-access``
   config option or the ``legacy_row_field_ordinal_access`` session property.
-* Optimize the :func:`ST_Intersection` function for rectangles aligned with coordinate axes
-  (e.g., polygons produced by the :func:`ST_Envelope` and :func:`bing_tile_polygon` functions).
+* Optimize the :func:`!ST_Intersection` function for rectangles aligned with coordinate axes
+  (e.g., polygons produced by the :func:`!ST_Envelope` and :func:`!bing_tile_polygon` functions).
 * Finish joins early when possible if one side has no rows. This happens for
   either side of an inner join, for the left side of a left join, and for the
   right side of a right join.
 * Improve predicate evaluation performance during predicate pushdown in planning.
 * Improve the performance of queries that use ``LIKE`` predicates on the columns of ``information_schema`` tables.
 * Improve the performance of map-to-map cast.
-* Improve the performance of :func:`ST_Touches`, :func:`ST_Within`, :func:`ST_Overlaps`, :func:`ST_Disjoint`,
-  and :func:`ST_Crosses` functions.
+* Improve the performance of :func:`!ST_Touches`, :func:`!ST_Within`, :func:`!ST_Overlaps`, :func:`!ST_Disjoint`,
+  and :func:`!ST_Crosses` functions.
 * Improve the serialization performance of geometry values.
 * Improve the performance of functions that return maps.
 * Improve the performance of joins and aggregations that include map columns.

--- a/presto-docs/src/main/sphinx/release/release-0.200.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.200.rst
@@ -9,15 +9,15 @@ General Changes
   has zero rows. This optimization can cause indefinite query hangs
   for queries that join against a small number of rows.
   This regression was introduced in 0.199.
-* Fix query execution failure for :func:`bing_tile_coordinates`.
+* Fix query execution failure for :func:`!bing_tile_coordinates`.
 * Remove the ``log()`` function. The arguments to the function were in the
   wrong order according to the SQL standard, resulting in incorrect results
   when queries were translated to or from other SQL implementations. The
   equivalent to ``log(x, b)`` is ``ln(x) / ln(b)``. The function can be
   restored with the ``deprecated.legacy-log-function`` config option.
 * Allow including a comment when adding a column to a table with ``ALTER TABLE``.
-* Add :func:`from_ieee754_32` and :func:`from_ieee754_64` functions.
-* Add :func:`ST_GeometryType` geospatial function.
+* Add :func:`!from_ieee754_32` and :func:`!from_ieee754_64` functions.
+* Add :func:`!ST_GeometryType` geospatial function.
 
 Hive Changes
 ------------

--- a/presto-docs/src/main/sphinx/release/release-0.201.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.201.rst
@@ -12,7 +12,7 @@ General Changes
 * System memory pool is now unused by default and it will eventually be removed completely.
   All memory allocations will now be served from the general/user memory pool. The old behavior
   can be restored with the ``deprecated.legacy-system-pool-enabled`` config option.
-* Improve performance and memory usage for queries using :func:`row_number` followed by a
+* Improve performance and memory usage for queries using :func:`!row_number` followed by a
   filter on the row numbers generated.
 * Improve performance and memory usage for queries using ``ORDER BY`` followed by a ``LIMIT``.
 * Improve performance of queries that process structural types and contain joins, aggregations,

--- a/presto-docs/src/main/sphinx/release/release-0.202.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.202.rst
@@ -6,14 +6,14 @@ General Changes
 ---------------
 
 * Fix correctness issue for queries involving aggregations over the result of an outer join (:issue:`10592`).
-* Fix :func:`map` to raise an error on duplicate keys rather than silently producing a corrupted map.
-* Fix :func:`map_from_entries` to raise an error when input array contains a ``null`` entry.
+* Fix :func:`!map` to raise an error on duplicate keys rather than silently producing a corrupted map.
+* Fix :func:`!map_from_entries` to raise an error when input array contains a ``null`` entry.
 * Fix out-of-memory error for bucketed execution by scheduling new splits on the same worker as
   the recently finished one.
 * Fix query failure when performing a ``GROUP BY`` on ``json`` or ``ipaddress`` types.
-* Fix correctness issue in :func:`line_locate_point`, :func:`ST_IsValid`, and :func:`geometry_invalid_reason`
+* Fix correctness issue in :func:`!line_locate_point`, :func:`!ST_IsValid`, and :func:`!geometry_invalid_reason`
   functions to not return values outside of the expected range.
-* Fix failure in :func:`geometry_to_bing_tiles` and :func:`ST_NumPoints` functions when
+* Fix failure in :func:`!geometry_to_bing_tiles` and :func:`!ST_NumPoints` functions when
   processing geometry collections.
 * Fix query failure in aggregation spilling (:issue:`10587`).
 * Remove support for ``SHOW PARTITIONS`` statement.
@@ -31,9 +31,9 @@ General Changes
 * Add support for column-level access control.
   Connectors have not yet been updated to take advantage of this support.
 * Add support for correlated subqueries with correlated ``OR`` predicates.
-* Add :func:`multimap_from_entries` function.
-* Add :func:`bing_tiles_around`, :func:`ST_NumGeometries`, :func:`ST_GeometryN`, and :func:`ST_ConvexHull` geospatial functions.
-* Add :func:`wilson_interval_lower` and :func:`wilson_interval_upper` functions.
+* Add :func:`!multimap_from_entries` function.
+* Add :func:`!bing_tiles_around`, :func:`!ST_NumGeometries`, :func:`!ST_GeometryN`, and :func:`!ST_ConvexHull` geospatial functions.
+* Add :func:`!wilson_interval_lower` and :func:`!wilson_interval_upper` functions.
 * Add ``IS DISTINCT FROM`` for ``json`` and ``ipaddress`` type.
 
 Hive Changes

--- a/presto-docs/src/main/sphinx/release/release-0.203.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.203.rst
@@ -5,7 +5,7 @@ Release 0.203
 General Changes
 ---------------
 
-* Fix spurious duplicate key errors from :func:`map`.
+* Fix spurious duplicate key errors from :func:`!map`.
 * Fix planning failure when a correlated subquery containing a ``LIMIT``
   clause is used within ``EXISTS`` (:issue:`10696`).
 * Fix out of memory error caused by missing pushback checks in data exchanges.

--- a/presto-docs/src/main/sphinx/release/release-0.204.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.204.rst
@@ -9,12 +9,12 @@ General Changes
 * Improve performance of correlated subqueries when filters from outer query
   can be propagated to the subquery.
 * Improve performance for correlated subqueries that contain inequalities.
-* Add support for all geometry types in :func:`ST_Area`.
-* Add :func:`ST_EnvelopeAsPts` function.
-* Add :func:`to_big_endian_32` and :func:`from_big_endian_32` functions.
+* Add support for all geometry types in :func:`!ST_Area`.
+* Add :func:`!ST_EnvelopeAsPts` function.
+* Add :func:`!to_big_endian_32` and :func:`!from_big_endian_32` functions.
 * Add cast between ``VARBINARY`` type and ``IPADDRESS`` type.
-* Make :func:`lpad` and :func:`rpad` functions support ``VARBINARY`` in addition to ``VARCHAR``.
-* Allow using arrays of mismatched lengths with :func:`zip_with`.
+* Make :func:`!lpad` and :func:`!rpad` functions support ``VARBINARY`` in addition to ``VARCHAR``.
+* Allow using arrays of mismatched lengths with :func:`!zip_with`.
   The missing positions are filled with ``NULL``.
 * Track execution statistics of ``AddExchanges`` and ``PredicatePushdown`` optimizer rules.
 

--- a/presto-docs/src/main/sphinx/release/release-0.205.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.205.rst
@@ -9,7 +9,7 @@ General Changes
   Previously, row expressions that included spaces would fail to parse.
   For example: ``cast(row(timestamp '2018-06-01') AS row(timestamp with time zone))``.
 * Fix distributed planning failure for complex queries when using bucketed execution.
-* Fix :func:`ST_ExteriorRing` to only accept polygons.
+* Fix :func:`!ST_ExteriorRing` to only accept polygons.
   Previously, it erroneously accepted other geometries.
 * Add the ``task.min-drivers-per-task`` and ``task.max-drivers-per-task`` config options.
   The former specifies the guaranteed minimum number of drivers a task will run concurrently

--- a/presto-docs/src/main/sphinx/release/release-0.206.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.206.rst
@@ -11,10 +11,10 @@ General Changes
   grouping columns is one. For example: ``SELECT c1, sum(c2) FROM t WHERE c1 = 'foo' GROUP BY c1``
 * Fix high memory pressure on the coordinator during the execution of queries
   using bucketed execution.
-* Add :func:`ST_Union`, :func:`ST_Geometries`, :func:`ST_PointN`, :func:`ST_InteriorRings`,
-  and :func:`ST_InteriorRingN` geospatial functions.
-* Add :func:`split_to_multimap` function.
-* Expand the :func:`approx_distinct` function to support the following types:
+* Add :func:`!ST_Union`, :func:`!ST_Geometries`, :func:`!ST_PointN`, :func:`!ST_InteriorRings`,
+  and :func:`!ST_InteriorRingN` geospatial functions.
+* Add :func:`!split_to_multimap` function.
+* Expand the :func:`!approx_distinct` function to support the following types:
   ``INTEGER``, ``SMALLINT``, ``TINYINT``, ``DECIMAL``, ``REAL``, ``DATE``,
   ``TIMESTAMP``, ``TIMESTAMP WITH TIME ZONE``, ``TIME``, ``TIME WITH TIME ZONE``, ``IPADDRESS``.
 * Add a resource group ID column to the ``system.runtime.queries`` table.

--- a/presto-docs/src/main/sphinx/release/release-0.207.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.207.rst
@@ -30,7 +30,7 @@ General Changes
 * Add support for column properties.
 * Add ``optimizer.max-reordered-joins`` configuration property to set the maximum number of joins that
   can be reordered at once using cost-based join reordering.
-* Add support for ``char`` type to :func:`approx_distinct`.
+* Add support for ``char`` type to :func:`!approx_distinct`.
 
 Security Changes
 ----------------

--- a/presto-docs/src/main/sphinx/release/release-0.208.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.208.rst
@@ -22,7 +22,7 @@ General Changes
 * Add a limit on the number of stages in a query.  The default is ``100`` and can
   be changed with the ``query.max-stage-count`` configuration property and the
   ``query_max_stage_count`` session property.
-* Add :func:`spooky_hash_v2_32` and :func:`spooky_hash_v2_64` functions.
+* Add :func:`!spooky_hash_v2_32` and :func:`!spooky_hash_v2_64` functions.
 * Add a cluster memory leak detector that logs queries that have possibly accounted for
   memory usage incorrectly on workers. This is a tool to for debugging internal errors.
 * Add support for correlated subqueries requiring coercions.

--- a/presto-docs/src/main/sphinx/release/release-0.209.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.209.rst
@@ -8,13 +8,13 @@ General Changes
 * Fix incorrect predicate pushdown when grouping sets contain the empty grouping set (:issue:`11296`).
 * Fix ``X-Forwarded-Proto`` header handling for requests to the ``/`` path (:issue:`11168`).
 * Fix a regression that results in execution failure when at least one
-  of the arguments to :func:`min_by` or :func:`max_by` is a constant ``NULL``.
+  of the arguments to :func:`!min_by` or :func:`!max_by` is a constant ``NULL``.
 * Fix failure when some buckets are completely filtered out during bucket-by-bucket execution.
 * Fix execution failure of queries due to a planning deficiency involving
   complex nested joins where a join that is not eligible for bucket-by-bucket
   execution feeds into the build side of a join that is eligible.
-* Improve numerical stability for :func:`corr`, :func:`covar_samp`,
-  :func:`regr_intercept`, and :func:`regr_slope`.
+* Improve numerical stability for :func:`!corr`, :func:`!covar_samp`,
+  :func:`!regr_intercept`, and :func:`!regr_slope`.
 * Do not include column aliases when checking column access permissions.
 * Eliminate unnecessary data redistribution for scalar correlated subqueries.
 * Remove table scan original constraint information from ``EXPLAIN`` output.
@@ -24,8 +24,8 @@ General Changes
 * Improve statistics estimation and fix potential negative nulls fraction
   estimates for expressions that include ``NOT`` or ``OR``.
 * Completely remove the ``SHOW PARTITIONS`` statement.
-* Add :func:`bing_tiles_around` variant that takes a radius.
-* Add the :func:`convex_hull_agg` and :func:`geometry_union_agg` geospatial aggregation functions.
+* Add :func:`!bing_tiles_around` variant that takes a radius.
+* Add the :func:`!convex_hull_agg` and :func:`!geometry_union_agg` geospatial aggregation functions.
 * Add ``(TYPE IO, FORMAT JSON)`` option for :doc:`/sql/explain` that shows
   input tables with constraints and the output table in JSON format.
 * Add :doc:`/connector/kudu`.

--- a/presto-docs/src/main/sphinx/release/release-0.211.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.211.rst
@@ -13,7 +13,7 @@ General Changes
   Consequently, TLS 1.0 or TLS 1.1 are no longer supported with the default configuration.
   The ``http-server.https.excluded-cipher`` config property can be set to empty string
   to restore the old behavior.
-* Add :func:`ST_GeomFromBinary` and :func:`ST_AsBinary` functions that convert
+* Add :func:`!ST_GeomFromBinary` and :func:`!ST_AsBinary` functions that convert
   geometries to and from Well-Known Binary format.
 * Remove the ``verbose_stats`` session property, and rename the ``task.verbose-stats``
   configuration property to ``task.per-operator-cpu-timer-enabled``.

--- a/presto-docs/src/main/sphinx/release/release-0.212.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.212.rst
@@ -5,14 +5,14 @@ Release 0.212
 General Changes
 ---------------
 
-* Fix query failures when the :func:`ST_GeomFromBinary` function is run on multiple rows.
+* Fix query failures when the :func:`!ST_GeomFromBinary` function is run on multiple rows.
 * Fix memory accounting for the build side of broadcast joins.
 * Fix occasional query failures when running ``EXPLAIN ANALYZE``.
-* Enhance :func:`ST_ConvexHull` and :func:`convex_hull_agg` functions to support geometry collections.
+* Enhance :func:`!ST_ConvexHull` and :func:`!convex_hull_agg` functions to support geometry collections.
 * Improve performance for some queries using ``DISTINCT``.
 * Improve performance for some queries that perform filtered global aggregations.
 * Remove ``round(x, d)`` and ``truncate(x, d)`` functions where ``d`` is a ``BIGINT`` (:issue:`11462`).
-* Add :func:`ST_LineString` function to form a ``LineString`` from an array of points.
+* Add :func:`!ST_LineString` function to form a ``LineString`` from an array of points.
 
 Hive Connector Changes
 ----------------------

--- a/presto-docs/src/main/sphinx/release/release-0.213.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.213.rst
@@ -42,10 +42,10 @@ General Changes
 Geospatial Changes
 ------------------
 
-* Fix :func:`ST_Distance` function to return ``NULL`` if any of the inputs is an
+* Fix :func:`!ST_Distance` function to return ``NULL`` if any of the inputs is an
   empty geometry as required by the SQL/MM specification.
-* Add :func:`ST_MultiPoint` function to construct multi-point geometry from an array of points.
-* Add :func:`geometry_union` function to efficiently union arrays of geometries.
+* Add :func:`!ST_MultiPoint` function to construct multi-point geometry from an array of points.
+* Add :func:`!geometry_union` function to efficiently union arrays of geometries.
 * Add support for distributed spatial joins (:issue:`11072`).
 
 Server RPM Changes

--- a/presto-docs/src/main/sphinx/release/release-0.214.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.214.rst
@@ -12,7 +12,7 @@ General Changes
 * Fix responses to client for certain types of errors that are encountered
   during query creation.
 * Improve error message when an invalid comparator is provided to the
-  :func:`array_sort` function.
+  :func:`!array_sort` function.
 * Improve performance of lookup operations on map data types.
 * Improve planning and query performance for queries with ``TINYINT``,
   ``SMALLINT`` and ``VARBINARY`` literals.
@@ -22,7 +22,7 @@ General Changes
 * Add session property ``optimize-top-n-row-number`` and configuration property
   ``optimizer.optimize-top-n-row-number`` to toggle the top N row number
   optimization.
-* Add :func:`ngrams` function to generate N-grams from an array.
+* Add :func:`!ngrams` function to generate N-grams from an array.
 * Add :ref:`qdigest <qdigest_type>` type and associated :doc:`/functions/qdigest`.
 * Add functionality to delay query execution until a minimum number of workers
   nodes are available. The minimum number of workers can be set with the

--- a/presto-docs/src/main/sphinx/release/release-0.215.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.215.rst
@@ -10,7 +10,7 @@ General Changes
 * Fix reporting of the processed input data for source stages in ``EXPLAIN ANALYZE``.
 * Fail queries that use non-leaf resource groups. Previously, they would remain queued forever.
 * Improve CPU usage for specific queries (:issue:`11757`).
-* Extend stats and cost model to support :func:`row_number` window function estimates.
+* Extend stats and cost model to support :func:`!row_number` window function estimates.
 * Improve the join type selection and the reordering of join sides for cases where
   the join output size cannot be estimated.
 * Add dynamic scheduling support to grouped execution. When a stage is executed
@@ -19,13 +19,13 @@ General Changes
   grouped execution. This feature can be enabled with the
   ``dynamic_schedule_for_grouped_execution`` session property or the
   ``dynamic-schedule-for-grouped-execution`` config property.
-* Add :func:`beta_cdf` and :func:`inverse_beta_cdf` functions.
+* Add :func:`!beta_cdf` and :func:`!inverse_beta_cdf` functions.
 * Split the reporting of raw input data and processed input data for source operators.
 * Remove collection and reporting of raw input data statistics for the ``Values``,
   ``Local Exchange``, and ``Local Merge Sort`` operators.
 * Simplify ``EXPLAIN (TYPE IO)`` output when there are too many discrete components.
   This avoids large output at the cost of reduced granularity.
-* Add :func:`parse_presto_data_size` function.
+* Add :func:`!parse_presto_data_size` function.
 * Add support for ``UNION ALL`` to optimizer's cost model.
 * Add support for estimating the cost of filters by using a default filter factor.
   The default value for the filter factor can be configured with the ``default_filter_factor_enabled``
@@ -34,9 +34,9 @@ General Changes
 Geospatial Changes
 ------------------
 
-* Add input validation checks to :func:`ST_LineString` to conform with the specification.
+* Add input validation checks to :func:`!ST_LineString` to conform with the specification.
 * Improve spatial join performance.
-* Enable spatial joins for join conditions expressed with the :func:`ST_Within` function.
+* Enable spatial joins for join conditions expressed with the :func:`!ST_Within` function.
 
 Web UI Changes
 --------------

--- a/presto-docs/src/main/sphinx/release/release-0.216.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.216.rst
@@ -5,13 +5,13 @@ Release 0.216
 General Changes
 ---------------
 
-* Fix correctness issue for :func:`array_intersect` and :func:`array_distinct` when input contains
+* Fix correctness issue for :func:`!array_intersect` and :func:`!array_distinct` when input contains
   both zeros and nulls.
 * Fix ``count(*)`` aggregation on empty relation when ``optimize_mixed_distinct_aggregation`` is enabled.
 * Improve table scan performance for structural types.
-* Improve performance for :func:`array_intersect`.
-* Add :func:`reduce_agg` aggregate function.
-* Add :func:`millisecond` function.
+* Improve performance for :func:`!array_intersect`.
+* Add :func:`!reduce_agg` aggregate function.
+* Add :func:`!millisecond` function.
 * Add an optimizer rule to filter the window partitions before executing the window operators.
 * Remove ``ON`` keyword for :doc:`/sql/show-stats`.
 * Restrict ``WHERE`` clause in :doc:`/sql/show-stats` to filters that can be pushed down to the connectors.

--- a/presto-docs/src/main/sphinx/release/release-0.217.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.217.rst
@@ -16,7 +16,7 @@ General Changes
   When this threshold is exceeded, a ``TOO_MANY_STAGES`` warning is raised.
 * Add per-task peak user memory usage to query statistics.
 * Add CLI support for showing the amount of data spilled during query execution.
-* Add :func:`ST_Points` function.
+* Add :func:`!ST_Points` function.
 * Add :doc:`/connector/elasticsearch`.
 * Remove the system memory pool and related configuration properties (``resources.reserved-system-memory``, ``deprecated.legacy-system-pool-enabled``) entirely.
   System memory pool was deprecated in 0.201, and it was unused by default since that release. All memory allocations will now be served from the general/user memory pool.

--- a/presto-docs/src/main/sphinx/release/release-0.218.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.218.rst
@@ -14,7 +14,7 @@ General Changes
 * Fix failures in regular expression functions for certain inputs where the pattern contains word boundaries (e.g. ``\b``).
 * Fix an issue that may cause a crash when using plugins that provide an event listener. (:issue:`11951`)
 * Fix a memory leak that occurs when a query fails with a semantic or permission error.
-* Improve performance for queries with ``FULL OUTER JOIN`` where join keys have the :func:``COALESCE`` function applied.
+* Improve performance for queries with ``FULL OUTER JOIN`` where join keys have the :func:`!`COALESCE`` function applied.
 * Improve cost based optimizer to make decisions based on estimated query peak memory.
 * Improve cost based optimizer for certain queries using ``ORDER BY``.
 * Improve performance for queries with an ``OUTER JOIN`` followed by ``LIMIT``.
@@ -22,9 +22,9 @@ General Changes
 * Add support for using binary encoding for coordinator-to-worker communication.
   This feature is experimental, and it can be enabled with the ``experimental.internal-communication.binary-transport-enabled`` configuration property.
   Enabling this feature may help with coordinator scalability and reduces network, CPU, and memory usage on the coordinator.
-* Add :func:`ST_Area` for the ``SphericalGeography`` type.
+* Add :func:`!ST_Area` for the ``SphericalGeography`` type.
 * Add a system table ``system.metadata.analyze_properties`` that shows the properties supported by the ``ANALYZE`` statement.
-* Add support for resolving key conflicts when using :func:`split_to_map`.
+* Add support for resolving key conflicts when using :func:`!split_to_map`.
 * Add support for role management (see :doc:`/sql/create-role`). Client library version 0.218 is required to use :doc:`/sql/set-role`. (:issue:`11645`)
 * Add support for processing JSON protocol messages by generating bytecode on the coordinator.
   This feature is experimental, and it can be enabled with the ``experimental.json-serde-codegen-enabled`` configuration property.

--- a/presto-docs/src/main/sphinx/release/release-0.219.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.219.rst
@@ -15,12 +15,12 @@ General Changes
 * Fix an issue that may cause procedure calls to fail if no queries were run after the server started up.
 * Fix an issue where the properties supported by the ``ANALYZE`` statement for a given connector would remain in the ``system.metadata.analyze_properties`` table
   even after the connector was removed.
-* Add :func:`ST_Length` for ``SphericalGeography`` type..
+* Add :func:`!ST_Length` for ``SphericalGeography`` type..
 * Add ``view_owner`` column to the ``information_schema.views`` system table.
 * Add a ``JSON`` version of the query plan to ``QueryCompletedEvent``.
 * Add support for creating warnings during parsing.
 * Add a warning for using the ``current_role`` reserved word as an identifier.
-* Add support for using the empty string as a delimiter for the :func:`split` function.
+* Add support for using the empty string as a delimiter for the :func:`!split` function.
   When an empty string is used as the delimiter, the string will be split into individual characters.
 
 Raptor Changes
@@ -43,7 +43,7 @@ Verifier Changes
 * Fix query timeout enforcement by replacing local timer with the ``query_max_execution_time`` session property.
 * Improve result comparison for floating point columns by using relative errors.
   Replace configuration property ``expected-double-precision`` with ``relative-error-margin``.
-* Improve result comparison for orderable array columns by applying :func:`array_sort` before :func:`checksum`.
+* Improve result comparison for orderable array columns by applying :func:`!array_sort` before :func:`!checksum`.
 * Improve result comparison for ``SELECT`` queries by rewriting ``SELECT`` queries as ``CREATE TABLE AS`` and using checksum queries to verify the results.
   This eliminates the row count limit for ``SELECT`` queries.
 * Reuse initial control query results for the determinism check. This reduces the maximum number of control query runs and eliminates the test query reruns.

--- a/presto-docs/src/main/sphinx/release/release-0.221.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.221.rst
@@ -8,12 +8,12 @@ General Changes
 * Fix a performance regression for some outer joins without equality predicates when
   ``join_distribution_type`` is set to ``AUTOMATIC``.
 * Improve performance for queries that have constant ``VARCHAR`` predicates on join columns.
-* Add a variant of :func:`strpos` that returns the position of the N-th instance of the substring.
-* Add :func:`strrpos` that returns the position of the N-th instance of a substring from the back of a string.
-* Add aggregation function :func:`entropy`.
-* Add classification aggregation functions :func:`classification_miss_rate`, :func:`classification_precision`,
-  :func:`classification_recall`, :func:`classification_thresholds`.
-* Add overload of :func:`approx_set` which takes in the maximum standard error.
+* Add a variant of :func:`!strpos` that returns the position of the N-th instance of the substring.
+* Add :func:`!strrpos` that returns the position of the N-th instance of a substring from the back of a string.
+* Add aggregation function :func:`!entropy`.
+* Add classification aggregation functions :func:`!classification_miss_rate`, :func:`!classification_precision`,
+  :func:`!classification_recall`, :func:`!classification_thresholds`.
+* Add overload of :func:`!approx_set` which takes in the maximum standard error.
 * Add ``max_tasks_per_stage`` session property and ``stage.max-tasks-per-stage`` config property to
   limit the number of tasks per stage for grouped execution.  Setting this session property allows queries
   running with grouped execution to use a predictable amount of memory independent of the cluster size.

--- a/presto-docs/src/main/sphinx/release/release-0.222.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.222.rst
@@ -26,10 +26,10 @@ General Changes
 * Add configuration property ``max-concurrent-materializations`` and session
   property ``max_concurrent_materializations`` to limit the number of plan
   sections that will run concurrently when using materialized exchanges.
-* Add support for computing :func:`approx_distinct` over BingTile values.
-* Add :func:`merge_hll` to merge an array of HyperLogLogs.
-* Add bitwise shift operations, :func:`bitwise_arithmetic_shift_right`,
-  :func:`bitwise_logical_shift_right` and :func:`bitwise_shift_left`.
+* Add support for computing :func:`!approx_distinct` over BingTile values.
+* Add :func:`!merge_hll` to merge an array of HyperLogLogs.
+* Add bitwise shift operations, :func:`!bitwise_arithmetic_shift_right`,
+  :func:`!bitwise_logical_shift_right` and :func:`!bitwise_shift_left`.
 
 Web UI Changes
 --------------

--- a/presto-docs/src/main/sphinx/release/release-0.223.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.223.rst
@@ -12,7 +12,7 @@ General Changes
   polling for task information update.
   ``experimental.task.info-update-refresh-max-wait`` is the configuration
   property to enable this.
-* Add support for multibyte characters in :func:`date_format`.
+* Add support for multibyte characters in :func:`!date_format`.
 
 Web UI Changes
 --------------

--- a/presto-docs/src/main/sphinx/release/release-0.227.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.227.rst
@@ -16,12 +16,12 @@ _______________
 * Improve performance of repartitioning data between stages.  The optimization can be
   enabled by the ``optimized_repartitioning`` session property or the
   ``experimental.optimized-repartitioning`` configuration property.
-* Add spatial join (broadcast and partitioned) support for :func:`ST_Equals`,
-  :func:`ST_Overlaps`, :func:`ST_Crosses`, and :func:`ST_Touches`.
+* Add spatial join (broadcast and partitioned) support for :func:`!ST_Equals`,
+  :func:`!ST_Overlaps`, :func:`!ST_Crosses`, and :func:`!ST_Touches`.
 * Add ``task_partitioned_writer_count`` session property to allow setting the number
   of concurrent writers for partitioned (bucketed) writes.
-* Add ``IPPREFIX`` type and :func:`ip_prefix` function.
-* Add :func:`differential_entropy` functions to compute differential entropy.
+* Add ``IPPREFIX`` type and :func:`!ip_prefix` function.
+* Add :func:`!differential_entropy` functions to compute differential entropy.
 * Remove syntax support for ``SET PATH`` and ``CURRENT_PATH``. The path information was
   never used by Presto.
 

--- a/presto-docs/src/main/sphinx/release/release-0.229.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.229.rst
@@ -4,8 +4,8 @@ Release 0.229
 
 General Changes
 _______________
-* Fix an issue that would cause query failure when calling :func:`geometry_to_bing_tiles` on certain degenerate geometries.
-* Add geospatial function :func:`line_interpolate_point`.
+* Fix an issue that would cause query failure when calling :func:`!geometry_to_bing_tiles` on certain degenerate geometries.
+* Add geospatial function :func:`!line_interpolate_point`.
 * Add support for ``CREATE FUNCTION``
 * Add support for passing ``X_Forwarded_For`` header from Proxy to coordinator.
 * Add support to respect configuration property ``stage.max-tasks-per-stage`` for limiting the number of tasks per scan.

--- a/presto-docs/src/main/sphinx/release/release-0.230.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.230.rst
@@ -9,13 +9,13 @@ _______________
 * Fix an issue where SQL functions do not respect behavior specification for null arguments during execution.
 * Fix compilation errors for expressions over types containing an extremely large number of nested types (:pr:`13405`).
 * Fix a regression in lambda evaluation (:issue:`13648`).
-* Fix :func:`geometry_to_bing_tiles` function for geometries at -180 longitude or 85.05112878 latitude.
+* Fix :func:`!geometry_to_bing_tiles` function for geometries at -180 longitude or 85.05112878 latitude.
 * Improve ``PRESTO_EXTRA_CREDENTIAL`` header parsing to allow for values contain multiple ``=`` characters and url-encoded characters.
 * Add support to list non-builtin functions in SHOW FUNCTIONS. The feature can be turned on by the configuration property ``list-non-built-in-functions``.
 * Add support for ``DROP FUNCTION``.
-* Add :func:`combinations` function, which returns ``n`` combinations of values in an array, up to ``n = 5``.
-* Add :func:`all_match()`, :func:`any_match()`, and :func:`none_match()` functions.
-* Add :func:`expand_envelope` function to return a geometry's envelope expanded by a distance.
+* Add :func:`!combinations` function, which returns ``n`` combinations of values in an array, up to ``n = 5``.
+* Add :func:`!all_match()`, :func:`!any_match()`, and :func:`!none_match()` functions.
+* Add :func:`!expand_envelope` function to return a geometry's envelope expanded by a distance.
 
 Hive Changes
 ____________

--- a/presto-docs/src/main/sphinx/release/release-0.231.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.231.rst
@@ -15,11 +15,11 @@ _______________
 * Fix SQL function compilation error when input parameters contain lambda.
 * Fix ``IS DISTINCT FROM`` for long decimals.
 * Improve error handling for geometry deserialization edge cases.
-* Improve performance of :func:`array_join`.
-* Improve efficiency of :func:`ST_Buffer`. The new implementation produces fewer buffer points on rounded corners, which will produce very similar but different results. It also better handles buffering with small (<1e-9) distances.
+* Improve performance of :func:`!array_join`.
+* Improve efficiency of :func:`!ST_Buffer`. The new implementation produces fewer buffer points on rounded corners, which will produce very similar but different results. It also better handles buffering with small (<1e-9) distances.
 * Improve OOM killer log output to put memory heavy nodes and queries first.
 * Improve efficiency by using JTS instead of Esri for many geometrical operations and fix incorrect calculation of extreme points in certain cases (:issue:`14031`).
-* Add forms of :func:`approx_percentile` accepting an accuracy parameter.
+* Add forms of :func:`!approx_percentile` accepting an accuracy parameter.
 * Add a new session property ``aggregation_partitioning_merging_strategy`` to configure partition merging strategy when adding exchange around aggregation node (:pr:`11262`).
 * Add ``IGNORE NULLS`` clause to various :doc:`/functions/window`.
 

--- a/presto-docs/src/main/sphinx/release/release-0.233.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.233.rst
@@ -12,13 +12,13 @@ _______________
 * Fix an optimizer failure introduced in ``0.229``, where a ``LIKE`` pattern is deduced into a constant, e.g., ``col LIKE 'a' and col = 'b'``.
 * Fix correctness issue in queries with joins over ``UNNEST``. (:issue:`14257`).
 * Fix ``ArbitraryOutputBuffer`` to avoid skewing output data distribution. (:pr:`14083`).
-* Fix an issue where :func:`classification_fall_out` cannot be found.
+* Fix an issue where :func:`!classification_fall_out` cannot be found.
 * Add support for async page transport with non-blocking IO. This can be enabled by the ``exchange.async-page-transport-enabled`` configuration property.
 * Add support to handle http request timeouts using multiple thread pools. This can be controlled by the ``task.http-timeout-concurrency`` configuration property.
 * Add support for soft affinity scheduling, which makes the best effort to fetch the same piece of data from the same worker,
   while allowing fallback to random workers if the preferred workers are too busy to handle additional splits. (See :doc:`/develop/connectors`).
 * Add hash functions ``fnv1_32``, ``fnv1_64``, ``fnv1a_32``, and ``fnv1a_64``.
-* Add IP address functions :func:`ip_subnet_min`, :func:`ip_subnet_max`, :func:`ip_subnet_range`, and :func:`is_subnet_of`.
+* Add IP address functions :func:`!ip_subnet_min`, :func:`!ip_subnet_max`, :func:`!ip_subnet_range`, and :func:`!is_subnet_of`.
 * Improve performance of ``StreamingAggregationOperator``.
 
 Hive Changes
@@ -52,12 +52,12 @@ _____________
 
 Geospatial Changes
 __________________
-* Improve :func:`ST_Points` to add support for major well-known spatial objects.
-  :func:`ST_Points` now supports ``POINT``, ``LINESTRING``, ``POLYGON``, ``MULTIPOINT``, ``MULTILINESTRING``, ``MULTIPOLYGON`` and ``GEOMETRYCOLLECTION``.
-* Improve :func:`ST_IsValid` and :func:`ST_IsSimple` to adhere to the ISO/OGC standards more closely.
+* Improve :func:`!ST_Points` to add support for major well-known spatial objects.
+  :func:`!ST_Points` now supports ``POINT``, ``LINESTRING``, ``POLYGON``, ``MULTIPOINT``, ``MULTILINESTRING``, ``MULTIPOLYGON`` and ``GEOMETRYCOLLECTION``.
+* Improve :func:`!ST_IsValid` and :func:`!ST_IsSimple` to adhere to the ISO/OGC standards more closely.
   The two functions used to return the same result but may now be different. Users should check both functions to be sure their geometries are well-behaved.
-  :func:`geometry_invalid_reason` will return different but semantically similar strings.
-* Improve performance of :func:`ST_Intersection` by simply returning the geometry if it has an enclosing envelope.
+  :func:`!geometry_invalid_reason` will return different but semantically similar strings.
+* Improve performance of :func:`!ST_Intersection` by simply returning the geometry if it has an enclosing envelope.
   This can reduce CPU cost by up to ``10^5x`` for complex polygons.
 
 SPI Changes

--- a/presto-docs/src/main/sphinx/release/release-0.235.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.235.rst
@@ -14,10 +14,10 @@ _______________
 * Add check to disallow invoking SQL functions in SQL function body.
 * Add support for limiting the total number of buffers per optimized repartitioning operator. The limit can be set by the configuration property ``driver.max-page-partitioning-buffer-count``.
 * Add peak task total memory to query stats.
-* Add :func:`scale_qdigest` function to scale a ``qdigest`` to a new weight.
-* Add :func:`myanmar_font_encoding` and :func:`myanmar_normalize_unicode` to support working with Burmese text
-* Add support for :func:`ST_AsText` to accept Spherical Geographies.
-* Add support for :func:`ST_Centroid` to accept Spherical Geography Points and MultiPoints.
+* Add :func:`!scale_qdigest` function to scale a ``qdigest`` to a new weight.
+* Add :func:`!myanmar_font_encoding` and :func:`!myanmar_normalize_unicode` to support working with Burmese text
+* Add support for :func:`!ST_AsText` to accept Spherical Geographies.
+* Add support for :func:`!ST_Centroid` to accept Spherical Geography Points and MultiPoints.
 
 Pinot Connector Changes
 _______________________

--- a/presto-docs/src/main/sphinx/release/release-0.237.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.237.rst
@@ -6,7 +6,7 @@ Release 0.237
 ==============
 
 * Add JSON format for ``EXPLAIN`` with type ``LOGICAL`` and ``DISTRIBUTED``.
-* Add functions :func:`array_sum`, :func:`array_average`, :func:`map_normalize`, :func:`set_agg` and :func:`flatten_geometry_collections`.
+* Add functions :func:`!array_sum`, :func:`!array_average`, :func:`!map_normalize`, :func:`!set_agg` and :func:`!flatten_geometry_collections`.
 * Support authentication for Druid connector.
 * Support for AWS IAM authorization to Elasticsearch connector.
 * Improve Elasticsearch query capabilities.
@@ -22,13 +22,13 @@ _______________
 * Fix compiler failure with function type when common sub-expression optimization is enabled.
 * Improve coordinator RPC performance by removing unused entries from ``TaskStatus``.
 * Add JSON format for ``EXPLAIN`` with type ``LOGICAL`` and ``DISTRIBUTED``.
-* Add functions :func:`array_sum`, :func:`array_average`, :func:`map_normalize` and :func:`set_agg`.
+* Add functions :func:`!array_sum`, :func:`!array_average`, :func:`!map_normalize` and :func:`!set_agg`.
 * Add session property ``warning_handling`` to control how warnings are handled. The options are ``SUPPRESS``, ``NORMAL`` and ``AS_ERROR``. The default value is ``NORMAL``.
 * Add support for defining SQL-invoked functions in plugins.
 * Add support to control which worker can receive tasks by implementing the ``NodeStatusService`` interface. See :pr:`14535`.
-* Add warning to use :func:`approx_distinct` when using ``COUNT(DISTINCT x)``.
+* Add warning to use :func:`!approx_distinct` when using ``COUNT(DISTINCT x)``.
 * Add support for listing functions whose names match a specified pattern using the ``SHOW FUNCTION LIKE`` syntax.
-* Add :func:`flatten_geometry_collections` function to recursively flatten GeometryCollections.
+* Add :func:`!flatten_geometry_collections` function to recursively flatten GeometryCollections.
 
 Cassandra Connector Changes
 ___________________________

--- a/presto-docs/src/main/sphinx/release/release-0.238.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.238.rst
@@ -29,7 +29,7 @@ _______________
 
 Geospatial Changes
 __________________
-* Fix error in :func:`geometry_invalid_reason`.
+* Fix error in :func:`!geometry_invalid_reason`.
 * Fix integer overflow in certain cases with Bing Tiles.
 
 Hive Changes

--- a/presto-docs/src/main/sphinx/release/release-0.239.2.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.239.2.rst
@@ -4,4 +4,4 @@ Release 0.239.2
 
 General Changes
 _______________
-* Fix incorrect results from :func:`classification_precision` (:pr:`15075`). This issue started from 0.239 release.
+* Fix incorrect results from :func:`!classification_precision` (:pr:`15075`). This issue started from 0.239 release.

--- a/presto-docs/src/main/sphinx/release/release-0.239.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.239.rst
@@ -21,7 +21,7 @@ Release 0.239
 
 General Changes
 _______________
-* Fix incorrect results from :func:`classification_miss_rate`, :func:`classification_fall_out` (:pr:`14740`).
+* Fix incorrect results from :func:`!classification_miss_rate`, :func:`!classification_fall_out` (:pr:`14740`).
 * Fix error in ``/v1/thread`` end point.
 * Fix an issue where the property ``ignore_stats_calculator_failures`` would not be honored
   for certain queries.
@@ -30,12 +30,12 @@ _______________
 * Optimize queries with repeated expressions in filters or projections by computing the
   common expressions only once. This can be disabled by the session property
   ``optimize_common_sub_expressions``.
-* Optimize queries containing only :func:`min` and :func:`max` on columns that can be
+* Optimize queries containing only :func:`!min` and :func:`!max` on columns that can be
   evaluated using metadata (e.g., Hive partitions). This is controlled by configuration property
   ``optimizer.optimize-metadata-queries`` and session property ``optimize_metadata_queries``.
   Note: Enabling this optimization might change query result if there are metadata that refers to
   empty data, see :pr:`14845` for examples.
-* Add aggregation function :func:`set_union`.
+* Add aggregation function :func:`!set_union`.
 * Add local disk spilling support for queries with ``ORDER BY`` or ``DISTINCT``.
 * Add new unified grouped execution configuration property ``grouped-execution-enabled`` and
   session property ``grouped_execution`` with default set to ``true``. The property

--- a/presto-docs/src/main/sphinx/release/release-0.240.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.240.rst
@@ -10,7 +10,7 @@ Release 0.240
 * Add ability to spill window functions to local disk when a worker is out of memory.
 * Add support for inlining SQL functions at query planning time.
 * Add support for limit pushdown through union.
-* Add :func:`geometry_from_geojson` and :func:`geometry_as_geojson` to convert geometries from and to GeoJSON format.
+* Add :func:`!geometry_from_geojson` and :func:`!geometry_as_geojson` to convert geometries from and to GeoJSON format.
 
 **Details**
 ==============
@@ -22,7 +22,7 @@ _______________
 * Add ``IF EXISTS`` and ``IF NOT EXISTS`` syntax to ``ALTER TABLE``.
 * Add ``query.max-scan-physical-bytes`` configuration and ``query_max_scan_physical_bytes`` session properties to limit total number of bytes read from storage during table scan. The default limit is 1PB.
 * Add support for inlining SQL functions at query planning time. This feature is enabled by default, and can be disabled with the ``inline_sql_functions`` session property.
-* Add :func:`geometry_from_geojson` and :func:`geometry_as_geojson` to convert geometries from and to GeoJSON format.
+* Add :func:`!geometry_from_geojson` and :func:`!geometry_as_geojson` to convert geometries from and to GeoJSON format.
 * Add support for pushdown of dereference expressions for querying nested data. This can be enabled with the ``pushdown_dereference_enabled`` session property or the ``experimental.pushdown-dereference-enabled`` configuration property.
 * Use local private credentials (json key file) to refresh GCS access token. Usage : presto-cli --extra-credential hive.gcs.credentials.path="${PRIVATE_KEY_JSON_PATH}".
 * Add ability to spill window functions to local disk when a worker is out of memory.
@@ -58,9 +58,9 @@ ______________________
 
 Geospatial Changes
 __________________
-* Improve :func:`geometry_to_bing_tiles` performance.  It is 50x faster on complex polygons, the limit on polygon complexity is removed, and some correctness bugs have been fixed.
+* Improve :func:`!geometry_to_bing_tiles` performance.  It is 50x faster on complex polygons, the limit on polygon complexity is removed, and some correctness bugs have been fixed.
 * Add geometry_to_dissolved_bing_tiles function, which dissolves complete sets of child tiles to their parent.
-* Introduce :func:`bing_tile_children` and :func:`bing_tile_parent` functions to get parents and children of a Bing tile.
+* Introduce :func:`!bing_tile_children` and :func:`!bing_tile_parent` functions to get parents and children of a Bing tile.
 
 Hive Changes
 ____________

--- a/presto-docs/src/main/sphinx/release/release-0.241.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.241.rst
@@ -7,7 +7,7 @@ Release 0.241
 
 General Changes
 _______________
-* Fix incorrect results from function :func:`classification_precision` introduced in release 0.239.
+* Fix incorrect results from function :func:`!classification_precision` introduced in release 0.239.
 * Improve performance for queries with broadcast or collocated joins by adding dynamic filtering and bucket pruning support. This can be enabled with the ``experimental.enable-dynamic-filtering`` configuration property and ``enable_dynamic_filtering`` system session property. For more information please refer to (:pr:`15077`).
 * Add new warning message for ``UNION`` queries without ``ALL`` or ``DISTINCT`` keywords.
 * Downgrade the ZSTD JNI compressor version to resolve the frequent excessive GC events introduced in version 0.238.
@@ -48,5 +48,5 @@ ___________
 
 Geospatial Changes
 __________________
-* Fix a bug when two envelopes intersect at a point for :func:`ST_Intersection`.
-* Add :func:`geometry_nearest_points` to find nearest points of a pair of geometries.
+* Fix a bug when two envelopes intersect at a point for :func:`!ST_Intersection`.
+* Add :func:`!geometry_nearest_points` to find nearest points of a pair of geometries.

--- a/presto-docs/src/main/sphinx/release/release-0.243.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.243.rst
@@ -16,8 +16,8 @@ Release 0.243
 
 **Highlights**
 ==============
-* Add :func:`approx_most_frequent` aggregation function.
-* Add support to :func:`truncate` function for specifying the number of digits to the right of the decimal point in the truncated result.
+* Add :func:`!approx_most_frequent` aggregation function.
+* Add support to :func:`!truncate` function for specifying the number of digits to the right of the decimal point in the truncated result.
 * Add support for ignoring access checks on columns that are referenced in the query, but are not required to compute the query results. This can be enabled with the ``check_access_control_on_utilized_columns_only`` session property.
 * Add support in verifier to verify ``CREATE VIEW`` and ``CREATE TABLE`` queries.
 
@@ -27,8 +27,8 @@ Release 0.243
 General Changes
 _______________
 * Fix query failure when using ``EXPLAIN`` with a ``USE`` statement.
-* Add :func:`approx_most_frequent` aggregation function.
-* Add support to :func:`truncate` function for specifying the number of digits to the right of the decimal point in the truncated result.
+* Add :func:`!approx_most_frequent` aggregation function.
+* Add support to :func:`!truncate` function for specifying the number of digits to the right of the decimal point in the truncated result.
 * Remove configuration property ``optimizer.optimize-full-outer-join-with-coalesce`` and the corresponding session property ``optimize_full_outer_join_with_coalesce``. The feature will always be enabled.
 * Remove deprecated configuration properties ``grouped-execution-for-aggregation-enabled`` and ``grouped-execution-for-join-enabled`` and their corresponding session properties ``grouped_execution_for_aggregation`` and ``grouped_execution_for_join``.  These have been replaced by a single configuration property ``grouped-execution-enabled`` and session property ``grouped_execution``.
 * Remove deprecated configuration property ``dynamic-schedule-for-grouped-execution`` and session property ``dynamic_schedule_for_grouped_execution``.

--- a/presto-docs/src/main/sphinx/release/release-0.244.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.244.rst
@@ -20,7 +20,7 @@ Release 0.244
 General Changes
 _______________
 * Fix an issue where queries could encounter an int overflow error during spilling.
-* Fix :func:`hamming_distance` to handle code point zero correctly.
+* Fix :func:`!hamming_distance` to handle code point zero correctly.
 * Fix caching and case-sensitivity bugs with type signatures for enum types.
 * Fix a bug where queries could produce wrong results when they have multiple lambda expressions that only differ in complex type constants (:issue:15424).
 * Improve performance of cross joins.

--- a/presto-docs/src/main/sphinx/release/release-0.247.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.247.rst
@@ -19,7 +19,7 @@ _______________
 * Fix a bug for reporting output data sizes for optimized repartitioning.
 * Fix accounting for revocable memory that could cause some queries not to spill when they should.
 * Fix a race condition in enum key lookup which caused queries using ``enum_key`` to crash occasionally with an internal error. (:pr:`15607`).
-* Add an implementation of :func:`array_intersect` that takes an array of arrays as input.
+* Add an implementation of :func:`!array_intersect` that takes an array of arrays as input.
 * Add support for temporary (session-scoped) functions.
 * Add support for specifying session properties via regex matching on client info using :doc:`/admin/session-property-managers`.
 

--- a/presto-docs/src/main/sphinx/release/release-0.248.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.248.rst
@@ -8,7 +8,7 @@ Release 0.248
 
 **Highlights**
 ==============
-* New aggregation function :func:`map_union_sum`.
+* New aggregation function :func:`!map_union_sum`.
 * Add support for overriding session properties using session property managers. See :doc:`/admin/session-property-managers`.
 
 **Details**
@@ -20,7 +20,7 @@ _______________
 * Add support for overriding session properties using session property managers :doc:`/admin/session-property-managers`. Setting ``overrideSessionProperties`` to true will cause the property to be overridden and remain overridden even if subsequent rules match the property but don't have ``overrideSessionProperties`` set.
 * Add support to drop multiple UDFs at the same time.
 * Add a REST endpoint ``/v1/taskInfo/{{taskId}}`` on the coordinator to get TaskInfo without needing to go directly to the worker's endpoint.
-* Add new aggregation function :func:`map_union_sum`.
+* Add new aggregation function :func:`!map_union_sum`.
 * Add support to configure ZSTD compression level for ORC writer.
 * Add warning for JOIN conditions with OR expressions.
 * Add configuration property ``internal-communication.https.trust-store-password`` to set the Java Truststore password used for https in internal communications between nodes.

--- a/presto-docs/src/main/sphinx/release/release-0.250.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.250.rst
@@ -9,7 +9,7 @@ General Changes
 _______________
 * Fix a memory leak in ``NodeTaskMap`` which could lead to Full GC or OOMs in coordinator.
 * Add support for configuring the maximum number of unacknowledged source splits per task. This can be enabled by setting the ``max_unacknowledged_splits_per_task`` session property or ``node-scheduler.max-unacknowledged-splits-per-task`` configuration property.
-* Add bitwise shift functions :func:`bitwise_left_shift`, :func:`bitwise_right_shift`, :func:`bitwise_right_shift_arithmetic` (:pr:`15730`)
+* Add bitwise shift functions :func:`!bitwise_left_shift`, :func:`!bitwise_right_shift`, :func:`!bitwise_right_shift_arithmetic` (:pr:`15730`)
 * Add support for creating, dropping, querying and seeing materialized view definitions. (:pr:`15589`, :pr:`15779`)
 
 **Contributors**

--- a/presto-docs/src/main/sphinx/release/release-0.252.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.252.rst
@@ -19,7 +19,7 @@ _______________
 * Add support for returning partial results for the queries by setting ``partial_results_enabled`` session property. Additionally ``partial_results_max_execution_time_multiplier``, ``partial_results_completion_ratio_threshold`` session properties can be set to configure the max execution time multiplier and minimum completion ratio threshold for the queries.
 * Add automatic query retry functionality for transient failures. This can be enabled by setting ``per-query-retry-limit`` to a non-zero integer to indicate the per query retry count.
 * Add support to coordinator endpoint ``/v1/info/state`` to return ``ACTIVE`` when the coordinator is not shutting down and the cluster has the minimum required workers.
-* Add functions :func:`chisquared_cdf` and :func:`inverse_chisquared_cdf`.
+* Add functions :func:`!chisquared_cdf` and :func:`!inverse_chisquared_cdf`.
 
 Security Changes
 ________________

--- a/presto-docs/src/main/sphinx/release/release-0.253.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.253.1.rst
@@ -4,4 +4,4 @@ Release 0.253.1
 
 General Changes
 _______________
-* Fix a CPU regression for queries using :func:`element_at` for ``MAP``. Introduced by :pr:`16027`
+* Fix a CPU regression for queries using :func:`!element_at` for ``MAP``. Introduced by :pr:`16027`

--- a/presto-docs/src/main/sphinx/release/release-0.253.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.253.rst
@@ -3,7 +3,7 @@ Release 0.253
 =============
 
 .. warning::
-    A CPU regression was introduced by :pr:`16027` for queries using :func:`element_at` with ``MAP``
+    A CPU regression was introduced by :pr:`16027` for queries using :func:`!element_at` with ``MAP``
 
 **Details**
 ===========
@@ -13,7 +13,7 @@ _______________
 * Fix amplified ``Cumulative User Memory`` metric in web UI.
 * Add tracking for system memory used by column statistics in ``TableFinishOperator``.
 * Add support for shutting down coordinator via ``/v1/info/state`` endpoint.
-* Add :func:`binomial_cdf` and :func:`inverse_binomial_cdf` functions.
+* Add :func:`!binomial_cdf` and :func:`!inverse_binomial_cdf` functions.
 
 Security Changes
 ________________

--- a/presto-docs/src/main/sphinx/release/release-0.254.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.254.rst
@@ -12,9 +12,9 @@ Release 0.254
 General Changes
 _______________
 * Fix a bug where queries that have both remote functions and a local function with only constant arguments could throw an ``IndexOutOfBoundException`` during planning. The bug was introduced by :pr:`16039`.
-* Fix a CPU regression for queries using :func:`element_at` for ``MAP``. Introduced by :pr:`16027`.
+* Fix a CPU regression for queries using :func:`!element_at` for ``MAP``. Introduced by :pr:`16027`.
 * Add fragment result caching support for ``UNNEST`` queries.
-* Add :func:`poisson_cdf` and :func:`inverse_poisson_cdf` functions.
+* Add :func:`!poisson_cdf` and :func:`!inverse_poisson_cdf` functions.
 * Add memory tracking in ``TableFinishOperator`` which can be enabled by setting the ``table-finish-operator-memory-tracking-enabled`` configuration property to ``true``. Enabling this property can help with investigating GC issues on the coordinator by allowing us to debug whether stats collection uses a lot of memory.
 * Remove spilling strategy ``PER_QUERY_MEMORY_LIMIT`` and add configuration property ``experimental.query-limit-spill-enabled`` and session property ``query_limit_spill_enabled``. When ``query_limit_spill_enabled`` is set to ``true`` and the spill strategy is not ``PER_TASK_MEMORY_THRESHOLD``, then we will spill whenever a query uses more than the per-node total memory limit in combined revocable and non-revocable memory.
 

--- a/presto-docs/src/main/sphinx/release/release-0.255.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.255.rst
@@ -9,7 +9,7 @@ General Changes
 _______________
 * Fix an issue where regular expression functions were not interruptible and could keep running for a long time after the query they were a part of failed.
 * Add support to interrupt runaway splits blocked in known situations. The interrupt timeout can be configured by the configuration property ``task.interrupt-runaway-splits-timeout``. The default value is ``600s``.
-* Added :func:`array_normalize` function to normalize an array by dividing each element by the p-norm of it.
+* Added :func:`!array_normalize` function to normalize an array by dividing each element by the p-norm of it.
 
 JDBC Changes
 ____________

--- a/presto-docs/src/main/sphinx/release/release-0.256.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.256.rst
@@ -11,8 +11,8 @@ _______________
 * Add configuration property ``experimental.distinct-aggregation-spill-enabled`` and session property ``distinct_aggregation_spill_enabled`` to disable spilling for distinct aggregations.
 * Add configuration property ``experimental.order-by-aggregation-spill-enabled`` and session property ``order_by_aggregation_spill_enabled`` to disable spilling for order by aggregations.
 * Add double quotes around the column domain values in the text query plan. Literal double quotes in values will be escaped with a backslash (``ab"c`` -> ``ab\"c``).
-* Add function :func:`array_frequency`.
-* Add support for :func:`zip` to take up to 7 arguments.
+* Add function :func:`!array_frequency`.
+* Add support for :func:`!zip` to take up to 7 arguments.
 
 Web UI Changes
 ______________

--- a/presto-docs/src/main/sphinx/release/release-0.257.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.257.rst
@@ -12,7 +12,7 @@ _______________
 * Fix query failures due to expressions with multiple ``is null`` checks on the same variable.
 * Improve memory usage of queries spilling in the join operator.
 * Improve expressions printed in query plans to be closer to valid SQL.
-* Add support to find the n-th instance in :func:`array_position`.
+* Add support to find the n-th instance in :func:`!array_position`.
 * Add support for correlated subqueries with complex expressions in the correlation.
 * Add support for the ``OFFSET`` clause in SQL query expressions. This feature can be enabled by setting the session property ``offset_clause_enabled`` or configuration property ``offset-clause-enabled`` to ``true``.
 

--- a/presto-docs/src/main/sphinx/release/release-0.258.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.258.rst
@@ -8,8 +8,8 @@ Release 0.258
 General Changes
 _______________
 * Fix a bug in SQL functions where a query could fail with a compiler error if the function has a lambda variable with the same name as a column or function input.
-* Add Cauchy distribution CDF :func:`cauchy_cdf` and inverse CDF :func:`inverse_cauchy_cdf` functions.
-* Add SQL functions :func:`array_dupes` and :func:`array_as_dupes`.
+* Add Cauchy distribution CDF :func:`!cauchy_cdf` and inverse CDF :func:`!inverse_cauchy_cdf` functions.
+* Add SQL functions :func:`!array_dupes` and :func:`!array_as_dupes`.
 * Add additional details to memory exceeded error messages to simplify debugging. Disabled by default. Can be enabled by setting the ``verbose_exceeded_memory_limit_errors_enabled`` session property to ``true``.
 * Support dynamic filtering with comparison operators. Can be enabled by setting the ``enable-dynamic-filtering`` property to ``true``. Disabled by default.
 

--- a/presto-docs/src/main/sphinx/release/release-0.259.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.259.rst
@@ -12,7 +12,7 @@ Release 0.259
 General Changes
 _______________
 * Fix ``ClassCastException`` that sometimes occurred for ``EXPLAIN`` queries when the query contained ``LIKE`` predicates.
-* Add Weibull distribution CDF :func:`weibull_cdf` and inverse CDF :func:`inverse_weibull_cdf` functions.
+* Add Weibull distribution CDF :func:`!weibull_cdf` and inverse CDF :func:`!inverse_weibull_cdf` functions.
 * Enable verbose error messages for ``EXCEEDED_LOCAL_MEMORY_LIMIT`` by default.  This can be disabled by setting the configuration property ``memory.verbose-exceeded-memory-limit-errors-enabled`` to ``false``.
 
 JDBC Driver Changes

--- a/presto-docs/src/main/sphinx/release/release-0.261.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.261.rst
@@ -4,7 +4,7 @@ Release 0.261
 
 **Highlights**
 ==============
-* Improve performance of :func:`SUM` and :func:`AVG` aggregate functions when used with ``DECIMAL`` type.
+* Improve performance of :func:`!SUM` and :func:`!AVG` aggregate functions when used with ``DECIMAL`` type.
 * Add column comment to metadata in JDBC based connector
 * Add hidden column ``$file_modified_time`` which is the time the file containing the row was last modified.
 * Add hidden column ``$file_size`` which is the size of the file containing the row.
@@ -16,7 +16,7 @@ Release 0.261
 General Changes
 _______________
 * Fix query failures for queries with shape ``AGG(IF(condition, expr))`` where expr could return exceptions for rows not matching ``condition``. These failures occurred when configuration property ``optimizer.aggregation-if-to-filter-rewrite-enabled`` was enabled.
-* Improve performance of :func:`SUM` and :func:`AVG` aggregate functions when used with ``DECIMAL`` type.
+* Improve performance of :func:`!SUM` and :func:`!AVG` aggregate functions when used with ``DECIMAL`` type.
 * Disable configuration property ``optimizer.aggregation-if-to-filter-rewrite-enabled`` by default.
 
 SPI Changes

--- a/presto-docs/src/main/sphinx/release/release-0.262.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.262.rst
@@ -13,7 +13,7 @@ Release 0.262
 
 General Changes
 _______________
-* Fix :func:`reduce_agg` to allow ``NULL`` as the result of input/combine functions, while also allowing only constant expressions and not ``NULL`` as the initial value.
+* Fix :func:`!reduce_agg` to allow ``NULL`` as the result of input/combine functions, while also allowing only constant expressions and not ``NULL`` as the initial value.
 * Fix a correctness bug which could be triggered for queries with aggregations on partitioning columns and filters on non-partitioning columns when both optimizing
   metadata queries and filter pushdown are enabled.
 * Add default size limit (100MB) to build side of broadcast join.

--- a/presto-docs/src/main/sphinx/release/release-0.264.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.264.rst
@@ -11,7 +11,7 @@ Release 0.264
 
 General Changes
 _______________
-* Add :func:`murmur3_x64_128` UDF that computes a hash equivalent to MurmurHash3_x64_128 (Murmur3F) in C++.
+* Add :func:`!murmur3_x64_128` UDF that computes a hash equivalent to MurmurHash3_x64_128 (Murmur3F) in C++.
 * Add a new configuration property ``experimental.dedup-based-distinct-aggregation-spill-enabled`` to enable deduplication of input data before spilling for distinct aggregates. This can be overridden by ``dedup_based_distinct_aggregation_spill_enabled`` session property.
 * Add configuration properties ``simple-ttl-node-selector.use-default-execution-time-estimate-as-fallback`` and ``simple-ttl-node-selector.default-execution-time-estimate``. The former configures ``SimpleTtlNodeSelector`` to use a default execution time estimate when there is no corresponding user-provided estimate. The latter configures the value of the default execution time estimate.
 * Add support for running task count ``runningTasks`` at the cluster level via ``v1/cluster`` endpoint.

--- a/presto-docs/src/main/sphinx/release/release-0.265.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.265.rst
@@ -8,7 +8,7 @@ Release 0.265
 General Changes
 _______________
 * Add a configuration property ``fragment-result-cache.max-cache-size`` to control the total on-disk size of fragment result cache. The default value is 100G.
-* Rename function ``array_dupes`` to :func:`array_duplicates`, and rename function ``array_has_dupes`` to :func:`array_has_duplicates`. Previous names are kept as aliases but will be deprecated in the future.
+* Rename function ``array_dupes`` to :func:`!array_duplicates`, and rename function ``array_has_dupes`` to :func:`!array_has_duplicates`. Previous names are kept as aliases but will be deprecated in the future.
 
 Verifier Changes
 ________________

--- a/presto-docs/src/main/sphinx/release/release-0.269.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.269.rst
@@ -7,7 +7,7 @@ Release 0.269
 
 General Changes
 _______________
-* Add :func:`uuid` to return a unique identifier.
+* Add :func:`!uuid` to return a unique identifier.
 
 Presto on Spark Changes
 _______________________
@@ -15,7 +15,7 @@ _______________________
 
 Accumulo Connector Changes
 __________________________
-* Replace :func:`uuid` from being connector specific to a standard function. In the process the return type has been changed from ``VARCHAR`` to ``UUID`` and existing use cases might need to perform a cast - ``CAST(UUID() AS VARCHAR)``.
+* Replace :func:`!uuid` from being connector specific to a standard function. In the process the return type has been changed from ``VARCHAR`` to ``UUID`` and existing use cases might need to perform a cast - ``CAST(UUID() AS VARCHAR)``.
 
 Delta Lake Connector Changes
 _____________________________

--- a/presto-docs/src/main/sphinx/release/release-0.270.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.270.rst
@@ -7,14 +7,14 @@ Release 0.270
 
 General Changes
 _______________
-* Fix error classification when an invalid timezone is passed as a parameter to :func:`from_unixtime`.
+* Fix error classification when an invalid timezone is passed as a parameter to :func:`!from_unixtime`.
 * Improve performance of ``DISTINCT LIMIT N`` queries for N <= 10000. This can be enabled with the session property ``hash_based_distinct_limit_enabled``
   or the configuration property ``hash-based-distinct-limit-enabled`` and the limit can be adjusted by using the session property ``hash_based_distinct_limit_threshold``
   or the configuration property ``hash-based-distinct-limit-threshold``.
-* Add :func:`last_day_of_month` UDF to return the last day of the month.
+* Add :func:`!last_day_of_month` UDF to return the last day of the month.
 * Add dynamic filtering support for right join.
 * Add support for any expression for dynamic filtering probe side.
-* Add new optimizer rule to simplify expressions like ``cardinality(map_keys(m))`` into ``cardinality((m))``. Same for :func:`map_values` function.
+* Add new optimizer rule to simplify expressions like ``cardinality(map_keys(m))`` into ``cardinality((m))``. Same for :func:`!map_values` function.
 * Add support for the following primitive types to Avro decoder: ``TINYINT``, ``SMALLINT``, ``INTEGER`` and ``REAL``.
 
 Hive Connector Changes

--- a/presto-docs/src/main/sphinx/release/release-0.272.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.272.rst
@@ -14,7 +14,7 @@ _______________
     Streaming aggregation can be enabled with the ``streaming_for_partial_aggregation_enabled`` session property or the ``streaming-for-partial-aggregation-enabled`` configuration property.
 * Add an adaptive stage scheduling policy that switches to phased execution mode once a query's stage count exceeds a configurable upper bound.
     This can be enabled by setting the session property ``execution_policy`` to ``phased`` and the stage count limit can be configured by the session property ``max_stage_count_for_eager_scheduling``.
-* Add :func:`secure_random()` function to return a cryptographically secure random number.
+* Add :func:`!secure_random()` function to return a cryptographically secure random number.
 
 Hive Connector Changes
 ______________________

--- a/presto-docs/src/main/sphinx/release/release-0.273.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.273.rst
@@ -22,19 +22,19 @@ _______________
 * Fix disaggregated coordinator resource group aggregation issue related to ``WAITING_FOR_PREREQUISITE`` queries. When a query is moved to WAITING_FOR_PREREQUISITE, resource manager would end up counting them towards running queries. This gives a wrong impression to coordinator about running queries and it would end up running less queries than configured.
 * Fix a bug where ``EXPLAIN (TYPE IO)`` did not include the index source from an index join.
 * Fix a memory over-counting issue for using varchar types that could cause queries to fail with exceeded memory limit errors.
-* Fix an off-by-one error during buffer size calculation in :func:`tdigest_agg`.
+* Fix an off-by-one error during buffer size calculation in :func:`!tdigest_agg`.
 * Fix memory tagging for UnnestOperator and TableWriterMergeOperator.
-* Improve performance of :func: `zip_with` when used inside a :func:`reduce_agg`.
-* Add :func:`to_base32` and :func:`from_base32` varbinary functions.
+* Improve performance of :func: `zip_with` when used inside a :func:`!reduce_agg`.
+* Add :func:`!to_base32` and :func:`!from_base32` varbinary functions.
 * Add support for ``TRUNCATE TABLE`` statement and associated :doc:`/sql/truncate`.
 * Add support to set timeout on the query analyzer runtime to prevent long running query analysis like complex regular expressions. The timeout duration can be set by the configuration property ``planner.query-analyzer-timeout`` or session property ``query_analyzer_timeout``.
-* Add :func:`trim_array` function that can be called to delete elements from the end of an ordinary array.
+* Add :func:`!trim_array` function that can be called to delete elements from the end of an ordinary array.
 * Add a new optimization for showing results for (interactive) distinct limit N as they become available with no buffering.  This can be enabled by setting the session property ``quick_distinct_limit_enabled`` to true.
 * Add support for casting timestamp with micro/nanosecond precision.
 * Add Read support for json & jsonb data types in postgresql.
 * Add support for local round robin shuffle to reduce the partial distinct limit output size.
 * Add support for column subfield access control checks in connectors. Connectors can specify subfield access control for row-type columns through ``checkCanSelectFromColumns()`` in SPI.
-* Add warnings for :func:`approx_distinct` and :func:`approx_set` with low ``MAX_STANDARD_ERROR``.
+* Add warnings for :func:`!approx_distinct` and :func:`!approx_set` with low ``MAX_STANDARD_ERROR``.
 * Add support for retrying queries that failed with max requests queued exception.
 * Update protoc and grpc version in presto-grpc-api module to adapt to linux aarch64.
 * Upgrade zstandard compression to version 1.5.2.2. This improves the cpu used for data compressed with zstandard by about 2%.
@@ -62,7 +62,7 @@ _________________________
 
 Mongodb Connector Changes
 _________________________
-* Add :func:`CAST(ObjectId() as STRING)`.
+* Add :func:`!CAST(ObjectId() as STRING)`.
 
 Pinot Connector Changes
 _______________________

--- a/presto-docs/src/main/sphinx/release/release-0.274.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.274.rst
@@ -11,7 +11,7 @@ Release 0.274
 General Changes
 _______________
 * Fix broadcast join memory leak caused by exceeding local memory query failure.
-* Add :func:`laplace_cdf` and :func:`inverse_laplace_cdf` functions.
+* Add :func:`!laplace_cdf` and :func:`!inverse_laplace_cdf` functions.
 * Reduce the memory footprint and improves the performance of segmented aggregation when the data is already ordered by a subset of the group-by keys. This can be enabled with the ``segmented_aggregation_enabled`` session property or the ``optimizer.segmented-aggregation-enabled`` configuration property.
 * Add memory limit check for join spilling and fail fast if exceeding to avoid unnecessary processing.
 * Add rate limiting functionality for each query on coordinator http endpoints.

--- a/presto-docs/src/main/sphinx/release/release-0.275.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.275.rst
@@ -8,8 +8,8 @@ Release 0.275
 General Changes
 _______________
 * Fix Disaggregated Coordinator to correctly identify running queries as leaked.
-* Add :func:`trimmed_mean` for :ref:`tdigest <tdigest_type>`.
-* Add :func:`construct_tdigest()` for :ref:`tdigest <tdigest_type>`.
+* Add :func:`!trimmed_mean` for :ref:`tdigest <tdigest_type>`.
+* Add :func:`!construct_tdigest()` for :ref:`tdigest <tdigest_type>`.
 * Add session property ``query_max_output_positions`` and configuration property ``query.max-output-positions`` to control how many rows a query can output. The query might end up returning more rows than the limit as the check is asynchronous.
 
 Hudi Changes

--- a/presto-docs/src/main/sphinx/release/release-0.276.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.276.rst
@@ -14,7 +14,7 @@ _______________
 * Fix a bug where a query with an order by clause and an unpartitioned window function sometimes returned unordered results.
 * Improve Graphviz output for JOIN nodes and estimate stats.
 * Reduce the number of hdfsConfiguration copies in the worker. This feature is enabled by default and can be controlled by setting the ``hive.copy-on-first-write-configuration`` configuration property appropriately.
-* Add support for complex JsonPath expressions in :func:`json_extract`, :func:`json_extract_scalar` and :func:`json_size` using `Jayway JsonPath <https://github.com/json-path/JsonPath>`_.
+* Add support for complex JsonPath expressions in :func:`!json_extract`, :func:`!json_extract_scalar` and :func:`!json_size` using `Jayway JsonPath <https://github.com/json-path/JsonPath>`_.
 * Add support to nested SQL functions with lambdas when ``inline_sql_functions = false``.
 * Add the GeoPlugin by default. Previously it was an optional plugin.
 * Add documentation for :doc:`/functions/tdigest`.
@@ -38,7 +38,7 @@ _____________
 * Fix an incorrect result issue caused by cross-join query pushdown by throwing errors instead of providing the wrong answer.
 * Add new config ``pinot.attempt-broker-queries`` to attempt to pushdown queries to brokers.
 * Add support for pinot controller and broker authentication with user and password.
-* Add pushdown support for :func:`coalesce` function.
+* Add pushdown support for :func:`!coalesce` function.
 
 Router Changes
 ______________

--- a/presto-docs/src/main/sphinx/release/release-0.277.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.277.rst
@@ -9,7 +9,7 @@ General Changes
 _______________
 * Fix compilation error in common subexpression elimination when duplicate expressions are present.
 * Fix enforcement of query analyzer timeout during planning.
-* Add UDF :func:`find_first` to find the first array element which matches a predicate.
+* Add UDF :func:`!find_first` to find the first array element which matches a predicate.
 * Add support to fail query when number of leaf plan nodes exceeds a limit. This can be controlled with ``leaf_node_limit_enabled`` and ``max_leaf_nodes_in_plan`` session properties.
 
 Delta Lake Connector Changes
@@ -19,7 +19,7 @@ ____________________________
 Pinot Connector Changes
 _______________________
 * Add Pinot ``BINARY`` column type.
-* Add Pinot UDF :func:`pinot_binary_decimal_to_double` to transform Pinot binary column to Double.
+* Add Pinot UDF :func:`!pinot_binary_decimal_to_double` to transform Pinot binary column to Double.
 
 **Credits**
 ===========

--- a/presto-docs/src/main/sphinx/release/release-0.278.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.278.1.rst
@@ -4,4 +4,4 @@ Release 0.278.1
 
 General Changes
 _______________
-* Fix a performance regression in :func:`ROUND`` caused by type casting. (:pr:`18451`)
+* Fix a performance regression in :func:`!ROUND`` caused by type casting. (:pr:`18451`)

--- a/presto-docs/src/main/sphinx/release/release-0.278.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.278.rst
@@ -4,23 +4,23 @@ Release 0.278
 
 .. warning::
 
-   There is a performance regression in :func:`ROUND`.
+   There is a performance regression in :func:`!ROUND`.
 
 **Details**
 ===========
 
 General Changes
 _______________
-* Fix :func:`ROUND` to prevent returning incorrect results due to integer / double overflows.
+* Fix :func:`!ROUND` to prevent returning incorrect results due to integer / double overflows.
 * Fix the compilation error when aggregation has order by clause and the input is a function.
 * Optimize ``IF(predicate, AGG(x))`` to aggregation with mask in plan level. This is controlled by system property ``optimize_conditional_aggregation_enabled`` and defaults to false.
 * Add new security API ``selectAuthorizedIdentity`` and new configuration property ``permissions.authorized-identity-selection-enable`` to enable ``selectAuthorizedIdentity``. ``selectAuthorizedIdentity`` prevents potential security loopholes, e.g., reading illegal data from a fake username.
 * Add memory limit check for HashBuilderOperator during memory revoke.
 * Add null masking for the Parquet decryption feature. When this feature is enabled and the user is denied access encrypted column, the columns will be removed in the requested schema sent to Parquet. Then it is filled out with ``NULL``  when the result is returned.
-* Add optimization for :func:`approx_percentile` functions evaluation. Multiple :func:`approx_percentile` functions on the same field will be combined into one :func:`approx_percentile` function which takes an array of percentile as arguments. The optimization is controlled by session property ``optimize_multiple_approx_percentile_on_same_field`` which is true by default.
+* Add optimization for :func:`!approx_percentile` functions evaluation. Multiple :func:`!approx_percentile` functions on the same field will be combined into one :func:`!approx_percentile` function which takes an array of percentile as arguments. The optimization is controlled by session property ``optimize_multiple_approx_percentile_on_same_field`` which is true by default.
 * Add optimization for outer join by add randomized value for NULL join keys to avoid skew in NULL. This optimization is turned off by default and can be turned on by setting ``optimizer.randomize-outer-join-null-key`` to true.
 * Add retry with increased partition count if query fails due to low partition count. This can be enabled with the ``spark_hash_partition_count_scaling_factor_on_out_of_memory`` and ``spark_retry_on_out_of_memory_higher_hash_partition_count_enabled`` session properties.
-* Add function :func:`map_subset`. This function takes a map and an array of keys and returns a map with entries from the input map with keys contained in the array supplied.
+* Add function :func:`!map_subset`. This function takes a map and an array of keys and returns a map with entries from the input map with keys contained in the array supplied.
 * Upgrade Apache Iceberg version from 0.14.0 to 0.14.1.
 * Upgrade Java Topology Suite (jts) library version to 1.19.0.
 

--- a/presto-docs/src/main/sphinx/release/release-0.279.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.279.rst
@@ -12,14 +12,14 @@ _______________
 * Fix weighted fair scheduling in disaggregated coordinator.
 * Fix max(x, n) and min(x, n) returning NULL on window aggregations.
 * Add an optimization that removes redundant distinct if the output is already distinct after a group by operation. The optimization is controlled by session property ``remove_redundant_distinct_aggregation`` which is default to false.
-* Add function :func:`array_sort_desc` to sort an array in the descending order.
-* Add function :func:`map_remove_null_values` to remove all the entries where the value is null from a given map.
-* Add function :func:`map_top_n_keys` to returns an array of the top N keys of the provided map. An optional lambda comparator can also be passed to perform a custom comparison of the keys. Returns all the keys if the value N is greater than or equal to size of the map. For N < 0, the function returns keys in the reverse order. For N = 0, the function returns empty array.
-* Add function :func:`map_top_n_values` to return top N values of the provided map. An optional lambda comparator can also be passed as parameter for custom sorting of the values.
-* Add function :func:`map_top_n` to truncate map items, keeping only the top N elements by value.
-* Add function :func:`remove_nulls` to remove null elements from an array.
-* Add functions :func:`array_min_by`, :func:`array_max_by`, to find the smallest or largest element of an array when applying a custom measuring function.
-* Extend functions :func:`array_frequency`, :func:`array_duplicates`, :func:`array_has_duplicates`, :func:`array_intersect(array(array(E))` to accept any type as input instead of only varchar/double.
+* Add function :func:`!array_sort_desc` to sort an array in the descending order.
+* Add function :func:`!map_remove_null_values` to remove all the entries where the value is null from a given map.
+* Add function :func:`!map_top_n_keys` to returns an array of the top N keys of the provided map. An optional lambda comparator can also be passed to perform a custom comparison of the keys. Returns all the keys if the value N is greater than or equal to size of the map. For N < 0, the function returns keys in the reverse order. For N = 0, the function returns empty array.
+* Add function :func:`!map_top_n_values` to return top N values of the provided map. An optional lambda comparator can also be passed as parameter for custom sorting of the values.
+* Add function :func:`!map_top_n` to truncate map items, keeping only the top N elements by value.
+* Add function :func:`!remove_nulls` to remove null elements from an array.
+* Add functions :func:`!array_min_by`, :func:`!array_max_by`, to find the smallest or largest element of an array when applying a custom measuring function.
+* Extend functions :func:`!array_frequency`, :func:`!array_duplicates`, :func:`!array_has_duplicates`, :func:`!array_intersect(array(array(E))` to accept any type as input instead of only varchar/double.
 * Add ``CONTROL`` as a new ``QueryType``. The ``CONTROL`` queryType represents statements of session control and transaction control types.
 * Remove two unused session parameters - ``hash_based_distinct_limit_enabled`` and ``hash_based_distinct_limit_threshold`` and the corresponding implementation in favor of the ``quick_distinct_limit_enabled`` feature.
 
@@ -38,7 +38,7 @@ _________________________
 
 Pinot Connector Changes
 _______________________
-* Add pushdown support for function :func:`STRPOS`.
+* Add pushdown support for function :func:`!STRPOS`.
 
 PostgreSQL Connector Changes
 ____________________________

--- a/presto-docs/src/main/sphinx/release/release-0.280.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.280.rst
@@ -9,12 +9,12 @@ General Changes
 _______________
 * Fix a race condition, where if a query was submitted before the resource group configuration had been loaded by the Presto server, all queries to the cluster would fail with a ``NullPointerException``. 
 * Fix a bug in the ``GatherAndMergeWindows`` optimization would produces invalid plans when the output of a window function was used in the frame definition of another window function.
-* Fix the output of :func:`find_first` function for ``NULL`` Now it will throw exception if the found matched value is NULL.
+* Fix the output of :func:`!find_first` function for ``NULL`` Now it will throw exception if the found matched value is NULL.
 * Fix a bug where duplicate items in ``UNNEST`` would lead to query compilation failure.
-* Improve the column access checks for :func:`transform` and :func:`cardinality` functions, such that only the required subfields are checked.
+* Improve the column access checks for :func:`!transform` and :func:`!cardinality` functions, such that only the required subfields are checked.
 * Improve filtering for large tables with ``LIMIT`` number of keys for queries that do simple ``GROUP BY LIMIT`` with no ``ORDER BY``. This feature can be enabled with a boolean session param: ``prefilter_for_groupby_limit``.
-* Add :func:`remove_nulls` to remove null elements from the given array.
-* Add function :func:`find_first_index` which returns the index of the first element which satisfies the condition.
+* Add :func:`!remove_nulls` to remove null elements from the given array.
+* Add function :func:`!find_first_index` which returns the index of the first element which satisfies the condition.
 * Add range with offset expression support to :doc:`/functions/window`.
 * Add the names of the functions invoked by the query to the completed event. This can be enabled with the ``log_invoked_function_names_enabled`` session property or the ``log-invoked-function-names-enabled`` configuration property.
 * Add a new runtime metric ``optimizerTimeNanos`` to measure the time taken by the optimizers. With this change the time taken by optimizers has been removed from runtime metric ``logicalPlannerTimeNanos``.

--- a/presto-docs/src/main/sphinx/release/release-0.281.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.281.rst
@@ -12,8 +12,8 @@ _______________
 * Improve outer join where the join key is from the output of another outer join which can have many null values. The optimization is controlled by session property ``randomize_outer_join_null_key_strategy`` and the default value is ``DISABLED``
 * Add timeouts for long running optimization rules.
 * Improve performance for queries with multiple similar aggregations, with and without filters. The optimization is controlled by session parameter merge_aggs_with_and_without_filter and by default it is set to false.* Add an optimization rule to merge aggregations when there are multiple duplicate aggregations in the aggregation node. The optimization is controlled by session property ``merge_duplicate_aggregations`` and default value is ``true``.
-* Add :func:`f_cdf()` and :func:`inverse_f_cdf()` functions.
-* Add :func:`gamma_cdf()`` and :func:`inverse_gamma_cdf()` functions.
+* Add :func:`!f_cdf()` and :func:`!inverse_f_cdf()` functions.
+* Add :func:`!gamma_cdf()`` and :func:`!inverse_gamma_cdf()` functions.
 * Add groups support to :doc:`/functions/window`.
 * Add optimization for joins when build side is empty at runtime. The optimization is controlled by session parameter ``optimize_join_probe_for_empty_build_runtime`` and by default it is set to ``false``.
 * Add system config to enable access log on presto-on-spark native. This can be enabled with the system config ``http-server.enable-access-log`` and default value is ``true``.

--- a/presto-docs/src/main/sphinx/release/release-0.282.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.282.rst
@@ -12,7 +12,7 @@ _______________
 * Improve performance of ``Explain (TYPE VALIDATE)`` by returning immediately after analysis and ACL checks complete without executing a dummy query. The output column is now called ``result`` rather than ``valid``.
 * Improve error handling when using custom ``FunctionNamespaceManagers``.
 * Improve null inferencing for join nodes. ``optimize_nulls_in_join`` session property is deprecated and is instead replaced with a new ``joins_not_null_inference_strategy`` session property (and corresponding configuration property ``optimizer.joins-not-null-inference-strategy``) to control null inferencing.
-* Add a new UDF :func:`array_cum_sum` to return an array whose elements are the cumulative sum of the input array.
+* Add a new UDF :func:`!array_cum_sum` to return an array whose elements are the cumulative sum of the input array.
 * Add a query optimization to rewrite left join with null check on right join key with semi join. It's controlled by session property ``rewrite_left_join_null_filter_to_semi_join`` and the default value is ``true``
 * Add an optimization for queries with empty input. The optimization is controlled by session property ``simplify_plan_with_empty_input`` and the default value is ``true``
 * Add an optimization to convert applicable cross join with an or filter to inner join. It's controlled by session property ``rewrite_cross_join_or_to_inner_join`` and the default value is ``true``

--- a/presto-docs/src/main/sphinx/release/release-0.283.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.283.rst
@@ -18,10 +18,10 @@ _______________
 * Improve performance of getting resource group metrics.
 * Add a optimizer rule ``RemoveIdentityProjectionsBelowProjection`` to remove identity projections under project node.
 * Add a session parameter ``use_broadcast_when_buildsize_small_probeside_unknown`` to choose join distribution type This session is default to false. When enabled, broadcast join will be chosen when one side of input is within broadcast limit and the other side is unknow.
-* Add function :func:`any_keys_match`.
-* Add function :func:`any_values_match`.
+* Add function :func:`!any_keys_match`.
+* Add function :func:`!any_values_match`.
 * Add option to add partial row number node for row number node with max count limit, enabled by session parameter ``add_partial_node_for_row_number_node_with_limit``.
-* Add string functions :func:`starts_with` and :func:`ends_with`.
+* Add string functions :func:`!starts_with` and :func:`!ends_with`.
 * Add support for broadcast join in Presto-on-Spark/Velox execution path.
 * Add support for internal authentication using JWT. Can be configured using configs ``internal-communication.jwt.enabled=[true/false]`` and ``internal-communication.shared-secret=<shared-secret-value>``.
 * Add support for worker isolation by configuring leaf and intermediate worker pools.

--- a/presto-docs/src/main/sphinx/release/release-0.284.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.284.rst
@@ -10,21 +10,21 @@ _______________
 * Fix correctness bug in the optimizer when ``randomize_outer_join_null_key`` is enabled.
 * Fix bug in array ``CONTAINS`` expression rewrite rule.
 * Fix bugs parsing lambda expressions.  The bugs may cause compile exception with message "Can not compile special form: WHEN" and lead to runtime exception of array out of bound access.
-* Fix :func:`min` and :func:`max` to verify second argument is unique.
+* Fix :func:`!min` and :func:`!max` to verify second argument is unique.
 * Fix access control checks for ``IS NULL`` and ``IS NOT NULL``.
 * Improve cache efficiency of history-based optimizer.
 * Improve cost-based optimizer to work with complex equi-join predicates.
 * Improve performance of outer join when nulls are present. It can be enabled by setting ``randomize_outer_join_null_key_strategy`` to be ``cost_based``. The trigger condition can be set by session properties ``randomize_outer_join_null_key_null_count_threshold`` and ``randomize_outer_join_null_key_null_ratio_threshold``.
 * Add field names when casting row to JSON.
-* Add :func:`array_top_n` to return an array of top ``N`` elements of a given array.
-* Add :func:`bitwise_xor_agg` function.
-* Add :func:`NOISY_COUNT_GAUSSIAN`.
-* Add :func:`NOISY_SUM_GAUSSIAN`.
-* Add :func:`NOISY_AVG_GAUSSIAN`.
+* Add :func:`!array_top_n` to return an array of top ``N`` elements of a given array.
+* Add :func:`!bitwise_xor_agg` function.
+* Add :func:`!NOISY_COUNT_GAUSSIAN`.
+* Add :func:`!NOISY_SUM_GAUSSIAN`.
+* Add :func:`!NOISY_AVG_GAUSSIAN`.
 * Add session property ``restrict_history_based_optimization_to_complex_query``. When set to ``TRUE``, only queries with join or aggregation will try to use HBO. The default value is ``TRUE``.
 * Add session property ``pull_expression_from_lambda_enabled`` to optimize lambda functions which have expressions not referring to arguments of the lambda function.  The default state is enabled using the value ``TRUE``.
 * Add ``rewrite_constant_array_contains_to_in_expression`` session property to improve the performance of ``CONTAINS`` expressions.  The default state is enabled using the value ``TRUE``.
-* Add function :func:`trail`.
+* Add function :func:`!trail`.
 * Add session property ``optimizers_to_enable_verbose_runtime_stats`` to enable runtime tracking for a set of optimizers.
 * Add support for ``EXPLAIN (TYPE VALIDATE)`` of ``EXPLAIN`` queries. Previously such queries would fail with an error.
 * Improve performance of cluster statistics reporting in the Presto coordinator by adding the configuration property ``cluster-stats-cache-expiration-duration``. The property is ``0`` (disabled) by default.

--- a/presto-docs/src/main/sphinx/release/release-0.285.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.285.rst
@@ -19,7 +19,7 @@ _______________
 * Improve performance of union when subqueries are empty.
 * Improve cost based optimizer join reordering to work with non-simple equi-join predicates. :pr:`21153`
 * Improve history based optimizer performance when nulls are present in joins. :pr:`21203`
-* Add :func:`array_least_frequent` function.
+* Add :func:`!array_least_frequent` function.
 * Add support for HANA connector. :pr:`21034`
 * Add task killer which is triggered when a worker is running out of memory and the garbage collector cannot reclaim sufficient memory. Two strategies are provided: full garbage collection, and frequent full garbage collection. :pr:`21254`
 * Add support to remove redundant `cast to varchar` expressions in a join condition. This feature is configurable by the session property ``remove_redundant_cast_to_varchar_in_join`` (enabled by default). :pr:`21050`

--- a/presto-docs/src/main/sphinx/release/release-0.55.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.55.rst
@@ -68,7 +68,7 @@ query to further limit the data scanned.
 json_array_get Function
 -----------------------
 
-The :func:`json_array_get` function makes it simple to fetch a single element from a
+The :func:`!json_array_get` function makes it simple to fetch a single element from a
 scalar json array.
 
 Non-reserved Keywords

--- a/presto-docs/src/main/sphinx/release/release-0.57.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.57.rst
@@ -14,7 +14,7 @@ fully supported. For example::
 
 .. note::
 
-    :func:`approx_distinct` should be used in preference to this
+    :func:`!approx_distinct` should be used in preference to this
     whenever an approximate answer is allowable as it is substantially
     faster and does not have any limits on the number of distinct items it
     can process. ``COUNT(DISTINCT ...)`` must transfer every item over the

--- a/presto-docs/src/main/sphinx/release/release-0.66.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.66.rst
@@ -36,7 +36,7 @@ This change comes at the cost of breaking existing queries that perform
 arithmetic operations directly on the ``BIGINT`` value returned from
 the date/time functions.
 
-As part of this work, we have also added the :func:`date_trunc` function
+As part of this work, we have also added the :func:`!date_trunc` function
 which is convenient for grouping data by a time span. For example, you
 can perform an aggregation by hour::
 
@@ -68,7 +68,7 @@ use the ``day`` unit instead::
     SELECT date_add('day', 1, TIMESTAMP '2014-03-08 09:00:00');
     -- 2014-03-09 09:00:00.000
 
-This works because the :func:`date_add` function treats the timestamp as
+This works because the :func:`!date_add` function treats the timestamp as
 list of fields, adds the value to the specified field and then rolls any
 overflow into the next higher field.
 
@@ -108,7 +108,7 @@ Localization
 In addition to time zones, the language of the user is important when
 parsing and printing date/time types. This release adds localization
 support to the Presto engine and functions that require it:
-:func:`date_format` and :func:`date_parse`.
+:func:`!date_format` and :func:`!date_parse`.
 For example, if we set the language to Spanish::
 
     SELECT date_format(TIMESTAMP '2001-01-09 09:04', '%M'); -- enero

--- a/presto-docs/src/main/sphinx/release/release-0.69.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.69.rst
@@ -89,7 +89,7 @@ Variable Length Binary Type
 ---------------------------
 
 Presto now supports the ``varbinary`` type for variable length binary data.
-Currently, the only supported function is :func:`length`.
+Currently, the only supported function is :func:`!length`.
 The Hive connector now maps the Hive ``BINARY`` type to ``varbinary``.
 
 General Changes

--- a/presto-docs/src/main/sphinx/release/release-0.70.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.70.rst
@@ -55,9 +55,9 @@ parameters string which has the form ``key=value,key=value``
 General Changes
 ---------------
 
-* New comparison functions: :func:`greatest` and :func:`least`
+* New comparison functions: :func:`!greatest` and :func:`!least`
 
-* New window functions: :func:`first_value`, :func:`last_value`, and :func:`nth_value`
+* New window functions: :func:`!first_value`, :func:`!last_value`, and :func:`!nth_value`
 
 * We have added a config option to disable falling back to the interpreter when
   expressions fail to be compiled to bytecode. To set this option, add 

--- a/presto-docs/src/main/sphinx/release/release-0.73.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.73.rst
@@ -12,7 +12,7 @@ This release also includes several bug fixes and performance improvements.
 General Changes
 ---------------
 
-* New window functions: :func:`lead`, and :func:`lag`
+* New window functions: :func:`!lead`, and :func:`!lag`
 
-* New scalar function: :func:`json_size`
+* New scalar function: :func:`!json_size`
 

--- a/presto-docs/src/main/sphinx/release/release-0.74.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.74.rst
@@ -21,12 +21,12 @@ General Changes
 ---------------
 
 * Show column comments in ``DESCRIBE``
-* Add :func:`try_cast` which works like :func:`cast` but returns ``null`` if the cast fails
+* Add :func:`!try_cast` which works like :func:`!cast` but returns ``null`` if the cast fails
 * ``nullif`` now correctly returns a value with the type of the first argument
-* Fix an issue with :func:`timezone_hour` returning results in milliseconds instead of hours
+* Fix an issue with :func:`!timezone_hour` returning results in milliseconds instead of hours
 * Show a proper error message when analyzing queries with non-equijoin clauses
 * Improve "too many failures" error message when coordinator can't talk to workers
-* Minor optimization of :func:`json_size` function
+* Minor optimization of :func:`!json_size` function
 * Improve feature normalization algorithm for machine learning functions
 * Add exponential back-off to the S3 FileSystem retry logic
 * Improve CPU efficiency of semi-joins

--- a/presto-docs/src/main/sphinx/release/release-0.75.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.75.rst
@@ -16,12 +16,12 @@ Hive Changes
 General Changes
 ---------------
 
-* Optimize :func:`count` with a constant to execute as the much faster ``count(*)``
+* Optimize :func:`!count` with a constant to execute as the much faster ``count(*)``
 * Add support for binary types to the JDBC driver
 * The legacy byte code compiler has been removed
 * New aggregation framework (~10% faster)
-* Added :func:`max_by` aggregation function
-* The ``approx_avg()`` function has been removed. Use :func:`avg` instead.
+* Added :func:`!max_by` aggregation function
+* The ``approx_avg()`` function has been removed. Use :func:`!avg` instead.
 * Fixed parsing of ``UNION`` queries that use both ``DISTINCT`` and ``ALL``
 * Fixed cross join planning error for certain query shapes
 * Added hex and base64 conversion functions for varbinary
@@ -34,7 +34,7 @@ General Changes
 JSON Function Changes
 ---------------------
 
-The :func:`json_extract` and :func:`json_extract_scalar` functions now support
+The :func:`!json_extract` and :func:`!json_extract_scalar` functions now support
 the square bracket syntax::
 
     SELECT json_extract(json, '$.store[book]');
@@ -58,7 +58,7 @@ when the node already has the maximum allowable splits, every task can schedule 
 Row Number Optimizations
 ------------------------
 
-Queries that use the :func:`row_number` function are substantially faster
+Queries that use the :func:`!row_number` function are substantially faster
 and can run on larger result sets for two types of queries.
 
 Performing a partitioned limit that choses ``N`` arbitrary rows per

--- a/presto-docs/src/main/sphinx/release/release-0.76.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.76.rst
@@ -61,7 +61,7 @@ General Changes
 ---------------
 
 * Fix hang in verifier when an exception occurs.
-* Fix :func:`chr` function to work with Unicode code points instead of ASCII code points.
+* Fix :func:`!chr` function to work with Unicode code points instead of ASCII code points.
 * The JDBC driver no longer hangs the JVM on shutdown (all threads are daemon threads).
 * Fix incorrect parsing of function arguments.
 * The bytecode compiler now caches generated code for join and group byqueries,

--- a/presto-docs/src/main/sphinx/release/release-0.77.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.77.rst
@@ -38,5 +38,5 @@ General Changes
 * Add ConnectorPageSource which is a more efficient interface for column-oriented sources
 * Add support for string partition keys in Cassandra
 * Add support for variable arity functions
-* Add support for :func:`count` for all types
+* Add support for :func:`!count` for all types
 * Fix bug in HashAggregation that could cause the operator to go in an infinite loop

--- a/presto-docs/src/main/sphinx/release/release-0.78.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.78.rst
@@ -8,7 +8,7 @@ ARRAY and MAP Types in Hive Connector
 The Hive connector now returns arrays and maps instead of json encoded strings,
 for columns whose underlying type is array or map. Please note that this is a backwards
 incompatible change, and the :doc:`/functions/json` will no longer work on these columns,
-unless you :func:`cast` them to the ``json`` type.
+unless you :func:`!cast` them to the ``json`` type.
 
 Session Properties
 ------------------
@@ -53,7 +53,7 @@ General Changes
 ---------------
 
 * Fix expression optimizer, so that it runs in linear time instead of exponential time.
-* Add :func:`cardinality` for maps.
+* Add :func:`!cardinality` for maps.
 * Fix race condition in SqlTask creation which can cause queries to hang.
 * Fix ``node-scheduler.multiple-tasks-per-node-enabled`` option.
 * Fix an exception when planning a query with a UNION under a JOIN.

--- a/presto-docs/src/main/sphinx/release/release-0.80.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.80.rst
@@ -49,7 +49,7 @@ Metadata-Only Query Optimization
 --------------------------------
 
 We now support an optimization that rewrites aggregation queries that are insensitive to the
-cardinality of the input (e.g., :func:`max`, :func:`min`, ``DISTINCT`` aggregates) to execute
+cardinality of the input (e.g., :func:`!max`, :func:`!min`, ``DISTINCT`` aggregates) to execute
 against table metadata.
 
 For example, if ``key``, ``key1`` and ``key2`` are partition keys, the following queries
@@ -87,10 +87,10 @@ General Changes
 * Add property ``task.verbose-stats`` to enable verbose statistics collection for
   tasks. The default is ``false``.
 * Format binary data in the CLI as a hex dump.
-* Add approximate numeric histogram function :func:`numeric_histogram`.
-* Add :func:`array_sort` function.
-* Add :func:`map_keys` and :func:`map_values` functions.
-* Make :func:`row_number` completely streaming.
+* Add approximate numeric histogram function :func:`!numeric_histogram`.
+* Add :func:`!array_sort` function.
+* Add :func:`!map_keys` and :func:`!map_values` functions.
+* Make :func:`!row_number` completely streaming.
 * Add property ``task.max-partial-aggregation-memory`` to configure the memory limit
   for the partial step of aggregations.
 * Fix exception when processing queries with an ``UNNEST`` operation where the output was not used.

--- a/presto-docs/src/main/sphinx/release/release-0.81.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.81.rst
@@ -12,4 +12,4 @@ General Changes
 ---------------
 
 * Fix handling of null and out-of-range offsets for
-  :func:`lead`, :func:`lag` and :func:`nth_value` functions.
+  :func:`!lead`, :func:`!lag` and :func:`!nth_value` functions.

--- a/presto-docs/src/main/sphinx/release/release-0.82.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.82.rst
@@ -4,7 +4,7 @@ Release 0.82
 
 * Presto now supports the :ref:`row_type` type, and all Hive structs are
   converted to ROWs, instead of JSON encoded VARCHARs.
-* Add :func:`current_timezone` function.
+* Add :func:`!current_timezone` function.
 * Improve planning performance for queries with thousands of columns.
 * Fix a regression that was causing excessive memory allocation and GC pressure
   in the coordinator.

--- a/presto-docs/src/main/sphinx/release/release-0.83.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.83.rst
@@ -12,7 +12,7 @@ General Changes
 
 * Fix resource leak in query queues.
 * Fix NPE when writing null ``ARRAY/MAP`` to Hive.
-* Fix :func:`json_array_get` to handle nested structures.
+* Fix :func:`!json_array_get` to handle nested structures.
 * Fix ``UNNEST`` on null collections.
 * Fix a regression where queries that fail during parsing or analysis do not expire.
 * Make ``JSON`` type comparable.

--- a/presto-docs/src/main/sphinx/release/release-0.86.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.86.rst
@@ -6,9 +6,9 @@ General Changes
 ---------------
 
 * Add support for inequality ``INNER JOIN`` when each term of the condition refers to only one side of the join.
-* Add :func:`ntile` function.
-* Add :func:`map` function to create a map from arrays of keys and values.
-* Add :func:`min_by` aggregation function.
+* Add :func:`!ntile` function.
+* Add :func:`!map` function to create a map from arrays of keys and values.
+* Add :func:`!min_by` aggregation function.
 * Add support for concatenating arrays with the ``||`` operator.
 * Add support for ``=`` and ``!=`` to ``JSON`` type.
 * Improve error message when ``DISTINCT`` is applied to types that are not comparable.
@@ -19,7 +19,7 @@ General Changes
 * Fix a regression where queries could be expired too soon on a highly loaded cluster.
 * Fix scheduling issue for queries involving tables from information_schema, which could result in
   inconsistent metadata.
-* Fix an issue with :func:`min_by` and :func:`max_by` that could result in an error when used with
+* Fix an issue with :func:`!min_by` and :func:`!max_by` that could result in an error when used with
   a variable-length type (e.g., ``VARCHAR``) in a ``GROUP BY`` query.
 * Fix rendering of array attributes in JMX connector.
 * Input rows/bytes are now tracked properly for ``JOIN`` queries.

--- a/presto-docs/src/main/sphinx/release/release-0.88.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.88.rst
@@ -5,14 +5,14 @@ Release 0.88
 General Changes
 ---------------
 
-* Added :func:`arbitrary` aggregation function.
+* Added :func:`!arbitrary` aggregation function.
 * Allow using all :doc:`/functions/aggregate` as :doc:`/functions/window`.
 * Support specifying window frames and correctly implement frames for all :doc:`/functions/window`.
-* Allow :func:`approx_distinct` aggregation function to accept a standard error parameter.
-* Implement :func:`least` and :func:`greatest` with variable number of arguments.
+* Allow :func:`!approx_distinct` aggregation function to accept a standard error parameter.
+* Implement :func:`!least` and :func:`!greatest` with variable number of arguments.
 * :ref:`array_type` is now comparable and can be used as ``GROUP BY`` keys or in ``ORDER BY`` expressions.
 * Implement ``=`` and ``<>`` operators for :ref:`row_type`.
 * Fix excessive garbage creation in the ORC reader.
-* Fix an issue that could cause queries using :func:`row_number()` and ``LIMIT`` to never terminate.
-* Fix an issue that could cause queries with :func:`row_number()` and specific filters to produce incorrect results.
+* Fix an issue that could cause queries using :func:`!row_number()` and ``LIMIT`` to never terminate.
+* Fix an issue that could cause queries with :func:`!row_number()` and specific filters to produce incorrect results.
 * Fixed an issue that caused the Cassandra plugin to fail to load with a SecurityException.

--- a/presto-docs/src/main/sphinx/release/release-0.90.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.90.rst
@@ -19,7 +19,7 @@ General Changes
 * Fix failure when accessing elements in an empty array.
 * Fix *"Remote page is too large"* errors.
 * Improve error message when attempting to cast a value to ``UNKNOWN``.
-* Update the :func:`approx_distinct` documentation with correct standard error bounds.
+* Update the :func:`!approx_distinct` documentation with correct standard error bounds.
 * Disable falling back to the interpreter when expressions fail to be compiled
   to bytecode. To enable this option, add ``compiler.interpreter-enabled=true``
   to the coordinator and worker config properties. Enabling this option will
@@ -30,11 +30,11 @@ General Changes
 Functions and Language Features
 -------------------------------
 
-* Add :func:`bool_and` and :func:`bool_or` aggregation functions.
-* Add standard SQL function :func:`every` as an alias for :func:`bool_and`.
-* Add :func:`year_of_week` function.
-* Add :func:`regexp_extract_all` function.
-* Add :func:`map_agg` aggregation function.
+* Add :func:`!bool_and` and :func:`!bool_or` aggregation functions.
+* Add standard SQL function :func:`!every` as an alias for :func:`!bool_and`.
+* Add :func:`!year_of_week` function.
+* Add :func:`!regexp_extract_all` function.
+* Add :func:`!map_agg` aggregation function.
 * Add support for casting ``JSON`` to ``ARRAY`` or ``MAP`` types.
 * Add support for unparenthesized expressions in ``VALUES`` clause.
 * Added :doc:`/sql/set-session`, :doc:`/sql/reset-session` and :doc:`/sql/show-session`.

--- a/presto-docs/src/main/sphinx/release/release-0.96.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.96.rst
@@ -5,7 +5,7 @@ Release 0.96
 General Changes
 ---------------
 
-* Fix :func:`try_cast` for ``TIMESTAMP`` and other types that
+* Fix :func:`!try_cast` for ``TIMESTAMP`` and other types that
   need access to session information.
 * Fix planner bug that could result in incorrect results for
   tables containing columns with the same prefix, underscores and numbers.

--- a/presto-docs/src/main/sphinx/release/release-0.98.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.98.rst
@@ -31,5 +31,5 @@ General Changes
 ---------------
 
 * Fix bug in ``UNNEST`` when output is unreferenced or partially referenced.
-* Make :func:`max` and :func:`min` functions work on all orderable types.
-* Optimize memory allocation in :func:`max_by` and other places that ``Block`` is used.
+* Make :func:`!max` and :func:`!min` functions work on all orderable types.
+* Optimize memory allocation in :func:`!max_by` and other places that ``Block`` is used.

--- a/presto-docs/src/main/sphinx/release/release-0.99.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.99.rst
@@ -7,4 +7,4 @@ General Changes
 * Reduce lock contention in ``TaskExecutor``.
 * Fix reading maps with null keys from ORC.
 * Fix precomputed hash optimization for nulls values.
-* Make :func:`contains()` work for all comparable types.
+* Make :func:`!contains()` work for all comparable types.

--- a/presto-docs/src/main/sphinx/rest/query.rst
+++ b/presto-docs/src/main/sphinx/rest/query.rst
@@ -3,9 +3,9 @@ Query Resource
 ==============
 
 The Query REST service is the most complex of the rest services. It
-contains detailed information about nodes, and other
-details that capture the state and history of a query being executed
-on a Presto installation.
+contains detailed information about nodes, and other details that 
+capture the state and history of a query being executed on a Presto 
+installation.
 
 .. function:: GET /v1/query
 
@@ -69,6 +69,6 @@ on a Presto installation.
     	   "outputDataSize" : "32B",
     	   "outputPositions" : 1
        },
-       "outputStage" : ...
+       "outputStage" : { }
      }
 

--- a/presto-docs/src/main/sphinx/rest/task.rst
+++ b/presto-docs/src/main/sphinx/rest/task.rst
@@ -24,7 +24,7 @@ execution of queries on a Presto installation.
 
    **Example response**:
 
-   .. sourcecode:: http
+   .. sourcecode:: json
 
       [ {
         "taskId" : "20131222_183944_00011_dk5x2.1.0",
@@ -89,7 +89,7 @@ execution of queries on a Presto installation.
 
    **Example response**:
 
-   .. sourcecode:: http
+   .. sourcecode:: json
 
       {
 	"taskId" : "20140115_170528_00004_dk5x2.0.0",

--- a/presto-docs/src/main/sphinx/security/internal-communication.rst
+++ b/presto-docs/src/main/sphinx/security/internal-communication.rst
@@ -130,7 +130,7 @@ There are multiple ways to enable internal authentication described in below sec
 
 Enable JWT authentication to authenticate all communication between nodes of the cluster.
 Enable JWT and set the shared secret to the same value in
-:ref:`config.properties <config-properties>` on all nodes of the cluster using below configs:
+:ref:`config.properties <config_properties>` on all nodes of the cluster using below configs:
 
 .. code-block:: text
 


### PR DESCRIPTION
## Description
Fixes the following doc build errors: 

* `WARNING: html_static_path entry 'static' does not exist`
* `/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/language/types.rst:3: WARNING: Duplicate explicit target name: "hyperloglog".`
* `/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/security/internal-communication.rst:131: WARNING: undefined label: 'config-properties'`
* `/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/functions/array.rst:83: WARNING: Literal block expected; none found.`


## Motivation and Context
Chips away at the remaining doc build errors, and builds on the work in #23033 , #23023, #22876 , and #22985 . 
Like the doc build errors I fixed in the other PRs, these errors don't stop the build but they're annoying, and these are easy and low-risk fixes.

Keeping the number of changes small to make reviewing easier and faster. Also, the remaining errors require more time to solve, so submit these solved problems for velocity. 

## Impact
Documentation.

## Test Plan
Local doc build. 

Before the fixes in this PR: 
**build succeeded, 23 warnings.**

After: 
**build succeeded, 19 warnings.**
 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

