### PR TITLE
Function to check if IPADDRESS is private. 

### DIFF
--- a/presto-docs/src/main/sphinx/functions/ip.rst
+++ b/presto-docs/src/main/sphinx/functions/ip.rst
@@ -10,6 +10,15 @@ IP Functions
         SELECT ip_prefix(CAST('192.168.255.255' AS IPADDRESS), 9); -- {192.128.0.0/9}
         SELECT ip_prefix('2001:0db8:85a3:0001:0001:8a2e:0370:7334', 48); -- {2001:db8:85a3::/48}
 
+.. function:: is_private_ip(ip_address) -> boolean
+
+    Returns whether ``ip_address`` of type ``IPADDRESS`` is a private or reserved IP address
+    that is not considered globally reachable by IANA. ::
+        SELECT is_private_ip(IPADDRESS '10.0.0.1'); -- true
+        SELECT is_private_ip(IPADDRESS '192.168.0.1'); -- true
+        SELECT is_private_ip(IPADDRESS '157.240.200.99'); -- false
+        SELECT is_private_ip(IPADDRESS '2a03:2880:f031:12:face:b00c:0:2'); -- false
+
 .. function:: ip_subnet_min(ip_prefix) -> ip_address
 
     Returns the smallest IP address of type ``IPADDRESS`` in the subnet

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -204,6 +204,7 @@ import com.facebook.presto.operator.scalar.WilsonInterval;
 import com.facebook.presto.operator.scalar.WordStemFunction;
 import com.facebook.presto.operator.scalar.queryplan.JsonPrestoQueryPlanFunctions;
 import com.facebook.presto.operator.scalar.sql.ArraySqlFunctions;
+import com.facebook.presto.operator.scalar.sql.IPSqlFunctions;
 import com.facebook.presto.operator.scalar.sql.MapNormalizeFunction;
 import com.facebook.presto.operator.scalar.sql.MapSqlFunctions;
 import com.facebook.presto.operator.scalar.sql.SimpleSamplingPercent;
@@ -993,6 +994,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .sqlInvokedScalar(MapNormalizeFunction.class)
                 .sqlInvokedScalars(ArraySqlFunctions.class)
                 .sqlInvokedScalars(ArrayIntersectFunction.class)
