### PR TITLE
[native] Reduce numer of http requests for Exchange

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -384,9 +384,6 @@ void PrestoExchangeSource::processDataResponse(
 
   if (complete) {
     abortResults();
-  } else if (!empty) {
-    // Acknowledge results for non-empty content.
-    acknowledgeResults(ackSequence);
   }
 }
 
@@ -420,6 +417,15 @@ void PrestoExchangeSource::processDataError(
     // The source must have been closed.
     VELOX_CHECK(closed_.load());
   }
+}
+
+void PrestoExchangeSource::pause() {
+  int64_t ackSequence;
+  {
+    std::lock_guard<std::mutex> l(queue_->mutex());
+    ackSequence = sequence_;
+  }
+  acknowledgeResults(ackSequence);
 }
 
 void PrestoExchangeSource::acknowledgeResults(int64_t ackSequence) {

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -106,6 +106,8 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
     return request(0, maxWait);
   }
 
+  void pause() override;
+
   // Create an exchange source using pooled connections.
   static std::shared_ptr<PrestoExchangeSource> create(
       const std::string& url,

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -216,7 +216,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kAnnouncementMaxFrequencyMs, 30'000), // 30s
           NUM_PROP(kHeartbeatFrequencyMs, 0),
           STR_PROP(kExchangeMaxErrorDuration, "3m"),
-          STR_PROP(kExchangeRequestTimeout, "10s"),
+          STR_PROP(kExchangeRequestTimeout, "20s"),
           STR_PROP(kExchangeConnectTimeout, "20s"),
           BOOL_PROP(kExchangeEnableConnectionPool, true),
           BOOL_PROP(kExchangeEnableBufferCopy, true),


### PR DESCRIPTION
## Description

Reduce number of HTTP requests issued by exchange protocol

## Motivation and Context

With high number of partitions the amount of data exchanged in a single round trip can be quite low (~50kb). This PR reduces number of explicit acknowledge calls as well as increases the long pool delay to avoid sending unnecessary pings when the buffers are empty (for example of not yet active stages).

## Impact

Improves cpu efficiency at a fully utilized cluster by ~5%.

## Test Plan

CI

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

