### PR TITLE
Allow Verifier to validate varchar as floating point

### DIFF
--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -158,30 +158,75 @@ queries.
 
 * **Floating Point Columns**
     * For ``DOUBLE`` and ``REAL`` columns, 4 columns are generated for verification:
-       * Sum of the finite values of the column
-       * ``NAN`` count of the column
-       * Positive infinity count of the column
-       * Negative infinity count of the column
+        * Sum of the finite values of the column
+        * ``NAN`` count of the column
+        * Positive infinity count of the column
+        * Negative infinity count of the column
     * Checks if ``NAN`` count, positive and negative infinity count matches.
     * Checks the nullity of control sum and test sum.
     * If either control mean or test mean very close 0, checks if both are close to 0.
     * Checks the relative error between control sum and test sum.
+* **VARCHAR Columns**
+    * For ``VARCHAR`` columns, a simple checksum column is generated for verification using the :func:`!checksum`.
+    * If ``validate-string-as-double`` is set, seven columns below are generated. If ``NULL`` counts are equal before and after casting all values to ``DOUBLE``, apply the floating point validation. Otherwise, check if the simple checksum matches.
+        * Checksum
+        * Count of the ``NULL`` values
+        * Count of the ``NULL`` values after all values are casted to ``DOUBLE``
+      After casting all values to ``DOUBLE``
+        * Sum of the finite values
+        * ``NAN`` count of the values
+        * Positive infinity count of the values
+        * Negative infinity count of the values
 * **Array Columns**
-    * 2 columns are generated for verification:
-       * Sum of the cardinality
-       * Array checksum
-    * For an array column ``arr`` of type ``array(E)``:
-       * If ``E`` is not orderable, array checksum is ``checksum(arr)``.
-       * If ``E`` is orderable, array checksum ``coalesce(checksum(try(array_sort(arr))), checksum(arr))``.
+    * For an array column ``arr`` of type ``array(E)``, three columns are generated for verification:
+        * Sum of the cardinality
+        * Checksum of the cardinality
+        * Array checksum
+            * If ``E`` is not orderable, array checksum is ``checksum(arr)``.
+            * If ``E`` is orderable, array checksum is ``coalesce(checksum(try(array_sort(arr))), checksum(arr))``.
+    * If ``use-error-margin-for-floating-point-arrays`` is set and E is ``DOUBLE`` or ``REAL``, these six columns below are generated instead. Check if the sum of the cardinality matches and if the checksum of the cardinality matches. Apply the floating point validation to the rest of results.
+        * Sum of the cardinality
+        * Checksum of the cardinality
+        * Sum of the finite elements of all array values
+        * Count of the ``NAN`` elements of all array values
+        * Count of the positive infinity elements of all array values
+        * Count of the negative infinity elements of all array values
+    * If ``validate-string-as-double`` is set and E is ``VARCHAR``, these nine columns below are generated instead. Check if the sum and the checksum of the cardinality match. If ``NULL`` counts are equal before and after casting all array elements to ``DOUBLE``, apply the floating point validation. Otherwise, check if the array checksum matches.
+        * Sum of the cardinality
+        * Checksum of the cardinality
+        * Array checksum ``checksum(array_sort(arr))``
+        * Count of the ``NULL`` elements of all array values
+        * Count of the ``NULL`` elements after all array elements are casted to ``DOUBLE``
+      After casting all array elements to ``DOUBLE``
+        * Sum of the finite elements of all array values
+        * Count of the ``NAN`` elements of all array values
+        * Count of the positive infinity elements of all array values
+        * Count of the negative infinity elements of all array values
 * **Map Columns**
-    * 4 columns are generated for verification:
-       * Sum of the cardinality
-       * Checksum of the map
-       * Array checksum of the key set
-       * Array checksum of the value set
+    * For a map column of type ``map(K, V)``, four columns are generated for verification:
+        * Sum of the cardinality
+        * Checksum of the map
+        * Array checksum of the key set
+        * Array checksum of the value set
+    * If ``validate-string-as-double`` is set and K is ``VARCHAR``, six additional columns are generated:
+        * Count of the ``NULL`` elements of all key sets
+        * Count of the ``NULL`` elements of the key sets after all map keys are casted to ``DOUBLE``
+      After casting all map keys to ``DOUBLE``
+        * Sum of the finite elements of all key sets
+        * Count of the ``NAN`` elements of all key sets
+        * Count of the positive infinity elements of all key sets
+        * Count of the negative infinity elements of all key sets
+    * If ``validate-string-as-double`` is set and V is ``VARCHAR``, six additional columns are generated:
+        * Count of the ``NULL`` elements of all value sets
+        * Count of the ``NULL`` elements of the value sets after all map values are casted to ``DOUBLE``
+      After casting all map values to ``DOUBLE``
+        * Sum of the finite elements of all value sets
+        * Count of the ``NAN`` elements of all value sets
+        * Count of the positive infinity elements of all value sets
+        * Count of the negative infinity elements of all value sets
 * **Row Columns**
     * Checksums row fields recursively according to the type of the fields.
-* For all other column types, generates a simple checksum using the :func:`!checksum` function.
+For all other column types, generates a simple checksum using the :func:`!checksum` function.
 
 Determinism
 -----------

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ArrayColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ArrayColumnChecksum.java
@@ -27,7 +27,7 @@ public class ArrayColumnChecksum
     private final Object checksum;
     private final Object cardinalityChecksum;
     private final long cardinalitySum;
