### PR TITLE
Add support for ALTER TABLE statement in MongoDB

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -268,4 +268,19 @@ SQL support
 ALTER TABLE
 ^^^^^^^^^^^
 
-The connector supports ``ALTER TABLE RENAME TO`` operation. Other uses of ``ALTER TABLE`` are not supported.
+.. code-block:: sql
+
+    ALTER TABLE mongodb.admin.sample_table ADD COLUMN new_col INT;
+    ALTER TABLE mongodb.admin.sample_table DROP COLUMN new_col;
+    ALTER TABLE mongodb.admin.sample_table RENAME COLUMN is_active TO is_enabled;
+    ALTER TABLE mongodb.admin.sample_table RENAME TO renamed_table;
+
+.. note:: Presto does not support altering the data type of a column directly with the ALTER TABLE command.
+
+ .. code-block:: sql
+
+   ALTER TABLE mongodb.admin.users ALTER COLUMN age TYPE BIGINT;
+
+ returns an error similar to the following:
+
+ ``Query 20240720_123348_00014_v7vrn failed: line 1:55: mismatched input 'int'. Expecting: 'FUNCTION', 'SCHEMA', 'TABLE'``

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
@@ -301,4 +301,22 @@ public class MongoMetadata
                 .map(m -> new MongoColumnHandle(m.getName(), m.getType(), m.isHidden()))
                 .collect(toList());
     }
+
+    @Override
+    public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
+    {
+        mongoSession.addColumn(((MongoTableHandle) tableHandle), column);
+    }
+
+    @Override
+    public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
+    {
+        mongoSession.renameColumn(((MongoTableHandle) tableHandle), ((MongoColumnHandle) source).getName(), target);
+    }
+
+    @Override
+    public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
+    {
+        mongoSession.dropColumn(((MongoTableHandle) tableHandle), ((MongoColumnHandle) column).getName());
+    }
 }

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -283,4 +283,19 @@ public class TestMongoIntegrationSmokeTest
         assertQuery("SELECT value FROM test_rename.tmp_rename_new_table", "SELECT 1");
         assertUpdate("DROP TABLE test_rename.tmp_rename_new_table");
     }
+
+    @Test
+    public void testAlterTable()
+    {
+        assertUpdate("CREATE TABLE test_alter.tmp_alter_table (value bigint)");
+        MongoCollection<Document> collection = mongoQueryRunner.getMongoClient().getDatabase("test_alter").getCollection("tmp_alter_table");
+        collection.insertOne(new Document(ImmutableMap.of("value", 1)));
+
+        assertUpdate("ALTER TABLE test_alter.tmp_alter_table ADD COLUMN email varchar");
+        collection.insertOne(new Document(ImmutableMap.of("value", 2, "email", "example@example.com")));
+        assertQuery("SELECT email from test_alter.tmp_alter_table WHERE email IS NOT NULL", "SELECT 'example@example.com'");
+        assertUpdate("ALTER TABLE test_alter.tmp_alter_table RENAME COLUMN email TO email_id");
+        assertQuery("SELECT email_id from test_alter.tmp_alter_table WHERE email_id IS NOT NULL", "SELECT 'example@example.com'");
+        assertUpdate("ALTER TABLE test_alter.tmp_alter_table DROP COLUMN email_id");
+    }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
[#23265 ](https://github.com/prestodb/presto/issues/23265)
Adding the ALTER TABLE support for MongoDB connector.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Introducing a new feature in the MongoDB connector: support for ALTER TABLE statements to ADD, DROP and RENAME columns.

## Test Plan
<!---Please fill in how you tested your change-->
Configured the MongoDB connector, by creating a catalog properties file in etc/catalog named mongodb.properties, to mount the MongoDb connector as the MongoDB catalog. Tested all three statements: ADD, DROP, and RENAME.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

MongoDB Connector Changes
* Add support for MongoDB ``ALTER TABLE`` statement. :pr:`23266`
```

