### PR TITLE
Add wrappers for Iceberg Schema and Iceberg PartitionSpec

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -73,7 +73,6 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Schema;
@@ -143,6 +142,8 @@ import static com.facebook.presto.iceberg.IcebergUtil.verifyTypeSupported;
 import static com.facebook.presto.iceberg.PartitionFields.getPartitionColumnName;
 import static com.facebook.presto.iceberg.PartitionFields.getTransformTerm;
 import static com.facebook.presto.iceberg.PartitionFields.toPartitionFields;
+import static com.facebook.presto.iceberg.PartitionSpecConverter.toPrestoPartitionSpec;
+import static com.facebook.presto.iceberg.SchemaConverter.toPrestoSchema;
 import static com.facebook.presto.iceberg.TableStatisticsMaker.getSupportedColumnStatistics;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
@@ -439,8 +440,8 @@ public abstract class IcebergAbstractMetadata
         return new IcebergInsertTableHandle(
                 table.getSchemaName(),
                 table.getIcebergTableName(),
-                SchemaParser.toJson(icebergTable.schema()),
-                PartitionSpecParser.toJson(icebergTable.spec()),
+                toPrestoSchema(icebergTable.schema(), typeManager),
+                toPrestoPartitionSpec(icebergTable.spec(), typeManager),
                 getColumns(icebergTable.schema(), icebergTable.spec(), typeManager),
                 icebergTable.location(),
                 getFileFormat(icebergTable),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -69,9 +69,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
@@ -124,6 +122,8 @@ import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.verifyTypeSupported;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
+import static com.facebook.presto.iceberg.PartitionSpecConverter.toPrestoPartitionSpec;
+import static com.facebook.presto.iceberg.SchemaConverter.toPrestoSchema;
 import static com.facebook.presto.iceberg.util.StatisticsUtil.calculateAndSetTableSize;
 import static com.facebook.presto.iceberg.util.StatisticsUtil.mergeHiveStatistics;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
@@ -315,8 +315,8 @@ public class IcebergHiveMetadata
         return new IcebergOutputTableHandle(
                 schemaName,
                 new IcebergTableName(tableName, DATA, Optional.empty(), Optional.empty()),
-                SchemaParser.toJson(metadata.schema()),
-                PartitionSpecParser.toJson(metadata.spec()),
+                toPrestoSchema(metadata.schema(), typeManager),
+                toPrestoPartitionSpec(metadata.spec(), typeManager),
                 getColumns(metadata.schema(), metadata.spec(), typeManager),
                 targetPath,
                 fileFormat,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
@@ -29,8 +29,8 @@ public class IcebergInsertTableHandle
     public IcebergInsertTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") IcebergTableName tableName,
-            @JsonProperty("schemaAsJson") String schemaAsJson,
-            @JsonProperty("partitionSpecAsJson") String partitionSpecAsJson,
+            @JsonProperty("schema") PrestoIcebergSchema schema,
+            @JsonProperty("partitionSpec") PrestoIcebergPartitionSpec partitionSpec,
             @JsonProperty("inputColumns") List<IcebergColumnHandle> inputColumns,
             @JsonProperty("outputPath") String outputPath,
             @JsonProperty("fileFormat") FileFormat fileFormat,
@@ -40,8 +40,8 @@ public class IcebergInsertTableHandle
         super(
                 schemaName,
                 tableName,
-                schemaAsJson,
-                partitionSpecAsJson,
+                schema,
+                partitionSpec,
                 inputColumns,
                 outputPath,
                 fileFormat,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -30,9 +30,7 @@ import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -53,6 +51,8 @@ import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.populateTableProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.verifyTypeSupported;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
+import static com.facebook.presto.iceberg.PartitionSpecConverter.toPrestoPartitionSpec;
+import static com.facebook.presto.iceberg.SchemaConverter.toPrestoSchema;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergNamespace;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -183,8 +183,8 @@ public class IcebergNativeMetadata
         return new IcebergOutputTableHandle(
                 schemaName,
                 new IcebergTableName(tableName, DATA, Optional.empty(), Optional.empty()),
-                SchemaParser.toJson(icebergTable.schema()),
-                PartitionSpecParser.toJson(icebergTable.spec()),
+                toPrestoSchema(icebergTable.schema(), typeManager),
+                toPrestoPartitionSpec(icebergTable.spec(), typeManager),
                 getColumns(icebergTable.schema(), icebergTable.spec(), typeManager),
                 icebergTable.location(),
                 fileFormat,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOutputTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOutputTableHandle.java
@@ -29,8 +29,8 @@ public class IcebergOutputTableHandle
     public IcebergOutputTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") IcebergTableName tableName,
-            @JsonProperty("schemaAsJson") String schemaAsJson,
-            @JsonProperty("partitionSpecAsJson") String partitionSpecAsJson,
+            @JsonProperty("schema") PrestoIcebergSchema schema,
+            @JsonProperty("partitionSpec") PrestoIcebergPartitionSpec partitionSpec,
             @JsonProperty("inputColumns") List<IcebergColumnHandle> inputColumns,
             @JsonProperty("outputPath") String outputPath,
             @JsonProperty("fileFormat") FileFormat fileFormat,
@@ -40,8 +40,8 @@ public class IcebergOutputTableHandle
         super(
                 schemaName,
                 tableName,
-                schemaAsJson,
-                partitionSpecAsJson,
+                schema,
+                partitionSpec,
                 inputColumns,
                 outputPath,
                 fileFormat,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
@@ -26,14 +26,14 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.io.LocationProvider;
 
 import javax.inject.Inject;
 
 import static com.facebook.presto.iceberg.IcebergUtil.getLocationProvider;
+import static com.facebook.presto.iceberg.PartitionSpecConverter.toIcebergPartitionSpec;
+import static com.facebook.presto.iceberg.SchemaConverter.toIcebergSchema;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergPageSinkProvider
@@ -76,8 +76,8 @@ public class IcebergPageSinkProvider
     private ConnectorPageSink createPageSink(ConnectorSession session, IcebergWritableTableHandle tableHandle)
     {
         HdfsContext hdfsContext = new HdfsContext(session, tableHandle.getSchemaName(), tableHandle.getTableName().getTableName());
-        Schema schema = SchemaParser.fromJson(tableHandle.getSchemaAsJson());
-        PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, tableHandle.getPartitionSpecAsJson());
+        Schema schema = toIcebergSchema(tableHandle.getSchema());
+        PartitionSpec partitionSpec = toIcebergPartitionSpec(tableHandle.getPartitionSpec()).toUnbound().bind(schema);
         LocationProvider locationProvider = getLocationProvider(new SchemaTableName(tableHandle.getSchemaName(), tableHandle.getTableName().getTableName()),
                 tableHandle.getOutputPath(), tableHandle.getStorageProperties());
         return new IcebergPageSink(

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergWritableTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergWritableTableHandle.java
@@ -26,8 +26,8 @@ public class IcebergWritableTableHandle
 {
     private final String schemaName;
     private final IcebergTableName tableName;
-    private final String schemaAsJson;
-    private final String partitionSpecAsJson;
+    private final PrestoIcebergSchema schema;
+    private final PrestoIcebergPartitionSpec partitionSpec;
     private final List<IcebergColumnHandle> inputColumns;
     private final String outputPath;
     private final FileFormat fileFormat;
@@ -37,8 +37,8 @@ public class IcebergWritableTableHandle
     public IcebergWritableTableHandle(
             String schemaName,
             IcebergTableName tableName,
-            String schemaAsJson,
-            String partitionSpecAsJson,
+            PrestoIcebergSchema schema,
+            PrestoIcebergPartitionSpec partitionSpec,
             List<IcebergColumnHandle> inputColumns,
             String outputPath,
             FileFormat fileFormat,
@@ -47,8 +47,8 @@ public class IcebergWritableTableHandle
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
-        this.schemaAsJson = requireNonNull(schemaAsJson, "schemaAsJson is null");
-        this.partitionSpecAsJson = requireNonNull(partitionSpecAsJson, "partitionSpecAsJson is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.partitionSpec = requireNonNull(partitionSpec, "partitionSpec is null");
         this.inputColumns = ImmutableList.copyOf(requireNonNull(inputColumns, "inputColumns is null"));
         this.outputPath = requireNonNull(outputPath, "filePrefix is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
@@ -69,15 +69,15 @@ public class IcebergWritableTableHandle
     }
 
     @JsonProperty
-    public String getSchemaAsJson()
+    public PrestoIcebergSchema getSchema()
     {
-        return schemaAsJson;
+        return schema;
     }
 
     @JsonProperty
-    public String getPartitionSpecAsJson()
+    public PrestoIcebergPartitionSpec getPartitionSpec()
     {
-        return partitionSpecAsJson;
+        return partitionSpec;
     }
 
     @JsonProperty

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/NestedFieldConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/NestedFieldConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.TypeManager;
+import org.apache.iceberg.types.Types.NestedField;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
+import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
+
+public final class NestedFieldConverter
+{
+    private NestedFieldConverter() {}
+
+    public static PrestoIcebergNestedField toPrestoNestedField(NestedField nestedField, TypeManager typeManager)
+    {
+        return new PrestoIcebergNestedField(
+                nestedField.isOptional(),
+                nestedField.fieldId(),
+                nestedField.name(),
+                toPrestoType(nestedField.type(), typeManager),
+                Optional.ofNullable(nestedField.doc()));
+    }
+
+    public static NestedField toIcebergNestedField(
+            PrestoIcebergNestedField nestedField,
+            Map<String, Integer> columnNameToIdMapping)
+    {
+        return NestedField.of(
+                nestedField.getId(),
+                nestedField.isOptional(),
+                nestedField.getName(),
+                toIcebergType(nestedField.getPrestoType(), nestedField.getName(), columnNameToIdMapping),
+                nestedField.getDoc().orElse(null));
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
@@ -18,7 +18,10 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Term;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -58,7 +61,15 @@ public final class PartitionFields
 
     public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields)
     {
-        PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
+        return parsePartitionFields(schema, fields, null);
+    }
+
+    public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields, @Nullable Integer specId)
+    {
+        PartitionSpec.Builder builder = Optional.ofNullable(specId)
+                .map(id -> PartitionSpec.builderFor(schema).withSpecId(id))
+                .orElseGet(() -> PartitionSpec.builderFor(schema));
+
         for (String field : fields) {
             parsePartitionField(builder, field);
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionSpecConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionSpecConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.TypeManager;
+import org.apache.iceberg.PartitionSpec;
+
+import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
+import static com.facebook.presto.iceberg.PartitionFields.toPartitionFields;
+import static com.facebook.presto.iceberg.SchemaConverter.toIcebergSchema;
+import static com.facebook.presto.iceberg.SchemaConverter.toPrestoSchema;
+
+public class PartitionSpecConverter
+{
+    private PartitionSpecConverter() {}
+
+    public static PrestoIcebergPartitionSpec toPrestoPartitionSpec(PartitionSpec spec, TypeManager typeManager)
+    {
+        return new PrestoIcebergPartitionSpec(
+                spec.specId(),
+                toPrestoSchema(spec.schema(), typeManager),
+                toPartitionFields(spec));
+    }
+
+    public static PartitionSpec toIcebergPartitionSpec(PrestoIcebergPartitionSpec spec)
+    {
+        return parsePartitionFields(
+                toIcebergSchema(spec.getSchema()),
+                spec.getFields(),
+                spec.getSpecId());
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergNestedField.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergNestedField.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoIcebergNestedField
+{
+    private final boolean optional;
+    private final int id;
+    private final String name;
+    private final Type prestoType;
+    private final Optional<String> doc;
+
+    @JsonCreator
+    public PrestoIcebergNestedField(
+            @JsonProperty("optional") boolean optional,
+            @JsonProperty("id") int id,
+            @JsonProperty("name") String name,
+            @JsonProperty("prestoType") Type prestoType,
+            @JsonProperty("doc") Optional<String> doc)
+    {
+        this.optional = optional;
+        this.id = id;
+        this.name = requireNonNull(name, "name is null");
+        this.prestoType = requireNonNull(prestoType, "prestoType is null");
+        this.doc = requireNonNull(doc, "doc is null");
+    }
+
+    @JsonProperty
+    public boolean isOptional()
+    {
+        return optional;
+    }
+
+    @JsonProperty
+    public int getId()
+    {
+        return id;
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public Type getPrestoType()
+    {
+        return prestoType;
+    }
+
+    @JsonProperty
+    public Optional<String> getDoc()
+    {
+        return doc;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(optional, id, name, prestoType, doc);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        PrestoIcebergNestedField other = (PrestoIcebergNestedField) obj;
+        return Objects.equals(this.optional, other.optional) &&
+                Objects.equals(this.id, other.id) &&
+                Objects.equals(this.name, other.name) &&
+                Objects.equals(this.prestoType, other.prestoType) &&
+                Objects.equals(this.doc, other.doc);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergPartitionSpec.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergPartitionSpec.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoIcebergPartitionSpec
+{
+    private final int specId;
+    private final PrestoIcebergSchema schema;
+    private final List<String> fields;
+
+    @JsonCreator
+    public PrestoIcebergPartitionSpec(
+            @JsonProperty("specId") int specId,
+            @JsonProperty("schema") PrestoIcebergSchema schema,
+            @JsonProperty("fields") List<String> fields)
+    {
+        this.specId = specId;
+        this.schema = requireNonNull(schema, "schema is null");
+        this.fields = ImmutableList.copyOf(requireNonNull(fields, "fields is null"));
+    }
+
+    @JsonProperty
+    public int getSpecId()
+    {
+        return specId;
+    }
+
+    @JsonProperty
+    public PrestoIcebergSchema getSchema()
+    {
+        return schema;
+    }
+
+    @JsonProperty
+    public List<String> getFields()
+    {
+        return fields;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(specId, schema, fields);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        PrestoIcebergPartitionSpec other = (PrestoIcebergPartitionSpec) obj;
+        return Objects.equals(this.specId, other.specId) &&
+                Objects.equals(this.schema, other.schema) &&
+                Objects.equals(this.fields, other.fields);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergSchema.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergSchema.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoIcebergSchema
+{
+    private final int schemaId;
+    private final List<PrestoIcebergNestedField> columns;
+    private final Map<String, Integer> columnNameToIdMapping;
+    private final Map<String, Integer> aliases;
+    private final Set<Integer> identifierFieldIds;
+
+    @JsonCreator
+    public PrestoIcebergSchema(
+            @JsonProperty("schemaId") int schemaId,
+            @JsonProperty("columns") List<PrestoIcebergNestedField> columns,
+            @JsonProperty("columnNameToIdMapping") Map<String, Integer> columnNameToIdMapping,
+            @JsonProperty("aliases") Map<String, Integer> aliases,
+            @JsonProperty("identifierFieldIds") Set<Integer> identifierFieldIds)
+    {
+        this.schemaId = schemaId;
+        this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+        this.columnNameToIdMapping = ImmutableMap.copyOf(requireNonNull(columnNameToIdMapping, "columnNameToIdMapping is null"));
+        this.aliases = aliases != null ? ImmutableMap.copyOf(aliases) : null;
+        this.identifierFieldIds = ImmutableSet.copyOf(requireNonNull(identifierFieldIds, "identifierFieldIds is null"));
+    }
+
+    @JsonProperty
+    public int getSchemaId()
+    {
+        return schemaId;
+    }
+
+    @JsonProperty
+    public List<PrestoIcebergNestedField> getColumns()
+    {
+        return columns;
+    }
+
+    @JsonProperty
+    public Map<String, Integer> getColumnNameToIdMapping()
+    {
+        return columnNameToIdMapping;
+    }
+
+    @JsonProperty
+    public Map<String, Integer> getAliases()
+    {
+        return aliases;
+    }
+
+    @JsonProperty
+    public Set<Integer> getIdentifierFieldIds()
+    {
+        return identifierFieldIds;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(schemaId, columns, columnNameToIdMapping, aliases, identifierFieldIds);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        PrestoIcebergSchema other = (PrestoIcebergSchema) obj;
+        return Objects.equals(this.schemaId, other.schemaId) &&
+                Objects.equals(this.columns, other.columns) &&
+                Objects.equals(this.columnNameToIdMapping, other.columnNameToIdMapping) &&
+                Objects.equals(this.aliases, other.aliases) &&
+                Objects.equals(this.identifierFieldIds, other.identifierFieldIds);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SchemaConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SchemaConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.TypeManager;
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.TypeUtil;
+
+import static com.facebook.presto.iceberg.NestedFieldConverter.toIcebergNestedField;
+import static com.facebook.presto.iceberg.NestedFieldConverter.toPrestoNestedField;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public final class SchemaConverter
+{
+    private SchemaConverter() {}
+
+    public static PrestoIcebergSchema toPrestoSchema(Schema schema, TypeManager typeManager)
+    {
+        return new PrestoIcebergSchema(
+                schema.schemaId(),
+                schema.columns().stream()
+                        .map(column -> toPrestoNestedField(column, typeManager))
+                        .collect(toImmutableList()),
+                ImmutableMap.copyOf(TypeUtil.indexByName(schema.asStruct())),
+                schema.getAliases(),
+                schema.identifierFieldIds());
+    }
+
+    public static Schema toIcebergSchema(PrestoIcebergSchema schema)
+    {
+        return new Schema(
+                schema.getSchemaId(),
+                schema.getColumns().stream()
+                        .map(nestedField -> toIcebergNestedField(nestedField, schema.getColumnNameToIdMapping()))
+                        .collect(toImmutableList()),
+                schema.getAliases(),
+                schema.getIdentifierFieldIds());
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestNestedFieldConverter.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestNestedFieldConverter.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.iceberg.NestedFieldConverter.toIcebergNestedField;
+import static com.facebook.presto.iceberg.NestedFieldConverter.toPrestoNestedField;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestNestedFieldConverter
+{
+    @DataProvider(name = "allTypes")
+    public static Object[][] testAllTypes()
+    {
+        return new Object[][] {
+                {1, "boolean"},
+                {1, "integer"},
+                {1, "array"},
+                {1, "bigint"},
+                {1, "real"},
+                {1, "double"},
+                {1, "map"},
+                {1, "decimal"},
+                {1, "varchar"},
+                {1, "varbinary"},
+                {1, "row"},
+                {1, "date"},
+                {1, "nested"}
+        };
+    }
+
+    @Test(dataProvider = "allTypes")
+    public void testToPrestoNestedField(int id, String name)
+    {
+        // Create a test TypeManager
+        TypeManager typeManager = createTestFunctionAndTypeManager();
+
+        // Create a mock NestedField
+        Types.NestedField nestedField = nestedField(id, name);
+
+        PrestoIcebergNestedField expectedPrestoNestedField = prestoIcebergNestedField(id, name, typeManager);
+
+        // Convert Iceberg NestedField to Presto Nested Field
+        PrestoIcebergNestedField prestoNestedField = toPrestoNestedField(nestedField, typeManager);
+
+        // Check that the result is not null
+        assertNotNull(prestoNestedField);
+
+        assertEquals(prestoNestedField, expectedPrestoNestedField);
+    }
+
+    @Test(dataProvider = "allTypes")
+    public void testToIcebergNestedField(int id, String name)
+    {
+        // Create a test TypeManager
+        TypeManager typeManager = createTestFunctionAndTypeManager();
+
+        // Create a mock Presto Nested Field
+        PrestoIcebergNestedField prestoNestedField = prestoIcebergNestedField(id, name, typeManager);
+
+        Types.NestedField expectedNestedField = nestedField(id, name);
+
+        // Convert Presto Nested Field to Iceberg NestedField
+        Types.NestedField nestedField = toIcebergNestedField(prestoNestedField, columnNameToIdMapping(name));
+
+        // Check that the result is not null
+        assertNotNull(nestedField);
+
+        assertEquals(nestedField, expectedNestedField);
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "Cannot convert Row type field row\\(integer, varchar\\) to Iceberg")
+    public void testFailOnAnonymousRowType()
+    {
+        // Create a test TypeManager
+        TypeManager typeManager = createTestFunctionAndTypeManager();
+
+        // Create a mock Presto Nested Field
+        PrestoIcebergNestedField prestoNestedField = prestoIcebergNestedField(1, "anonymous_row", typeManager);
+
+        // Convert Presto Nested Field to Iceberg NestedField
+        Types.NestedField nestedField = toIcebergNestedField(prestoNestedField, columnNameToIdMapping("anonymous_row"));
+    }
+
+    protected static PrestoIcebergNestedField prestoIcebergNestedField(
+            int id,
+            String name,
+            TypeManager typeManager)
+    {
+        com.facebook.presto.common.type.Type prestoType;
+        switch (name) {
+            case "boolean":
+                prestoType = BOOLEAN;
+                break;
+            case "integer":
+                prestoType = INTEGER;
+                break;
+            case "array":
+                prestoType = new ArrayType(createUnboundedVarcharType());
+                break;
+            case "bigint":
+                prestoType = BIGINT;
+                break;
+            case "real":
+                prestoType = REAL;
+                break;
+            case "double":
+                prestoType = DOUBLE;
+                break;
+            case "map":
+                prestoType = typeManager.getParameterizedType(StandardTypes.MAP, ImmutableList.of(
+                        TypeSignatureParameter.of(INTEGER.getTypeSignature()),
+                        TypeSignatureParameter.of(createUnboundedVarcharType().getTypeSignature())));
+                break;
+            case "decimal":
+                prestoType = createDecimalType(5, 2);
+                break;
+            case "varchar":
+                prestoType = createUnboundedVarcharType();
+                break;
+            case "varbinary":
+                prestoType = VARBINARY;
+                break;
+            case "row":
+                prestoType = RowType.from(ImmutableList.of(
+                        RowType.field("int", INTEGER),
+                        RowType.field("varchar", createUnboundedVarcharType())));
+                break;
+            case "anonymous_row":
+                prestoType = RowType.from(ImmutableList.of(
+                        RowType.field(INTEGER),
+                        RowType.field(createUnboundedVarcharType())));
+                break;
+            case "date":
+                prestoType = DATE;
+                break;
+            case "nested":
+                prestoType = RowType.from(ImmutableList.of(
+                        RowType.field("int", INTEGER),
+                        RowType.field("varchar", createUnboundedVarcharType()),
+                        RowType.field(
+                                "row",
+                                RowType.from(ImmutableList.of(
+                                        RowType.field("int", INTEGER),
+                                        RowType.field("varchar", createUnboundedVarcharType())))),
+                        RowType.field(
+                                "map",
+                                typeManager.getParameterizedType(StandardTypes.MAP, ImmutableList.of(
+                                        TypeSignatureParameter.of(INTEGER.getTypeSignature()),
+                                        TypeSignatureParameter.of(createUnboundedVarcharType().getTypeSignature()))))));
+                break;
+            default:
+                prestoType = null;
+        }
+
+        return new PrestoIcebergNestedField(true, id, name, prestoType, Optional.empty());
+    }
+
+    protected static Types.NestedField nestedField(int id, String name)
+    {
+        Type icebergType;
+
+        switch (name) {
+            case "boolean":
+                icebergType = Types.BooleanType.get();
+                break;
+            case "integer":
+                icebergType = Types.IntegerType.get();
+                break;
+            case "array":
+                icebergType = array();
+                break;
+            case "bigint":
+                icebergType = Types.LongType.get();
+                break;
+            case "real":
+                icebergType = Types.FloatType.get();
+                break;
+            case "double":
+                icebergType = Types.DoubleType.get();
+                break;
+            case "map":
+                icebergType = map();
+                break;
+            case "decimal":
+                icebergType = decimal(5, 2);
+                break;
+            case "varchar":
+                icebergType = Types.StringType.get();
+                break;
+            case "varbinary":
+                icebergType = Types.BinaryType.get();
+                break;
+            case "row":
+                icebergType = struct();
+                break;
+            case "date":
+                icebergType = Types.DateType.get();
+                break;
+            case "nested":
+                icebergType = nested();
+                break;
+            default:
+                icebergType = null;
+        }
+
+        return optional(id, name, icebergType);
+    }
+
+    private Map<String, Integer> columnNameToIdMapping(String name)
+    {
+        Map<String, Integer> mapping = new HashMap<>();
+        switch (name) {
+            case "boolean":
+            case "integer":
+            case "bigint":
+            case "real":
+            case "double":
+            case "decimal":
+            case "varchar":
+            case "varbinary":
+            case "date":
+                mapping.put(name, 1);
+                break;
+            case "array":
+                mapping.put(name, 1);
+                mapping.put(name + ".element", 1);
+                break;
+            case "map":
+                mapping.put(name, 1);
+                mapping.put(name + ".key", 1);
+                mapping.put(name + ".value", 2);
+                break;
+            case "row":
+                mapping.put(name, 1);
+                mapping.put(name + ".int", 1);
+                mapping.put(name + ".varchar", 2);
+                break;
+            case "nested":
+                mapping.put(name, 1);
+                mapping.put(name + ".int", 1);
+                mapping.put(name + ".varchar", 2);
+                mapping.put(name + ".row", 3);
+                mapping.put(name + ".map", 4);
+                mapping.put(name + ".row.int", 1);
+                mapping.put(name + ".row.varchar", 2);
+                mapping.put(name + ".map.key", 1);
+                mapping.put(name + ".map.value", 2);
+                break;
+        }
+        return mapping;
+    }
+
+    private static Type array()
+    {
+        return Types.ListType.ofOptional(1, Types.StringType.get());
+    }
+
+    private static Type map()
+    {
+        return Types.MapType.ofOptional(1, 2, Types.IntegerType.get(), Types.StringType.get());
+    }
+
+    private static Type decimal(int precision, int scale)
+    {
+        return Types.DecimalType.of(precision, scale);
+    }
+
+    private static Type struct()
+    {
+        List<Types.NestedField> fields = new ArrayList<>();
+
+        fields.add(optional(1, "int", Types.IntegerType.get()));
+        fields.add(optional(2, "varchar", Types.StringType.get()));
+
+        return Types.StructType.of(fields);
+    }
+
+    private static Type nested()
+    {
+        List<Types.NestedField> fields = new ArrayList<>();
+
+        fields.add(optional(1, "int", Types.IntegerType.get()));
+        fields.add(optional(2, "varchar", Types.StringType.get()));
+        fields.add(optional(3, "row", struct()));
+        fields.add(optional(4, "map", map()));
+
+        return Types.StructType.of(fields);
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestPartitionSpecConverter.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestPartitionSpecConverter.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.TypeManager;
+import org.apache.iceberg.PartitionSpec;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.iceberg.PartitionSpecConverter.toIcebergPartitionSpec;
+import static com.facebook.presto.iceberg.PartitionSpecConverter.toPrestoPartitionSpec;
+import static com.facebook.presto.iceberg.TestSchemaConverter.prestoIcebergSchema;
+import static com.facebook.presto.iceberg.TestSchemaConverter.schema;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestPartitionSpecConverter
+{
+    @DataProvider(name = "allTransforms")
+    public static Object[][] testAllTransforms()
+    {
+        return new Object[][] {
+                {"identity", "varchar"},
+                {"year", "date"},
+                {"month", "date"},
+                {"day", "date"},
+                {"bucket", "bigint"},
+                {"truncate", "varchar"}
+        };
+    }
+
+    @Test(dataProvider = "allTransforms")
+    public void testToPrestoPartitionSpec(String transform, String name)
+    {
+        // Create a test TypeManager
+        TypeManager typeManager = createTestFunctionAndTypeManager();
+
+        // Create a mock PartitionSpec
+        PartitionSpec partitionSpec = partitionSpec(transform, name);
+
+        PrestoIcebergPartitionSpec expectedPrestoPartitionSpec = prestoIcebergPartitionSpec(transform, name, typeManager);
+
+        // Convert Iceberg PartitionSpec to Presto Iceberg Partition Spec
+        PrestoIcebergPartitionSpec prestoIcebergPartitionSpec = toPrestoPartitionSpec(partitionSpec, typeManager);
+
+        // Check that the result is not null
+        assertNotNull(prestoIcebergPartitionSpec);
+
+        assertEquals(prestoIcebergPartitionSpec, expectedPrestoPartitionSpec);
+    }
+
+    @Test(dataProvider = "allTransforms")
+    public void testToIcebergPartitionSpec(String transform, String name)
+    {
+        // Create a test TypeManager
+        TypeManager typeManager = createTestFunctionAndTypeManager();
+
+        // Create a mock PartitionSpec
+        PrestoIcebergPartitionSpec prestoPartitionSpec = prestoIcebergPartitionSpec(transform, name, typeManager);
+
+        PartitionSpec expectedPartitionSpec = partitionSpec(transform, name);
+
+        // Convert Presto Partition Spec to Iceberg PartitionSpec
+        PartitionSpec partitionSpec = toIcebergPartitionSpec(prestoPartitionSpec);
+
+        // Check that the result is not null
+        assertNotNull(partitionSpec);
+
+        assertEquals(partitionSpec, expectedPartitionSpec);
+    }
+
+    @Test(dataProvider = "allTransforms")
+    public void validateConversion(String transform, String name)
+    {
+        // Create a test TypeManager
+        TypeManager typeManager = createTestFunctionAndTypeManager();
+
+        // Original Iceberg PartitionSpec
+        PartitionSpec originalPartitionSpec = partitionSpec(transform, name);
+
+        // Convert to Presto Partition Spec
+        PrestoIcebergPartitionSpec prestoIcebergPartitionSpec = toPrestoPartitionSpec(originalPartitionSpec, typeManager);
+
+        // Convert PrestoIcebergPartitionSpec back into Iceberg PartitionSpec
+        PartitionSpec finalPartitionSpec = toIcebergPartitionSpec(prestoIcebergPartitionSpec);
+
+        assertNotNull(finalPartitionSpec);
+
+        assertEquals(originalPartitionSpec, finalPartitionSpec);
+
+        assertTrue(originalPartitionSpec.schema().sameSchema(finalPartitionSpec.schema()));
+    }
+
+    private static PrestoIcebergPartitionSpec prestoIcebergPartitionSpec(String transform, String name, TypeManager typeManager)
+    {
+        List<String> fields = new ArrayList<>();
+
+        switch (transform) {
+            case "identity":
+                fields.add(name);
+                break;
+            case "year":
+            case "month":
+            case "day":
+                fields.add(format("%s(%s)", transform, name));
+                break;
+            case "bucket":
+            case "truncate":
+                fields.add(format("%s(%s, 3)", transform, name));
+                break;
+        }
+
+        return new PrestoIcebergPartitionSpec(0, prestoIcebergSchema(typeManager), fields);
+    }
+
+    private static PartitionSpec partitionSpec(String transform, String name)
+    {
+        PartitionSpec.Builder builder = PartitionSpec.builderFor(schema()).withSpecId(0);
+
+        switch (transform) {
+            case "identity":
+                builder.identity(name);
+                break;
+            case "year":
+                builder.year(name);
+                break;
+            case "month":
+                builder.month(name);
+                break;
+            case "day":
+                builder.day(name);
+                break;
+            case "bucket":
+                builder.bucket(name, 3);
+                break;
+            case "truncate":
+                builder.truncate(name, 3);
+                break;
+        }
+
+        return builder.build();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestSchemaConverter.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestSchemaConverter.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.TypeManager;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.facebook.presto.iceberg.TestNestedFieldConverter.nestedField;
+import static com.facebook.presto.iceberg.TestNestedFieldConverter.prestoIcebergNestedField;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static java.util.Collections.emptySet;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestSchemaConverter
+{
+    @Test
+    public void testToPrestoSchema()
+    {
+        // Create a test TypeManager
+        TypeManager typeManager = createTestFunctionAndTypeManager();
+
+        // Create a mock Schema
+        Schema mockSchema = schema();
+
+        PrestoIcebergSchema expectedPrestoIcebergSchema = prestoIcebergSchema(typeManager);
+
+        // Convert to PrestoIcebergSchema
+        PrestoIcebergSchema prestoSchema = SchemaConverter.toPrestoSchema(mockSchema, typeManager);
+
+        // Check that the result is not null
+        assertNotNull(prestoSchema);
+
+        assertEquals(prestoSchema, expectedPrestoIcebergSchema);
+    }
+
+    @Test
+    public void testToIcebergSchema()
+    {
+        // Create a test TypeManager
+        TypeManager typeManager = createTestFunctionAndTypeManager();
+
+        // Create a mock Presto Iceberg Schema
+        PrestoIcebergSchema prestoSchema = prestoIcebergSchema(typeManager);
+
+        Schema expectedIcebergSchema = schema();
+
+        // Convert Presto Iceberg Schema to Iceberg Schema
+        Schema schema = SchemaConverter.toIcebergSchema(prestoSchema);
+
+        // Check that the result is not null
+        assertNotNull(schema);
+
+        assertTrue(schema.sameSchema(expectedIcebergSchema));
+    }
+
+    protected static PrestoIcebergSchema prestoIcebergSchema(TypeManager typeManager)
+    {
+        List<PrestoIcebergNestedField> columns = new ArrayList<>(Arrays.asList(
+                prestoIcebergNestedField(1, "boolean", typeManager),
+                prestoIcebergNestedField(2, "integer", typeManager),
+                prestoIcebergNestedField(3, "array", typeManager),
+                prestoIcebergNestedField(4, "bigint", typeManager),
+                prestoIcebergNestedField(5, "real", typeManager),
+                prestoIcebergNestedField(6, "double", typeManager),
+                prestoIcebergNestedField(7, "map", typeManager),
+                prestoIcebergNestedField(8, "decimal", typeManager),
+                prestoIcebergNestedField(9, "varchar", typeManager),
+                prestoIcebergNestedField(10, "varbinary", typeManager),
+                prestoIcebergNestedField(11, "row", typeManager),
+                prestoIcebergNestedField(12, "date", typeManager)));
+
+        Map<String, Integer> columnNameToIdMapping = getColumnNameToIdMapping();
+
+        return new PrestoIcebergSchema(0, columns, columnNameToIdMapping, null, emptySet());
+    }
+
+    private static Map<String, Integer> getColumnNameToIdMapping()
+    {
+        Map<String, Integer> columnNameToIdMapping = new HashMap<>();
+        columnNameToIdMapping.put("boolean", 1);
+        columnNameToIdMapping.put("integer", 2);
+        columnNameToIdMapping.put("array", 3);
+        columnNameToIdMapping.put("bigint", 4);
+        columnNameToIdMapping.put("real", 5);
+        columnNameToIdMapping.put("double", 6);
+        columnNameToIdMapping.put("map", 7);
+        columnNameToIdMapping.put("decimal", 8);
+        columnNameToIdMapping.put("varchar", 9);
+        columnNameToIdMapping.put("varbinary", 10);
+        columnNameToIdMapping.put("row", 11);
+        columnNameToIdMapping.put("date", 12);
+        columnNameToIdMapping.put("array.element", 13);
+        columnNameToIdMapping.put("map.key", 14);
+        columnNameToIdMapping.put("map.value", 15);
+        columnNameToIdMapping.put("row.int", 16);
+        columnNameToIdMapping.put("row.varchar", 17);
+
+        return columnNameToIdMapping;
+    }
+
+    protected static Schema schema()
+    {
+        List<NestedField> fields = new ArrayList<>(Arrays.asList(
+                nestedField(1, "boolean"),
+                nestedField(2, "integer"),
+                nestedField(3, "array"),
+                nestedField(4, "bigint"),
+                nestedField(5, "real"),
+                nestedField(6, "double"),
+                nestedField(7, "map"),
+                nestedField(8, "decimal"),
+                nestedField(9, "varchar"),
+                nestedField(10, "varbinary"),
+                nestedField(11, "row"),
+                nestedField(12, "date")));
+
+        Type schemaAsStruct = Types.StructType.of(fields);
+        AtomicInteger nextFieldId = new AtomicInteger(1);
+        schemaAsStruct = TypeUtil.assignFreshIds(schemaAsStruct, nextFieldId::getAndIncrement);
+
+        return new Schema(schemaAsStruct.asStructType().fields());
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
As part of an ongoing effort to support iceberg writes in Presto C++, since we don't have iceberg C++ library support to parse the JSON strings for Schema and PartitionSpec, we will send the respective Presto wrapper classes as part of the IcebergInsertTableHandle and InsertOutputTableHandle

Depends on #23172 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
To prevent re-implementing JSON parsers for Iceberg Schema and Iceberg PartitionSpec in Presto C++ and eliminate the need to maintain the code with a fast-paced iceberg library, we have created wrapper classes and sending them instead of the JSON strings to workers during writes.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No user impact

## Test Plan
<!---Please fill in how you tested your change-->
CI build pipelines and manually verified writing partitioned and non-partitioned iceberg tables using Java Workers to ensure no impact.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== NO RELEASE NOTE ==
```

