### PR TITLE
[docs] Fix formatting for map_key_exists in functions/map.rst

### DIFF
--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -101,7 +101,7 @@ Map Functions
 
 .. function:: map_key_exists(x(K, V), k) -> boolean
 
-    Returns whether the given key exists in the map. Returns ``true`` if key is present in the input map, returns ``false`` if not present.
+    Returns whether the given key exists in the map. Returns ``true`` if key is present in the input map, returns ``false`` if not present.::
 
         SELECT map_key_exists(MAP(ARRAY['x','y'], ARRAY[100,200]), 'x'); -- TRUE
 


### PR DESCRIPTION
## Description
Fix formatting for the example for `map_key_exists` in [functions/map.rst.](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/functions/map.rst).

## Motivation and Context
Improves consistency in formatting of examples in the documentation. 

## Impact
Documentation. 

## Test Plan
Local docs build. 

Before: 
<img width="778" alt="Screenshot 2024-08-01 at 11 08 02 AM" src="https://github.com/user-attachments/assets/2ceb48bc-3eaf-41b0-ade0-5978b412cc23">

After: 
<img width="793" alt="Screenshot 2024-08-01 at 11 08 11 AM" src="https://github.com/user-attachments/assets/6ba6fcbe-e485-4e1a-a4a6-777b3a5a5965">

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

