### PR TITLE
[Docs] Fix typo in iceberg configuration property `iceberg.file-format`

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -275,7 +275,7 @@ Property Name                                           Description             
                                                         is required if the iceberg.catalog.type is ``hadoop``.
                                                         Otherwise, it will be ignored.
 
-``iceberg.file-format``                                 The storage file format for Iceberg tables. The available     ``ORC``
+``iceberg.file-format``                                 The storage file format for Iceberg tables. The available     ``PARQUET``
                                                         values are ``PARQUET`` and ``ORC``.
 
 ``iceberg.compression-codec``                           The compression codec to use when writing files. The          ``GZIP``


### PR DESCRIPTION
## Description

Fix the default value of Iceberg configuration property `iceberg.file-format` in docs, should be `PARQUET` rather than `ORC`.

## Motivation and Context

N/A

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

