### PR TITLE
[native]Add data cache related server operations

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
@@ -63,6 +63,12 @@ class PrestoServerOperations {
 
   std::string serverOperationAnnouncer(proxygen::HTTPMessage* message);
 
+  // Clears the in-memory (and optional ssd) cache.
+  std::string serverOperationClearCache(proxygen::HTTPMessage* message);
+
+  // Writes the in-memory cache into SSD and makes checkpoints.
+  std::string serverOperationWriteSsd(proxygen::HTTPMessage* message);
+
   TaskManager* const taskManager_;
   PrestoServer* const server_;
 };

--- a/presto-native-execution/presto_cpp/main/ServerOperation.cpp
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.cpp
@@ -20,6 +20,7 @@ const folly::F14FastMap<std::string, ServerOperation::Action>
     ServerOperation::kActionLookup{
         {"clearCache", ServerOperation::Action::kClearCache},
         {"getCacheStats", ServerOperation::Action::kGetCacheStats},
+        {"writeSsd", ServerOperation::Action::kWriteSSD},
         {"setProperty", ServerOperation::Action::kSetProperty},
         {"getProperty", ServerOperation::Action::kGetProperty},
         {"getDetail", ServerOperation::Action::kGetDetail},
@@ -32,6 +33,7 @@ const folly::F14FastMap<ServerOperation::Action, std::string>
     ServerOperation::kReverseActionLookup{
         {ServerOperation::Action::kClearCache, "clearCache"},
         {ServerOperation::Action::kGetCacheStats, "getCacheStats"},
+        {ServerOperation::Action::kWriteSSD, "writeSsd"},
         {ServerOperation::Action::kSetProperty, "setProperty"},
         {ServerOperation::Action::kGetProperty, "getProperty"},
         {ServerOperation::Action::kGetDetail, "getDetail"},

--- a/presto-native-execution/presto_cpp/main/ServerOperation.h
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.h
@@ -32,7 +32,9 @@ struct ServerOperation {
 
   /// The action this operation is trying to take
   enum class Action {
-    /// Applicable to kConnector. Clears the connector cache.
+    /// Applicable to kConnector and kServer. If it is for kConnector, it clears
+    /// the connector cache. If it is for kServer, it clears the memory (and
+    /// ssd) cache.
     kClearCache,
     /// Applicable to kConnector. Returns stats of the connector cache.
     kGetCacheStats,
@@ -52,6 +54,8 @@ struct ServerOperation {
     kSetState,
     /// Applicable to kServer. Enable/disable Presto Announcer.
     kAnnouncer,
+    /// Applicable to kServer. Write in-memory cache data to SSD.
+    kWriteSSD,
   };
 
   static const folly::F14FastMap<std::string, Target> kTargetLookup;


### PR DESCRIPTION
Add to support (1) clear in-memory and ssd cache; (2) write in-memory cache to ssd and make
checkpoints

```
== NO RELEASE NOTE ==
```

