### PR TITLE
Extend MongoDB connector support binData

### DIFF
--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaNotFoundException;
@@ -46,6 +47,7 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.result.DeleteResult;
 import io.airlift.slice.Slice;
 import org.bson.Document;
+import org.bson.types.Binary;
 import org.bson.types.ObjectId;
 
 import java.util.ArrayList;
@@ -518,6 +520,9 @@ public class MongoSession
         }
         else if (value instanceof ObjectId) {
             typeSignature = OBJECT_ID.getTypeSignature();
+        }
+        else if (value instanceof Binary) {
+            typeSignature = VarbinaryType.VARBINARY.getTypeSignature();
         }
         else if (value instanceof List) {
             List<Optional<TypeSignature>> subTypes = ((List<?>) value).stream()

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -247,6 +247,19 @@ public class TestMongoIntegrationSmokeTest
         assertOneNotNullResult("SELECT id FROM tmp_objectid WHERE id = ObjectId('ffffffffffffffffffffffff')");
     }
 
+    @Test
+    public void testBinarys()
+    {
+        assertUpdate("CREATE TABLE tmp_binary AS SELECT cast('value' as varbinary) AS _varbinary", 1);
+        assertOneNotNullResult("SELECT _varbinary FROM tmp_binary");
+
+        MaterializedResult results = getQueryRunner().execute(getSession(), "SELECT _varbinary FROM tmp_binary").toTestTypes();
+        assertEquals(results.getRowCount(), 1);
+
+        MaterializedRow row = results.getMaterializedRows().get(0);
+        assertEquals(row.getField(0), "value".getBytes(UTF_8));
+    }
+
     private void assertOneNotNullResult(String query)
     {
         MaterializedResult results = getQueryRunner().execute(getSession(), query).toTestTypes();

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoSession.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoSession.java
@@ -28,8 +28,11 @@ import static com.facebook.presto.common.predicate.Range.greaterThanOrEqual;
 import static com.facebook.presto.common.predicate.Range.lessThan;
 import static com.facebook.presto.common.predicate.Range.range;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.testng.Assert.assertEquals;
 
@@ -37,6 +40,7 @@ public class TestMongoSession
 {
     private static final MongoColumnHandle COL1 = new MongoColumnHandle("col1", BIGINT, false);
     private static final MongoColumnHandle COL2 = new MongoColumnHandle("col2", createUnboundedVarcharType(), false);
+    private static final MongoColumnHandle COL3 = new MongoColumnHandle("col3", VARBINARY, false);
 
     @Test
     public void testBuildQuery()
@@ -49,6 +53,18 @@ public class TestMongoSession
         Document expected = new Document()
                 .append(COL1.getName(), new Document().append("$gt", 100L).append("$lte", 200L))
                 .append(COL2.getName(), new Document("$eq", "a value"));
+        assertEquals(query, expected);
+    }
+
+    @Test
+    public void testBuildQueryBinaryType()
+    {
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                COL3, Domain.singleValue(VARBINARY, wrappedBuffer("VarBinary Value".getBytes(UTF_8)))));
+
+        Document query = MongoSession.buildQuery(tupleDomain);
+        Document expected = new Document()
+                .append(COL3.getName(), new Document().append("$eq", "VarBinary Value"));
         assertEquals(query, expected);
     }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Extend MongoDB connector support binData
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Extend MongoDB connector support [binData] https://github.com/prestodb/presto/issues/23083
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

MongoDB Connector
* Support varbinary data type in MongoDB (pr:`23386`)
```

