### PR TITLE
[Iceberg] Add table refresh retry configurations

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -12,8 +12,8 @@ Metastores
 Iceberg tables store most of the metadata in the metadata files, along with the data on the
 filesystem, but it still requires a central place to find the current location of the
 current metadata pointer for a table. This central place is called the ``Iceberg Catalog``.
-The Presto Iceberg connector supports different types of Iceberg Catalogs : ``Hive Metastore``,
-``GLUE``, ``NESSIE``, ``REST`` and ``HADOOP``.
+The Presto Iceberg connector supports different types of Iceberg Catalogs : ``HIVE``,
+``NESSIE``, ``REST``, and ``HADOOP``.
 
 To configure the Iceberg connector, create a catalog properties file
 ``etc/catalog/iceberg.properties``. To define the catalog type, ``iceberg.catalog.type`` property
@@ -44,6 +44,48 @@ as a Hive connector.
     connector.name=iceberg
     hive.metastore=glue
     iceberg.catalog.type=hive
+
+There are additional configurations available when using the Iceberg connector configured with Hive
+or Glue catalogs.
+
+======================================================== ============================================================= ============
+Property Name                                            Description                                                   Default
+======================================================== ============================================================= ============
+``hive.metastore.uri``                                   The URI(s) of the Hive metastore to connect to using the
+                                                         Thrift protocol. If multiple URIs are provided, the first
+                                                         URI is used by default, and the rest of the URIs are
+                                                         fallback metastores.
+
+                                                         Example: ``thrift://192.0.2.3:9083`` or
+                                                         ``thrift://192.0.2.3:9083,thrift://192.0.2.4:9083``.
+
+                                                         This property is required if the
+                                                         ``iceberg.catalog.type`` is ``hive`` and ``hive.metastore``
+                                                         is ``thrift``.
+
+``iceberg.hive-statistics-merge-strategy``               Comma separated list of statistics to use from the
+                                                         Hive Metastore to override Iceberg table statistics.
+                                                         The available values are ``NUMBER_OF_DISTINCT_VALUES``
+                                                         and ``TOTAL_SIZE_IN_BYTES``.
+
+                                                         **Note**: Only valid when the Iceberg connector is
+                                                         configured with Hive.
+
+``iceberg.hive.table-refresh.backoff-min-sleep-time``    The minimum amount of time to sleep between retries when      100ms
+                                                         refreshing table metadata.
+
+``iceberg.hive.table-refresh.backoff-max-sleep-time``    The maximum amount of time to sleep between retries when      5s
+                                                         refreshing table metadata.
+
+``iceberg.hive.table-refresh.max-retry-time``            The maximum amount of time to take across all retries before  1min
+                                                         failing a table metadata refresh operation.
+
+``iceberg.hive.table-refresh.retries``                   The number of times to retry after errors when refreshing     20
+                                                         table metadata using the Hive metastore.
+
+``iceberg.hive.table-refresh.backoff-scale-factor``      The multiple used to scale subsequent wait time between       4.0
+                                                         retries.
+======================================================== ============================================================= ============
 
 Nessie catalog
 ^^^^^^^^^^^^^^
@@ -194,35 +236,11 @@ To use a Hadoop catalog, configure the catalog type as
     iceberg.catalog.type=hadoop
     iceberg.catalog.warehouse=hdfs://hostname:port
 
-Configuration Properties
-------------------------
-
-.. note::
-
-    The Iceberg connector supports configuration options for
-    `Amazon S3 <https://prestodb.io/docs/current/connector/hive.html##amazon-s3-configuration>`_
-    as a Hive connector.
-
-The following configuration properties are available:
+Hadoop catalog configuration properties:
 
 ======================================================= ============================================================= ============
 Property Name                                           Description                                                   Default
 ======================================================= ============================================================= ============
