### PR TITLE
Use assertEquals instead of assertTrue when testing equality

### DIFF
--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
@@ -30,7 +30,6 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestBlackHoleMetadata
@@ -68,8 +67,8 @@ public class TestBlackHoleMetadata
         metadata.finishCreateTable(SESSION, table, ImmutableList.of(), ImmutableList.of());
 
         List<SchemaTableName> tables = metadata.listTables(SESSION, Optional.empty());
-        assertTrue(tables.size() == 1, "Expected only one table.");
-        assertTrue(tables.get(0).getTableName().equals("temp_table"), "Expected table with name 'temp_table'");
+        assertEquals(tables.size(), 1, "Expected only one table.");
+        assertEquals(tables.get(0).getTableName(), "temp_table", "Expected table with name 'temp_table'");
     }
 
     @Test
@@ -82,7 +81,7 @@ public class TestBlackHoleMetadata
         }
         catch (PrestoException ex) {
             assertEquals(ex.getErrorCode(), NOT_FOUND.toErrorCode());
-            assertTrue(ex.getMessage().equals("Schema schema1 not found"));
+            assertEquals(ex.getMessage(), "Schema schema1 not found");
         }
     }
 

--- a/presto-common/src/test/java/com/facebook/presto/common/predicate/TestMarker.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/predicate/TestMarker.java
@@ -101,7 +101,7 @@ public class TestMarker
         // of their indexes.
         for (int i = 0; i < markers.size(); i++) {
             for (int j = 0; j < markers.size(); j++) {
-                assertTrue(markers.get(i).compareTo(markers.get(j)) == Integer.compare(i, j));
+                assertEquals(markers.get(i).compareTo(markers.get(j)), Integer.compare(i, j));
             }
         }
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
@@ -221,7 +221,7 @@ public class TestHiveCommitHandleOutput
 
         assertEquals(handle.getSerializedCommitOutputForRead(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)), "");
         assertFalse(handle.getSerializedCommitOutputForWrite(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)).isEmpty());
-        assertTrue(handle.getSerializedCommitOutputForWrite(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)).equals(serializedCommitOutput));
+        assertEquals(handle.getSerializedCommitOutputForWrite(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)), serializedCommitOutput);
     }
 
     private HiveMetadata getHiveMetadata(TestingExtendedHiveMetastore metastore, HiveClientConfig hiveClientConfig, ListeningExecutorService listeningExecutor)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2927,7 +2927,7 @@ public class TestHiveIntegrationSmokeTest
             int bucket = (int) row.getField(2);
 
             assertEquals(col1, col0 + 11);
