### PR TITLE
Fix Iceberg read failing for Decimal type

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonSessionProperties.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonSessionProperties.java
@@ -41,6 +41,8 @@ public class HiveCommonSessionProperties
 {
     @VisibleForTesting
     public static final String RANGE_FILTERS_ON_SUBSCRIPTS_ENABLED = "range_filters_on_subscripts_enabled";
+    @VisibleForTesting
+    public static final String PARQUET_BATCH_READ_OPTIMIZATION_ENABLED = "parquet_batch_read_optimization_enabled";
 
     private static final String NODE_SELECTION_STRATEGY = "node_selection_strategy";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
@@ -55,7 +57,6 @@ public class HiveCommonSessionProperties
     private static final String ORC_STREAM_BUFFER_SIZE = "orc_stream_buffer_size";
     private static final String ORC_TINY_STRIPE_THRESHOLD = "orc_tiny_stripe_threshold";
     private static final String ORC_ZSTD_JNI_DECOMPRESSION_ENABLED = "orc_zstd_jni_decompression_enabled";
-    private static final String PARQUET_BATCH_READ_OPTIMIZATION_ENABLED = "parquet_batch_read_optimization_enabled";
     private static final String PARQUET_BATCH_READER_VERIFICATION_ENABLED = "parquet_batch_reader_verification_enabled";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_USE_COLUMN_NAMES = "parquet_use_column_names";

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
@@ -43,6 +43,7 @@ import com.facebook.presto.parquet.batchreader.decoders.plain.TimestampPlainValu
 import com.facebook.presto.parquet.batchreader.decoders.rle.BinaryRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.BooleanRLEValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int32RLEDictionaryValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.rle.Int32ShortDecimalRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int64RLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int64TimestampMicrosRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.LongDecimalRLEDictionaryValuesDecoder;
@@ -168,6 +169,9 @@ public class Decoders
             switch (type) {
                 case INT32:
                 case FLOAT: {
+                    if (isDecimalType(columnDescriptor) && isShortDecimalType(columnDescriptor)) {
+                        return new Int32ShortDecimalRLEDictionaryValuesDecoder(bitWidth, inputStream, (IntegerDictionary) dictionary);
+                    }
                     return new Int32RLEDictionaryValuesDecoder(bitWidth, inputStream, (IntegerDictionary) dictionary);
                 }
                 case INT64: {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/Int32ShortDecimalRLEDictionaryValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/Int32ShortDecimalRLEDictionaryValuesDecoder.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.parquet.batchreader.decoders.rle;
+
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.ShortDecimalValuesDecoder;
+import com.facebook.presto.parquet.dictionary.IntegerDictionary;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class Int32ShortDecimalRLEDictionaryValuesDecoder
+        extends Int32RLEDictionaryValuesDecoder
+        implements ShortDecimalValuesDecoder
+{
+    public Int32ShortDecimalRLEDictionaryValuesDecoder(int bitWidth, InputStream in, IntegerDictionary dictionary)
+    {
+        super(bitWidth, in, dictionary);
+    }
+
+    @Override
+    public void readNext(long[] values, int offset, int length) throws IOException
+    {
+        int[] tempValues = new int[length];
+        super.readNext(tempValues, 0, length);
+        for (int i = 0; i < length; i++) {
+            values[offset + i] = tempValues[i];
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fix https://github.com/prestodb/presto/issues/23274

After the introduction of the decimal batch reader(https://github.com/prestodb/presto/pull/22636) in Presto, when trying to read iceberg tables with decimal columns with parquet_batch_read_optimization_enabled=true, we are getting the below error
```
java.lang.ClassCastException: com.facebook.presto.parquet.batchreader.decoders.rle.Int32RLEDictionaryValuesDecoder cannot be cast to com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder$ShortDecimalValuesDecoder
	at com.facebook.presto.parquet.batchreader.ShortDecimalFlatBatchReader.readNextPage(ShortDecimalFlatBatchReader.java:139)
	at com.facebook.presto.parquet.batchreader.ShortDecimalFlatBatchReader.readWithNull(ShortDecimalFlatBatchReader.java:156)
	at com.facebook.presto.parquet.batchreader.ShortDecimalFlatBatchReader.readNext(ShortDecimalFlatBatchReader.java:104)
	at com.facebook.presto.parquet.reader.ParquetReader.readPrimitive(ParquetReader.java:389)
	at com.facebook.presto.parquet.reader.ParquetReader.readColumnChunk(ParquetReader.java:550)
	at com.facebook.presto.parquet.reader.ParquetReader.readBlock(ParquetReader.java:533)
	at com.facebook.presto.hive.parquet.ParquetPageSource$ParquetBlockLoader.load(ParquetPageSource.java:230)
	at com.facebook.presto.hive.parquet.ParquetPageSource$ParquetBlockLoader.load(ParquetPageSource.java:208)
	at com.facebook.presto.common.block.LazyBlock.assureLoaded(LazyBlock.java:313)
	at com.facebook.presto.common.block.LazyBlock.getLoadedBlock(LazyBlock.java:304)
	at com.facebook.presto.common.Page.getLoadedPage(Page.java:335)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:269)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:441)
	at com.facebook.presto.operator.Driver.lambda$processFor$10(Driver.java:324)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:750)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:317)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1079)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:165)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:621)
	at com.facebook.presto.$gen.Presto_null__testversion____20240722_195546_1.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
The issue happens when trying to read dictionary-encoded data.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```

Iceberg Connector Changes
* Fix Iceberg read failing for Decimal type. :pr:`23305`
```


CC: @tdcmeehan @yingsu00 @imjalpreet 
