### PR TITLE
Apply info column filters during split generation

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.io.IOException;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Executor;
@@ -71,7 +72,7 @@ public class BackgroundHiveSplitLoader
     public BackgroundHiveSplitLoader(
             Table table,
             Iterable<HivePartitionMetadata> partitions,
-            Optional<Domain> pathDomain,
+            Map<Integer, Domain> infoColumnConstraints,
             Optional<BucketSplitInfo> tableBucketInfo,
             ConnectorSession session,
             HdfsEnvironment hdfsEnvironment,
@@ -87,7 +88,7 @@ public class BackgroundHiveSplitLoader
         checkArgument(loaderConcurrency > 0, "loaderConcurrency must be > 0, found: %s", loaderConcurrency);
         this.executor = requireNonNull(executor, "executor is null");
         this.partitions = new ConcurrentLazyQueue<>(requireNonNull(partitions, "partitions is null"));
-        this.delegatingPartitionLoader = new DelegatingPartitionLoader(table, pathDomain, tableBucketInfo, session, hdfsEnvironment, namenodeStats, directoryLister, fileIterators, recursiveDirWalkerEnabled, schedulerUsesHostAddresses, partialAggregationsPushedDown);
+        this.delegatingPartitionLoader = new DelegatingPartitionLoader(table, infoColumnConstraints, tableBucketInfo, session, hdfsEnvironment, namenodeStats, directoryLister, fileIterators, recursiveDirWalkerEnabled, schedulerUsesHostAddresses, partialAggregationsPushedDown);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/DelegatingPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/DelegatingPartitionLoader.java
@@ -39,7 +39,7 @@ public class DelegatingPartitionLoader
 
     public DelegatingPartitionLoader(
             Table table,
-            Optional<Domain> pathDomain,
+            Map<Integer, Domain> infoColumnConstraints,
             Optional<BucketSplitInfo> tableBucketInfo,
             ConnectorSession session,
             HdfsEnvironment hdfsEnvironment,
@@ -53,7 +53,7 @@ public class DelegatingPartitionLoader
         this.session = requireNonNull(session, "session is null");
         this.storagePartitionLoader = new StoragePartitionLoader(
                 table,
-                pathDomain,
+                infoColumnConstraints,
                 tableBucketInfo,
                 session,
                 hdfsEnvironment,
@@ -63,7 +63,7 @@ public class DelegatingPartitionLoader
                 recursiveDirWalkerEnabled,
                 schedulerUsesHostAddresses,
                 partialAggregationsPushedDown);
-        this.manifestPartitionLoader = new ManifestPartitionLoader(table, pathDomain, session, hdfsEnvironment, namenodeStats, directoryLister, recursiveDirWalkerEnabled, schedulerUsesHostAddresses);
+        this.manifestPartitionLoader = new ManifestPartitionLoader(table, infoColumnConstraints, session, hdfsEnvironment, namenodeStats, directoryLister, recursiveDirWalkerEnabled, schedulerUsesHostAddresses);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
@@ -277,4 +277,10 @@ public class HiveColumnHandle
     {
         return column.getHiveColumnIndex() == FILE_MODIFIED_TIME_COLUMN_INDEX;
     }
+
+    public static boolean isInfoColumnHandle(HiveColumnHandle column)
+    {
+        return isPathColumnHandle(column) || isFileSizeColumnHandle(column)
+                || isFileModifiedTimeColumnHandle(column);
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -67,7 +67,7 @@ public class ManifestPartitionLoader
     private static final String[] BLOCK_LOCATION_HOSTS = {"localhost"};
 
     private final Table table;
-    private final Optional<Domain> pathDomain;
+    Map<Integer, Domain> infoColumnConstraints;
     private final ConnectorSession session;
     private final HdfsEnvironment hdfsEnvironment;
     private final HdfsContext hdfsContext;
@@ -78,7 +78,7 @@ public class ManifestPartitionLoader
 
     public ManifestPartitionLoader(
             Table table,
-            Optional<Domain> pathDomain,
+            Map<Integer, Domain> infoColumnConstraints,
             ConnectorSession session,
             HdfsEnvironment hdfsEnvironment,
             NamenodeStats namenodeStats,
@@ -87,7 +87,7 @@ public class ManifestPartitionLoader
             boolean schedulerUsesHostAddresses)
     {
         this.table = requireNonNull(table, "table is null");
-        this.pathDomain = requireNonNull(pathDomain, "pathDomain is null");
+        this.infoColumnConstraints = requireNonNull(infoColumnConstraints, "pathDomain is null");
         this.session = requireNonNull(session, "session is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName(), table.getStorage().getLocation(), false);
@@ -133,7 +133,7 @@ public class ManifestPartitionLoader
             }
         }
 
-        InternalHiveSplitFactory splitFactory = createInternalHiveSplitFactory(table, partition, session, pathDomain, hdfsEnvironment, hdfsContext, schedulerUsesHostAddresses);
+        InternalHiveSplitFactory splitFactory = createInternalHiveSplitFactory(table, partition, session, infoColumnConstraints, hdfsEnvironment, hdfsContext, schedulerUsesHostAddresses);
 
         return hiveSplitSource.addToQueue(fileListBuilder.build().stream()
                 .map(status -> splitFactory.createInternalHiveSplit(status, true))
@@ -146,7 +146,7 @@ public class ManifestPartitionLoader
             Table table,
             HivePartitionMetadata partition,
             ConnectorSession session,
-            Optional<Domain> pathDomain,
+            Map<Integer, Domain> infoColumnConstraints,
             HdfsEnvironment hdfsEnvironment,
             HdfsContext hdfsContext,
             boolean schedulerUsesHostAddresses)
@@ -167,7 +167,7 @@ public class ManifestPartitionLoader
         return new InternalHiveSplitFactory(
                 fileSystem,
                 inputFormat,
-                pathDomain,
+                infoColumnConstraints,
                 getNodeSelectionStrategy(session),
                 getMaxInitialSplitSize(session),
                 false,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -49,6 +49,7 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
@@ -99,7 +100,7 @@ public class StoragePartitionLoader
     private static final ListenableFuture<?> COMPLETED_FUTURE = immediateFuture(null);
 
     private final Table table;
-    private final Optional<Domain> pathDomain;
+    Map<Integer, Domain> infoColumnConstraints;
     private final Optional<BucketSplitInfo> tableBucketInfo;
     private final HdfsEnvironment hdfsEnvironment;
     private final HdfsContext hdfsContext;
@@ -113,7 +114,7 @@ public class StoragePartitionLoader
 
     public StoragePartitionLoader(
             Table table,
-            Optional<Domain> pathDomain,
+            Map<Integer, Domain> infoColumnConstraints,
             Optional<BucketSplitInfo> tableBucketInfo,
             ConnectorSession session,
             HdfsEnvironment hdfsEnvironment,
@@ -125,7 +126,7 @@ public class StoragePartitionLoader
             boolean partialAggregationsPushedDown)
     {
         this.table = requireNonNull(table, "table is null");
-        this.pathDomain = requireNonNull(pathDomain, "pathDomain is null");
+        this.infoColumnConstraints = requireNonNull(infoColumnConstraints, "infoColumnConstraints is null");
         this.tableBucketInfo = requireNonNull(tableBucketInfo, "tableBucketInfo is null");
         this.session = requireNonNull(session, "session is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -232,7 +233,7 @@ public class StoragePartitionLoader
         return new InternalHiveSplitFactory(
                 fs,
                 inputFormat,
-                pathDomain,
+                infoColumnConstraints,
                 getNodeSelectionStrategy(session),
                 getMaxInitialSplitSize(session),
                 s3SelectPushdownEnabled,


### PR DESCRIPTION
## Description
Fix incorrect results when filtering on info columns like $file_size, $file_modified_time. Below is the explanation of the bug encountered.

Run multiple inserts on the table to have at least two different files created for the table.

presto:tpch> select regionkey,name,"$file_size" from region2 order by "$file_size";

regionkey | name | $file_size
-----------+-------------+------------
0 | AFRICA | 701
1 | AMERICA | 881

If we have a filter "$file_size"=701 in the query, we expect it to return only the first row from above. But it returns both the rows with file_size set to 701, the incorrect result is below.

presto:tpch> select regionkey,name,"$file_size" from region2 where "$file_size"=701;

regionkey | name | $file_size
-----------+-------------+------------
0 | AFRICA | 701
1 | AMERICA | 701

## Motivation and Context
To fix filtering by info columns in coordinator during split generation. Currently, we do this only for `$path` column, extended this for `$file_size` and `$file_modified_time`.

## Impact
No user facing impact.

## Test Plan
Added new tests and modified existing tests for `$path` and `$bucket` to verify the result correctness.

```
== RELEASE NOTES ==

Hive Connector Changes
*  Fix filtering by info columns $file_size and $file_modified_time, which were ignored before. :pr:`23411`
```


