### PR TITLE
[docs] Fix formatting in rest/node.rst and statement.rst

### DIFF
--- a/presto-docs/src/main/sphinx/rest/node.rst
+++ b/presto-docs/src/main/sphinx/rest/node.rst
@@ -25,26 +25,25 @@ Node Resource
 
    **Example response**:
 
-      .. sourcecode:: http
+   .. sourcecode:: http
 
-         HTTP/1.1 200 OK
-         Vary: Accept
-         Content-Type: text/javascript
+      HTTP/1.1 200 OK
+      Vary: Accept
+      Content-Type: text/javascript
 
-         [
-	   {
-       	     "uri":"http://10.209.57.156:8080",
-	     "recentRequests":25.181940555111073,
-	     "recentFailures":0.0,
-	     "recentSuccesses":25.195472984170983,
-	     "lastRequestTime":"2013-12-22T13:32:44.673-05:00",
-	     "lastResponseTime":"2013-12-22T13:32:44.677-05:00",
-	     "age":"14155.28ms",
-	     "recentFailureRatio":0.0,
-	     "recentFailuresByType":{}
-	   }
-	 ]
-
+      [
+         {
+            "uri":"http://10.209.57.156:8080",
+            "recentRequests":25.181940555111073,
+            "recentFailures":0.0,
+            "recentSuccesses":25.195472984170983,
+            "lastRequestTime":"2013-12-22T13:32:44.673-05:00",
+            "lastResponseTime":"2013-12-22T13:32:44.677-05:00",
+            "age":"14155.28ms",
+            "recentFailureRatio":0.0,
+            "recentFailuresByType":{}
+         }
+      ]
 
    If a node is experiencing errors, you'll see a response that looks
    like the following. Here we have a node which has experienced a
@@ -53,37 +52,37 @@ Node Resource
 
    **Example response with Errors**:
 
-      .. sourcecode:: http
-        
-        HTTP/1.1 200 OK
-        Vary: Accept
-        Content-Type: text/javascript
+   .. sourcecode:: http
 
-        [
-            {
-                "age": "4.45m",
-                "lastFailureInfo": {
-                    "message": "Connect Timeout",
-                    "stack": [
-                        "org.eclipse.jetty.io.ManagedSelector$ConnectTimeout.run(ManagedSelector.java:683)",
-                        ....
-                        "java.lang.Thread.run(Thread.java:745)"
-                    ],
-                    "suppressed": [],
-                    "type": "java.net.SocketTimeoutException"
-                },
-                "lastRequestTime": "2017-08-05T11:53:00.647Z",
-                "lastResponseTime": "2017-08-05T11:53:00.647Z",
-                "recentFailureRatio": 0.47263053472046446,
-                "recentFailures": 2.8445543205610617,
-                "recentFailuresByType": {
-                    "java.net.SocketTimeoutException": 2.8445543205610617
-                },
-                "recentRequests": 6.018558073577414,
-                "recentSuccesses": 3.1746446343010297,
-                "uri": "http://172.19.0.3:8080"
-            }
-        ]
+      HTTP/1.1 200 OK
+      Vary: Accept
+      Content-Type: text/javascript
+
+      [
+         {
+            "age": "4.45m",
+            "lastFailureInfo": {
+                "message": "Connect Timeout",
+                "stack": [
+                    "org.eclipse.jetty.io.ManagedSelector$ConnectTimeout.run(ManagedSelector.java:683)",
+                    ....
+                    "java.lang.Thread.run(Thread.java:745)"
+                ],
+                "suppressed": [],
+                "type": "java.net.SocketTimeoutException"
+            },
+            "lastRequestTime": "2017-08-05T11:53:00.647Z",
+            "lastResponseTime": "2017-08-05T11:53:00.647Z",
+            "recentFailureRatio": 0.47263053472046446,
+            "recentFailures": 2.8445543205610617,
+            "recentFailuresByType": {
+                "java.net.SocketTimeoutException": 2.8445543205610617
+            },
+            "recentRequests": 6.018558073577414,
+            "recentSuccesses": 3.1746446343010297,
+            "uri": "http://172.19.0.3:8080"
+         }
+      ]
 
 .. function:: GET /v1/node/failed
 
@@ -94,35 +93,35 @@ Node Resource
 
    **Example response**:
 
-      .. sourcecode:: http
+   .. sourcecode:: http
 
