### PR TITLE
Fix bug when row IDs are needed but row numbers aren't

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
@@ -111,12 +111,17 @@ public class OrcSelectivePageSource
     public Page getNextPage()
     {
         try {
-            Page page = recordReader.getNextPage();
+            Page page;
+            if (supplyRowIDs) {
+                page = recordReader.getNextPage(true);
+                page = fillInRowIDs(page);
+            }
+            else {
+                page = recordReader.getNextPage();
+            }
+
             if (page == null) {
                 close();
-            }
-            else if (supplyRowIDs) { // If we need a row ID block, synthesize it here.
-                page = fillInRowIDs(page);
             }
             return page;
         }
@@ -147,7 +152,7 @@ public class OrcSelectivePageSource
         // figure out which block is the row ID and replace it
         page = page.replaceColumn(rowIDColumnIndex.getAsInt(), rowIDs);
 
-        if (!appendRowNumberEnabled) {
+        if (!this.appendRowNumberEnabled) {
             // remove the row number block now that the row IDs have been constructed unless it was also requested
             page = page.dropColumn(page.getChannelCount() - 1);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -630,6 +630,12 @@ public class OrcSelectiveRecordReader
     public Page getNextPage()
             throws IOException
     {
+        return getNextPage(this.appendRowNumber);
+    }
+
+    public Page getNextPage(boolean withRowNumbers)
+            throws IOException
+    {
         if (constantFilterIsFalse) {
             return null;
         }
@@ -721,7 +727,7 @@ public class OrcSelectiveRecordReader
             }
         }
 
-        Block[] blocks = new Block[ appendRowNumber ? outputColumns.size() + 1 : outputColumns.size()];
+        Block[] blocks = new Block[ withRowNumbers ? outputColumns.size() + 1 : outputColumns.size()];
         for (int i = 0; i < outputColumns.size(); i++) {
             int columnIndex = outputColumns.get(i);
             if (constantValues[columnIndex] != null) {
@@ -742,7 +748,7 @@ public class OrcSelectiveRecordReader
             }
         }
 
-        if (appendRowNumber) {
+        if (withRowNumbers) {
             blocks[outputColumns.size()] = createRowNumbersBlock(positionsToRead, positionCount, this.getFilePosition());
         }
         Page page = new Page(positionCount, blocks);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveRecordReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveRecordReader.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
+import static com.facebook.presto.orc.OrcTester.Format.DWRF;
+import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
+import static com.facebook.presto.orc.OrcTester.createCustomOrcSelectiveRecordReader;
+import static com.facebook.presto.orc.OrcTester.writeOrcColumnsPresto;
+import static com.facebook.presto.orc.TestingOrcPredicate.createOrcPredicate;
+import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static org.testng.Assert.assertEquals;
+
+public class TestOrcSelectiveRecordReader
+{
+    @Test
+    public void testGetNextPage_withRowNumbers()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(VARCHAR);
+        List<List<?>> values = ImmutableList.of(ImmutableList.of("a", ""));
+
+        TempFile tempFile = new TempFile();
+        writeOrcColumnsPresto(tempFile.getFile(), ORC_12, NONE, Optional.empty(), types, values, NOOP_WRITER_STATS);
+
+        OrcPredicate orcPredicate = createOrcPredicate(types, values, DWRF, false);
+        Map<Integer, Type> includedColumns = IntStream.range(0, types.size())
+                .boxed()
+                .collect(toImmutableMap(Function.identity(), types::get));
+        List<Integer> outputColumns = IntStream.range(0, types.size())
+                .boxed()
+                .collect(toImmutableList());
+        OrcAggregatedMemoryContext systemMemoryUsage = new TestingHiveOrcAggregatedMemoryContext();
+        try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReader(
+                tempFile.getFile(),
+                ORC_12.getOrcEncoding(),
+                orcPredicate,
+                types,
+                1,
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                OrcTester.OrcReaderSettings.builder().build().getRequiredSubfields(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                includedColumns,
+                outputColumns,
+                false,
+                systemMemoryUsage,
+                false)) {
+            assertEquals(recordReader.getReaderPosition(), 0);
+            assertEquals(recordReader.getFilePosition(), 0);
+
+            Page page = recordReader.getNextPage(true);
+            // One VARCHAR column and one row number column
+            assertEquals(2, page.getChannelCount());
+            Block block = page.getBlock(1);
+            assertEquals(block.getPositionCount(), 1);
+            assertEquals(block.getLong(0), 0, "First row number is not zero");
+        }
+    }
+
+    @Test
+    public void testGetNextPage_withoutRowNumbers()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(VARCHAR);
+        List<List<?>> values = ImmutableList.of(ImmutableList.of("a", ""));
+
+        TempFile tempFile = new TempFile();
+        writeOrcColumnsPresto(tempFile.getFile(), ORC_12, NONE, Optional.empty(), types, values, NOOP_WRITER_STATS);
+
+        OrcPredicate orcPredicate = createOrcPredicate(types, values, DWRF, false);
+        Map<Integer, Type> includedColumns = IntStream.range(0, types.size())
+                .boxed()
+                .collect(toImmutableMap(Function.identity(), types::get));
+        List<Integer> outputColumns = IntStream.range(0, types.size())
+                .boxed()
+                .collect(toImmutableList());
+        OrcAggregatedMemoryContext systemMemoryUsage = new TestingHiveOrcAggregatedMemoryContext();
+        try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReader(
+                tempFile.getFile(),
+                ORC_12.getOrcEncoding(),
+                orcPredicate,
+                types,
+                1,
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                OrcTester.OrcReaderSettings.builder().build().getRequiredSubfields(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                includedColumns,
+                outputColumns,
+                false,
+                systemMemoryUsage,
+                false)) {
+            assertEquals(recordReader.getReaderPosition(), 0);
+            assertEquals(recordReader.getFilePosition(), 0);
+
+            Page page = recordReader.getNextPage();
+            // One VARCHAR column, no row number column
+            assertEquals(1, page.getChannelCount());
+            Block block = page.getBlock(0);
+            assertEquals(block.getPositionCount(), 1);
+        }
+    }
+}


### PR DESCRIPTION
Fix bug in selective page source where row IDs were needed but row numbers weren't

## Description
When row IDs are needed, make sure the selective record reader supplies row numbers.

## Motivation and Context
Selective readers were throwing exceptions when reading $row_id columns unless they had also requested row numbers.

```
com.facebook.presto.spi.PrestoException: Failed to read ORC file: ws://ws.dw.vll0dw0/namespace/instagram/warehouse/b662395dd05943dbb92a5acaf824fc72/203654a34f13427d834efc0d97ec4490/ds=2024-06-29/user_bucket=0/part-00003
	at com.facebook.presto.hive.orc.OrcSelectivePageSource.getNextPage(OrcSelectivePageSource.java:137)
	at com.facebook.presto.hive.metalake.MetalakePageSource.getNextPage(MetalakePageSource.java:85)
	at com.facebook.presto.operator.ScanFilterAndProjectOperator.processPageSource(ScanFilterAndProjectOperator.java:295)
	at com.facebook.presto.operator.ScanFilterAndProjectOperator.getOutput(ScanFilterAndProjectOperator.java:260)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:441)
	at com.facebook.presto.operator.Driver.lambda$processFor$10(Driver.java:324)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:750)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:317)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1079)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:165)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:621)
	at com.facebook.presto.$gen.Presto_0_288_edge14_2_SNAPSHOT_$_git_commit_id_abbrev___0_288_edge14_2____20240614_082452_1.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 0
	at com.facebook.presto.common.Page.getBlock(Page.java:165)
	at com.facebook.presto.hive.orc.OrcSelectivePageSource.fillInRowIDs(OrcSelectivePageSource.java:144)
	at com.facebook.presto.hive.orc.OrcSelectivePageSource.getNextPage(OrcSelectivePageSource.java:119)
	... 14 more
```

## Impact
Row IDs are now correctly filled in in selective record reader

## Test Plan
Added new unit tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

