### PR TITLE
Improve correctness of stddev and variance with partial aggregation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
@@ -217,9 +217,15 @@ public final class AggregationUtils
         if (count == 0) {
             return;
         }
+        if (state.getCount() == 0) {
+            state.setCount(count);
+            state.setMean(mean);
+            state.setM2(m2);
+            return;
+        }
         long newCount = count + state.getCount();
-        double newMean = ((count * mean) + (state.getCount() * state.getMean())) / (double) newCount;
         double delta = mean - state.getMean();
+        double newMean = state.getMean() + delta / newCount * count;
         state.setM2(state.getM2() + m2 + delta * delta * count * state.getCount() / (double) newCount);
         state.setCount(newCount);
         state.setMean(newMean);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1238,6 +1238,30 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testZeroVarianceSamp()
+    {
+        assertQuery("SELECT VAR_SAMP(6523763181031200) FROM LINEITEM");
+    }
+
+    @Test
+    public void testZeroVariancePop()
+    {
+        assertQuery("SELECT VAR_POP(6523763181031200) FROM LINEITEM");
+    }
+
+    @Test
+    public void testZeroStddevSamp()
+    {
+        assertQuery("SELECT STDDEV_SAMP(6523763181031200) FROM LINEITEM");
+    }
+
+    @Test
+    public void testZeroStddevPop()
+    {
+        assertQuery("SELECT STDDEV_POP(6523763181031200) FROM LINEITEM");
+    }
+
+    @Test
     public void testVariancePop()
     {
         // int64


### PR DESCRIPTION
## Description
When merging varianceStates for partial aggregation, if the current state has zero rows, use the values from the other state without doing computation. This prevents introducing error due to imprecision in floating point numbers.

Additionally, change the way we combine means. This ensures that we do not introduce error due to imprecision in multiplication/division when the delta is 0. I think it should in general improve the error introduced by the mean computation, but I don't have a rigorous proof or even experimental data for this.

## Motivation and Context
Queries with 0 variance on large values can return inconsistent and incorrect stddev due to error introduced by floating point arithmetic.  For example, see the following result for a stddev and variance computations over a constant.
```
presto> SELECT count(*), stddev(6523763181031200), variance(6523763181031200) from test_table;
  _col0   |       _col1        |      _col2       
----------+--------------------+------------------
 61782553 | 2.2677238191332383 | 5.14257131986424 
(1 row)
```

that same query with partial aggregation disabled returns correct results
```

presto> set session prefer_partial_aggregation=false;
SET SESSION           
presto> SELECT count(*), stddev(6523763181031200), variance(6523763181031200) from test_table;
  _col0   | _col1 | _col2 
----------+-------+-------
 61782553 |   0.0 |   0.0 
(1 row)
```

This change reduces the amount of error we introduce in merging variance states during partial aggregation for certain cases to improve the accuracy of our variance and stddev functions.

## Impact
Ensures that when variance or stddev is zero, results are always correct, and reduces the error we introduce for other cases. 

## Test Plan
new unit tests
production verifier run  (in progress)

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve stddev and variance functions to always return correct results when input is constant. :pr:`23447`
```

