### PR TITLE
Use the JVM timezone in HiveQueryRunner

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -65,7 +65,7 @@ import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tests.QueryAssertions.copyTables;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static java.util.Locale.ENGLISH;
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 public final class HiveQueryRunner
 {
@@ -83,7 +83,6 @@ public final class HiveQueryRunner
     public static final String TPCDS_BUCKETED_SCHEMA = "tpcds_bucketed";
     public static final MetastoreContext METASTORE_CONTEXT = new MetastoreContext("test_user", "test_queryId", Optional.empty(), Collections.emptySet(), Optional.empty(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER, WarningCollector.NOOP, new RuntimeStats());
     private static final String TEMPORARY_TABLE_SCHEMA = "__temporary_tables__";
-    private static final DateTimeZone TIME_ZONE = DateTimeZone.forID("America/Bahia_Banderas");
 
     public static DistributedQueryRunner createQueryRunner(TpchTable<?>... tables)
             throws Exception
@@ -186,7 +185,9 @@ public final class HiveQueryRunner
             boolean addJmxPlugin)
             throws Exception
     {
-        assertEquals(DateTimeZone.getDefault(), TIME_ZONE, "Timezone not configured correctly. Add -Duser.timezone=America/Bahia_Banderas to your JVM arguments");
+        DateTimeZone timeZone = DateTimeZone.getDefault();
+        assertNotNull(timeZone, "Timezone not configured correctly. Add -Duser.timezone=America/Bahia_Banderas to your JVM arguments");
+
         setupLogging();
 
         Map<String, String> systemProperties = ImmutableMap.<String, String>builder()
@@ -228,7 +229,7 @@ public final class HiveQueryRunner
 
             Map<String, String> hiveProperties = ImmutableMap.<String, String>builder()
                     .putAll(extraHiveProperties)
-                    .put("hive.time-zone", TIME_ZONE.getID())
+                    .put("hive.time-zone", timeZone.getID())
                     .put("hive.security", security)
                     .put("hive.max-partitions-per-scan", "1000")
                     .put("hive.assume-canonical-partition-keys", "true")


### PR DESCRIPTION
## Description
`HiveMetaData` only checks the JVM time zone:
https://github.com/prestodb/presto/blob/4f74f52f36709944ba9eea18b0559ec7dd691d36/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java#L3375

The `TIME_ZONE` constant in `HiveQueryRunner` does not work when the time zone was set differently. In other words, the `TIME_ZONE` constant is useless, thus removing it.
https://github.com/prestodb/presto/blob/4f74f52f36709944ba9eea18b0559ec7dd691d36/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java#L86

On the other hand, per #8713, feeding `-Duser.timezone=America/Bahia_Banderas` as a JVM argument should work, but still sees the assertion failure below. Do NOT know why.

## Motivation and Context
Before this PR, running `HiveExternalWorkerQueryRunner` would fail on a machine w/ a different time zone, even w/ adding `-Duser.timezone=America/Bahia_Banderas` as a JVM argument in IntelliJ IDEA.
```sh
2024-08-16T08:15:40.224+0800	INFO	main	stderr	Exception in thread "main" 
2024-08-16T08:15:40.224+0800	INFO	main	stderr	java.lang.AssertionError: Timezone not configured correctly. Add -Duser.timezone=America/Bahia_Banderas to your JVM arguments expected [America/Bahia_Banderas] but found [Asia/Seoul]
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at org.testng.Assert.fail(Assert.java:110)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at org.testng.Assert.failNotEquals(Assert.java:1413)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at org.testng.Assert.assertEqualsImpl(Assert.java:149)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at org.testng.Assert.assertEquals(Assert.java:131)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at com.facebook.presto.hive.HiveQueryRunner.createQueryRunner(HiveQueryRunner.java:189)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at com.facebook.presto.hive.HiveQueryRunner.createQueryRunner(HiveQueryRunner.java:161)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at com.facebook.presto.hive.HiveQueryRunner.createQueryRunner(HiveQueryRunner.java:145)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at com.facebook.presto.hive.HiveQueryRunner.createQueryRunner(HiveQueryRunner.java:130)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createJavaQueryRunner(PrestoNativeQueryRunnerUtils.java:138)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createJavaQueryRunner(PrestoNativeQueryRunnerUtils.java:121)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createJavaQueryRunner(PrestoNativeQueryRunnerUtils.java:115)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createJavaQueryRunner(PrestoNativeQueryRunnerUtils.java:103)
2024-08-16T08:15:40.225+0800	INFO	main	stderr		at com.facebook.presto.nativeworker.HiveExternalWorkerQueryRunner.main(HiveExternalWorkerQueryRunner.java:32)
```


```
== NO RELEASE NOTE ==
```

