### PR TITLE
Add additional scheduler instrumentation

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -41,6 +41,9 @@ public class RuntimeMetricName
     public static final String GET_PARTITIONS_BY_NAMES_TIME_NANOS = "getPartitionsByNamesTimeNanos";
     public static final String GET_TABLE_TIME_NANOS = "getTableTimeNanos";
     public static final String GET_SPLITS_TIME_NANOS = "getSplitsTimeNanos";
+    public static final String SCHEDULER_CPU_TIME_NANOS = "schedulerCpuTimeNanos";
+    public static final String SCHEDULER_WALL_TIME_NANOS = "schedulerWallTimeNanos";
+    public static final String SCHEDULER_BLOCKED_TIME_NANOS = "schedulerBlockedTimeNanos";
     public static final String LOGICAL_PLANNER_TIME_NANOS = "logicalPlannerTimeNanos";
     public static final String OPTIMIZER_TIME_NANOS = "optimizerTimeNanos";
     public static final String GET_CANONICAL_INFO_TIME_NANOS = "getCanonicalInfoTimeNanos";
@@ -53,6 +56,9 @@ public class RuntimeMetricName
     public static final String TASK_SCHEDULED_TIME_NANOS = "taskScheduledTimeNanos";
     // Blocked time for the operators due to waiting for inputs.
     public static final String TASK_BLOCKED_TIME_NANOS = "taskBlockedTimeNanos";
+    public static final String TASK_UPDATE_DELIVERED_WALL_TIME_NANOS = "taskUpdateDeliveredWallTimeNanos";
+    public static final String TASK_UPDATE_SERIALIZED_CPU_TIME_NANOS = "taskUpdateSerializedCpuNanos";
+    public static final String TASK_PLAN_SERIALIZED_CPU_TIME_NANOS = "taskPlanSerializedCpuNanos";
     // Time taken for a read call to storage
     public static final String STORAGE_READ_TIME_NANOS = "storageReadTimeNanos";
     // Size of the data retrieved by read call to storage

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
@@ -34,5 +34,6 @@ public interface RemoteTaskFactory
             OutputBuffers outputBuffers,
             NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
-            TableWriteInfo tableWriteInfo);
+            TableWriteInfo tableWriteInfo,
+            SchedulerStatsTracker schedulerStatsTracker);
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SchedulerStatsTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SchedulerStatsTracker.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+public interface SchedulerStatsTracker
+{
+    SchedulerStatsTracker NOOP = new SchedulerStatsTracker()
+    {
+        @Override
+        public void recordTaskUpdateDeliveredTime(long nanos) {}
+
+        @Override
+        public void recordTaskUpdateSerializedCpuTime(long nanos) {}
+
+        @Override
+        public void recordTaskPlanSerializedCpuTime(long nanos) {}
+    };
+
+    void recordTaskUpdateDeliveredTime(long nanos);
+
+    void recordTaskUpdateSerializedCpuTime(long nanos);
+
+    void recordTaskPlanSerializedCpuTime(long nanos);
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.ErrorCode;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.scheduler.ScheduleResult;
 import com.facebook.presto.execution.scheduler.SplitSchedulerStats;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.failureDetector.FailureDetector;
@@ -535,7 +536,8 @@ public final class SqlStageExecution
                 outputBuffers,
                 nodeTaskMap.createTaskStatsTracker(node, taskId),
                 summarizeTaskInfo,
-                tableWriteInfo);
+                tableWriteInfo,
+                stateMachine);
 
         completeSources.forEach(task::noMoreSplits);
 
@@ -567,6 +569,16 @@ public final class SqlStageExecution
     public void recordGetSplitTime(long start)
     {
         stateMachine.recordGetSplitTime(start);
+    }
+
+    public void recordSchedulerRunningTime(long cpuTimeNanos, long wallTimeNanos)
+    {
+        stateMachine.recordSchedulerRunningTime(cpuTimeNanos, wallTimeNanos);
+    }
+
+    public void recordSchedulerBlockedTime(ScheduleResult.BlockedReason reason, long nanos)
+    {
+        stateMachine.recordSchedulerBlockedTime(reason, nanos);
     }
 
     private static Split createRemoteSplitFor(TaskId taskId, URI remoteSourceTaskLocation, TaskId remoteSourceTaskId)

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.common.RuntimeMetricName.DRIVER_COUNT_PER_TASK;
-import static com.facebook.presto.common.RuntimeMetricName.GET_SPLITS_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.TASK_BLOCKED_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.TASK_ELAPSED_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.TASK_QUEUED_TIME_NANOS;
@@ -66,6 +65,7 @@ public class StageExecutionInfo
             List<TaskInfo> taskInfos,
             DateTime schedulingComplete,
             DistributionSnapshot getSplitDistribution,
