### PR TITLE
[native] Add support for Ubuntu aarch64 build on Mac M1

### DIFF
--- a/presto-native-execution/docker-compose.yml
+++ b/presto-native-execution/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     # Usage:
     #   docker-compose build ubuntu-native-dependency
     #   podman compose build ubuntu-native-dependency
-    image: presto/prestissimo-dependency:amd64-ubuntu-22.04
+    image: presto/prestissimo-dependency:ubuntu-22.04
     build:
       context: .
       dockerfile: scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -25,19 +25,20 @@ services:
     # Usage:
     #   docker-compose build ubuntu-native-runtime
     #   podman compose build ubuntu-native-runtime
-    image: presto/prestissimo-runtime:amd64-ubuntu-22.04
+    image: presto/prestissimo-runtime:ubuntu-22.04
     build:
       args:
-        - DEPENDENCY_IMAGE=presto/prestissimo-dependency:amd64-ubuntu-22.04
-        - BASE_IMAGE=amd64/ubuntu:22.04
+          # A few files in Velox require significant memory to compile and link.
+          # Build requires 18GB of memory for 2 threads.
+        - NUM_THREADS=2 # default value for NUM_THREADS.
+        - DEPENDENCY_IMAGE=presto/prestissimo-dependency:ubuntu-22.04
+        - BASE_IMAGE=ubuntu:22.04
         - OSNAME=ubuntu
-        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF \
-                            -DPRESTO_ENABLE_PARQUET=ON \
+        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF
+                            -DPRESTO_ENABLE_PARQUET=ON
                             -DPRESTO_ENABLE_S3=ON
       context: .
       dockerfile: scripts/dockerfiles/prestissimo-runtime.dockerfile
-    environment:
-      NUM_THREADS: 8 # default value for NUM_THREADS
 
   centos-native-dependency:
     # Usage:
@@ -55,10 +56,11 @@ services:
     image: presto/prestissimo-runtime:centos8
     build:
       args:
-        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF \
-                            -DPRESTO_ENABLE_PARQUET=ON \
+          # A few files in Velox require significant memory to compile and link.
+          # Build requires 18GB of memory for 2 threads.
+        - NUM_THREADS=2 # default value for NUM_THREADS
+        - EXTRA_CMAKE_FLAGS=-DPRESTO_ENABLE_TESTING=OFF
+                            -DPRESTO_ENABLE_PARQUET=ON
                             -DPRESTO_ENABLE_S3=ON
       context: .
       dockerfile: scripts/dockerfiles/prestissimo-runtime.dockerfile
-    environment:
-      NUM_THREADS: 8 # default value for NUM_THREADS

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -26,7 +26,7 @@ ENV BUILD_DIR=""
 RUN mkdir -p /prestissimo /runtime-libraries
 COPY . /prestissimo/
 RUN EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
-    make -j${NUM_THREADS} --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR}
+    NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR}
 RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found") && \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | awk 'NF == 4 { system("cp " $3 " /runtime-libraries") }'
 

--- a/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG base=amd64/ubuntu:22.04
+ARG base=ubuntu:22.04
 FROM ${base}
 
 # Set a default timezone, can be overriden via ARG


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Remove amd64 tag so that both x86_64 and arm64 arch can be supported.
Fix NUM_THREADS to be specified as an argument to build.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

