### PR TITLE
Add iceberg table properties for maintenance of previous metadata files

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -313,7 +313,13 @@ Property Name                                           Description             
 
                                                         Set to ``0`` to disable metadata optimization.
 
-``iceberg.split-manager-threads``                       Number of threads to use for generating Iceberg splits.        ``Number of available processors``
+``iceberg.split-manager-threads``                       Number of threads to use for generating Iceberg splits.       ``Number of available processors``
+
+``iceberg.metadata-previous-versions-max``              The max number of old metadata files to keep in current       ``100``
+                                                        metadata log.
+
+``iceberg.metadata-delete-after-commit``                Set to ``true`` to delete the oldest metadata files after     ``false``
+                                                        each commit.
 ======================================================= ============================================================= ============
 
 Table Properties
@@ -355,6 +361,12 @@ Property Name                             Description                           
 ``delete_mode``                            Optionally specifies the write delete mode of the Iceberg        ``merge-on-read``
                                            specification to use for new tables, either ``copy-on-write``
                                            or ``merge-on-read``.
+
+``metadata_previous_versions_max``         Optionally specifies the max number of old metadata files to     ``100``
+                                           keep in current metadata log.
+
+``metadata_delete_after_commit``           Set to ``true`` to delete the oldest metadata file after         ``false``
+                                           each commit.
 =======================================   ===============================================================   ============
 
 The table definition below specifies format ``ORC``, partitioning by columns ``c1`` and ``c2``,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -119,6 +119,8 @@ import static com.facebook.presto.iceberg.IcebergTableProperties.DELETE_MODE;
 import static com.facebook.presto.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableProperties.FORMAT_VERSION;
 import static com.facebook.presto.iceberg.IcebergTableProperties.LOCATION_PROPERTY;
+import static com.facebook.presto.iceberg.IcebergTableProperties.METADATA_DELETE_AFTER_COMMIT;
+import static com.facebook.presto.iceberg.IcebergTableProperties.METADATA_PREVIOUS_VERSIONS_MAX;
 import static com.facebook.presto.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableType.CHANGELOG;
 import static com.facebook.presto.iceberg.IcebergTableType.DATA;
@@ -552,6 +554,8 @@ public abstract class IcebergAbstractMetadata
         }
 
         properties.put(DELETE_MODE, IcebergUtil.getDeleteMode(icebergTable));
+        properties.put(METADATA_PREVIOUS_VERSIONS_MAX, IcebergUtil.getMetadataPreviousVersionsMax(icebergTable));
+        properties.put(METADATA_DELETE_AFTER_COMMIT, IcebergUtil.isMetadataDeleteAfterCommit(icebergTable));
 
         return properties.build();
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -36,6 +36,8 @@ import static com.facebook.presto.iceberg.util.StatisticsUtil.decodeMergeFlags;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
+import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
+import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
 
 public class IcebergConfig
 {
@@ -53,6 +55,8 @@ public class IcebergConfig
     private boolean pushdownFilterEnabled;
     private boolean deleteAsJoinRewriteEnabled = true;
     private int rowsForMetadataOptimizationThreshold = 1000;
+    private int metadataPreviousVersionsMax = METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
+    private boolean metadataDeleteAfterCommit = METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
 
     private EnumSet<ColumnStatisticType> hiveStatisticsMergeFlags = EnumSet.noneOf(ColumnStatisticType.class);
     private String fileIOImpl = HadoopFileIO.class.getName();
@@ -347,6 +351,33 @@ public class IcebergConfig
     public IcebergConfig setSplitManagerThreads(int splitManagerThreads)
     {
         this.splitManagerThreads = splitManagerThreads;
+        return this;
+    }
+
+    @Min(0)
+    public int getMetadataPreviousVersionsMax()
+    {
+        return metadataPreviousVersionsMax;
+    }
+
+    @Config("iceberg.metadata-previous-versions-max")
+    @ConfigDescription("The max number of old metadata files to keep in metadata log")
+    public IcebergConfig setMetadataPreviousVersionsMax(int metadataPreviousVersionsMax)
+    {
+        this.metadataPreviousVersionsMax = metadataPreviousVersionsMax;
+        return this;
+    }
+
+    public boolean isMetadataDeleteAfterCommit()
+    {
+        return metadataDeleteAfterCommit;
+    }
+
+    @Config("iceberg.metadata-delete-after-commit")
+    @ConfigDescription("Whether enables to delete the oldest metadata file after commit")
+    public IcebergConfig setMetadataDeleteAfterCommit(boolean metadataDeleteAfterCommit)
+    {
+        this.metadataDeleteAfterCommit = metadataDeleteAfterCommit;
         return this;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -40,6 +41,8 @@ public class IcebergTableProperties
     public static final String FORMAT_VERSION = "format_version";
     public static final String COMMIT_RETRIES = "commit_retries";
     public static final String DELETE_MODE = "delete_mode";
+    public static final String METADATA_PREVIOUS_VERSIONS_MAX = "metadata_previous_versions_max";
+    public static final String METADATA_DELETE_AFTER_COMMIT = "metadata_delete_after_commit";
     private static final String DEFAULT_FORMAT_VERSION = "2";
 
     private final List<PropertyMetadata<?>> tableProperties;
@@ -93,6 +96,16 @@ public class IcebergTableProperties
                         false,
                         value -> RowLevelOperationMode.fromName((String) value),
                         RowLevelOperationMode::modeName))