+            RuntimeStats stageRuntimeStats,
             DataSize peakUserMemoryReservation,
             DataSize peakNodeTotalMemoryReservation,
             int finishedLifespans,
@@ -116,7 +116,7 @@ public class StageExecutionInfo
 
         Map<String, OperatorStats> operatorToStats = new HashMap<>();
         RuntimeStats mergedRuntimeStats = new RuntimeStats();
-        mergedRuntimeStats.addMetricValueIgnoreZero(GET_SPLITS_TIME_NANOS, NANO, (long) getSplitDistribution.getTotal());
+        mergedRuntimeStats.mergeWith(stageRuntimeStats);
 
         List<TaskStats> allTaskStats = new ArrayList<>();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
@@ -15,7 +15,9 @@ package com.facebook.presto.execution;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.Distribution;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.execution.scheduler.ScheduleResult;
 import com.facebook.presto.execution.scheduler.SplitSchedulerStats;
 import com.facebook.presto.operator.BlockedReason;
 import com.facebook.presto.operator.TaskStats;
@@ -36,6 +38,14 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.common.RuntimeMetricName.GET_SPLITS_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.SCHEDULER_BLOCKED_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.SCHEDULER_CPU_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.SCHEDULER_WALL_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.TASK_PLAN_SERIALIZED_CPU_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.TASK_UPDATE_DELIVERED_WALL_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.TASK_UPDATE_SERIALIZED_CPU_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.execution.StageExecutionState.ABORTED;
 import static com.facebook.presto.execution.StageExecutionState.CANCELED;
 import static com.facebook.presto.execution.StageExecutionState.FAILED;
@@ -59,6 +69,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 @ThreadSafe
 public class StageExecutionStateMachine
+        implements SchedulerStatsTracker
 {
     private static final Logger log = Logger.get(StageExecutionStateMachine.class);
 
@@ -77,6 +88,8 @@ public class StageExecutionStateMachine
     private final AtomicLong peakNodeTotalMemory = new AtomicLong();
     private final AtomicLong currentUserMemory = new AtomicLong();
     private final AtomicLong currentTotalMemory = new AtomicLong();
+
+    private final RuntimeStats runtimeStats = new RuntimeStats();
 
     public StageExecutionStateMachine(
             StageExecutionId stageExecutionId,
@@ -341,6 +354,7 @@ public class StageExecutionStateMachine
                 taskInfos,
                 schedulingComplete.get(),
                 getSplitDistribution.snapshot(),
+                runtimeStats,
                 succinctBytes(peakUserMemory.get()),
                 succinctBytes(peakNodeTotalMemory.get()),
                 finishedLifespans,
@@ -352,6 +366,37 @@ public class StageExecutionStateMachine
         long elapsedNanos = System.nanoTime() - startNanos;
         getSplitDistribution.add(elapsedNanos);
         scheduledStats.getGetSplitTime().add(elapsedNanos, NANOSECONDS);
+        runtimeStats.addMetricValue(GET_SPLITS_TIME_NANOS, NANO, elapsedNanos);
+    }
+
+    public void recordSchedulerRunningTime(long cpuTimeNanos, long wallTimeNanos)
+    {
+        runtimeStats.addMetricValue(SCHEDULER_CPU_TIME_NANOS, NANO, max(cpuTimeNanos, 0));
+        runtimeStats.addMetricValue(SCHEDULER_WALL_TIME_NANOS, NANO, max(wallTimeNanos, 0));
+    }
+
+    public void recordSchedulerBlockedTime(ScheduleResult.BlockedReason reason, long nanos)
+    {
+        requireNonNull(reason, "reason is null");
+        runtimeStats.addMetricValue(SCHEDULER_BLOCKED_TIME_NANOS + "-" + reason, NANO, max(nanos, 0));
+    }
+
+    @Override
+    public void recordTaskUpdateDeliveredTime(long nanos)
+    {
+        runtimeStats.addMetricValue(TASK_UPDATE_DELIVERED_WALL_TIME_NANOS, NANO, max(nanos, 0));
+    }
+
+    @Override
+    public void recordTaskUpdateSerializedCpuTime(long nanos)
+    {
+        runtimeStats.addMetricValue(TASK_UPDATE_SERIALIZED_CPU_TIME_NANOS, NANO, max(nanos, 0));
+    }
+
+    @Override
+    public void recordTaskPlanSerializedCpuTime(long nanos)
+    {
+        runtimeStats.addMetricValue(TASK_PLAN_SERIALIZED_CPU_TIME_NANOS, NANO, max(nanos, 0));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
@@ -49,7 +49,8 @@ public class TrackingRemoteTaskFactory
             OutputBuffers outputBuffers,
             NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
-            TableWriteInfo tableWriteInfo)
+            TableWriteInfo tableWriteInfo,
+            SchedulerStatsTracker schedulerStatsTracker)
     {
         RemoteTask task = remoteTaskFactory.createRemoteTask(session,
                 taskId,
@@ -59,7 +60,8 @@ public class TrackingRemoteTaskFactory
                 outputBuffers,
                 nodeStatsTracker,
                 summarizeTaskInfo,
-                tableWriteInfo);
+                tableWriteInfo,
+                schedulerStatsTracker);
 
         task.addStateChangeListener(new UpdateQueryStats(stateMachine));
         return task;

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -31,6 +31,7 @@ import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.RemoteTaskFactory;
+import com.facebook.presto.execution.SchedulerStatsTracker;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
@@ -216,7 +217,8 @@ public class HttpRemoteTaskFactory
             OutputBuffers outputBuffers,
             NodeTaskMap.NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
