### PR TITLE
[native] Add metrics for memory pushback mechanism

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -18,7 +18,6 @@
 #include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/PrestoServer.h"
 #include "presto_cpp/main/common/Counters.h"
-#include "presto_cpp/main/http/HttpClient.h"
 #include "presto_cpp/main/http/filters/HttpEndpointLatencyFilter.h"
 #include "velox/common/base/PeriodicStatsReporter.h"
 #include "velox/common/base/StatsReporter.h"
@@ -286,25 +285,25 @@ class HiveConnectorStatsReporter {
       std::shared_ptr<velox::connector::hive::HiveConnector> connector)
       : connector_(std::move(connector)),
         numElementsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumElementsFormat,
+            kCounterHiveFileHandleCacheNumElementsFormat.toString(),
             connector_->connectorId())),
         pinnedSizeMetricName_(fmt::format(
-            kCounterHiveFileHandleCachePinnedSizeFormat,
+            kCounterHiveFileHandleCachePinnedSizeFormat.toString(),
             connector_->connectorId())),
         curSizeMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheCurSizeFormat,
+            kCounterHiveFileHandleCacheCurSizeFormat.toString(),
             connector_->connectorId())),
         numAccumulativeHitsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumAccumulativeHitsFormat,
+            kCounterHiveFileHandleCacheNumAccumulativeHitsFormat.toString(),
             connector_->connectorId())),
         numAccumulativeLookupsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumAccumulativeLookupsFormat,
+            kCounterHiveFileHandleCacheNumAccumulativeLookupsFormat.toString(),
             connector_->connectorId())),
         numHitsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumHitsFormat,
+            kCounterHiveFileHandleCacheNumHitsFormat.toString(),
             connector_->connectorId())),
         numLookupsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumLookupsFormat,
+            kCounterHiveFileHandleCacheNumLookupsFormat.toString(),
             connector_->connectorId())) {
     DEFINE_METRIC(numElementsMetricName_, velox::StatType::AVG);
     DEFINE_METRIC(pinnedSizeMetricName_, velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -97,6 +97,9 @@ void registerPrestoMetrics() {
       95,
       99,
       100);
+  DEFINE_METRIC(kCounterMemoryPushbackCount, facebook::velox::StatType::COUNT);
+  DEFINE_HISTOGRAM_METRIC(
+      kCounterMemoryPushbackLatencyMs, 10'000, 0, 100'000, 50, 90, 99, 100);
 
   // NOTE: Metrics type exporting for file handle cache counters are in
   // PeriodicTaskManager because they have dynamic names. The following counters

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -136,21 +136,33 @@ constexpr folly::StringPiece kCounterOsNumForcedContextSwitches{
     "presto_cpp.os_num_forced_context_switches"};
 
 /// ================== HiveConnector Counters ==================
+
 /// Format template strings use 'constexpr std::string_view' to be 'fmt::format'
 /// compatible.
-constexpr std::string_view kCounterHiveFileHandleCacheNumElementsFormat{
+constexpr folly::StringPiece kCounterHiveFileHandleCacheNumElementsFormat{
     "presto_cpp.{}.hive_file_handle_cache_num_elements"};
-constexpr std::string_view kCounterHiveFileHandleCachePinnedSizeFormat{
+constexpr folly::StringPiece kCounterHiveFileHandleCachePinnedSizeFormat{
     "presto_cpp.{}.hive_file_handle_cache_pinned_size"};
-constexpr std::string_view kCounterHiveFileHandleCacheCurSizeFormat{
+constexpr folly::StringPiece kCounterHiveFileHandleCacheCurSizeFormat{
     "presto_cpp.{}.hive_file_handle_cache_cur_size"};
-constexpr std::string_view kCounterHiveFileHandleCacheNumAccumulativeHitsFormat{
-    "presto_cpp.{}.hive_file_handle_cache_num_accumulative_hits"};
-constexpr std::string_view
+constexpr folly::StringPiece
+    kCounterHiveFileHandleCacheNumAccumulativeHitsFormat{
+        "presto_cpp.{}.hive_file_handle_cache_num_accumulative_hits"};
+constexpr folly::StringPiece
     kCounterHiveFileHandleCacheNumAccumulativeLookupsFormat{
         "presto_cpp.{}.hive_file_handle_cache_num_accumulative_lookups"};
-constexpr std::string_view kCounterHiveFileHandleCacheNumHitsFormat{
+constexpr folly::StringPiece kCounterHiveFileHandleCacheNumHitsFormat{
     "presto_cpp.{}.hive_file_handle_cache_num_hits"};
-constexpr std::string_view kCounterHiveFileHandleCacheNumLookupsFormat{
+constexpr folly::StringPiece kCounterHiveFileHandleCacheNumLookupsFormat{
     "presto_cpp.{}.hive_file_handle_cache_num_lookups"};
+
+/// ================== Memory Pushback Counters =================
+
+/// Number of times memory pushback mechanism is triggered.
+constexpr folly::StringPiece kCounterMemoryPushbackCount{
+    "presto_cpp.memory_pushback_count"};
+/// Latency distribution of each memory pushback run in range of [0, 100s] and
+/// reports P50, P90, P99, and P100.
+constexpr folly::StringPiece kCounterMemoryPushbackLatencyMs{
+    "presto_cpp.memory_pushback_latency_ms"};
 } // namespace facebook::presto


### PR DESCRIPTION
## Description
Adds 2 memory push back related metrics to the system. One pushback count, one pushback latency. This will help us understand how pushback mechanism works in our system and what could be improved.
```
== RELEASE NOTE ==
```
Following 2 metrics were added in Presto Native:
- presto_cpp.memory_pushback_count -- Number of times memory pushback mechanism is triggered.
- presto_cpp.memory_pushback_latency_ms -- Latency distribution of each memory pushback run in range of [0, 100s] and reports P50, P90, P99, and P100.