### PR TITLE
[docs] Fix formatting in admin/verifier.rst

### DIFF
--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -226,6 +226,7 @@ queries.
         * Count of the negative infinity elements of all value sets
 * **Row Columns**
     * Checksums row fields recursively according to the type of the fields.
+    
 For all other column types, generates a simple checksum using the :func:`!checksum` function.
 
 Determinism


### PR DESCRIPTION
## Description
Fixes doc build error 

`/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/admin/verifier.rst:229: WARNING: Bullet list ends without a blank line; unexpected unindent.`

## Motivation and Context
Builds on work in https://github.com/prestodb/presto/pull/23090, https://github.com/prestodb/presto/pull/23033, https://github.com/prestodb/presto/pull/22876, https://github.com/prestodb/presto/pull/22985, and https://github.com/prestodb/presto/pull/23210.

Like the doc build errors I fixed in the other PRs, these errors don't stop the build but they're annoying, and these are easy and low-risk fixes.

## Impact
Documentation builds.

## Test Plan
Local doc build. 

Before: 
* `/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/admin/verifier.rst:229: WARNING: Bullet list ends without a blank line; unexpected unindent.`
* `build succeeded, 20 warnings.`

After: 
* WARNING does not appear
* `build succeeded, 19 warnings.`
 
## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

