### PR TITLE
[Native] Add support for running functional tests on Mac M1/ARM64

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -317,6 +317,14 @@
         </profile>
         <profile>
             <id>docker-build</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.facebook.presto</groupId>
+                    <artifactId>presto-server</artifactId>
+                    <version>${project.version}</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -373,6 +381,23 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>dependency</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <configuration>
+                                    <repository>presto-native-dependency</repository>
+                                    <tag>latest</tag>
+                                    <contextDirectory>${project.basedir}</contextDirectory>
+                                    <dockerfile>${project.basedir}/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile</dockerfile>
+                                    <buildArgs>
+                                        <BUILD_TYPE>Release</BUILD_TYPE>
+                                    </buildArgs>
+                                    <writeTestMetadata>false</writeTestMetadata>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>worker</id>
                                 <phase>install</phase>
                                 <goals>
@@ -385,8 +410,13 @@
                                     <dockerfile>${project.basedir}/scripts/dockerfiles/prestissimo-runtime.dockerfile</dockerfile>
                                     <buildArgs>
                                         <BUILD_TYPE>Release</BUILD_TYPE>
-                                        <DEPENDENCY_IMAGE>public.ecr.aws/oss-presto/presto-native-dependency:latest</DEPENDENCY_IMAGE>
+                                        <DEPENDENCY_IMAGE>presto-native-dependency:latest</DEPENDENCY_IMAGE>
+                                        <EXTRA_CMAKE_FLAGS>-DPRESTO_ENABLE_TESTING=OFF</EXTRA_CMAKE_FLAGS>
+                                        <NUM_THREADS>2</NUM_THREADS>
+                                        <BASE_IMAGE>ubuntu:22.04</BASE_IMAGE>
+                                        <OSNAME>ubuntu</OSNAME>
                                     </buildArgs>
+                                    <pullNewerImage>false</pullNewerImage>
                                     <writeTestMetadata>false</writeTestMetadata>
                                 </configuration>
                             </execution>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -84,9 +84,7 @@ public class ContainerQueryRunner
         this.schema = schema;
         this.numberOfWorkers = numberOfWorkers;
 
-        // TODO: This framework is tested only in Ubuntu x86_64, as there is no support to run the native docker images in ARM based system,
-        // Once this is fixed, the container details can be added as properties in VM options for testing in IntelliJ.
-
+        // The container details can be added as properties in VM options for testing in IntelliJ.
         coordinator = createCoordinator();
         for (int i = 0; i < numberOfWorkers; i++) {
             workers.add(createNativeWorker(7777 + i, "native-worker-" + i));
@@ -128,7 +126,7 @@ public class ContainerQueryRunner
         ContainerQueryRunnerUtils.createNativeWorkerVeloxProperties(nodeId);
         return new GenericContainer<>(PRESTO_WORKER_IMAGE)
                 .withExposedPorts(port)
-                .withNetwork(network).withNetworkAliases("presto-worker")
+                .withNetwork(network).withNetworkAliases(nodeId)
                 .withFileSystemBind(BASE_DIR + "/testcontainers/" + nodeId + "/etc", "/opt/presto-server/etc", BindMode.READ_ONLY)
                 .withFileSystemBind(BASE_DIR + "/testcontainers/" + nodeId + "/entrypoint.sh", "/opt/entrypoint.sh", BindMode.READ_ONLY)
                 .waitingFor(Wait.forLogMessage(".*Announcement succeeded: HTTP 202.*", 1));

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunnerUtils.java
@@ -131,6 +131,7 @@ public class ContainerQueryRunnerUtils
         properties.setProperty("node.environment", "testing");
         properties.setProperty("node.location", "testing-location");
         properties.setProperty("node.id", nodeId);
+        properties.setProperty("node.internal-address", nodeId);
         createPropertiesFile("testcontainers/" + nodeId + "/etc/node.properties", properties);
     }
 

--- a/presto-native-execution/testcontainers/README.md
+++ b/presto-native-execution/testcontainers/README.md
@@ -2,7 +2,7 @@
 
 This Java test framework allows you to run test cases by deploying Presto coordinator and worker nodes in containers.
 For more information, see [Testcontainers for Java](https://java.testcontainers.org/).
-#### To set up Docker services and basic build tools on Ubuntu 22.04 x86_64 machine, run the following commands:
+#### To set up Docker services and basic build tools on Ubuntu 22.04 machine, run the following commands:
 ```
 apt install podman-docker
 apt install make
@@ -13,6 +13,16 @@ Reference: https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394
 ```
 curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3build1_amd64.deb
 dpkg -i containernetworking-plugins_1.1.1+ds1-3build1_amd64.deb
+```
+#### To set up Docker services on a Mac machine, run the following commands:
+```
+brew install podman
+podman machine init --cpus 12 --memory 18000 --disk-size 160
+```
+Run the following commands to make Podman as the default Docker service and start it.
+```
+sudo /opt/homebrew/Cellar/podman/5.0.3/bin/podman-mac-helper install
+podman machine start
 ```
 
 ## Quick Start
@@ -41,10 +51,13 @@ Go to the tests with containers at  `TestPrestoContainerBasicQueries`.
 Edit the run/debug configuration of the test or test case, and add the following as environment variables:
 ```
 TESTCONTAINERS_RYUK_DISABLED=true
-DOCKER_HOST=unix:///run/podman/podman.sock
 ```
 Then, run or debug the test.
 
+To run the functional tests using existing docker images, specify `-DcoordinatorImage` and `-DworkerImage` in the run/debug configurations of the test as VM options. For example:
+```
+-DcoordinatorImage="public.ecr.aws/oss-presto/presto:0.287-20240619190653-db8458d" -DworkerImage="public.ecr.aws/oss-presto/presto-native:0.287-20240619190653-db8458d"
+```
 ##### Note
 * Existing java and native docker files are reused for functional testing. The coordinator and worker configurations are generated in the utility class.
 * The functional test framework has been tested with the tpch.tiny schema, using standard column naming. Please note that this configuration is a current limitation, as it has only been tested with this schema and does not require any data loading.


### PR DESCRIPTION
Added configuration to build `presto-native-dependency` image.
Update Readme to run Functional Testing Framework in Mac M1

Resolves: https://github.com/prestodb/presto/issues/23086
Depends: https://github.com/prestodb/presto/pull/23094

```
== NO RELEASE NOTE ==
```

