### PR TITLE
Fix rollback after statement fail in non-autocommit transaction

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryPreparer.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryPreparer.java
@@ -166,6 +166,11 @@ public class BuiltInQueryPreparer
             return StatementUtils.isTransactionControlStatement(getStatement());
         }
 
+        public boolean isRollbackStatement()
+        {
+            return StatementUtils.isRollbackStatement(getStatement());
+        }
+
         @Override
         public boolean isExplainTypeValidate()
         {

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/StatementUtils.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/utils/StatementUtils.java
@@ -178,4 +178,9 @@ public final class StatementUtils
     {
         return statement instanceof StartTransaction || statement instanceof Commit || statement instanceof Rollback;
     }
+
+    public static boolean isRollbackStatement(Statement statement)
+    {
+        return statement instanceof Rollback;
+    }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -102,6 +102,12 @@ public class TestCassandraDistributed
     }
 
     @Override
+    public void testNonAutoCommitTransactionWithFailAndRollback()
+    {
+        // Ignore since Cassandra connector currently does not support create table
+    }
+
+    @Override
     public void testUpdate()
     {
         // Updates are not supported by the connector

--- a/presto-common/src/main/java/com/facebook/presto/common/analyzer/PreparedQuery.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/analyzer/PreparedQuery.java
@@ -50,6 +50,11 @@ public abstract class PreparedQuery
         throw new UnsupportedOperationException("isTransactionControlStatement method is not supported!");
     }
 
+    public boolean isRollbackStatement()
+    {
+        throw new UnsupportedOperationException("isRollbackStatement method is not supported!");
+    }
+
     public Class<?> getStatementClass()
     {
         throw new UnsupportedOperationException("getStatementClass method is not supported!");

--- a/presto-main-base/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/Session.java
@@ -365,10 +365,19 @@ public final class Session
 
     public Session beginTransactionId(TransactionId transactionId, TransactionManager transactionManager, AccessControl accessControl)
     {
+        return beginTransactionId(transactionId, false, transactionManager, accessControl);
+    }
+
+    public Session beginTransactionId(TransactionId transactionId, boolean enableRollback, TransactionManager transactionManager, AccessControl accessControl)
+    {
         requireNonNull(transactionId, "transactionId is null");
         checkArgument(!this.transactionId.isPresent(), "Session already has an active transaction");
         requireNonNull(transactionManager, "transactionManager is null");
         requireNonNull(accessControl, "accessControl is null");
+
+        if (enableRollback) {
+            transactionManager.enableRollback(transactionId);
+        }
 
         for (Entry<String, String> property : systemProperties.entrySet()) {
             // verify permissions

--- a/presto-main-base/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -313,7 +313,7 @@ public class DispatchManager
 
             session = sessionBuilder.build();
             if (sessionContext.getTransactionId().isPresent()) {
-                session = session.beginTransactionId(sessionContext.getTransactionId().get(), transactionManager, accessControl);
+                session = session.beginTransactionId(sessionContext.getTransactionId().get(), preparedQuery.isRollbackStatement(), transactionManager, accessControl);
             }
 
             // mark existing transaction as active

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.server;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
 
@@ -25,12 +24,6 @@ import static com.facebook.presto.Session.SessionBuilder;
 public class NoOpSessionSupplier
         implements SessionSupplier
 {
-    @Override
-    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
-    {
-        throw new UnsupportedOperationException();
-    }
-
     @Override
     public SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -74,16 +74,6 @@ public class QuerySessionSupplier
     }
 
     @Override
-    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
-    {
-        Session session = createSessionBuilder(queryId, context, warningCollectorFactory).build();
-        if (context.getTransactionId().isPresent()) {
-            session = session.beginTransactionId(context.getTransactionId().get(), transactionManager, accessControl);
-        }
-        return session;
-    }
-
-    @Override
     public SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
     {
         SessionBuilder sessionBuilder = Session.builder(sessionPropertyManager)

--- a/presto-main-base/src/main/java/com/facebook/presto/server/SessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/SessionSupplier.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.server;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
 
@@ -21,7 +20,5 @@ import static com.facebook.presto.Session.SessionBuilder;
 
 public interface SessionSupplier
 {
-    Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
-
     SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/transaction/DelegatingTransactionManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/transaction/DelegatingTransactionManager.java
@@ -94,6 +94,12 @@ public class DelegatingTransactionManager
     }
 
     @Override
+    public void enableRollback(TransactionId transactionId)
+    {
+        delegate.enableRollback(transactionId);
+    }
+
+    @Override
     public CatalogMetadata getCatalogMetadata(TransactionId transactionId, ConnectorId connectorId)
     {
         return delegate.getCatalogMetadata(transactionId, connectorId);

--- a/presto-main-base/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
@@ -81,6 +81,12 @@ public class NoOpTransactionManager
     }
 
     @Override
+    public void enableRollback(TransactionId transactionId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public CatalogMetadata getCatalogMetadata(TransactionId transactionId, ConnectorId connectorId)
     {
         throw new UnsupportedOperationException();

--- a/presto-main-base/src/main/java/com/facebook/presto/transaction/TransactionManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/transaction/TransactionManager.java
@@ -49,6 +49,8 @@ public interface TransactionManager
 
     Optional<CatalogMetadata> getOptionalCatalogMetadata(TransactionId transactionId, String catalogName);
 
+    void enableRollback(TransactionId transactionId);
+
     CatalogMetadata getCatalogMetadata(TransactionId transactionId, ConnectorId connectorId);
 
     CatalogMetadata getCatalogMetadataForWrite(TransactionId transactionId, ConnectorId connectorId);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
@@ -104,7 +104,7 @@ public class TestQuerySessionSupplier
                 return WarningCollector.NOOP;
             }
         };
-        Session session = sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory);
+        Session session = sessionSupplier.createSessionBuilder(new QueryId("test_query_id"), context, warningCollectorFactory).build();
 
         assertEquals(session.getQueryId(), new QueryId("test_query_id"));
         assertEquals(session.getUser(), "testUser");
@@ -178,6 +178,6 @@ public class TestQuerySessionSupplier
                 return WarningCollector.NOOP;
             }
         };
-        sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory);
+        sessionSupplier.createSessionBuilder(new QueryId("test_query_id"), context, warningCollectorFactory).build();
     }
 }


### PR DESCRIPTION
## Description

This PR fix the session corruption cause by a failed statement in non-autocommit transaction, enable executing `rollback` to end the aborted transaction block.

## Motivation

Fix: #23246 

## Test Plan

 - Newly added test cases in hive and iceberg to simulate the scenarios described in #23246
 - Manually confirm the fix in CLI console

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

