### PR TITLE
Refactor to better separate queueing and execution phase 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchQueryFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchQueryFactory.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.analyzer.PreparedQuery;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.analyzer.AnalyzerProvider;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 
 import java.util.Optional;
@@ -32,7 +31,6 @@ public interface DispatchQueryFactory
      * This interface API is defined to setting up all preparation works for query before it being executed.
      *
      * @param session the session
-     * @param analyzerProvider the analyzer provider
      * @param query the query
      * @param preparedQuery the prepared query
      * @param slug the unique query slug for each {@code Query} object
@@ -45,7 +43,6 @@ public interface DispatchQueryFactory
      */
     DispatchQuery createDispatchQuery(
             Session session,
-            AnalyzerProvider analyzerProvider,
             String query,
             PreparedQuery preparedQuery,
             String slug,

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedLocalDispatchQueryFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedLocalDispatchQueryFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.dispatcher;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.event.QueryMonitor;
+import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.execution.LocationFactory;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.presto.util.Failures.toFailure;
+import static java.util.Objects.requireNonNull;
+
+public class FailedLocalDispatchQueryFactory
+        implements FailedDispatchQueryFactory
+{
+    private final QueryMonitor queryMonitor;
+    private final LocationFactory locationFactory;
+    private final ExecutorService executor;
+
+    @Inject
+    public FailedLocalDispatchQueryFactory(QueryMonitor queryMonitor, LocationFactory locationFactory, DispatchExecutor dispatchExecutor)
+    {
+        this.queryMonitor = requireNonNull(queryMonitor, "queryMonitor is null");
+        this.locationFactory = requireNonNull(locationFactory, "locationFactory is null");
+        this.executor = requireNonNull(dispatchExecutor, "dispatchExecutor is null").getExecutor();
+    }
+
+    @Override
+    public FailedDispatchQuery createFailedDispatchQuery(Session session, String query, Optional<ResourceGroupId> resourceGroup, Throwable throwable)
+    {
+        ExecutionFailureInfo failure = toFailure(throwable);
+        FailedDispatchQuery failedDispatchQuery = new FailedDispatchQuery(
+                session,
+                query,
+                locationFactory.createQueryLocation(session.getQueryId()),
+                resourceGroup,
+                failure,
+                executor);
+
+        BasicQueryInfo queryInfo = failedDispatchQuery.getBasicQueryInfo();
+
+        queryMonitor.queryCreatedEvent(queryInfo);
+        queryMonitor.queryImmediateFailureEvent(queryInfo, failure);
+
+        return failedDispatchQuery;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQueryFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQueryFactory.java
@@ -28,9 +28,9 @@ import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.analyzer.AnalyzerProvider;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.sql.analyzer.AnalyzerProviderManager;
 import com.facebook.presto.tracing.NoopTracerProvider;
 import com.facebook.presto.tracing.QueryStateTracingListener;
 import com.facebook.presto.transaction.TransactionManager;
@@ -42,6 +42,7 @@ import javax.inject.Inject;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import static com.facebook.presto.SystemSessionProperties.getAnalyzerType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 
@@ -64,6 +65,7 @@ public class LocalDispatchQueryFactory
     private final ListeningExecutorService executor;
 
     private final QueryPrerequisitesManager queryPrerequisitesManager;
+    private final AnalyzerProviderManager analyzerProviderManager;
 
     /**
      * Instantiates a new Local dispatch query factory.
@@ -90,7 +92,8 @@ public class LocalDispatchQueryFactory
             ExecutionFactoriesManager executionFactoriesManager,
             ClusterSizeMonitor clusterSizeMonitor,
             DispatchExecutor dispatchExecutor,
-            QueryPrerequisitesManager queryPrerequisitesManager)
+            QueryPrerequisitesManager queryPrerequisitesManager,
+            AnalyzerProviderManager analyzerProviderManager)
     {
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -104,6 +107,7 @@ public class LocalDispatchQueryFactory
 
         this.executor = requireNonNull(dispatchExecutor, "executorService is null").getExecutor();
         this.queryPrerequisitesManager = requireNonNull(queryPrerequisitesManager, "queryPrerequisitesManager is null");
+        this.analyzerProviderManager = requireNonNull(analyzerProviderManager, "analyzerProviderManager is null");
     }
 
     /**
@@ -131,7 +135,6 @@ public class LocalDispatchQueryFactory
     @Override
     public DispatchQuery createDispatchQuery(
             Session session,
-            AnalyzerProvider analyzerProvider,
             String query,
             PreparedQuery preparedQuery,
             String slug,
@@ -164,7 +167,7 @@ public class LocalDispatchQueryFactory
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported statement type: " + preparedQuery.getStatementClass().getSimpleName());
             }
 
-            return queryExecutionFactory.createQueryExecution(analyzerProvider, preparedQuery, stateMachine, slug, retryCount, warningCollector, queryType);
+            return queryExecutionFactory.createQueryExecution(analyzerProviderManager.getAnalyzerProvider(getAnalyzerType(session)), preparedQuery, stateMachine, slug, retryCount, warningCollector, queryType);
         });
 
         return new LocalDispatchQuery(

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -28,6 +28,7 @@ import com.facebook.presto.dispatcher.DispatchExecutor;
 import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.dispatcher.DispatchQueryFactory;
 import com.facebook.presto.dispatcher.FailedDispatchQueryFactory;
+import com.facebook.presto.dispatcher.FailedLocalDispatchQueryFactory;
 import com.facebook.presto.dispatcher.LocalDispatchQueryFactory;
 import com.facebook.presto.event.QueryMonitor;
 import com.facebook.presto.event.QueryMonitorConfig;
@@ -192,7 +193,7 @@ public class CoordinatorModule
         // dispatcher
         binder.bind(DispatchManager.class).in(Scopes.SINGLETON);
         newExporter(binder).export(DispatchManager.class).withGeneratedName();
-        binder.bind(FailedDispatchQueryFactory.class).in(Scopes.SINGLETON);
+        binder.bind(FailedDispatchQueryFactory.class).to(FailedLocalDispatchQueryFactory.class);
         binder.bind(DispatchExecutor.class).in(Scopes.SINGLETON);
         newExporter(binder).export(DispatchExecutor.class).withGeneratedName();
 

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -72,7 +72,9 @@ import com.facebook.presto.operator.ForScheduler;
 import com.facebook.presto.operator.OperatorInfo;
 import com.facebook.presto.resourcemanager.ForResourceManager;
 import com.facebook.presto.resourcemanager.ResourceManagerProxy;
+import com.facebook.presto.server.protocol.ExecutingQueryResponseProvider;
 import com.facebook.presto.server.protocol.ExecutingStatementResource;
+import com.facebook.presto.server.protocol.LocalExecutingQueryResponseProvider;
 import com.facebook.presto.server.protocol.LocalQueryProvider;
 import com.facebook.presto.server.protocol.QueryBlockingRateLimiter;
 import com.facebook.presto.server.protocol.QueuedStatementResource;
@@ -187,6 +189,7 @@ public class CoordinatorModule
         newExporter(binder).export(QueryBlockingRateLimiter.class).withGeneratedName();
 
         binder.bind(LocalQueryProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ExecutingQueryResponseProvider.class).to(LocalExecutingQueryResponseProvider.class).in(Scopes.SINGLETON);
 
         jaxrsBinder(binder).bind(TaskInfoResource.class);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -30,6 +30,7 @@ import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.spi.CoordinatorPlugin;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.analyzer.AnalyzerProvider;
+import com.facebook.presto.spi.analyzer.QueryPreparerProvider;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
@@ -46,6 +47,7 @@ import com.facebook.presto.spi.tracing.TracerProvider;
 import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
 import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
 import com.facebook.presto.sql.analyzer.AnalyzerProviderManager;
+import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.tracing.TracerProviderManager;
 import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManager;
@@ -127,6 +129,7 @@ public class PluginManager
     private final HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager;
     private final TracerProviderManager tracerProviderManager;
     private final AnalyzerProviderManager analyzerProviderManager;
+    private final QueryPreparerProviderManager queryPreparerProviderManager;
     private final NodeStatusNotificationManager nodeStatusNotificationManager;
 
     @Inject
@@ -137,6 +140,7 @@ public class PluginManager
             Metadata metadata,
             ResourceGroupManager<?> resourceGroupManager,
             AnalyzerProviderManager analyzerProviderManager,
+            QueryPreparerProviderManager queryPreparerProviderManager,
             AccessControlManager accessControlManager,
             PasswordAuthenticatorManager passwordAuthenticatorManager,
             EventListenerManager eventListenerManager,
@@ -178,6 +182,7 @@ public class PluginManager
         this.historyBasedPlanStatisticsManager = requireNonNull(historyBasedPlanStatisticsManager, "historyBasedPlanStatisticsManager is null");
         this.tracerProviderManager = requireNonNull(tracerProviderManager, "tracerProviderManager is null");
         this.analyzerProviderManager = requireNonNull(analyzerProviderManager, "analyzerProviderManager is null");
+        this.queryPreparerProviderManager = requireNonNull(queryPreparerProviderManager, "queryPreparerProviderManager is null");
         this.nodeStatusNotificationManager = requireNonNull(nodeStatusNotificationManager, "nodeStatusNotificationManager is null");
     }
 
@@ -332,6 +337,11 @@ public class PluginManager
         for (AnalyzerProvider analyzerProvider : plugin.getAnalyzerProviders()) {
             log.info("Registering analyzer provider %s", analyzerProvider.getType());
             analyzerProviderManager.addAnalyzerProvider(analyzerProvider);
+        }
+
+        for (QueryPreparerProvider preparerProvider : plugin.getQueryPreparerProviders()) {
+            log.info("Registering query preparer provider %s", preparerProvider.getType());
+            queryPreparerProviderManager.addQueryPreparerProvider(preparerProvider);
         }
 
         for (NodeStatusNotificationProviderFactory nodeStatusNotificationProviderFactory : plugin.getNodeStatusNotificationProviderFactory()) {

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -177,12 +177,14 @@ import com.facebook.presto.sql.analyzer.AnalyzerProviderManager;
 import com.facebook.presto.sql.analyzer.BuiltInAnalyzerProvider;
 import com.facebook.presto.sql.analyzer.BuiltInQueryAnalyzer;
 import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer;
+import com.facebook.presto.sql.analyzer.BuiltInQueryPreparerProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.SingleStreamSpillerChoice;
 import com.facebook.presto.sql.analyzer.ForMetadataExtractor;
 import com.facebook.presto.sql.analyzer.MetadataExtractor;
 import com.facebook.presto.sql.analyzer.MetadataExtractorMBean;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
+import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -317,6 +319,8 @@ public class ServerMainModule
 
         // analyzer
         binder.bind(BuiltInQueryPreparer.class).in(Scopes.SINGLETON);
+        binder.bind(BuiltInQueryPreparerProvider.class).in(Scopes.SINGLETON);
+        binder.bind(QueryPreparerProviderManager.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, QueryExplainer.class);
         binder.bind(BuiltInQueryAnalyzer.class).in(Scopes.SINGLETON);
         binder.bind(BuiltInAnalyzerProvider.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingQueryResponseProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingQueryResponseProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.protocol;
+
+import com.facebook.presto.dispatcher.DispatchInfo;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.util.Optional;
+
+public interface ExecutingQueryResponseProvider
+{
+    /**
+     * Generally, the Presto protocol redirects the client from QueuedStatementResource
+     * to ExecutingStatementResource once the query has been de-queued and begun execution.
+     * But this redirect might add too much latency for certain very low latency use cases.
+     * This interface allows for a response from ExecutingStatementResource to be wired into
+     * QueuedStatementResource, so that the client can receive results directly from the
+     * QueuedStatement endpoint, without having to be redirected to the ExecutingStatement endpoint.
+     *
+     * This interface is required for https://github.com/prestodb/presto/issues/23455
+     *
+     * @param queryId query id
+     * @param slug nonce to protect the query
+     * @param dispatchInfo information about state of the query
+     * @param uriInfo endpoint URI
+     * @param xPrestoPrefixUrl prefix URL, that is useful if a proxy is being used
+     * @param scheme HTTP scheme
+     * @param maxWait duration to wait for query results
+     * @param targetResultSize target result size of first response
+     * @param compressionEnabled enable compression
+     * @param nestedDataSerializationEnabled enable nested data serialization
+     * @param binaryResults generate results in binary format, rather than JSON
+     * @return the ExecutingStatement's Response, if available
+     */
+    Optional<ListenableFuture<Response>> waitForExecutingResponse(
+            QueryId queryId,
+            String slug,
+            DispatchInfo dispatchInfo,
+            UriInfo uriInfo,
+            String xPrestoPrefixUrl,
+            String scheme,
+            Duration maxWait,
+            DataSize targetResultSize,
+            boolean compressionEnabled,
+            boolean nestedDataSerializationEnabled,
+            boolean binaryResults);
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/LocalExecutingQueryResponseProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/LocalExecutingQueryResponseProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.protocol;
+
+import com.facebook.presto.dispatcher.DispatchInfo;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.util.Optional;
+
+import static com.google.common.util.concurrent.Futures.transform;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.util.Objects.requireNonNull;
+
+public class LocalExecutingQueryResponseProvider
+        implements ExecutingQueryResponseProvider
+{
+    private final LocalQueryProvider queryProvider;
+
+    @Inject
+    public LocalExecutingQueryResponseProvider(LocalQueryProvider queryProvider)
+    {
+        this.queryProvider = requireNonNull(queryProvider, "queryProvider is null");
+    }
+
+    @Override
+    public Optional<ListenableFuture<Response>> waitForExecutingResponse(
+            QueryId queryId,
+            String slug,
+            DispatchInfo dispatchInfo,
+            UriInfo uriInfo,
+            String xPrestoPrefixUrl,
+            String scheme,
+            Duration maxWait,
+            DataSize targetResultSize,
+            boolean compressionEnabled,
+            boolean nestedDataSerializationEnabled,
+            boolean binaryResults)
+    {
+        Query query;
+        try {
+            query = queryProvider.getQuery(queryId, slug);
+        }
+        catch (WebApplicationException e) {
+            return Optional.empty();
+        }
+        return Optional.of(transform(
+                query.waitForResults(0, uriInfo, scheme, maxWait, targetResultSize, binaryResults),
+                results -> QueryResourceUtil.toResponse(query, results, xPrestoPrefixUrl, compressionEnabled, nestedDataSerializationEnabled),
+                directExecutor()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryPreparerProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryPreparerProvider.java
@@ -13,22 +13,23 @@
  */
 package com.facebook.presto.sql.analyzer;
 
-import com.facebook.presto.spi.analyzer.AnalyzerProvider;
-import com.facebook.presto.spi.analyzer.QueryAnalyzer;
-import com.google.inject.Inject;
+import com.facebook.presto.spi.analyzer.QueryPreparer;
+import com.facebook.presto.spi.analyzer.QueryPreparerProvider;
+
+import javax.inject.Inject;
 
 import static java.util.Objects.requireNonNull;
 
-public class BuiltInAnalyzerProvider
-        implements AnalyzerProvider
+public class BuiltInQueryPreparerProvider
+        implements QueryPreparerProvider
 {
     private static final String PROVIDER_NAME = "BUILTIN";
-    private final BuiltInQueryAnalyzer queryAnalyzer;
+    private final BuiltInQueryPreparer queryPreparer;
 
     @Inject
-    public BuiltInAnalyzerProvider(BuiltInQueryAnalyzer queryAnalyzer)
+    public BuiltInQueryPreparerProvider(BuiltInQueryPreparer queryPreparer)
     {
-        this.queryAnalyzer = requireNonNull(queryAnalyzer, "queryAnalyzer is null");
+        this.queryPreparer = requireNonNull(queryPreparer, "queryPreparer is null");
     }
 
     @Override
@@ -38,8 +39,8 @@ public class BuiltInAnalyzerProvider
     }
 
     @Override
-    public QueryAnalyzer getQueryAnalyzer()
+    public QueryPreparer getQueryPreparer()
     {
-        return queryAnalyzer;
+        return queryPreparer;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryPreparerProviderManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryPreparerProviderManager.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.analyzer.QueryPreparerProvider;
+
+import javax.inject.Inject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.facebook.presto.spi.StandardErrorCode.UNSUPPORTED_ANALYZER_TYPE;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class QueryPreparerProviderManager
+{
+    private final Map<String, QueryPreparerProvider> queryPreparerProviders = new HashMap<>();
+
+    @Inject
+    public QueryPreparerProviderManager(BuiltInQueryPreparerProvider queryPreparerProvider)
+    {
+        addQueryPreparerProvider(queryPreparerProvider);
+    }
+
+    public void addQueryPreparerProvider(QueryPreparerProvider preparerProvider)
+    {
+        requireNonNull(preparerProvider, "preparerProvider is null");
+
+        if (queryPreparerProviders.putIfAbsent(preparerProvider.getType(), preparerProvider) != null) {
+            throw new IllegalArgumentException(format("Query preparer provider '%s' is already registered", preparerProvider.getType()));
+        }
+    }
+
+    public QueryPreparerProvider getQueryPreparerProvider(String preparerType)
+    {
+        if (queryPreparerProviders.containsKey(preparerType)) {
+            return queryPreparerProviders.get(preparerType);
+        }
+
+        throw new PrestoException(UNSUPPORTED_ANALYZER_TYPE, "Unsupported query preparer type: " + preparerType);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -161,8 +161,10 @@ import com.facebook.presto.sql.analyzer.BuiltInAnalyzerProvider;
 import com.facebook.presto.sql.analyzer.BuiltInQueryAnalyzer;
 import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer;
 import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer.BuiltInPreparedQuery;
+import com.facebook.presto.sql.analyzer.BuiltInQueryPreparerProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
+import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -488,7 +490,9 @@ public class LocalQueryRunner
                 ImmutableSet.of());
 
         BuiltInQueryAnalyzer queryAnalyzer = new BuiltInQueryAnalyzer(metadata, sqlParser, accessControl, Optional.empty(), metadataExtractorExecutor);
-        BuiltInAnalyzerProvider analyzerProvider = new BuiltInAnalyzerProvider(new BuiltInQueryPreparer(sqlParser), queryAnalyzer);
+        BuiltInAnalyzerProvider analyzerProvider = new BuiltInAnalyzerProvider(queryAnalyzer);
+        BuiltInQueryPreparer queryPreparer = new BuiltInQueryPreparer(sqlParser);
+        BuiltInQueryPreparerProvider queryPreparerProvider = new BuiltInQueryPreparerProvider(queryPreparer);
 
         this.pluginManager = new PluginManager(
                 nodeInfo,
@@ -497,6 +501,7 @@ public class LocalQueryRunner
                 metadata,
                 new NoOpResourceGroupManager(),
                 new AnalyzerProviderManager(analyzerProvider),
+                new QueryPreparerProviderManager(queryPreparerProvider),
                 accessControl,
                 new PasswordAuthenticatorManager(),
                 new EventListenerManager(),

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -162,11 +162,13 @@ import com.facebook.presto.sql.analyzer.AnalyzerProviderManager;
 import com.facebook.presto.sql.analyzer.BuiltInAnalyzerProvider;
 import com.facebook.presto.sql.analyzer.BuiltInQueryAnalyzer;
 import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer;
+import com.facebook.presto.sql.analyzer.BuiltInQueryPreparerProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.ForMetadataExtractor;
 import com.facebook.presto.sql.analyzer.MetadataExtractor;
 import com.facebook.presto.sql.analyzer.MetadataExtractorMBean;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
+import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -428,6 +430,8 @@ public class PrestoSparkModule
 
         // analyzer
         binder.bind(BuiltInQueryPreparer.class).in(Scopes.SINGLETON);
+        binder.bind(BuiltInQueryPreparerProvider.class).in(Scopes.SINGLETON);
+        binder.bind(QueryPreparerProviderManager.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, QueryExplainer.class);
         binder.bind(BuiltInQueryAnalyzer.class).in(Scopes.SINGLETON);
         binder.bind(BuiltInAnalyzerProvider.class).in(Scopes.SINGLETON);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.block.BlockEncoding;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.analyzer.AnalyzerProvider;
+import com.facebook.presto.spi.analyzer.QueryPreparerProvider;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
@@ -128,6 +129,11 @@ public interface Plugin
     }
 
     default Iterable<AnalyzerProvider> getAnalyzerProviders()
+    {
+        return emptyList();
+    }
+
+    default Iterable<QueryPreparerProvider> getQueryPreparerProviders()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryPreparerProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryPreparerProvider.java
@@ -13,9 +13,9 @@
  */
 package com.facebook.presto.spi.analyzer;
 
-public interface AnalyzerProvider
+public interface QueryPreparerProvider
 {
     String getType();
 
-    QueryAnalyzer getQueryAnalyzer();
+    QueryPreparer getQueryPreparer();
 }


### PR DESCRIPTION
## Description
This change refactors some classes to separate queueing and execution phase in the code organization. It is the first set of changes. 

## Motivation and Context
This is the first set of refactoring to support RFC5 https://github.com/prestodb/rfcs/pull/23. However, this refactor stands on its own for improving code organization, and is valuable regardless of the RFC. 

## Impact
No impact 

## Test Plan
mvn test + verifier run, this is a straightforward refactor 

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

