### PR TITLE
Implement S3 metrics collection and reporting

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -18,6 +18,10 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/exec/Task.h"
 
+// Include S3 metrics headers
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Metrics.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3MetricsAggregator.h"
+
 namespace folly {
 class CPUThreadPoolExecutor;
 class IOThreadPoolExecutor;
@@ -93,6 +97,9 @@ class PeriodicTaskManager {
 
   /// Stops all periodic tasks. Returns only when everything is stopped.
   void stop();
+
+  /// Add S3 metrics reporting task
+  void addS3MetricsTask();
 
  private:
   void addExecutorStatsTask();

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.cpp
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "presto_cpp/main/runtime-metrics/PrometheusStatsReporter.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Metrics.h"
 
 #include <prometheus/collectable.h>
 #include <prometheus/counter.h>
@@ -49,6 +50,24 @@ struct PrometheusStatsReporter::PrometheusImpl {
 PrometheusStatsReporter::PrometheusStatsReporter(
     const std::map<std::string, std::string>& labels) {
   impl_ = std::make_shared<PrometheusImpl>(labels);
+
+  // Register S3 metrics
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3ActiveConnections, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3StartedUploads, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3FailedUploads, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3SuccessfulUploads, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3MetadataCalls, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3ListStatusCalls, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3ListLocatedStatusCalls, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3ListObjectsCalls, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3OtherReadErrors, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3AwsAbortedExceptions, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3SocketExceptions, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3GetObjectErrors, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3GetMetadataErrors, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3GetObjectRetries, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3GetMetadataRetries, facebook::velox::StatType::COUNT);
+    registerMetricExportType(facebook::velox::filesystems::kMetricS3ReadRetries, facebook::velox::StatType::COUNT);
 }
 
 void PrometheusStatsReporter::registerMetricExportType(


### PR DESCRIPTION
## Description
This PR introduces the functionality to capture and report S3 metrics in the Presto C++ codebase

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

