### PR TITLE
Fix existing DetermineJoinDistribution Tests

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -264,10 +264,10 @@ public class TestDetermineJoinDistributionType
                 .on(p ->
                         p.join(
                                 INNER,
-                                p.values(new PlanNodeId("valuesA"), aRows, p.variable("A1", BIGINT)),
+                                p.values(new PlanNodeId("valuesA"), aRows, p.variable("A1", BIGINT), p.variable("A2", BIGINT)),
                                 p.values(new PlanNodeId("valuesB"), bRows, p.variable("B1", BIGINT)),
                                 ImmutableList.of(new EquiJoinClause(p.variable("A1", BIGINT), p.variable("B1", BIGINT))),
-                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("B1", BIGINT)),
+                                ImmutableList.of(p.variable("A1", BIGINT), p.variable("A2", BIGINT), p.variable("B1", BIGINT)),
                                 Optional.empty()))
                 .matches(join(
                         INNER,
@@ -275,7 +275,7 @@ public class TestDetermineJoinDistributionType
                         Optional.empty(),
                         Optional.of(REPLICATED),
                         values(ImmutableMap.of("B1", 0)),
-                        values(ImmutableMap.of("A1", 0))));
+                        values(ImmutableMap.of("A1", 0, "A2", 1))));
     }
 
     @Test
@@ -305,11 +305,11 @@ public class TestDetermineJoinDistributionType
                                 Optional.empty()))
                 .matches(join(
                         INNER,
-                        ImmutableList.of(equiJoinClause("B1", "A1")),
+                        ImmutableList.of(equiJoinClause("A1", "B1")),
                         Optional.empty(),
                         Optional.of(REPLICATED),
-                        values(ImmutableMap.of("B1", 0)),
-                        values(ImmutableMap.of("A1", 0))));
+                        values(ImmutableMap.of("A1", 0)),
+                        values(ImmutableMap.of("B1", 0))));
     }
 
     @Test


### PR DESCRIPTION
## Description
Fix existing DetermineJoinDistribution Tests

## Motivation and Context
Many of our flip tests in the TestDetermineJoinDistribution class do not properly test if it is flipping as the order does not matter

## Impact
In the future, any changes to the logic of these classes will be tested in a better manner than they currently are

## Test Plan
Amended existing tests and made sure they do not pass with flipped nodes

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

