### PR TITLE
Make division by zero query failed errors clearer

### DIFF
--- a/presto-docs/src/main/sphinx/functions/conditional.rst
+++ b/presto-docs/src/main/sphinx/functions/conditional.rst
@@ -159,7 +159,7 @@ Query failure without ``TRY``:
 
 .. code-block:: none
 
-    Query failed: / by zero
+    Query failed: Division by zero
 
 Default values with ``TRY`` and ``COALESCE``:
 

--- a/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
@@ -111,7 +111,7 @@ public final class BigintOperators
             return left / right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 
@@ -123,7 +123,7 @@ public final class BigintOperators
             return left % right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -88,7 +88,7 @@ public final class DoubleOperators
             return left / right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 
@@ -100,7 +100,7 @@ public final class DoubleOperators
             return left % right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
@@ -105,7 +105,7 @@ public final class IntegerOperators
             return left / right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 
@@ -117,7 +117,7 @@ public final class IntegerOperators
             return left % right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
@@ -105,7 +105,7 @@ public final class SmallintOperators
             return left / right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 
@@ -117,7 +117,7 @@ public final class SmallintOperators
             return left % right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
@@ -103,7 +103,7 @@ public final class TinyintOperators
             return left / right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 
@@ -115,7 +115,7 @@ public final class TinyintOperators
             return left % right;
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(DIVISION_BY_ZERO, e);
+            throw new PrestoException(DIVISION_BY_ZERO, "Division by zero");
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
@@ -49,7 +49,7 @@ public class TestFailureFunction
             }
             catch (PrestoException e) {
                 assertEquals(e.getErrorCode(), DIVISION_BY_ZERO.toErrorCode());
-                assertTrue(e.getMessage().contains("/ by zero"));
+                assertTrue(e.getMessage().contains("Division by zero"));
             }
         }
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -753,7 +753,7 @@ public class TestPrestoSparkQueryRunner
     @Test
     public void testFailures()
     {
-        assertQueryFails("SELECT * FROM orders WHERE custkey / (orderkey - orderkey) = 0", "/ by zero");
+        assertQueryFails("SELECT * FROM orders WHERE custkey / (orderkey - orderkey) = 0", "Division by zero");
         assertQueryFails(
                 "CREATE TABLE hive.hive_test.hive_orders_test_failures AS " +
                         "(SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
@@ -762,7 +762,7 @@ public class TestPrestoSparkQueryRunner
                         "(SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
                         "FROM orders " +
                         "WHERE custkey / (orderkey - orderkey) = 0 )",
-                "/ by zero");
+                "Division by zero");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3114,7 +3114,7 @@ public abstract class AbstractTestQueries
         assertQueryFails("SELECT TRY()", "line 1:8: The 'try' function must have exactly one argument");
 
         // check that TRY is not pushed down
-        assertQueryFails("SELECT TRY(x) IS NULL FROM (SELECT 1/y AS x FROM (VALUES 1, 2, 3, 0, 4) t(y))", "/ by zero");
+        assertQueryFails("SELECT TRY(x) IS NULL FROM (SELECT 1/y AS x FROM (VALUES 1, 2, 3, 0, 4) t(y))", "Division by zero");
         assertQuery("SELECT x IS NULL FROM (SELECT TRY(1/y) AS x FROM (VALUES 3, 0, 4) t(y))", "VALUES false, true, false");
 
         // test try with lambda function


### PR DESCRIPTION
## Description
Make division by zero query failed errors more clear and ensuring standardization between different error messages for a singular exception

## Motivation and Context
fixed #23215

## Impact
Make debugging and error information more clear

## Test Plan
Existing and amended tests pass without regression

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