+                .sqlInvokedScalars(IPSqlFunctions.class)
                 .sqlInvokedScalars(MapSqlFunctions.class)
                 .sqlInvokedScalars(SimpleSamplingPercent.class)
                 .sqlInvokedScalars(StringSqlFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/IPSqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/IPSqlFunctions.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlType;
+
+public class IPSqlFunctions
+{
+    private IPSqlFunctions() {}
+
+    @SqlInvokedScalarFunction(value = "is_private_ip", deterministic = true, calledOnNullInput = false)
+    @Description("Returns whether ip is a private or reserved IP address that is not globally reachable.")
+    @SqlParameter(name = "ip", type = "IPADDRESS")
+    @SqlType("boolean")
+    public static String isPrivateIpAddress()
+    {
+        /*
+         We take our definitions from what IANA considers *not* "globally reachable" in
+         https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml and
+         https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml.
+        */
+        return "RETURN " +
+                "IF(STRPOS(CAST(ip AS VARCHAR), '.') > 0, " +  // if IPv4
+
+        /*
+         Creating IPPREFIX objects are relatively expensive, so we prefer to
+         perform the cheaper STARTS_WITH prefix check when possible.
+         Note that '.'s are only trailing octets of length less than 3.
+        */
+                "STARTS_WITH(CAST(ip AS VARCHAR), '0.') OR " +           // RFC1122: "This host on this network"
+                "STARTS_WITH(CAST(ip AS VARCHAR), '10.') OR " +          // RFC1918: Private-Use
+                "STARTS_WITH(CAST(ip AS VARCHAR), '127') OR " +          // RFC1122: Loopback
+                "STARTS_WITH(CAST(ip AS VARCHAR), '169.254') OR " +      // RFC3927: Link Local
+                "STARTS_WITH(CAST(ip AS VARCHAR), '192.0.0.') OR " +     // RFC6890: IETF Protocol Assignments
+                "STARTS_WITH(CAST(ip AS VARCHAR), '192.0.2.') OR " +     // RFC5737: Documentation (TEST-NET-1)
+                "STARTS_WITH(CAST(ip AS VARCHAR), '192.88.99.') OR " +   // RFC3068: 6to4 Relay anycast
+                "STARTS_WITH(CAST(ip AS VARCHAR), '192.168') OR " +      // RFC1918: Private-Use
+                "STARTS_WITH(CAST(ip AS VARCHAR), '198.51.100') OR " +   // RFC5737: Documentation (TEST-NET-2)
+                "STARTS_WITH(CAST(ip AS VARCHAR), '203.0.113') OR " +    // RFC5737: Documentation (TEST-NET-3)
+
+                "TRY_CAST(IP_PREFIX(ip, 10) AS VARCHAR) = '100.64.0.0/10' OR " +    // RFC6598: Shared Address Space
+                "TRY_CAST(IP_PREFIX(ip, 12) AS VARCHAR) = '172.16.0.0/12' OR " +    // RFC1918: Private-Use
+                "TRY_CAST(IP_PREFIX(ip, 15) AS VARCHAR) = '198.18.0.0/15' OR " +    // RFC2544: Benchmarking
+                "TRY_CAST(IP_PREFIX(ip, 4) AS VARCHAR) = '240.0.0.0/4' " +   // RFC1112: Multicast, RFC1112: Reserved, RFC0919: Limited Broadcast
+
+                ", " + // ends the first (IPv4) condition of the IF block
+
+                // IPv6 conditions
+                "TRY_CAST(IP_PREFIX(ip, 128) AS VARCHAR) IN ('::/128','::1/128') OR " +     // RFC4291: Loopback and Unspecified address
+                "TRY_CAST(IP_PREFIX(ip, 96) AS VARCHAR) = '::ffff:0:0/96' OR " +            // RFC4291: IPv4-mapped Address
+                "TRY_CAST(IP_PREFIX(ip, 64) AS VARCHAR) = '100::/64' OR " +                 // RFC6666: Discard-Only Address Block
+                "TRY_CAST(IP_PREFIX(ip, 48) AS VARCHAR) IN ('64:ff9b:1::/48','2001:2::/48') OR " +  // RFC8215: IPv4-IPv6 Translation and RFC5180,RFC Errata 1752: Benchmarking
+                "TRY_CAST(IP_PREFIX(ip, 32) AS VARCHAR) = '2001:db8::/32' OR " +            // RFC3849: Documentation
+                "TRY_CAST(IP_PREFIX(ip, 23) AS VARCHAR) = '2001::/23' OR " +                // RFC2928: IETF Protocol Assignments
+                "TRY_CAST(IP_PREFIX(ip, 16) AS VARCHAR) = '5f00::/16' OR " +                // RFC-ietf-6man-sids-06: Segment Routing (SRv6)
+                "TRY_CAST(IP_PREFIX(ip, 10) AS VARCHAR) = 'fe80::/10' OR " +                // RFC4291: Link-Local Unicast
+                "TRY_CAST(IP_PREFIX(ip, 7) AS VARCHAR) = 'fc00::/7'" +                      // RFC4193, RFC8190: Unique Local
+
+                ")";  // closes IF condition
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestIPSqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestIPSqlFunctions.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar.sql;
 
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -21,264 +22,49 @@ import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 public class TestIPSqlFunctions
         extends AbstractTestFunctions
 {
-    @Test
-    public void testIsPrivateTrue()
+    @DataProvider(name = "private-ip-provider")
+    public Object[][] privateIpProvider()
     {
-        /*
-         * IPv4
-         */
+        return new Object[][] {
+                // The first and last IP address in each private range
+                {"0.0.0.0"}, {"0.255.255.255"},         // 0.0.0.0/8 RFC1122: "This host on this network"
+                {"10.0.0.0"}, {"10.255.255.255"},       // 10.0.0.0/8 RFC1918: Private-Use
+                {"100.64.0.0"}, {"100.127.255.255"},    // 100.64.0.0/10 RFC6598: Shared Address Space
+                {"127.0.0.0"}, {"127.255.255.255"},     // 127.0.0.0/8 RFC1122: Loopback
+                {"169.254.0.0"}, {"169.254.255.255"},   // 169.254.0.0/16 RFC3927: Link Local
+                {"172.16.0.0"}, {"172.31.255.255"},     // 172.16.0.0/12 RFC1918: Private-Use
+                {"192.0.0.0"}, {"192.0.0.255"},         // 192.0.0.0/24 RFC6890: IETF Protocol Assignments
+                {"192.0.2.0"}, {"192.0.2.255"},         // 192.0.2.0/24 RFC5737: Documentation (TEST-NET-1)
+                {"192.88.99.0"}, {"192.88.99.255"},     // 192.88.99.0/24 RFC3068: 6to4 Relay anycast
+                {"192.168.0.0"}, {"192.168.255.255"},   // 192.168.0.0/16 RFC1918: Private-Use
+                {"198.18.0.0"}, {"198.19.255.255"},     // 198.18.0.0/15 RFC2544: Benchmarking
+                {"198.51.100.0"}, {"198.51.100.255"},   // 198.51.100.0/24 RFC5737: Documentation (TEST-NET-2)
+                {"203.0.113.0"}, {"203.0.113.255"},     // 203.0.113.0/24 RFC5737: Documentation (TEST-NET-3)
+                {"240.0.0.0"}, {"255.255.255.255"},     // 240.0.0.0/4 RFC1112: Reserved
+                {"::"}, {"::"},                         // ::/128 RFC4291: Unspecified address
+                {"::1"}, {"::1"},                       // ::1/128 RFC4291: Loopback address
+                {"100::"}, {"100::ffff:ffff:ffff:ffff"},                        // 100::/64 RFC6666: Discard-Only Address Block
+                {"64:ff9b:1::"}, {"64:ff9b:1:ffff:ffff:ffff:ffff:ffff"},        // 64:ff9b:1::/48 RFC8215: IPv4-IPv6 Translation
+                {"2001:2::"}, {"2001:2:0:ffff:ffff:ffff:ffff:ffff"},            // 2001:2::/48 RFC5180,RFC Errata 1752: Benchmarking
+                {"2001:db8::"}, {"2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"},     // 2001:db8::/32 RFC3849: Documentation
+                {"2001::"}, {"2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff"},         // 2001::/23 RFC2928: IETF Protocol Assignments
+                {"5f00::"}, {"5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},        // 5f00::/16 RFC-ietf-6man-sids-06: Segment Routing (SRv6)
+                {"fe80::"}, {"febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},        // fe80::/10 RFC4291: Link-Local Unicast
+                {"fc00::"}, {"fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},        // fc00::/7 RFC4193, RFC8190: Unique Local
+                // some IPs in the middle of ranges
+                {"10.1.2.3"},
+                {"100.64.3.2"},
+                {"192.168.55.99"},
+                {"2001:0DB8:0000:0000:face:b00c:0000:0000"},
+                {"0100:0000:0000:0000:ffff:ffff:0000:0000"}
+        };
+    }
 
-        // 0.0.0.0/8 RFC1122: "This host on this network"
+    @Test (dataProvider = "private-ip-provider")
+    public void testIsPrivateTrue(String ipAddress)
+    {
         assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '0.0.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '0.255.255.255')",
-                BOOLEAN,
-                true);
-
-        // 10.0.0.0/8 RFC1918: Private-Use
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '10.0.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '10.255.255.255')",
-                BOOLEAN,
-                true);
-
-        // 100.64.0.0/10 RFC6598: Shared Address Space
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '100.64.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '100.127.255.255')",
-                BOOLEAN,
-                true);
-
-        // 127.0.0.0/8 RFC1122: Loopback
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '127.0.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '127.255.255.255')",
-                BOOLEAN,
-                true);
-
-        // 169.254.0.0/16 RFC3927: Link Local
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '169.254.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '169.254.255.255')",
-                BOOLEAN,
-                true);
-
-        // 172.16.0.0/12 RFC1918: Private-Use
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '172.16.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '172.31.255.255')",
-                BOOLEAN,
-                true);
-
-        // 192.0.0.0/24 RFC6890: IETF Protocol Assignments
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '192.0.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '192.0.0.255')",
-                BOOLEAN,
-                true);
-
-        // 192.0.2.0/24 RFC5737: Documentation (TEST-NET-1)
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '192.0.2.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '192.0.2.255')",
-                BOOLEAN,
-                true);
-
-        // 192.88.99.0/24 RFC3068: 6to4 Relay anycast
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '192.88.99.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '192.88.99.255')",
-                BOOLEAN,
-                true);
-
-        // 192.168.0.0/16 RFC1918: Private-Use
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '192.168.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '192.168.255.255')",
-                BOOLEAN,
-                true);
-
-        // 198.18.0.0/15 RFC2544: Benchmarking
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '198.18.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '198.19.255.255')",
-                BOOLEAN,
-                true);
-
-        // 198.51.100.0/24 RFC5737: Documentation (TEST-NET-2)
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '198.51.100.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '198.51.100.255')",
-                BOOLEAN,
-                true);
-
-        // 203.0.113.0/24 RFC5737: Documentation (TEST-NET-3)
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '203.0.113.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '203.0.113.255')",
-                BOOLEAN,
-                true);
-
-        // 240.0.0.0/4 RFC1112: Reserved
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '240.0.0.0')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '255.255.255.255')",
-                BOOLEAN,
-                true);
-
-        // ::/128 RFC4291: Loopback and Unspecified address
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '::')",
-                BOOLEAN,
-                true);
-
-        // ::1/128 RFC4291: Loopback and Unspecified address
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '::1')",
-                BOOLEAN,
-                true);
-
-        // 100::/64 RFC6666: Discard-Only Address Block
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '100::')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '100::ffff:ffff:ffff:ffff')",
-                BOOLEAN,
-                true);
-
-        // 64:ff9b:1::/48 RFC8215: IPv4-IPv6 Translation
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '64:ff9b:1::')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '64:ff9b:1:ffff:ffff:ffff:ffff:ffff')",
-                BOOLEAN,
-                true);
-
-        // 2001:2::/48 RFC5180,RFC Errata 1752: Benchmarking
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '2001:2::')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '2001:2:0:ffff:ffff:ffff:ffff:ffff')",
-                BOOLEAN,
-                true);
-
-        // 2001:db8::/32 RFC3849: Documentation
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '2001:db8::')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '2001:db8:ffff:ffff:ffff:ffff:ffff:ffff')",
-                BOOLEAN,
-                true);
-
-        // 2001::/23 RFC2928: IETF Protocol Assignments
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '2001::')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff')",
-                BOOLEAN,
-                true);
-
-        // 5f00::/16 RFC-ietf-6man-sids-06: Segment Routing (SRv6)
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '5f00::')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff')",
-                BOOLEAN,
-                true);
-
-        // fe80::/10 RFC4291: Link-Local Unicast
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS 'fe80::')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS 'febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff')",
-                BOOLEAN,
-                true);
-
-        // fc00::/7 RFC4193, RFC8190: Unique Local
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS 'fc00::')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS 'fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')",
-                BOOLEAN,
-                true);
-
-        // test a few IP addresses in the middle of the ranges
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '10.1.2.3')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '100.64.3.2')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '192.168.55.99')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '2001:0DB8:0000:0000:face:b00c:0000:0000')",
-                BOOLEAN,
-                true);
-        assertFunction(
-                "IS_PRIVATE_IP(IPADDRESS '0100:0000:0000:0000:ffff:ffff:0000:0000')",
+                "IS_PRIVATE_IP(IPADDRESS '" + ipAddress + "')",
                 BOOLEAN,
                 true);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestIPSqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestIPSqlFunctions.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+
