### PR TITLE
[native] Fix build break for file not found in Utils.cpp

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -15,7 +15,7 @@
 #include "presto_cpp/main/common/Utils.h"
 #include <fmt/format.h>
 #include <sys/resource.h>
-#include "velox/velox/common/process/ThreadDebugInfo.h"
+#include "velox/common/process/ThreadDebugInfo.h"
 
 namespace facebook::presto::util {
 

--- a/presto-native-execution/presto_cpp/main/common/Utils.h
+++ b/presto-native-execution/presto_cpp/main/common/Utils.h
@@ -40,6 +40,8 @@ long getProcessCpuTimeNs();
 /// The reason is that the Folly based implementation relies
 /// on libunwind to perform the symbolization which doesn't
 /// exist for MacOS.
+/// In addition, the Velox based implementation provides additonal
+/// context such as the queryId.
 void installSignalHandler();
 
 } // namespace facebook::presto::util


### PR DESCRIPTION
In addition, add a requested comment from the PR review.

Fixes a build break on Linux from PR https://github.com/prestodb/presto/pull/23320.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

