### PR TITLE
[docs] Add DBeaver documentation to /clients/

### DIFF
--- a/presto-docs/src/main/sphinx/clients.rst
+++ b/presto-docs/src/main/sphinx/clients.rst
@@ -7,3 +7,4 @@ Presto Clients
 
     clients/presto-cli
     clients/presto-console
+    clients/dbeaver

--- a/presto-docs/src/main/sphinx/clients/dbeaver.rst
+++ b/presto-docs/src/main/sphinx/clients/dbeaver.rst
@@ -1,0 +1,29 @@
+=======
+DBeaver
+=======
+
+`DBeaver <https://dbeaver.io/>`_ is a multiplatform open source database tool. Follow these steps to configure DBeaver to query Presto.
+
+Install and Run DBeaver
+=======================
+
+Download and install DBeaver from `DBeaver Download <https://dbeaver.io/download/>`_, then launch DBeaver.
+
+Configure DBeaver
+=================
+
+1. In DBeaver, select **Database** > **New Database Connection**. 
+
+2. Select **PrestoDB**, then **Next**. If the **Main** tab is not selected, select it. 
+
+3. If the Presto server is not running locally, select **URL** and edit the default value in **JDBC URL**. 
+
+4. In **Username**, enter a user name - the default is `admin`. 
+
+5. Select **Test Connection**. 
+
+   Note: You may be prompted to download a driver. If needed, follow the prompts in the popup **Driver settings** window to do so. 
+
+   When successful, a **Connection test** window is displayed that shows "Connected".
+
+6. Select **Finish**. 


### PR DESCRIPTION
## Description
Add documentation how to configure [DBeaver](https://dbeaver.io/) to connect to Presto.

## Motivation and Context
Expands the number of clients documented for use with Presto, and builds on #23188.

## Impact
Documentation.

## Test Plan
* Tested and developed the steps in the documentation with a locally running Presto server and a locally running DBeaver Community instance.
* Tested the documentation with a local doc build.


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... Add :doc:`/clients/dbeaver` documentation :pr:`23189`
```