+public class TestIPSqlFunctions
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testIsPrivateTrue()
+    {
+        /*
+         * IPv4
+         */
+
+        // 0.0.0.0/8 RFC1122: "This host on this network"
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '0.0.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '0.255.255.255')",
+                BOOLEAN,
+                true);
+
+        // 10.0.0.0/8 RFC1918: Private-Use
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '10.0.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '10.255.255.255')",
+                BOOLEAN,
+                true);
+
+        // 100.64.0.0/10 RFC6598: Shared Address Space
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '100.64.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '100.127.255.255')",
+                BOOLEAN,
+                true);
+
+        // 127.0.0.0/8 RFC1122: Loopback
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '127.0.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '127.255.255.255')",
+                BOOLEAN,
+                true);
+
+        // 169.254.0.0/16 RFC3927: Link Local
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '169.254.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '169.254.255.255')",
+                BOOLEAN,
+                true);
+
+        // 172.16.0.0/12 RFC1918: Private-Use
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '172.16.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '172.31.255.255')",
+                BOOLEAN,
+                true);
+
+        // 192.0.0.0/24 RFC6890: IETF Protocol Assignments
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '192.0.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '192.0.0.255')",
+                BOOLEAN,
+                true);
+
+        // 192.0.2.0/24 RFC5737: Documentation (TEST-NET-1)
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '192.0.2.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '192.0.2.255')",
+                BOOLEAN,
+                true);
+
+        // 192.88.99.0/24 RFC3068: 6to4 Relay anycast
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '192.88.99.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '192.88.99.255')",
+                BOOLEAN,
+                true);
+
+        // 192.168.0.0/16 RFC1918: Private-Use
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '192.168.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '192.168.255.255')",
+                BOOLEAN,
+                true);
+
+        // 198.18.0.0/15 RFC2544: Benchmarking
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '198.18.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '198.19.255.255')",
+                BOOLEAN,
+                true);
+
+        // 198.51.100.0/24 RFC5737: Documentation (TEST-NET-2)
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '198.51.100.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '198.51.100.255')",
+                BOOLEAN,
+                true);
+
+        // 203.0.113.0/24 RFC5737: Documentation (TEST-NET-3)
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '203.0.113.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '203.0.113.255')",
+                BOOLEAN,
+                true);
+
+        // 240.0.0.0/4 RFC1112: Reserved
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '240.0.0.0')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '255.255.255.255')",
+                BOOLEAN,
+                true);
+
+
+        // ::/128 RFC4291: Loopback and Unspecified address
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '::')",
+                BOOLEAN,
+                true);
+
+        // ::1/128 RFC4291: Loopback and Unspecified address
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '::1')",
+                BOOLEAN,
+                true);
+
+        // 100::/64 RFC6666: Discard-Only Address Block
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '100::')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '100::ffff:ffff:ffff:ffff')",
+                BOOLEAN,
+                true);
+
+        // 64:ff9b:1::/48 RFC8215: IPv4-IPv6 Translation
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '64:ff9b:1::')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '64:ff9b:1:ffff:ffff:ffff:ffff:ffff')",
+                BOOLEAN,
+                true);
+
+        // 2001:2::/48 RFC5180,RFC Errata 1752: Benchmarking
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '2001:2::')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '2001:2:0:ffff:ffff:ffff:ffff:ffff')",
+                BOOLEAN,
+                true);
+
+        // 2001:db8::/32 RFC3849: Documentation
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '2001:db8::')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '2001:db8:ffff:ffff:ffff:ffff:ffff:ffff')",
+                BOOLEAN,
+                true);
+
+        // 2001::/23 RFC2928: IETF Protocol Assignments
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '2001::')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff')",
+                BOOLEAN,
+                true);
+
+        // 5f00::/16 RFC-ietf-6man-sids-06: Segment Routing (SRv6)
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '5f00::')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff')",
+                BOOLEAN,
+                true);
+
+        // fe80::/10 RFC4291: Link-Local Unicast
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS 'fe80::')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS 'febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff')",
+                BOOLEAN,
+                true);
+
+        // fc00::/7 RFC4193, RFC8190: Unique Local
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS 'fc00::')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS 'fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')",
+                BOOLEAN,
+                true);
+
+
+        // test a few IP addresses in the middle of the ranges
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '10.1.2.3')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '100.64.3.2')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '192.168.55.99')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '2001:0DB8:0000:0000:face:b00c:0000:0000')",
+                BOOLEAN,
+                true);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '0100:0000:0000:0000:ffff:ffff:0000:0000')",
+                BOOLEAN,
+                true);
+    }
+
+    @Test
+    public void testIsReservedFalse()
+    {
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '157.240.200.99')",
+                BOOLEAN,
+                false);
+        assertFunction(
+                "IS_PRIVATE_IP(IPADDRESS '2a03:2880:f031:12:face:b00c:0:2')",
+                BOOLEAN,
+                false);
+    }
+
+    @Test
+    public void testIsReservedIpNull()
+    {
+        assertFunction(
+                "IS_PRIVATE_IP(NULL)",
+                BOOLEAN,
+                null);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestIPSqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestIPSqlFunctions.java
@@ -168,7 +168,6 @@ public class TestIPSqlFunctions
                 BOOLEAN,
                 true);
 
