### PR TITLE
Accept query id and slug in QueuedStatement

### DIFF
--- a/presto-docs/src/main/sphinx/rest/statement.rst
+++ b/presto-docs/src/main/sphinx/rest/statement.rst
@@ -117,6 +117,21 @@ Statement Resource
         }
       }
 
+.. function:: PUT /v1/statement/{queryId}?slug={slug}
+
+   :query query: SQL Query to execute
+   :query queryId: Query identifier to associate with this query
+   :query slug: Nonce to associate with this query, that will be required for subsequent requests
+   :reqheader X-Presto-User: User to execute statement on behalf of (optional)
+   :reqheader X-Presto-Source: Source of query
+   :reqheader X-Presto-Catalog: Catalog to execute query against
+   :reqheader X-Presto-Schema: Schema to execute query against
+
+   Submits a statement to Presto for execution. This function is
+   the analogue of the POST, and behaves exactly the same. The
+   difference is that a query id and slug can be explicitly provided,
+   instead of Presto generating it.
+
 .. function:: GET /v1/statement/{queryId}/{token}
 
    :query queryId: The query identifier returned from the initial POST to /v1/statement

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.HttpUriBuilder;
 import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.http.client.StatusResponseHandler;
+import com.facebook.airlift.http.client.UnexpectedResponseException;
 import com.facebook.airlift.http.client.jetty.JettyHttpClient;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.testing.Closeables;
@@ -26,6 +27,7 @@ import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.type.TimeZoneNotSupportedException;
+import com.facebook.presto.execution.QueryIdGenerator;
 import com.facebook.presto.execution.buffer.PagesSerdeFactory;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.QueryId;
@@ -48,9 +50,11 @@ import java.util.List;
 
 import static com.facebook.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.fromRequest;
 import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
 import static com.facebook.airlift.http.client.Request.Builder.prepareHead;
 import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.Request.Builder.preparePut;
 import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
@@ -263,6 +267,103 @@ public class TestServer
     }
 
     @Test
