### PR TITLE
[native] Convert cast to substr when target is capped varchar

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -159,6 +159,40 @@ std::vector<TypedExprPtr> VeloxExprConverter::toVeloxExpr(
 }
 
 namespace {
+static const char* kVarchar = "varchar";
+
+/// Convert cast of varchar to substr if target type is varchar with max length.
+/// Throw an exception for cast of varchar to varchar with max length.
+std::optional<TypedExprPtr> convertCastToVarcharWithMaxLength(
+    const std::string& returnType,
+    const std::vector<TypedExprPtr>& args,
+    bool nullOnFailure) {
+  if (nullOnFailure) {
+    VELOX_NYI("TRY_CAST of varchar to {} is not supported.", returnType);
+  }
+
+  // Parse the max length from the return type string in the format of
+  // varchar(max_length). Assume return type string is valid given
+  // TypeParser.yy.
+  char* end;
+  const auto length =
+      strtol(returnType.data() + strlen(kVarchar) + 1, &end, 10);
+  VELOX_DCHECK(errno != ERANGE);
+  VELOX_DCHECK(end == returnType.data() + returnType.size() - 1);
+
+  VELOX_DCHECK_EQ(args.size(), 1);
+  const auto arg = args[0];
+
+  return std::make_shared<CallTypedExpr>(
+      arg->type(),
+      std::vector<TypedExprPtr>{
+          arg,
+          std::make_shared<ConstantTypedExpr>(velox::BIGINT(), 1LL),
+          std::make_shared<ConstantTypedExpr>(velox::BIGINT(), (int64_t)length),
+      },
+      "presto.default.substr");
+}
+
 /// Converts cast and try_cast functions to CastTypedExpr with nullOnFailure
 /// flag set to false and true appropriately.
 /// Removes cast to Re2JRegExp type. Velox doesn't have such type and uses
@@ -166,6 +200,8 @@ namespace {
 /// regular expressions needlessly.
 /// Removes cast to CodePoints type. Velox doesn't have such type and uses
 /// different mechanisms to implement trim functions efficiently.
+/// Convert cast of varchar to substr if the target type is varchar with max
+/// length. Throw an exception for cast of varchar to varchar with max length.
 std::optional<TypedExprPtr> tryConvertCast(
     const protocol::Signature& signature,
     const std::string& returnType,
@@ -217,6 +253,15 @@ std::optional<TypedExprPtr> tryConvertCast(
 
   if (returnType == kCodePoints) {
     return args[0];
+  }
+
+  // When the return type is varchar with max length, truncate if only the
+  // argument type is varchar (or varchar with max length). Non-varchar argument
+  // types are not truncated.
+  if (returnType.find(kVarchar) == 0 &&
+      args[0]->type()->kind() == TypeKind::VARCHAR &&
+      returnType.size() > strlen(kVarchar)) {
+    return convertCastToVarcharWithMaxLength(returnType, args, nullOnFailure);
   }
 
   auto type = typeParser->parse(returnType);

--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -49,6 +49,54 @@ class RowExpressionTest : public ::testing::Test {
     ASSERT_EQ(cexpr->value().toJson(cexpr->type()), value);
   }
 
+  std::string makeCastToVarchar(
+      bool isTryCast,
+      const std::string& inputType,
+      const std::string& returnType) {
+    std::string signatureNameField = isTryCast
+        ? R"("name": "presto.default.try_cast")"
+        : R"("name": "presto.default.$operator$cast")";
+    std::string inputTypeField = fmt::format("\"{}\"", inputType);
+    std::string returnTypeField =
+        fmt::format("\"returnType\": \"{}\"", returnType);
+
+    std::string result = R"##(
+      {
+        "@type": "call",
+        "arguments": [
+          {
+            "@type": "variable",
+            "name": "my_col",
+            "type": )##" +
+        inputTypeField + R"##(
+          }
+        ],
+        "displayName": "CAST",
+        "functionHandle": {
+          "@type": "$static",
+          "signature": {
+            "argumentTypes": [
+    )##" +
+        inputTypeField + R"##(
+            ],
+            "kind": "SCALAR",
+    )##" +
+        signatureNameField + R"##(,
+            "longVariableConstraints": [],
+    )##" +
+        returnTypeField + R"##(,
+            "typeVariableConstraints": [],
+            "variableArity": false
+          }
+        },
+    )##" +
+        returnTypeField + R"##(
+      }
+    )##";
+
+    return result;
+  }
+
   std::shared_ptr<memory::MemoryPool> pool_;
   std::unique_ptr<VeloxExprConverter> converter_;
   TypeParser typeParser_;
@@ -487,6 +535,96 @@ TEST_F(RowExpressionTest, call) {
       ASSERT_EQ(cexpr->type()->toString(), "VARCHAR");
       ASSERT_EQ(cexpr->value().toJson(cexpr->type()), "\"foo\"");
     }
