### PR TITLE
Fix cte consumer cost calculation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.CteReferenceNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.JoinDistributionType;
 import com.facebook.presto.spi.plan.LimitNode;
@@ -174,6 +175,12 @@ public class CostCalculatorUsingExchanges
         {
             LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node));
             return costForSource(node, localCost);
+        }
+
+        @Override
+        public PlanCostEstimate visitCteReference(CteReferenceNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
@@ -172,7 +172,8 @@ public class CostCalculatorUsingExchanges
         @Override
         public PlanCostEstimate visitCteConsumer(CteConsumerNode node, Void context)
         {
-            return node.getOriginalSource().accept(this, context);
+            LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node).getOutputSizeInBytes(node));
+            return costForSource(node, localCost);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/cost/CteReferenceStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CteReferenceStatsRule.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.CteReferenceNode;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.plan.Patterns.cteReference;
+
+public class CteReferenceStatsRule
+        implements ComposableStatsCalculator.Rule<CteReferenceNode>
+{
+    private static final Pattern<CteReferenceNode> PATTERN = cteReference();
+
+    @Override
+    public Pattern<CteReferenceNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(CteReferenceNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
+    {
+        return Optional.of(sourceStats.getStats(node.getSource()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
@@ -84,6 +84,7 @@ public class StatsCalculatorModule
         rules.add(new SequenceStatsRule());
         rules.add(new CteProducerStatsRule());
         rules.add(new CteConsumerStatsRule());
+        rules.add(new CteReferenceStatsRule());
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.plan.AggregationNode.GroupingSetDescriptor;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.CteReferenceNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -850,6 +851,12 @@ public class CanonicalPlanGenerator
     public Optional<PlanNode> visitCteConsumer(CteConsumerNode node, Context context)
     {
         return node.getOriginalSource().accept(this, context);
+    }
+
+    @Override
+    public Optional<PlanNode> visitCteReference(CteReferenceNode node, Context context)
+    {
+        return node.getSource().accept(this, context);
     }
 
     private Aggregation getCanonicalAggregation(Aggregation aggregation, Map<VariableReferenceExpression, VariableReferenceExpression> context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -18,6 +18,7 @@ import com.facebook.presto.matching.Property;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.CteReferenceNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IntersectNode;
 import com.facebook.presto.spi.plan.JoinType;
@@ -133,6 +134,11 @@ public class Patterns
     public static Pattern<CteConsumerNode> cteConsumer()
     {
         return typeOf(CteConsumerNode.class);
+    }
+
+    public static Pattern<CteReferenceNode> cteReference()
+    {
+        return typeOf(CteReferenceNode.class);
     }
 
     public static Pattern<SequenceNode> sequenceNode()

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -473,15 +473,11 @@ public class TestCostCalculator
                 new PlanNodeId("cteConsumer"),
                 ts1.getOutputVariables(),
                 "test_cte", ts1);
+        // This just symbolizes that the tablescan(original planNode) was more expensive but we used the stats from the stats store
         Map<String, PlanNodeStatsEstimate> stats = ImmutableMap.of(
-                "ts1", statsEstimate(ts1, 4000));
-        Map<String, PlanCostEstimate> costs = ImmutableMap.of(
-                "ts1", new PlanCostEstimate(1000, 10, 10, 1000));
-        assertCost(cteConsumerNode, costs, stats)
-                .cpu(4500)
-                .memory(0)
-                .network(0);
-        assertCost(cteConsumerNode, costs, stats)
+                "cteConsumer", statsEstimate(ts1, 4000),
+                "ts1", statsEstimate(ts1, 10000000));
+        assertCost(cteConsumerNode, ImmutableMap.of(), stats)
                 .cpu(4500)
                 .memory(0)
                 .network(0);

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.CteReferenceNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.JoinDistributionType;
 import com.facebook.presto.spi.plan.JoinType;
@@ -481,6 +482,20 @@ public class TestCostCalculator
                 .cpu(4500)
                 .memory(0)
                 .network(0);
+    }
+
+    @Test
+    public void testCteReferenceCost()
+    {
+        TableScanNode ts1 = tableScan("ts1", "orderkey");
+        CteReferenceNode cteReferenceNode = new CteReferenceNode(
+                Optional.empty(),
+                new PlanNodeId("cteReference"),
+                ts1,
+                "test");
+        Map<String, PlanNodeStatsEstimate> stats = ImmutableMap.of(
+                "ts1", statsEstimate(ts1, 4000));
+        assertCost(cteReferenceNode, ImmutableMap.of(), stats);
     }
 
     @Test


### PR DESCRIPTION
## Description
2 commits
1. Fixes cost calculation for CTE Consumer Nodes. Previously the cost of cte consumer nodes was taken as the original source cost, however thats not true since its just a tablescan.
We can use the stats calculator (which uses the original source stats [here](https://github.com/prestodb/presto/blob/98988861d4f11295ef88549a7d4c254d47b9ac0e/presto-main/src/main/java/com/facebook/presto/cost/CteConsumerStatsRule.java#L26))  to get the stats and then use the cost of the source.
2.  Adds cost calculation for cteReference which is just for completeleness right now but maybe useful when doing the auto replacement



## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

