### PR TITLE
[native] Update gtest targets

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -207,6 +207,7 @@ add_subdirectory(velox)
 if(PRESTO_ENABLE_TESTING)
   set(BUILD_TESTING ON) # some third-party dependency could have disabled this.
   include(CTest) # include after project() but before add_subdirectory()
+  find_package(GTest)
   include_directories(${VELOX_GTEST_INCUDE_DIR})
 else()
   add_definitions(-DVELOX_DISABLE_GOOGLETEST)

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -21,8 +21,8 @@ target_link_libraries(
   velox_exception
   velox_file
   ${RE2}
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)
 
 set_property(TARGET presto_common_test PROPERTY JOB_POOL_LINK
                                                 presto_link_job_pool)

--- a/presto-native-execution/presto_cpp/main/http/filters/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/filters/tests/CMakeLists.txt
@@ -17,5 +17,5 @@ add_test(
   COMMAND presto_http_filter_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(presto_http_filter_test http_filters presto_http gtest
-                      gtest_main)
+target_link_libraries(presto_http_filter_test http_filters presto_http
+                      GTest::gtest GTest::gtest_main)

--- a/presto-native-execution/presto_cpp/main/http/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/tests/CMakeLists.txt
@@ -16,7 +16,8 @@ add_test(
   COMMAND presto_http_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(presto_http_test presto_http gtest gtest_main)
+target_link_libraries(presto_http_test presto_http GTest::gtest
+                      GTest::gtest_main)
 
 set_property(TARGET presto_http_test PROPERTY JOB_POOL_LINK
                                               presto_link_job_pool)
@@ -29,5 +30,6 @@ if(PRESTO_ENABLE_JWT)
     COMMAND presto_http_jwt_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  target_link_libraries(presto_http_jwt_test presto_http gtest gtest_main)
+  target_link_libraries(presto_http_jwt_test presto_http GTest::gtest
+                        GTest::gtest_main)
 endif()

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -34,9 +34,9 @@ target_link_libraries(
   velox_exec
   velox_memory
   velox_exec
-  gmock
-  gtest
-  gtest_main)
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main)
 
 set_property(TARGET presto_operators_test PROPERTY JOB_POOL_LINK
                                                    presto_link_job_pool)

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/tests/CMakeLists.txt
@@ -16,4 +16,4 @@ add_test(
   COMMAND prometheus_reporter_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(prometheus_reporter_test velox_exec_test_lib
-                      prometheus_reporter gtest gtest_main)
+                      prometheus_reporter GTest::gtest GTest::gtest_main)

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -43,9 +43,9 @@ target_link_libraries(
   velox_aggregates
   velox_hive_partition_function
   ${RE2}
-  gmock
-  gtest
-  gtest_main)
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main)
 
 set_property(TARGET presto_server_test PROPERTY JOB_POOL_LINK
                                                 presto_link_job_pool)
@@ -64,7 +64,7 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
     presto_server_remote_function
     velox_expression
     velox_temp_path
-    gmock
-    gtest
-    gtest_main)
+    GTest::gmock
+    GTest::gtest
+    GTest::gtest_main)
 endif()