-        HTTP/1.1 200 OK
-        Vary: Accept
-        Content-Type: text/javascript
+      HTTP/1.1 200 OK
+      Vary: Accept
+      Content-Type: text/javascript
 
-        [
-            {
-                "age": "1.37m",
-                "lastFailureInfo": {
-                    "message": "Connect Timeout",
-                    "stack": [
-                        "org.eclipse.jetty.io.ManagedSelector$ConnectTimeout.run(ManagedSelector.java:683)",
-                        .....
-                        "java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)",
-                        "java.lang.Thread.run(Thread.java:745)"
-                    ],
-                    "suppressed": [],
-                    "type": "java.net.SocketTimeoutException"
-                },
-                "lastRequestTime": "2017-08-05T11:52:42.647Z",
-                "lastResponseTime": "2017-08-05T11:52:42.647Z",
-                "recentFailureRatio": 0.22498784153043677,
-                "recentFailures": 20.11558290058638,
-                "recentFailuresByType": {
-                    "java.net.SocketTimeoutException": 20.11558290058638
-                },
-                "recentRequests": 89.40742203558189,
-                "recentSuccesses": 69.30583024727453,
-                "uri": "http://172.19.0.3:8080"
-            }
-        ]
+      [
+         {
+            "age": "1.37m",
+            "lastFailureInfo": {
+                "message": "Connect Timeout",
+                "stack": [
+                    "org.eclipse.jetty.io.ManagedSelector$ConnectTimeout.run(ManagedSelector.java:683)",
+                    ....
+                    "java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)",
+                    "java.lang.Thread.run(Thread.java:745)"
+                ],
+                "suppressed": [],
+                "type": "java.net.SocketTimeoutException"
+            },
+            "lastRequestTime": "2017-08-05T11:52:42.647Z",
+            "lastResponseTime": "2017-08-05T11:52:42.647Z",
+            "recentFailureRatio": 0.22498784153043677,
+            "recentFailures": 20.11558290058638,
+            "recentFailuresByType": {
+                "java.net.SocketTimeoutException": 20.11558290058638
+            },
+            "recentRequests": 89.40742203558189,
+            "recentSuccesses": 69.30583024727453,
+            "uri": "http://172.19.0.3:8080"
+         }
+      ]

--- a/presto-docs/src/main/sphinx/rest/statement.rst
+++ b/presto-docs/src/main/sphinx/rest/statement.rst
@@ -34,89 +34,88 @@ Statement Resource
 
    **Example request**:
 
-      .. sourcecode:: http
+   .. sourcecode:: http
 
-         POST /v1/statement HTTP/1.1
-	 Host: localhost:8001
-	 X-Presto-Catalog: jmx
-	 X-Presto-Source: presto-cli
-	 X-Presto-Schema: jmx
-	 User-Agent: StatementClient/0.55-SNAPSHOT
-	 X-Presto-User: tobrie1
-	 Content-Length: 41
+      POST /v1/statement HTTP/1.1
+      Host: localhost:8001
+      X-Presto-Catalog: jmx
+      X-Presto-Source: presto-cli
+      X-Presto-Schema: jmx
+      User-Agent: StatementClient/0.55-SNAPSHOT
+      X-Presto-User: tobrie1
+      Content-Length: 41
 
-	 select name from "java.lang:type=runtime"
+      select name from "java.lang:type=runtime"  
 
    **Example response**:
 
-      .. sourcecode:: http
+   .. sourcecode:: http
 
-         HTTP/1.1 200 OK
- 	 Content-Type: application/json
-	 X-Content-Type-Options: nosniff
-	 Transfer-Encoding: chunked
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+      X-Content-Type-Options: nosniff
+      Transfer-Encoding: chunked
 
