### PR TITLE
[docs] Fix doc links in READMEs

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -139,7 +139,7 @@ Please keep in mind that if you run tests on Hive of version not greater than 1.
 First version of Hive capable of running tests from `post_hive_1_0_1` group is Hive 1.1.0.
 
 For more information on the various ways in which Presto can be configured to
-interact with Kerberized Hive and Hadoop, please refer to the [Hive connector documentation](https://prestodb.github.io/docs/current/connector/hive.html).
+interact with Kerberized Hive and Hadoop, please refer to the [Hive connector documentation](https://prestodb.io/docs/current/connector/hive.html).
 
 ### Running a single test
 

--- a/presto-server/README.txt
+++ b/presto-server/README.txt
@@ -2,4 +2,4 @@ Presto is a distributed SQL query engine.
 
 Please see the website for installation instructions:
 
-https://prestodb.github.io/
+https://prestodb.io/docs/current/installation.html

--- a/presto-spark-package/README.txt
+++ b/presto-spark-package/README.txt
@@ -2,4 +2,4 @@ Presto is a distributed SQL query engine.
 
 Please see the website for installation instructions:
 
-https://prestodb.github.io/
+https://prestodb.io/docs/current/installation.html


### PR DESCRIPTION
## Description
Fixes the links to the Presto documentation that are in the READMEs for 

* [presto-product-tests](https://github.com/prestodb/presto/blob/master/presto-product-tests/README.md) - the link for **Hive connector documentation**
* [presto-server](https://github.com/prestodb/presto/blob/master/presto-server/README.txt) - link to Presto installation documentation 
* [presto-spark-package](https://github.com/prestodb/presto/blob/master/presto-spark-package/README.txt) - link to Presto installation documentation 

## Motivation and Context
Fixes concerns raised in [this comment](https://github.com/prestodb/presto/issues/23209#issuecomment-2230094643) on #23209. 

Builds on the work in #23216. 

## Impact
READMEs. 

## Test Plan
Tested replacement links that they successfully link to a destination. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```
