### PR TITLE
Add Presto Procedure to invalidate Metastore Cache

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -207,23 +207,26 @@ Metastore Configuration Properties
 
 The required Hive metastore can be configured with a number of properties.
 
-======================================= ============================================================ ============
-Property Name                                      Description                                       Default
-======================================= ============================================================ ============
-``hive.metastore-timeout``              Timeout for Hive metastore requests.                         ``10s``
+======================================================= ============================================================= ============
+Property Name                                                         Description                                       Default
+======================================================= ============================================================= ============
+``hive.metastore-timeout``                               Timeout for Hive metastore requests.                           ``10s``
 
-``hive.metastore-cache-ttl``            Duration how long cached metastore data should be considered ``0s``
-                                        valid.
+``hive.metastore-cache-ttl``                             Duration how long cached metastore data should be considered   ``0s``
+                                                         valid.
 
-``hive.metastore-cache-maximum-size``   Hive metastore cache maximum size.                            10000
+``hive.metastore-cache-maximum-size``                    Hive metastore cache maximum size.                              10000
 
-``hive.metastore-refresh-interval``     Asynchronously refresh cached metastore data after access    ``0s``
-                                        if it is older than this but is not yet expired, allowing
-                                        subsequent accesses to see fresh data.
+``hive.metastore-refresh-interval``                      Asynchronously refresh cached metastore data after access      ``0s``
+                                                         if it is older than this but is not yet expired, allowing
+                                                         subsequent accesses to see fresh data.
 
-``hive.metastore-refresh-max-threads``  Maximum threads used to refresh cached metastore data.        100
+``hive.metastore-refresh-max-threads``                   Maximum threads used to refresh cached metastore data.          100
 
-======================================= ============================================================ ============
+``hive.invalidate-metastore-cache-procedure-enabled``    When enabled, users will be able to invalidate metastore        false
+                                                         cache on demand.
+
+======================================================= ============================================================= ============
 
 AWS Glue Catalog Configuration Properties
 -----------------------------------------
@@ -951,6 +954,25 @@ The following procedures are available:
 * ``system.invalidate_directory_list_cache(directory_path)``
 
   Invalidate directory list cache for specified directory_path.
+
+* ``system.invalidate_metastore_cache()``
+
+  Invalidate all metastore caches.
+
+* ``system.invalidate_metastore_cache(schema_name)``
+
+  Invalidate all metastore cache entries linked to a specific schema.
+
+* ``system.invalidate_metastore_cache(schema_name, table_name)``
+
+  Invalidate all metastore cache entries linked to a specific table.
+
+* ``system.invalidate_metastore_cache(schema_name, table_name, partition_columns, partition_values)``
+
+  Invalidate all metastore cache entries linked to a specific partition.
+
+Note: To enable ``system.invalidate_metastore_cache`` procedure, please refer to the properties that
+apply to Hive Metastore and are listed in the `Metastore Configuration Properties`_ table.
 
 Extra Hidden Columns
 --------------------

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
@@ -52,6 +52,7 @@ public class MetastoreClientConfig
     private int partitionCacheColumnCountLimit = 500;
     private HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType = HiveMetastoreAuthenticationType.NONE;
     private boolean deleteFilesOnTableDrop;
