### PR TITLE
[Native] Add alias substring for substr function

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -51,6 +51,9 @@ std::string mapScalarFunction(const std::string& name) {
       {"presto.default.$operator$not_equal", "presto.default.neq"},
       {"presto.default.$operator$subtract", "presto.default.minus"},
       {"presto.default.$operator$subscript", "presto.default.subscript"},
+      {"presto.default.$operator$subscript", "presto.default.subscript"},
+      // Substring.
+      {"substring", "presto.default.substr"},
       // Special form function overrides.
       {"presto.default.in", "in"},
   };

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -822,9 +822,12 @@ public abstract class AbstractTestNativeGeneralQueries
     public void testStringFunctions()
     {
         // Substr, length, trim.
-        assertQuery("SELECT substr(comment, 1, 10), length(comment), trim(comment) FROM orders");
+        assertQuery("SELECT substr(comment, 5), length(comment), trim(comment) FROM orders");
         assertQuery("SELECT substr(comment, 1, 10), length(comment), ltrim(comment) FROM orders");
         assertQuery("SELECT substr(comment, 1, 10), length(comment), rtrim(comment) FROM orders");
+
+        assertQuery("SELECT substring(comment, 5), length(comment), trim(comment) FROM orders");
+        assertQuery("SELECT substring(comment, 1, 10), length(comment), ltrim(comment) FROM orders");
 
         assertQuery("SELECT trim(comment, ' ns'), ltrim(comment, 'a b c'), rtrim(comment, 'l y') FROM orders");
 


### PR DESCRIPTION
## Description
Presto allows usage of substring as an alias of substr.

e2e tests

```
== NO RELEASE NOTE ==
```

