### PR TITLE
Immutable still good but Guava not required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,7 @@ We recommend you use IntelliJ as your IDE. The code style template for the proje
   time0Bto100KB.add(nanos, NANOSECONDS);
   ```
     
-  * Prefer Immutable collections in Guava when possible. For example, instead of using
+  * Prefer Immutable collections when possible. For example, instead of using
     
   ```java
   expressions.stream()


### PR DESCRIPTION
Don't specify that we prefer Guava over JDK built-in immutability

## Description
Remove "in Guava"

## Motivation and Context
Multiple PRs have pointed to this as a reason to use ImmutableList.of() instead of Collections.emptyList() etc. 

## Impact
none

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