+    private boolean invalidateMetastoreCacheProcedureEnabled;
 
     public HostAndPort getMetastoreSocksProxy()
     {
@@ -301,6 +302,19 @@ public class MetastoreClientConfig
     public MetastoreClientConfig setDeleteFilesOnTableDrop(boolean deleteFilesOnTableDrop)
     {
         this.deleteFilesOnTableDrop = deleteFilesOnTableDrop;
+        return this;
+    }
+
+    public boolean isInvalidateMetastoreCacheProcedureEnabled()
+    {
+        return invalidateMetastoreCacheProcedureEnabled;
+    }
+
+    @Config("hive.invalidate-metastore-cache-procedure-enabled")
+    @ConfigDescription("When enabled, users will be able to invalidate metastore cache on demand")
+    public MetastoreClientConfig setInvalidateMetastoreCacheProcedureEnabled(boolean invalidateMetastoreCacheProcedureEnabled)
+    {
+        this.invalidateMetastoreCacheProcedureEnabled = invalidateMetastoreCacheProcedureEnabled;
         return this;
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InvalidateMetastoreCacheProcedure.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InvalidateMetastoreCacheProcedure.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.hive.HiveColumnConverterProvider;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.facebook.presto.spi.procedure.Procedure.Argument;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.getMetastoreHeaders;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class InvalidateMetastoreCacheProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle INVALIDATE_METASTORE_CACHE = methodHandle(
+            InvalidateMetastoreCacheProcedure.class,
+            "invalidateMetastoreCache",
+            ConnectorSession.class,
+            String.class,
+            String.class,
+            List.class,
+            List.class);
+
+    private final Optional<InMemoryCachingHiveMetastore> inMemoryCachingHiveMetastore;
+
+    @Inject
+    public InvalidateMetastoreCacheProcedure(ExtendedHiveMetastore extendedHiveMetastore)
+    {
+        requireNonNull(extendedHiveMetastore, "extendedHiveMetastore is null");
+        if (extendedHiveMetastore instanceof InMemoryCachingHiveMetastore) {
+            this.inMemoryCachingHiveMetastore = Optional.of((InMemoryCachingHiveMetastore) extendedHiveMetastore);
+        }
+        else {
+            this.inMemoryCachingHiveMetastore = Optional.empty();
+        }
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "invalidate_metastore_cache",
+                ImmutableList.of(
+                        new Argument("schema_name", VARCHAR, false, null),
+                        new Argument("table_name", VARCHAR, false, null),
+                        new Argument("partition_columns", "array(varchar)", false, null),
+                        new Argument("partition_values", "array(varchar)", false, null)),
+                INVALIDATE_METASTORE_CACHE.bindTo(this));
+    }
+
+    public void invalidateMetastoreCache(ConnectorSession session, String schemaName, String tableName, List<String> partitionColumnNames, List<String> partitionValues)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doInvalidateMetastoreCache(
+                    session,
+                    Optional.ofNullable(schemaName),
+                    Optional.ofNullable(tableName),
+                    Optional.ofNullable(partitionColumnNames).orElse(ImmutableList.of()),
+                    Optional.ofNullable(partitionValues).orElse(ImmutableList.of()));
+        }
+    }
+
+    private void doInvalidateMetastoreCache(
+            ConnectorSession session,
+            Optional<String> schemaName,
+            Optional<String> tableName,
+            List<String> partitionColumnNames,
+            List<String> partitionValues)
+    {
+        if (!inMemoryCachingHiveMetastore.isPresent()) {
+            throw new PrestoException(NOT_SUPPORTED, "Metastore Cache is not enabled");
+        }
+
+        MetastoreContext metastoreContext = new MetastoreContext(
+                session.getIdentity(),
+                session.getQueryId(),
+                session.getClientInfo(),
+                session.getClientTags(),
+                session.getSource(),
+                getMetastoreHeaders(session),
+                false,
+                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
+                session.getWarningCollector(),
+                session.getRuntimeStats());
+
+        checkArgument(
+                partitionColumnNames.size() == partitionValues.size(),
+                "Procedure parameters partition_columns and partition_values should be of same length");
+
+        if (!schemaName.isPresent() && !tableName.isPresent() && partitionColumnNames.isEmpty()) {
+            inMemoryCachingHiveMetastore.get().invalidateAll();
+        }
+        else if (schemaName.isPresent() && !tableName.isPresent() && partitionColumnNames.isEmpty()) {
+            inMemoryCachingHiveMetastore.get().invalidateCache(metastoreContext, schemaName.get());
+        }
+        else if (schemaName.isPresent() && tableName.isPresent() && partitionColumnNames.isEmpty()) {
+            inMemoryCachingHiveMetastore.get().invalidateCache(metastoreContext, schemaName.get(), tableName.get());
+        }
+        else if (schemaName.isPresent() && tableName.isPresent()) {
+            inMemoryCachingHiveMetastore.get().invalidateCache(
+                    metastoreContext,
+                    schemaName.get(),
+                    tableName.get(),
+                    partitionColumnNames,
+                    partitionValues);
+        }
+        else {
+            throw new PrestoException(INVALID_PROCEDURE_ARGUMENT, "Invalid parameters passed");
+        }
+    }
+}

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
@@ -49,7 +49,8 @@ public class TestMetastoreClientConfig
                 .setPartitionCacheValidationPercentage(0)
                 .setPartitionCacheColumnCountLimit(500)
                 .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.NONE)
-                .setDeleteFilesOnTableDrop(false));
+                .setDeleteFilesOnTableDrop(false)
+                .setInvalidateMetastoreCacheProcedureEnabled(false));
     }
 
     @Test
