### PR TITLE
[native] Fix Meta internal build caused by folly::StringPiece

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -285,25 +285,25 @@ class HiveConnectorStatsReporter {
       std::shared_ptr<velox::connector::hive::HiveConnector> connector)
       : connector_(std::move(connector)),
         numElementsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumElementsFormat.toString(),
+            kCounterHiveFileHandleCacheNumElementsFormat,
             connector_->connectorId())),
         pinnedSizeMetricName_(fmt::format(
-            kCounterHiveFileHandleCachePinnedSizeFormat.toString(),
+            kCounterHiveFileHandleCachePinnedSizeFormat,
             connector_->connectorId())),
         curSizeMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheCurSizeFormat.toString(),
+            kCounterHiveFileHandleCacheCurSizeFormat,
             connector_->connectorId())),
         numAccumulativeHitsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumAccumulativeHitsFormat.toString(),
+            kCounterHiveFileHandleCacheNumAccumulativeHitsFormat,
             connector_->connectorId())),
         numAccumulativeLookupsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumAccumulativeLookupsFormat.toString(),
+            kCounterHiveFileHandleCacheNumAccumulativeLookupsFormat,
             connector_->connectorId())),
         numHitsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumHitsFormat.toString(),
+            kCounterHiveFileHandleCacheNumHitsFormat,
             connector_->connectorId())),
         numLookupsMetricName_(fmt::format(
-            kCounterHiveFileHandleCacheNumLookupsFormat.toString(),
+            kCounterHiveFileHandleCacheNumLookupsFormat,
             connector_->connectorId())) {
     DEFINE_METRIC(numElementsMetricName_, velox::StatType::AVG);
     DEFINE_METRIC(pinnedSizeMetricName_, velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -139,21 +139,20 @@ constexpr folly::StringPiece kCounterOsNumForcedContextSwitches{
 
 /// Format template strings use 'constexpr std::string_view' to be 'fmt::format'
 /// compatible.
-constexpr folly::StringPiece kCounterHiveFileHandleCacheNumElementsFormat{
+constexpr std::string_view kCounterHiveFileHandleCacheNumElementsFormat{
     "presto_cpp.{}.hive_file_handle_cache_num_elements"};
-constexpr folly::StringPiece kCounterHiveFileHandleCachePinnedSizeFormat{
+constexpr std::string_view kCounterHiveFileHandleCachePinnedSizeFormat{
     "presto_cpp.{}.hive_file_handle_cache_pinned_size"};
-constexpr folly::StringPiece kCounterHiveFileHandleCacheCurSizeFormat{
+constexpr std::string_view kCounterHiveFileHandleCacheCurSizeFormat{
     "presto_cpp.{}.hive_file_handle_cache_cur_size"};
-constexpr folly::StringPiece
-    kCounterHiveFileHandleCacheNumAccumulativeHitsFormat{
-        "presto_cpp.{}.hive_file_handle_cache_num_accumulative_hits"};
-constexpr folly::StringPiece
+constexpr std::string_view kCounterHiveFileHandleCacheNumAccumulativeHitsFormat{
+    "presto_cpp.{}.hive_file_handle_cache_num_accumulative_hits"};
+constexpr std::string_view
     kCounterHiveFileHandleCacheNumAccumulativeLookupsFormat{
         "presto_cpp.{}.hive_file_handle_cache_num_accumulative_lookups"};
-constexpr folly::StringPiece kCounterHiveFileHandleCacheNumHitsFormat{
+constexpr std::string_view kCounterHiveFileHandleCacheNumHitsFormat{
     "presto_cpp.{}.hive_file_handle_cache_num_hits"};
-constexpr folly::StringPiece kCounterHiveFileHandleCacheNumLookupsFormat{
+constexpr std::string_view kCounterHiveFileHandleCacheNumLookupsFormat{
     "presto_cpp.{}.hive_file_handle_cache_num_lookups"};
 
 /// ================== Memory Pushback Counters =================


### PR DESCRIPTION
folly::StringPiece is not compatible with fmt::format(). Change it back to std::string_view
```
== NO RELEASE NOTE ==
```