-	 {
-	    "id":"20140108_110629_00011_dk5x2",
-	    "infoUri":"http://localhost:8001/v1/query/20140108_110629_00011_dk5x2",
-	    "partialCancelUri":"http://10.193.207.128:8080/v1/stage/20140108_110629_00011_dk5x2.1",
-	    "nextUri":"http://localhost:8001/v1/statement/20140108_110629_00011_dk5x2/1",
-	    "columns":
-	    [
-	       {
-	          "name":"name",
-		  "type":"varchar"
-	       }
-            ],
-	    "stats":
-	    {
-	       "state":"RUNNING",
-	       "scheduled":false,
-	       "nodes":1,
-	       "totalSplits":0,
-	       "queuedSplits":0,
-	       "runningSplits":0,
-	       "completedSplits":0,
-	       "cpuTimeMillis":0,
-	       "wallTimeMillis":0,
-	       "processedRows":0,
-	       "processedBytes":0,
-	       "rootStage":
-	       {
-	          "stageId":"0",
-	          "state":"SCHEDULED",
-	          "done":false,
-	          "nodes":1,
-	          "totalSplits":0,
-	          "queuedSplits":0,
-	          "runningSplits":0,
-	          "completedSplits":0,
-	          "cpuTimeMillis":0,
-	          "wallTimeMillis":0,
-	          "processedRows":0,
-	          "processedBytes":0,
-	          "subStages":
-		  [
-		     {
-		        "stageId":"1",
-			"state":"SCHEDULED",
-			"done":false,
-			"nodes":1,
-			"totalSplits":0,
-			"queuedSplits":0,
-			"runningSplits":0,
-			"completedSplits":0,
-			"cpuTimeMillis":0,
-			"wallTimeMillis":0,
-			"processedRows":0,
-			"processedBytes":0,
-			"subStages":[]
-		     }
-		  ]
-	       }
-	    }
-	 }
-
+      {
+        "id":"20140108_110629_00011_dk5x2",
+        "infoUri":"http://localhost:8001/v1/query/20140108_110629_00011_dk5x2",
+        "partialCancelUri":"http://10.193.207.128:8080/v1/stage/20140108_110629_00011_dk5x2.1",
+        "nextUri":"http://localhost:8001/v1/statement/20140108_110629_00011_dk5x2/1",
+        "columns":
+        [
+            {
+              "name":"name",
+              "type":"varchar"
+            }
+        ],
+        "stats":
+        {
+           "state":"RUNNING",
+           "scheduled":false,
+           "nodes":1,
+           "totalSplits":0,
+           "queuedSplits":0,
+           "runningSplits":0,
+           "completedSplits":0,
+           "cpuTimeMillis":0,
+           "wallTimeMillis":0,
+           "processedRows":0,
+           "processedBytes":0,
+           "rootStage":
+           {
+              "stageId":"0",
+              "state":"SCHEDULED",
+              "done":false,
+              "nodes":1,
+              "totalSplits":0,
+              "queuedSplits":0,
+              "runningSplits":0,
+              "completedSplits":0,
+              "cpuTimeMillis":0,
+              "wallTimeMillis":0,
+              "processedRows":0,
+              "processedBytes":0,
+              "subStages":
+              [
+                 {
+                    "stageId":"1",
+                    "state":"SCHEDULED",
+                    "done":false,
+                    "nodes":1,
+                    "totalSplits":0,
+                    "queuedSplits":0,
+                    "runningSplits":0,
+                    "completedSplits":0,
+                    "cpuTimeMillis":0,
+                    "wallTimeMillis":0,
+                    "processedRows":0,
+                    "processedBytes":0,
+                    "subStages":[]
+                 }
+              ]
+           }
+        }
+      }
 
 .. function:: GET /v1/statement/{queryId}/{token}
 
@@ -131,85 +130,85 @@ Statement Resource
 
    **Example request**:
 
-      .. sourcecode:: http
+   .. sourcecode:: http
 
-         GET /v1/statement/20140108_110629_00011_dk5x2/1 HTTP/1.1
-         Host: localhost:8001
-         User-Agent: StatementClient/0.55-SNAPSHOT
+      GET /v1/statement/20140108_110629_00011_dk5x2/1 HTTP/1.1
+      Host: localhost:8001
+      User-Agent: StatementClient/0.55-SNAPSHOT
 
    **Example response**:
 
-      .. sourcecode:: http
+   .. sourcecode:: http
 
-         HTTP/1.1 200 OK
-	 Content-Type: application/json
-	 X-Content-Type-Options: nosniff
-	 Vary: Accept-Encoding, User-Agent
-	 Transfer-Encoding: chunked
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+      X-Content-Type-Options: nosniff
+      Vary: Accept-Encoding, User-Agent
+      Transfer-Encoding: chunked
 