-            assertTrue(col1 % 2 == 0);
+            assertEquals(col1 % 2, 0);
 
             // Because Hive's hash function for integer n is h(n) = n.
             assertEquals(bucket, col0 % 2);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryR
 import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -180,7 +181,8 @@ public class TestIcebergSplitManager
     {
         Session session = sessionWithFilterPushdown(filterPushdown);
         List<TableScanNode> tableScanNodes = getTableScanFromOptimizedPlanOfSql(sql, session);
-        assertTrue(tableScanNodes != null && tableScanNodes.size() == 1);
+        assertNotNull(tableScanNodes);
+        assertEquals(tableScanNodes.size(), 1);
 
         TransactionId transactionId = transactionManager.beginTransaction(false);
         session = session.beginTransactionId(transactionId, transactionManager, new AllowAllAccessControl());

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestUpdateablePriorityQueue.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestUpdateablePriorityQueue.java
@@ -44,7 +44,7 @@ public class TestUpdateablePriorityQueue
     @Test
     public void testStochasticPriorityQueue()
     {
-        assertTrue(populateAndExtract(new StochasticPriorityQueue<>()).size() == 3);
+        assertEquals(populateAndExtract(new StochasticPriorityQueue<>()).size(), 3);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
@@ -144,7 +144,7 @@ public final class GroupByHashYieldAssertion
                 assertTrue(operator.getOperatorContext().isWaitingForMemory().isDone());
 
                 // assert the hash capacity is not changed; otherwise, we should have yielded
-                assertTrue(oldCapacity == getHashCapacity.apply(operator));
+                assertEquals(oldCapacity, getHashCapacity.apply(operator));
 
                 // We are not going to rehash; therefore, assert the memory increase only comes from the aggregator
                 assertLessThan(actualIncreasedMemory, additionalMemoryInBytes);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -285,7 +285,7 @@ public class TestExchangeClient
         //  wait for client to decide there are no more pages
         assertNull(getNextPage(exchangeClient));
         assertEquals(exchangeClient.getStatus().getBufferedPages(), 0);
-        assertTrue(exchangeClient.getStatus().getBufferedBytes() == 0);
+        assertEquals(exchangeClient.getStatus().getBufferedBytes(), 0);
         assertTrue(exchangeClient.isClosed());
         assertStatus(exchangeClient.getStatus().getPageBufferClientStatuses().get(0), location, "closed", 3, 5, 5, "not scheduled");
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleHistogramAggregation.java
@@ -100,7 +100,7 @@ public class TestDoubleHistogramAggregation
         Accumulator accumulator = factory.createAccumulator(UpdateMemory.NOOP);
         Block result = getFinalBlock(accumulator);
 
-        assertTrue(result.getPositionCount() == 1);
+        assertEquals(result.getPositionCount(), 1);
         assertTrue(result.isNull(0));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealHistogramAggregation.java
@@ -101,7 +101,7 @@ public class TestRealHistogramAggregation
         Accumulator accumulator = factory.createAccumulator(UpdateMemory.NOOP);
         Block result = getFinalBlock(accumulator);
 
-        assertTrue(result.getPositionCount() == 1);
+        assertEquals(result.getPositionCount(), 1);
         assertTrue(result.isNull(0));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -284,7 +284,7 @@ public final class FunctionAssertions
         Object actual = selectSingleValue(projection, expectedType, compiler);
         assertTrue(actual instanceof ArrayList);
         ArrayList<Object> arrayList = (ArrayList) actual;
-        assertTrue(arrayList.size() == expected.size());
+        assertEquals(arrayList.size(), expected.size());
         for (int i = 0; i < arrayList.size(); ++i) {
             assertEquals((double) arrayList.get(i), expected.get(i), delta);
         }
@@ -295,7 +295,7 @@ public final class FunctionAssertions
         Object actual = selectSingleValue(projection, expectedType, compiler);
         assertTrue(actual instanceof ArrayList);
         ArrayList<Object> arrayList = (ArrayList) actual;
-        assertTrue(arrayList.size() == expected.size());
+        assertEquals(arrayList.size(), expected.size());
         for (int i = 0; i < arrayList.size(); ++i) {
             assertEquals((float) arrayList.get(i), expected.get(i), delta);
         }
@@ -350,7 +350,7 @@ public final class FunctionAssertions
         HashSet<Object> resultSet = new HashSet<>(results);
 
         // we should only have a single result
-        assertTrue(resultSet.size() == 1, "Expected only one result unique result, but got " + resultSet);
+        assertEquals(resultSet.size(), 1, "Expected only one result unique result, but got " + resultSet);
 
         return Iterables.getOnlyElement(resultSet);
     }
@@ -733,7 +733,7 @@ public final class FunctionAssertions
         HashSet<Boolean> resultSet = new HashSet<>(results);
 
         // we should only have a single result
-        assertTrue(resultSet.size() == 1, "Expected only [" + expected + "] result unique result, but got " + resultSet);
+        assertEquals(resultSet.size(), 1, "Expected only [" + expected + "] result unique result, but got " + resultSet);
 
         assertEquals((boolean) Iterables.getOnlyElement(resultSet), expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
@@ -178,10 +178,10 @@ public abstract class AbstractTestType
         assertEquals(block.isNull(position), expectedStackValue == null);
 
         if (type.isOrderable()) {
-            assertTrue(ASC_NULLS_FIRST.compareBlockValue(type, block, position, expectedBlock, 0) == 0);
-            assertTrue(ASC_NULLS_LAST.compareBlockValue(type, block, position, expectedBlock, 0) == 0);
-            assertTrue(DESC_NULLS_FIRST.compareBlockValue(type, block, position, expectedBlock, 0) == 0);
-            assertTrue(DESC_NULLS_LAST.compareBlockValue(type, block, position, expectedBlock, 0) == 0);
+            assertEquals(ASC_NULLS_FIRST.compareBlockValue(type, block, position, expectedBlock, 0), 0);
+            assertEquals(ASC_NULLS_LAST.compareBlockValue(type, block, position, expectedBlock, 0), 0);
+            assertEquals(DESC_NULLS_FIRST.compareBlockValue(type, block, position, expectedBlock, 0), 0);
+            assertEquals(DESC_NULLS_LAST.compareBlockValue(type, block, position, expectedBlock, 0), 0);
         }
         else {
             try {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -94,7 +94,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.nCopies;
 import static java.util.Collections.singletonList;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestArrayOperators
@@ -852,7 +851,7 @@ public class TestArrayOperators
             fail("Access to array with double subscript should fail");
         }
         catch (SemanticException e) {
-            assertTrue(e.getCode() == TYPE_MISMATCH);
+            assertEquals(e.getCode(), TYPE_MISMATCH);
         }
 
         assertFunction("ARRAY[NULL][1]", UNKNOWN, null);

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestServerInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestServerInfoResource.java
@@ -155,7 +155,6 @@ public class TestServerInfoResource
             return client.execute(request, new ThriftResponseHandler<>(thriftCodeManager.getCodec(NodeState.class))).getValue();
         }
         else {
-            requestBuilder = getJsonTransportBuilder(prepareGet());
             return client.execute(request, createJsonResponseHandler(jsonCodec(NodeState.class)));
         }
     }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestBlackHoleSmoke.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestBlackHoleSmoke.java
@@ -89,7 +89,7 @@ public class TestBlackHoleSmoke
             fail("Expected exception to be thrown here!");
         }
         catch (RuntimeException ex) { // it has to RuntimeException as FailureInfo$FailureException is private
-            assertTrue(ex.getMessage().equals("line 1:1: Destination table 'blackhole.default.nation' already exists"));
+            assertEquals(ex.getMessage(), "line 1:1: Destination table 'blackhole.default.nation' already exists");
         }
         finally {
             assertThatQueryReturnsValue("DROP TABLE nation", true);
@@ -102,8 +102,8 @@ public class TestBlackHoleSmoke
         assertThatQueryReturnsValue("CREATE TABLE nation as SELECT * FROM tpch.tiny.nation", 25L);
 
         List<QualifiedObjectName> tableNames = listBlackHoleTables();
-        assertTrue(tableNames.size() == 1, "Expected only one table.");
-        assertTrue(tableNames.get(0).getObjectName().equals("nation"), "Expected 'nation' table.");
+        assertEquals(tableNames.size(), 1, "Expected only one table.");
+        assertEquals(tableNames.get(0).getObjectName(), "nation", "Expected 'nation' table.");
 
         assertThatQueryReturnsValue("INSERT INTO nation SELECT * FROM tpch.tiny.nation", 25L);
 
@@ -156,7 +156,7 @@ public class TestBlackHoleSmoke
             fail("Expected exception to be thrown here!");
         }
         catch (RuntimeException ex) {
-            assertTrue(ex.getMessage().equals("Schema schema1 not found"));
+            assertEquals(ex.getMessage(), "Schema schema1 not found");
         }
 
         int tablesAfterCreate = listBlackHoleTables().size();
