### PR TITLE
[native] Add presto.default-namespace Prestissimo config property

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -95,6 +95,14 @@ The configuration properties of Presto C++ workers are described here, in alphab
 
   In-memory cache.
 
+``presto.default-namespace``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``presto.default``
+
+  Specifies the namespace prefix for native C++ functions.
+
 ``query.max-memory-per-node``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -224,6 +224,7 @@ void PrestoServer::run() {
       address_ = fmt::format("[{}]", address_);
     }
     nodeLocation_ = nodeConfig->nodeLocation();
+    prestoBuiltinFunctionPrefix_ = systemConfig->prestoDefaultNamespacePrefix();
   } catch (const VeloxUserError& e) {
     PRESTO_STARTUP_LOG(ERROR) << "Failed to start server due to " << e.what();
     exit(EXIT_FAILURE);
@@ -1166,11 +1167,12 @@ void PrestoServer::registerCustomOperators() {
 }
 
 void PrestoServer::registerFunctions() {
-  static const std::string kPrestoDefaultPrefix{"presto.default."};
-  velox::functions::prestosql::registerAllScalarFunctions(kPrestoDefaultPrefix);
+  velox::functions::prestosql::registerAllScalarFunctions(
+      prestoBuiltinFunctionPrefix_);
   velox::aggregate::prestosql::registerAllAggregateFunctions(
-      kPrestoDefaultPrefix);
-  velox::window::prestosql::registerAllWindowFunctions(kPrestoDefaultPrefix);
+      prestoBuiltinFunctionPrefix_);
+  velox::window::prestosql::registerAllWindowFunctions(
+      prestoBuiltinFunctionPrefix_);
   if (SystemConfig::instance()->registerTestFunctions()) {
     velox::functions::prestosql::registerAllScalarFunctions(
         "json.test_schema.");

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -269,6 +269,7 @@ class PrestoServer {
   std::string address_;
   std::string nodeLocation_;
   folly::SSLContextPtr sslContext_;
+  std::string prestoBuiltinFunctionPrefix_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -228,7 +228,7 @@ SystemConfig::SystemConfig() {
           STR_PROP(kCacheVeloxTtlThreshold, "2d"),
           STR_PROP(kCacheVeloxTtlCheckInterval, "1h"),
           BOOL_PROP(kEnableRuntimeMetricsCollection, false),
-      };
+          STR_PROP(kPrestoDefaultNamespacePrefix, "presto.default")};
 }
 
 SystemConfig* SystemConfig::instance() {
@@ -681,6 +681,10 @@ int32_t SystemConfig::largestSizeClassPages() const {
 
 bool SystemConfig::enableRuntimeMetricsCollection() const {
   return optionalProperty<bool>(kEnableRuntimeMetricsCollection).value();
+}
+
+std::string SystemConfig::prestoDefaultNamespacePrefix() const {
+  return optionalProperty(kPrestoDefaultNamespacePrefix).value().append(".");
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -585,6 +585,10 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kDriverMaxPagePartitioningBufferSize{
       "driver.max-page-partitioning-buffer-size"};
 
+  // Specifies the default Presto namespace prefix.
+  static constexpr std::string_view kPrestoDefaultNamespacePrefix{
+      "presto.default-namespace"};
+
   SystemConfig();
 
   virtual ~SystemConfig() = default;
@@ -802,6 +806,7 @@ class SystemConfig : public ConfigBase {
   bool enableRuntimeMetricsCollection() const;
 
   bool prestoNativeSidecar() const;
+  std::string prestoDefaultNamespacePrefix() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -18,8 +18,13 @@ target_link_libraries(
   presto_common_test
   presto_common
   presto_exception
+  velox_aggregates
   velox_exception
   velox_file
+  velox_functions_prestosql
+  velox_function_registry
+  velox_presto_types
+  velox_window
   ${RE2}
   gtest
   gtest_main)

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -12,16 +12,58 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
+#include <unordered_set>
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Configs.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/Window.h"
+#include "velox/functions/FunctionRegistry.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
 
 namespace facebook::presto::test {
 
 using namespace velox;
+
+namespace {
+
+template <typename FunctionMap>
+bool validateDefaultNamespacePrefix(
+    const FunctionMap& functionMap,
+    const std::string& prestoDefaultNamespacePrefix) {
+  static const std::unordered_set<std::string> kBlockList = {
+      "row_constructor", "in", "is_null"};
+
+  std::vector<std::string> prestoDefaultNamespacePrefixParts;
+  folly::split(
+      '.',
+      prestoDefaultNamespacePrefix,
+      prestoDefaultNamespacePrefixParts,
+      true);
+
+  for (const auto& [functionName, _] : functionMap) {
+    // Skip internal functions. They don't have any prefix.
+    if ((kBlockList.count(functionName) != 0) ||
+        (functionName.find("$internal$") != std::string::npos)) {
+      continue;
+    }
+
+    std::vector<std::string> parts;
+    folly::split('.', functionName, parts, true);
+    if ((parts.size() != 3) ||
+        (parts[0] != prestoDefaultNamespacePrefixParts[0]) ||
+        (parts[1] != prestoDefaultNamespacePrefixParts[1])) {
+      return false;
+    }
+  }
+  return true;
+}
+} // namespace
 
 class ConfigTest : public testing::Test {
  protected:
@@ -255,4 +297,35 @@ TEST_F(ConfigTest, optionalNodeId) {
   EXPECT_EQ(nodeId, config.nodeId());
 }
 
+TEST_F(ConfigTest, prestoDefaultNamespacePrefix) {
+  SystemConfig config;
+  init(
+      config,
+      {{std::string(SystemConfig::kPrestoDefaultNamespacePrefix),
+        "presto.default"}});
+  std::string prestoBuiltinFunctionPrefix =
+      config.prestoDefaultNamespacePrefix();
+
+  velox::functions::prestosql::registerAllScalarFunctions(
+      prestoBuiltinFunctionPrefix);
+  velox::aggregate::prestosql::registerAllAggregateFunctions(
+      prestoBuiltinFunctionPrefix);
+  velox::window::prestosql::registerAllWindowFunctions(
+      prestoBuiltinFunctionPrefix);
+
+  // Get all registered scalar functions in Velox
+  auto scalarFunctions = getFunctionSignatures();
+  ASSERT_TRUE(validateDefaultNamespacePrefix(
+      scalarFunctions, prestoBuiltinFunctionPrefix));
+
+  // Get all registered aggregate functions in Velox
+  auto aggregateFunctions = exec::aggregateFunctions().copy();
+  ASSERT_TRUE(validateDefaultNamespacePrefix(
+      aggregateFunctions, prestoBuiltinFunctionPrefix));
+
+  // Get all registered window functions in Velox
+  auto windowFunctions = exec::windowFunctions();
+  ASSERT_TRUE(validateDefaultNamespacePrefix(
+      windowFunctions, prestoBuiltinFunctionPrefix));
+}
 } // namespace facebook::presto::test

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.h
@@ -14,11 +14,20 @@
 #pragma once
 
 #include <stdexcept>
+#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/types/TypeParser.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/core/Expressions.h"
 
 namespace facebook::presto {
+
+namespace {
+inline std::string formatDefaultNamespacePrefix(
+    const std::string& functionName,
+    const std::string& prestoDefaultNamespacePrefix) {
+  return fmt::format("{}{}", prestoDefaultNamespacePrefix, functionName);
+}
+} // namespace
 
 class VeloxExprConverter {
  public:

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -483,7 +483,10 @@ std::shared_ptr<protocol::CallExpression> isFunctionCall(
 /// CallExpression. Returns nullptr if input expression is something else.
 std::shared_ptr<protocol::CallExpression> isNot(
     const std::shared_ptr<protocol::RowExpression>& expression) {
-  static const std::string_view kNot = "presto.default.not";
+  static const std::string prestoDefaultNamespacePrefix =
+      SystemConfig::instance()->prestoDefaultNamespacePrefix();
+  static const std::string kNot =
+      formatDefaultNamespacePrefix(prestoDefaultNamespacePrefix, "not");
   return isFunctionCall(expression, kNot);
 }
 
@@ -491,7 +494,7 @@ std::shared_ptr<protocol::CallExpression> isNot(
 /// CallExpression. Returns nullptr if input expression is something else.
 std::shared_ptr<protocol::CallExpression> isGreaterThan(
     const std::shared_ptr<protocol::RowExpression>& expression) {
-  static const std::string_view kGreaterThan =
+  static const std::string kGreaterThan =
       "presto.default.$operator$greater_than";
   return isFunctionCall(expression, kGreaterThan);
 }
@@ -1524,11 +1527,13 @@ namespace {
 core::WindowNode::Function makeRowNumberFunction(
     const protocol::VariableReferenceExpression& rowNumberVariable,
     const TypeParser& typeParser) {
+  static const std::string prestoDefaultNamespacePrefix =
+      SystemConfig::instance()->prestoDefaultNamespacePrefix();
   core::WindowNode::Function function;
   function.functionCall = std::make_shared<core::CallTypedExpr>(
       stringToType(rowNumberVariable.type, typeParser),
       std::vector<core::TypedExprPtr>{},
-      "presto.default.row_number");
+      formatDefaultNamespacePrefix(prestoDefaultNamespacePrefix, "row_number"));
 
   function.frame.type = core::WindowNode::WindowType::kRows;
   function.frame.startType = core::WindowNode::BoundType::kUnboundedPreceding;

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.h
@@ -14,6 +14,7 @@
 
 #include <stdexcept>
 #include <vector>
+#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/operators/ShuffleInterface.h"
 #include "presto_cpp/presto_protocol/presto_protocol.h"
 #include "velox/core/Expressions.h"


### PR DESCRIPTION
## Description

Adds the `presto.default-namespace` config property. 

Resolves: #23385 


## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
Prestissimo Changes
* Add ``presto.default-namespace`` Prestissimo configuration property :pr:`23384`
```


