### PR TITLE
Transform in values to in filter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -349,6 +349,7 @@ public final class SystemSessionProperties
     public static final String JOIN_PREFILTER_BUILD_SIDE = "join_prefilter_build_side";
     public static final String OPTIMIZER_USE_HISTOGRAMS = "optimizer_use_histograms";
     public static final String WARN_ON_COMMON_NAN_PATTERNS = "warn_on_common_nan_patterns";
+    public static final String TRANSFORM_IN_VALUES_TO_IN_FILTER = "transform_in_values_to_in_filter";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1948,6 +1949,10 @@ public final class SystemSessionProperties
                 booleanProperty(WARN_ON_COMMON_NAN_PATTERNS,
                         "Whether to give a warning for some common issues relating to NaNs",
                         featuresConfig.getWarnOnCommonNanPatterns(),
+                        false),
+                booleanProperty(TRANSFORM_IN_VALUES_TO_IN_FILTER,
+                        "Transform in values to in filter instead of semijoin whenever possible",
+                        featuresConfig.getTransformInValuesToInFilter(),
                         false));
     }
 
@@ -3249,5 +3254,10 @@ public final class SystemSessionProperties
     public static boolean warnOnCommonNanPatterns(Session session)
     {
         return session.getSystemProperty(WARN_ON_COMMON_NAN_PATTERNS, Boolean.class);
+    }
+
+    public static boolean isTransformInValuesToInFilterEnabled(Session session)
+    {
+        return session.getSystemProperty(TRANSFORM_IN_VALUES_TO_IN_FILTER, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -314,6 +314,7 @@ public class FeaturesConfig
 
     private boolean useNewNanDefinition = true;
     private boolean warnOnPossibleNans;
+    private boolean transformInValuesToInFilterEnabled;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -3157,6 +3158,19 @@ public class FeaturesConfig
     public FeaturesConfig setWarnOnCommonNanPatterns(boolean warnOnPossibleNans)
     {
         this.warnOnPossibleNans = warnOnPossibleNans;
+        return this;
+    }
+
+    public boolean getTransformInValuesToInFilter()
+    {
+        return transformInValuesToInFilterEnabled;
+    }
+
+    @Config("transform_in_values_to_in_filter")
+    @ConfigDescription("Transform the in values form to in filter instead of semijoin whenever possible")
+    public FeaturesConfig setTransformInValuesToInFilter(boolean transformInValuesToInFilterEnabled)
+    {
+        this.transformInValuesToInFilterEnabled = transformInValuesToInFilterEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -138,6 +138,7 @@ import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedSingleR
 import com.facebook.presto.sql.planner.iterative.rule.TransformDistinctInnerJoinToLeftEarlyOutJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformDistinctInnerJoinToRightEarlyOutJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformExistsApplyToLateralNode;
+import com.facebook.presto.sql.planner.iterative.rule.TransformInValuesToInFilter;
 import com.facebook.presto.sql.planner.iterative.rule.TransformUncorrelatedInPredicateSubqueryToDistinctInnerJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformUncorrelatedInPredicateSubqueryToSemiJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformUncorrelatedLateralToJoin;
@@ -476,6 +477,14 @@ public class PlanOptimizers
                                 new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),
                                 new TransformCorrelatedScalarAggregationToJoin(metadata.getFunctionAndTypeManager()),
                                 new TransformCorrelatedLateralJoinToJoin(metadata.getFunctionAndTypeManager()))),
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.<Rule<?>>builder()
+                                .add(new TransformInValuesToInFilter())
+                                .build()),
                 new IterativeOptimizer(
                         metadata,
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformInValuesToInFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformInValuesToInFilter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.SystemSessionProperties.isTransformInValuesToInFilterEnabled;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
+import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
+import static com.facebook.presto.sql.planner.plan.Patterns.filteringSource;
+import static com.facebook.presto.sql.planner.plan.Patterns.project;
+import static com.facebook.presto.sql.planner.plan.Patterns.semiJoin;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.planner.plan.Patterns.values;
+import static com.facebook.presto.sql.relational.Expressions.specialForm;
+
+/**
+ * This optimizer looks for SemiJoinNode whose filteringSource has only one column, then transform the SemijoinNode into ProjectNode with predicate variable for filtering.
+ * <p/>
+ * Plan before optimizer:
+ * <pre>
+ * SemiJoinNode (semiJoinOutput variable c):
+ *   - source (sourceJoinVariable a)
+ *   - filteringSource (one column variable b)
+ *       - ProjectNode
+ *            - ValuesNode
+ * </pre>
+ * <p/>
+ * Plan after optimizer:
+ * <pre>
+ * ProjectNode:
+ *   - source
+ *   - assignments(identityAssignments of source output,c in b)
+ * </pre>
+ */
+public class TransformInValuesToInFilter
+        implements Rule<SemiJoinNode>
+{
+    private static final Pattern<SemiJoinNode> PATTERN = semiJoin().with(filteringSource()
+            .matching(project().with(source()
+                    .matching(values()))));
+
+    @Override
+    public Pattern<SemiJoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isTransformInValuesToInFilterEnabled(session);
+    }
+
+    @Override
+    public Result apply(SemiJoinNode semiJoinNode, Captures captures, Context context)
+    {
+        PlanNode source = semiJoinNode.getSource();
+        return context.getLookup().resolveGroup(semiJoinNode.getFilteringSource()).findFirst()
+                .flatMap(projectNode -> context.getLookup().resolveGroup(projectNode.getSources().get(0)).findFirst())
+                .map(ValuesNode.class::cast)
+                .map(ValuesNode::getRows)
+                // check that all values are only a single row expression (no struct/row types)
+                .filter(valuesRows -> valuesRows.stream().noneMatch(row -> row.size() > 1))
+                .map(rows -> rows.stream().map(row -> row.get(0)).iterator())
+                .map(args -> {
+                    RowExpression predicate = specialForm(IN, BOOLEAN, ImmutableList.<RowExpression>builder().add(semiJoinNode.getSourceJoinVariable()).addAll(args).build());
+                    Assignments.Builder builder = Assignments.builder();
+                    builder.putAll(identityAssignments(source.getOutputVariables()))
+                            .put(semiJoinNode.getSemiJoinOutput(), predicate);
+                    ProjectNode projectNode = new ProjectNode(context.getIdAllocator().getNextId(), source, builder.build());
+                    return Result.ofPlanNode(projectNode);
+                }).orElse(Result.empty());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -227,6 +227,11 @@ public class Patterns
                 Optional.empty());
     }
 