-``hive.metastore.uri``                                  The URI(s) of the Hive metastore to connect to using the
-                                                        Thrift protocol. If multiple URIs are provided, the first
-                                                        URI is used by default, and the rest of the URIs are
-                                                        fallback metastores.
-
-                                                        Example: ``thrift://192.0.2.3:9083`` or
-                                                        ``thrift://192.0.2.3:9083,thrift://192.0.2.4:9083``.
-
-                                                        This property is required if the
-                                                        ``iceberg.catalog.type`` is ``hive``. Otherwise, it will
-                                                        be ignored.
-
-``iceberg.catalog.type``                                The catalog type for Iceberg tables. The available values     ``hive``
-                                                        are ``hive``, ``hadoop``, and ``nessie``.
-
 ``iceberg.catalog.warehouse``                           The catalog warehouse root path for Iceberg tables.
 
                                                         Example: ``hdfs://nn:8020/warehouse/path``
@@ -232,6 +250,24 @@ Property Name                                           Description             
 ``iceberg.catalog.cached-catalog-num``                  The number of Iceberg catalogs to cache. This property is     ``10``
                                                         required if the ``iceberg.catalog.type`` is ``hadoop``.
                                                         Otherwise, it will be ignored.
+======================================================= ============================================================= ============
+
+Configuration Properties
+------------------------
+
+.. note::
+
+    The Iceberg connector supports configuration options for
+    `Amazon S3 <https://prestodb.io/docs/current/connector/hive.html##amazon-s3-configuration>`_
+    as a Hive connector.
+
+The following configuration properties are available for all catalog types:
+
+======================================================= ============================================================= ============
+Property Name                                           Description                                                   Default
+======================================================= ============================================================= ============
+``iceberg.catalog.type``                                The catalog type for Iceberg tables. The available values     ``HIVE``
+                                                        are ``HIVE``, ``HADOOP``, and ``NESSIE`` and ``REST``.
 
 ``iceberg.hadoop.config.resources``                     The path(s) for Hadoop configuration resources.
 
@@ -261,14 +297,6 @@ Property Name                                           Description             
                                                         as a join with the data of the equality delete files.
 
 ``iceberg.enable-parquet-dereference-pushdown``         Enable parquet dereference pushdown.                          ``true``
-
-``iceberg.hive-statistics-merge-strategy``              Comma separated list of statistics to use from the
-                                                        Hive Metastore to override Iceberg table statistics.
-                                                        The available values are ``NUMBER_OF_DISTINCT_VALUES``
-                                                        and ``TOTAL_SIZE_IN_BYTES``.
-
-                                                        **Note**: Only valid when the Iceberg connector is
-                                                        configured with Hive.
 
 ``iceberg.statistic-snapshot-record-difference-weight`` The amount that the difference in total record count matters
                                                         when calculating the closest snapshot when picking

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -151,8 +151,8 @@ public class IcebergHiveMetadata
     private final ExtendedHiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final DateTimeZone timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(TimeZone.getDefault().getID())));
-
     private final FilterStatsCalculatorService filterStatsCalculatorService;
+    private final IcebergHiveTableOperationsConfig hiveTableOeprationsConfig;
 
     public IcebergHiveMetadata(
             ExtendedHiveMetastore metastore,
@@ -162,12 +162,14 @@ public class IcebergHiveMetadata
             RowExpressionService rowExpressionService,
             JsonCodec<CommitTaskData> commitTaskCodec,
             NodeVersion nodeVersion,
-            FilterStatsCalculatorService filterStatsCalculatorService)
+            FilterStatsCalculatorService filterStatsCalculatorService,
+            IcebergHiveTableOperationsConfig hiveTableOeprationsConfig)
     {
         super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, nodeVersion);
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
+        this.hiveTableOeprationsConfig = requireNonNull(hiveTableOeprationsConfig, "hiveTableOperationsConfig is null");
     }
 
     public ExtendedHiveMetastore getMetastore()
