### PR TITLE
Aggressively prune query info after completion

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
@@ -115,7 +115,10 @@ public class FailedDispatchQuery
     public void cancel() {}
 
     @Override
-    public void pruneInfo() {}
+    public void pruneExpiredQueryInfo() {}
+
+    @Override
+    public void pruneFinishedQueryInfo() {}
 
     @Override
     public QueryId getQueryId()
@@ -194,5 +197,5 @@ public class FailedDispatchQuery
 
     @Override
     public void setResourceGroupQueryLimits(ResourceGroupQueryLimits resourceGroupQueryLimits)
-    { }
+    {}
 }

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
@@ -357,9 +357,15 @@ public class LocalDispatchQuery
     }
 
     @Override
-    public void pruneInfo()
+    public void pruneExpiredQueryInfo()
     {
-        stateMachine.pruneQueryInfo();
+        stateMachine.pruneQueryInfoExpired();
+    }
+
+    @Override
+    public void pruneFinishedQueryInfo()
+    {
+        stateMachine.pruneQueryInfoFinished();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/AccessControlCheckerExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AccessControlCheckerExecution.java
@@ -327,7 +327,13 @@ public class AccessControlCheckerExecution
     }
 
     @Override
-    public void pruneInfo()
+    public void pruneExpiredQueryInfo()
+    {
+        // no-op
+    }
+
+    @Override
+    public void pruneFinishedQueryInfo()
     {
         // no-op
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -162,6 +162,7 @@ public abstract class DataDefinitionExecution<T extends Statement>
     {
         return DataSize.succinctBytes(0);
     }
+
     @Override
     public long getOutputPositions()
     {
@@ -290,7 +291,13 @@ public abstract class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
-    public void pruneInfo()
+    public void pruneExpiredQueryInfo()
+    {
+        // no-op
+    }
+
+    @Override
+    public void pruneFinishedQueryInfo()
     {
         // no-op
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -19,7 +19,9 @@ import com.facebook.presto.common.ErrorCode;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsAndCosts;
+import com.facebook.presto.cost.VariableStatsEstimate;
 import com.facebook.presto.execution.QueryExecution.QueryOutputInfo;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
@@ -38,13 +40,17 @@ import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.security.SelectedRole;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
+import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.sql.planner.CanonicalPlanWithInfo;
+import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.transaction.TransactionInfo;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.FutureCallback;
@@ -93,6 +99,8 @@ import static com.facebook.presto.util.Failures.toFailure;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.String.format;
@@ -1046,7 +1054,24 @@ public class QueryStateMachine
      * Remove large objects from the query info object graph, e.g : plan, stats, stage summaries, failed attempts
      * Used when pruning expired queries from the state machine
      */
-    public void pruneQueryInfo()
+    public void pruneQueryInfoExpired()
+    {
+        Optional<QueryInfo> finalInfo = finalQueryInfo.get();
+        if (!finalInfo.isPresent() || !finalInfo.get().getOutputStage().isPresent()) {
+            return;
+        }
+        QueryInfo queryInfo = finalInfo.get();
+        QueryInfo prunedQueryInfo;
+
+        prunedQueryInfo = pruneExpiredQueryInfo(queryInfo, getMemoryPool());
+        finalQueryInfo.compareAndSet(finalInfo, Optional.of(prunedQueryInfo));
+    }
+
+    /**
+     * Remove the largest objects from the query info object graph, e.g : extraneous stats, costs,
+     * and histograms to reduce memory utilization
+     */
+    public void pruneQueryInfoFinished()
     {
         Optional<QueryInfo> finalInfo = finalQueryInfo.get();
         if (!finalInfo.isPresent() || !finalInfo.get().getOutputStage().isPresent()) {
@@ -1054,20 +1079,150 @@ public class QueryStateMachine
         }
 
         QueryInfo queryInfo = finalInfo.get();
+        QueryInfo prunedQueryInfo;
+
+        // no longer needed in the session after query finishes
+        session.getPlanNodeStatsMap().clear();
+        session.getPlanNodeCostMap().clear();
+        // inputs contain some statistics which should be cleared
+        inputs.getAndUpdate(QueryStateMachine::pruneInputHistograms);
+        // query listeners maintain state in their arguments which holds
+        // onto plan nodes and statistics. Since finalQueryInfo was
+        // already set it should be in a terminal state and be safe to
+        // clear the listeners.
+        finalQueryInfo.clearEventListeners();
+        planStatsAndCosts.getAndUpdate(stats -> Optional.ofNullable(stats)
+                .map(QueryStateMachine::pruneHistogramsFromStatsAndCosts)
+                .orElse(null));
+        prunedQueryInfo = pruneFinishedQueryInfo(queryInfo, inputs.get());
+        finalQueryInfo.compareAndSet(finalInfo, Optional.of(prunedQueryInfo));
+    }
+
+    private static QueryInfo pruneFinishedQueryInfo(QueryInfo queryInfo, Set<Input> prunedInputs)
+    {
+        return new QueryInfo(
+                queryInfo.getQueryId(),
+                queryInfo.getSession(),
+                queryInfo.getState(),
+                queryInfo.getMemoryPool(),
+                queryInfo.isScheduled(),
+                queryInfo.getSelf(),
+                queryInfo.getFieldNames(),
+                queryInfo.getQuery(),
+                queryInfo.getExpandedQuery(),
+                queryInfo.getPreparedQuery(),
+                queryInfo.getQueryStats(),
+                queryInfo.getSetCatalog(),
+                queryInfo.getSetSchema(),
+                queryInfo.getSetSessionProperties(),
+                queryInfo.getResetSessionProperties(),
+                queryInfo.getSetRoles(),
+                queryInfo.getAddedPreparedStatements(),
+                queryInfo.getDeallocatedPreparedStatements(),
+                queryInfo.getStartedTransactionId(),
+                queryInfo.isClearTransactionId(),
+                queryInfo.getUpdateType(),
+                queryInfo.getOutputStage().map(QueryStateMachine::pruneStatsFromStageInfo),
+                queryInfo.getFailureInfo(),
+                queryInfo.getErrorCode(),
+                queryInfo.getWarnings(),
+                prunedInputs,
+                queryInfo.getOutput(),
+                queryInfo.isFinalQueryInfo(),
+                queryInfo.getResourceGroupId(),
+                queryInfo.getQueryType(),
+                queryInfo.getFailedTasks(),
+                queryInfo.getRuntimeOptimizedStages(),
+                queryInfo.getAddedSessionFunctions(),
+                queryInfo.getRemovedSessionFunctions(),
+                pruneHistogramsFromStatsAndCosts(queryInfo.getPlanStatsAndCosts()),
+                queryInfo.getOptimizerInformation(),
+                queryInfo.getCteInformationList(),
+                queryInfo.getScalarFunctions(),
+                queryInfo.getAggregateFunctions(),
+                queryInfo.getWindowFunctions(),
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                queryInfo.getPrestoSparkExecutionContext());
+    }
+
+    private static Set<Input> pruneInputHistograms(Set<Input> inputs)
+    {
+        return inputs.stream().map(input -> new Input(input.getConnectorId(),
+                        input.getSchema(),
+                        input.getTable(),
+                        input.getConnectorInfo(),
+                        input.getColumns(),
+                        input.getStatistics().map(tableStats -> TableStatistics.buildFrom(tableStats)
+                                .setColumnStatistics(ImmutableMap.copyOf(
+                                        Maps.transformValues(tableStats.getColumnStatistics(),
+                                                columnStats -> ColumnStatistics.buildFrom(columnStats)
+                                                        .setHistogram(Optional.empty())
+                                                        .build())))
+                                .build()),
+                        input.getSerializedCommitOutput()))
+                .collect(toImmutableSet());
+    }
+
+    protected static StatsAndCosts pruneHistogramsFromStatsAndCosts(StatsAndCosts statsAndCosts)
+    {
+        Map<PlanNodeId, PlanNodeStatsEstimate> newStats = statsAndCosts.getStats()
+                .entrySet()
+                .stream()
+                .collect(toImmutableMap(entry -> entry.getKey(),
+                        entry -> PlanNodeStatsEstimate.buildFrom(entry.getValue())
+                                .addVariableStatistics(ImmutableMap.copyOf(
+                                        Maps.transformValues(
+                                                entry.getValue().getVariableStatistics(),
+                                                variableStats -> VariableStatsEstimate.buildFrom(variableStats)
+                                                        .setHistogram(Optional.empty())
+                                                        .build())))
+                                .build()));
+
+        return new StatsAndCosts(newStats,
+                statsAndCosts.getCosts());
+    }
+
+    private static StageInfo pruneStatsFromStageInfo(StageInfo stage)
+    {
+        return new StageInfo(
+                stage.getStageId(),
+                stage.getSelf(),
+                stage.getPlan().map(plan -> new PlanFragment(
+                        plan.getId(),
+                        plan.getRoot(),
+                        plan.getVariables(),
+                        plan.getPartitioning(),
+                        plan.getTableScanSchedulingOrder(),
+                        plan.getPartitioningScheme(),
+                        plan.getStageExecutionDescriptor(),
+                        plan.isOutputTableWriterFragment(),
+                        plan.getStatsAndCosts().map(QueryStateMachine::pruneHistogramsFromStatsAndCosts),
+                        plan.getJsonRepresentation())), // Remove the plan
+                stage.getLatestAttemptExecutionInfo(),
+                stage.getPreviousAttemptsExecutionInfos(), // Remove failed attempts
+                stage.getSubStages().stream()
+                        .map(QueryStateMachine::pruneStatsFromStageInfo)
+                        .collect(toImmutableList()), // Remove the substages
+                stage.isRuntimeOptimized());
+    }
+
+    private static QueryInfo pruneExpiredQueryInfo(QueryInfo queryInfo, VersionedMemoryPoolId pool)
+    {
         Optional<StageInfo> prunedOutputStage = queryInfo.getOutputStage().map(outputStage -> new StageInfo(
                 outputStage.getStageId(),
                 outputStage.getSelf(),
                 Optional.empty(), // Remove the plan
                 pruneStageExecutionInfo(outputStage.getLatestAttemptExecutionInfo()),
                 ImmutableList.of(), // Remove failed attempts
-                ImmutableList.of(),
-                outputStage.isRuntimeOptimized())); // Remove the substages
+                ImmutableList.of(), // Remove the substages
+                outputStage.isRuntimeOptimized()));
 
-        QueryInfo prunedQueryInfo = new QueryInfo(
+        return new QueryInfo(
                 queryInfo.getQueryId(),
                 queryInfo.getSession(),
                 queryInfo.getState(),
-                getMemoryPool().getId(),
+                pool.getId(),
                 queryInfo.isScheduled(),
                 queryInfo.getSelf(),
                 queryInfo.getFieldNames(),
@@ -1107,7 +1262,6 @@ public class QueryStateMachine
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 queryInfo.getPrestoSparkExecutionContext());
-        finalQueryInfo.compareAndSet(finalInfo, Optional.of(prunedQueryInfo));
     }
 
     private static StageExecutionInfo pruneStageExecutionInfo(StageExecutionInfo info)

--- a/presto-main/src/main/java/com/facebook/presto/execution/StateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StateMachine.java
@@ -283,6 +283,11 @@ public class StateMachine<T>
         return terminalStates.contains(state);
     }
 
+    public void clearEventListeners()
+    {
+        stateChangeListeners.clear();
+    }
+
     @VisibleForTesting
     List<StateChangeListener<T>> getStateChangeListeners()
     {

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -217,7 +217,11 @@ public class MockQueryExecution
     }
 
     @Override
-    public void pruneInfo()
+    public void pruneExpiredQueryInfo()
+    { }
+
+    @Override
+    public void pruneFinishedQueryInfo()
     { }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
@@ -132,6 +132,16 @@ public final class ColumnStatistics
         return new Builder();
     }
 
