### PR TITLE
[native] Revert coordinator and native process logs merging in e2e tests.

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -426,8 +426,8 @@ public class PrestoNativeQueryRunnerUtils
                         return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1")
                                 .directory(tempDirectoryPath.toFile())
                                 .redirectErrorStream(true)
-                                .redirectOutput(ProcessBuilder.Redirect.INHERIT)
-                                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                                .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
+                                .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("worker." + workerIndex + ".out").toFile()))
                                 .start();
                     }
                     catch (IOException e) {


### PR DESCRIPTION
## Description
Revert https://github.com/prestodb/presto/pull/23100 

## Motivation and Context
https://github.com/prestodb/presto/pull/23100 does not merge logs in CI systems. It can do locally when someone runs e2e tests in Mac. @czentgr is looking for better solutions, meanwhile we need to keep log files for worker instead of merging those.

## Impact
None

## Test Plan
Ran e2e tests

```
== NO RELEASE NOTE ==
```

