### PR TITLE
[docs] Fix doc build error in release-0.288.rst

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.288.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.288.rst
@@ -4,7 +4,7 @@ Release 0.288
 
 **Highlights**
 ==============
-* Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. For more information, see `RFC-0001-nan-definition.md <https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md>`_. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
+* Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. For more information, see `RFC-0001-nan-definition.md <https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md>`_. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386` 
 * Add procedure `expire_snapshots` to remove old snapshots in Iceberg. :pr:`22609`
 * Add support for Iceberg REST catalog. :pr:`22417`
 * Add support for ``NOT NULL`` column constraints in the CREATE TABLE and ALTER TABLE statements. This only takes effect for Hive connector now. :pr:`22064`
@@ -36,7 +36,7 @@ _______________
 * Improve error code for cast from DOUBLE or REAL to BIGINT, INTEGER, SMALLINT or TINYINT for out of range values from NUMERIC_VALUE_OUT_OF_RANGE to INVALID_CAST_ARGUMENT. :pr:`22917`
 * Improve handling of floating point numbers in Presto to consistently treat NaNs as larger than any other number and equal to itself. It also changes the handling of positive and negative zero to always be considered equal to each other. Read more here: https://github.com/prestodb/rfcs/blob/main/RFC-0001-nan-definition.md. The new nan behavior can be disabled by setting the configuration property use-new-nan-definition to false. This configuration property is intended to be temporary to ease migration in the short term, and will be removed in a future release. :pr:`22386`
 * Improve the performance of reading common table expressions (CTE). :pr:`22478`
-* Improve join performance by prefiltering the build side with distinct keys from the probe side. This can be enabled with the ``join_prefilter_build_side `` session property. :pr:`22667`
+* Improve join performance by prefiltering the build side with distinct keys from the probe side. This can be enabled with the ``join_prefilter_build_side`` session property. :pr:`22667`
 * Add HBO for CTE materialized query. :pr:`22606`
 * Add support for CTAS on bucketed (but not partitioned) tables for Presto C++ clusters. :pr:`22737`
 * Add support for ``NOT NULL`` column constraints in the CREATE TABLE and ALTER TABLE statements. This only takes effect for Hive connector now. :pr:`22064`


### PR DESCRIPTION
## Description
Fixes doc build error 

`/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/release/release-0.288.rst:39: WARNING: Inline literal start-string without end-string.`

I thought that I had caught this in #23079 but apparently not. 

## Motivation and Context
Builds on work in #23090, #23033, #22876, and #22985. 

Like the doc build errors I fixed in the other PRs, these errors don't stop the build but they're annoying, and these are easy and low-risk fixes.

## Impact
Documentation builds. 

## Test Plan
Local doc builds: 

before: 
`build succeeded, 20 warnings.`

after:
`build succeeded, 19 warnings.`

Reviewed local doc build to confirm the fix didn't break any text display or formatting errors. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