@@ -344,7 +344,7 @@ public class TestBlackHoleSmoke
 
     private void assertThatNoBlackHoleTableIsCreated()
     {
-        assertTrue(listBlackHoleTables().size() == 0, "No blackhole tables expected");
+        assertTrue(listBlackHoleTables().isEmpty(), "No blackhole tables expected");
     }
 
     private List<QualifiedObjectName> listBlackHoleTables()
@@ -362,9 +362,9 @@ public class TestBlackHoleSmoke
         MaterializedResult rows = session == null ? queryRunner.execute(sql) : queryRunner.execute(session, sql);
         MaterializedRow materializedRow = Iterables.getOnlyElement(rows);
         int fieldCount = materializedRow.getFieldCount();
-        assertTrue(fieldCount == 1, format("Expected only one column, but got '%d'", fieldCount));
+        assertEquals(fieldCount, 1, format("Expected only one column, but got '%d'", fieldCount));
         Object value = materializedRow.getField(0);
         assertEquals(value, expected);
-        assertTrue(Iterables.getOnlyElement(rows).getFieldCount() == 1);
+        assertEquals(Iterables.getOnlyElement(rows).getFieldCount(), 1);
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestServerInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestServerInfoResource.java
@@ -33,7 +33,6 @@ import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestServerInfoResource
 {
@@ -70,7 +69,7 @@ public class TestServerInfoResource
 
             ServerInfoResource serverInfoResource = coordinator.getServerInfoResource();
             NodeState nodeState = serverInfoResource.getServerState();
-            assertTrue(nodeState == NodeState.ACTIVE);
+            assertEquals(nodeState, NodeState.ACTIVE);
         }
     }
 
@@ -89,11 +88,11 @@ public class TestServerInfoResource
             Response response = serverInfoResource.updateState(NodeState.INACTIVE);
             assertEquals(response.getStatus(), 200);
             NodeState nodeState = serverInfoResource.getServerState();
-            assertTrue(nodeState == NodeState.INACTIVE);
+            assertEquals(nodeState, NodeState.INACTIVE);
             response = serverInfoResource.updateState(NodeState.ACTIVE);
             assertEquals(response.getStatus(), 200);
             nodeState = serverInfoResource.getServerState();
-            assertTrue(nodeState == NodeState.ACTIVE);
+            assertEquals(nodeState, NodeState.ACTIVE);
         }
     }
 
@@ -112,7 +111,7 @@ public class TestServerInfoResource
             Response response = serverInfoResource.updateState(NodeState.SHUTTING_DOWN);
             assertEquals(response.getStatus(), 200);
             NodeState nodeState = serverInfoResource.getServerState();
-            assertTrue(nodeState == NodeState.SHUTTING_DOWN);
+            assertEquals(nodeState, NodeState.SHUTTING_DOWN);
         }
     }
 


### PR DESCRIPTION
## Description
Use assertEquals instead of assertTrue when testing equality

## Motivation and Context
More informative failure messages

## Impact
none

## Test Plan
mvn test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

