### PR TITLE
Make hashCode consistent with equals

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilter.java
@@ -1435,7 +1435,7 @@ public interface TupleDomainFilter
         @Override
         public int hashCode()
         {
-            return Objects.hash(Arrays.hashCode(values), nullAllowed);
+            return Objects.hash(Arrays.deepHashCode(values), nullAllowed);
         }
 
         @Override


### PR DESCRIPTION
## Description
equals uses deepEquals on values. hashCode should too

## Motivation and Context
bug

## Impact
none

## Test Plan
mvn test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

