### PR TITLE
Minor fix in Iceberg Connector Docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -491,14 +491,16 @@ JMX queries to get the metrics and verify the cache usage::
 
     SELECT * FROM jmx.current."com.facebook.presto.hive:name=iceberg_parquetmetadata,type=cachestatsmbean";
 
-Metastore Versioned Cache
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Metastore Cache
+^^^^^^^^^^^^^^^
 
-Metastore cache only caches schema and table names. Other metadata would be fetched from the filesystem.
+Metastore Cache only caches the schema, table, and table statistics. The table object cached in the `tableCache`
+is only used for reading the table metadata location and table properties and, the rest of the table metadata
+is fetched from the filesystem/object storage metadata location.
 
 .. note::
 
-    Metastore Versioned Cache would be applicable only for Hive Catalog in the Presto Iceberg connector.
+    Metastore Cache would be applicable only for Hive Catalog in the Presto Iceberg connector.
 
 .. code-block:: none
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Current metastore implementations in Presto don't support partition versioning yet. So, I fixed the cache name from `Metastore Versioned Cache` to `Metastore Cache` in Iceberg docs.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
N.A.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No user impact

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

