### PR TITLE
Update ElasticSearch from v6.0.0 to v7.17.23

### DIFF
--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -13,8 +13,13 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.log4j.version>2.17.1</dep.log4j.version>
-        <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
+        <dep.elasticsearch.version>7.17.23</dep.elasticsearch.version>
+        <dep.httpasyncclient.version>4.1.4</dep.httpasyncclient.version>
+        <dep.httpclient.version>4.5.14</dep.httpclient.version>
+        <dep.httpcore.version>4.4.16</dep.httpcore.version>
+        <dep.httpcore-nio.version>4.4.12</dep.httpcore-nio.version>
         <dep.snakeyaml.version>2.0</dep.snakeyaml.version>
+        <dep.lucene-analyzers-common.version>8.11.3</dep.lucene-analyzers-common.version>
     </properties>
 
     <dependencies>
@@ -32,6 +37,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+            <version>${dep.lucene-analyzers-common.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -57,6 +69,13 @@
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>json</artifactId>
+            <exclusions>
+                <!-- com.facebook.airlift:json:0.209 brings in jackson-dataformat-smile 2.10.0 vs (2.11.0) -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-smile</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -102,6 +121,30 @@
         </dependency>
 
         <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-x-content</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+            <exclusions>
+                <!-- org.elasticsearch:elasticsearch-x-content: 7.17.23 brings in jackson-dataformat-yaml 2.14.2 vs (2.11.0) -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <!-- org.elasticsearch:elasticsearch-x-content: 7.17.23 brings in jackson-dataformat-smile 2.14.2 vs (2.11.0) -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-smile</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-core</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
             <version>${dep.elasticsearch.version}</version>
@@ -122,22 +165,16 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-nio</artifactId>
-            <version>4.4.5</version>
+            <version>${dep.httpcore-nio.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>${dep.httpclient.version}</version>
 
             <exclusions>
-                <!-- elasticsearch-rest-high-level-client 6.0.0 brings in httpcore 4.4.5 vs (4.4.4) -->
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-
-                    <!-- elasticsearch-rest-high-level-client 6.0.0 brings in commons-codec 1.10 vs (1.9) -->
+                    <!-- elasticsearch-rest-high-level-client 7.17.23 brings in commons-codec 1.10 vs (1.9) -->
                 <exclusion>
                     <groupId>commons-codec</groupId>
                     <artifactId>commons-codec</artifactId>
@@ -152,13 +189,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.5</version>
+            <version>${dep.httpcore.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
-            <version>4.1.2</version>
+            <version>${dep.httpasyncclient.version}</version>
 
             <exclusions>
                 <exclusion>
@@ -280,6 +317,12 @@
             <artifactId>presto-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+           <exclusions>
+                <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-analyzers-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -292,6 +335,12 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-analyzers-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -366,6 +415,10 @@
             <artifactId>elasticsearch</artifactId>
             <version>${dep.elasticsearch.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-analyzers-common</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.elasticsearch</groupId>
                     <artifactId>jna</artifactId>

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchClientUtil.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchClientUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class ElasticsearchClientUtil
+{
+    private ElasticsearchClientUtil()
+    {
+    }
+    public static Request buildRequest(String method, String endpoint, Map<String, String> params, HttpEntity entity,
+                                 Collection<Header> headers)
+    {
+        Request request = new Request(method, endpoint);
+        request.addParameters(params);
+        request.setEntity(entity);
+        RequestOptions.Builder requestOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+        headers.forEach(header -> requestOptionsBuilder.addHeader(header.getName(), header.getValue()));
+        request.setOptions(requestOptionsBuilder);
+        return request;
+    }
+}

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchClientUtilTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchClientUtilTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.amazonaws.util.Base64;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchClientUtil.buildRequest;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
+
+public class ElasticsearchClientUtilTest
+{
+    @Test
+    public void testBuildRequest() throws UnsupportedEncodingException
+    {
+        String method = "POST";
+        String endpoint = "/test/_doc?refresh";
+        HttpEntity entity = new NStringEntity("");
+        Map<String, String> paramMap = new HashMap<>();
+        paramMap.put("debug", "true");
+        paramMap.put("logLevel", "verbose");
+        Header authorizationHeader = new BasicHeader("Authorization", format("Basic %s",
+                Base64.encodeAsString(format("%s:%s", "USER", "PASSWORD").getBytes(StandardCharsets.UTF_8))));
+        Request request = buildRequest(method, endpoint,
+                paramMap,
+                entity,
+                ImmutableList.of(authorizationHeader));
+        assertEquals(request.getMethod(), method, "Wrong method in the request");
+        assertEquals(request.getMethod(), method, "Wrong endpoint in the request");
+        assertEquals(request.getEntity(), entity, "Wrong entity in the request");
+        assertEquals(request.getParameters(), paramMap, "Wrong parameters in the request");
+        RequestOptions requestOptions = request.getOptions();
+        List<Header> headers = requestOptions.getHeaders();
+        assertEquals(headers.size(), 1, "Wrong number of headers in the request");
+        assertEquals(headers.get(0).getName(), authorizationHeader.getName(), "Wrong name of the header in the request");
+        assertEquals(headers.get(0).getValue(), authorizationHeader.getValue(), "Wrong value for the header in the request");
+    }
+}

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import io.airlift.tpch.TpchTable;
 import org.apache.http.HttpHost;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.intellij.lang.annotations.Language;
@@ -39,7 +40,7 @@ import static java.lang.String.format;
 public class ElasticsearchConnectorTest
         extends AbstractTestIntegrationSmokeTest
 {
-    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0";
+    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch:7.13.4";
     private ElasticsearchServer elasticsearch;
     private RestHighLevelClient client;
 
@@ -219,6 +220,6 @@ public class ElasticsearchConnectorTest
             throws IOException
     {
         client.getLowLevelClient()
-                .performRequest("PUT", format("/%s/_alias/%s", index, alias));
+                .performRequest(new Request("PUT", format("/%s/_alias/%s", index, alias)));
     }
 }

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchLoader.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchLoader.java
@@ -24,8 +24,9 @@ import com.facebook.presto.tests.AbstractTestingPrestoClient;
 import com.facebook.presto.tests.ResultsSession;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -43,7 +44,7 @@ import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 public class ElasticsearchLoader
         extends AbstractTestingPrestoClient<Void>
@@ -110,7 +111,7 @@ public class ElasticsearchLoader
             }
             request.setRefreshPolicy(IMMEDIATE);
             try {
-                restClient.bulk(request);
+                restClient.bulk(request, RequestOptions.DEFAULT);
             }
             catch (IOException e) {
                 throw new RuntimeException(e);

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchNode.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchNode.java
@@ -25,6 +25,6 @@ public class ElasticsearchNode
 {
     public ElasticsearchNode(Settings preparedSettings, Collection<Class<? extends Plugin>> classpathPlugins)
     {
-        super(InternalSettingsPreparer.prepareEnvironment(preparedSettings, null), classpathPlugins);
+        super(InternalSettingsPreparer.prepareEnvironment(preparedSettings, null, null, null), classpathPlugins, true);
     }
 }

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -27,6 +27,8 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.intellij.lang.annotations.Language;
@@ -39,6 +41,7 @@ import java.util.Map;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.elasticsearch.ElasticsearchClientUtil.buildRequest;
 import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -50,7 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestElasticsearchIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
-    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0";
+    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch:7.13.4";
     private ElasticsearchServer elasticsearch;
     private RestHighLevelClient client;
 
@@ -163,80 +166,78 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
-                "      \"_meta\": {" +
-                "        \"presto\": {" +
-                "          \"a\": {" +
-                "            \"b\": {" +
-                "              \"y\": {" +
-                "                \"isArray\": true" +
-                "              }" +
-                "            }" +
-                "          }," +
-                "          \"c\": {" +
-                "            \"f\": {" +
-                "              \"g\": {" +
-                "                \"isArray\": true" +
-                "              }," +
-                "              \"isArray\": true" +
-                "            }" +
-                "          }," +
-                "          \"j\": {" +
-                "            \"isArray\": true" +
-                "          }," +
-                "          \"k\": {" +
-                "            \"isArray\": true" +
-                "          }" +
-                "        }" +
-                "      }," +
-                "      \"properties\":{" +
+                "    \"_meta\": {" +
+                "      \"presto\": {" +
                 "        \"a\": {" +
-                "          \"type\": \"object\"," +
-                "          \"properties\": {" +
-                "            \"b\": {" +
-                "              \"type\": \"object\"," +
-                "              \"properties\": {" +
-                "                \"x\": {" +
-                "                  \"type\": \"integer\"" +
-                "                }," +
-                "                \"y\": {" +
-                "                  \"type\": \"keyword\"" +
-                "                }" +
-                "              } " +
+                "          \"b\": {" +
+                "            \"y\": {" +
+                "              \"isArray\": true" +
                 "            }" +
                 "          }" +
                 "        }," +
                 "        \"c\": {" +
-                "          \"type\": \"object\"," +
-                "          \"properties\": {" +
-                "            \"d\": {" +
-                "              \"type\": \"keyword\"" +
+                "          \"f\": {" +
+                "            \"g\": {" +
+                "              \"isArray\": true" +
                 "            }," +
-                "            \"e\": {" +
-                "              \"type\": \"keyword\"" +
-                "            }," +
-                "            \"f\": {" +
-                "              \"type\": \"object\"," +
-                "              \"properties\": {" +
-                "                \"g\": {" +
-                "                  \"type\": \"integer\"" +
-                "                }," +
-                "                \"h\": {" +
-                "                  \"type\": \"integer\"" +
-                "                }" +
-                "              } " +
-                "            }" +
+                "            \"isArray\": true" +
                 "          }" +
                 "        }," +
-                "        \"i\": {" +
-                "          \"type\": \"long\"" +
-                "        }," +
                 "        \"j\": {" +
-                "          \"type\": \"long\"" +
+                "          \"isArray\": true" +
                 "        }," +
                 "        \"k\": {" +
-                "          \"type\": \"long\"" +
+                "          \"isArray\": true" +
                 "        }" +
+                "      }" +
+                "    }," +
+                "    \"properties\":{" +
+                "      \"a\": {" +
+                "        \"type\": \"object\"," +
+                "        \"properties\": {" +
+                "          \"b\": {" +
+                "            \"type\": \"object\"," +
+                "            \"properties\": {" +
+                "              \"x\": {" +
+                "                \"type\": \"integer\"" +
+                "              }," +
+                "              \"y\": {" +
+                "                \"type\": \"keyword\"" +
+                "              }" +
+                "            } " +
+                "          }" +
+                "        }" +
+                "      }," +
+                "      \"c\": {" +
+                "        \"type\": \"object\"," +
+                "        \"properties\": {" +
+                "          \"d\": {" +
+                "            \"type\": \"keyword\"" +
+                "          }," +
+                "          \"e\": {" +
+                "            \"type\": \"keyword\"" +
+                "          }," +
+                "          \"f\": {" +
+                "            \"type\": \"object\"," +
+                "            \"properties\": {" +
+                "              \"g\": {" +
+                "                \"type\": \"integer\"" +
+                "              }," +
+                "              \"h\": {" +
+                "                \"type\": \"integer\"" +
+                "              }" +
+                "            } " +
+                "          }" +
+                "        }" +
+                "      }," +
+                "      \"i\": {" +
+                "        \"type\": \"long\"" +
+                "      }," +
+                "      \"j\": {" +
+                "        \"type\": \"long\"" +
+                "      }," +
+                "      \"k\": {" +
+                "        \"type\": \"long\"" +
                 "      }" +
                 "    }" +
                 "  }" +
@@ -357,20 +358,18 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
-                "      \"properties\": {" +
-                "        \"boolean_column\":   { \"type\": \"boolean\" }," +
-                "        \"float_column\":     { \"type\": \"float\" }," +
-                "        \"double_column\":    { \"type\": \"double\" }," +
-                "        \"integer_column\":   { \"type\": \"integer\" }," +
-                "        \"long_column\":      { \"type\": \"long\" }," +
-                "        \"keyword_column\":   { \"type\": \"keyword\" }," +
-                "        \"text_column\":      { \"type\": \"text\" }," +
-                "        \"binary_column\":    { \"type\": \"binary\" }," +
-                "        \"timestamp_column\": { \"type\": \"date\" }" +
-                "      }" +
-                "    }" +
-                "  }" +
+                "    \"properties\": {" +
+                "      \"boolean_column\":   { \"type\": \"boolean\" }," +
+                "      \"float_column\":     { \"type\": \"float\" }," +
+                "      \"double_column\":    { \"type\": \"double\" }," +
+                "      \"integer_column\":   { \"type\": \"integer\" }," +
+                "      \"long_column\":      { \"type\": \"long\" }," +
+                "      \"keyword_column\":   { \"type\": \"keyword\" }," +
+                "      \"text_column\":      { \"type\": \"text\" }," +
+                "      \"binary_column\":    { \"type\": \"binary\" }," +
+                "      \"timestamp_column\": { \"type\": \"date\" }" +
+                "     }" +
+                "   }" +
                 "}";
 
         createIndex(indexName, mapping);
@@ -421,18 +420,16 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
-                "      \"properties\": {" +
-                "        \"boolean_column\":   { \"type\": \"boolean\" }," +
-                "        \"float_column\":     { \"type\": \"float\" }," +
-                "        \"double_column\":    { \"type\": \"double\" }," +
-                "        \"integer_column\":   { \"type\": \"integer\" }," +
-                "        \"long_column\":      { \"type\": \"long\" }," +
-                "        \"keyword_column\":   { \"type\": \"keyword\" }," +
-                "        \"text_column\":      { \"type\": \"text\" }," +
-                "        \"binary_column\":    { \"type\": \"binary\" }," +
-                "        \"timestamp_column\": { \"type\": \"date\" }" +
-                "      }" +
+                "    \"properties\": {" +
+                "      \"boolean_column\":   { \"type\": \"boolean\" }," +
+                "      \"float_column\":     { \"type\": \"float\" }," +
+                "      \"double_column\":    { \"type\": \"double\" }," +
+                "      \"integer_column\":   { \"type\": \"integer\" }," +
+                "      \"long_column\":      { \"type\": \"long\" }," +
+                "      \"keyword_column\":   { \"type\": \"keyword\" }," +
+                "      \"text_column\":      { \"type\": \"text\" }," +
+                "      \"binary_column\":    { \"type\": \"binary\" }," +
+                "      \"timestamp_column\": { \"type\": \"date\" }" +
                 "    }" +
                 "  }" +
                 "}";
@@ -534,20 +531,18 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
-                "      \"properties\": {" +
-                "        \"field\": {" +
-                "          \"properties\": {" +
-                "            \"boolean_column\":   { \"type\": \"boolean\" }," +
-                "            \"float_column\":     { \"type\": \"float\" }," +
-                "            \"double_column\":    { \"type\": \"double\" }," +
-                "            \"integer_column\":   { \"type\": \"integer\" }," +
-                "            \"long_column\":      { \"type\": \"long\" }," +
-                "            \"keyword_column\":   { \"type\": \"keyword\" }," +
-                "            \"text_column\":      { \"type\": \"text\" }," +
-                "            \"binary_column\":    { \"type\": \"binary\" }," +
-                "            \"timestamp_column\": { \"type\": \"date\" }" +
-                "          }" +
+                "    \"properties\": {" +
+                "      \"field\": {" +
+                "        \"properties\": {" +
+                "          \"boolean_column\":   { \"type\": \"boolean\" }," +
+                "          \"float_column\":     { \"type\": \"float\" }," +
+                "          \"double_column\":    { \"type\": \"double\" }," +
+                "          \"integer_column\":   { \"type\": \"integer\" }," +
+                "          \"long_column\":      { \"type\": \"long\" }," +
+                "          \"keyword_column\":   { \"type\": \"keyword\" }," +
+                "          \"text_column\":      { \"type\": \"text\" }," +
+                "          \"binary_column\":    { \"type\": \"binary\" }," +
+                "          \"timestamp_column\": { \"type\": \"date\" }" +
                 "        }" +
                 "      }" +
                 "    }" +
@@ -604,23 +599,21 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
-                "      \"properties\": {" +
-                "        \"nested_field\": {" +
-                "          \"type\":\"nested\"," +
-                "          \"properties\": {" +
-                "            \"boolean_column\":   { \"type\": \"boolean\" }," +
-                "            \"float_column\":     { \"type\": \"float\" }," +
-                "            \"double_column\":    { \"type\": \"double\" }," +
-                "            \"integer_column\":   { \"type\": \"integer\" }," +
-                "            \"long_column\":      { \"type\": \"long\" }," +
-                "            \"keyword_column\":   { \"type\": \"keyword\" }," +
-                "            \"text_column\":      { \"type\": \"text\" }," +
-                "            \"binary_column\":    { \"type\": \"binary\" }," +
-                "            \"timestamp_column\": { \"type\": \"date\" }," +
-                "            \"ipv4_column\":      { \"type\": \"ip\" }," +
-                "            \"ipv6_column\":      { \"type\": \"ip\" }" +
-                "          }" +
+                "    \"properties\": {" +
+                "      \"nested_field\": {" +
+                "        \"type\":\"nested\"," +
+                "        \"properties\": {" +
+                "          \"boolean_column\":   { \"type\": \"boolean\" }," +
+                "          \"float_column\":     { \"type\": \"float\" }," +
+                "          \"double_column\":    { \"type\": \"double\" }," +
+                "          \"integer_column\":   { \"type\": \"integer\" }," +
+                "          \"long_column\":      { \"type\": \"long\" }," +
+                "          \"keyword_column\":   { \"type\": \"keyword\" }," +
+                "          \"text_column\":      { \"type\": \"text\" }," +
+                "          \"binary_column\":    { \"type\": \"binary\" }," +
+                "          \"timestamp_column\": { \"type\": \"date\" }," +
+                "          \"ipv4_column\":      { \"type\": \"ip\" }," +
+                "          \"ipv6_column\":      { \"type\": \"ip\" }" +
                 "        }" +
                 "      }" +
                 "    }" +
@@ -752,9 +745,9 @@ public class TestElasticsearchIntegrationSmokeTest
     private void index(String index, Map<String, Object> document)
             throws IOException
     {
-        client.index(new IndexRequest(index, "doc")
+        client.index(new IndexRequest(index)
                 .source(document)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE));
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), RequestOptions.DEFAULT);
     }
 
     @Test
@@ -789,20 +782,21 @@ public class TestElasticsearchIntegrationSmokeTest
             throws IOException
     {
         client.getLowLevelClient()
-                .performRequest("PUT", format("/%s/_alias/%s", index, alias));
+                .performRequest(new Request("PUT", format("/%s/_alias/%s", index, alias)));
     }
 
     private void removeAlias(String index, String alias)
             throws IOException
     {
         client.getLowLevelClient()
-                .performRequest("DELETE", format("/%s/_alias/%s", index, alias));
+                .performRequest(new Request("DELETE", format("/%s/_alias/%s", index, alias)));
     }
 
     private void createIndex(String indexName, @Language("JSON") String mapping)
             throws IOException
     {
         client.getLowLevelClient()
-                .performRequest("PUT", "/" + indexName, ImmutableMap.of(), new NStringEntity(mapping, ContentType.APPLICATION_JSON));
+                .performRequest(buildRequest("PUT", "/" + indexName, ImmutableMap.of(),
+                        new NStringEntity(mapping, ContentType.APPLICATION_JSON), ImmutableList.of()));
     }
 }

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestPasswordAuthentication.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestPasswordAuthentication.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import static com.facebook.presto.elasticsearch.ElasticsearchClientUtil.buildRequest;
 import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
 import static com.google.common.io.Resources.getResource;
 import static java.lang.String.format;
@@ -93,12 +94,13 @@ public class TestPasswordAuthentication
                 .build());
 
         client.getLowLevelClient()