+                .add(integerProperty(
+                        METADATA_PREVIOUS_VERSIONS_MAX,
+                        "The max number of old metadata files to keep in metadata log",
+                        icebergConfig.getMetadataPreviousVersionsMax(),
+                        false))
+                .add(booleanProperty(
+                        METADATA_DELETE_AFTER_COMMIT,
+                        "Whether enables to delete the oldest metadata file after commit",
+                        icebergConfig.isMetadataDeleteAfterCommit(),
+                        false))
                 .build();
 
         columnProperties = ImmutableList.of(stringProperty(
@@ -142,5 +155,15 @@ public class IcebergTableProperties
     public static RowLevelOperationMode getDeleteMode(Map<String, Object> tableProperties)
     {
         return (RowLevelOperationMode) tableProperties.get(DELETE_MODE);
+    }
+
+    public static Integer getMetadataPreviousVersionsMax(Map<String, Object> tableProperties)
+    {
+        return (Integer) tableProperties.get(METADATA_PREVIOUS_VERSIONS_MAX);
+    }
+
+    public static Boolean isMetadataDeleteAfterCommit(Map<String, Object> tableProperties)
+    {
+        return (Boolean) tableProperties.get(METADATA_DELETE_AFTER_COMMIT);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -179,6 +179,10 @@ import static org.apache.iceberg.TableProperties.DELETE_MODE;
 import static org.apache.iceberg.TableProperties.DELETE_MODE_DEFAULT;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.apache.iceberg.TableProperties.MERGE_MODE;
+import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED;
+import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
+import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX;
+import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
 import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE;
@@ -1079,6 +1083,11 @@ public final class IcebergUtil
             propertiesBuilder.put(DELETE_MODE, deleteMode.modeName());
         }
 
+        Integer metadataPreviousVersionsMax = IcebergTableProperties.getMetadataPreviousVersionsMax(tableMetadata.getProperties());
+        propertiesBuilder.put(METADATA_PREVIOUS_VERSIONS_MAX, String.valueOf(metadataPreviousVersionsMax));
+
+        Boolean metadataDeleteAfterCommit = IcebergTableProperties.isMetadataDeleteAfterCommit(tableMetadata.getProperties());
+        propertiesBuilder.put(METADATA_DELETE_AFTER_COMMIT_ENABLED, String.valueOf(metadataDeleteAfterCommit));
         return propertiesBuilder.build();
     }
 
@@ -1097,6 +1106,20 @@ public final class IcebergUtil
         return RowLevelOperationMode.fromName(table.properties()
                 .getOrDefault(DELETE_MODE, DELETE_MODE_DEFAULT)
                 .toUpperCase(Locale.ENGLISH));
+    }
+
+    public static int getMetadataPreviousVersionsMax(Table table)
+    {
+        return Integer.parseInt(table.properties()
+                .getOrDefault(METADATA_PREVIOUS_VERSIONS_MAX,
+                        String.valueOf(METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT)));
+    }
+
+    public static boolean isMetadataDeleteAfterCommit(Table table)
+    {
+        return Boolean.valueOf(table.properties()
+                .getOrDefault(METADATA_DELETE_AFTER_COMMIT_ENABLED,
+                        String.valueOf(METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT)));
     }
 
     public static Optional<PartitionData> partitionDataFromJson(PartitionSpec spec, Optional<String> partitionDataAsJson)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -140,7 +140,9 @@ public class IcebergDistributedSmokeTestBase
                         "   delete_mode = 'merge-on-read',\n" +
                         "   format = 'PARQUET',\n" +
                         "   format_version = '2',\n" +