@@ -75,6 +76,7 @@ public class TestMetastoreClientConfig
                 .put("hive.partition-cache-column-count-limit", "50")
                 .put("hive.metastore.authentication.type", "KERBEROS")
                 .put("hive.metastore.thrift.delete-files-on-table-drop", "true")
+                .put("hive.invalidate-metastore-cache-procedure-enabled", "true")
                 .build();
 
         MetastoreClientConfig expected = new MetastoreClientConfig()
@@ -96,7 +98,8 @@ public class TestMetastoreClientConfig
                 .setPartitionCacheValidationPercentage(60.0)
                 .setPartitionCacheColumnCountLimit(50)
                 .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.KERBEROS)
-                .setDeleteFilesOnTableDrop(true);
+                .setDeleteFilesOnTableDrop(true)
+                .setInvalidateMetastoreCacheProcedureEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveProcedureModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveProcedureModule.java
@@ -13,23 +13,28 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.hive.metastore.InvalidateMetastoreCacheProcedure;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.google.inject.Binder;
-import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 
 public class HiveProcedureModule
-        implements Module
+        extends AbstractConfigurationAwareModule
 {
     @Override
-    public void configure(Binder binder)
+    protected void setup(Binder binder)
     {
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(CreateEmptyPartitionProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(SyncPartitionMetadataProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(DirectoryListCacheInvalidationProcedure.class).in(Scopes.SINGLETON);
+
+        if (buildConfigObject(MetastoreClientConfig.class).isInvalidateMetastoreCacheProcedureEnabled()) {
+            procedures.addBinding().toProvider(InvalidateMetastoreCacheProcedure.class).in(Scopes.SINGLETON);
+        }
     }
 }

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiModule.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiModule.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.hudi;
 
 import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.facebook.presto.cache.CacheConfig;
 import com.facebook.presto.cache.CacheFactory;
 import com.facebook.presto.cache.CacheStats;
@@ -39,6 +40,7 @@ import com.facebook.presto.hive.gcs.HiveGcsConfig;
 import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
 import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.InvalidateMetastoreCacheProcedure;
 import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
 import com.facebook.presto.hudi.split.ForHudiBackgroundSplitLoader;
@@ -53,10 +55,11 @@ import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorSplitManager;
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeNodePartitioningProvider;
+import com.facebook.presto.spi.procedure.Procedure;
 import com.google.inject.Binder;
-import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
 import org.weakref.jmx.testing.TestingMBeanServer;
 
 import javax.inject.Singleton;
@@ -76,7 +79,7 @@ import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class HudiModule
-        implements Module
+        extends AbstractConfigurationAwareModule
 {
     private final ClassLoader classLoader;
     private final String connectorId;
@@ -88,7 +91,7 @@ public class HudiModule
     }
 
     @Override
-    public void configure(Binder binder)
+    protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(HiveClientConfig.class);
         configBinder(binder).bindConfig(MetastoreConfig.class);
@@ -127,6 +130,11 @@ public class HudiModule
         binder.bind(HudiSessionProperties.class).in(Scopes.SINGLETON);
 
         binder.bind(ConnectorAccessControl.class).to(AllowAllAccessControl.class).in(Scopes.SINGLETON);
+
+        Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
+        if (buildConfigObject(MetastoreClientConfig.class).isInvalidateMetastoreCacheProcedureEnabled()) {
+            procedures.addBinding().toProvider(InvalidateMetastoreCacheProcedure.class).in(Scopes.SINGLETON);
+        }
     }
 
     @ForCachingHiveMetastore

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -37,6 +37,7 @@ import com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration;
 import com.facebook.presto.hive.gcs.GcsConfigurationInitializer;
 import com.facebook.presto.hive.gcs.HiveGcsConfig;
 import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
+import com.facebook.presto.hive.metastore.InvalidateMetastoreCacheProcedure;
 import com.facebook.presto.iceberg.nessie.IcebergNessieConfig;
 import com.facebook.presto.iceberg.optimizer.IcebergPlanOptimizerProvider;
 import com.facebook.presto.iceberg.procedure.ExpireSnapshotsProcedure;
@@ -109,7 +110,7 @@ public class IcebergCommonModule
     }
 
     @Override