+    public void testQueryWithPreMintedQueryIdAndSlug()
+    {
+        QueryId queryId = new QueryIdGenerator().createNextQueryId();
+        String slug = "xxx";
+        Request request = preparePut()
+                .setUri(uriFor("/v1/statement/", queryId, slug))
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .setHeader(PRESTO_CATALOG, "catalog")
+                .setHeader(PRESTO_SCHEMA, "schema")
+                .build();
+
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        // verify slug in nextUri is same as requested
+        assertEquals(queryResults.getNextUri().getQuery(), "slug=xxx");
+
+        // verify nextUri points to requested query id
+        assertEquals(queryResults.getNextUri().getPath(), format("/v1/statement/queued/%s/1", queryId));
+
+        while (queryResults.getNextUri() != null) {
+            queryResults = client.execute(prepareGet().setUri(queryResults.getNextUri()).build(), createJsonResponseHandler(QUERY_RESULTS_CODEC));
+        }
+
+        if (queryResults.getError() != null) {
+            fail(queryResults.getError().toString());
+        }
+
+        // verify query id was passed down properly
+        assertEquals(server.getDispatchManager().getQueryInfo(queryId).getQueryId(), queryId);
+    }
+
+    @Test
+    public void testPutStatementIdempotency()
+    {
+        QueryId queryId = new QueryIdGenerator().createNextQueryId();
+        Request request = preparePut()
+                .setUri(uriFor("/v1/statement/", queryId, "slug"))
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .setHeader(PRESTO_CATALOG, "catalog")
+                .setHeader(PRESTO_SCHEMA, "schema")
+                .build();
+
+        client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+        // Execute PUT request again should succeed
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        while (queryResults.getNextUri() != null) {
+            queryResults = client.execute(prepareGet().setUri(queryResults.getNextUri()).build(), createJsonResponseHandler(QUERY_RESULTS_CODEC));
+        }
+        if (queryResults.getError() != null) {
+            fail(queryResults.getError().toString());
+        }
+    }
+
+    @Test(expectedExceptions = UnexpectedResponseException.class, expectedExceptionsMessageRegExp = "Expected response code to be \\[.*\\], but was 409")
+    public void testPutStatementWithDifferentSlugFails()
+    {
+        QueryId queryId = new QueryIdGenerator().createNextQueryId();
+        Request request = preparePut()
+                .setUri(uriFor("/v1/statement/", queryId, "slug"))
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .setHeader(PRESTO_CATALOG, "catalog")
+                .setHeader(PRESTO_SCHEMA, "schema")
+                .build();
+        client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        Request badRequest = fromRequest(request)
+                .setUri(uriFor("/v1/statement/", queryId, "different_slug"))
+                .build();
+        client.execute(badRequest, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+    }
+
+    @Test(expectedExceptions = UnexpectedResponseException.class, expectedExceptionsMessageRegExp = "Expected response code to be \\[.*\\], but was 409")
+    public void testPutStatementAfterGetFails()
+    {
+        QueryId queryId = new QueryIdGenerator().createNextQueryId();
+        Request request = preparePut()
+                .setUri(uriFor("/v1/statement/", queryId, "slug"))
+                .setBodyGenerator(createStaticBodyGenerator("show catalogs", UTF_8))
+                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_SOURCE, "source")
+                .setHeader(PRESTO_CATALOG, "catalog")
+                .setHeader(PRESTO_SCHEMA, "schema")
+                .build();
+
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+        client.execute(prepareGet().setUri(queryResults.getNextUri()).build(), createJsonResponseHandler(QUERY_RESULTS_CODEC));
+        client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+    }
+
+    @Test
     public void testTransactionSupport()
     {
         Request request = preparePost()
@@ -326,5 +427,14 @@ public class TestServer
     public URI uriFor(String path)
     {
         return HttpUriBuilder.uriBuilderFrom(server.getBaseUrl()).replacePath(path).build();
+    }
+
+    public URI uriFor(String path, QueryId queryId, String slug)
+    {
+        return HttpUriBuilder.uriBuilderFrom(server.getBaseUrl())
+                .replacePath(path)
+                .appendPath(queryId.getId())
+                .addParameter("slug", slug)
+                .build();
     }
 }

--- a/presto-openapi/src/main/resources/queued_statement.yaml
+++ b/presto-openapi/src/main/resources/queued_statement.yaml
@@ -46,6 +46,59 @@ paths:
                 $ref: './schemas.yaml/#/components/schemas/QueryResults'
         '400':
           description: Bad request
+  /v1/statement/{queryId}:
+    put:
+      summary: Submit a new query
+      description: Submits a new query to the Presto coordinator, with a pre-minted query id and slug
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              description: The statement or SQL query string to be submitted
+      parameters:
+        - name: queryId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The query id to associate with this query
+        - name: slug
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Nonce to associate with this query, which is required for future requests
+        - name: binaryResults
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: Whether to return results in binary format
+        - name: X-Forwarded-Proto
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Forwarded protocol (http or https)
+        - name: Presto-Prefix-URL
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Prefix URL for Presto
+      responses:
+        '200':
+          description: Query submitted successfully
+          content:
+            application/json:
+              schema:
+                $ref: './schemas.yaml/#/components/schemas/QueryResults'
+        '400':
+          description: Bad request
+        '409':
+          description: Conflict, this query already exists
   /v1/statement/queued/retry/{queryId}:
     get:
       summary: Retry a failed query


### PR DESCRIPTION
## Description
This change adds support for QueuedStatementResource to accept a pre-minted query id and slug. 

## Motivation and Context
This is required for RFC5 https://github.com/prestodb/rfcs/pull/23 

## Impact
There is no user-facing or performance impact. 

## Test Plan
Added test in TestServer

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Add support in QueuedStatement protocol to accept pre-minted query id and slug :pr:`23407`
```

