### PR TITLE
Add additional type support for KLL Sketches

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchAggregationFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.aggregation.sketch.kll;
 
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.AggregationState;
 import com.facebook.presto.spi.function.CombineFunction;
@@ -31,36 +32,37 @@ public class KllSketchAggregationFunction
      * here.
      */
     private static final int DEFAULT_K = 200;
+
     private KllSketchAggregationFunction()
     {
     }
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") long value)
+    public static void input(@TypeParameter("T") Type type, @AggregationState KllSketchAggregationState state, @SqlType("T") long value)
     {
-        KllSketchWithKAggregationFunction.input(state, value, DEFAULT_K);
+        KllSketchWithKAggregationFunction.input(type, state, value, DEFAULT_K);
     }
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") double value)
+    public static void input(@TypeParameter("T") Type type, @AggregationState KllSketchAggregationState state, @SqlType("T") double value)
     {
-        KllSketchWithKAggregationFunction.input(state, value, DEFAULT_K);
+        KllSketchWithKAggregationFunction.input(type, state, value, DEFAULT_K);
     }
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") Slice value)
+    public static void input(@TypeParameter("T") Type type, @AggregationState KllSketchAggregationState state, @SqlType("T") Slice value)
     {
-        KllSketchWithKAggregationFunction.input(state, value, DEFAULT_K);
+        KllSketchWithKAggregationFunction.input(type, state, value, DEFAULT_K);
     }
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") boolean value)
+    public static void input(@TypeParameter("T") Type type, @AggregationState KllSketchAggregationState state, @SqlType("T") boolean value)
     {
-        KllSketchWithKAggregationFunction.input(state, value, DEFAULT_K);
+        KllSketchWithKAggregationFunction.input(type, state, value, DEFAULT_K);
     }
 
     @CombineFunction

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchStateSerializer.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
 import com.facebook.presto.spi.function.TypeParameter;
-import io.airlift.slice.Slices;
 import org.apache.datasketches.kll.KllItemsSketch;
 import org.apache.datasketches.memory.Memory;
 
