### PR TITLE
[native] Switch to use new config base class from Velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
@@ -17,7 +17,8 @@ target_link_libraries(presto_exception velox_exception)
 set_property(TARGET presto_exception PROPERTY JOB_POOL_LINK
                                               presto_link_job_pool)
 
-target_link_libraries(presto_common velox_config velox_core velox_exception)
+target_link_libraries(presto_common velox_common_config velox_core
+                      velox_exception)
 set_property(TARGET presto_common PROPERTY JOB_POOL_LINK presto_link_job_pool)
 
 if(PRESTO_ENABLE_TESTING)

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -61,7 +61,8 @@ class ConfigTest : public testing::Test {
   void init(
       ConfigBase& config,
       std::unordered_map<std::string, std::string> properties) {
-    config.initialize(std::make_unique<core::MemConfig>(std::move(properties)));
+    config.initialize(
+        std::make_unique<config::ConfigBase>(std::move(properties)));
   }
 
   std::string configFilePath;

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
@@ -37,7 +37,7 @@ class HttpJwtTestSuite : public ::testing::TestWithParam<bool> {
     memory::MemoryManager::testingSetInstance({});
   }
 
-  std::unique_ptr<Config> jwtSystemConfig(
+  std::unique_ptr<config::ConfigBase> jwtSystemConfig(
       const std::unordered_map<std::string, std::string> configOverride = {})
       const {
     std::unordered_map<std::string, std::string> systemConfig{
@@ -52,15 +52,15 @@ class HttpJwtTestSuite : public ::testing::TestWithParam<bool> {
       systemConfig[configName] = configValue;
     }
 
-    return std::make_unique<core::MemConfigMutable>(systemConfig);
+    return std::make_unique<config::ConfigBase>(std::move(systemConfig), true);
   }
 
   void setupJwtNodeConfig() const {
     std::unordered_map<std::string, std::string> nodeConfigValues{
         {std::string(NodeConfig::kMutableConfig), std::string("true")},
         {std::string(NodeConfig::kNodeId), std::string("testnode")}};
-    std::unique_ptr<Config> rawNodeConfig =
-        std::make_unique<core::MemConfig>(nodeConfigValues);
+    std::unique_ptr<config::ConfigBase> rawNodeConfig =
+        std::make_unique<config::ConfigBase>(std::move(nodeConfigValues));
     NodeConfig::instance()->initialize(std::move(rawNodeConfig));
   }
 
@@ -108,7 +108,7 @@ class HttpJwtTestSuite : public ::testing::TestWithParam<bool> {
         sendGet(client.get(), "/async/msg", sendDelayMs, "TestBody");
 
     auto serverConfig = jwtSystemConfig(serverSystemConfigOverride);
-    auto valuesMap = serverConfig->valuesCopy();
+    auto valuesMap = serverConfig->rawConfigsCopy();
     /// The request is delayed. Meanwhile update the config so the server
     /// might use a different configuration, if provided.
     for (auto key : valuesMap) {


### PR DESCRIPTION
Velox has consolidated config classes. Switch Presto native to use the new config class and deprecate the old one.
```
== NO RELEASE NOTE ==
```