+    public static Property<SemiJoinNode, PlanNode> filteringSource()
+    {
+        return optionalProperty("filteringSource", node -> Optional.of(node.getFilteringSource()));
+    }
+
     public static Property<PlanNode, List<PlanNode>> sources()
     {
         return property("sources", PlanNode::getSources);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -274,7 +274,8 @@ public class TestFeaturesConfig
                 .setPrintEstimatedStatsFromCache(false)
                 .setUseHistograms(false)
                 .setUseNewNanDefinition(true)
-                .setWarnOnCommonNanPatterns(false));
+                .setWarnOnCommonNanPatterns(false)
+                .setTransformInValuesToInFilter(false));
     }
 
     @Test
@@ -493,6 +494,7 @@ public class TestFeaturesConfig
                 .put("optimizer.use-histograms", "true")
                 .put("use-new-nan-definition", "false")
                 .put("warn-on-common-nan-patterns", "true")
+                .put("transform_in_values_to_in_filter", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -708,7 +710,8 @@ public class TestFeaturesConfig
                 .setPrintEstimatedStatsFromCache(true)
                 .setUseHistograms(true)
                 .setUseNewNanDefinition(false)
-                .setWarnOnCommonNanPatterns(true);
+                .setWarnOnCommonNanPatterns(true)
+                .setTransformInValuesToInFilter(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformInValuesToInFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformInValuesToInFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.TRANSFORM_IN_VALUES_TO_IN_FILTER;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+
+public class TestTransformInValuesToInFilter
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoesNotFireOnWithTwoColumns()
+    {
+        tester().assertThat(new TransformInValuesToInFilter())
+                .setSystemProperty(TRANSFORM_IN_VALUES_TO_IN_FILTER, "true")
+                .on(p -> p.semiJoin(p.variable("x"),
+                        p.variable("c"),
+                        p.variable("d"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        p.values(p.variable("x"), p.variable("y")),
+                        p.project(p.values(p.getIdAllocator().getNextId(), 2, p.variable("a"), p.variable("b")), assignment(p.variable("c"), p.variable("a")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testFiresOnOneColumn()
+    {
+        tester().assertThat(new TransformInValuesToInFilter())
+                .setSystemProperty(TRANSFORM_IN_VALUES_TO_IN_FILTER, "true")
+                .on(p -> p.semiJoin(p.variable("x"),
+                        p.variable("c"),
+                        p.variable("d"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        p.values(p.variable("x"), p.variable("y")),
+                        p.project(p.values(p.getIdAllocator().getNextId(), 2, p.variable("a")), assignment(p.variable("c"), p.variable("a")))))
+                .matches(node(ProjectNode.class, values("x", "y")));
+    }
+}


### PR DESCRIPTION
## Description
IN (VALUES ...) should be translated into simple IN LIST

## Motivation and Context
The issue comes from #22728 IN (VALUES ..) should be translated as simple IN LIST
If VALUES table only has one column, transformed it into IN LIST

## Impact
Add another optimization rule: 
If filteringSource of SemiJoinNode comes from a ValueNode with only one column, transform it into a ProjectNode with outputVariable of the SemiJoinNode assigned to the IN LIST predicate. The outputVariable will be filtered in a later stage. 

## Test Plan
Test the rule fires on in the scenario and returns correct query plan.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
