### PR TITLE
[Iceberg]Fix analyze table whose column name ends with `_` + number

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -769,9 +769,9 @@ public abstract class IcebergDistributedTestBase
     @Test
     public void testReadWriteStats()
     {
-        assertUpdate("CREATE TABLE test_stats (col0 int, col1 varchar)");
+        assertUpdate("CREATE TABLE test_stats (col0 int, col_1 varchar)");
         assertTrue(getQueryRunner().tableExists(getSession(), "test_stats"));
-        assertTableColumnNames("test_stats", "col0", "col1");
+        assertTableColumnNames("test_stats", "col0", "col_1");
 
         // test that stats don't exist before analyze
         Function<Map<ColumnHandle, ColumnStatistics>, Map<String, ColumnStatistics>> remapper = (input) -> input.entrySet().stream().collect(Collectors.toMap(e -> ((IcebergColumnHandle) e.getKey()).getName(), Map.Entry::getValue));
@@ -788,9 +788,9 @@ public abstract class IcebergDistributedTestBase
         ColumnStatistics columnStat = columnStats.get("col0");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(3.0));
         assertEquals(columnStat.getDataSize(), Estimate.unknown());
-        columnStat = columnStats.get("col1");
+        columnStat = columnStats.get("col_1");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(3.0));
-        double dataSize = (double) (long) getQueryRunner().execute("SELECT sum_data_size_for_stats(col1) FROM test_stats").getOnlyValue();
+        double dataSize = (double) (long) getQueryRunner().execute("SELECT sum_data_size_for_stats(col_1) FROM test_stats").getOnlyValue();
         assertEquals(columnStat.getDataSize().getValue(), dataSize);
 
         // test after inserting the same values, we still get the same estimate
@@ -800,7 +800,7 @@ public abstract class IcebergDistributedTestBase
         columnStat = columnStats.get("col0");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(3.0));
         assertEquals(columnStat.getDataSize(), Estimate.unknown());
-        columnStat = columnStats.get("col1");
+        columnStat = columnStats.get("col_1");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(3.0));
         assertEquals(columnStat.getDataSize().getValue(), dataSize);
 
@@ -811,9 +811,9 @@ public abstract class IcebergDistributedTestBase
         columnStat = columnStats.get("col0");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(3.0));
         assertEquals(columnStat.getDataSize(), Estimate.unknown());
-        columnStat = columnStats.get("col1");
+        columnStat = columnStats.get("col_1");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(3.0));
-        dataSize = (double) (long) getQueryRunner().execute("SELECT sum_data_size_for_stats(col1) FROM test_stats").getOnlyValue();
+        dataSize = (double) (long) getQueryRunner().execute("SELECT sum_data_size_for_stats(col_1) FROM test_stats").getOnlyValue();
         assertEquals(columnStat.getDataSize().getValue(), dataSize);
 
         // test after inserting a new value, but not analyzing, the estimate is the same.
@@ -823,7 +823,7 @@ public abstract class IcebergDistributedTestBase
         columnStat = columnStats.get("col0");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(3.0));
         assertEquals(columnStat.getDataSize(), Estimate.unknown());
-        columnStat = columnStats.get("col1");
+        columnStat = columnStats.get("col_1");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(3.0));
         assertEquals(columnStat.getDataSize().getValue(), dataSize);
 
@@ -834,9 +834,9 @@ public abstract class IcebergDistributedTestBase
         columnStat = columnStats.get("col0");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(4.0));
         assertEquals(columnStat.getDataSize(), Estimate.unknown());
-        columnStat = columnStats.get("col1");
+        columnStat = columnStats.get("col_1");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(4.0));
-        dataSize = (double) (long) getQueryRunner().execute("SELECT sum_data_size_for_stats(col1) FROM test_stats").getOnlyValue();
+        dataSize = (double) (long) getQueryRunner().execute("SELECT sum_data_size_for_stats(col_1) FROM test_stats").getOnlyValue();
         assertEquals(columnStat.getDataSize().getValue(), dataSize);
 
         // test adding a null value is successful, and analyze still runs successfully
@@ -847,9 +847,9 @@ public abstract class IcebergDistributedTestBase
         columnStat = columnStats.get("col0");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(4.0));
         assertEquals(columnStat.getDataSize(), Estimate.unknown());
-        columnStat = columnStats.get("col1");
+        columnStat = columnStats.get("col_1");
         assertEquals(columnStat.getDistinctValuesCount(), Estimate.of(4.0));
-        dataSize = (double) (long) getQueryRunner().execute("SELECT sum_data_size_for_stats(col1) FROM test_stats").getOnlyValue();
+        dataSize = (double) (long) getQueryRunner().execute("SELECT sum_data_size_for_stats(col_1) FROM test_stats").getOnlyValue();
         assertEquals(columnStat.getDataSize().getValue(), dataSize);
 
         assertUpdate("DROP TABLE test_stats");


### PR DESCRIPTION
## Description

We can create Iceberg table with column names like `col_0`, `col_1` etc. For example:

```
presto:default> create table test_stats (col_0 int, col_1 varchar);
presto:default> insert into test_stats values (1, 'abc'), (2, 'xyz'), (3, 'lmnopqrst');
presto:default> select col_1, col_0 from test_stats;

   col_1   | col_0 
-----------+-------
 abc       |     1 
 xyz       |     2 
 lmnopqrst |     3 
(3 rows)
```

However, when we execute `analyze` for table `test_stats` on HADOOP catalog, we will get an exception:

```
presto:default> analyze test_stats;

Query 20240818_142002_00000_w6rki failed: Column 'col_0' cannot be resolved
```

The reason is, in Iceberg connector on HADOOP catalog, we wrapped column `col_0` into sql function body `RETURN sketch_theta("col_0")` to calculate its NDV value. However, when we trying to resolve this sql function body, we would find that the parameter `col_0` has been changed in the outer input variable because of its special format, referring to https://github.com/prestodb/presto/blob/master/presto-spi/src/main/java/com/facebook/presto/spi/VariableAllocator.java#L103 .

This PR makes necessary translation for the column names in the sql function body when executing analyze on Iceberg tables.

## Motivation and Context

Fix the error when analyze for Iceberg table whose column name ends with `_` + number on HADOOP catalog

## Impact

N/A

## Test Plan

 - Refactor existing test case `IcebergDistributedTestBase.testReadWriteStats()` to cover the scenario mentioned above

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

