### PR TITLE
Fix error message for invalid real cast

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/RealOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RealOperators.java
@@ -124,7 +124,7 @@ public final class RealOperators
             return DoubleMath.roundToLong(intBitsToFloat((int) value), HALF_UP);
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to bigint", value), e);
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to bigint", intBitsToFloat((int) value)), e);
         }
     }
 
@@ -136,7 +136,7 @@ public final class RealOperators
             return DoubleMath.roundToInt(intBitsToFloat((int) value), HALF_UP);
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to integer", value), e);
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to integer", intBitsToFloat((int) value)), e);
         }
     }
 
@@ -148,7 +148,7 @@ public final class RealOperators
             return Shorts.checkedCast(DoubleMath.roundToInt(intBitsToFloat((int) value), HALF_UP));
         }
         catch (ArithmeticException | IllegalArgumentException e) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to smallint", value), e);
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to smallint", intBitsToFloat((int) value)), e);
         }
     }
 
@@ -160,7 +160,7 @@ public final class RealOperators
             return SignedBytes.checkedCast(DoubleMath.roundToInt(intBitsToFloat((int) value), HALF_UP));
         }
         catch (ArithmeticException | IllegalArgumentException e) {
-            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to tinyint", value), e);
+            throw new PrestoException(INVALID_CAST_ARGUMENT, format("Unable to cast %s to tinyint", intBitsToFloat((int) value)), e);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRealOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRealOperators.java
@@ -196,10 +196,10 @@ public class TestRealOperators
         assertFunction("CAST(REAL'1.98' as BIGINT)", BIGINT, 2L);
         assertFunction("CAST(REAL'-0.0' as BIGINT)", BIGINT, 0L);
 
-        assertInvalidFunction("CAST(cast(nan() AS REAL) as BIGINT)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(cast(infinity() AS REAL) as BIGINT)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as BIGINT)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(REAL '" + Float.MAX_VALUE + "' as BIGINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(nan() AS REAL) as BIGINT)", INVALID_CAST_ARGUMENT, "Unable to cast NaN to bigint");
+        assertInvalidFunction("CAST(cast(infinity() AS REAL) as BIGINT)", INVALID_CAST_ARGUMENT, "Unable to cast Infinity to bigint");
+        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as BIGINT)", INVALID_CAST_ARGUMENT, "Unable to cast -Infinity to bigint");
+        assertInvalidFunction("CAST(REAL '" + Float.MAX_VALUE + "' as BIGINT)", INVALID_CAST_ARGUMENT, "Unable to cast 3.4028235E38 to bigint");
     }
 
     @Test
@@ -217,12 +217,12 @@ public class TestRealOperators
         assertFunction("cast(REAL '" + -0x1.0p31 + "' as integer)", INTEGER, (int) -0x1.0p31);
         assertFunction("cast(REAL '" + Math.nextUp(-0x1.0p31f) + "' as integer)", INTEGER, (int) Math.nextUp(-0x1.0p31f));
 
-        assertInvalidFunction("cast(9.3E9 as integer)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("cast(-9.3E9 as integer)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(cast(nan() AS REAL) as INTEGER)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(cast(infinity() AS REAL) as INTEGER)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as INTEGER)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(REAL '" + (Integer.MAX_VALUE + 0.6) + "' as INTEGER)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("cast(9.3E9 as integer)", INVALID_CAST_ARGUMENT, "Unable to cast 9.3E9 to integer");
+        assertInvalidFunction("cast(-9.3E9 as integer)", INVALID_CAST_ARGUMENT, "Unable to cast -9.3E9 to integer");
+        assertInvalidFunction("CAST(cast(nan() AS REAL) as INTEGER)", INVALID_CAST_ARGUMENT, "Unable to cast NaN to integer");
+        assertInvalidFunction("CAST(cast(infinity() AS REAL) as INTEGER)", INVALID_CAST_ARGUMENT, "Unable to cast Infinity to integer");
+        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as INTEGER)", INVALID_CAST_ARGUMENT, "Unable to cast -Infinity to integer");
+        assertInvalidFunction("CAST(REAL '" + (Integer.MAX_VALUE + 0.6) + "' as INTEGER)", INVALID_CAST_ARGUMENT, "Unable to cast 2.14748365E9 to integer");
     }
 
     @Test
@@ -232,10 +232,10 @@ public class TestRealOperators
         assertFunction("CAST(REAL'-754.1985' AS SMALLINT)", SMALLINT, (short) -754);
         assertFunction("CAST(REAL'9.99' AS SMALLINT)", SMALLINT, (short) 10);
         assertFunction("CAST(REAL'-0.0' AS SMALLINT)", SMALLINT, (short) 0);
-        assertInvalidFunction("CAST(cast(nan() AS REAL) as SMALLINT)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(cast(infinity() AS REAL) as SMALLINT)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as SMALLINT)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(REAL '" + (Short.MAX_VALUE + 0.6) + "' as SMALLINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(nan() AS REAL) as SMALLINT)", INVALID_CAST_ARGUMENT, "Unable to cast NaN to smallint");
+        assertInvalidFunction("CAST(cast(infinity() AS REAL) as SMALLINT)", INVALID_CAST_ARGUMENT, "Unable to cast Infinity to smallint");
+        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as SMALLINT)", INVALID_CAST_ARGUMENT, "Unable to cast -Infinity to smallint");
+        assertInvalidFunction("CAST(REAL '" + (Short.MAX_VALUE + 0.6) + "' as SMALLINT)", INVALID_CAST_ARGUMENT, "Unable to cast 32767.6 to smallint");
     }
 
     @Test
@@ -245,10 +245,10 @@ public class TestRealOperators
         assertFunction("CAST(REAL'-128.234' AS TINYINT)", TINYINT, (byte) -128);
         assertFunction("CAST(REAL'9.99' AS TINYINT)", TINYINT, (byte) 10);
         assertFunction("CAST(REAL'-0.0' AS TINYINT)", TINYINT, (byte) 0);
-        assertInvalidFunction("CAST(cast(nan() AS REAL) as TINYINT)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(cast(infinity() AS REAL) as TINYINT)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as TINYINT)", INVALID_CAST_ARGUMENT);
-        assertInvalidFunction("CAST(REAL '" + (Byte.MAX_VALUE + 0.6) + "' as TINYINT)", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("CAST(cast(nan() AS REAL) as TINYINT)", INVALID_CAST_ARGUMENT, "Unable to cast NaN to tinyint");
+        assertInvalidFunction("CAST(cast(infinity() AS REAL) as TINYINT)", INVALID_CAST_ARGUMENT, "Unable to cast Infinity to tinyint");
+        assertInvalidFunction("CAST(cast(-infinity() AS REAL) as TINYINT)", INVALID_CAST_ARGUMENT, "Unable to cast -Infinity to tinyint");
+        assertInvalidFunction("CAST(REAL '" + (Byte.MAX_VALUE + 0.6) + "' as TINYINT)", INVALID_CAST_ARGUMENT, "Unable to cast 127.6 to tinyint");
     }
 
     @Test


### PR DESCRIPTION
## Description
The error message for invalid cast from REAL ->
BIGINT/INTEGER/SMALLINT/TINYINT was previously returning the integer bits underlying the float instead of the float value itself. This fixes that to use the float value in the error message. For example, casting a NaN value to bigint that was represented as 0xFFC00000 would fail with the message "Unable to cast -4194304 to bigint".  Now the error message will say "Unable to cast NaN to bigint".

## Motivation and Context
The motivation is to fix the error message to be clearer.

## Impact
Improved error message

## Test Plan
Unit tests for the new error message.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

