### PR TITLE
Send periodic query progress events

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitorConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitorConfig.java
@@ -14,16 +14,21 @@
 package com.facebook.presto.event;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
+import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 
 import javax.validation.constraints.NotNull;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 public class QueryMonitorConfig
 {
     private DataSize maxOutputStageJsonSize = new DataSize(16, Unit.MEGABYTE);
+    private Duration queryProgressPublishInterval = new Duration(0, MINUTES);
 
     @MinDataSize("1kB")
     @MaxDataSize("1GB")
@@ -37,6 +42,19 @@ public class QueryMonitorConfig
     public QueryMonitorConfig setMaxOutputStageJsonSize(DataSize maxOutputStageJsonSize)
     {
         this.maxOutputStageJsonSize = maxOutputStageJsonSize;
+        return this;
+    }
+
+    public Duration getQueryProgressPublishInterval()
+    {
+        return queryProgressPublishInterval;
+    }
+
+    @Config("event.query-progress-publish-interval")
+    @ConfigDescription("How frequently to publish query progress events. 0 duration disables the publication of these events.")
+    public QueryMonitorConfig setQueryProgressPublishInterval(Duration queryProgressPublishInterval)
+    {
+        this.queryProgressPublishInterval = queryProgressPublishInterval;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryProgressMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryProgressMonitor.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.event;
+
+import com.facebook.presto.dispatcher.DispatchManager;
+import com.facebook.presto.server.BasicQueryInfo;
+import io.airlift.units.Duration;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.concurrent.GuardedBy;
+import javax.inject.Inject;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+public class QueryProgressMonitor
+{
+    private final AtomicLong monotonicallyIncreasingEventId = new AtomicLong();
+
+    private final QueryMonitor queryMonitor;
+    private final DispatchManager dispatchManager;
+    private final Duration queryProgressPublishInterval;
+
+    @GuardedBy("this")
+    private ScheduledExecutorService queryProgressMonitorExecutor;
+
+    @Inject
+    public QueryProgressMonitor(
+            QueryMonitor queryMonitor,
+            DispatchManager dispatchManager,
+            QueryMonitorConfig queryMonitorConfig)
+    {
+        this.queryMonitor = requireNonNull(queryMonitor, "queryMonitor is null");
+        this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
+        this.queryProgressPublishInterval = requireNonNull(queryMonitorConfig, "queryMonitorConfig is null").getQueryProgressPublishInterval();
+    }
+
+    @PostConstruct
+    public synchronized void start()
+    {
+        if (queryProgressPublishInterval.getValue() > 0) {
+            if (queryProgressMonitorExecutor == null) {
+                queryProgressMonitorExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("query-progress-monitor-executor"));
+            }
+
+            queryProgressMonitorExecutor.scheduleWithFixedDelay(
+                    this::publishQueryProgressEvent,
+                    (long) queryProgressPublishInterval.getValue(),
+                    (long) queryProgressPublishInterval.getValue(),
+                    queryProgressPublishInterval.getUnit());
+        }
+    }
+
+    @PreDestroy
+    public synchronized void stop()
+    {
+        if (queryProgressMonitorExecutor != null) {
+            queryProgressMonitorExecutor.shutdown();
+        }
+    }
+
+    private void publishQueryProgressEvent()
+    {
+        for (BasicQueryInfo basicQueryInfo : dispatchManager.getQueries()) {
+            if (!basicQueryInfo.getState().isDone()) {
+                queryMonitor.publishQueryProgressEvent(monotonicallyIncreasingEventId.incrementAndGet(), basicQueryInfo);
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/eventlistener/EventListenerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/eventlistener/EventListenerManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryProgressEvent;
 import com.facebook.presto.spi.eventlistener.QueryUpdatedEvent;
 import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
 import com.google.common.annotations.VisibleForTesting;
@@ -113,6 +114,12 @@ public class EventListenerManager
     {
         configuredEventListener.get()
                 .ifPresent(eventListener -> eventListener.queryUpdated(queryUpdatedEvent));
+    }
+
+    public void publishQueryProgress(QueryProgressEvent queryProgressEvent)
+    {
+        configuredEventListener.get()
+                .ifPresent(eventListener -> eventListener.publishQueryProgress(queryProgressEvent));
     }
 
     public void splitCompleted(SplitCompletedEvent splitCompletedEvent)

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -31,6 +31,7 @@ import com.facebook.presto.dispatcher.FailedDispatchQueryFactory;
 import com.facebook.presto.dispatcher.LocalDispatchQueryFactory;
 import com.facebook.presto.event.QueryMonitor;
 import com.facebook.presto.event.QueryMonitorConfig;
+import com.facebook.presto.event.QueryProgressMonitor;
 import com.facebook.presto.execution.ClusterSizeMonitor;
 import com.facebook.presto.execution.ExecutionFactoriesManager;
 import com.facebook.presto.execution.ExplainAnalyzeContext;
@@ -163,6 +164,7 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(OperatorInfo.class);
         configBinder(binder).bindConfig(QueryMonitorConfig.class);
         binder.bind(QueryMonitor.class).in(Scopes.SINGLETON);
+        binder.bind(QueryProgressMonitor.class).in(Scopes.SINGLETON);
 
         // query manager
         jaxrsBinder(binder).bind(QueryResource.class);

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingEventListenerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingEventListenerManager.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryProgressEvent;
 import com.facebook.presto.spi.eventlistener.QueryUpdatedEvent;
 import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
 import com.google.common.collect.ImmutableMap;
@@ -57,6 +58,14 @@ public class TestingEventListenerManager
     {
         if (configuredEventListener.get().isPresent()) {
             configuredEventListener.get().get().queryUpdated(queryUpdatedEvent);
+        }
+    }
+
+    @Override
+    public void publishQueryProgress(QueryProgressEvent queryProgressEvent)
+    {
+        if (configuredEventListener.get().isPresent()) {
+            configuredEventListener.get().get().publishQueryProgress(queryProgressEvent);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
+++ b/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryProgressEvent;
 import com.facebook.presto.spi.eventlistener.QueryUpdatedEvent;
 import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisites;
@@ -520,6 +521,12 @@ public class TestLocalDispatchQuery
         public void queryUpdated(QueryUpdatedEvent queryUpdatedEvent)
         {
             fail("Query update events should not be created in this test");
+        }
+
+        @Override
+        public void publishQueryProgress(QueryProgressEvent queryProgressEvent)
+        {
+            fail("Query Progress events should not be created in this test");
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/event/TestQueryMonitorConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/event/TestQueryMonitorConfig.java
@@ -15,9 +15,11 @@ package com.facebook.presto.event;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
@@ -30,7 +32,8 @@ public class TestQueryMonitorConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(QueryMonitorConfig.class)
-                .setMaxOutputStageJsonSize(new DataSize(16, Unit.MEGABYTE)));
+                .setMaxOutputStageJsonSize(new DataSize(16, Unit.MEGABYTE))
+                .setQueryProgressPublishInterval(new Duration(0, TimeUnit.MINUTES)));
     }
 
     @Test
@@ -38,10 +41,12 @@ public class TestQueryMonitorConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("event.max-output-stage-size", "512kB")
+                .put("event.query-progress-publish-interval", "2m")
                 .build();
 
         QueryMonitorConfig expected = new QueryMonitorConfig()
-                .setMaxOutputStageJsonSize(new DataSize(512, Unit.KILOBYTE));
+                .setMaxOutputStageJsonSize(new DataSize(512, Unit.KILOBYTE))
+                .setQueryProgressPublishInterval(new Duration(2, TimeUnit.MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/EventListener.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/EventListener.java
@@ -27,6 +27,10 @@ public interface EventListener
     {
     }
 
+    default void publishQueryProgress(QueryProgressEvent queryProgressEvent)
+    {
+    }
+
     default void queryCompleted(QueryCompletedEvent queryCompletedEvent)
     {
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryProgressEvent.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryProgressEvent.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.eventlistener;
+
+import com.facebook.presto.common.resourceGroups.QueryType;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryProgressEvent
+{
+    private final long monotonicallyIncreasingEventId;
+    private final QueryMetadata metadata;
+    private final QueryStatistics statistics;
+    private final QueryContext context;
+    private final Optional<QueryType> queryType;
+    private final Instant createTime;
+
+    public QueryProgressEvent(
+            long monotonicallyIncreasingEventId,
+            QueryMetadata metadata,
+            QueryStatistics statistics,
+            QueryContext context,
+            Optional<QueryType> queryType,
+            Instant createTime)
+    {
+        this.monotonicallyIncreasingEventId = monotonicallyIncreasingEventId;
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.statistics = requireNonNull(statistics, "statistics is null");
+        this.context = requireNonNull(context, "context is null");
+        this.queryType = requireNonNull(queryType, "queryType is null");
+        this.createTime = requireNonNull(createTime, "createTime is null");
+    }
+
+    public long getMonotonicallyIncreasingEventId()
+    {
+        return monotonicallyIncreasingEventId;
+    }
+
+    public QueryMetadata getMetadata()
+    {
+        return metadata;
+    }
+
+    public QueryStatistics getStatistics()
+    {
+        return statistics;
+    }
+
+    public QueryContext getContext()
+    {
+        return context;
+    }
+
+    public Optional<QueryType> getQueryType()
+    {
+        return queryType;
+    }
+
+    public Instant getCreateTime()
+    {
+        return createTime;
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
@@ -19,6 +19,7 @@ import com.facebook.presto.resourceGroups.ResourceGroupManagerPlugin;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryProgressEvent;
 import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.DistributedQueryRunner;
@@ -32,6 +33,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -44,6 +46,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.stream.Collectors.toSet;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
@@ -54,6 +57,7 @@ public class TestEventListener
 
     private DistributedQueryRunner queryRunner;
     private Session session;
+    private long lastSeenQueryProgressEventId;
 
     @BeforeClass
     private void setUp()
@@ -65,7 +69,12 @@ public class TestEventListener
                 .setSchema("tiny")
                 .setClientInfo("{\"clientVersion\":\"testVersion\"}")
                 .build();
-        queryRunner = new DistributedQueryRunner(session, 1);
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("event.query-progress-publish-interval", "1ms")
+                .build();
+
+        queryRunner = new DistributedQueryRunner(session, 1, properties);
         queryRunner.installPlugin(new TpchPlugin());
         queryRunner.installPlugin(new TestingEventListenerPlugin(generatedEvents));
         queryRunner.installPlugin(new ResourceGroupManagerPlugin());
@@ -101,8 +110,8 @@ public class TestEventListener
     public void testConstantQuery()
             throws Exception
     {
-        // QueryCreated: 1, QueryCompleted: 1, Splits: 1
-        runQueryAndWaitForEvents("SELECT 1", 3);
+        // QueryCreated: 1, QueryProgressEvent:1, QueryCompleted: 1, Splits: 1
+        runQueryAndWaitForEvents("SELECT 1", 4);
 
         QueryCreatedEvent queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
         assertEquals(queryCreatedEvent.getContext().getServerVersion(), "testversion");
@@ -111,6 +120,16 @@ public class TestEventListener
         assertEquals(queryCreatedEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
         assertEquals(queryCreatedEvent.getMetadata().getQuery(), "SELECT 1");
         assertFalse(queryCreatedEvent.getMetadata().getPreparedQuery().isPresent());
+
+        QueryProgressEvent queryProgressEvent = generatedEvents.getQueryProgressEvent();
+        assertNotNull(queryProgressEvent);
+        assertTrue(queryProgressEvent.getMonotonicallyIncreasingEventId() > lastSeenQueryProgressEventId);
+        lastSeenQueryProgressEventId = queryProgressEvent.getMonotonicallyIncreasingEventId();
+        assertTrue(queryProgressEvent.getContext().getResourceGroupId().isPresent());
+        assertEquals(queryProgressEvent.getContext().getResourceGroupId().get(), createResourceGroupId("global", "user-user"));
+        assertEquals(queryProgressEvent.getStatistics().getTotalRows(), 0L);
+        assertEquals(queryProgressEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
+        assertEquals(queryCreatedEvent.getMetadata().getQueryId(), queryProgressEvent.getMetadata().getQueryId());
 
         QueryCompletedEvent queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
         assertTrue(queryCompletedEvent.getContext().getResourceGroupId().isPresent());
@@ -131,8 +150,8 @@ public class TestEventListener
             throws Exception
     {
         // We expect the following events
-        // QueryCreated: 1, QueryCompleted: 1, Splits: SPLITS_PER_NODE (leaf splits) + LocalExchange[SINGLE] split + Aggregation/Output split
-        int expectedEvents = 1 + 1 + SPLITS_PER_NODE + 1 + 1;
+        // QueryCreated: 1, QueryProgressEvent:1, QueryCompleted: 1, Splits: SPLITS_PER_NODE (leaf splits) + LocalExchange[SINGLE] split + Aggregation/Output split
+        int expectedEvents = 1 + 1 + 1 + SPLITS_PER_NODE + 1 + 1;
         runQueryAndWaitForEvents("SELECT sum(linenumber) FROM lineitem", expectedEvents);
 
         QueryCreatedEvent queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
@@ -142,6 +161,16 @@ public class TestEventListener
         assertEquals(queryCreatedEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
         assertEquals(queryCreatedEvent.getMetadata().getQuery(), "SELECT sum(linenumber) FROM lineitem");
         assertFalse(queryCreatedEvent.getMetadata().getPreparedQuery().isPresent());
+
+        QueryProgressEvent queryProgressEvent = generatedEvents.getQueryProgressEvent();
+        assertNotNull(queryProgressEvent);
+        assertTrue(queryProgressEvent.getMonotonicallyIncreasingEventId() > lastSeenQueryProgressEventId);
+        lastSeenQueryProgressEventId = queryProgressEvent.getMonotonicallyIncreasingEventId();
+        assertTrue(queryProgressEvent.getContext().getResourceGroupId().isPresent());
+        assertEquals(queryProgressEvent.getContext().getResourceGroupId().get(), createResourceGroupId("global", "user-user"));
+        assertEquals(queryProgressEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
+        assertEquals(queryCreatedEvent.getMetadata().getQueryId(), queryProgressEvent.getMetadata().getQueryId());
+        assertFalse(queryProgressEvent.getMetadata().getPreparedQuery().isPresent());
 
         QueryCompletedEvent queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
         assertTrue(queryCompletedEvent.getContext().getResourceGroupId().isPresent());
@@ -183,8 +212,8 @@ public class TestEventListener
         String selectQuery = "SELECT count(*) FROM lineitem WHERE shipmode = ?";
         String prepareQuery = "PREPARE stmt FROM " + selectQuery;
 
-        // QueryCreated: 1, QueryCompleted: 1, Splits: 0
-        runQueryAndWaitForEvents(prepareQuery, 2);
+        // QueryCreated: 1, QueryProgressEvent: 1, QueryCompleted: 1, Splits: 0
+        runQueryAndWaitForEvents(prepareQuery, 3);
 
         QueryCreatedEvent queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
         assertEquals(queryCreatedEvent.getContext().getServerVersion(), "testversion");
@@ -193,6 +222,16 @@ public class TestEventListener
         assertEquals(queryCreatedEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
         assertEquals(queryCreatedEvent.getMetadata().getQuery(), prepareQuery);
         assertFalse(queryCreatedEvent.getMetadata().getPreparedQuery().isPresent());
+
+        QueryProgressEvent queryProgressEvent = generatedEvents.getQueryProgressEvent();
+        assertNotNull(queryProgressEvent);
+        assertTrue(queryProgressEvent.getMonotonicallyIncreasingEventId() > lastSeenQueryProgressEventId);
+        lastSeenQueryProgressEventId = queryProgressEvent.getMonotonicallyIncreasingEventId();
+        assertTrue(queryProgressEvent.getContext().getResourceGroupId().isPresent());
+        assertEquals(queryProgressEvent.getContext().getResourceGroupId().get(), createResourceGroupId("global", "user-user"));
+        assertEquals(queryProgressEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
+        assertEquals(queryCreatedEvent.getMetadata().getQueryId(), queryProgressEvent.getMetadata().getQueryId());
+        assertFalse(queryProgressEvent.getMetadata().getPreparedQuery().isPresent());
 
         QueryCompletedEvent queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
         assertTrue(queryCompletedEvent.getContext().getResourceGroupId().isPresent());
@@ -208,8 +247,8 @@ public class TestEventListener
         Session sessionWithPrepare = Session.builder(session).addPreparedStatement("stmt", selectQuery).build();
 
         // We expect the following events
-        // QueryCreated: 1, QueryCompleted: 1, Splits: SPLITS_PER_NODE (leaf splits) + LocalExchange[SINGLE] split + Aggregation/Output split
-        int expectedEvents = 1 + 1 + SPLITS_PER_NODE + 1 + 1;
+        // QueryCreated: 1, QueryProgressEvent:1, QueryCompleted: 1, Splits: SPLITS_PER_NODE (leaf splits) + LocalExchange[SINGLE] split + Aggregation/Output split
+        int expectedEvents = 1 + 1 + 1 + SPLITS_PER_NODE + 1 + 1;
         runQueryAndWaitForEvents("EXECUTE stmt USING 'SHIP'", expectedEvents, sessionWithPrepare);
 
         queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
@@ -220,6 +259,17 @@ public class TestEventListener
         assertEquals(queryCreatedEvent.getMetadata().getQuery(), "EXECUTE stmt USING 'SHIP'");
         assertTrue(queryCreatedEvent.getMetadata().getPreparedQuery().isPresent());
         assertEquals(queryCreatedEvent.getMetadata().getPreparedQuery().get(), selectQuery);
+
+        queryProgressEvent = generatedEvents.getQueryProgressEvent();
+        assertNotNull(queryProgressEvent);
+        assertTrue(queryProgressEvent.getMonotonicallyIncreasingEventId() > lastSeenQueryProgressEventId);
+        lastSeenQueryProgressEventId = queryProgressEvent.getMonotonicallyIncreasingEventId();
+        assertTrue(queryProgressEvent.getContext().getResourceGroupId().isPresent());
+        assertEquals(queryProgressEvent.getContext().getResourceGroupId().get(), createResourceGroupId("global", "user-user"));
+        assertEquals(queryProgressEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
+        assertEquals(queryCreatedEvent.getMetadata().getQueryId(), queryProgressEvent.getMetadata().getQueryId());
+        assertTrue(queryProgressEvent.getMetadata().getPreparedQuery().isPresent());
+        assertEquals(queryProgressEvent.getMetadata().getPreparedQuery().get(), selectQuery);
 
         queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
         assertTrue(queryCompletedEvent.getContext().getResourceGroupId().isPresent());
@@ -239,13 +289,17 @@ public class TestEventListener
             throws Exception
     {
         // We expect the following events
-        // QueryCreated: 1, QueryCompleted: 1, Splits: SPLITS_PER_NODE (leaf splits) + LocalExchange[SINGLE] split + Aggregation/Output split
-        int expectedEvents = 1 + 1 + SPLITS_PER_NODE + 1 + 1;
+        // QueryCreated: 1, QueryProgressEvent:1, QueryCompleted: 1, Splits: SPLITS_PER_NODE (leaf splits) + LocalExchange[SINGLE] split + Aggregation/Output split
+        int expectedEvents = 1 + 1 + 1 + SPLITS_PER_NODE + 1 + 1;
         MaterializedResult result = runQueryAndWaitForEvents("SELECT 1 FROM lineitem", expectedEvents);
         QueryCreatedEvent queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
+        QueryProgressEvent queryProgressEvent = generatedEvents.getQueryProgressEvent();
         QueryCompletedEvent queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
         QueryStats queryStats = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(new QueryId(queryCreatedEvent.getMetadata().getQueryId())).getQueryStats();
 
+        assertNotNull(queryProgressEvent);
+        assertTrue(queryProgressEvent.getMonotonicallyIncreasingEventId() > lastSeenQueryProgressEventId);
+        lastSeenQueryProgressEventId = queryProgressEvent.getMonotonicallyIncreasingEventId();
         assertTrue(queryStats.getOutputDataSize().toBytes() > 0L);
         assertTrue(queryCompletedEvent.getStatistics().getOutputBytes() > 0L);
         assertEquals(result.getRowCount(), queryStats.getOutputPositions());
@@ -253,9 +307,13 @@ public class TestEventListener
 
         runQueryAndWaitForEvents("SELECT COUNT(1) FROM lineitem", expectedEvents);
         queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
+        queryProgressEvent = generatedEvents.getQueryProgressEvent();
         queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
         queryStats = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(new QueryId(queryCreatedEvent.getMetadata().getQueryId())).getQueryStats();
 
+        assertNotNull(queryProgressEvent);
+        assertTrue(queryProgressEvent.getMonotonicallyIncreasingEventId() > lastSeenQueryProgressEventId);
+        lastSeenQueryProgressEventId = queryProgressEvent.getMonotonicallyIncreasingEventId();
         assertTrue(queryStats.getOutputDataSize().toBytes() > 0L);
         assertTrue(queryCompletedEvent.getStatistics().getOutputBytes() > 0L);
         assertEquals(1L, queryStats.getOutputPositions());
@@ -266,7 +324,7 @@ public class TestEventListener
     public void testGraphvizQueryPlanOutput()
             throws Exception
     {
-        int expectedEvents = 1 + 1 + SPLITS_PER_NODE + 1 + 1;
+        int expectedEvents = 1 + 1 + 1 + SPLITS_PER_NODE + 1 + 1;
         String query = "EXPLAIN (type distributed, format graphviz) SELECT * FROM LINEITEM limit 1";
         Session sessionForEventLoggingWithStats = Session.builder(session)
                 .setSystemProperty("print_stats_for_non_join_query", "true")
@@ -282,6 +340,7 @@ public class TestEventListener
         private ImmutableList.Builder<QueryCreatedEvent> queryCreatedEvents;
         private ImmutableList.Builder<QueryCompletedEvent> queryCompletedEvents;
         private ImmutableList.Builder<SplitCompletedEvent> splitCompletedEvents;
+        private QueryProgressEvent queryProgressEvent;
 
         private CountDownLatch eventsLatch;
 
@@ -290,6 +349,7 @@ public class TestEventListener
             queryCreatedEvents = ImmutableList.builder();
             queryCompletedEvents = ImmutableList.builder();
             splitCompletedEvents = ImmutableList.builder();
+            queryProgressEvent = null;
 
             eventsLatch = new CountDownLatch(numEvents);
         }
@@ -318,6 +378,15 @@ public class TestEventListener
             eventsLatch.countDown();
         }
 
+        public synchronized void addQueryProgress(QueryProgressEvent event)
+        {
+            // Store only one QueryProgress event
+            if (queryProgressEvent == null) {
+                queryProgressEvent = event;
+                eventsLatch.countDown();
+            }
+        }
+
         public List<QueryCreatedEvent> getQueryCreatedEvents()
         {
             return queryCreatedEvents.build();
@@ -331,6 +400,11 @@ public class TestEventListener
         public List<SplitCompletedEvent> getSplitCompletedEvents()
         {
             return splitCompletedEvents.build();
+        }
+
+        public QueryProgressEvent getQueryProgressEvent()
+        {
+            return queryProgressEvent;
         }
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListenerPlugin.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListenerPlugin.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryProgressEvent;
 import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
 import com.google.common.collect.ImmutableList;
 
@@ -94,6 +95,12 @@ public class TestEventListenerPlugin
         public void splitCompleted(SplitCompletedEvent splitCompletedEvent)
         {
             eventsBuilder.addSplitCompleted(splitCompletedEvent);
+        }
+
+        @Override
+        public void publishQueryProgress(QueryProgressEvent queryProgressEvent)
+        {
+            eventsBuilder.addQueryProgress(queryProgressEvent);
         }
     }
 }


### PR DESCRIPTION
## Description
Add support for sending periodic progress events for Queued/Running queries using EventListener interface. 

## Motivation and Context
This change enables coordinators to push their current state of Queued/Running queries as progress events which can be logged to different sources for analysis purposes. Progress event is sent every 1 minute for each queued/running queries.

## Impact
None

## Test Plan
Added a Unit test to check for queryProgress events. 
Existing tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.


```
== RELEASE NOTES ==
General Changes
* Add a new configuration property ``event.query-progress-publish-interval`` to specify the time interval at which progress events should be generated. Default is every 1 minute. :pr:`23195`
```