--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -16,8 +16,8 @@ add_test(presto_velox_split_test presto_velox_split_test)
 
 target_link_libraries(
   presto_velox_split_test
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   presto_operators
   presto_protocol
   velox_hive_connector
@@ -42,8 +42,8 @@ add_dependencies(presto_expressions_test presto_operators presto_protocol
 
 target_link_libraries(
   presto_expressions_test
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   $<TARGET_OBJECTS:presto_protocol>
   $<TARGET_OBJECTS:presto_type_converter>
   $<TARGET_OBJECTS:presto_types>
@@ -87,5 +87,5 @@ target_link_libraries(
   presto_types
   velox_hive_connector
   velox_tpch_connector
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
@@ -35,8 +35,8 @@ add_dependencies(presto_protocol_test presto_protocol)
 
 target_link_libraries(
   presto_protocol_test
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   $<TARGET_OBJECTS:presto_protocol>
   velox_type
   velox_encode


### PR DESCRIPTION
## Description
https://github.com/facebookincubator/velox/pull/10422 uses the latest gtest (1.15.2) installed from brew on MacOS, and as a follow-up, the `gtest` target needs to change accordingly in `presto_cpp`.

A fresh build is required, otherwise `gtest` still refers to the bundled-built 1.13 in `build_dir/_deps/gtest-*`.

```shell
[530/547] Linking CXX executable presto_cpp/main/operators/tests/presto_operators_test
FAILED: presto_cpp/main/operators/tests/presto_operators_test 
: && /opt/homebrew/opt/ccache/libexec/c++ -mcpu=apple-m1+crc -std=c++17 -fvisibility=hidden -Wno-nullability-completeness -Wno-deprecated-declarations -Wreorder -g -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  presto_cpp/presto_protocol/CMakeFiles/presto_protocol.dir/presto_protocol.cpp.o presto_cpp/presto_protocol/CMakeFiles/presto_protocol.dir/Base64Util.cpp.o presto_cpp/presto_protocol/CMakeFiles/presto_protocol.dir/DataSize.cpp.o presto_cpp/presto_protocol/CMakeFiles/presto_protocol.dir/Duration.cpp.o presto_cpp/presto_protocol/CMakeFiles/presto_protocol.dir/ConnectorProtocol.cpp.o presto_cpp/main/types/CMakeFiles/presto_type_converter.dir/TypeParser.cpp.o presto_cpp/main/types/CMakeFiles/presto_types.dir/PrestoToVeloxQueryPlan.cpp.o presto_cpp/main/types/CMakeFiles/presto_types.dir/PrestoToVeloxExpr.cpp.o presto_cpp/main/types/CMakeFiles/presto_types.dir/PrestoToVeloxPlanValidator.cpp.o presto_cpp/main/types/CMakeFiles/presto_types.dir/PrestoToVeloxSplit.cpp.o presto_cpp/main/types/CMakeFiles/presto_types.dir/PrestoToVeloxConnector.cpp.o presto_cpp/main/operators/tests/CMakeFiles/presto_operators_test.dir/PlanNodeSerdeTest.cpp.o presto_cpp/main/operators/tests/CMakeFiles/presto_operators_test.dir/UnsafeRowShuffleTest.cpp.o presto_cpp/main/operators/tests/CMakeFiles/presto_operators_test.dir/BroadcastTest.cpp.o -o presto_cpp/main/operators/tests/presto_operators_test  -Wl,-rpath,/opt/homebrew/lib  presto_cpp/main/operators/tests/libpresto_operators_plan_builder.a  presto_cpp/main/operators/libpresto_operators.a  velox/velox/vector/fuzzer/libvelox_vector_fuzzer.a  velox/velox/exec/tests/utils/libvelox_exec_test_lib.a  velox/velox/connectors/hive/libvelox_hive_partition_function.a  velox/velox/vector/tests/utils/libvelox_vector_test_lib.a  velox/velox/type/libvelox_type.a  velox/velox/vector/libvelox_vector.a  velox/velox/exec/libvelox_exec.a  velox/velox/common/memory/libvelox_memory.a  velox/velox/exec/libvelox_exec.a  -lgmock  -lgtest  /opt/homebrew/lib/libgtest_main.a  presto_cpp/main/common/libpresto_common.a  velox/velox/type/parser/libvelox_type_parser.a  velox/velox/exec/tests/utils/libvelox_temp_path.a  velox/velox/dwio/common/tests/utils/libvelox_dwio_common_test_utils.a  velox/velox/vector/tests/utils/libvelox_vector_test_lib.a  /opt/homebrew/lib/libgtest_main.a  velox/velox/type/fbhive/libvelox_type_fbhive.a  velox/velox/parse/libvelox_parse_parser.a  velox/velox/duckdb/conversion/libvelox_duckdb_parser.a  velox/velox/duckdb/conversion/libvelox_duckdb_conversion.a  velox/velox/parse/libvelox_parse_expression.a  velox/velox/parse/libvelox_parse_utils.a  velox/velox/functions/libvelox_function_registry.a  _deps/duckdb-build/src/libduckdb_static.a  _deps/duckdb-build/third_party/fsst/libduckdb_fsst.a  _deps/duckdb-build/third_party/fmt/libduckdb_fmt.a  _deps/duckdb-build/third_party/libpg_query/libduckdb_pg_query.a  _deps/duckdb-build/third_party/re2/libduckdb_re2.a  _deps/duckdb-build/third_party/miniz/libduckdb_miniz.a  _deps/duckdb-build/third_party/utf8proc/libduckdb_utf8proc.a  _deps/duckdb-build/third_party/hyperloglog/libduckdb_hyperloglog.a  _deps/duckdb-build/third_party/fastpforlib/libduckdb_fastpforlib.a  _deps/duckdb-build/third_party/mbedtls/libduckdb_mbedtls.a  /opt/homebrew/lib/libgtest.a  velox/velox/common/file/tests/libvelox_file_test_utils.a  velox/velox/connectors/hive/libvelox_hive_partition_function.a  velox/velox/dwio/dwrf/writer/libvelox_dwio_dwrf_writer.a  /opt/homebrew/lib/liblzo2.dylib  velox/velox/connectors/hive/iceberg/libvelox_hive_iceberg_splitreader.a  velox/velox/dwio/catalog/fbhive/libvelox_dwio_catalog_fbhive.a  velox/velox/dwio/orc/reader/libvelox_dwio_orc_reader.a  velox/velox/dwio/dwrf/reader/libvelox_dwio_dwrf_reader.a  velox/velox/dwio/dwrf/common/libvelox_dwio_dwrf_common.a  velox/velox/common/config/libvelox_common_config.a  velox/velox/dwio/dwrf/utils/libvelox_dwio_dwrf_utils.a  velox/velox/dwio/dwrf/proto/libvelox_dwio_dwrf_proto.a  velox/velox/dwio/parquet/libvelox_dwio_parquet_reader.a  velox/velox/dwio/parquet/reader/libvelox_dwio_native_parquet_reader.a  velox/velox/dwio/common/compression/libvelox_dwio_common_compression.a  velox/velox/dwio/parquet/thrift/libvelox_dwio_parquet_thrift.a  velox/velox/dwio/parquet/libvelox_dwio_parquet_writer.a  velox/velox/dwio/parquet/writer/libvelox_dwio_arrow_parquet_writer.a  velox/velox/dwio/parquet/writer/arrow/libvelox_dwio_arrow_parquet_writer_lib.a  velox/velox/dwio/common/libvelox_dwio_common.a  velox/velox/common/io/libvelox_common_io.a  velox/velox/dwio/common/encryption/libvelox_dwio_common_encryption.a  velox/velox/dwio/common/exception/libvelox_dwio_common_exception.a  _deps/protobuf-build/libprotobufd.a  velox/velox/dwio/parquet/writer/arrow/generated/libvelox_dwio_arrow_parquet_writer_thrift_lib.a  velox/velox/dwio/parquet/writer/arrow/util/libvelox_dwio_arrow_parquet_writer_util_lib.a  /opt/homebrew/lib/liblz4.dylib  /opt/homebrew/lib/libzstd.dylib  /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/libz.tbd  /opt/homebrew/lib/libsnappy.dylib  velox/CMake/resolve_dependency_modules/arrow/arrow_ep/install/lib/libarrow.a  /velox_dependency_install/lib/libre2.a  velox/CMake/resolve_dependency_modules/arrow/arrow_ep/src/arrow_ep-build/thrift_ep-install/lib/libthrift.a  velox/velox/connectors/hive/storage_adapters/s3fs/libvelox_s3fs.a  velox/velox/connectors/hive/storage_adapters/hdfs/libvelox_hdfs.a  velox/velox/connectors/hive/storage_adapters/gcs/libvelox_gcs.a  velox/velox/connectors/hive/storage_adapters/abfs/libvelox_abfs.a  velox/velox/tpch/gen/libvelox_tpch_gen.a  velox/velox/tpch/gen/dbgen/libdbgen.a  velox/velox/functions/prestosql/registration/libvelox_functions_prestosql.a  velox/velox/functions/prestosql/libvelox_functions_prestosql_impl.a  velox/velox/external/md5/libvelox_external_md5.a  velox/velox/functions/prestosql/types/libvelox_presto_types.a  velox/velox/functions/prestosql/json/libvelox_functions_json.a  velox/velox/functions/lib/libvelox_functions_lib_date_time_formatter.a  _deps/libstemmer/src/libstemmer/libstemmer.a  velox/velox/functions/lib/libvelox_is_null_functions.a  _deps/simdjson-build/libsimdjson.a  velox/velox/functions/prestosql/aggregates/libvelox_aggregates.a  velox/velox/common/hyperloglog/libvelox_common_hyperloglog.a  velox/velox/functions/lib/aggregates/libvelox_functions_aggregates.a  velox/velox/exec/libvelox_exec.a  velox/velox/expression/libvelox_expression.a  velox/velox/core/libvelox_core.a  velox/velox/common/caching/libvelox_caching.a  velox/velox/expression/libvelox_expression_functions.a  velox/velox/expression/type_calculation/libvelox_type_calculation.a  velox/velox/expression/signature_parser/libvelox_signature_parser.a  /velox_dependency_install/lib/libdouble-conversion.a  velox/velox/connectors/libvelox_connector.a  velox/velox/core/libvelox_config.a  velox/velox/vector/arrow/libvelox_arrow_bridge.a  velox/velox/serializers/libvelox_presto_serializer.a  velox/velox/row/libvelox_row_fast.a  velox/velox/functions/lib/libvelox_functions_lib.a  velox/velox/functions/lib/libvelox_functions_util.a  velox/velox/vector/libvelox_vector.a  velox/velox/buffer/libvelox_buffer.a  velox/velox/common/memory/libvelox_memory.a  velox/velox/type/libvelox_type.a  velox/velox/type/tz/libvelox_type_tz.a  velox/velox/common/encode/libvelox_encode.a  velox/velox/common/serialization/libvelox_serialization.a  velox/velox/external/date/libvelox_external_date.a  velox/velox/common/base/libvelox_status.a  /velox_dependency_install/lib/libre2.a  velox/velox/common/time/libvelox_time.a  velox/velox/common/base/libvelox_exception.a  velox/velox/common/base/libvelox_common_base.a  velox/velox/common/file/libvelox_file.a  velox/velox/common/testutil/libvelox_test_util.a  velox/velox/common/compression/libvelox_common_compression.a  velox/velox/common/process/libvelox_process.a  velox/velox/common/base/libvelox_exception.a  velox/velox/common/base/libvelox_common_base.a  velox/velox/common/file/libvelox_file.a  velox/velox/common/testutil/libvelox_test_util.a  velox/velox/common/compression/libvelox_common_compression.a  velox/velox/common/process/libvelox_process.a  /velox_dependency_install/lib/libfolly.a  /opt/homebrew/lib/libboost_regex-mt.dylib  /opt/homebrew/lib/libboost_context-mt.dylib  /opt/homebrew/lib/libboost_filesystem-mt.dylib  /opt/homebrew/lib/libboost_atomic-mt.dylib  /opt/homebrew/lib/libboost_program_options-mt.dylib  /opt/homebrew/lib/libboost_system-mt.dylib  /opt/homebrew/lib/libboost_thread-mt.dylib  /velox_dependency_install/lib/libdouble-conversion.a  /opt/homebrew/lib/libgflags.2.2.2.dylib  /opt/homebrew/lib/libglog.dylib  /opt/homebrew/lib/libevent.dylib  /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/libz.tbd  /opt/homebrew/Cellar/openssl@3/3.3.1/lib/libssl.dylib  /opt/homebrew/Cellar/openssl@3/3.3.1/lib/libcrypto.dylib  /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/libbz2.tbd  /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/liblzma.tbd  /opt/homebrew/lib/liblz4.dylib  /opt/homebrew/lib/libzstd.dylib  /opt/homebrew/lib/libsnappy.dylib  /opt/homebrew/lib/libsodium.dylib  -lc++abi  /velox_dependency_install/lib/libfmt.a  /opt/homebrew/lib/libgflags.2.2.2.dylib  /opt/homebrew/lib/libglog.dylib  /opt/homebrew/lib/libgtest.a && :
ld: library 'gmock' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)

ninja: build stopped: subcommand failed.

```

```
== NO RELEASE NOTE ==
```

