### PR TITLE
Fix assignments for equijoin on TimestampWithTimeZone

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
@@ -29,6 +29,19 @@ public final class TimestampWithTimeZoneType
         super(parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
     }
 
+    /**
+     * Timestamp with time zone represents a single point in time.  Multiple timestamps with timezones may
+     * each refer to the same point in time.  For example, 9:00am in New York is the same point in time as
+     * 2:00pm in London.  While those two timestamps may be encoded differently, they each refer to the same
+     * point in time.  Therefore, it's possible encode multiple timestamps which each represent the same
+     * point in time, and hence it's not safe to use equality as a proxy for identity.
+     */
+    @Override
+    public boolean equalValuesAreIdentical()
+    {
+        return false;
+    }
+
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/Type.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/Type.java
@@ -48,6 +48,14 @@ public interface Type
     boolean isOrderable();
 
     /**
+     * True if there can only be one canonical representation of data corresponding to this type.
+     */
+    default boolean equalValuesAreIdentical()
+    {
+        return true;
+    }
+
+    /**
      * Gets the Java class type used to represent this value on the stack during
      * expression execution.
      * <p>

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -578,7 +578,7 @@ public class UnaliasSymbolReferences
 
             if (node.getType().equals(INNER)) {
                 canonicalCriteria.stream()
-                        .filter(clause -> clause.getLeft().getType().equals(clause.getRight().getType()))
+                        .filter(clause -> clause.getLeft().getType().equals(clause.getRight().getType()) && clause.getLeft().getType().equalValuesAreIdentical())
                         .filter(clause -> node.getOutputVariables().contains(clause.getLeft()))
                         .forEach(clause -> map(clause.getRight(), clause.getLeft()));
             }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.plan.JoinType.INNER;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestUnaliasSymbolReferences
+        extends BasePlanTest
+{
+    @Test
+    public void testJoinTimestampsWithTimezonesPreservesAssignments()
+    {
+        // Although the two timestamps are the same point in time, they are in different timezones,
+        // so the optimizer should not collapse the two assignments.
+        assertPlan("WITH source AS (" +
+                        "SELECT * FROM (" +
+                        "    VALUES" +
+                        "        (TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles')," +
+                        "        (TIMESTAMP '2001-08-22 06:04:05.321 America/New_York')" +
+                        ") AS tbl (tstz)" +
+                        ")" +
+                        "SELECT * FROM source a JOIN source b ON a.tstz = b.tstz",
+                anyTree(
+                        join(INNER, ImmutableList.of(equiJoinClause("LEFT_BAR", "RIGHT_BAR")),
+                                anyTree(values("LEFT_BAR")),
+                                anyTree(values("RIGHT_BAR")))
+                                .withNumberOfOutputColumns(2)
+                                .withExactOutputs("LEFT_BAR", "RIGHT_BAR")));
+    }
+
+    @Test
+    public void testIdenticalValuesCollapseAssignments()
+    {
+        // We take the same table as in #testJoinTimestampsWithTimezonesPreservesAssignments but convert the
+        // values to UTC epoch time as a double.  The optimizer should collapse the two identical values into
+        // a single assignment, because doubles are ensured to be represented only a single way.
+        assertPlan("WITH source AS (" +
+                        "SELECT * FROM (" +
+                        "    VALUES" +
+                        "        (to_unixtime(TIMESTAMP '2001-08-22 03:04:05.321 America/Los_Angeles'))," +
+                        "        (to_unixtime(TIMESTAMP '2001-08-22 06:04:05.321 America/New_York'))" +
+                        ") AS tbl (tstz)" +
+                        ")" +
+                        "SELECT * FROM source a JOIN source b ON a.tstz = b.tstz",
+                anyTree(
+                        join(INNER, ImmutableList.of(equiJoinClause("LEFT_BAR", "RIGHT_BAR")),
+                                anyTree(values("LEFT_BAR")),
+                                anyTree(values("RIGHT_BAR")))
+                                .withNumberOfOutputColumns(1)
+                                .withExactOutputs("LEFT_BAR")));
+    }
+}


### PR DESCRIPTION
TimestampWithTimeZone can be represented in multiple equivalant ways. This breaks an optimization introduced by f6c2252 because while the values may be semantically equivalent, the contents may still differ.  To support this, and future types that may end up needing this support (such as JSON), a new flag is introduced to the type to indicate whether or not the values of the type may support more than one representation.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix equijoin over timestamp with timezone types (:pr:`23319`)

SPI Changes
* Add ``equalValuesAreIdentical`` to ``Type``.  Override this method to return ``false`` when the values of the type may have more than one canonical representation.
```

