### PR TITLE
Enable hbo tracking for cte producer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/TemporaryTableUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/TemporaryTableUtil.java
@@ -176,7 +176,8 @@ public class TemporaryTableUtil
             TableHandle tableHandle,
             List<VariableReferenceExpression> outputs,
             Map<VariableReferenceExpression, ColumnMetadata> variableToColumnMap,
-            VariableReferenceExpression outputVar)
+            VariableReferenceExpression outputVar,
+            Optional<PlanNode> statsEquivalentPlanNode)
     {
         SchemaTableName schemaTableName = metadata.getTableMetadata(session, tableHandle).getTable();
         TableWriterNode.InsertReference insertReference = new TableWriterNode.InsertReference(tableHandle, schemaTableName);
@@ -195,6 +196,7 @@ public class TemporaryTableUtil
                 new TableWriterNode(
                         source.getSourceLocation(),
                         idAllocator.getNextId(),
+                        statsEquivalentPlanNode,
                         source,
                         Optional.of(insertReference),
                         variableAllocator.newVariable("rows", BIGINT),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -843,12 +843,30 @@ public class CanonicalPlanGenerator
     @Override
     public Optional<PlanNode> visitCteProducer(CteProducerNode node, Context context)
     {
-        return node.getSource().accept(this, context);
+        Optional<PlanNode> source = node.getSource().accept(this, context);
+        if (!source.isPresent()) {
+            return Optional.empty();
+        }
+        List<VariableReferenceExpression> outputVariables = node.getOutputVariables().stream()
+                .map(variable -> inlineAndCanonicalize(context.getExpressions(), variable))
+                .sorted()
+                .collect(toImmutableList());
+        PlanNode canonicalCteProducer = new CteProducerNode(
+                Optional.empty(),
+                planNodeidAllocator.getNextId(),
+                source.get(),
+                node.getCteId(),
+                node.getRowCountVariable(),
+                outputVariables);
+        context.addPlan(node, new CanonicalPlan(canonicalCteProducer, strategy));
+        return Optional.of(canonicalCteProducer);
     }
 
     @Override
     public Optional<PlanNode> visitCteConsumer(CteConsumerNode node, Context context)
     {
+        // ToDo: Current assumption is that the cte producer generates same hashes as the original node.
+        // This will generate wrong stats after cte materialization since original hashes will be updated
         return node.getOriginalSource().accept(this, context);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
@@ -159,7 +159,8 @@ public class PhysicalCteOptimizer
                     temporaryTableHandle,
                     actualSource.getOutputVariables(),
                     variableToColumnMap,
-                    node.getRowCountVariable());
+                    node.getRowCountVariable(),
+                    node.getStatsEquivalentPlanNode());
         }
 
         public boolean isPlanRewritten()


### PR DESCRIPTION
## Description
This PR adds tracking of hbo stats for cte producer nodes.
The fixes are 1. to propagate stats equivalent plan nodes to the table writers.
2. Canonicalize and register hashes of the cte producer nodes

I wrote a local unit test and confirmed with debugging that the cte producer hbo stats were available when run again, need to write a test somehow

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

