### PR TITLE
Let connector metadata existing in presto-main utilize newer SPI method

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/system/GlobalSystemConnector.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/GlobalSystemConnector.java
@@ -88,7 +88,11 @@ public class GlobalSystemConnector
             }
 
             @Override
-            public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+            public ConnectorTableLayoutResult getTableLayoutForConstraint(
+                    ConnectorSession session,
+                    ConnectorTableHandle table,
+                    Constraint<ColumnHandle> constraint,
+                    Optional<Set<ColumnHandle>> desiredColumns)
             {
                 throw new UnsupportedOperationException();
             }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesMetadata.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
@@ -78,11 +77,15 @@ public class SystemTablesMetadata
     }
 
     @Override
-    public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+    public ConnectorTableLayoutResult getTableLayoutForConstraint(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            Constraint<ColumnHandle> constraint,
+            Optional<Set<ColumnHandle>> desiredColumns)
     {
         SystemTableHandle tableHandle = (SystemTableHandle) table;
         ConnectorTableLayout layout = new ConnectorTableLayout(new SystemTableLayoutHandle(tableHandle.getConnectorId(), tableHandle, constraint.getSummary()));
-        return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
+        return new ConnectorTableLayoutResult(layout, constraint.getSummary());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
@@ -99,9 +99,13 @@ public class TestingMetadata
     }
 
     @Override
-    public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+    public ConnectorTableLayoutResult getTableLayoutForConstraint(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            Constraint<ColumnHandle> constraint,
+            Optional<Set<ColumnHandle>> desiredColumns)
     {
-        return ImmutableList.of(new ConnectorTableLayoutResult(new ConnectorTableLayout(INSTANCE), TupleDomain.all()));
+        return new ConnectorTableLayoutResult(new ConnectorTableLayout(INSTANCE), TupleDomain.all());
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/connector/MockConnectorFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/connector/MockConnectorFactory.java
@@ -203,7 +203,11 @@ public class MockConnectorFactory
             }
 
             @Override
-            public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+            public ConnectorTableLayoutResult getTableLayoutForConstraint(
+                    ConnectorSession session,
+                    ConnectorTableHandle table,
+                    Constraint<ColumnHandle> constraint,
+                    Optional<Set<ColumnHandle>> desiredColumns)
             {
                 throw new UnsupportedOperationException();
             }


### PR DESCRIPTION
## Description

PR #21933 has deprecated SPI method `ConnectorMetadata.getTableLayouts()`, and introduced a new SPI method `ConnectorMetadata.getTableLayoutForConstraint()` to replace it.

This PR re-factor the implementations of `ConnectorMetadata` existing in `presto-main` to utilize the newly defined SPI method, and stop to use the deprecated method.

## Motivation and Context

Make the implementations of `ConnectorMetadata` in `presto-main` more clear and concise

## Test Plan

 - Make sure the re-factor do not affect existing test cases

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