-    // For array(floating point) we have extra aggregations collected.
+    // For array(floating point) or array(varchar) we have extra aggregations collected.
     private final Optional<FloatingPointColumnChecksum> floatingPointChecksum;
 
     public ArrayColumnChecksum(

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ColumnValidatorUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ColumnValidatorUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.checksum;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.sql.tree.IsNullPredicate;
+import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
+import com.facebook.presto.sql.tree.LambdaExpression;
+import com.facebook.presto.sql.tree.SingleColumn;
+import com.facebook.presto.verifier.framework.Column;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.facebook.presto.sql.QueryUtil.functionCall;
+import static com.facebook.presto.sql.QueryUtil.identifier;
+import static com.facebook.presto.verifier.framework.VerifierUtil.delimitedIdentifier;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class ColumnValidatorUtil
+{
+    private static final Logger LOG = Logger.get(ColumnValidatorUtil.class);
+
+    private ColumnValidatorUtil() {}
+
+    public static List<SingleColumn> generateNullCountColumns(Column column, Column asDoubleColumn)
+    {
+        if (column.getType() instanceof ArrayType) {
+            checkArgument(asDoubleColumn.getType() instanceof ArrayType, "Expect ArrayType, found %s", asDoubleColumn.getType().getDisplayName());
+            // sum(cardinality(filter(column, x -> x is null)))
+            return ImmutableList.of(
+                    new SingleColumn(
+                            functionCall("sum", functionCall("cardinality", functionCall("filter",
+                                    column.getExpression(),
+                                    new LambdaExpression(ImmutableList.of(new LambdaArgumentDeclaration(identifier("x"))), new IsNullPredicate(identifier("x")))))),
+                            delimitedIdentifier(getNullCountColumnAlias(column))),
+                    new SingleColumn(
+                            functionCall("sum", functionCall("cardinality", functionCall("filter",
+                                    asDoubleColumn.getExpression(),
+                                    new LambdaExpression(ImmutableList.of(new LambdaArgumentDeclaration(identifier("x"))), new IsNullPredicate(identifier("x")))))),
+                            delimitedIdentifier(getNullCountColumnAlias(asDoubleColumn))));
+        }
+        else {
+            // count_if(column is null).
+            return ImmutableList.of(
+                    new SingleColumn(functionCall("count_if",
+                            new IsNullPredicate(column.getExpression())), delimitedIdentifier(getNullCountColumnAlias(column))),
+                    new SingleColumn(functionCall("count_if",
+                            new IsNullPredicate(asDoubleColumn.getExpression())), delimitedIdentifier(getNullCountColumnAlias(asDoubleColumn))));
+        }
+    }
+
+    // Assume both controlResult and testResult contain the results of one column count_if(column is null) and one column count_if(try_cast(column as double) is null). If the
+    // results of the two columns are equal in controlResult as well as testResult, it indicates all varchar values of the column are able to be casted to double and returns
+    // true. Otherwise, returns false.
+    public static boolean isStringAsDoubleColumn(Column column, ChecksumResult controlResult, ChecksumResult testResult)
+    {
+        return Objects.equals(controlResult.getChecksum(getNullCountColumnAlias(column)), controlResult.getChecksum(getAsDoubleNullCountColumnAlias(column))) &&
+                Objects.equals(testResult.getChecksum(getNullCountColumnAlias(column)), testResult.getChecksum(getAsDoubleNullCountColumnAlias(column)));
+    }
+
+    public static String getNullCountColumnAlias(Column column)
+    {
+        return column.getName() + "$null_count";
+    }
+
+    public static String getAsDoubleNullCountColumnAlias(Column column)
+    {
+        return column.getName() + "_as_double$null_count";
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnChecksum.java
@@ -16,7 +16,9 @@ package com.facebook.presto.verifier.checksum;
 import javax.annotation.Nullable;
 
 import java.util.Objects;
+import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 
 public class MapColumnChecksum
@@ -25,6 +27,8 @@ public class MapColumnChecksum
     private final Object checksum;
     private final Object keysChecksum;
     private final Object valuesChecksum;
+    private final Optional<FloatingPointColumnChecksum> keysFloatingPointChecksum;
+    private final Optional<FloatingPointColumnChecksum> valuesFloatingPointChecksum;
     private final Object cardinalityChecksum;
     private final long cardinalitySum;
 
@@ -32,12 +36,16 @@ public class MapColumnChecksum
             @Nullable Object checksum,
             @Nullable Object keysChecksum,
             @Nullable Object valuesChecksum,
+            Optional<FloatingPointColumnChecksum> keysFloatingPointChecksum,
+            Optional<FloatingPointColumnChecksum> valuesFloatingPointChecksum,
             @Nullable Object cardinalityChecksum,
             long cardinalitySum)
     {
         this.checksum = checksum;
         this.keysChecksum = keysChecksum;
         this.valuesChecksum = valuesChecksum;
+        this.keysFloatingPointChecksum = keysFloatingPointChecksum;
+        this.valuesFloatingPointChecksum = valuesFloatingPointChecksum;
         this.cardinalityChecksum = cardinalityChecksum;
         this.cardinalitySum = cardinalitySum;
     }
@@ -58,6 +66,18 @@ public class MapColumnChecksum
     public Object getValuesChecksum()
     {
         return valuesChecksum;
+    }
+
+    public FloatingPointColumnChecksum getKeysFloatingPointChecksum()
+    {
+        checkArgument(keysFloatingPointChecksum.isPresent(), "Expect Floating Point Checksum to be present, but it is not");
+        return keysFloatingPointChecksum.get();
+    }
+
+    public FloatingPointColumnChecksum getValuesFloatingPointChecksum()
+    {
+        checkArgument(valuesFloatingPointChecksum.isPresent(), "Expect Floating Point Checksum to be present, but it is not");
+        return valuesFloatingPointChecksum.get();
     }
 
     @Override
@@ -86,6 +106,8 @@ public class MapColumnChecksum
         return Objects.equals(checksum, o.checksum) &&
                 Objects.equals(keysChecksum, o.keysChecksum) &&
                 Objects.equals(valuesChecksum, o.valuesChecksum) &&
+                Objects.equals(keysFloatingPointChecksum, o.keysFloatingPointChecksum) &&
+                Objects.equals(valuesFloatingPointChecksum, o.valuesFloatingPointChecksum) &&
                 Objects.equals(cardinalityChecksum, o.cardinalityChecksum) &&
                 Objects.equals(cardinalitySum, o.cardinalitySum);
     }
@@ -93,12 +115,17 @@ public class MapColumnChecksum
     @Override
     public int hashCode()
     {
-        return Objects.hash(checksum, keysChecksum, valuesChecksum, cardinalityChecksum, cardinalitySum);
+        return Objects.hash(checksum, keysChecksum, valuesChecksum, keysFloatingPointChecksum, valuesFloatingPointChecksum, cardinalityChecksum, cardinalitySum);
     }
 
     @Override
     public String toString()
     {
-        return format("checksum: %s, keys_checksum: %s, values_checksum: %s, cardinality_checksum: %s, cardinality_sum: %s", checksum, keysChecksum, valuesChecksum, cardinalityChecksum, cardinalitySum);
+        String result = format("checksum: %s, cardinality_checksum: %s, cardinality_sum: %s", checksum, cardinalityChecksum, cardinalitySum);
+        result += keysFloatingPointChecksum.isPresent() ? "" : format(", keys_checksum: %s", keysChecksum);
+        result += valuesFloatingPointChecksum.isPresent() ? "" : format(", values_checksum: %s", valuesChecksum);
+        result += keysFloatingPointChecksum.isPresent() ? format(". [keys] %s", keysFloatingPointChecksum.get()) : "";
+        result += valuesFloatingPointChecksum.isPresent() ? format(". [values] %s", valuesFloatingPointChecksum.get()) : "";
+        return result;
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnValidator.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.checksum;
 
+import com.facebook.presto.common.type.AbstractVarcharType;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.MapType;
@@ -23,7 +24,10 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.verifier.framework.Column;
+import com.facebook.presto.verifier.framework.VerifierConfig;
 import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Objects;
@@ -31,69 +35,177 @@ import java.util.Optional;
 
 import static com.facebook.presto.sql.QueryUtil.functionCall;
 import static com.facebook.presto.verifier.checksum.ArrayColumnValidator.generateArrayChecksum;
+import static com.facebook.presto.verifier.checksum.ArrayColumnValidator.getAsDoubleArrayColumn;
 import static com.facebook.presto.verifier.framework.VerifierUtil.delimitedIdentifier;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 public class MapColumnValidator
         implements ColumnValidator
 {
+    private final FloatingPointColumnValidator floatingPointValidator;
+    private final boolean validateStringAsDouble;
+
+    @Inject
+    public MapColumnValidator(VerifierConfig config, FloatingPointColumnValidator floatingPointValidator)
+    {
+        this.floatingPointValidator = requireNonNull(floatingPointValidator, "floatingPointValidator is null");
+        this.validateStringAsDouble = config.isValidateStringAsDouble();
+    }
+
     @Override
     public List<SingleColumn> generateChecksumColumns(Column column)
     {
         checkArgument(column.getType() instanceof MapType, "Expect MapType, found %s", column.getType().getDisplayName());
         Type keyType = ((MapType) column.getType()).getKeyType();
         Type valueType = ((MapType) column.getType()).getValueType();
+        ImmutableList.Builder<SingleColumn> builder = ImmutableList.builder();
 
         Expression checksum = functionCall("checksum", column.getExpression());
         Expression keysChecksum = generateArrayChecksum(functionCall("map_keys", column.getExpression()), new ArrayType(keyType));
+        // checksum(cardinality(map_column))
         Expression mapCardinalityChecksum = functionCall("checksum", functionCall("cardinality", column.getExpression()));
+        // coalesce(sum(cardinality(map_column)), 0)
         Expression mapCardinalitySum = new CoalesceExpression(
                 functionCall("sum", functionCall("cardinality", column.getExpression())),
                 new LongLiteral("0"));
+
+        builder.add(new SingleColumn(checksum, Optional.of(delimitedIdentifier(getChecksumColumnAlias(column)))));
+        builder.add(new SingleColumn(keysChecksum, Optional.of(delimitedIdentifier(getKeysChecksumColumnAlias(column)))));
 
         // We need values checksum in one case only: when key is a floating point type and value is not.
         // In such case, when both column checksum and the key checksum do not match, we cannot tell if the values match or not.
         // Meaning we cannot resolve column mismatch, because value type is not a floating type and a mismatch in the values could indicate a real correctness issue.
         // In order to resolve column mismatch in such a situation, generate an extra checksum for the values.
-        if (isFloatingPointType(keyType) && !isFloatingPointType(valueType)) {
+        if ((isFloatingPointType(keyType) || shouldValidateStringAsDouble(keyType)) && !isFloatingPointType(valueType)) {
             Expression valuesChecksum = generateArrayChecksum(functionCall("map_values", column.getExpression()), new ArrayType(valueType));
-            return ImmutableList.of(
-                    new SingleColumn(checksum, Optional.of(delimitedIdentifier(getChecksumColumnAlias(column)))),
-                    new SingleColumn(keysChecksum, Optional.of(delimitedIdentifier(getKeysChecksumColumnAlias(column)))),
-                    new SingleColumn(valuesChecksum, Optional.of(delimitedIdentifier(getValuesChecksumColumnAlias(column)))),
-                    new SingleColumn(mapCardinalityChecksum, Optional.of(delimitedIdentifier(getCardinalityChecksumColumnAlias(column)))),
-                    new SingleColumn(mapCardinalitySum, Optional.of(delimitedIdentifier(getCardinalitySumColumnAlias(column)))));
+            builder.add(new SingleColumn(valuesChecksum, Optional.of(delimitedIdentifier(getValuesChecksumColumnAlias(column)))));
         }
 
-        return ImmutableList.of(
-                new SingleColumn(checksum, Optional.of(delimitedIdentifier(getChecksumColumnAlias(column)))),
-                new SingleColumn(keysChecksum, Optional.of(delimitedIdentifier(getKeysChecksumColumnAlias(column)))),
-                new SingleColumn(mapCardinalityChecksum, Optional.of(delimitedIdentifier(getCardinalityChecksumColumnAlias(column)))),
-                new SingleColumn(mapCardinalitySum, Optional.of(delimitedIdentifier(getCardinalitySumColumnAlias(column)))));
+        if (shouldValidateStringAsDouble(keyType)) {
+            Column keysColumn = getKeysColumn(column);
+            builder.addAll(ArrayColumnValidator.generateStringArrayChecksumColumns(keysColumn));
+        }
+        if (shouldValidateStringAsDouble(valueType)) {
+            Column valuesColumn = getValuesColumn(column);
+            builder.addAll(ArrayColumnValidator.generateStringArrayChecksumColumns(valuesColumn));
+        }
+
+        builder.add(new SingleColumn(mapCardinalityChecksum, Optional.of(delimitedIdentifier(getCardinalityChecksumColumnAlias(column)))));
+        builder.add(new SingleColumn(mapCardinalitySum, Optional.of(delimitedIdentifier(getCardinalitySumColumnAlias(column)))));
+
+        return builder.build();
     }
 
     @Override
     public List<ColumnMatchResult<MapColumnChecksum>> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult)
     {
-        MapColumnChecksum controlChecksum = toColumnChecksum(column, controlResult);
-        MapColumnChecksum testChecksum = toColumnChecksum(column, testResult);
+        checkArgument(
+                controlResult.getRowCount() == testResult.getRowCount(),
+                "Test row count (%s) does not match control row count (%s)",
+                testResult.getRowCount(),
+                controlResult.getRowCount());
 
-        return ImmutableList.of(new ColumnMatchResult<>(Objects.equals(controlChecksum, testChecksum), column, controlChecksum, testChecksum));
+        Type keyType = ((MapType) column.getType()).getKeyType();
+        Type valueType = ((MapType) column.getType()).getValueType();
+        Column keysColumn = getKeysColumn(column);
+        Column valuesColumn = getValuesColumn(column);
+
+        boolean isDoubleKeyAsString = shouldValidateStringAsDouble(keyType) && ColumnValidatorUtil.isStringAsDoubleColumn(keysColumn, controlResult, testResult);
+        boolean isDoubleValueAsString = shouldValidateStringAsDouble(valueType) && ColumnValidatorUtil.isStringAsDoubleColumn(valuesColumn, controlResult, testResult);
+        MapColumnChecksum controlChecksum = toColumnChecksum(column, controlResult, isDoubleKeyAsString, isDoubleValueAsString);
+        MapColumnChecksum testChecksum = toColumnChecksum(column, testResult, isDoubleKeyAsString, isDoubleValueAsString);
+
+        if (!isDoubleKeyAsString && !isDoubleValueAsString) {
+            return ImmutableList.of(new ColumnMatchResult<>(Objects.equals(controlChecksum, testChecksum), column, controlChecksum, testChecksum));
+        }
+
+        if (!Objects.equals(controlChecksum.getCardinalityChecksum(), testChecksum.getCardinalityChecksum()) ||
+                !Objects.equals(controlChecksum.getCardinalitySum(), testChecksum.getCardinalitySum())) {
+            return ImmutableList.of(new ColumnMatchResult<>(false, column, Optional.of("cardinality mismatch"), controlChecksum, testChecksum));
+        }
+
+        Optional<String> errorMessage = Optional.empty();
+        boolean isKeyMatched = Objects.equals(controlChecksum.getKeysChecksum(), testChecksum.getKeysChecksum());
+        if (isDoubleKeyAsString) {
+            ColumnMatchResult<FloatingPointColumnChecksum> result =
+                    floatingPointValidator.validate(getAsDoubleArrayColumn(keysColumn), controlChecksum.getKeysFloatingPointChecksum(), testChecksum.getKeysFloatingPointChecksum());
+            isKeyMatched = isKeyMatched || result.isMatched();
+            if (result.getMessage().isPresent()) {
+                errorMessage = Optional.of("Map key " + result.getMessage().get());
+            }
+        }
+        boolean isValueMatched = Objects.equals(controlChecksum.getValuesChecksum(), testChecksum.getValuesChecksum());
+        if (isDoubleValueAsString) {
+            ColumnMatchResult<FloatingPointColumnChecksum> result =
+                    floatingPointValidator.validate(getAsDoubleArrayColumn(valuesColumn), controlChecksum.getValuesFloatingPointChecksum(), testChecksum.getValuesFloatingPointChecksum());
+            isValueMatched = isValueMatched || result.isMatched();
+            if (result.getMessage().isPresent()) {
+                errorMessage = errorMessage.isPresent() ?
+                        Optional.of(errorMessage.get() + ", map value " + result.getMessage().get()) :
+                        Optional.of("Map value " + result.getMessage().get());
+            }
+        }
+
+        return ImmutableList.of(new ColumnMatchResult<>(isKeyMatched && isValueMatched, column, errorMessage, controlChecksum, testChecksum));
     }
 
-    private static MapColumnChecksum toColumnChecksum(Column column, ChecksumResult checksumResult)
+    private MapColumnChecksum toColumnChecksum(Column column, ChecksumResult checksumResult, boolean isDoubleKeyAsString, boolean isDoubleValueAsString)
     {
+        Type keyType = ((MapType) column.getType()).getKeyType();
+        Type valueType = ((MapType) column.getType()).getValueType();
+
+        Optional<FloatingPointColumnChecksum> keysFloatingPointChecksum = Optional.empty();
+        if (isDoubleKeyAsString) {
+            Column keysColumn = getAsDoubleArrayColumn(getKeysColumn(column));
+            keysFloatingPointChecksum = Optional.of(FloatingPointColumnValidator.toColumnChecksum(keysColumn, checksumResult, checksumResult.getRowCount()));
+        }
+        Optional<FloatingPointColumnChecksum> valuesFloatingPointChecksum = Optional.empty();
+        if (isDoubleValueAsString) {
+            Column valuesColumn = getAsDoubleArrayColumn(getValuesColumn(column));
+            valuesFloatingPointChecksum = Optional.of(FloatingPointColumnValidator.toColumnChecksum(valuesColumn, checksumResult, checksumResult.getRowCount()));
+        }
+        Object valuesChecksum = null;
+        if ((isFloatingPointType(keyType) || isDoubleKeyAsString) && !isFloatingPointType(valueType)) {
+            valuesChecksum = checksumResult.getChecksum(getValuesChecksumColumnAlias(column));
+        }
+
+        if (checksumResult.getRowCount() == 0) {
+            return new MapColumnChecksum(null, null, null, keysFloatingPointChecksum, valuesFloatingPointChecksum, null, 0);
+        }
+
         return new MapColumnChecksum(
                 checksumResult.getChecksum(getChecksumColumnAlias(column)),
                 checksumResult.getChecksum(getKeysChecksumColumnAlias(column)),
-                checksumResult.getChecksums().containsKey(getValuesChecksumColumnAlias(column)) ? checksumResult.getChecksum(getValuesChecksumColumnAlias(column)) : null,
+                valuesChecksum,
+                keysFloatingPointChecksum,
+                valuesFloatingPointChecksum,
                 checksumResult.getChecksum(getCardinalityChecksumColumnAlias(column)),
                 (long) checksumResult.getChecksum(getCardinalitySumColumnAlias(column)));
+    }
+
+    private boolean shouldValidateStringAsDouble(Type columnType)
+    {
+        return validateStringAsDouble && columnType instanceof AbstractVarcharType;
     }
 
     private static boolean isFloatingPointType(Type type)
     {
         return type instanceof DoubleType || type instanceof RealType;
+    }
+
+    private static Column getKeysColumn(Column column)
+    {
+        checkArgument(column.getType() instanceof MapType, "Expect MapType, found %s", column.getType().getDisplayName());
+        Type keyType = ((MapType) column.getType()).getKeyType();
+        return Column.create(column.getName() + "_key_array", functionCall("map_keys", column.getExpression()), new ArrayType(keyType));
+    }
+
+    private static Column getValuesColumn(Column column)
+    {
+        checkArgument(column.getType() instanceof MapType, "Expect MapType, found %s", column.getType().getDisplayName());
+        Type valueType = ((MapType) column.getType()).getValueType();
+        return Column.create(column.getName() + "_value_array", functionCall("map_values", column.getExpression()), new ArrayType(valueType));
     }
 
     private static String getChecksumColumnAlias(Column column)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnChecksum.java
@@ -16,23 +16,34 @@ package com.facebook.presto.verifier.checksum;
 import javax.annotation.Nullable;
 
 import java.util.Objects;
+import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 
 public class SimpleColumnChecksum
         extends ColumnChecksum
 {
     private final Object checksum;
+    private final Optional<FloatingPointColumnChecksum> asDoubleChecksum;
 
-    public SimpleColumnChecksum(@Nullable Object checksum)
+    public SimpleColumnChecksum(@Nullable Object checksum, Optional<FloatingPointColumnChecksum> asDoubleChecksum)
     {
         this.checksum = checksum;
+        this.asDoubleChecksum = asDoubleChecksum;
     }
 
     @Nullable
     public Object getChecksum()
     {
         return checksum;
+    }
+
+    public FloatingPointColumnChecksum getAsDoubleChecksum()
+    {
+        checkArgument(asDoubleChecksum.isPresent(), "Expect as-double checksum to be present, but it is not");
+
+        return asDoubleChecksum.get();
     }
 
     @Override
@@ -45,18 +56,24 @@ public class SimpleColumnChecksum
             return false;
         }
         SimpleColumnChecksum o = (SimpleColumnChecksum) obj;
-        return Objects.equals(checksum, o.checksum);
+        return Objects.equals(checksum, o.checksum) &&
+                Objects.equals(asDoubleChecksum, o.asDoubleChecksum);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(checksum);
+        return Objects.hash(checksum, asDoubleChecksum);
     }
 
     @Override
     public String toString()
     {
-        return format("%s", checksum);
+        if (asDoubleChecksum.isPresent()) {
+            return asDoubleChecksum.get().toString();
+        }
+        else {
+            return format("checksum: %s", checksum);
+        }
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnValidator.java
@@ -13,37 +13,101 @@
  */
 package com.facebook.presto.verifier.checksum;
 
+import com.facebook.presto.common.type.AbstractVarcharType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.verifier.framework.Column;
+import com.facebook.presto.verifier.framework.VerifierConfig;
 import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.verifier.framework.VerifierUtil.delimitedIdentifier;
+import static java.util.Objects.requireNonNull;
 
 public class SimpleColumnValidator
         implements ColumnValidator
 {
+    private final FloatingPointColumnValidator floatingPointValidator;
+    private final boolean validateStringAsDouble;
+
+    @Inject
+    public SimpleColumnValidator(VerifierConfig config, FloatingPointColumnValidator floatingPointValidator)
+    {
+        this.floatingPointValidator = requireNonNull(floatingPointValidator, "floatingPointValidator is null");
+        this.validateStringAsDouble = config.isValidateStringAsDouble();
+    }
+
     @Override
     public List<SingleColumn> generateChecksumColumns(Column column)
     {
-        return ImmutableList.of(
-                new SingleColumn(
-                        new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(column.getExpression())),
-                        Optional.of(delimitedIdentifier(getChecksumColumnAlias(column)))));
+        ImmutableList.Builder<SingleColumn> columnsBuilder = ImmutableList.builder();
+        // checksum(column)
+        Expression checksum = new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(column.getExpression()));
+        columnsBuilder.add(new SingleColumn(checksum, delimitedIdentifier(getChecksumColumnAlias(column))));
+
+        if (shouldValidateStringAsDouble(column)) {
+            Column asDoubleColumn = getAsDoubleColumn(column);
+            columnsBuilder.addAll(floatingPointValidator.generateChecksumColumns(asDoubleColumn));
+            columnsBuilder.addAll(ColumnValidatorUtil.generateNullCountColumns(column, asDoubleColumn));
+        }
+        return columnsBuilder.build();
     }
 
     @Override
     public List<ColumnMatchResult<SimpleColumnChecksum>> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult)
     {
-        String checksumColumnAlias = getChecksumColumnAlias(column);
-        SimpleColumnChecksum controlChecksum = new SimpleColumnChecksum(controlResult.getChecksum(checksumColumnAlias));
-        SimpleColumnChecksum testChecksum = new SimpleColumnChecksum(testResult.getChecksum(checksumColumnAlias));
+        boolean isStringAsDouble = shouldValidateStringAsDouble(column) && ColumnValidatorUtil.isStringAsDoubleColumn(column, controlResult, testResult);
+
+        SimpleColumnChecksum controlChecksum = toColumnChecksum(column, controlResult, isStringAsDouble);
+        SimpleColumnChecksum testChecksum = toColumnChecksum(column, testResult, isStringAsDouble);
+
+        if (isStringAsDouble) {
+            Column asDoubleColumn = getAsDoubleColumn(column);
+            ColumnMatchResult<FloatingPointColumnChecksum> asDoubleMatchResult =
+                    floatingPointValidator.validate(asDoubleColumn, controlChecksum.getAsDoubleChecksum(), testChecksum.getAsDoubleChecksum());
+            return ImmutableList.of(new ColumnMatchResult<>(asDoubleMatchResult.isMatched(), column, asDoubleMatchResult.getMessage(), controlChecksum, testChecksum));
+        }
+
         return ImmutableList.of(new ColumnMatchResult<>(Objects.equals(controlChecksum, testChecksum), column, controlChecksum, testChecksum));
+    }
+
+    private static SimpleColumnChecksum toColumnChecksum(Column column, ChecksumResult checksumResult, boolean isStringAsDouble)
+    {
+        Object checksum = checksumResult.getChecksum(getChecksumColumnAlias(column));
+
+        if (isStringAsDouble) {
+            Column asDoubleColumn = getAsDoubleColumn(column);
+            return new SimpleColumnChecksum(
+                    checksum,
+                    Optional.of(FloatingPointColumnValidator.toColumnChecksum(asDoubleColumn, checksumResult, checksumResult.getRowCount())));
+        }
+        return new SimpleColumnChecksum(checksum, Optional.empty());
+    }
+
+    private boolean shouldValidateStringAsDouble(Column column)
+    {
+        Type columnType = column.getType();
+        return (validateStringAsDouble && columnType instanceof AbstractVarcharType);
+    }
+
+    private static Column getAsDoubleColumn(Column column)
+    {
+        return Column.create(column.getName() + "_as_double", getAsDoubleExpression(column), DOUBLE);
+    }
+
+    private static Expression getAsDoubleExpression(Column column)
+    {
+        return new Cast(column.getExpression(), DOUBLE.getDisplayName(), true, false);
     }
 
     private static String getChecksumColumnAlias(Column column)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
@@ -53,6 +53,7 @@ public class VerifierConfig
     private double relativeErrorMargin = 1e-4;
     private double absoluteErrorMargin = 1e-12;
     private boolean useErrorMarginForFloatingPointArrays = true;
+    private boolean validateStringAsDouble;
     private boolean smartTeardown;
     private int verificationResubmissionLimit = 6;
 
@@ -265,6 +266,19 @@ public class VerifierConfig
     public VerifierConfig setUseErrorMarginForFloatingPointArrays(boolean useErrorMarginForFloatingPointArrays)
     {
         this.useErrorMarginForFloatingPointArrays = useErrorMarginForFloatingPointArrays;
+        return this;
+    }
+
+    public boolean isValidateStringAsDouble()
+    {
+        return validateStringAsDouble;
+    }
+
+    @ConfigDescription("When set to true, validate string column as double if the values are all in the floating point format.")
+    @Config("validate-string-as-double")
+    public VerifierConfig setValidateStringAsDouble(boolean validateStringAsDouble)
+    {
+        this.validateStringAsDouble = validateStringAsDouble;
         return this;
     }
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
@@ -141,11 +141,11 @@ public class VerifierTestUtil
     {
         Map<Column.Category, Provider<ColumnValidator>> lazyValidators = new HashMap<>();
         Map<Column.Category, Provider<ColumnValidator>> validators = ImmutableMap.of(
-                Column.Category.SIMPLE, SimpleColumnValidator::new,
+                Column.Category.SIMPLE, () -> new SimpleColumnValidator(verifierConfig, new FloatingPointColumnValidator(verifierConfig)),
                 Column.Category.FLOATING_POINT, () -> new FloatingPointColumnValidator(verifierConfig),
                 Column.Category.ARRAY, () -> new ArrayColumnValidator(verifierConfig, new FloatingPointColumnValidator(verifierConfig)),
                 Column.Category.ROW, () -> new RowColumnValidator(lazyValidators),
-                Column.Category.MAP, MapColumnValidator::new);
+                Column.Category.MAP, () -> new MapColumnValidator(verifierConfig, new FloatingPointColumnValidator(verifierConfig)));
         lazyValidators.putAll(validators);
         return new ChecksumValidator(validators);
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
@@ -53,7 +53,8 @@ public class TestVerifierConfig
                 .setRunningMode("control-test")
                 .setExtendedVerification(false)
                 .setSaveSnapshot(false)
-                .setFunctionSubstitutes(null));
+                .setFunctionSubstitutes(null)
+                .setValidateStringAsDouble(false));
     }
 
     @Test
