### PR TITLE
Use property to deactivate UI profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ resource JAR is included on the classpath of Presto coordinator, it will be able
 resources.
 
 None of the Java code relies on the Presto UI project being compiled, so it is possible to exclude
-this UI when building Presto. It can be excluded by disabling the `ui` maven profile with `-P \!ui`:
+this UI when building Presto. Add the property `-DskipUI` to the maven command to disable building
+the `ui` maven module.
 
-    ./mvnw clean install -P \!ui
+    ./mvnw clean install -DskipUI
 
 You must have [Node.js](https://nodejs.org/en/download/) and [Yarn](https://yarnpkg.com/en/) installed to build the UI. When using  Maven to build
 the project, Node and yarn are installed in the `presto-ui/target` folder. Add the node and yarn

--- a/pom.xml
+++ b/pom.xml
@@ -2489,7 +2489,9 @@
         <profile>
             <id>ui</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!skipUI</name>
+                </property>
             </activation>
             <modules>
                 <module>presto-ui</module>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -576,11 +576,13 @@
     <profiles>
         <profile>
             <!-- Requires the UI as a dependency by default. If the UI is   -->
-            <!-- not required, turn off this profile (-P '!ui') to prevent  -->
+            <!-- not required, turn off this profile (-DskipUI) to prevent  -->
             <!-- building it      -->
             <id>ui</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!skipUI</name>
+                </property>
             </activation>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
## Description
In lieu of the activeByDefault, use a property instead to disable building the UI

## Motivation and Context

We have seen build failures occurring when users try to introduce new maven profiles to the POMs.

The UI currently uses the `activeByDefault` directive. It doesn't do what the user might expect. Other profiles which are activeByDefault can override this in the root POM but not submodule POMs, so the the build of the child  module might not be able to find the presto-ui dependency, causing a build failure.

This changes instead uses the `<property>` profile activation which will only deactivate this profile in the case a specific property (skipUI) is present. This can be passed to the maven arguments as simply `-DskipUI`, similar to the surefire plugin's `-DskipTests`

See the following for more discussion:
https://stackoverflow.com/questions/5309379/how-to-keep-maven-profiles-which-are-activebydefault-active-even-if-another-prof

## Impact

CI/scripts which build presto and skip the UI may need to update their command line arguments to use `-DskipUI` instead.

## Test Plan

Local build with various combinations of arguments including and not including `-DskipUI`

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