-                        "   location = '%s'\n" +
+                        "   location = '%s',\n" +
+                        "   metadata_delete_after_commit = false,\n" +
+                        "   metadata_previous_versions_max = 100\n" +
                         ")", getLocation("tpch", "orders")));
     }
 
@@ -418,6 +420,8 @@ public class IcebergDistributedSmokeTestBase
                         "   format = '" + fileFormat + "',\n" +
                         "   format_version = '2',\n" +
                         "   location = '%s',\n" +
+                        "   metadata_delete_after_commit = false,\n" +
+                        "   metadata_previous_versions_max = 100,\n" +
                         "   partitioning = ARRAY['order_status','ship_priority','bucket(order_key, 9)']\n" +
                         ")",
                 getSession().getCatalog().get(),
@@ -617,7 +621,9 @@ public class IcebergDistributedSmokeTestBase
                 "   delete_mode = 'merge-on-read',\n" +
                 "   format = 'ORC',\n" +
                 "   format_version = '2',\n" +
-                "   location = '%s'\n" +
+                "   location = '%s',\n" +
+                "   metadata_delete_after_commit = false,\n" +
+                "   metadata_previous_versions_max = 100\n" +
                 ")";
         String createTableSql = format(createTableTemplate, "test table comment", getLocation("tpch", "test_table_comments"));
 
@@ -706,6 +712,8 @@ public class IcebergDistributedSmokeTestBase
                 "   format = 'PARQUET',\n" +
                 "   format_version = '2',\n" +
                 "   location = '%s',\n" +
+                "   metadata_delete_after_commit = false,\n" +
+                "   metadata_previous_versions_max = 100,\n" +
                 "   partitioning = ARRAY['adate']\n" +
                 ")", getLocation("tpch", "test_create_table_like_original")));
 
@@ -719,7 +727,9 @@ public class IcebergDistributedSmokeTestBase
                 "   delete_mode = 'merge-on-read',\n" +
                 "   format = 'PARQUET',\n" +
                 "   format_version = '2',\n" +
-                "   location = '%s'\n" +
+                "   location = '%s',\n" +
+                "   metadata_delete_after_commit = false,\n" +
+                "   metadata_previous_versions_max = 100\n" +
                 ")", getLocation("tpch", "test_create_table_like_copy1")));
         dropTable(session, "test_create_table_like_copy1");
 
@@ -728,7 +738,9 @@ public class IcebergDistributedSmokeTestBase
                 "   delete_mode = 'merge-on-read',\n" +
                 "   format = 'PARQUET',\n" +
                 "   format_version = '2',\n" +
-                "   location = '%s'\n" +
+                "   location = '%s',\n" +
+                "   metadata_delete_after_commit = false,\n" +
+                "   metadata_previous_versions_max = 100\n" +
                 ")", getLocation("tpch", "test_create_table_like_copy2")));
         dropTable(session, "test_create_table_like_copy2");
 
@@ -738,6 +750,8 @@ public class IcebergDistributedSmokeTestBase
                 "   format = 'PARQUET',\n" +
                 "   format_version = '2',\n" +
                 "   location = '%s',\n" +
+                "   metadata_delete_after_commit = false,\n" +
+                "   metadata_previous_versions_max = 100,\n" +
                 "   partitioning = ARRAY['adate']\n" +
                 ")", catalogType.equals(CatalogType.HIVE) ?
                 getLocation("tpch", "test_create_table_like_original") :
@@ -750,6 +764,8 @@ public class IcebergDistributedSmokeTestBase
                 "   format = 'ORC',\n" +
                 "   format_version = '2',\n" +
                 "   location = '%s',\n" +
+                "   metadata_delete_after_commit = false,\n" +
+                "   metadata_previous_versions_max = 100,\n" +
                 "   partitioning = ARRAY['adate']\n" +
                 ")", catalogType.equals(CatalogType.HIVE) ?
                 getLocation("tpch", "test_create_table_like_original") :
@@ -791,7 +807,9 @@ public class IcebergDistributedSmokeTestBase
                         "   delete_mode = '%s',\n" +
                         "   format = 'PARQUET',\n" +
                         "   format_version = '%s',\n" +
-                        "   location = '%s'\n" +
+                        "   location = '%s',\n" +
+                        "   metadata_delete_after_commit = false,\n" +
+                        "   metadata_previous_versions_max = 100\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -33,6 +33,8 @@ import static com.facebook.presto.spi.statistics.ColumnStatisticType.TOTAL_SIZE_
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT;
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
+import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
+import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
 
 public class TestIcebergConfig
 {
@@ -60,7 +62,9 @@ public class TestIcebergConfig
                 .setMaxManifestCacheSize(IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT)
                 .setManifestCacheExpireDuration(IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT)
                 .setManifestCacheMaxContentLength(IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT)
-                .setSplitManagerThreads(Runtime.getRuntime().availableProcessors()));
+                .setSplitManagerThreads(Runtime.getRuntime().availableProcessors())
+                .setMetadataPreviousVersionsMax(METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT)
+                .setMetadataDeleteAfterCommit(METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT));
     }
 
     @Test
