### PR TITLE
Fixing NaN in coordinator UI on load

### DIFF
--- a/presto-ui/src/utils.js
+++ b/presto-ui/src/utils.js
@@ -325,6 +325,9 @@ export function computeRate(count: number, ms: number): number {
 }
 
 export function precisionRound(n: number): string {
+    if (n === undefined) {
+        return "";
+    }
     if (n < 10) {
         return n.toFixed(2);
     }


### PR DESCRIPTION
## Description
Currently on loading coordinator UI it shows NaN for some values, this change will check for NaN and would return Unknown in it's place.

## Motivation and Context
Fixing issue https://github.com/prestodb/presto/issues/23186

## Impact
After this change NaN would be shown as Unkown initially on load

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/da01f04a-a353-4ab9-a5f0-591d9ad28207">


## Release Notes

```
== NO RELEASE NOTE ==
```