-            TableWriteInfo tableWriteInfo)
+            TableWriteInfo tableWriteInfo,
+            SchedulerStatsTracker schedulerStatsTracker)
     {
         return new HttpRemoteTask(
                 session,
@@ -254,6 +256,7 @@ public class HttpRemoteTaskFactory
                 queryManager,
                 taskUpdateRequestSize,
                 handleResolver,
-                connectorTypeSerdeManager);
+                connectorTypeSerdeManager,
+                schedulerStatsTracker);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -147,7 +147,8 @@ public class MockRemoteTaskFactory
                 createInitialEmptyOutputBuffers(BROADCAST),
                 nodeStatsTracker,
                 true,
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                SchedulerStatsTracker.NOOP);
     }
 
     @Override
@@ -160,7 +161,8 @@ public class MockRemoteTaskFactory
             OutputBuffers outputBuffers,
             NodeTaskMap.NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
-            TableWriteInfo tableWriteInfo)
+            TableWriteInfo tableWriteInfo,
+            SchedulerStatsTracker schedulerStatsTracker)
     {
         return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, nodeStatsTracker);
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -36,6 +36,7 @@ import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.NodeTaskMap;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.RemoteTask;
+import com.facebook.presto.execution.SchedulerStatsTracker;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.execution.TaskManagerConfig;
@@ -265,7 +266,8 @@ public class TestHttpRemoteTask
                 createInitialEmptyOutputBuffers(OutputBuffers.BufferType.BROADCAST),
                 new NodeTaskMap.NodeStatsTracker(i -> {}, i -> {}, (age, i) -> {}),
                 true,
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                SchedulerStatsTracker.NOOP);
     }
 
     private static HttpRemoteTaskFactory createHttpRemoteTaskFactory(TestingTaskResource testingTaskResource, boolean useThriftEncoding)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -22,6 +22,7 @@ import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.StatementStats;
 import com.facebook.presto.common.ErrorCode;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.common.transaction.TransactionId;
@@ -423,6 +424,7 @@ public class PrestoSparkQueryExecutionFactory
                 taskInfos,
                 DateTime.now(),
                 new Distribution().snapshot(),
+                new RuntimeStats(),
                 succinctBytes(peakUserMemoryReservationInBytes),
                 succinctBytes(peakNodeTotalMemoryReservationInBytes),
                 1,


### PR DESCRIPTION
## Description

Track CPU, Wall time of scheduler; TaskUpdate latency;

## Motivation and Context

To have a visibility of scheduler efficiency on query latency.

## Impact

No significant efficiency impact expected

## Test Plan

- CI (to make sure nothing breaks)
- Manually verify reported metrics on a couple of queries

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

