### PR TITLE
Refine the CircleCI criteria

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,5 +25,6 @@ workflows:
           # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
           mapping: |
             presto-native-execution/.* run_native_specific_jobs true
+            (?!presto-docs).*(?<!.md) run_linux_tests true
           base-revision: master
           config-path: .circleci/continue_config.yml

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -17,7 +17,7 @@ parameters:
     default: false
   run_linux_tests:
     type: boolean
-    default: true
+    default: false
 
 workflows:
   version: 2
@@ -82,7 +82,7 @@ jobs:
     parameters:
       run_linux_tests:
         type: boolean
-        default: true
+        default: false
     steps:
       - run: echo "Run Linux tests is << parameters.run_linux_tests >>"
       - when:
@@ -146,7 +146,7 @@ jobs:
     parameters:
       run_linux_tests:
         type: boolean
-        default: true
+        default: false
     parallelism: 5
     steps:
       - run: echo "Run Linux tests is << parameters.run_linux_tests >>"
@@ -198,7 +198,7 @@ jobs:
     parameters:
       run_linux_tests:
         type: boolean
-        default: true
+        default: false
     parallelism: 5
     steps:
       - run: echo "Run Linux tests is << parameters.run_linux_tests >>"


### PR DESCRIPTION
## Description
change the default value of the `run_linux_tests` param to false and any non-doc change sets the value to true.

## Motivation and Context
fixed: #23217

## Impact
A PR that contains doc only changes will not trigger the CircleCI test

## Test Plan
Need to use the PR to verify the change. The current PR will still trigger the CircleCI. Need to create a dummy doc-only PR to verify the change.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