-    public void setup(Binder binder)
+    protected void setup(Binder binder)
     {
         binder.bind(HdfsEnvironment.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(CacheConfig.class);
@@ -156,6 +157,10 @@ public class IcebergCommonModule
         procedures.addBinding().toProvider(UnregisterTableProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(ExpireSnapshotsProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(RemoveOrphanFiles.class).in(Scopes.SINGLETON);
+
+        if (buildConfigObject(MetastoreClientConfig.class).isInvalidateMetastoreCacheProcedureEnabled()) {
+            procedures.addBinding().toProvider(InvalidateMetastoreCacheProcedure.class).in(Scopes.SINGLETON);
+        }
 
         // for orc
         binder.bind(EncryptionLibrary.class).annotatedWith(HiveDwrfEncryptionProvider.ForCryptoService.class).to(UnsupportedEncryptionLibrary.class).in(Scopes.SINGLETON);

--- a/presto-product-tests/conf/presto/etc/catalog/hive_with_metastore_cache.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/hive_with_metastore_cache.properties
@@ -1,0 +1,26 @@
+#
+# WARNING
+# ^^^^^^^
+# This configuration file is for development only and should NOT be used be
+# used in production. For example configuration, see the Presto documentation.
+#
+
+connector.name=hive-hadoop2
+hive.metastore.uri=thrift://hadoop-master:9083
+hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
+hive.config.resources=/docker/volumes/conf/presto/etc/hive-default-fs-site.xml
+hive.allow-add-column=true
+hive.allow-drop-column=true
+hive.allow-rename-column=true
+hive.allow-drop-table=true
+hive.allow-rename-table=true
+hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100
+hive.collect-column-statistics-on-write=true
+
+# Enable Metastore Cache
+hive.metastore-cache-ttl=60m
+hive.metastore-refresh-interval=20m
+
+# Enable Invalidate Metastore Cache Procedure
+hive.invalidate-metastore-cache-procedure-enabled=true

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -66,6 +66,7 @@ public final class TestGroups
     public static final String AVRO = "avro";
     public static final String ICEBERG = "iceberg";
     public static final String HIVE_LIST_CACHING = "hive_list_caching";
+    public static final String INVALIDATE_METASTORE_CACHE = "invalidate_metastore_cache";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInvalidateMetastoreCacheProcedure.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInvalidateMetastoreCacheProcedure.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.hive;
+
+import io.prestodb.tempto.AfterTestWithContext;
+import io.prestodb.tempto.BeforeTestWithContext;
+import io.prestodb.tempto.ProductTest;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.TestGroups.INVALIDATE_METASTORE_CACHE;
+import static com.facebook.presto.tests.utils.QueryExecutors.onHive;
+import static com.facebook.presto.tests.utils.QueryExecutors.onPresto;
+import static io.prestodb.tempto.assertions.QueryAssert.Row.row;
+import static io.prestodb.tempto.assertions.QueryAssert.assertThat;
+
+public class TestInvalidateMetastoreCacheProcedure
+        extends ProductTest
+{
+    @BeforeTestWithContext
+    public void setUp()
+    {
+        // CREATE SCHEMAS
+        onPresto().executeQuery("CREATE SCHEMA IF NOT EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema1");
+        onPresto().executeQuery("CREATE SCHEMA IF NOT EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema2");
+
+        // CREATE TABLES IN SCHEMA 1
+        onPresto().executeQuery("CREATE TABLE IF NOT EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation AS SELECT * FROM tpch.tiny.nation");
+        onPresto().executeQuery("CREATE TABLE IF NOT EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.region AS SELECT * FROM tpch.tiny.region");
+
+        // CREATE TABLES IN SCHEMA 2
+        onPresto().executeQuery("CREATE TABLE IF NOT EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema2.nation AS SELECT * FROM tpch.tiny.nation");
+        onPresto().executeQuery("CREATE TABLE IF NOT EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema2.region AS SELECT * FROM tpch.tiny.region");
+
+        // CREATE A PARTITIONED TABLE
+        onPresto().executeQuery(
+                "CREATE TABLE IF NOT EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation_partitioned(" +
+                        "nationkey bigint," +
+                        " name varchar(25)," +
+                        " regionkey bigint)" +
+                        " WITH (partitioned_by = ARRAY['regionkey'])");
+
+        onPresto().executeQuery(
+                "INSERT INTO hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation_partitioned" +
+                        " SELECT nationkey, name, regionkey FROM tpch.tiny.nation");
+
+        onPresto().executeQuery("CALL hive_with_metastore_cache.system.invalidate_metastore_cache()");
+    }
+
+    @Test(groups = {INVALIDATE_METASTORE_CACHE})
+    public void testInvalidateFullMetastoreCache()
+    {
+        assertThat(onPresto().executeQuery("SELECT nationkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation"))
+                .hasRowsCount(25);
+        assertThat(onPresto().executeQuery("select tablecachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+                .contains(row(0), row(1));
+
+        // Rename Column outside Presto
+        onHive().executeQuery("ALTER TABLE test_invalidate_metastore_cache_schema1.nation CHANGE nationkey key bigint");
+
+        // This should fail as Presto has old metadata cached
+        assertThat(() -> onPresto().executeQuery("SELECT key FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation"))
+                .failsWithMessageMatching(".*Column 'key' cannot be resolved");
+
+        // This should pass after invalidating Metastore Cache
+        onPresto().executeQuery("CALL hive_with_metastore_cache.system.invalidate_metastore_cache()");
+        assertThat(onPresto().executeQuery("SELECT key FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation"))
+                .hasRowsCount(25);
+    }
+
+    @Test(groups = {INVALIDATE_METASTORE_CACHE}, dependsOnMethods = "testInvalidateFullMetastoreCache")
+    public void testInvalidateMetastoreCacheBySchema()
+    {
+        assertThat(onPresto().executeQuery("SELECT nationkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation"))
+                .hasRowsCount(25);
+        assertThat(onPresto().executeQuery("SELECT nationkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema2.nation"))
+                .hasRowsCount(25);
+        assertThat(onPresto().executeQuery("select tablecachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+                .contains(row(0), row(2));
+
+        // Rename Column outside Presto
+        onHive().executeQuery("ALTER TABLE test_invalidate_metastore_cache_schema2.nation CHANGE nationkey key bigint");
+
+        // This should fail as Presto has old metadata cached
+        assertThat(() -> onPresto().executeQuery("SELECT key FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema2.nation"))
+                .failsWithMessageMatching(".*Column 'key' cannot be resolved");
+
+        // This should still fail after invalidating Metastore Cache only for test_invalidate_metastore_cache_schema1
+        onPresto().executeQuery("CALL hive_with_metastore_cache.system.invalidate_metastore_cache('test_invalidate_metastore_cache_schema1')");
+        assertThat(() -> onPresto().executeQuery("SELECT key FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema2.nation"))
+                .failsWithMessageMatching(".*Column 'key' cannot be resolved");
+
+        // This should pass after invalidating Metastore Cache for test_invalidate_metastore_cache_schema2
+        onPresto().executeQuery("CALL hive_with_metastore_cache.system.invalidate_metastore_cache('test_invalidate_metastore_cache_schema2')");
+        assertThat(onPresto().executeQuery("SELECT key FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema2.nation"))
+                .hasRowsCount(25);
+    }
+
+    @Test(groups = {INVALIDATE_METASTORE_CACHE}, dependsOnMethods = "testInvalidateMetastoreCacheBySchema")
+    public void testInvalidateMetastoreCacheByTable()
+    {
+        assertThat(onPresto().executeQuery("SELECT nationkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation"))
+                .hasRowsCount(25);
+        assertThat(onPresto().executeQuery("SELECT * FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.region"))
+                .hasRowsCount(5);
+        assertThat(onPresto().executeQuery("select tablecachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+                .contains(row(0), row(2));
+
+        // Rename Column outside Presto
+        onHive().executeQuery("ALTER TABLE test_invalidate_metastore_cache_schema1.nation CHANGE nationkey key bigint");
+
+        // This should fail as Presto has old metadata cached
+        assertThat(() -> onPresto().executeQuery("SELECT key FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation"))
+                .failsWithMessageMatching(".*Column 'key' cannot be resolved");
+
+        // This should still fail after invalidating Metastore Cache only for test_invalidate_metastore_cache_schema1.region
+        onPresto().executeQuery("CALL hive_with_metastore_cache.system.invalidate_metastore_cache('test_invalidate_metastore_cache_schema1', 'region')");
+        assertThat(() -> onPresto().executeQuery("SELECT key FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation"))
+                .failsWithMessageMatching(".*Column 'key' cannot be resolved");
+
+        // This should pass after invalidating Metastore Cache for test_invalidate_metastore_cache_schema2
+        onPresto().executeQuery("CALL hive_with_metastore_cache.system.invalidate_metastore_cache('test_invalidate_metastore_cache_schema1', 'nation')");
+        assertThat(onPresto().executeQuery("SELECT key FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation"))
+                .hasRowsCount(25);
+    }
+
+    @Test(groups = {INVALIDATE_METASTORE_CACHE}, dependsOnMethods = "testInvalidateMetastoreCacheByTable")
+    public void testInvalidateMetastoreCacheByPartition()
+    {
+        assertThat(onPresto().executeQuery("SELECT * FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.\"nation_partitioned$partitions\""))
+                .hasRowsCount(5);
+        assertThat(onPresto().executeQuery("SELECT DISTINCT regionkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation_partitioned"))
+                .hasRowsCount(5);
+        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionnamescachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+                .contains(row(1, 5, 1));
+
+        // Add new partition outside Presto
+        onHive().executeQuery("INSERT INTO test_invalidate_metastore_cache_schema1.nation_partitioned PARTITION(regionkey=5) VALUES(26, 'new_nation')");
+
+        // This should not be able to show the new partition
+        assertThat(onPresto().executeQuery("SELECT * FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.\"nation_partitioned$partitions\""))
+                .hasRowsCount(5);
+        assertThat(onPresto().executeQuery("SELECT DISTINCT regionkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation_partitioned"))
+                .hasRowsCount(5);
+        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionnamescachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+                .contains(row(1, 5, 1));
+
+        // After invalidating the cache, we should be able to see the new partition once we invalidate any partition in the table
+        onPresto().executeQuery("CALL hive_with_metastore_cache.system.invalidate_metastore_cache('test_invalidate_metastore_cache_schema1', 'nation_partitioned', ARRAY['regionkey'], ARRAY['0'])");
+        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionnamescachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+                .contains(row(1, 4, 0));
+        assertThat(onPresto().executeQuery("SELECT * FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.\"nation_partitioned$partitions\""))
+                .hasRowsCount(6);
+        assertThat(onPresto().executeQuery("SELECT DISTINCT regionkey FROM hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation_partitioned"))
+                .hasRowsCount(6)
+                .contains(row(5));
+        assertThat(onPresto().executeQuery("select tablecachesize, partitioncachesize, partitionnamescachesize from jmx.current.\"com.facebook.presto.hive.metastore:name=hive_with_metastore_cache,type=metastorecachestats\""))
+                .contains(row(1, 6, 1));
+    }
+
+    @AfterTestWithContext
+    public void tearDown()
+    {
+        onPresto().executeQuery("DROP TABLE IF EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation");
+        onPresto().executeQuery("DROP TABLE IF EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.region");
+        onPresto().executeQuery("DROP TABLE IF EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema1.nation_partitioned");
+        onPresto().executeQuery("DROP SCHEMA IF EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema1");
+
+        onPresto().executeQuery("DROP TABLE IF EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema2.nation");
+        onPresto().executeQuery("DROP TABLE IF EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema2.region");
+        onPresto().executeQuery("DROP SCHEMA IF EXISTS hive_with_metastore_cache.test_invalidate_metastore_cache_schema2");
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add a new Presto Procedure to invalidate Metastore Cache

Procedure can be used in the below ways:

- [x] `CALL catalog.system.invalidate_metastore_cache()`: Invalidate full metastore cache
- [x] `CALL catalog.system.invalidate_metastore_cache(schema_name)`: Invalidate cache entries linked to a specific schema
- [x] `CALL catalog.system.invalidate_metastore_cache(schema_name, table_name)`: Invalidate cache entries linked to a specific table
- [x] `CALL catalog.system.invalidate_metastore_cache(schema_name, table_name, partition_columns, partition_values)`: Invalidate cache entries linked to a specific partition

TODO

- [x] Add a test
- [x] Add relevant documentation

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Resolves #20403

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Presto Users can now invalidate metastore cache without restarting the cluster and without waiting for TTL/Refresh Period to pass. 

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Add ``catalog.system.invalidate_metastore_cache`` procedure to invalidate all, or portions of, the metastore cache. :pr:`23401`

Iceberg Connector Changes
* Add ``catalog.system.invalidate_metastore_cache`` procedure to invalidate all, or portions of, the metastore cache. :pr:`23401`

Hudi Connector Changes
* Add ``catalog.system.invalidate_metastore_cache`` procedure to invalidate all, or portions of, the metastore cache. :pr:`23401`

Delta Connector Changes
* Add ``catalog.system.invalidate_metastore_cache`` procedure to invalidate all, or portions of, the metastore cache. :pr:`23401`
```