### PR TITLE
Correction of Logging Statement in presto_OrderingCompiler_internalCompilePageWithPositionComparator.java

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
@@ -249,7 +249,7 @@ public class OrderingCompiler
             comparator = pageWithPositionsComparatorClass.getConstructor().newInstance();
         }
         catch (Throwable t) {
-            log.error(t, "Error compiling comparator for channels %s with order %s", sortChannels, sortChannels);
+            log.error(t, "Error compiling comparator for channels %s with order %s", sortChannels, sortOrders);
             comparator = new SimplePageWithPositionComparator(types, sortChannels, sortOrders);
         }
         return comparator;


### PR DESCRIPTION
## Descriptions
We found a wrong variable use in logging statement in internalCompilePageWithPositionComparator.java

### Reason for change
The original logging statement used `sortChannels` twice, inaccurately suggesting that both channels and orders were represented by `sortChannels`. The corrected logging statement now uses `sortOrders` for the order portion of the message, ensuring that the static text accurately reflects the dynamic variables.
