### PR TITLE
Improve CTE materialization execution tests

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeCteExecutionParquet.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeCteExecutionParquet.java
@@ -21,6 +21,7 @@ import static com.facebook.presto.SystemSessionProperties.CTE_FILTER_AND_PROJECT
 import static com.facebook.presto.SystemSessionProperties.CTE_MATERIALIZATION_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.PARTITIONING_PROVIDER_CATALOG;
 import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.VERBOSE_OPTIMIZER_INFO_ENABLED;
 
 @Test(groups = {"parquet"})
 public class TestPrestoNativeCteExecutionParquet
@@ -54,6 +55,7 @@ public class TestPrestoNativeCteExecutionParquet
     {
         return Session.builder(super.getSession())
                 .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "true")
+                .setSystemProperty(VERBOSE_OPTIMIZER_INFO_ENABLED, "true")
                 .setSystemProperty(PARTITIONING_PROVIDER_CATALOG, "hive")
                 .setSystemProperty(CTE_MATERIALIZATION_STRATEGY, "ALL")
                 .setSystemProperty(CTE_FILTER_AND_PROJECTION_PUSHDOWN_ENABLED, "true")


### PR DESCRIPTION
Add method verifyResults and checkCTEInfoMatch to test whether CTEs are materialized by checking if the Explain plan has the expected CTEInfo element.

Existing tests were only asserting if results of executing the query are the same with and without using a CTE materialization strategy. These new methods go further and also check that the expected CTEs were materialized.

Refactor existing tests to use the verifyResults method or in the case of more complex queries the method checkCTEInfoMatch. In order for Explain plan to include the CTEInfo element, the system property VERBOSE_OPTIMIZER_INFO_ENABLED needs to be set for the session.

## Description
The existing CTE execution tests are only checking that the query results are the same with and without using a CTE materialization strategy during execution. Two new test helper methods verifyResults and checkCTEInfoMatch were introduced to also check the the Explain plan for the query execution included a CTEInfo element to verify that the CTEs are materialized.  

## Motivation and Context
Fix an open issue about improving existing CTE materialization tests to check beyond just the results of the query and verify the CTE materialization. See https://github.com/prestodb/presto/issues/21688

## Impact
The only changes are to improve existing tests. There is no public facing functionality impact.

## Test Plan
The only changes are to improve existing tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```