-	 383
-	 {
-	    "id":"20140108_110629_00011_dk5x2",
-	    "infoUri":"http://localhost:8001/v1/query/20140108_110629_00011_dk5x2",
-	    "columns":
-	    [
-	       {
-	          "name":"name",
-		  "type":"varchar"
-	       }
-            ],
-	    "data":
-	    [
-	       ["4165@domU-12-31-39-0F-CC-72"]
-	    ],
-	    "stats":
-	    {
-	       "state":"FINISHED",
-	       "scheduled":true,
-	       "nodes":1,
-	       "totalSplits":2,
-	       "queuedSplits":0,
-	       "runningSplits":0,
-	       "completedSplits":2,
-	       "cpuTimeMillis":1,
-	       "wallTimeMillis":4,
-	       "processedRows":1,
-	       "processedBytes":27,
-	       "rootStage":
-	       {
-	          "stageId":"0",
-		  "state":"FINISHED",
-		  "done":true,
-		  "nodes":1,
-		  "totalSplits":1,
-		  "queuedSplits":0,
-		  "runningSplits":0,
-		  "completedSplits":1,
-		  "cpuTimeMillis":0,
-		  "wallTimeMillis":0,
-		  "processedRows":1,
-		  "processedBytes":32,
-		  "subStages":
-		  [
-		     {
-		        "stageId":"1",
-			"state":"FINISHED",
-			"done":true,
-			"nodes":1,
-			"totalSplits":1,
-			"queuedSplits":0,
-			"runningSplits":0,
-			"completedSplits":1,
-			"cpuTimeMillis":0,
-			"wallTimeMillis":4,
-			"processedRows":1,
-			"processedBytes":27,
-			"subStages":[]
-		     }
-		  ]
-	       }
-	    }
-	 }
+      383
+      {
+        "id":"20140108_110629_00011_dk5x2",
+        "infoUri":"http://localhost:8001/v1/query/20140108_110629_00011_dk5x2",
+        "columns":
+        [
+           {
+              "name":"name",
+              "type":"varchar"
+           }
+        ],
+        "data":
+        [
+           ["4165@domU-12-31-39-0F-CC-72"]
+        ],
+        "stats":
+        {
+           "state":"FINISHED",
+           "scheduled":true,
+           "nodes":1,
+           "totalSplits":2,
+           "queuedSplits":0,
+           "runningSplits":0,
+           "completedSplits":2,
+           "cpuTimeMillis":1,
+           "wallTimeMillis":4,
+           "processedRows":1,
+           "processedBytes":27,
+           "rootStage":
+           {
+              "stageId":"1",
+              "state":"FINISHED",
+              "done":true,
+              "nodes":1,
+              "totalSplits":1,
+              "queuedSplits":0,
+              "runningSplits":0,
+              "completedSplits":1,
+              "cpuTimeMillis":0,
+              "wallTimeMillis":0,
+              "processedRows":1,
+              "processedBytes":32,
+              "subStages":
+              [
+                  {
+                    "stageId":"1",
+                    "state":"FINISHED",
+                    "done":true,
+                    "nodes":1,
+                    "totalSplits":1,
+                    "queuedSplits":0,
+                    "runningSplits":0,
+                    "completedSplits":1,
+                    "cpuTimeMillis":0,
+                    "wallTimeMillis":4,
+                    "processedRows":1,
+                    "processedBytes":27,
+                    "subStages":[]
+                 }
+              ]
+           }
+        }
+      }
 
 .. function:: DELETE /v1/statement/{queryId}/{token}
 


### PR DESCRIPTION
## Description
Fix formatting of `.. sourcecode:: http` blocks in [rest/node.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/rest/node.rst) and [rest/statement.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/rest/statement.rst) to remove vertical gray bars in the left margin that are present due to indenting issues in the files. 

## Motivation and Context
Improves the visual consistency of the docs, builds on related work such as in #22777. 

## Impact
Documentation.

## Test Plan
Local doc builds. So many local doc builds. 

Screenshot before: 
<img width="491" alt="Screenshot 2024-08-14 at 2 28 07 PM" src="https://github.com/user-attachments/assets/b9a1cad6-62fa-4b0a-bed1-bba46d759d94">

Screenshot after: 
<img width="770" alt="Screenshot 2024-08-14 at 2 27 59 PM" src="https://github.com/user-attachments/assets/607cc72a-029d-42aa-a705-17fcba6cba47">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

