### PR TITLE
Fix cross join with constant input optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -1944,7 +1944,7 @@ public final class SystemSessionProperties
                 booleanProperty(
                         REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT,
                         "If one input of the cross join is a single row with constant value, remove this cross join and replace with a project node",
-                        false,
+                        featuresConfig.isRemoveCrossJoinWithSingleConstantRow(),
                         false),
                 new PropertyMetadata<>(
                         DEFAULT_VIEW_SECURITY_MODE,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveCrossJoinWithConstantInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveCrossJoinWithConstantInput.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.RowExpressionVariableInliner;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
@@ -146,6 +147,6 @@ public class RemoveCrossJoinWithConstantInput
 
     private static Map<VariableReferenceExpression, RowExpression> updateAssignments(Map<VariableReferenceExpression, RowExpression> mapping, Map<VariableReferenceExpression, RowExpression> newAssignments)
     {
-        return mapping.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue() instanceof VariableReferenceExpression ? newAssignments.get(entry.getValue()) : entry.getValue()));
+        return mapping.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> RowExpressionVariableInliner.inlineVariables(newAssignments, entry.getValue())));
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7658,6 +7658,7 @@ public abstract class AbstractTestQueries
                 "values (2.0, 1)");
         assertQuery(enableOptimization, "WITH t(msg) AS (SELECT * FROM (VALUES ROW(CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))))) SELECT b.msg.x FROM t a, t b WHERE a.msg.y = b.msg.y limit 100",
                 "values 1");
+        assertQuery(enableOptimization, "select orderkey, col1 from orders cross join (select cast(col as varchar) col1 from (values 1) t(col))");
     }
 
     /**


### PR DESCRIPTION
## Description
Fix optimizations disabled in https://github.com/prestodb/presto/pull/23313
When there is call expression between values and cross join, it will lead to compilation error. This PR fix it.

## Motivation and Context
Bug fix

## Impact
Bug fix

## Test Plan
End to end test and new unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

