### PR TITLE
[Native] Update prometheus stats reporter CMAKE flag in docker compose file

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -114,8 +114,8 @@ PrestoExchangeSource::PrestoExchangeSource(
       sslContext_,
       [](size_t bufferBytes) {
         RECORD_METRIC_VALUE(kCounterHttpClientPrestoExchangeNumOnBody);
-        RECORD_HISTOGRAM_METRIC_VALUE(
-            kCounterHttpClientPrestoExchangeOnBodyBytes, bufferBytes);
+        //RECORD_HISTOGRAM_METRIC_VALUE(
+        //    kCounterHttpClientPrestoExchangeOnBodyBytes, bufferBytes);
       });
 }
 

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.cpp
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.cpp
@@ -152,9 +152,9 @@ void PrometheusStatsReporter::registerHistogramMetricExportType(
   // TODO: Registering histogram metrics appears to be causing a slowdown:
   // https://github.ibm.com/lakehouse/velox/issues/232. They are disabled
   // till further investigation into this issue.
-  return;
-//  registerHistogramMetricExportType(
-//      key.toString().c_str(), bucketWidth, min, max, pcts);
+  // return;
+  registerHistogramMetricExportType(
+      key.toString().c_str(), bucketWidth, min, max, pcts);
 }
 
 void PrometheusStatsReporter::addMetricValue(
@@ -209,23 +209,22 @@ void PrometheusStatsReporter::addHistogramMetricValue(
   // TODO: Registering histogram metrics appears to be causing a slowdown:
   // https://github.ibm.com/lakehouse/velox/issues/232. They are disabled
   // till further investigation into this issue.
-  return;
-//  auto metricIterator = registeredMetricsMap_.find(key);
-//  if (metricIterator == registeredMetricsMap_.end()) {
-//    VLOG(1) << "addMetricValue for unregistered metric " << key;
-//    return;
-//  }
-//  auto histogram = reinterpret_cast<::prometheus::Histogram*>(
-//      metricIterator->second.metricPtr);
-//  histogram->Observe(value);
-//
-//  std::string summaryKey = std::string(key).append(kSummarySuffix);
-//  metricIterator = registeredMetricsMap_.find(summaryKey);
-//  if (metricIterator != registeredMetricsMap_.end()) {
-//    auto summary = reinterpret_cast<::prometheus::Summary*>(
-//        metricIterator->second.metricPtr);
-//    summary->Observe(value);
-//  }
+  // return;
+  auto metricIterator = registeredMetricsMap_.find(key);
+  if (metricIterator == registeredMetricsMap_.end()) {
+    VLOG(1) << "addMetricValue for unregistered metric " << key;
+    return;
+  }
+  auto histogram = reinterpret_cast<::prometheus::Histogram*>(
+      metricIterator->second.metricPtr);
+  histogram->Observe(value);
+
+  std::string summaryKey = std::string(key).append(kSummarySuffix);
+  metricIterator = registeredMetricsMap_.find(summaryKey);
+  if (metricIterator != registeredMetricsMap_.end()) {
+    auto summary = reinterpret_cast<::prometheus::Summary*>(
+        metricIterator->second.metricPtr);
+    summary->Observe(value);
 }
 
 void PrometheusStatsReporter::addHistogramMetricValue(


### PR DESCRIPTION
## Description
[This change](https://github.com/prestodb/presto/pull/23204/files) modified the cmake flag to enable prometheus stats reporter. The docker file needs to reflect the latest flag name.