### PR TITLE
Unescape like pattern, and check for one character escape string when in row expression interpreter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -922,7 +922,8 @@ public class RowExpressionInterpreter
                 // this corresponds to ExpressionInterpreter::getConstantPattern
                 if (hasEscape) {
                     // like_pattern(pattern, escape)
-                    possibleCompiledPattern = functionInvoker.invoke(((CallExpression) possibleCompiledPattern).getFunctionHandle(), session.getSqlFunctionProperties(), nonCompiledPattern, escape);
+                    Slice unescapedPattern = unescapeLiteralLikePattern((Slice) nonCompiledPattern, (Slice) escape);
+                    possibleCompiledPattern = functionInvoker.invoke(((CallExpression) possibleCompiledPattern).getFunctionHandle(), session.getSqlFunctionProperties(), unescapedPattern, escape);
                 }
                 else {
                     // like_pattern(pattern)

--- a/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
@@ -149,6 +149,7 @@ public final class LikeFunctions
         }
 
         String stringEscape = escape.toStringUtf8();
+        checkCondition(stringEscape.length() == 1, INVALID_FUNCTION_ARGUMENT, "Escape string must be a single character");
         char escapeChar = stringEscape.charAt(0);
         String stringPattern = pattern.toStringUtf8();
         StringBuilder unescapedPattern = new StringBuilder(stringPattern.length());

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestConditions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestConditions.java
@@ -41,9 +41,9 @@ public class TestConditions
 
         assertFunction("'_monkey_' like '\\_monkey\\_'", BOOLEAN, false);
         assertFunction("'_monkey_' like 'X_monkeyX_' escape 'X'", BOOLEAN, true);
-        assertFunction("'_monkey_' like '_monkey_' escape ''", BOOLEAN, true);
+        assertFunction("'_monkey_' like '_monkey_'", BOOLEAN, true);
 
-        assertFunction("'*?.(){}+|^$,\\' like '*?.(){}+|^$,\\' escape ''", BOOLEAN, true);
+        assertFunction("'*?.(){}+|^$,\\' like '*?.(){}+|^$,\\'", BOOLEAN, true);
 
         assertFunction("null like 'monkey'", BOOLEAN, null);
         assertFunction("'monkey' like null", BOOLEAN, null);
@@ -61,9 +61,9 @@ public class TestConditions
 
         assertFunction("'_monkey_' not like '\\_monkey\\_'", BOOLEAN, true);
         assertFunction("'_monkey_' not like 'X_monkeyX_' escape 'X'", BOOLEAN, false);
-        assertFunction("'_monkey_' not like '_monkey_' escape ''", BOOLEAN, false);
+        assertFunction("'_monkey_' not like '_monkey_'", BOOLEAN, false);
 
-        assertFunction("'*?.(){}+|^$,\\' not like '*?.(){}+|^$,\\' escape ''", BOOLEAN, false);
+        assertFunction("'*?.(){}+|^$,\\' not like '*?.(){}+|^$,\\'", BOOLEAN, false);
 
         assertFunction("null not like 'monkey'", BOOLEAN, null);
         assertFunction("'monkey' not like null", BOOLEAN, null);

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestLikeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestLikeFunctions.java
@@ -166,6 +166,7 @@ public class TestLikeFunctions
         assertThrows(PrestoException.class, () -> likePattern(utf8Slice("#"), utf8Slice("#")));
         assertThrows(PrestoException.class, () -> likePattern(utf8Slice("abc#abc"), utf8Slice("#")));
         assertThrows(PrestoException.class, () -> likePattern(utf8Slice("abc#"), utf8Slice("#")));
+        assertThrows(PrestoException.class, () -> likePattern(utf8Slice("abc#"), utf8Slice("c#")));
     }
 
     @Test
@@ -191,5 +192,11 @@ public class TestLikeFunctions
         assertEquals(unescapeLiteralLikePattern(utf8Slice("abc#_"), utf8Slice("#")), utf8Slice("abc_"));
         assertEquals(unescapeLiteralLikePattern(utf8Slice("a##bc#_"), utf8Slice("#")), utf8Slice("a#bc_"));
         assertEquals(unescapeLiteralLikePattern(utf8Slice("a###_bc"), utf8Slice("#")), utf8Slice("a#_bc"));
+    }
+
+    @Test
+    public void testUnescapeInvalidLikePattern()
+    {
+        assertThrows(PrestoException.class, () -> unescapeLiteralLikePattern(utf8Slice("abc"), utf8Slice("ab")));
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestLikeQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestLikeQueries.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestLikeQueries
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("test")
+                .setSchema("default")
+                .build();
+        return new DistributedQueryRunner(session, 1);
+    }
+
+    @Test
+    public void testLikeQueriesWithEscape()
+    {
+        assertQuerySucceeds("SELECT IF('_T' LIKE '#_T' ESCAPE '#', c0, c1) FROM (values (true, false)) t(c0, c1)");
+        assertQuerySucceeds("SELECT IF(c2 LIKE 'T' ESCAPE '#', c0, c1) FROM (values (true, false, 'T')) t(c0, c1, c2)");
+        assertQueryFails("SELECT IF('T' LIKE '###T' ESCAPE '##', c0, c1) FROM (values (true, false)) t(c0, c1)", ".*Escape string must be a single character$");
+        assertQueryFails("SELECT IF(c2 LIKE '' ESCAPE '', c0, c1) FROM (values (true, false, 'T')) t(c0, c1, c2)", ".*Escape string must be a single character$");
+    }
+}


### PR DESCRIPTION
## Description
fix bug described in issue #23450 

```
== RELEASE NOTES ==

General Changes
* Fix bug to unescape like pattern and validate escape string with no unresolved value :pr:`23456`
```