@@ -86,6 +87,7 @@ public class TestVerifierConfig
                 .put("extended-verification", "true")
                 .put("save-snapshot", "true")
                 .put("function-substitutes", "/approx_distinct(c)/count(c)/")
+                .put("validate-string-as-double", "true")
                 .build();
         VerifierConfig expected = new VerifierConfig()
                 .setWhitelist("a,b,c")
@@ -113,7 +115,8 @@ public class TestVerifierConfig
                 .setRunningMode("query-bank")
                 .setExtendedVerification(true)
                 .setSaveSnapshot(true)
-                .setFunctionSubstitutes("/approx_distinct(c)/count(c)/");
+                .setFunctionSubstitutes("/approx_distinct(c)/count(c)/")
+                .setValidateStringAsDouble(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
@@ -45,7 +45,10 @@ public class TestIgnoredFunctionsMismatchResolver
     @Test
     public void testDefault()
     {
-        ColumnMatchResult<?> mismatchedColumn = createMismatchedColumn(VARCHAR, new SimpleColumnChecksum(binary(0xa)), new SimpleColumnChecksum(binary(0xb)));
+        ColumnMatchResult<?> mismatchedColumn = createMismatchedColumn(
+                VARCHAR,
+                new SimpleColumnChecksum(binary(0xa), Optional.empty()),
+                new SimpleColumnChecksum(binary(0xb), Optional.empty()));
 
         // resolved
         assertResolved(createBundle("CREATE TABLE test AS SELECT rand() x FROM source"), mismatchedColumn);

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestStructuredColumnMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestStructuredColumnMismatchResolver.java
@@ -75,11 +75,11 @@ public class TestStructuredColumnMismatchResolver
     @Test
     public void testResolveMap()
     {
-        MapColumnChecksum cs1 = new MapColumnChecksum(binary(0x1), binary(0xa), null, binary(0xc), 1);
-        MapColumnChecksum cs2 = new MapColumnChecksum(binary(0x2), binary(0xb), null, binary(0xc), 1);
-        MapColumnChecksum cs3 = new MapColumnChecksum(binary(0x3), binary(0xa), null, binary(0xc), 1);
-        MapColumnChecksum cs4 = new MapColumnChecksum(binary(0x1), binary(0xa), null, binary(0x1c), 1);
-        MapColumnChecksum cs5 = new MapColumnChecksum(binary(0x1), binary(0xa), null, binary(0xc), 2);
+        MapColumnChecksum cs1 = new MapColumnChecksum(binary(0x1), binary(0xa), null, Optional.empty(), Optional.empty(), binary(0xc), 1);
+        MapColumnChecksum cs2 = new MapColumnChecksum(binary(0x2), binary(0xb), null, Optional.empty(), Optional.empty(), binary(0xc), 1);
+        MapColumnChecksum cs3 = new MapColumnChecksum(binary(0x3), binary(0xa), null, Optional.empty(), Optional.empty(), binary(0xc), 1);
+        MapColumnChecksum cs4 = new MapColumnChecksum(binary(0x1), binary(0xa), null, Optional.empty(), Optional.empty(), binary(0x1c), 1);
+        MapColumnChecksum cs5 = new MapColumnChecksum(binary(0x1), binary(0xa), null, Optional.empty(), Optional.empty(), binary(0xc), 2);
 
         // Resolved - both floating points, cardinality is good.
         assertResolved(createMismatchedColumn(mapType(DOUBLE, DOUBLE), cs1, cs2));
@@ -88,12 +88,12 @@ public class TestStructuredColumnMismatchResolver
         assertNotResolved(createMismatchedColumn(mapType(DOUBLE, DOUBLE), cs1, cs4));
         assertNotResolved(createMismatchedColumn(mapType(DOUBLE, DOUBLE), cs1, cs5));
 
-        MapColumnChecksum csFloatNonFloat1 = new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xa), binary(0xc), 1);
-        MapColumnChecksum csFloatNonFloat2 = new MapColumnChecksum(binary(0x2), binary(0xb), binary(0xa), binary(0xc), 1);
-        MapColumnChecksum csFloatNonFloat3 = new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xa), binary(0x1c), 1);
-        MapColumnChecksum csFloatNonFloat4 = new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xa), binary(0x1c), 2);
-        MapColumnChecksum csFloatNonFloat5 = new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xb), binary(0xc), 1);
-        MapColumnChecksum csFloatNonFloat6 = new MapColumnChecksum(binary(0x2), binary(0xb), binary(0xb), binary(0xc), 1);
+        MapColumnChecksum csFloatNonFloat1 = new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xa), Optional.empty(), Optional.empty(), binary(0xc), 1);
+        MapColumnChecksum csFloatNonFloat2 = new MapColumnChecksum(binary(0x2), binary(0xb), binary(0xa), Optional.empty(), Optional.empty(), binary(0xc), 1);
+        MapColumnChecksum csFloatNonFloat3 = new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xa), Optional.empty(), Optional.empty(), binary(0x1c), 1);
+        MapColumnChecksum csFloatNonFloat4 = new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xa), Optional.empty(), Optional.empty(), binary(0x1c), 2);
+        MapColumnChecksum csFloatNonFloat5 = new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xb), Optional.empty(), Optional.empty(), binary(0xc), 1);
+        MapColumnChecksum csFloatNonFloat6 = new MapColumnChecksum(binary(0x2), binary(0xb), binary(0xb), Optional.empty(), Optional.empty(), binary(0xc), 1);
 
         // Resolved - key floating points, cardinality is good.
         assertResolved(createMismatchedColumn(mapType(DOUBLE, INTEGER), csFloatNonFloat1, csFloatNonFloat2));
