### PR TITLE
[Iceberg]Fix test failures caused by concurrently handle the same table

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRemoveOrphanFilesProcedureBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRemoveOrphanFilesProcedureBase.java
@@ -62,6 +62,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public abstract class TestRemoveOrphanFilesProcedureBase
         extends AbstractTestQueryFramework
 {
@@ -97,7 +98,7 @@ public abstract class TestRemoveOrphanFilesProcedureBase
     @Test
     public void testRemoveOrphanFilesInEmptyTable()
     {
-        String tableName = "test_empty_table";
+        String tableName = "test_empty_remove_orphan_files_table";
         Session session = getQueryRunner().getDefaultSession();
         try {
             assertUpdate(format("create table %s (a int, b varchar)", tableName));
@@ -121,7 +122,7 @@ public abstract class TestRemoveOrphanFilesProcedureBase
     @Test(dataProvider = "timezones")
     public void testRemoveOrphanFilesInMetadataAndDataFolder(String zoneId, boolean legacyTimestamp)
     {
-        String tableName = "test_table";
+        String tableName = "test_remove_orphan_files_table";
         Session session = sessionForTimezone(zoneId, legacyTimestamp);
         try {
             assertUpdate(session, format("create table %s (a int, b varchar)", tableName));
@@ -172,8 +173,8 @@ public abstract class TestRemoveOrphanFilesProcedureBase
     public void testRemoveOrphanFilesWithNonDefaultMetadataPath(String zoneId, boolean legacyTimestamp)
     {
         Session session = sessionForTimezone(zoneId, legacyTimestamp);
-        String tempTableName = "temp_test_table";
-        String tableName = "test_table";
+        String tempTableName = "temp_test_table_with_specified_metadata_path";
+        String tableName = "test_table_with_specified_metadata_path";
         String tableTargetPath = createTempDir().toURI().toString();
         File metadataDir = new File(createTempDir().getAbsolutePath(), "metadata");
         metadataDir.mkdir();
@@ -223,8 +224,8 @@ public abstract class TestRemoveOrphanFilesProcedureBase
     public void testRemoveOrphanFilesWithNonDefaultDataPath(String zoneId, boolean legacyTimestamp)
     {
         Session session = sessionForTimezone(zoneId, legacyTimestamp);
-        String tempTableName = "temp_test_table";
-        String tableName = "test_table";
+        String tempTableName = "temp_test_table_with_specified_data_path";
+        String tableName = "test_table_with_specified_data_path";
         String tableTargetPath = createTempDir().toURI().toString();
         File dataDir = new File(createTempDir().getAbsolutePath(), "metadata");
         dataDir.mkdir();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRemoveOrphanFilesProcedureHadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRemoveOrphanFilesProcedureHadoop.java
@@ -21,6 +21,7 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.Map;
@@ -42,10 +43,10 @@ public class TestRemoveOrphanFilesProcedureHadoop
         super(HADOOP, ImmutableMap.of());
     }
 
-    @Override
+    @Test(dataProvider = "timezones")
     public void testRemoveOrphanFilesWithNonDefaultMetadataPath(String zoneId, boolean legacyTimestamp)
     {
-        String tempTableName = "temp_test_table";
+        String tempTableName = "temp_test_table_with_specified_metadata_path";
         String tableTargetPath = createTempDir().toURI().toString();
         String specifiedMetadataPath = createTempDir().getAbsolutePath();
 


### PR DESCRIPTION
## Description

The PR fix the test failures in `TestRemoveOrphanFilesProcedureBase`. These failures are caused  by concurrently running the test methods which handle table with the same name in the same catalog, so may affect each other.

## Motivation and Context

Fix test failures appear in: https://github.com/prestodb/presto/actions/runs/10184749910/job/28172882513?pr=23341

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

