### PR TITLE
Refactor try-catch clause for createOrcPageSource

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -258,13 +258,14 @@ public class OrcBatchPageSourceFactory
                     partitionID,
                     rowGroupID);
         }
-        catch (Exception e) {
+        catch (IOException | RuntimeException exception) {
             try {
+                //in case the OrcReader did not close the OrcDataSource
                 orcDataSource.close();
             }
             catch (IOException ignored) {
             }
-            throw mapToPrestoException(e, path, fileSplit);
+            throw mapToPrestoException(exception, path, fileSplit);
         }
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/orc/TestOrcBatchPageSourceFactory.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/orc/TestOrcBatchPageSourceFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.orc;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.hive.DwrfEncryptionMetadata;
+import com.facebook.presto.hive.EncryptionInformation;
+import com.facebook.presto.hive.FileFormatDataSourceStats;
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveDwrfEncryptionProvider;
+import com.facebook.presto.hive.HiveFileSplit;
+import com.facebook.presto.hive.TestOrcBatchPageSourceMemoryTracking;
+import com.facebook.presto.orc.OrcReaderOptions;
+import com.facebook.presto.orc.StorageStripeMetadataSource;
+import com.facebook.presto.orc.StripeMetadataSourceFactory;
+import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveFileContext.DEFAULT_HIVE_FILE_CONTEXT;
+import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_AND_TYPE_MANAGER;
+import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static com.facebook.presto.hive.HiveTestUtils.SESSION;
+import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestOrcBatchPageSourceFactory
+{
+    @Test
+    public void testCreateOrcPageSourceException() throws Exception
+    {
+        List<TestOrcBatchPageSourceMemoryTracking.TestColumn> testColumns = ImmutableList.<TestOrcBatchPageSourceMemoryTracking.TestColumn>builder()
+                .add(new TestOrcBatchPageSourceMemoryTracking.TestColumn("p_empty_string", javaStringObjectInspector, () -> "", true))
+                .add(new TestOrcBatchPageSourceMemoryTracking.TestColumn("p_string", javaStringObjectInspector, () -> Long.toHexString(893247L), false))
+                .build();
+        Path tempFilePath = Paths.get(System.getProperty("java.io.tmpdir"),
+                "presto_test_orc_batch_page_source_factory", "temp.orc");
+        ImmutableList.Builder<HiveColumnHandle> columnsBuilder = ImmutableList.builder();
+        Configuration configuration = new JobConf(new Configuration(false));
+        try {
+            FileSplit fileSplit = TestOrcBatchPageSourceMemoryTracking.createTestFile(tempFilePath.toAbsolutePath().toString(),
+                    new OrcOutputFormat(), new OrcSerde(), null, testColumns, 1, 1);
+            HiveFileSplit hiveFileSplit = new HiveFileSplit(
+                    fileSplit.getPath().toString(),
+                    fileSplit.getStart(),
+                    fileSplit.getLength(),
+                    fileSplit.getLength(),
+                    Instant.now().toEpochMilli(),
+                    Optional.empty(),
+                    ImmutableMap.of(),
+                    0);
+            OrcReaderOptions orcReaderOptions = null; //need to be set to null to trigger PrestoException
+            Optional<EncryptionInformation> encryptionInformation =
+                    Optional.of(EncryptionInformation.fromEncryptionMetadata(DwrfEncryptionMetadata.forPerField(
+                            ImmutableMap.of("field1", "test1".getBytes()),
+                            ImmutableMap.of(),
+                            "test_algo",
+                            "test_provider")));
+            try (ConnectorPageSource connectorPageSource = OrcBatchPageSourceFactory.createOrcPageSource(ORC, HDFS_ENVIRONMENT,
+                    configuration, hiveFileSplit, columnsBuilder.build(), true,
+                    TupleDomain.all(), DateTimeZone.getDefault(), FUNCTION_AND_TYPE_MANAGER, true,
+                    new FileFormatDataSourceStats(), 100, new StorageOrcFileTailSource(),
+                    StripeMetadataSourceFactory.of(new StorageStripeMetadataSource()), DEFAULT_HIVE_FILE_CONTEXT, orcReaderOptions,
+                    encryptionInformation, HiveDwrfEncryptionProvider.NO_ENCRYPTION.toDwrfEncryptionProvider(), SESSION, Optional.empty())) {
+                fail("createOrcPageSource call should have resulted in an PrestoException.");
+            }
+            catch (PrestoException pe) {
+                assertTrue(pe.getMessage().contains("orcReaderOptions is null"), "Incorrect PrestoException was thrown.");
+            }
+        }
+        finally {
+            Files.deleteIfExists(tempFilePath);
+        }
+    }
+}


### PR DESCRIPTION
Refactor the OrcBatchPageSourceFactory.createOrcPageSource method as it catches raw java.lang.Exception which is not a recommended practice. A better practice involves catching the specific Exception types that can be thrown in the try-catch block. Kept theOrcDataSource object outside of a try-with-resources block as it is the responsibility of the ConnectorPageSource to close both the reader and datasource.

Added an unit test to verify that any RuntimeException thrown in try block is still mapped to a PrestoException and thrown as expected.

## Description
Refactor the try-catch block to catch specific IOException and RuntimeException class rather than unspecific Exception class.

## Motivation and Context
Refactor the OrcBatchPageSourceFactory.createOrcPageSource to follow best practices for Closeable resource creation and exception handling.
https://github.com/prestodb/presto/issues/22068

## Impact
None

## Test Plan
Added a new unit test class TestOrcBatchPageSourceFactory with a new unit test to that any RuntimeException thrown in try block is still mapped to a PrestoException and thrown as expected.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