-                .performRequest(
+                .performRequest(buildRequest(
                         "POST",
                         "/test/_doc?refresh",
                         ImmutableMap.of(),
                         new NStringEntity(json, ContentType.APPLICATION_JSON),
-                        new BasicHeader("Authorization", format("Basic %s", Base64.encodeAsString(format("%s:%s", USER, PASSWORD).getBytes(StandardCharsets.UTF_8)))));
+                        ImmutableList.of(new BasicHeader("Authorization", format("Basic %s",
+                                Base64.encodeAsString(format("%s:%s", USER, PASSWORD).getBytes(StandardCharsets.UTF_8)))))));
 
         assertions.assertQuery("SELECT * FROM test",
                 "VALUES BIGINT '42'");


### PR DESCRIPTION
Bumped org.elasticsearch:elasticsearch from 6.0.0 to 7.17.23. Added exclusions to address 'failed while enforcing requireupperbounddeps' errors. Replaced hardcoded version numbers with property values. Declared lucene-analyzers-common dependency so integration tests can run. Updated imports to reflect new package names and deleted any method calls for methods that were removed in v7+. Updated performRequest method calls to take a Request object rather than parts of that make up a request since that overloaded method signature was removed in v7+. Provided an utility class to generate a Request from parts of a request to simplify refactoring. Updated request execution calls from the RestHighLevelClient (HLC) to include a RequestOptions.DEFAULT argument since the overloaded method with optional headers argument was removed in v7+.

