### PR TITLE
Fix round for input out of long range

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRoundFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRoundFunction.java
@@ -44,13 +44,15 @@ public class BenchmarkRoundFunction
     private double operand2;
     private double operand3;
     private double operand4;
+    private double operand5;
     private float floatOperand0;
     private float floatOperand1;
     private float floatOperand2;
     private float floatOperand3;
     private float floatOperand4;
+    private float floatOperand5;
 
-    @Param({"0", "1", "2", "3", "4"})
+    @Param({"0", "1", "2", "3", "4", "5"})
     private int numberOfDecimals;
 
     @Setup
@@ -61,12 +63,14 @@ public class BenchmarkRoundFunction
         operand2 = -754.2008;
         operand3 = 0x1.fffffffffffffp-2;
         operand4 = -0x1.fffffffffffffp-2;
+        operand5 = (double) Long.MAX_VALUE;
 
         floatOperand0 = 0.5f;
         floatOperand1 = 754.1985f;
         floatOperand2 = -754.2008f;
         floatOperand3 = 0x1.fffffep-2f;
         floatOperand4 = -0x1.fffffep-2f;
+        floatOperand5 = 2.0f;
     }
 
     @Benchmark
@@ -77,6 +81,7 @@ public class BenchmarkRoundFunction
         bh.consume(MathFunctions.round(operand2, numberOfDecimals));
         bh.consume(MathFunctions.round(operand3, numberOfDecimals));
         bh.consume(MathFunctions.round(operand4, numberOfDecimals));
+        bh.consume(MathFunctions.round(operand5, numberOfDecimals));
     }
 
     @Benchmark
@@ -87,6 +92,7 @@ public class BenchmarkRoundFunction
         bh.consume(roundBaseline(operand2, numberOfDecimals));
         bh.consume(roundBaseline(operand3, numberOfDecimals));
         bh.consume(roundBaseline(operand4, numberOfDecimals));
+        bh.consume(roundBaseline(operand5, numberOfDecimals));
     }
 
     @Benchmark
@@ -97,6 +103,7 @@ public class BenchmarkRoundFunction
         bh.consume(MathFunctions.round(floatOperand2, numberOfDecimals));
         bh.consume(MathFunctions.round(floatOperand3, numberOfDecimals));
         bh.consume(MathFunctions.round(floatOperand4, numberOfDecimals));
+        bh.consume(MathFunctions.round(floatOperand5, numberOfDecimals));
     }
 
     @Benchmark
@@ -107,6 +114,7 @@ public class BenchmarkRoundFunction
         bh.consume(roundBaseline(floatOperand2, numberOfDecimals));
         bh.consume(roundBaseline(floatOperand3, numberOfDecimals));
         bh.consume(roundBaseline(floatOperand4, numberOfDecimals));
+        bh.consume(roundBaseline(floatOperand5, numberOfDecimals));
     }
 
     @Description("round to given number of decimal places")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -808,6 +808,18 @@ public class TestMathFunctions
         assertFunction("round(REAL '-3.5', 1)", REAL, -3.5f);
         assertFunction("round(REAL '-3.5001', 1)", REAL, -3.5f);
         assertFunction("round(REAL '-3.99', 1)", REAL, -4.0f);
+        assertFunction("round(REAL '9000000000000000000.0')", REAL, 9000000000000000000.0f);
+        assertFunction("round(REAL '300000000.0', 1)", REAL, 300000000.0f);
+        assertFunction("round(REAL '-300000000.0', 1)", REAL, -300000000.0f);
+        assertFunction("round(REAL '90000000.0', 1000)", REAL, 90000000.0f);
+        assertFunction("round(REAL '300000000.0', 100)", REAL, 300000000.0f);
+        assertFunction("round(REAL '-300000000.0', 100)", REAL, -300000000.0f);
+        assertFunction("round(DOUBLE '9223372036854775900.0')", DOUBLE, 9223372036854775900.0d);
+        assertFunction("round(DOUBLE '3574559470676000000.0', 1)", DOUBLE, 3574559470676000000.0d);
+        assertFunction("round(DOUBLE '-3574559470676000000.0', 1)", DOUBLE, -3574559470676000000.0d);
+        assertFunction("round(DOUBLE '92233720368547759.0', 100)", DOUBLE, 92233720368547759.0d);
+        assertFunction("round(DOUBLE '35745594706760000.0', 100)", DOUBLE, 35745594706760000.0d);
+        assertFunction("round(DOUBLE '-35745594706760000.0', 100)", DOUBLE, -35745594706760000.0d);
 
         // ROUND short DECIMAL -> short DECIMAL
         assertFunction("round(DECIMAL '0')", createDecimalType(1, 0), SqlDecimal.of("0"));


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/23329

## Description
Math function `round(x, d)` returns wrong results when `x*(10^d)` is out of the range [Long.MIN_VALUE, Long.MAX_VALUE]. For those input, the result will be capped at `Long.MIN_VALUE/d` or `Long.MAX_VALUE/d`.

If `x*(10^d)` is larger than `Long.MAX_VALUE` or smaller than `Long.MIN_VALUE`, it should be converted into `BigDecimal` to ensure an accurate result.