@@ -178,7 +180,7 @@ public class IcebergHiveMetadata
     @Override
     protected org.apache.iceberg.Table getRawIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        return getHiveIcebergTable(metastore, hdfsEnvironment, session, schemaTableName);
+        return getHiveIcebergTable(metastore, hdfsEnvironment, hiveTableOeprationsConfig, session, schemaTableName);
     }
 
     @Override
@@ -296,6 +298,7 @@ public class IcebergHiveMetadata
                 getMetastoreContext(session),
                 hdfsEnvironment,
                 hdfsContext,
+                hiveTableOeprationsConfig,
                 schemaName,
                 tableName,
                 session.getUser(),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
@@ -38,6 +38,7 @@ public class IcebergHiveMetadataFactory
     final RowExpressionService rowExpressionService;
     final NodeVersion nodeVersion;
     final FilterStatsCalculatorService filterStatsCalculatorService;
+    final IcebergHiveTableOperationsConfig operationsConfig;
 
     @Inject
     public IcebergHiveMetadataFactory(
@@ -48,7 +49,8 @@ public class IcebergHiveMetadataFactory
             RowExpressionService rowExpressionService,
             JsonCodec<CommitTaskData> commitTaskCodec,
             NodeVersion nodeVersion,
-            FilterStatsCalculatorService filterStatsCalculatorService)
+            FilterStatsCalculatorService filterStatsCalculatorService,
+            IcebergHiveTableOperationsConfig operationsConfig)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -58,10 +60,20 @@ public class IcebergHiveMetadataFactory
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
+        this.operationsConfig = requireNonNull(operationsConfig, "operationsConfig is null");
     }
 
     public ConnectorMetadata create()
     {
-        return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, functionResolution, rowExpressionService, commitTaskCodec, nodeVersion, filterStatsCalculatorService);
+        return new IcebergHiveMetadata(
+                metastore,
+                hdfsEnvironment,
+                typeManager,
+                functionResolution,
+                rowExpressionService,
+                commitTaskCodec,
+                nodeVersion,
+                filterStatsCalculatorService,
+                operationsConfig);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
@@ -49,6 +49,7 @@ public class IcebergHiveModule
     {
         install(new HiveMetastoreModule(this.connectorId, this.metastore));
         binder.bind(ExtendedHiveMetastore.class).to(InMemoryCachingHiveMetastore.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(IcebergHiveTableOperationsConfig.class);
 
         configBinder(binder).bindConfig(MetastoreClientConfig.class);
         binder.bind(PartitionMutator.class).to(HivePartitionMutator.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveTableOperationsConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveTableOperationsConfig.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+
+import static io.airlift.units.Duration.succinctDuration;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class IcebergHiveTableOperationsConfig
+{
+    private Duration tableRefreshBackoffMinSleepTime = succinctDuration(100, MILLISECONDS);
+    private Duration tableRefreshBackoffMaxSleepTime = succinctDuration(5, SECONDS);
+    private Duration tableRefreshMaxRetryTime = succinctDuration(1, MINUTES);
+    private double tableRefreshBackoffScaleFactor = 4.0;
+    private int tableRefreshRetries = 20;
+
+    @MinDuration("1ms")
+    public Duration getTableRefreshBackoffMinSleepTime()
+    {
+        return tableRefreshBackoffMinSleepTime;
+    }
+
+    @Config("iceberg.hive.table-refresh.backoff-min-sleep-time")
+    @ConfigDescription("The minimum amount of time to sleep between retries when refreshing table metadata")
+    public IcebergHiveTableOperationsConfig setTableRefreshBackoffMinSleepTime(Duration tableRefreshBackoffMinSleepTime)
+    {
+        this.tableRefreshBackoffMinSleepTime = tableRefreshBackoffMinSleepTime;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getTableRefreshBackoffMaxSleepTime()
+    {
+        return tableRefreshBackoffMaxSleepTime;
+    }
+
+    @Config("iceberg.hive.table-refresh.backoff-max-sleep-time")
+    @ConfigDescription("The maximum amount of time to sleep between retries when refreshing table metadata")
+    public IcebergHiveTableOperationsConfig setTableRefreshBackoffMaxSleepTime(Duration tableRefreshBackoffMaxSleepTime)
+    {
+        this.tableRefreshBackoffMaxSleepTime = tableRefreshBackoffMaxSleepTime;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getTableRefreshMaxRetryTime()
+    {
+        return tableRefreshMaxRetryTime;
+    }
+
+    @Config("iceberg.hive.table-refresh.max-retry-time")
+    @ConfigDescription("The maximum amount of time to take across all retries before failing a table metadata refresh operation")
+    public IcebergHiveTableOperationsConfig setTableRefreshMaxRetryTime(Duration tableRefreshMaxRetryTime)
+    {
+        this.tableRefreshMaxRetryTime = tableRefreshMaxRetryTime;
+        return this;
+    }
+
+    @Min(1)
+    public double getTableRefreshBackoffScaleFactor()
+    {
+        return tableRefreshBackoffScaleFactor;
+    }
+
+    @Config("iceberg.hive.table-refresh.backoff-scale-factor")
+    @ConfigDescription("The multiple used to scale subsequent wait time between retries")
+    public IcebergHiveTableOperationsConfig setTableRefreshBackoffScaleFactor(double tableRefreshBackoffScaleFactor)
+    {
+        this.tableRefreshBackoffScaleFactor = tableRefreshBackoffScaleFactor;
+        return this;
+    }
+
+    @Config("iceberg.hive.table-refresh.retries")
+    @ConfigDescription("The number of times to retry after errors when refreshing table metadata using the Hive metastore")
+    public IcebergHiveTableOperationsConfig setTableRefreshRetries(int tableRefreshRetries)
+    {
+        this.tableRefreshRetries = tableRefreshRetries;
+        return this;
+    }
+
+    @Min(0)
+    public int getTableRefreshRetries()
+    {
+        return tableRefreshRetries;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -216,7 +216,7 @@ public final class IcebergUtil
         return icebergMetadata.getIcebergTable(session, table);
     }
 
-    public static Table getHiveIcebergTable(ExtendedHiveMetastore metastore, HdfsEnvironment hdfsEnvironment, ConnectorSession session, SchemaTableName table)
+    public static Table getHiveIcebergTable(ExtendedHiveMetastore metastore, HdfsEnvironment hdfsEnvironment, IcebergHiveTableOperationsConfig config, ConnectorSession session, SchemaTableName table)
     {
         HdfsContext hdfsContext = new HdfsContext(session, table.getSchemaName(), table.getTableName());
         TableOperations operations = new HiveTableOperations(
@@ -224,6 +224,7 @@ public final class IcebergUtil
                 new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getClientTags(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER, session.getWarningCollector(), session.getRuntimeStats()),
                 hdfsEnvironment,
                 hdfsContext,
+                config,
                 table.getSchemaName(),
                 table.getTableName());
         return new BaseTable(operations, quotedTableName(table));

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -941,7 +941,6 @@ public abstract class IcebergDistributedTestBase
             // assert either case as we don't have good control over the timing of when statistics files are written
             ColumnStatistics col0Stats = columnStatsFor(statistics, "col0");
             ColumnStatistics col1Stats = columnStatsFor(statistics, "col1");
-            System.out.printf("distinct @ %s count col0: %s%n", snaps.get(i), col0Stats.getDistinctValuesCount());
             final int idx = i;
             assertEither(
                     () -> assertEquals(col0Stats.getDistinctValuesCount(), Estimate.of(idx)),

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
@@ -61,6 +61,7 @@ public class TestIcebergMetadataListing
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
                 .put("hive.metastore", "file")
                 .put("hive.metastore.catalog.dir", catalogDirectory.toFile().toURI().toString())
+                .put("iceberg.hive.table-refresh.max-retry-time", "500ms") // improves test time for testTableDropWithMissingMetadata
                 .build();
 
         queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
@@ -135,7 +136,7 @@ public class TestIcebergMetadataListing
         }
         tableMetadataDir.delete();
 
-        assertQueryFails("SELECT * FROM iceberg.test_metadata_schema.iceberg_table1", "Could not read table schema");
+        assertQueryFails("SELECT * FROM iceberg.test_metadata_schema.iceberg_table1", "Table metadata is missing");
         assertQuerySucceeds("DROP TABLE iceberg.test_metadata_schema.iceberg_table1");
         assertQuery("SHOW TABLES FROM iceberg.test_metadata_schema", "VALUES 'iceberg_table2'");
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestHiveTableOperationsConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestHiveTableOperationsConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.hive;
+
+import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.Duration.succinctDuration;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestHiveTableOperationsConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(IcebergHiveTableOperationsConfig.class)
+                .setTableRefreshBackoffMinSleepTime(succinctDuration(100, MILLISECONDS))
+                .setTableRefreshBackoffMaxSleepTime(succinctDuration(5, SECONDS))
+                .setTableRefreshMaxRetryTime(succinctDuration(1, MINUTES))
+                .setTableRefreshBackoffScaleFactor(4.0)
+                .setTableRefreshRetries(20));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("iceberg.hive.table-refresh.backoff-min-sleep-time", "10s")
+                .put("iceberg.hive.table-refresh.backoff-max-sleep-time", "20s")
+                .put("iceberg.hive.table-refresh.max-retry-time", "30s")
+                .put("iceberg.hive.table-refresh.retries", "42")
+                .put("iceberg.hive.table-refresh.backoff-scale-factor", "2.0")
+                .build();
+
+        IcebergHiveTableOperationsConfig expected = new IcebergHiveTableOperationsConfig()
+                .setTableRefreshBackoffMinSleepTime(succinctDuration(10, SECONDS))
+                .setTableRefreshBackoffMaxSleepTime(succinctDuration(20, SECONDS))
+                .setTableRefreshMaxRetryTime(succinctDuration(30, SECONDS))
+                .setTableRefreshBackoffScaleFactor(2.0)
+                .setTableRefreshRetries(42);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergDistributedHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergDistributedHive.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg.hive;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.iceberg.IcebergDistributedTestBase;
+import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.spi.ConnectorId;
@@ -66,6 +67,7 @@ public class TestIcebergDistributedHive
 
         return IcebergUtil.getHiveIcebergTable(getFileHiveMetastore(),
                 getHdfsEnvironment(),
+                new IcebergHiveTableOperationsConfig(),
                 getQueryRunner().getDefaultSession().toConnectorSession(connectorId),
                 SchemaTableName.valueOf("tpch." + tableName));
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
@@ -24,6 +24,7 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
+import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
@@ -78,6 +79,7 @@ public class TestIcebergSmokeHive
     {
         return IcebergUtil.getHiveIcebergTable(getFileHiveMetastore(),
                 getHdfsEnvironment(),
+                new IcebergHiveTableOperationsConfig(),
                 session,
                 SchemaTableName.valueOf(schema + "." + tableName));
     }


### PR DESCRIPTION
## Description

1. Add configurations for the table refresh retries inside of `HiveTableOperations`
2. Catch and rethrow the original exception when all retries on table refresh fail.
3. Fix a test which executed very slowly (6 minutes -> 3 seconds!) due to not being able to configure these retries

## Motivation and Context

We have a test which takes a long time to finish due to this retry being unconfigurable. Additionally, there have been community reports where the errors are opaque and queries hang due to this retry.

Adding a configuration and error logging should help determine root causes and allow users to improve the behavior of query hangs by specifying these configuration properties.

## Impact

Additional configurations available in the Iceberg connector.

## Test Plan

- Added relevant configuration tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* The Iceberg connector when configured with Hive, can now configure table metadata refresh timeouts. See documentation for details.
```

