### PR TITLE
Add warning for IGNORE NULL with Window agggregates

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -56,6 +56,12 @@ public final class FunctionResolution
         implements StandardFunctionResolution
 {
     private final FunctionAndTypeResolver functionAndTypeResolver;
+    private final List<QualifiedObjectName> windowValueFunctions = ImmutableList.of(
+            QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "lead"),
+            QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "lag"),
+            QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "first_value"),
+            QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "last_value"),
+            QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "nth_value"));
 
     public FunctionResolution(FunctionAndTypeResolver functionAndTypeResolver)
     {
@@ -359,5 +365,10 @@ public final class FunctionResolution
     public boolean isElementAtFunction(FunctionHandle functionHandle)
     {
         return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "element_at"));
+    }
+
+    public boolean isWindowValueFunction(FunctionHandle functionHandle)
+    {
+        return windowValueFunctions.contains(functionAndTypeResolver.getFunctionMetadata(functionHandle).getName());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -29,11 +29,13 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.planner.CompilerConfig;
 import com.facebook.presto.tracing.TracingConfig;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.List;
 
 import static com.facebook.presto.spi.StandardWarningCode.PERFORMANCE_WARNING;
+import static com.facebook.presto.spi.StandardWarningCode.SEMANTIC_WARNING;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.AMBIGUOUS_ATTRIBUTE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.CANNOT_HAVE_AGGREGATIONS_WINDOWS_OR_GROUPING;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.CATALOG_NOT_SPECIFIED;
@@ -148,6 +150,36 @@ public class TestAnalyzer
         assertNoWarning(analyzeWithWarnings("SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b = t2.b"));
         assertNoWarning(analyzeWithWarnings("SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND IF(t2.b = t1.a OR t2.b = null, 'YES', 'NO') = 'YES'"));
         assertNoWarning(analyzeWithWarnings("SELECT * FROM t1 JOIN t2 ON t1.a = t2.a \n" + "AND (t1.b = t2.b OR t1.b > t2.b)"));
+    }
+
+    @Test
+    public void testIgnoreNullWarning()
+    {
+        List<String> valueFunctions = ImmutableList.of(
+                "NTH_VALUE(c, 1)",
+                "FIRST_VALUE(c)",
+                "LAST_VALUE(c)",
+                "LEAD(c, 1)",
+                "LAG(c, 1)");
+
+        for (String function : valueFunctions) {
+            assertNoWarning(analyzeWithWarnings("SELECT a, " + function + " IGNORE NULLS OVER\n" +
+                    "(ORDER BY b) FROM (VALUES (1, 1, 3), (1, 2, null), (1, 4, 2)) AS t(a, b, c)"));
+        }
+
+        List<String> aggAndRankingFunctions = ImmutableList.of(
+                "ARRAY_AGG(c)",
+                "ARBITRARY(c)",
+                "RANK()",
+                "DENSE_RANK()");
+
+        for (String function : aggAndRankingFunctions) {
+            assertHasWarning(
+                    analyzeWithWarnings("SELECT a, " + function + " IGNORE NULLS OVER\n" +
+                            "(ORDER BY b) FROM (VALUES (1, 1, 3), (1, 2, null), (1, 4, 2)) AS t(a, b, c)"),
+                    SEMANTIC_WARNING,
+                    "IGNORE NULLS is not used for aggregate and ranking window functions. This will cause queries to fail in future versions.");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description
Added a warning when an IGNORE NULL clause is used on any non lag, lead, first or last value function. Presto will not throw an error in other cases, but it also will not ignore null values. See issue #21304 

== RELEASE NOTES ==

General Changes
* Add a warning when an IGNORE NULL clause is used on any non lag, lead, first, last, or nth value function.  :pr:`23325`