Benchmark result with this change:
```
# Run complete. Total time: 00:25:08

Benchmark                              (numberOfDecimals)   Mode  Cnt         Score        Error  Units
BenchmarkRoundFunction.doubleActual                     0  thrpt   60    298867.516 ±   9961.644  ops/s
BenchmarkRoundFunction.doubleActual                     1  thrpt   60    219511.307 ±   3344.664  ops/s
BenchmarkRoundFunction.doubleActual                     2  thrpt   60    642481.004 ±  11810.420  ops/s
BenchmarkRoundFunction.doubleActual                     3  thrpt   60    217920.971 ±   3695.692  ops/s
BenchmarkRoundFunction.doubleActual                     4  thrpt   60    219664.784 ±   3206.934  ops/s
BenchmarkRoundFunction.doubleActual                     5  thrpt   60    216051.165 ±   2555.130  ops/s
BenchmarkRoundFunction.doubleBaseline                   0  thrpt   60    607311.057 ±   5578.969  ops/s
BenchmarkRoundFunction.doubleBaseline                   1  thrpt   60    345819.946 ±   5712.654  ops/s
BenchmarkRoundFunction.doubleBaseline                   2  thrpt   60  27923712.153 ± 597294.957  ops/s
BenchmarkRoundFunction.doubleBaseline                   3  thrpt   60    343735.371 ±   6130.457  ops/s
BenchmarkRoundFunction.doubleBaseline                   4  thrpt   60    351087.133 ±    963.895  ops/s
BenchmarkRoundFunction.doubleBaseline                   5  thrpt   60    348487.338 ±   3955.763  ops/s
BenchmarkRoundFunction.floatActual                      0  thrpt   60    585703.127 ±   5328.677  ops/s
BenchmarkRoundFunction.floatActual                      1  thrpt   60    343793.043 ±   1477.987  ops/s
BenchmarkRoundFunction.floatActual                      2  thrpt   60   9379826.485 ±  95952.298  ops/s
BenchmarkRoundFunction.floatActual                      3  thrpt   60    340129.088 ±   3635.711  ops/s
BenchmarkRoundFunction.floatActual                      4  thrpt   60    336565.825 ±   5019.106  ops/s
BenchmarkRoundFunction.floatActual                      5  thrpt   60    336563.982 ±   7660.090  ops/s
BenchmarkRoundFunction.floatBaseline                    0  thrpt   60    606287.075 ±   8736.616  ops/s
BenchmarkRoundFunction.floatBaseline                    1  thrpt   60    349715.134 ±   2727.740  ops/s
BenchmarkRoundFunction.floatBaseline                    2  thrpt   60  14186037.916 ±  34290.777  ops/s
BenchmarkRoundFunction.floatBaseline                    3  thrpt   60    348065.895 ±   1420.496  ops/s
BenchmarkRoundFunction.floatBaseline                    4  thrpt   60    350946.308 ±   3244.912  ops/s
BenchmarkRoundFunction.floatBaseline                    5  thrpt   60    348444.408 ±   3504.253  ops/s
```

Benchmark result on master branch.
```
# Run complete. Total time: 00:21:03

Benchmark                              (numberOfDecimals)   Mode  Cnt         Score        Error  Units
BenchmarkRoundFunction.doubleActual                     0  thrpt   60    690634.216 ±  20739.165  ops/s
BenchmarkRoundFunction.doubleActual                     1  thrpt   60    415751.785 ±   4067.704  ops/s
BenchmarkRoundFunction.doubleActual                     2  thrpt   60  32559616.044 ± 589717.227  ops/s
BenchmarkRoundFunction.doubleActual                     3  thrpt   60    415809.437 ±   3728.994  ops/s
BenchmarkRoundFunction.doubleActual                     4  thrpt   60    416181.806 ±  15496.893  ops/s
BenchmarkRoundFunction.doubleBaseline                   0  thrpt   60    726541.785 ±   7719.942  ops/s
BenchmarkRoundFunction.doubleBaseline                   1  thrpt   60    418189.946 ±   3564.488  ops/s
BenchmarkRoundFunction.doubleBaseline                   2  thrpt   60  33253527.693 ± 569631.700  ops/s
BenchmarkRoundFunction.doubleBaseline                   3  thrpt   60    419243.733 ±   3563.650  ops/s
BenchmarkRoundFunction.doubleBaseline                   4  thrpt   60    420840.177 ±   3197.434  ops/s
BenchmarkRoundFunction.floatActual                      0  thrpt   60    731232.237 ±   4871.556  ops/s
BenchmarkRoundFunction.floatActual                      1  thrpt   60    418939.402 ±   5833.378  ops/s
BenchmarkRoundFunction.floatActual                      2  thrpt   60  27445132.524 ± 374279.048  ops/s
BenchmarkRoundFunction.floatActual                      3  thrpt   60    412789.029 ±  12791.468  ops/s
BenchmarkRoundFunction.floatActual                      4  thrpt   60    412160.908 ±   3427.482  ops/s
BenchmarkRoundFunction.floatBaseline                    0  thrpt   60    721697.494 ±   5005.889  ops/s
BenchmarkRoundFunction.floatBaseline                    1  thrpt   60    413726.146 ±   3250.087  ops/s
BenchmarkRoundFunction.floatBaseline                    2  thrpt   60  16631828.068 ± 607173.468  ops/s
BenchmarkRoundFunction.floatBaseline                    3  thrpt   60    419449.785 ±   2925.653  ops/s
BenchmarkRoundFunction.floatBaseline                    4  thrpt   60    422200.030 ±   2979.564  ops/s
```

```
== NO RELEASE NOTE ==
```

