### PR TITLE
Upgrade presto-maven-plugin to 0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2363,7 +2363,7 @@
                 <plugin>
                     <groupId>com.facebook.presto</groupId>
                     <artifactId>presto-maven-plugin</artifactId>
-                    <version>0.4</version>
+                    <version>0.5</version>
                     <extensions>true</extensions>
                 </plugin>
 


### PR DESCRIPTION
## Description

Upgrade `presto-maven-plugin` to the latest `0.5` version.

## Motivation and Context

Release `presto-maven-plugin:0.5` has fix https://github.com/prestodb/presto-maven-plugin/pull/11 that resolves https://github.com/prestodb/presto-maven-plugin/issues/1 issue.
The fix allows to build (at least) `presto-tpch`, `presto-password-authenticators`, `presto-session-property-managers`, `presto-node-ttl-fetchers` and `presto-cluster-ttl-providers` modules on Windows.

## Impact

Developers can build more Presto modules on Windows.

## Test Plan

Tested manually with the following commands:
```shell
mvn -f presto-tpch/pom.xml clean install -DskipTests=true
mvn -f presto-password-authenticators/pom.xml clean install -DskipTests=true
mvn -f presto-session-property-managers/pom.xml clean install -DskipTests=true
mvn -f presto-node-ttl-fetchers/pom.xml clean install -DskipTests=true
mvn -f presto-cluster-ttl-providers/pom.xml clean install -DskipTests=true
```

For instance, build result for `presto-tpch` **before** the upgrade:
```shell
$ mvn -f presto-tpch/pom.xml clean install -DskipTests=true
[INFO] Scanning for projects...
[INFO] 
[INFO] Using the MultiThreadedBuilder implementation with a thread count of 12
[INFO] 
[INFO] ------------------< com.facebook.presto:presto-tpch >-------------------
[INFO] Building presto-tpch 0.289-SNAPSHOT
...
[INFO] --- presto:0.4:generate-service-descriptor (default-generate-service-descriptor) @ presto-tpch ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.519 s (Wall Clock)
[INFO] Finished at: 2024-06-26T23:42:49+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.facebook.presto:presto-maven-plugin:0.4:generate-service-descriptor (default-generate-service-descriptor) on project presto-tpch: Execution default-generate-service-descriptor of goal com.facebook.presto:prest
o-maven-plugin:0.4:generate-service-descriptor failed: A required class was missing while executing com.facebook.presto:presto-maven-plugin:0.4:generate-service-descriptor: com/facebook/presto/tpch/ColumnNaming (wrong name: com\facebook\presto\tpch\ColumnNaming)
```

Build result for `presto-tpch` **after** the upgrade:
```shell
$ mvn -f presto-tpch/pom.xml clean install -DskipTests=true
[INFO] Scanning for projects...
[INFO] 
[INFO] Using the MultiThreadedBuilder implementation with a thread count of 12
[INFO] 
[INFO] ------------------< com.facebook.presto:presto-tpch >-------------------
[INFO] Building presto-tpch 0.289-SNAPSHOT
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.322 s (Wall Clock)
[INFO] Finished at: 2024-06-26T23:42:19+02:00
[INFO] ------------------------------------------------------------------------
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

