### PR TITLE
[Native] Add runtime metric for bytes processed

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -210,6 +210,8 @@ void PeriodicTaskManager::updateTaskStats() {
   auto taskNumbers = taskManager_->getTaskNumbers(numTasks);
   RECORD_METRIC_VALUE(kCounterNumTasks, taskManager_->getNumTasks());
   RECORD_METRIC_VALUE(
+      kCounterNumTasksBytesProcessed, taskManager_->getBytesProcessed());
+  RECORD_METRIC_VALUE(
       kCounterNumTasksRunning, taskNumbers[velox::exec::TaskState::kRunning]);
   RECORD_METRIC_VALUE(
       kCounterNumTasksFinished, taskNumbers[velox::exec::TaskState::kFinished]);

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -1144,6 +1144,15 @@ std::array<size_t, 5> TaskManager::getTaskNumbers(size_t& numTasks) const {
   return res;
 }
 
+int64_t TaskManager::getBytesProcessed() const {
+  const auto taskMap = *taskMap_.rlock();
+  int64_t totalCount = 0;
+  for (const auto& pair : taskMap) {
+    totalCount += pair.second->info.stats.processedInputDataSizeInBytes;
+  }
+  return totalCount;
+}
+
 void TaskManager::shutdown() {
   size_t numTasks;
   auto taskNumbers = getTaskNumbers(numTasks);

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -134,6 +134,9 @@ class TaskManager {
     return taskMap_.rlock()->size();
   }
 
+  /// Returns the processed input data size in bytes for tasks.
+  int64_t getBytesProcessed() const;
+
   /// Stores the number of drivers in various states of execution.
   velox::exec::Task::DriverCounts getDriverCounts() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -47,6 +47,7 @@ void registerPrestoMetrics() {
       kCounterHttpClientNumConnectionsCreated, facebook::velox::StatType::SUM);
   DEFINE_METRIC(kCounterNumQueryContexts, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasks, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterNumTasksBytesProcessed, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasksRunning, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasksFinished, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasksCancelled, facebook::velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -56,6 +56,8 @@ constexpr folly::StringPiece kCounterNumQueryContexts{
     "presto_cpp.num_query_contexts"};
 
 constexpr folly::StringPiece kCounterNumTasks{"presto_cpp.num_tasks"};
+constexpr folly::StringPiece kCounterNumTasksBytesProcessed{
+    "presto_cpp.num_tasks_bytes_processed"};
 constexpr folly::StringPiece kCounterNumTasksRunning{
     "presto_cpp.num_tasks_running"};
 constexpr folly::StringPiece kCounterNumTasksFinished{


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Added in kCounterNumTasksBytesProcessed to have the processedInputDataSizeInBytes metric tracked by prometheus from the native worker.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Need prestissimo to report bytes queried and written to the product segment source

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

