### PR TITLE
Refactor qualifyObjectName method to FunctionAndTypeResolver

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/FunctionAndTypeResolver.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/FunctionAndTypeResolver.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.sql.tree.QualifiedName;
 
 import java.util.Collection;
 import java.util.List;
@@ -49,4 +50,6 @@ public interface FunctionAndTypeResolver
     boolean isTypeOnlyCoercion(Type actualType, Type expectedType);
 
     FunctionHandle lookupCast(String castType, Type fromType, Type toType);
+
+    QualifiedObjectName qualifyObjectName(QualifiedName name);
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/AlterFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AlterFunctionTask.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -72,7 +71,7 @@ public class AlterFunctionTask
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.empty(), parameters, parameterLookup, warningCollector);
         analyzer.analyze(statement);
 
-        QualifiedObjectName functionName = qualifyObjectName(statement.getFunctionName());
+        QualifiedObjectName functionName = metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver().qualifyObjectName(statement.getFunctionName());
         AlterRoutineCharacteristics alterRoutineCharacteristics = new AlterRoutineCharacteristics(
                 statement.getCharacteristics().getNullCallClause()
                         .map(com.facebook.presto.sql.tree.RoutineCharacteristics.NullCallClause::name)

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.metadata.SessionFunctionHandle.SESSION_NAMESPACE;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
@@ -107,7 +106,7 @@ public class CreateFunctionTask
     {
         QualifiedObjectName functionName = statement.isTemporary() ?
                 QualifiedObjectName.valueOf(SESSION_NAMESPACE, statement.getFunctionName().getSuffix()) :
-                qualifyObjectName(statement.getFunctionName());
+                metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver().qualifyObjectName(statement.getFunctionName());
         List<Parameter> parameters = statement.getParameters().stream()
                 .map(parameter -> new Parameter(parameter.getName().toString(), parseTypeSignature(parameter.getType())))
                 .collect(toImmutableList());

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropFunctionTask.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.metadata.SessionFunctionHandle.SESSION_NAMESPACE;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -82,7 +81,7 @@ public class DropFunctionTask
         }
         else {
             metadata.getFunctionAndTypeManager().dropFunction(
-                    qualifyObjectName(statement.getFunctionName()),
+                    metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver().qualifyObjectName(statement.getFunctionName()),
                     parameterTypes,
                     statement.isExists());
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -152,7 +152,6 @@ import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.DEFAULT_NAMESPACE;
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.spi.StandardErrorCode.OPERATOR_NOT_FOUND;
 import static com.facebook.presto.spi.StandardWarningCode.SEMANTIC_WARNING;
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
@@ -1826,7 +1825,11 @@ public class ExpressionAnalyzer
             FunctionAndTypeResolver functionAndTypeResolver)
     {
         try {
-            return functionAndTypeResolver.resolveFunction(sessionFunctions, transactionId, qualifyObjectName(node.getName()), argumentTypes);
+            return functionAndTypeResolver.resolveFunction(
+                    sessionFunctions,
+                    transactionId,
+                    functionAndTypeResolver.qualifyObjectName(node.getName()),
+                    argumentTypes);
         }
         catch (PrestoException e) {
             if (e.getErrorCode().getCode() == StandardErrorCode.FUNCTION_NOT_FOUND.toErrorCode().getCode()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -123,7 +123,6 @@ import static com.facebook.presto.common.type.TypeUtils.isEnumType;
 import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.metadata.CastType.CAST;
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.function.FunctionImplementationType.JAVA;
 import static com.facebook.presto.spi.function.FunctionImplementationType.SQL;
@@ -919,7 +918,7 @@ public class ExpressionInterpreter
             FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().resolveFunction(
                     Optional.of(session.getSessionFunctions()),
                     session.getTransactionId(),
-                    qualifyObjectName(node.getName()),
+                    metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver().qualifyObjectName(node.getName()),
                     fromTypes(argumentTypes));
             FunctionMetadata functionMetadata = metadata.getFunctionAndTypeManager().getFunctionMetadata(functionHandle);
             if (!functionMetadata.isCalledOnNullInput()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -129,7 +129,6 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.metadata.CastType.CAST;
 import static com.facebook.presto.metadata.CastType.TRY_CAST;
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.BIND;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
@@ -520,7 +519,7 @@ public final class SqlToRowExpressionTranslator
                     functionAndTypeResolver.resolveFunction(
                             Optional.of(sessionFunctions),
                             transactionId,
-                            qualifyObjectName(node.getName()),
+                            functionAndTypeResolver.qualifyObjectName(node.getName()),
                             argumentTypes),
                     getType(node),
                     arguments);

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -108,7 +108,6 @@ import static com.facebook.presto.connector.informationSchema.InformationSchemaM
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLES;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES;
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.DEFAULT_NAMESPACE;
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
 import static com.facebook.presto.metadata.MetadataListing.listSchemas;
 import static com.facebook.presto.metadata.MetadataUtil.createCatalogSchemaName;
@@ -587,7 +586,7 @@ final class ShowQueriesRewrite
         @Override
         protected Node visitShowCreateFunction(ShowCreateFunction node, Void context)
         {
-            QualifiedObjectName functionName = qualifyObjectName(node.getName());
+            QualifiedObjectName functionName = metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver().qualifyObjectName(node.getName());
             Collection<? extends SqlFunction> functions = metadata.getFunctionAndTypeManager().getFunctions(session, functionName);
             if (node.getParameterTypes().isPresent()) {
                 List<TypeSignature> parameterTypes = node.getParameterTypes().get().stream()

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionAndTypeManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionAndTypeManager.java
@@ -54,7 +54,6 @@ import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ArgumentProperty.valueTypeArgumentProperty;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
@@ -475,7 +474,7 @@ public class TestFunctionAndTypeManager
             return functionAndTypeManager.resolveFunction(
                     Optional.empty(),
                     TEST_SESSION.getTransactionId(),
-                    qualifyObjectName(QualifiedName.of(TEST_FUNCTION_NAME)),
+                    functionAndTypeManager.getFunctionAndTypeResolver().qualifyObjectName(QualifiedName.of(TEST_FUNCTION_NAME)),
                     fromTypeSignatures(parameterTypes));
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.metadata.FunctionExtractor.extractFunctions;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
@@ -88,7 +87,7 @@ public abstract class AbstractTestAggregationFunction
         FunctionHandle functionHandle = functionAndTypeManager.resolveFunction(
                 Optional.empty(),
                 session.getTransactionId(),
-                qualifyObjectName(QualifiedName.of(getFunctionName())),
+                functionAndTypeManager.getFunctionAndTypeResolver().qualifyObjectName(QualifiedName.of(getFunctionName())),
                 parameterTypes);
         return functionAndTypeManager.getJavaAggregateFunctionImplementation(functionHandle);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
@@ -51,7 +51,6 @@ import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
-import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectName;
 import static com.facebook.presto.spi.plan.JoinDistributionType.PARTITIONED;
 import static com.facebook.presto.spi.plan.JoinDistributionType.REPLICATED;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
@@ -580,7 +579,7 @@ public class TestReorderJoins
                                         tester.getMetadata().getFunctionAndTypeManager().resolveFunction(
                                                 Optional.empty(),
                                                 Optional.empty(),
-                                                qualifyObjectName(RANDOM),
+                                                tester.getMetadata().getFunctionAndTypeManager().getFunctionAndTypeResolver().qualifyObjectName(RANDOM),
                                                 ImmutableList.of()),
                                         BIGINT,
                                         ImmutableList.of())))))


### PR DESCRIPTION
## Description
Refactoring qualifyObjectName function to FunctionAndTypeResolver. 
This change will be needed to incorporate switching of the namespaces on the coordinator side.

For more context:
https://github.com/prestodb/presto/pull/23358/commits/99c628c5dcd459850c29d213b8091757442d37d7#r1785165710

Resolves: #23385 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

