### PR TITLE
[native] Fix driver count reporting from worker

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -590,10 +590,10 @@ void PrestoTask::updateExecutionInfoLocked(
   prestoTaskStats.outputPositions = 0;
   prestoTaskStats.outputDataSizeInBytes = 0;
 
-  prestoTaskStats.totalDrivers = veloxTaskStats.numTotalSplits;
-  prestoTaskStats.queuedDrivers = veloxTaskStats.numQueuedSplits;
-  prestoTaskStats.runningDrivers = veloxTaskStats.numRunningSplits;
-  prestoTaskStats.completedDrivers = veloxTaskStats.numFinishedSplits;
+  prestoTaskStats.queuedDrivers = veloxTaskStats.numQueuedDrivers;
+  prestoTaskStats.totalDrivers = veloxTaskStats.numTotalDrivers;
+  prestoTaskStats.runningDrivers = veloxTaskStats.numRunningDrivers;
+  prestoTaskStats.completedDrivers = veloxTaskStats.numCompletedDrivers;
 
   prestoTaskStats.pipelines.resize(veloxTaskStats.pipelineStats.size());
   for (int i = 0; i < veloxTaskStats.pipelineStats.size(); ++i) {


### PR DESCRIPTION
We were reporting split counts to driver count. This PR fixes it.
```
== NO RELEASE NOTE ==
```

