### PR TITLE
Fix failure with enabling JDBC autocommit

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -187,10 +187,11 @@ public class PrestoConnection
             throws SQLException
     {
         checkOpen();
-        boolean wasAutoCommit = this.autoCommit.getAndSet(autoCommit);
+        boolean wasAutoCommit = this.autoCommit.get();
         if (autoCommit && !wasAutoCommit) {
             commit();
         }
+        this.autoCommit.set(autoCommit);
     }
 
     @Override


### PR DESCRIPTION
## Description
There was a bug where enabling autocommit when it had previously been false would cause failure like:
java.sql.SQLException: Connection is in auto-commit mode

This was due to calling commit() from setAutoCommit() after autocommit had already been changed to true.
## Motivation and Context
Fixes #15916

## Impact
Fixes a failure when using JDBC when setting AutoCommit from false to true
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
unit test
## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

JDBC Changes
* Fix failure when setting autoCommit from false to true :pr:`23453`