@@ -88,6 +92,8 @@ public class TestIcebergConfig
                 .put("iceberg.io.manifest.cache.expiration-interval-ms", "600000")
                 .put("iceberg.io.manifest.cache.max-content-length", "10485760")
                 .put("iceberg.split-manager-threads", "42")
+                .put("iceberg.metadata-previous-versions-max", "1")
+                .put("iceberg.metadata-delete-after-commit", "true")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -111,7 +117,9 @@ public class TestIcebergConfig
                 .setMaxManifestCacheSize(1048576000)
                 .setManifestCacheExpireDuration(600000)
                 .setManifestCacheMaxContentLength(10485760)
-                .setSplitManagerThreads(42);
+                .setSplitManagerThreads(42)
+                .setMetadataPreviousVersionsMax(1)
+                .setMetadataDeleteAfterCommit(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
@@ -89,11 +89,11 @@ public class TestIcebergSystemTablesNessie
     {
         assertQuery(String.format("SHOW COLUMNS FROM test_schema.\"%s$properties\"", tableName),
                 "VALUES ('key', 'varchar', '', '')," + "('value', 'varchar', '', '')");
-        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 7");
+        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 8");
         List<MaterializedRow> materializedRows = computeActual(getSession(),
                 String.format("SELECT * FROM test_schema.\"%s$properties\"", tableName)).getMaterializedRows();
 
-        assertThat(materializedRows).hasSize(7);
+        assertThat(materializedRows).hasSize(8);
         assertThat(materializedRows)
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.delete.mode", deleteMode)))
@@ -106,7 +106,9 @@ public class TestIcebergSystemTablesNessie
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.delete-after-commit.enabled", "false")))
                 .anySatisfy(row -> assertThat(row)
-                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "commit.retry.num-retries", "4")));
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "commit.retry.num-retries", "4")))
+                .anySatisfy(row -> assertThat(row)
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.previous-versions-max", "100")));
     }
 
     @Override
@@ -114,11 +116,11 @@ public class TestIcebergSystemTablesNessie
     {
         assertQuery(String.format("SHOW COLUMNS FROM test_schema.\"%s$properties\"", tableName),
                 "VALUES ('key', 'varchar', '', '')," + "('value', 'varchar', '', '')");
-        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 8");
+        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 9");
         List<MaterializedRow> materializedRows = computeActual(getSession(),
                 String.format("SELECT * FROM test_schema.\"%s$properties\"", tableName)).getMaterializedRows();
 
-        assertThat(materializedRows).hasSize(8);
+        assertThat(materializedRows).hasSize(9);
         assertThat(materializedRows)
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.delete.mode", deleteMode)))
@@ -133,6 +135,8 @@ public class TestIcebergSystemTablesNessie
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.delete-after-commit.enabled", "false")))
                 .anySatisfy(row -> assertThat(row)
-                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "commit.retry.num-retries", "4")));
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "commit.retry.num-retries", "4")))
+                .anySatisfy(row -> assertThat(row)
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.previous-versions-max", "100")));
     }
 }


### PR DESCRIPTION
## Description

This PR enables to set Iceberg table properties `metadata_previous_versions_max` and `metadata_delete_after_commit` to specify the number of previous metadata files that need to be tracked, and whether to delete the metadata files that no longer be tracked after each commit.

Besides, this PR also enable our own version of `HiveTableOperations` to support deleting old metadata files after commit based on the table properties. This feature has been supported by Iceberg's native version of `HiveTableOperations`.

## Motivation and Context

The metadata files of an iceberg table will grow to a very large amount, as almost each operation will lead in a new one.
So we need to provide a method to delete unnecessary metadata files.

## Impact

When executing `show create table ...`, two additional table properties would be shown. Except that, there is no impact on existing use cases, as the default values are the same as before.

## Test Plan

 - Test cases added to show the impact of new table properties

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add table properties `metadata_previous_versions_max` and `metadata_delete_after_commit` to maintain the previous metadata files :pr:`23260`
* Enable Iceberg with hive catalog to support deleting old metadata files after commit based on the table properties :pr:`23260`
```