@@ -119,7 +119,10 @@ public class TestStructuredColumnMismatchResolver
     @Test
     public void testNotResolved()
     {
-        assertNotResolved(createMismatchedColumn(VARCHAR, new SimpleColumnChecksum(binary(0xa)), new SimpleColumnChecksum(binary(0xb))));
+        assertNotResolved(createMismatchedColumn(
+                VARCHAR,
+                new SimpleColumnChecksum(binary(0xa), Optional.empty()),
+                new SimpleColumnChecksum(binary(0xb), Optional.empty())));
         assertNotResolved(createMismatchedColumn(
                 DOUBLE,
                 new FloatingPointColumnChecksum(1.0, 0, 0, 0, 5),
@@ -135,9 +138,12 @@ public class TestStructuredColumnMismatchResolver
                 new ArrayColumnChecksum(binary(0xb), binary(0xc), 1, Optional.empty()));
         ColumnMatchResult<?> resolvable2 = createMismatchedColumn(
                 mapType(REAL, DOUBLE),
-                new MapColumnChecksum(binary(0x1), binary(0xa), null, binary(0xc), 1),
-                new MapColumnChecksum(binary(0x4), binary(0xb), null, binary(0xc), 1));
-        ColumnMatchResult<?> nonResolvable = createMismatchedColumn(VARCHAR, new SimpleColumnChecksum(binary(0xa)), new SimpleColumnChecksum(binary(0xb)));
+                new MapColumnChecksum(binary(0x1), binary(0xa), null, Optional.empty(), Optional.empty(), binary(0xc), 1),
+                new MapColumnChecksum(binary(0x4), binary(0xb), null, Optional.empty(), Optional.empty(), binary(0xc), 1));
+        ColumnMatchResult<?> nonResolvable = createMismatchedColumn(
+                VARCHAR,
+                new SimpleColumnChecksum(binary(0xa), Optional.empty()),
+                new SimpleColumnChecksum(binary(0xb), Optional.empty()));
 
         assertResolved(resolvable1, resolvable2);
         assertNotResolved(resolvable1, nonResolvable);


### PR DESCRIPTION
## Description

Treat varchar column as double and apply floating point column validation, if it is detected that the varchar column is derived from casting floating points. This applies to the simple varchar column, array(varchar) column and map(varchar, varchar). Structured column types with deeper nested varchars are not supported.

Add verifier config --validate-string-as-double.

Resolve https://github.com/prestodb/presto/issues/23348

## Motivation and Context
Today Presto Verifier reports MISMATCH in ColumnValidator for simple columns or structured output columns composed by varchar, for real world test cases. This raises false negative and creates overhead for Verifier users utilizing the Verifier results. Verifier needs to apply floating point error margin for this case.

## Impact
Remove false negative when validating varchar columns derived from casting floating points. When --validate-string-as-double is set to true, Verifier control and test checksum queries will include more columns and become more expensive.

## Test Plan
Unit tests and production tests.

## Contributor checklist

## Release Notes

```
== RELEASE NOTES ==

Verifier Changes
* Add verifier config --validate-string-as-double to control applying floating point validation to the column composed of varchar, if it is detected that the varchar column is derived from casting floating points. :pr:`23312`

