### PR TITLE
Fix bug when property exist in both connector,catalog session properties

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -39,6 +39,7 @@ import org.intellij.lang.annotations.Language;
 
 import java.io.Closeable;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -134,7 +135,7 @@ public abstract class AbstractTestingPrestoClient<T>
 
     private static ClientSession toClientSession(Session session, URI server, Duration clientRequestTimeout)
     {
-        ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+        Map<String, String> properties = new HashMap<>();
         properties.putAll(session.getSystemProperties());
         for (Entry<String, Map<String, String>> connectorProperties : session.getUnprocessedCatalogProperties().entrySet()) {
             for (Entry<String, String> entry : connectorProperties.getValue().entrySet()) {
@@ -171,7 +172,7 @@ public abstract class AbstractTestingPrestoClient<T>
                 session.getTimeZoneKey().getId(),
                 session.getLocale(),
                 resourceEstimates.build(),
-                properties.build(),
+                ImmutableMap.copyOf(properties),
                 session.getPreparedStatements(),
                 session.getIdentity().getRoles(),
                 session.getIdentity().getExtraCredentials(),


### PR DESCRIPTION
## Description
Fix bug when property exist in both connector,catalog session properties

## Motivation and Context
After :pr: `23206`, when a session property exists in both catalog and connector properties, the tests fail since an immutable map cannot have two same keys.

## Impact
None

## Test Plan
existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