@@ -46,12 +45,7 @@ public class KllSketchStateSerializer
     @Override
     public void serialize(KllSketchAggregationState state, BlockBuilder out)
     {
-        if (state.getSketch() == null) {
-            out.appendNull();
-            return;
-        }
-
-        VARBINARY.writeSlice(out, Slices.wrappedBuffer(state.getSketch().toByteArray()));
+        KllSketchWithKAggregationFunction.output(state, out);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchWithKAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/sketch/kll/KllSketchWithKAggregationFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.aggregation.sketch.kll;
 
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.AggregationState;
@@ -24,15 +25,7 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.apache.datasketches.common.ArrayOfBooleansSerDe;
-import org.apache.datasketches.common.ArrayOfDoublesSerDe;
-import org.apache.datasketches.common.ArrayOfItemsSerDe;
-import org.apache.datasketches.common.ArrayOfLongsSerDe;
-import org.apache.datasketches.common.ArrayOfStringsSerDe;
 import org.apache.datasketches.kll.KllItemsSketch;
-
-import java.util.Comparator;
-import java.util.function.Supplier;
 
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
@@ -50,45 +43,45 @@ public class KllSketchWithKAggregationFunction
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") long value, @SqlType(BIGINT) long k)
+    public static void input(@TypeParameter("T") Type type, @AggregationState KllSketchAggregationState state, @SqlType("T") long value, @SqlType(BIGINT) long k)
     {
-        initializeSketch(state, () -> Long::compareTo, ArrayOfLongsSerDe::new, k);
+        initializeSketch(state, type, k);
         KllItemsSketch<Long> sketch = state.getSketch();
         state.addMemoryUsage(() -> -getEstimatedKllInMemorySize(sketch, long.class));
-        state.getSketch().update(value);
+        state.update(value);
         state.addMemoryUsage(() -> getEstimatedKllInMemorySize(sketch, long.class));
     }
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") double value, @SqlType(BIGINT) long k)
+    public static void input(@TypeParameter("T") Type type, @AggregationState KllSketchAggregationState state, @SqlType("T") double value, @SqlType(BIGINT) long k)
     {
-        initializeSketch(state, () -> Double::compareTo, ArrayOfDoublesSerDe::new, k);
+        initializeSketch(state, type, k);
         KllItemsSketch<Double> sketch = state.getSketch();
         state.addMemoryUsage(() -> -getEstimatedKllInMemorySize(sketch, double.class));
-        state.getSketch().update(value);
+        state.update(value);
         state.addMemoryUsage(() -> getEstimatedKllInMemorySize(sketch, double.class));
     }
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") Slice value, @SqlType(BIGINT) long k)
+    public static void input(@TypeParameter("T") Type type, @AggregationState KllSketchAggregationState state, @SqlType("T") Slice value, @SqlType(BIGINT) long k)
     {
-        initializeSketch(state, () -> String::compareTo, ArrayOfStringsSerDe::new, k);
+        initializeSketch(state, type, k);
         KllItemsSketch sketch = state.getSketch();
         state.addMemoryUsage(() -> -getEstimatedKllInMemorySize(sketch, Slice.class));
-        state.getSketch().update(value.toStringUtf8());
+        state.update(value);
         state.addMemoryUsage(() -> getEstimatedKllInMemorySize(sketch, Slice.class));
     }
 
     @InputFunction
     @TypeParameter("T")
-    public static void input(@AggregationState KllSketchAggregationState state, @SqlType("T") boolean value, @SqlType(BIGINT) long k)
+    public static void input(@TypeParameter("T") Type type, @AggregationState KllSketchAggregationState state, @SqlType("T") boolean value, @SqlType(BIGINT) long k)
     {
-        initializeSketch(state, () -> Boolean::compareTo, ArrayOfBooleansSerDe::new, k);
+        initializeSketch(state, type, k);
         KllItemsSketch<Boolean> sketch = state.getSketch();
         state.addMemoryUsage(() -> -getEstimatedKllInMemorySize(sketch, boolean.class));
-        state.getSketch().update(value);
+        state.update(value);
         state.addMemoryUsage(() -> getEstimatedKllInMemorySize(sketch, boolean.class));
     }
 
@@ -117,15 +110,22 @@ public class KllSketchWithKAggregationFunction
         VARBINARY.writeSlice(out, Slices.wrappedBuffer(state.getSketch().toByteArray()));
     }
 
-    private static <T> void initializeSketch(KllSketchAggregationState state, Supplier<Comparator<T>> comparator, Supplier<ArrayOfItemsSerDe<T>> serdeSupplier, long k)
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void initializeSketch(KllSketchAggregationState state, Type type, long k)
     {
+        if (state.getSketch() != null) {
+            return;
+        }
+
         if (k < 8 || k > MAX_K) {
             throw new PrestoException(INVALID_ARGUMENTS, format("k value must satisfy 8 <= k <= %d: %d", MAX_K, k));
         }
-        if (state.getSketch() == null) {
-            KllItemsSketch<T> sketch = KllItemsSketch.newHeapInstance((int) k, comparator.get(), serdeSupplier.get());
-            state.setSketch(sketch);
-            state.addMemoryUsage(() -> getEstimatedKllInMemorySize(sketch, state.getType().getJavaType()));
-        }
+
+        KllSketchAggregationState.SketchParameters parameters = KllSketchAggregationState.getSketchParameters(type);
+        KllItemsSketch sketch = KllItemsSketch.newHeapInstance((int) k, parameters.getComparator(), parameters.getSerde());
+
+        state.setSketch(sketch);
+        state.setConversion(parameters.getConversion());
+        state.addMemoryUsage(() -> getEstimatedKllInMemorySize(sketch, state.getType().getJavaType()));
     }
 }


### PR DESCRIPTION
## Description

This PR adds support for additional types in the KLL aggregation functions. New types supported:

1. real
2. smallint
3. tinyint
5. date
6. time
7. timestamp
8. timestamp with timezone

## Motivation and Context

More type support for histogram statistic use.

## Impact

No API impact. Just additions to existing function surface

## Test Plan

- New tests for each supported type.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

