### PR TITLE
Fix for Pull request 23127

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 /*/var/
 /presto-product-tests/**/var/
 pom.xml.versionsBackup
+dependency-reduced-pom.xml
 test-output/
 test-reports/
 /atlassian-ide-plugin.xml

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -80,7 +80,7 @@
             <artifactId>guava</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.google.errorprone</groupId>
+                    <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
                 <exclusion>


### PR DESCRIPTION
## Description
Fixing the issue I described in https://github.com/prestodb/presto/pull/23127#discussion_r1692558490

## Motivation and Context
presto-jdbc is supposed to be a shaded jar but it is now inadvertently dragging in the org.checkerframework classes unshaded. This is causing build issues with projects consuming presto-jdbc since they now see duplicate classes for org.checkerframework -- one coming from guava and another from this unshaded presto-jdbc.

## Impact
Projects using presto-jdbc should now build

## Test Plan
At Meta, we have an internal service that uses presto-jdbc and that builds now. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

