### PR TITLE
Do not capitalize version and environment on web UI

### DIFF
--- a/presto-router/src/main/resources/router_ui/src/components/PageTitle.jsx
+++ b/presto-router/src/main/resources/router_ui/src/components/PageTitle.jsx
@@ -124,7 +124,7 @@ export class PageTitle extends React.Component<Props, State> {
                                 <li>
                                     <span className="navbar-cluster-info">
                                         <span className="uppercase">Environment</span><br/>
-                                        <span className="text uppercase" id="environment">{info.environment}</span>
+                                        <span className="text" id="environment">{info.environment}</span>
                                     </span>
                                 </li>
                             </ul>

--- a/presto-ui/src/components/PageTitle.jsx
+++ b/presto-ui/src/components/PageTitle.jsx
@@ -140,13 +140,13 @@ export class PageTitle extends React.Component<Props, State> {
                                 <li>
                                     <span className="navbar-cluster-info">
                                         <span className="uppercase">Version</span><br/>
-                                        <span className="text uppercase" id="version-number">{info.nodeVersion.version}</span>
+                                        <span className="text" id="version-number">{info.nodeVersion.version}</span>
                                     </span>
                                 </li>
                                 <li>
                                     <span className="navbar-cluster-info">
                                         <span className="uppercase">Environment</span><br/>
-                                        <span className="text uppercase" id="environment">{info.environment}</span>
+                                        <span className="text" id="environment">{info.environment}</span>
                                     </span>
                                 </li>
                                 <li>


### PR DESCRIPTION
Capitalizing makes it not copy friendly

```
== NO RELEASE NOTE ==
```

