### PR TITLE
Improve the documentation for two memory counters

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -109,9 +109,9 @@ The configuration properties of Presto C++ workers are described here, in alphab
 * **Type:** ``integer``
 * **Default value:** ``38``
 
-  The total memory capacity that can be used across all query executions. 
-  Memory for system usage such as disk spilling and cache prefetch which 
-  are not counted in query memory usage.
+  Specifies the total amount of memory in GB that can be used for all queries on a
+  worker node. Memory for system usage such as disk spilling and cache prefetch are
+  not counted in it.
 
 ``query-reserved-memory-gb``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,13 +119,10 @@ The configuration properties of Presto C++ workers are described here, in alphab
 * **Type:** ``integer``
 * **Default value:** ``4``
 
-  Specifies the amount of query memory capacity reserved 
-  to ensure that each query has the minimal memory capacity to run. A query can 
-  only allocate from the reserved query memory if its current capacity is less 
-  than the minimal memory capacity as specified by 
-  ``memory-pool-reserved-capacity``. 
-  
-  The exceeding capacity must allocate from the non-reserved query memory.
+  Specifies the total amount of memory in GB reserved for the queries on
+  a worker node. A query can only allocate from this reserved space if
+  1) the non-reserved space in ``query-memory-gb`` is used up; and 2) the amount
+  it tries to get is less than ``memory-pool-reserved-capacity``.
 
 ``system-memory-gb``
 ^^^^^^^^^^^^^^^^^^^^
@@ -133,7 +130,9 @@ The configuration properties of Presto C++ workers are described here, in alphab
 * **Type:** ``integer``
 * **Default value:** ``40``
 
-  Memory allocation limit enforced via internal memory allocator. 
+  Memory allocation limit enforced via internal memory allocator. It consists of two parts:
+  1) Memory used by the queries as specified in ``query-memory-gb``; 2) Memory used by the
+  system, such as disk spilling and cache prefetch.
 
   Set ``system-memory-gb`` to the available machine memory of the deployment.
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -255,21 +255,21 @@ class SystemConfig : public ConfigBase {
 
   /// Indicates if the process is configured as a sidecar.
   static constexpr std::string_view kNativeSidecar{"native-sidecar"};
-  /// Specifies the total memory capacity that can be used by query execution in
-  /// GB. The query memory capacity should be configured less than the system
-  /// memory capacity ('system-memory-gb') to reserve memory for system usage
-  /// such as disk spilling and cache prefetch which are not counted in query
-  /// memory usage.
+
+  /// Specifies the total amount of memory in GB that the queries can use on a
+  /// single worker node. It should be configured to be less than the total
+  /// system memory capacity ('system-memory-gb') such that there is enough room
+  /// left for the system (as opposed to for the queries), such as disk spilling
+  /// and cache prefetch.
   ///
   /// NOTE: the query memory capacity is enforced by memory arbitrator so that
   /// this config only applies if the memory arbitration has been enabled.
   static constexpr std::string_view kQueryMemoryGb{"query-memory-gb"};
 
-  /// Specifies the amount of query memory capacity reserved to ensure that each
-  /// query has minimal memory capacity to run. A query can only allocate from
-  /// the reserved query memory if its current capacity is less than the minimal
-  /// memory capacity as specified by 'memory-pool-reserved-capacity'. The
-  /// exceeding capacity has to allocate from the non-reserved query memory.
+  /// Specifies the total amount of memory in GB reserved for the queries on
+  /// a single worker node. A query can only allocate from this reserved space
+  /// if 1) the non-reserved space in "query-memory-gb" is used up; and 2) the
+  /// amount it tries to get is less than 'memory-pool-reserved-capacity'.
   ///
   /// NOTE: the reserved query memory capacity is enforced by memory arbitrator
   /// so that this config only applies if the memory arbitration has been
@@ -375,8 +375,10 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kMemoryPoolInitCapacity{
       "memory-pool-init-capacity"};
 
-  /// The minimal amount of memory capacity in bytes reserved for each query
-  /// memory pool.
+  /// The amount of memory in bytes reserved for each query memory pool. When
+  /// a query tries to allocate memory from the reserved space whose size is
+  /// specified by 'query-reserved-memory-gb', it cannot allocate more than the
+  /// value specified in 'memory-pool-reserved-capacity'.
   static constexpr std::string_view kMemoryPoolReservedCapacity{
       "memory-pool-reserved-capacity"};
 


### PR DESCRIPTION
## Description
Following the discussion of 0.288 release notes, I'm making these changes to clarify the two memory counters meanings. They are `query-memory-gb` and `query-reserved-memory-gb`.

## Impact
Help the user to understand these counters better

## Test Plan


## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.



```
== NO RELEASE NOTE ==
```

