### PR TITLE
Fix typo in LifespanAndStageStateTracker

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TableFinishOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableFinishOperator.java
@@ -417,10 +417,10 @@ public class TableFinishOperator
                     return true;
                 }
                 case LIFESPAN_COMMIT: {
-                    // Case 2: Lifespan commit is required
+                    // Case 3: Lifespan commit is required
                     checkState(lifespanAndStage.lifespan != Lifespan.taskWide(), "Recoverable lifespan cannot be TASK_WIDE");
 
-                    // Case 2a: Current (stage, lifespan) combination is already committed
+                    // Case 3a: Current (stage, lifespan) combination is already committed
                     if (committedRecoverableLifespanAndStages.containsKey(lifespanAndStage)) {
                         checkState(
                                 !committedRecoverableLifespanAndStages.get(lifespanAndStage).getTaskId().equals(tableCommitContext.getTaskId()),
@@ -428,7 +428,7 @@ public class TableFinishOperator
                         return false;
                     }
 
-                    // Case 2b: Current (stage, lifespan) combination is not yet committed
+                    // Case 3b: Current (stage, lifespan) combination is not yet committed
                     Map<TaskId, LifespanAndStageState> lifespanStageStatesPerTask = uncommittedRecoverableLifespanAndStageStates.computeIfAbsent(lifespanAndStage, ignored -> new HashMap<>());
                     lifespanStageStatesPerTask.computeIfAbsent(
                             tableCommitContext.getTaskId(), ignored -> new LifespanAndStageState(


### PR DESCRIPTION
## Description

This PR fix the incorrect case number in `LifespanAndStageStateTracker.update(...)`.

## Motivation and Context

N/A

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

