### PR TITLE
Switch default Parquet writer version to PARQUET_1_0

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -914,7 +914,7 @@ Parquet Writer Version
 
 Presto now supports Parquet writer versions V1 and V2 for the Hive catalog.
 It can be toggled using the session property ``parquet_writer_version`` and the config property ``hive.parquet.writer.version``.
-Valid values for these properties are ``PARQUET_1_0`` and ``PARQUET_2_0``. Default is ``PARQUET_2_0``.
+Valid values for these properties are ``PARQUET_1_0`` and ``PARQUET_2_0``. Default is ``PARQUET_1_0``.
 
 Procedures
 ----------

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1236,7 +1236,7 @@ Parquet Writer Version
 
 Presto now supports Parquet writer versions V1 and V2 for the Iceberg catalog.
 It can be toggled using the session property ``parquet_writer_version`` and the config property ``hive.parquet.writer.version``.
-Valid values for these properties are ``PARQUET_1_0`` and ``PARQUET_2_0``. Default is ``PARQUET_2_0``.
+Valid values for these properties are ``PARQUET_1_0`` and ``PARQUET_2_0``. Default is ``PARQUET_1_0``.
 
 Example Queries
 ^^^^^^^^^^^^^^^

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSessionProperties.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSessionProperties.java
@@ -81,14 +81,14 @@ public class TestHiveSessionProperties
                         new OrcFileWriterConfig(),
                         new ParquetFileWriterConfig(),
                         new CacheConfig().setCachingEnabled(true)).getSessionProperties());
-        assertEquals(getParquetWriterVersion(connectorSession), PARQUET_2_0);
+        assertEquals(getParquetWriterVersion(connectorSession), PARQUET_1_0);
 
         connectorSession = new TestingConnectorSession(
                 new HiveSessionProperties(
                         new HiveClientConfig(),
                         new OrcFileWriterConfig(),
-                        new ParquetFileWriterConfig().setWriterVersion(PARQUET_1_0),
+                        new ParquetFileWriterConfig().setWriterVersion(PARQUET_2_0),
                         new CacheConfig().setCachingEnabled(true)).getSessionProperties());
-        assertEquals(getParquetWriterVersion(connectorSession), PARQUET_1_0);
+        assertEquals(getParquetWriterVersion(connectorSession), PARQUET_2_0);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSkipEmptyFiles.java
@@ -47,7 +47,7 @@ import static java.lang.String.format;
 import static java.nio.file.Files.createTempFile;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
 import static org.testng.Assert.assertEquals;
 
@@ -208,7 +208,7 @@ public class TestHiveSkipEmptyFiles
                 new Iterable[] {Collections.singleton(1)},
                 1,
                 GZIP,
-                PARQUET_2_0);
+                PARQUET_1_0);
         createTempFile(tempDirectory, randomUUID().toString(), randomUUID().toString());
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTypeWidening.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTypeWidening.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -124,7 +124,7 @@ public class TestHiveTypeWidening
                 new Iterable[] {Collections.singletonList(getExpectedValueForType(baseType))},
                 1,
                 GZIP,
-                PARQUET_2_0);
+                PARQUET_1_0);
         logger.info("First file written");
         File secondParquetFile = new File(temporaryDirectory, randomUUID().toString());
         ParquetTester.writeParquetFileFromPresto(secondParquetFile,
@@ -133,7 +133,7 @@ public class TestHiveTypeWidening
                 new Iterable[] {Collections.singletonList(getExpectedValueForType(widenedType))},
                 1,
                 GZIP,
-                PARQUET_2_0);
+                PARQUET_1_0);
         logger.info("Second file written");
         return temporaryDirectory;
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetFileWriterConfig.java
@@ -36,7 +36,7 @@ public class TestParquetFileWriterConfig
                 .setParquetOptimizedWriterEnabled(false)
                 .setBlockSize(new DataSize(ParquetWriter.DEFAULT_BLOCK_SIZE, BYTE))
                 .setPageSize(new DataSize(ParquetWriter.DEFAULT_PAGE_SIZE, BYTE))
-                .setWriterVersion(ParquetProperties.WriterVersion.PARQUET_2_0));
+                .setWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0));
     }
 
     @Test
@@ -46,14 +46,14 @@ public class TestParquetFileWriterConfig
                 .put("hive.parquet.optimized-writer.enabled", "true")
                 .put("hive.parquet.writer.block-size", "234MB")
                 .put("hive.parquet.writer.page-size", "11MB")
-                .put("hive.parquet.writer.version", "PARQUET_1_0")
+                .put("hive.parquet.writer.version", "PARQUET_2_0")
                 .build();
 
         ParquetFileWriterConfig expected = new ParquetFileWriterConfig()
                 .setParquetOptimizedWriterEnabled(true)
                 .setBlockSize(new DataSize(234, MEGABYTE))
                 .setPageSize(new DataSize(11, MEGABYTE))
-                .setWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0);
+                .setWriterVersion(ParquetProperties.WriterVersion.PARQUET_2_0);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
@@ -261,7 +261,7 @@ public class BenchmarkParquetPageSource
                     values,
                     ROWS,
                     compressionCodecName,
-                    ParquetProperties.WriterVersion.PARQUET_2_0);
+                    ParquetProperties.WriterVersion.PARQUET_1_0);
 
             //Set up PageProcessor
             List<RowExpression> projections = getProjections(type);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetReaderMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetReaderMemoryTracking.java
@@ -70,7 +70,7 @@ public class TestParquetReaderMemoryTracking
 
             while (parquetReader.nextBatch() > 0) {
                 Block block = parquetReader.readBlock(field);
-                assertBetweenInclusive(parquetReader.getSystemMemoryUsage(), 320000L, 370000L);
+                assertBetweenInclusive(parquetReader.getSystemMemoryUsage(), 320000L, 420000L);
                 blocks.add(block);
             }
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
@@ -23,7 +23,7 @@ public class ParquetWriterOptions
 {
     protected static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.valueOf("128MB");
     protected static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.valueOf("1MB");
-    public static final WriterVersion DEFAULT_WRITER_VERSION = WriterVersion.PARQUET_2_0;
+    public static final WriterVersion DEFAULT_WRITER_VERSION = WriterVersion.PARQUET_1_0;
 
     public static ParquetWriterOptions.Builder builder()
     {

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkDecimalColumnBatchReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkDecimalColumnBatchReader.java
@@ -77,7 +77,7 @@ import static java.lang.String.format;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE;
 import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_PAGE_SIZE;
 import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
@@ -109,7 +109,7 @@ public class BenchmarkDecimalColumnBatchReader
     })
     // PARQUET_1_0 => PLAIN
     // PARQUET_2_0 => DELTA_BYTE_ARRAY, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY
-    public static WriterVersion writerVersion = PARQUET_2_0;
+    public static WriterVersion writerVersion = PARQUET_1_0;
 
     public static void main(String[] args)
             throws Throwable


### PR DESCRIPTION
We must switch the default to PARQUET_1_0 since its the most compatible/stable Parquet version.
Parquet V2 spec is not official. The various implementations out there have potential compatibility issues.
Trino and Spark default to PARQUET_1_0.

Resolves https://github.com/prestodb/presto/issues/23366

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Switch default Parquet writer version to PARQUET_1_0. 
Please set the hive config `hive.parquet.writer.version = PARQUET_2_0` for old behavior. :pr:`23369`

```


