### PR TITLE
[native] Merge coordinator and native process logs in e2e tests.

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -414,8 +414,8 @@ public class PrestoNativeQueryRunnerUtils
                         return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1")
                                 .directory(tempDirectoryPath.toFile())
                                 .redirectErrorStream(true)
-                                .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
-                                .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".err").toFile()))
+                                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                                .redirectError(ProcessBuilder.Redirect.INHERIT)
                                 .start();
                     }
                     catch (IOException e) {


### PR DESCRIPTION
## Description
Merging worker and coordinator logs in same output.

## Motivation and Context
Often we need to see worker logs while running e2e tests. This is hard to do in CI and testing systems as worker log is burried inside. This makes debugging hard and often impossible if worker process never even starts. Here merging both logs in same output to see worker logs along with cooridnator logs. While the log gets mixed, its very easy to separate between java and c++ format, plus any issue is printed immidiately.

## Impact
None

## Test Plan
Ran locally and observed worker logs showing up in console. Example:

```
2024-06-28T01:25:24.341-0500	INFO	Service Thread	com.facebook.airlift.stats.JmxGcMonitor	Major GC: application 0ms, stopped 181ms: 255.07MB -> 244.36MB
2024-06-28T01:25:24.341-0500	INFO	Service Thread	com.facebook.airlift.stats.JmxGcMonitor	Major GC: application 0ms, stopped 181ms: 255.07MB -> 244.36MB
2024-06-28T01:25:24.341-0500	INFO	Service Thread	com.facebook.airlift.stats.JmxGcMonitor	Major GC: application 0ms, stopped 181ms: 255.07MB -> 244.36MB
I20240627 23:25:25.761371 3974755 TaskManager.cpp:539] Starting task 20240628_062522_00000_zfxjc.1.0.0.0 with 16 max drivers.
I20240627 23:25:25.820855 3974755 TaskManager.cpp:539] Starting task 20240628_062522_00000_zfxjc.2.0.0.0 with 16 max drivers.
```

```
== NO RELEASE NOTE ==
```

