### PR TITLE
[native] Fix maxWaitMicros timeout of future is not effective

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -894,6 +894,9 @@ folly::Future<std::unique_ptr<Result>> TaskManager::getResults(
               maxSize,
               *bufferManager_);
         }
+        // Keep the promiseHolder alive to make sure that maxWaitMicros is
+        // effective.
+        keepPromiseAlive(promiseHolder, state);
         return std::move(future)
             .via(httpSrvCpuExecutor_)
             .onTimeout(std::chrono::microseconds(maxWaitMicros), timeoutFn);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
The `maxWaitMicros` timeout in `TaskManager.getResults` is not effective. This will return immediately whether the output buffer has data or not.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Discovered when debugging getting task results over http.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Make promiseHolder alive to make maxWaitMicros timeout effective.

## Test Plan
<!---Please fill in how you tested your change-->
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

