### PR TITLE
Use efficient empty string test

### DIFF
--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/raw/RawRowEncoder.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/raw/RawRowEncoder.java
@@ -169,7 +169,7 @@ public class RawRowEncoder
         private static FieldType parseFieldType(String dataFormat, String columnName)
         {
             try {
-                if (!dataFormat.equals("")) {
+                if (!dataFormat.isEmpty()) {
                     return FieldType.valueOf(dataFormat.toUpperCase(Locale.ENGLISH));
                 }
                 return FieldType.BYTE;


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Switch from using `equals("")` to instead checking length when determining if a string is non-empty.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Efficiency: String length tests in Java are a simple property lookup, whereas `equals` does more work.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

Very minor performance improvement. Whilst the impact may be trivial, the fact that this code may be called often makes it more worthwhile.

## Test Plan
<!---Please fill in how you tested your change-->

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality. [n/a]
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines). [n/a]
- [x] Adequate tests were added if applicable. [n/a]
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

