### PR TITLE
Fix explain plan to include materialized info for CTEs when verbose optimizer is enabled #23288

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -324,8 +324,9 @@ public class TextRenderer
 
     private String cteInformationToText(List<CTEInformation> cteInformationList)
     {
-        List<String> cteInfo = cteInformationList.stream().map(
-                x -> x.getCteName() + ": " + x.getNumberOfReferences() + " (is_view: " + x.getIsView() + ")")
+        List<String> cteInfo = cteInformationList.stream().map(x -> x.getCteName() + ": " + x.getNumberOfReferences()
+                        + " (is_view: " + x.getIsView() + ")"
+                        + " (is_materialized: " + x.isMaterialized() + ")")
                 .collect(toList());
 
         return "CTEInfo: [" + String.join(", ", cteInfo) + "]\n";

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -1443,8 +1443,8 @@ public abstract class AbstractTestDistributedQueries
         MaterializedResult materializedResult = computeActual(session, "explain " + query);
         String explain = (String) getOnlyElement(materializedResult.getOnlyColumnAsSet());
 
-        checkCTEInfo(explain, "tbl", 2, false);
-        checkCTEInfo(explain, "tbl2", 1, false);
+        checkCTEInfo(explain, "tbl", 2, false, false);
+        checkCTEInfo(explain, "tbl2", 1, false, false);
     }
 
     @Test
@@ -1460,13 +1460,13 @@ public abstract class AbstractTestDistributedQueries
         MaterializedResult resultExplainQuery = computeActual(session, "EXPLAIN with cte1 as (select * from v), v as (select 2 as x) select * from cte1, v, v");
         String explainString = (String) resultExplainQuery.getOnlyValue();
 
-        checkCTEInfo(explainString, "cte1", 1, false);
+        checkCTEInfo(explainString, "cte1", 1, false, false);
 
         // view "catalog.schema.v" is referenced once, and the cte "v" twice in the above query
-        checkCTEInfo(explainString, "v", 2, false);
+        checkCTEInfo(explainString, "v", 2, false, false);
 
         String viewName = format("%s.%s.v", getSession().getCatalog().get(), getSession().getSchema().get());
-        checkCTEInfo(explainString, viewName, 1, true);
+        checkCTEInfo(explainString, viewName, 1, true, false);
     }
 
     @Test
@@ -1493,11 +1493,11 @@ public abstract class AbstractTestDistributedQueries
         MaterializedResult resultExplainQuery = computeActual(sessionNoCatalog, sql);
         String explainString = (String) resultExplainQuery.getOnlyValue();
 
-        checkCTEInfo(explainString, "cte1", 1, false);
+        checkCTEInfo(explainString, "cte1", 1, false, false);
 
         // view "catalog.schema.v" is referenced once, and the cte "v" twice in the above query
-        checkCTEInfo(explainString, "v", 2, false);
-        checkCTEInfo(explainString, viewName, 1, true);
+        checkCTEInfo(explainString, "v", 2, false, false);
+        checkCTEInfo(explainString, viewName, 1, true, false);
     }
 
     @Test
@@ -1548,7 +1548,7 @@ public abstract class AbstractTestDistributedQueries
                 ".*task_writer_count is invalid.*");
     }
 
-    private void checkCTEInfo(String explain, String name, int frequency, boolean isView)
+    protected void checkCTEInfo(String explain, String name, int frequency, boolean isView, boolean isMaterialized)
     {
         String regex = "CTEInfo.*";
         Pattern pattern = Pattern.compile(regex);
@@ -1556,7 +1556,7 @@ public abstract class AbstractTestDistributedQueries
         assertTrue(matcher.find());
 
         String cteInfo = matcher.group();
-        assertTrue(cteInfo.contains(name + ": " + frequency + " (is_view: " + isView + ")"));
+        assertTrue(cteInfo.contains(name + ": " + frequency + " (is_view: " + isView + ")" + " (is_materialized: " + isMaterialized + ")"));
     }
 
     private String sanitizePlan(String explain)


### PR DESCRIPTION
## Description
Fixes CTE Info to include whether the cte was materialized in the explain plan when verbose optimization is enabled

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```


