### PR TITLE
[native] Prestissimo worker metrics documentation

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -124,6 +124,13 @@ The configuration properties of Presto C++ workers are described here, in alphab
   1) the non-reserved space in ``query-memory-gb`` is used up; and 2) the amount
   it tries to get is less than ``memory-pool-reserved-capacity``.
 
+``runtime-metrics-collection-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+  Enables collection of worker level metrics.
+
 ``system-memory-gb``
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -67,6 +67,7 @@ Compilers (and versions) not mentioned are known to not work or have not been tr
 | CentOS 9/RHEL 9 | `gcc12` |
 
 ### Build Prestissimo
+#### Parquet and S3 Supprt
 To enable Parquet and S3 support, set `PRESTO_ENABLE_PARQUET = "ON"`,
 `PRESTO_ENABLE_S3 = "ON"` in the environment.
 
@@ -76,6 +77,7 @@ This dependency can be installed by running the script below from the
 
 `./velox/scripts/setup-adapters.sh aws`
 
+#### JWT Authentication
 To enable JWT authentication support, set `PRESTO_ENABLE_JWT = "ON"` in
 the environment.
 
@@ -84,6 +86,17 @@ This dependency can be installed by running the script below from the
 `presto/presto-native-execution` directory.
 
 `./scripts/setup-adapters.sh jwt`
+
+#### Worker Metrics Collection
+
+To enable worker level metrics collection and to enable the REST API `v1/info/metrics`
+follow these steps:
+
+*Pre-build setup:* `./scripts/setup-adapters.sh prometheus`
+
+*CMake flags:* `PRESTO_STATS_REPORTER_TYPE=PROMETHEUS`
+
+*Runtime configuration:* `runtime-metrics-collection-enabled=true`
 
 * After installing the above dependencies, from the
 `presto/presto-native-execution` directory, run `make`


### PR DESCRIPTION
## Description
Added Prestissimo worker metrics related config documentation.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

