### PR TITLE
[native] Add support for cache periodic full persistence

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -119,6 +119,14 @@ bool isCacheTtlEnabled() {
   return false;
 }
 
+bool isCachePeriodicFullPersistenceEnabled() {
+  const auto* systemConfig = SystemConfig::instance();
+  return systemConfig->asyncDataCacheEnabled() &&
+      systemConfig->asyncCacheSsdGb() > 0 &&
+      systemConfig->asyncCacheFullPersistenceInterval() >
+      std::chrono::seconds::zero();
+}
+
 } // namespace
 
 std::string nodeState2String(NodeState nodeState) {
@@ -944,6 +952,49 @@ void PrestoServer::addServerPeriodicTasks() {
         },
         ttlCheckInterval,
         "cache_ttl");
+  }
+
+  if (isCachePeriodicFullPersistenceEnabled()) {
+    PRESTO_STARTUP_LOG(INFO)
+        << "Initializing cache periodic full persistence task...";
+    auto* cache = velox::cache::AsyncDataCache::getInstance();
+    VELOX_CHECK_NOT_NULL(cache);
+    auto* ssdCache = cache->ssdCache();
+    VELOX_CHECK_NOT_NULL(ssdCache);
+    const auto* systemConfig = SystemConfig::instance();
+    const int64_t cacheFullPersistenceIntervalUs =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            systemConfig->asyncCacheFullPersistenceInterval())
+            .count();
+    const auto asyncCacheSsdCheckpointGb =
+        systemConfig->asyncCacheSsdCheckpointGb();
+    periodicTaskManager_->addTask(
+        [asyncCacheSsdCheckpointGb, cache, ssdCache]() {
+          try {
+            if (!ssdCache->startWrite()) {
+              return;
+            }
+            LOG(INFO) << "Persisting full cache to SSD...";
+            cache->saveToSsd(true);
+            ssdCache->waitForWriteToFinish();
+            LOG(INFO) << "Cache full persistence completed.";
+
+            if (asyncCacheSsdCheckpointGb == 0) {
+              return;
+            }
+
+            if (!ssdCache->startWrite()) {
+              return;
+            }
+
+            ssdCache->checkpoint();
+            ssdCache->waitForWriteToFinish();
+          } catch (const std::exception& e) {
+            LOG(ERROR) << "Failed to persistent cache to SSD: " << e.what();
+          }
+        },
+        cacheFullPersistenceIntervalUs,
+        "cache_full_persistence");
   }
 }
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -189,6 +189,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kAsyncCacheMaxSsdWriteRatio, 0.7),
           NUM_PROP(kAsyncCacheSsdSavableRatio, 0.125),
           NUM_PROP(kAsyncCacheMinSsdSavableBytes, 1 << 24 /*16MB*/),
+          STR_PROP(kAsyncCacheFullPersistenceInterval, "0s"),
           BOOL_PROP(kAsyncCacheSsdDisableFileCow, false),
           BOOL_PROP(kSsdCacheChecksumEnabled, false),
           BOOL_PROP(kSsdCacheReadVerificationEnabled, false),
@@ -468,6 +469,12 @@ double SystemConfig::asyncCacheSsdSavableRatio() const {
 
 int32_t SystemConfig::asyncCacheMinSsdSavableBytes() const {
   return optionalProperty<int32_t>(kAsyncCacheMinSsdSavableBytes).value();
+}
+
+std::chrono::duration<double> SystemConfig::asyncCacheFullPersistenceInterval()
+    const {
+  return velox::core::toDuration(
+      optionalProperty(kAsyncCacheFullPersistenceInterval).value());
 }
 
 bool SystemConfig::asyncCacheSsdDisableFileCow() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -341,6 +341,11 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kAsyncCacheMinSsdSavableBytes{
       "async-cache-min-ssd-savable-bytes"};
 
+  /// The interval for persisting full memory cache to SSD. Setting this config
+  /// to a non-zero value will activate periodic cache persistence.
+  static constexpr std::string_view kAsyncCacheFullPersistenceInterval{
+      "async-cache-full-persistence-interval"};
+
   /// In file systems, such as btrfs, supporting cow (copy on write), the ssd
   /// cache can use all ssd space and stop working. To prevent that, use this
   /// option to disable cow for cache files.
@@ -694,6 +699,8 @@ class SystemConfig : public ConfigBase {
   double asyncCacheSsdSavableRatio() const;
 
   int32_t asyncCacheMinSsdSavableBytes() const;
+
+  std::chrono::duration<double> asyncCacheFullPersistenceInterval() const;
 
   bool asyncCacheSsdDisableFileCow() const;
 


### PR DESCRIPTION
## Description
Currently, maxWriteRatio(AsyncDataCache::Options), the maximum ratio of the number of in-memory cache entries being written to the SSD cache over the total number of cache entries, is set to the default value of 0.7, meaning that we only persist 70% of cache entries to the SSD and upon server restart 30% of cache will be lost.

This change adds an optional periodic daemon to flush cache data to ssd. This can help to make sure all the in-memory data is flushed to ssd.

```
== RELEASE NOTES ==

General Changes
* Add support for persisting full memory cache to SSD periodically on Presto C++ worker. This can be enabled by setting `cache.velox.full-persistence-interval` to a non-zero value. :pr:`23192`
```

