### PR TITLE
Prepend jdbc: to DatabaseMetaData.getURL result

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDatabaseMetaData.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDatabaseMetaData.java
@@ -33,6 +33,7 @@ import static java.util.Objects.requireNonNull;
 public class PrestoDatabaseMetaData
         implements DatabaseMetaData
 {
+    private static final String JDBC_URL_START = "jdbc:";
     private static final String SEARCH_STRING_ESCAPE = "\\";
 
     private final PrestoConnection connection;
@@ -60,7 +61,7 @@ public class PrestoDatabaseMetaData
     public String getURL()
             throws SQLException
     {
-        return connection.getURI().toString();
+        return JDBC_URL_START + connection.getURI().toString();
     }
 
     @Override

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDatabaseMetaData.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDatabaseMetaData.java
@@ -174,6 +174,14 @@ public class TestPrestoDatabaseMetaData
         }
     }
 
+    @Test
+    public void testGetUrl()
+            throws Exception
+    {
+        DatabaseMetaData metaData = connection.getMetaData();
+        assertEquals(metaData.getURL(), "jdbc:presto://" + server.getAddress());
+    }
+
     private static void assertColumnSpec(ResultSet rs, int dataType, Long precision, Long numPrecRadix, String typeName)
             throws SQLException
     {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -304,6 +304,17 @@ public class JdbcTests
         }
     }
 
+    @Test(groups = JDBC)
+    @Requires(ImmutableNationTable.class)
+    public void testMetaDataGetURL()
+            throws SQLException
+    {
+        DatabaseMetaData metaData = metaData();
+        String url = metaData.getURL();
+        assertThat(url).startsWith("jdbc:presto://");
+        assertThat(url).isEqualTo(prestoJdbcURL);
+    }
+
     private QueryResult queryResult(Statement statement, String query)
             throws SQLException
     {


### PR DESCRIPTION
Fixed the PrestoDatabaseMetaData implementation of the getURL method to 
include the jdbc: prefix in the resulting URL. A JDBC URL always starts with 
jdbc:.

Added an unit and a product test to verify that the database connection URL 
starts with the expected jdbc: prefix.

## Description
Append the jdbc: prefix to the URL that is returned from the 
PrestoDatabaseMetaData implementation of the getURL method.

## Motivation and Context
A JDBC URL return from the getURL method of the 
DatabaseMetaData interface provides a way of identifying a 
database so that the appropriate driver recognizes it and 
connects to it. A JDBC URL always starts with jdbc: which was
lacking in the current PrestoDatabaseMetaData implementation 
of the getURL method.
https://github.com/prestodb/presto/issues/19312

## Impact
Callers of the method PrestoDatabaseMetaData.getURL will be 
able to use the resulting URL directly without having to prepend 
the jdbc: prefix themselves.

## Test Plan
Added a unit test in the TestPrestoDatabaseMetaData class and
a product test in JdbcTests class that asserts the URL starts with t
the jdbc: prefix and the rest of the URL did not change.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

JDBC
* Fix the PrestoDatabaseMetaData.getURL method to include the jdbc: prefix in the returned URL :pr:`23397`


