### PR TITLE
Revert "[native]Add data cache related server operations"

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
@@ -14,8 +14,6 @@
 #include "presto_cpp/main/PrestoServerOperations.h"
 #include <velox/common/base/Exceptions.h>
 #include <velox/common/base/VeloxException.h>
-#include <velox/common/caching/AsyncDataCache.h>
-#include <velox/common/caching/SsdCache.h>
 #include <velox/common/process/TraceContext.h>
 #include "presto_cpp/main/PrestoServer.h"
 #include "presto_cpp/main/ServerOperation.h"
@@ -252,10 +250,6 @@ std::string PrestoServerOperations::serverOperation(
       return serverOperationSetState(message);
     case ServerOperation::Action::kAnnouncer:
       return serverOperationAnnouncer(message);
-    case ServerOperation::Action::kClearCache:
-      return serverOperationClearCache(message);
-    case ServerOperation::Action::kWriteSSD:
-      return serverOperationWriteSsd(message);
     default:
       break;
   }
@@ -316,60 +310,4 @@ std::string PrestoServerOperations::serverOperationAnnouncer(
   return "No PrestoServer to change announcer of (it is nullptr).";
 }
 
-std::string PrestoServerOperations::serverOperationClearCache(
-    proxygen::HTTPMessage* message) {
-  static const std::string kMemoryCacheType = "memory";
-  static const std::string kServerCacheType = "ssd";
-
-  std::string type = message->getQueryParam("type");
-  if (type.empty()) {
-    type = kMemoryCacheType;
-  }
-  if (type != kMemoryCacheType && type != kServerCacheType) {
-    VELOX_USER_FAIL(
-        "Unknown cache type '{}' for server cache clear operation", type);
-  }
-
-  auto* cache = velox::cache::AsyncDataCache::getInstance();
-  if (cache == nullptr) {
-    return "No memory cache set on server";
-  }
-
-  cache->clear();
-  if (type == kMemoryCacheType) {
-    return "Cleared memory cache";
-  }
-
-  auto* ssdCache = cache->ssdCache();
-  if (ssdCache == nullptr) {
-    return "No ssd cache set on server";
-  }
-  ssdCache->clear();
-  return "Cleared ssd cache";
-}
-
-std::string PrestoServerOperations::serverOperationWriteSsd(
-    proxygen::HTTPMessage* message) {
-  auto* cache = velox::cache::AsyncDataCache::getInstance();
-  if (cache == nullptr) {
-    return "No memory cache set on server";
-  }
-  auto* ssdCache = cache->ssdCache();
-  if (ssdCache == nullptr) {
-    return "No ssd cache set on server";
-  }
-
-  if (!ssdCache->startWrite()) {
-    return "Failed to start write to ssd cache";
-  }
-  cache->saveToSsd(true);
-  ssdCache->waitForWriteToFinish();
-
-  if (!ssdCache->startWrite()) {
-    return "Failed to start checkpoint on ssd cache";
-  }
-  ssdCache->checkpoint();
-  ssdCache->waitForWriteToFinish();
-  return "Succeeded write ssd cache";
-}
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.h
@@ -63,12 +63,6 @@ class PrestoServerOperations {
 
   std::string serverOperationAnnouncer(proxygen::HTTPMessage* message);
 
-  // Clears the in-memory (and optional ssd) cache.
-  std::string serverOperationClearCache(proxygen::HTTPMessage* message);
-
-  // Writes the in-memory cache into SSD and makes checkpoints.
-  std::string serverOperationWriteSsd(proxygen::HTTPMessage* message);
-
   TaskManager* const taskManager_;
   PrestoServer* const server_;
 };

--- a/presto-native-execution/presto_cpp/main/ServerOperation.cpp
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.cpp
@@ -20,7 +20,6 @@ const folly::F14FastMap<std::string, ServerOperation::Action>
     ServerOperation::kActionLookup{
         {"clearCache", ServerOperation::Action::kClearCache},
         {"getCacheStats", ServerOperation::Action::kGetCacheStats},
-        {"writeSsd", ServerOperation::Action::kWriteSSD},
         {"setProperty", ServerOperation::Action::kSetProperty},
         {"getProperty", ServerOperation::Action::kGetProperty},
         {"getDetail", ServerOperation::Action::kGetDetail},
@@ -33,7 +32,6 @@ const folly::F14FastMap<ServerOperation::Action, std::string>
     ServerOperation::kReverseActionLookup{
         {ServerOperation::Action::kClearCache, "clearCache"},
         {ServerOperation::Action::kGetCacheStats, "getCacheStats"},
-        {ServerOperation::Action::kWriteSSD, "writeSsd"},
         {ServerOperation::Action::kSetProperty, "setProperty"},
         {ServerOperation::Action::kGetProperty, "getProperty"},
         {ServerOperation::Action::kGetDetail, "getDetail"},

--- a/presto-native-execution/presto_cpp/main/ServerOperation.h
+++ b/presto-native-execution/presto_cpp/main/ServerOperation.h
@@ -32,9 +32,7 @@ struct ServerOperation {
 
   /// The action this operation is trying to take
   enum class Action {
-    /// Applicable to kConnector and kServer. If it is for kConnector, it clears
-    /// the connector cache. If it is for kServer, it clears the memory (and
-    /// ssd) cache.
+    /// Applicable to kConnector. Clears the connector cache.
     kClearCache,
     /// Applicable to kConnector. Returns stats of the connector cache.
     kGetCacheStats,
@@ -54,8 +52,6 @@ struct ServerOperation {
     kSetState,
     /// Applicable to kServer. Enable/disable Presto Announcer.
     kAnnouncer,
-    /// Applicable to kServer. Write in-memory cache data to SSD.
-    kWriteSSD,
   };
 
   static const folly::F14FastMap<std::string, Target> kTargetLookup;


### PR DESCRIPTION
This reverts commit b73ab7df31e4d969c44fd953e5cb8e36a18eb55b.

Fix deterministic CI failure.
Resolves: https://github.com/prestodb/presto/issues/23156


```
== NO RELEASE NOTE ==
```

