### PR TITLE
[native] Update clang check CI image

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -70,7 +70,7 @@ executors:
       MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
   check:
     docker:
-      - image: prestocpp/velox-check:mikesh-20210609
+      - image: public.ecr.aws/oss-presto/velox-dev:check
   macos-intel:
     macos:
       xcode: "14.3.0"
@@ -281,11 +281,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Update velox"
-          command: |
-            cd presto-native-execution
-            make velox-submodule
-      - run:
           name: Check formatting
           command: |
             cd presto-native-execution
@@ -295,11 +290,6 @@ jobs:
     executor: check
     steps:
       - checkout
-      - run:
-          name: "Update velox"
-          command: |
-            cd presto-native-execution
-            make velox-submodule
       - run:
           name: "Check license headers"
           command: |


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Fix for `clang-format:75:1: error: unknown key 'InsertNewlineAtEOF'
InsertNewlineAtEOF: true`
Resolves https://github.com/prestodb/presto/issues/23221

Exclude Velox from the header and format check in CI. 
The Velox project does these checks.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