+  }
+}
+
+TEST_F(RowExpressionTest, castToVarchar) {
+  // CAST(varchar_col AS varchar)
+  {
+    std::shared_ptr<protocol::CallExpression> p =
+        json::parse(makeCastToVarchar(false, "varchar", "varchar"));
+
+    auto expr = converter_->toVeloxExpr(p);
+
+    auto returnExpr = std::dynamic_pointer_cast<const CastTypedExpr>(expr);
+    ASSERT_NE(returnExpr, nullptr);
+    ASSERT_FALSE(returnExpr->nullOnFailure());
+    ASSERT_EQ(returnExpr->type()->toString(), "VARCHAR");
+  }
+  // TRY_CAST(varchar_col AS varchar)
+  {
+    std::shared_ptr<protocol::CallExpression> p =
+        json::parse(makeCastToVarchar(true, "varchar", "varchar"));
+
+    auto expr = converter_->toVeloxExpr(p);
+
+    auto returnExpr = std::dynamic_pointer_cast<const CastTypedExpr>(expr);
+    ASSERT_NE(returnExpr, nullptr);
+    ASSERT_TRUE(returnExpr->nullOnFailure());
+    ASSERT_EQ(returnExpr->type()->toString(), "VARCHAR");
+  }
+  // CAST(varchar_col AS varchar(3))
+  {
+    std::shared_ptr<protocol::CallExpression> p =
+        json::parse(makeCastToVarchar(false, "varchar", "varchar(3)"));
+
+    auto expr = converter_->toVeloxExpr(p);
+
+    auto returnExpr = std::dynamic_pointer_cast<const CallTypedExpr>(expr);
+    ASSERT_NE(returnExpr, nullptr);
+    ASSERT_EQ(returnExpr->name(), "presto.default.substr");
+
+    auto returnArg = std::dynamic_pointer_cast<const ConstantTypedExpr>(
+        returnExpr->inputs()[2]);
+    ASSERT_EQ(returnArg->type()->toString(), "BIGINT");
+    ASSERT_EQ(returnArg->value().toJson(returnArg->type()), "3");
+  }
+  // CAST(varchar_col AS varchar(1000))
+  {
+    std::shared_ptr<protocol::CallExpression> p =
+        json::parse(makeCastToVarchar(false, "varchar", "varchar(1000)"));
+
+    auto expr = converter_->toVeloxExpr(p);
+
+    auto returnExpr = std::dynamic_pointer_cast<const CallTypedExpr>(expr);
+    ASSERT_NE(returnExpr, nullptr);
+    ASSERT_EQ(returnExpr->name(), "presto.default.substr");
+
+    auto returnArg = std::dynamic_pointer_cast<const ConstantTypedExpr>(
+        returnExpr->inputs()[2]);
+    ASSERT_EQ(returnArg->type()->toString(), "BIGINT");
+    ASSERT_EQ(returnArg->value().toJson(returnArg->type()), "1000");
+  }
+  // TRY_CAST(varchar_col AS varchar(3))
+  {
+    std::shared_ptr<protocol::CallExpression> p =
+        json::parse(makeCastToVarchar(true, "varchar", "varchar(3)"));
+
+    ASSERT_THROW(converter_->toVeloxExpr(p), VeloxRuntimeError);
+  }
+  // CAST(nonvarchar_col AS varchar(3))
+  {
+    std::shared_ptr<protocol::CallExpression> p =
+        json::parse(makeCastToVarchar(false, "double", "varchar(3)"));
+
+    auto expr = converter_->toVeloxExpr(p);
+
+    auto returnExpr = std::dynamic_pointer_cast<const CastTypedExpr>(expr);
+    ASSERT_NE(returnExpr, nullptr);
+    ASSERT_FALSE(returnExpr->nullOnFailure());
+    ASSERT_EQ(returnExpr->type()->toString(), "VARCHAR");
+  }
+  // TRY_CAST(nonvarchar_col AS varchar(3))
+  {
+    std::shared_ptr<protocol::CallExpression> p =
+        json::parse(makeCastToVarchar(true, "double", "varchar(3)"));
+
+    auto expr = converter_->toVeloxExpr(p);
+
+    auto returnExpr = std::dynamic_pointer_cast<const CastTypedExpr>(expr);
+    ASSERT_NE(returnExpr, nullptr);
+    ASSERT_TRUE(returnExpr->nullOnFailure());
+    ASSERT_EQ(returnExpr->type()->toString(), "VARCHAR");
   }
 }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -428,6 +428,14 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery("SELECT CAST(true as VARCHAR), CAST(false as VARCHAR)");
         assertQuery("SELECT CAST(0.0 as VARCHAR)");
 
+        // Cast to varchar(n).
+        assertQuery("SELECT CAST(comment as VARCHAR(1)) FROM orders");
+        assertQuery("SELECT CAST(comment as VARCHAR(1000)) FROM orders WHERE LENGTH(comment) < 1000");
+        assertQuery("SELECT CAST(c0 AS VARCHAR(1)) FROM ( VALUES (NULL) ) t(c0)");
+        assertQuery("SELECT CAST(c0 AS VARCHAR(1)) FROM ( VALUES ('') ) t(c0)");
+        assertQuery("SELECT CAST(is_returned as VARCHAR(1)), CAST(linenumber_as_tinyint as VARCHAR(1)), CAST(linenumber_as_smallint as VARCHAR(1)), " +
+                "CAST(linenumber as VARCHAR(1)), CAST(tax_as_real as VARCHAR(1)), CAST(tax as VARCHAR(1)) FROM lineitem");
+
         assertQuery("SELECT try_cast(linenumber as TINYINT), try_cast(linenumber AS SMALLINT), "
                 + "try_cast(linenumber AS INTEGER), try_cast(linenumber AS BIGINT), try_cast(quantity AS REAL), "
                 + "try_cast(orderkey AS DOUBLE), try_cast(orderkey AS VARCHAR) FROM lineitem");


### PR DESCRIPTION
Convert cast to the call to substr() if the target type is varchar with max length in plan in PrestoToVeloxExpression. Raise exception for try_cast, which will handle later when we align the try_cast behavior.

Resolve https://github.com/facebookincubator/velox/issues/7264

```
== NO RELEASE NOTE ==
```

