### PR TITLE
[docs] Fix table formatting in history-based-optimization.rst

### DIFF
--- a/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
+++ b/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
@@ -31,7 +31,7 @@ The following configuration properties are available for HBO:
 
 ============================================================= =========================================================================================================================== ===================================
 Configuration Property Name                                   Description                                                                                                                 Default value
-===========================================================   =========================================================================================================================== ===================================
+============================================================= =========================================================================================================================== ===================================
 ``optimizer.use-history-based-plan-statistics``               Use historical statistics for query optimization.                                                                           ``False``
 ``optimizer.track-history-based-plan-statistics``             Recording the statistics of the current query as history statistics so as to be used by future queries.                     ``False``
 ``optimizer.track-history-stats-from-failed-queries``         Track history based plan statistics from complete plan fragments in failed queries.                                         ``True``


### PR DESCRIPTION
## Description
New error in local doc build: 

` /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst:34: ERROR: Malformed table. 
Column span alignment problem in table line 3. `

and 

`build succeeded, 20 warnings.`


## Motivation and Context
Fixes one error in the doc build because the table is incorrectly formatted. 

## Impact
Documentation. 

## Test Plan
Local doc builds. 

Before fix: 

` /Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst:34: ERROR: Malformed table. 
Column span alignment problem in table line 3. `

and 

`build succeeded, 20 warnings.`

After fix: 

`ERROR: Malformed table. ` does not appear.

`build succeeded, 19 warnings.`


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

