### PR TITLE
[native] Add hook for Velox plan validation.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -25,6 +25,7 @@
 #include "presto_cpp/main/PeriodicHeartbeatManager.h"
 #include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/PrestoServerOperations.h"
+#include "presto_cpp/main/types/PrestoToVeloxPlanValidator.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/MemoryAllocator.h"
 #if __has_include("filesystem")
@@ -172,6 +173,11 @@ class PrestoServer {
   /// Invoked to enable stats reporting and register counters.
   virtual void enableWorkerStatsReporting();
 
+  /// Invoked to initialize Presto to Velox plan validator.
+  virtual void initPrestoToVeloxPlanValidator();
+
+  PrestoToVeloxPlanValidator* getPlanValidator();
+
   /// Invoked to get the list of filters passed to the http server.
   std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
   getHttpServerFilters();
@@ -231,6 +237,8 @@ class PrestoServer {
 
   // Executor for spilling.
   std::shared_ptr<folly::CPUThreadPoolExecutor> spillerExecutor_;
+
+  std::shared_ptr<PrestoToVeloxPlanValidator> planValidator_;
 
   std::unique_ptr<http::HttpClientConnectionPool> exchangeSourceConnectionPool_;
 

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -344,6 +344,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTask(
           VeloxInteractiveQueryPlanConverter converter(queryCtx.get(), pool_);
           planFragment = converter.toVeloxQueryPlan(
               prestoPlan, updateRequest.tableWriteInfo, taskId);
+          planValidator_->validatePlanFragment(planFragment);
         }
 
         return taskManager_.createOrUpdateTask(

--- a/presto-native-execution/presto_cpp/main/TaskResource.h
+++ b/presto-native-execution/presto_cpp/main/TaskResource.h
@@ -15,6 +15,7 @@
 
 #include "presto_cpp/main/TaskManager.h"
 #include "presto_cpp/main/http/HttpServer.h"
+#include "presto_cpp/main/types/PrestoToVeloxPlanValidator.h"
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::presto {
@@ -22,11 +23,13 @@ namespace facebook::presto {
 class TaskResource {
  public:
   explicit TaskResource(
-      TaskManager& taskManager,
       velox::memory::MemoryPool* pool,
-      folly::Executor* httpSrvCpuExecutor)
+      folly::Executor* httpSrvCpuExecutor,
+      PrestoToVeloxPlanValidator* planValidator,
+      TaskManager& taskManager)
       : httpSrvCpuExecutor_(httpSrvCpuExecutor),
         pool_{pool},
+        planValidator_(planValidator),
         taskManager_(taskManager) {}
 
   void registerUris(http::HttpServer& server);
@@ -97,6 +100,7 @@ class TaskResource {
 
   folly::Executor* const httpSrvCpuExecutor_;
   velox::memory::MemoryPool* const pool_;
+  PrestoToVeloxPlanValidator* const planValidator_;
 
   TaskManager& taskManager_;
 };

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -244,8 +244,14 @@ class TaskManagerTest : public testing::Test {
 
     taskManager_ = std::make_unique<TaskManager>(
         driverExecutor_.get(), httpSrvCpuExecutor_.get(), nullptr);
+
+    auto validator =
+        std::make_shared<facebook::presto::PrestoToVeloxPlanValidator>();
     taskResource_ = std::make_unique<TaskResource>(
-        *taskManager_.get(), leafPool_.get(), httpSrvCpuExecutor_.get());
+        leafPool_.get(),
+        httpSrvCpuExecutor_.get(),
+        validator.get(),
+        *taskManager_.get());
 
     auto httpServer = std::make_unique<http::HttpServer>(
         httpSrvIOExecutor_,

--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -15,8 +15,10 @@ add_library(presto_type_converter OBJECT TypeParser.cpp)
 target_link_libraries(presto_type_converter velox_type_parser)
 
 add_library(
-  presto_types OBJECT PrestoToVeloxQueryPlan.cpp PrestoToVeloxExpr.cpp
-                      PrestoToVeloxSplit.cpp PrestoToVeloxConnector.cpp)
+  presto_types OBJECT
+  PrestoToVeloxQueryPlan.cpp PrestoToVeloxExpr.cpp
+  PrestoToVeloxPlanValidator.cpp PrestoToVeloxSplit.cpp
+  PrestoToVeloxConnector.cpp)
 add_dependencies(presto_types presto_operators presto_type_converter velox_type
                  velox_type_fbhive velox_dwio_dwrf_proto)
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxPlanValidator.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxPlanValidator.cpp
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/types/PrestoToVeloxPlanValidator.h"
+
+namespace facebook::presto {
+bool PrestoToVeloxPlanValidator::validatePlanFragment(
+    const velox::core::PlanFragment& fragment) {
+  return true;
+}
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxPlanValidator.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxPlanValidator.h
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "velox/core/PlanFragment.h"
+
+namespace facebook::presto {
+class PrestoToVeloxPlanValidator {
+ public:
+  virtual bool validatePlanFragment(const velox::core::PlanFragment& fragment);
+  virtual ~PrestoToVeloxPlanValidator() = default;
+};
+} // namespace facebook::presto


### PR DESCRIPTION
## Description
This PR adds a hook to further check presto to velox converted plan.

## Motivation and Context
After Presto plan is converted to Velox plan, it is often required to disable certain features based on the generated plan. The reasoning is even though the plan is converted properly, due to arbitary limitation in Velox (either correctness or performacne), we may want to fail the query execution. Adding a hook (similar to spilling directory), allows us to customize query execution and make it configurable based on current capabilities of Velox. 

## Impact
None

## Test Plan
Ran worker and cooridnator, printed logs inside dummy validator and observed it was printed.

```
== NO RELEASE NOTE ==
```

