### PR TITLE
[docs] Add Superset documentation to /clients/

### DIFF
--- a/presto-docs/src/main/sphinx/clients.rst
+++ b/presto-docs/src/main/sphinx/clients.rst
@@ -8,3 +8,4 @@ Presto Clients
     clients/presto-cli
     clients/presto-console
     clients/dbeaver
+    clients/superset

--- a/presto-docs/src/main/sphinx/clients/superset.rst
+++ b/presto-docs/src/main/sphinx/clients/superset.rst
@@ -1,0 +1,37 @@
+===============
+Apache Superset
+===============
+
+`Apache Superset <https://superset.apache.org/>`_ is an open source data exploration tool. 
+Follow these steps to configure Superset to query Presto. 
+
+1. Install or deploy Superset following the `Superset documentation <https://superset.apache.org/docs/intro>`_. 
+
+   Note: When running Superset for the first time, an error may be displayed similar to the following: 
+
+   `validating superset/docker-compose-image-tag.yml: services.db.env_file.0 must be a string`
+
+   See `Superset discussion 28184 <https://github.com/apache/superset/discussions/28184>`_ for more information. 
+
+2. You may need `pyhive` to configure Superset to connect to Presto. See `Presto <https://superset.apache.org/docs/configuration/databases#presto>`_.
+
+3. Log into Superset as described in `Log into Superset <https://superset.apache.org/docs/quickstart#3-log-into-superset>`_. 
+
+4. In the Superset UI, select `+` in the upper right to display the drop-down menu, then select `Data`, then `Connect database`.
+
+5. In the `Connect a database` window, select `Presto`.
+
+6. In `SLQAlchemy URI`, enter a connection string using the following format: 
+
+   `presto://{hostname}:{port}/{database}`
+
+   For example, `presto://<Presto-IP-address>:8080/system`
+
+   For more information, see the Superset documentation for connecting to `Presto <https://superset.apache.org/docs/configuration/databases#presto>`_.
+
+7. Select `Test Connection`. If the message `Connection looks good!` is displayed, continue. 
+
+   Note: If your Presto server is running locally, `localhost` may not resolve DNS successfully from the Superset docker-compose launched instance to the local Presto server. Replace `<Presto-IP-address>` with your system's actual IP address. 
+
+8. Select `Connect`.
+


### PR DESCRIPTION
## Description
Add documentation how to configure [Apache Superset](https://superset.apache.org/) to connect to Presto. 

## Motivation and Context
Expands the number of clients documented for use with Presto. Builds on recent work in #23189.

## Impact
Documentation. 

## Test Plan
* Tested and developed the steps in the documentation with a locally running Presto server and a locally running Superset instance.
* Tested the documentation with a local doc build. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... Add :doc:`/clients/superset` documentation :pr:`23194`