Bumped ES server version from 6.0.0 to 7.13.4 for the integration tests since the v7+ HLC is not backward compatible with older ES server versions. Update test inputs to remove mapping types as indices created in ES v7+ no longer accept mapping types.

Added an unit test to verify that utility class generates the expected Request object based on the provided parts of the request.

## Description
Bumped org.elasticsearch:elasticsearch from 6.0.0 to 7.17.23. Added exclusions to address 'failed while enforcing requireupperbounddeps' errors. Replaced hardcoded version numbers with property values. Declared lucene-analyzers-common dependency so integration tests can run. Updated imports to reflect new package names and deleted any method calls for methods that were removed in v7+. Updated performRequest method calls to take a Request object rather than parts of that make up a request since that overloaded method signature was removed in v7+. Provided an utility class to generate a Request from parts of a request to simplify refactoring. Updated request execution calls from the RestHighLevelClient (HLC) to include a RequestOptions.DEFAULT argument since the overloaded method with optional headers argument was removed in v7+.

Bumped ES server version from 6.0.0 to 7.13.4 for the integration tests since the v7+ HLC is not backward compatible with older ES server versions. Update test inputs to remove mapping types as indices created in ES v7+ no longer accept mapping types.

## Motivation and Context
Previous version of org.elasticsearch:elasticsearch in presto-elasticsearch was v6.0.0 which GA-ed in Nov 2017.  Move to the latest version of v7.
https://github.com/prestodb/presto/issues/21837

## Impact
The Elasticsearch v7.0 RestHighLevelClient (HLC) is not backwards compatible with Elasticsearch servers less than v7.0. Users will need to upgrade their Elasticsearch servers to be at least v7.0 or higher.

## Test Plan
Refactor and updated Elasticsearch integration tests to handle new Elasticsearch 7.0 requirements and ensure existing tests still pass. Added an unit test to verify that utility class generates the expected Request object based on the provided parts of the request 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Connector
* Upgrade Elasticsearch version from 6.0.0 to 7.17.23. The Elasticsearch v7.0 RestHighLevelClient (HLC) is not backwards compatible with Elasticsearch servers less than v7.0. :pr:`23463`


