### PR TITLE
Ensure connector specific session properties be valid in test framework

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -25,6 +25,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.MetadataUtil;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -138,6 +139,12 @@ public abstract class AbstractTestingPrestoClient<T>
         for (Entry<String, Map<String, String>> connectorProperties : session.getUnprocessedCatalogProperties().entrySet()) {
             for (Entry<String, String> entry : connectorProperties.getValue().entrySet()) {
                 properties.put(connectorProperties.getKey() + "." + entry.getKey(), entry.getValue());
+            }
+        }
+
+        for (Entry<ConnectorId, Map<String, String>> connectorProperties : session.getConnectorProperties().entrySet()) {
+            for (Entry<String, String> entry : connectorProperties.getValue().entrySet()) {
+                properties.put(connectorProperties.getKey().getCatalogName() + "." + entry.getKey(), entry.getValue());
             }
         }
 


### PR DESCRIPTION
## Description

In some test cases, when we manually start a transaction in a session, then execute statements within this session, we would find that the given connector specific session properties be invalid in server side. These session properties were lost during the session conversion. This PR fix such problem.

Fix #23207 

## Motivation and Context

Make sure that connector specific session properties be valid in server side in test cases

## Impact

N/A

## Test Plan

 - New test case to ensure that connector specific session properties be valid in scenarios described above

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