-
         // ::/128 RFC4291: Loopback and Unspecified address
         assertFunction(
                 "IS_PRIVATE_IP(IPADDRESS '::')",
@@ -260,7 +259,6 @@ public class TestIPSqlFunctions
                 "IS_PRIVATE_IP(IPADDRESS 'fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')",
                 BOOLEAN,
                 true);
-
 
         // test a few IP addresses in the middle of the ranges
         assertFunction(


### PR DESCRIPTION
## Description
Adding the `is_private_ip` UDF that checks whether an IP address is within private or reserved range that is not globally reachable. We take our definitions from what IANA considers *not* "globally reachable" in
[https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) and
[https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml](https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml).

## Motivation and Context
When working with network data, filtering private IP address space is a common requirement. Without a standard function to handle it, it has led to numerous instances of:
* Incorrect/partial detection because of the scattered nature of Internet RFCs.
* Code duplication and general clutter to handle ~25 IP address block conditions.

## Test Plan
Added unit tests that check that the boundaries of all include private ranges return `true` while non-private ranges return `false`.

`mvn clean install -Dtest=TestIPSqlFunctions -Dmaven.javadoc.skip=true -DskipUI -T1C -fn -pl presto-main`

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

```
== RELEASE NOTES ==

General Changes
* - Add function :func:`is_private_ip` :pr:`23243`
```