+    public static Builder buildFrom(ColumnStatistics statistics)
+    {
+        return new Builder()
+                .setRange(statistics.getRange())
+                .setDataSize(statistics.getDataSize())
+                .setNullsFraction(statistics.getNullsFraction())
+                .setDistinctValuesCount(statistics.getDistinctValuesCount())
+                .setHistogram(statistics.getHistogram());
+    }
+
     /**
      * If one of the estimates below is unspecified, the default "unknown" estimate value
      * (represented by floating point NaN) may cause the resulting symbol statistics

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
@@ -116,6 +116,15 @@ public final class TableStatistics
         return new Builder();
     }
 
+    public static Builder buildFrom(TableStatistics tableStatistics)
+    {
+        return new Builder()
+                .setRowCount(tableStatistics.getRowCount())
+                .setTotalSize(tableStatistics.getTotalSize())
+                .setConfidenceLevel(tableStatistics.getConfidence())
+                .setColumnStatistics(tableStatistics.getColumnStatistics());
+    }
+
     public static final class Builder
     {
         private Estimate rowCount = Estimate.unknown();
@@ -151,6 +160,13 @@ public final class TableStatistics
             requireNonNull(columnHandle, "columnHandle can not be null");
             requireNonNull(columnStatistics, "columnStatistics can not be null");
             this.columnStatisticsMap.put(columnHandle, columnStatistics);
+            return this;
+        }
+
+        public Builder setColumnStatistics(Map<ColumnHandle, ColumnStatistics> columnStatistics)
+        {
+            requireNonNull(columnStatistics, "columnStatistics can not be null");
+            this.columnStatisticsMap.putAll(columnStatistics);
             return this;
         }
 

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
@@ -335,7 +335,7 @@ public class TestEventListener
         assertEquals(queryCompletedEvent.getMetadata().getGraphvizPlan().get(), getOnlyElement(expected.getOnlyColumnAsSet()));
     }
 
-    static class EventsBuilder
+    public static class EventsBuilder
     {
         private ImmutableList.Builder<QueryCreatedEvent> queryCreatedEvents;
         private ImmutableList.Builder<QueryCompletedEvent> queryCompletedEvents;

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListenerPlugin.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListenerPlugin.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 
 public class TestEventListenerPlugin
 {
-    static class TestingEventListenerPlugin
+    public static class TestingEventListenerPlugin
             implements Plugin
     {
         private final EventsBuilder eventsBuilder;
@@ -46,7 +46,7 @@ public class TestEventListenerPlugin
         }
     }
 
-    private static class TestingEventListenerFactory
+    public static class TestingEventListenerFactory
             implements EventListenerFactory
     {
         private final EventsBuilder eventsBuilder;
@@ -69,7 +69,7 @@ public class TestEventListenerPlugin
         }
     }
 
-    private static class TestingEventListener
+    public static class TestingEventListener
             implements EventListener
     {
         private final EventsBuilder eventsBuilder;


### PR DESCRIPTION
## Description

This change aggressively prunes query plan metadata before query expiry. It is mostly limited to query plan statistics.

With this change and with histograms enabled in #22365, this cuts the coordinator heap utilization by anywhere between 50% and 75% after running a portion of the TPC-DS benchmark (3-4GiB -> 600-800MiB)

## Motivation and Context

Previously, we only pruned information from old queries after the expiration queue filled. With the addition of histograms query statistics can take two orders of magnitude more memory than previous statistics. Without pruning statistics we will much more quickly hit memory limits of the JVM.

Specifically, these are the areas where we try to clear references to save memory:

- Session: `planNodeStatsMap` and `planCostMapMap`
- QueryStateMachine: clear statistics from `inputs` and `planStatsAndCosts`
- StateMachine: Once final queryInfo reaches a terminal state, we should clear the event listeners to release references to local variables which maintain the SqlQuerySchedule and Stage execution information
- Prune all histograms from `finalQueryInfo`'s `planStatsAndCosts` and from the entire `StageInfo` graph.

Fixes #23254 

## Impact

- Results from the QueryInfo API after execution finishes will always return column statistics with empty histograms

## Test Plan

- Added a new test which verifies that a query completed event is generated before all queryInfo pruning is done

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

