### PR TITLE
[native] Add documentation for the build properties of LinuxMemoryChecker

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -144,3 +144,41 @@ The configuration properties of Presto C++ workers are described here, in alphab
 
   Number of drivers to use per task. Defaults to hardware CPUs.
 
+Build-enabled Properties
+----------------
+The following properties are available only if certain properties are enabled at build time via CMakeLists.txt.
+
+LinuxMemoryChecker
+^^^^^^^^^^^^^^^^^^
+
+Enabling the LinuxMemoryChecker by setting ``PRESTO_ENABLE_LINUX_MEMORY_CHECKER`` 
+to ON in presto-native-execution/CMakeLists.txt will make the following properties available:
+
+``systemMemPushbackEnabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+If true, starts memory limit checker to trigger memory pushback when
+server is under low memory pressure.
+
+``systemMemLimitBytes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Specifies the system memory limit that triggers the memory pushback if
+the server memory usage is beyond this limit. This only applies if
+``systemMemPushbackEnabled`` is true.
+
+``systemMemShrinkBytes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Specifies the amount of memory to shrink when the memory pushback is
+triggered. This only applies if ``systemMemPushbackEnabled`` is true.
+

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -146,13 +146,13 @@ The configuration properties of Presto C++ workers are described here, in alphab
 
 Build-enabled Properties
 ----------------
-The following properties are available only if certain properties are enabled at build time via CMakeLists.txt.
+The following properties are available only if certain properties are enabled at build time by using CMakeLists.txt.
 
 LinuxMemoryChecker
 ^^^^^^^^^^^^^^^^^^
 
 Enabling the LinuxMemoryChecker by setting ``PRESTO_ENABLE_LINUX_MEMORY_CHECKER`` 
-to ON in presto-native-execution/CMakeLists.txt will make the following properties available:
+to ``ON`` in presto-native-execution/CMakeLists.txt will make the following properties from PeriodicMemoryChecker available:
 
 ``systemMemPushbackEnabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -160,7 +160,7 @@ to ON in presto-native-execution/CMakeLists.txt will make the following properti
 * **Type:** ``boolean``
 * **Default value:** ``false``
 
-If true, starts memory limit checker to trigger memory pushback when
+If set to ``true``, starts memory limit checker to trigger memory pushback when
 server is under low memory pressure.
 
 ``systemMemLimitBytes``
@@ -171,7 +171,7 @@ server is under low memory pressure.
 
 Specifies the system memory limit that triggers the memory pushback if
 the server memory usage is beyond this limit. This only applies if
-``systemMemPushbackEnabled`` is true.
+``systemMemPushbackEnabled`` is ``true``.
 
 ``systemMemShrinkBytes``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -180,5 +180,5 @@ the server memory usage is beyond this limit. This only applies if
 * **Default value:** ``0``
 
 Specifies the amount of memory to shrink when the memory pushback is
-triggered. This only applies if ``systemMemPushbackEnabled`` is true.
+triggered. This only applies if ``systemMemPushbackEnabled`` is ``true``.
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Adding Build-enabled properties LinuxMemoryChecker for documentation. Documenting the work done for LinuxMemoryChecker in https://github.com/prestodb/presto/pull/22997.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

