### PR TITLE
[Iceberg]Support setting the max number of columns for which metrics are collected

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -320,6 +320,9 @@ Property Name                                           Description             
 
 ``iceberg.metadata-delete-after-commit``                Set to ``true`` to delete the oldest metadata files after     ``false``
                                                         each commit.
+
+``iceberg.metrics-max-inferred-column``                 The maximum number of columns for which metrics               ``100``
+                                                        are collected.
 ======================================================= ============================================================= ============
 
 Table Properties
@@ -367,6 +370,9 @@ Property Name                             Description                           
 
 ``metadata_delete_after_commit``           Set to ``true`` to delete the oldest metadata file after         ``false``
                                            each commit.
+
+``metrics_max_inferred_column``            Optionally specifies the maximum number of columns for which     ``100``
+                                           metrics are collected.
 =======================================   ===============================================================   ============
 
 The table definition below specifies format ``ORC``, partitioning by columns ``c1`` and ``c2``,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -122,6 +122,7 @@ import static com.facebook.presto.iceberg.IcebergTableProperties.FORMAT_VERSION;
 import static com.facebook.presto.iceberg.IcebergTableProperties.LOCATION_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableProperties.METADATA_DELETE_AFTER_COMMIT;
 import static com.facebook.presto.iceberg.IcebergTableProperties.METADATA_PREVIOUS_VERSIONS_MAX;
+import static com.facebook.presto.iceberg.IcebergTableProperties.METRICS_MAX_INFERRED_COLUMN;
 import static com.facebook.presto.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableType.CHANGELOG;
 import static com.facebook.presto.iceberg.IcebergTableType.DATA;
@@ -559,6 +560,7 @@ public abstract class IcebergAbstractMetadata
         properties.put(DELETE_MODE, IcebergUtil.getDeleteMode(icebergTable));
         properties.put(METADATA_PREVIOUS_VERSIONS_MAX, IcebergUtil.getMetadataPreviousVersionsMax(icebergTable));
         properties.put(METADATA_DELETE_AFTER_COMMIT, IcebergUtil.isMetadataDeleteAfterCommit(icebergTable));
+        properties.put(METRICS_MAX_INFERRED_COLUMN, IcebergUtil.getMetricsMaxInferredColumn(icebergTable));
 
         return properties.build();
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -71,6 +71,8 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.MetricsModes.None;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
@@ -589,8 +591,10 @@ public abstract class IcebergAbstractMetadata
     @Override
     public TableStatisticsMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
+        Table table = getIcebergTable(session, tableMetadata.getTable());
+        MetricsConfig metricsConfig = MetricsConfig.forTable(table);
         Set<ColumnStatisticMetadata> columnStatistics = tableMetadata.getColumns().stream()
-                .filter(column -> !column.isHidden())
+                .filter(column -> !column.isHidden() && metricsConfig.columnMode(column.getName()) != None.get())
                 .flatMap(meta -> getSupportedColumnStatistics(meta.getName(), meta.getType()).stream())
                 .collect(toImmutableSet());
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -38,6 +38,7 @@ import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
+import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT;
 
 public class IcebergConfig
 {
@@ -57,6 +58,7 @@ public class IcebergConfig
     private int rowsForMetadataOptimizationThreshold = 1000;
     private int metadataPreviousVersionsMax = METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
     private boolean metadataDeleteAfterCommit = METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
+    private int metricsMaxInferredColumn = METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT;
 
     private EnumSet<ColumnStatisticType> hiveStatisticsMergeFlags = EnumSet.noneOf(ColumnStatisticType.class);
     private String fileIOImpl = HadoopFileIO.class.getName();
@@ -378,6 +380,19 @@ public class IcebergConfig
     public IcebergConfig setMetadataDeleteAfterCommit(boolean metadataDeleteAfterCommit)
     {
         this.metadataDeleteAfterCommit = metadataDeleteAfterCommit;
+        return this;
+    }
+
+    public int getMetricsMaxInferredColumn()
+    {
+        return metricsMaxInferredColumn;
+    }
+
+    @Config("iceberg.metrics-max-inferred-column")
+    @ConfigDescription("The maximum number of columns for which metrics are collected")
+    public IcebergConfig setMetricsMaxInferredColumn(int metricsMaxInferredColumn)
+    {
+        this.metricsMaxInferredColumn = metricsMaxInferredColumn;
         return this;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.LocationProvider;
 
 import java.time.Instant;
@@ -105,10 +106,10 @@ public class IcebergPageSink
     private long writtenBytes;
     private long systemMemoryUsage;
     private long validationCpuNanos;
+    private Table table;
 
     public IcebergPageSink(
-            Schema outputSchema,
-            PartitionSpec partitionSpec,
+            Table table,
             LocationProvider locationProvider,
             IcebergFileWriterFactory fileWriterFactory,
             PageIndexerFactory pageIndexerFactory,
@@ -121,8 +122,9 @@ public class IcebergPageSink
             int maxOpenWriters)
     {
         requireNonNull(inputColumns, "inputColumns is null");
-        this.outputSchema = requireNonNull(outputSchema, "outputSchema is null");
-        this.partitionSpec = requireNonNull(partitionSpec, "partitionSpec is null");
+        this.table = requireNonNull(table, "table is null");
+        this.outputSchema = table.schema();
+        this.partitionSpec = table.spec();
         this.locationProvider = requireNonNull(locationProvider, "locationProvider is null");
         this.fileWriterFactory = requireNonNull(fileWriterFactory, "fileWriterFactory is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -322,7 +324,7 @@ public class IcebergPageSink
                 session,
                 hdfsContext,
                 fileFormat,
-                MetricsConfig.getDefault());
+                MetricsConfig.forTable(table));
 
         return new WriteContext(writer, outputPath, partitionData);
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
@@ -27,11 +27,15 @@ import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.LocationProvider;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static com.facebook.presto.iceberg.IcebergUtil.getLocationProvider;
+import static com.facebook.presto.iceberg.IcebergUtil.getShallowWrappedIcebergTable;
 import static com.facebook.presto.iceberg.PartitionSpecConverter.toIcebergPartitionSpec;
 import static com.facebook.presto.iceberg.SchemaConverter.toIcebergSchema;
 import static java.util.Objects.requireNonNull;
@@ -80,9 +84,9 @@ public class IcebergPageSinkProvider
         PartitionSpec partitionSpec = toIcebergPartitionSpec(tableHandle.getPartitionSpec()).toUnbound().bind(schema);
         LocationProvider locationProvider = getLocationProvider(new SchemaTableName(tableHandle.getSchemaName(), tableHandle.getTableName().getTableName()),
                 tableHandle.getOutputPath(), tableHandle.getStorageProperties());
+        Table table = getShallowWrappedIcebergTable(schema, partitionSpec, tableHandle.getStorageProperties(), Optional.empty());
         return new IcebergPageSink(
-                schema,
-                partitionSpec,
+                table,
                 locationProvider,
                 fileWriterFactory,
                 pageIndexerFactory,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -43,6 +43,7 @@ public class IcebergTableProperties
     public static final String DELETE_MODE = "delete_mode";
     public static final String METADATA_PREVIOUS_VERSIONS_MAX = "metadata_previous_versions_max";
     public static final String METADATA_DELETE_AFTER_COMMIT = "metadata_delete_after_commit";
+    public static final String METRICS_MAX_INFERRED_COLUMN = "metrics_max_inferred_column";
     private static final String DEFAULT_FORMAT_VERSION = "2";
 
     private final List<PropertyMetadata<?>> tableProperties;
@@ -106,6 +107,11 @@ public class IcebergTableProperties
                         "Whether enables to delete the oldest metadata file after commit",
                         icebergConfig.isMetadataDeleteAfterCommit(),
                         false))
+                .add(integerProperty(
+                        METRICS_MAX_INFERRED_COLUMN,
+                        "The maximum number of columns for which metrics are collected",
+                        icebergConfig.getMetricsMaxInferredColumn(),
+                        false))
                 .build();
 
         columnProperties = ImmutableList.of(stringProperty(
@@ -165,5 +171,10 @@ public class IcebergTableProperties
     public static Boolean isMetadataDeleteAfterCommit(Map<String, Object> tableProperties)
     {
         return (Boolean) tableProperties.get(METADATA_DELETE_AFTER_COMMIT);
+    }
+
+    public static Integer getMetricsMaxInferredColumn(Map<String, Object> tableProperties)
+    {
+        return (Integer) tableProperties.get(METRICS_MAX_INFERRED_COLUMN);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -189,6 +189,8 @@ import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_EN
 import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX;
 import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
+import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS;
+import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT;
 import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE;
@@ -1133,6 +1135,9 @@ public final class IcebergUtil
 
         Boolean metadataDeleteAfterCommit = IcebergTableProperties.isMetadataDeleteAfterCommit(tableMetadata.getProperties());
         propertiesBuilder.put(METADATA_DELETE_AFTER_COMMIT_ENABLED, String.valueOf(metadataDeleteAfterCommit));
+
+        Integer metricsMaxInferredColumn = IcebergTableProperties.getMetricsMaxInferredColumn(tableMetadata.getProperties());
+        propertiesBuilder.put(METRICS_MAX_INFERRED_COLUMN_DEFAULTS, String.valueOf(metricsMaxInferredColumn));
         return propertiesBuilder.build();
     }
 
@@ -1165,6 +1170,13 @@ public final class IcebergUtil
         return Boolean.valueOf(table.properties()
                 .getOrDefault(METADATA_DELETE_AFTER_COMMIT_ENABLED,
                         String.valueOf(METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT)));
+    }
+
+    public static int getMetricsMaxInferredColumn(Table table)
+    {
+        return Integer.parseInt(table.properties()
+                .getOrDefault(METRICS_MAX_INFERRED_COLUMN_DEFAULTS,
+                        String.valueOf(METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT)));
     }
 
     public static Optional<PartitionData> partitionDataFromJson(PartitionSpec spec, Optional<String> partitionDataAsJson)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -63,6 +63,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
@@ -223,6 +224,11 @@ public final class IcebergUtil
         checkArgument(metadata instanceof IcebergAbstractMetadata, "metadata must be instance of IcebergAbstractMetadata!");
         IcebergAbstractMetadata icebergMetadata = (IcebergAbstractMetadata) metadata;
         return icebergMetadata.getIcebergTable(session, table);
+    }
+
+    public static Table getShallowWrappedIcebergTable(Schema schema, PartitionSpec spec, Map<String, String> properties, Optional<SortOrder> sortOrder)
+    {
+        return new PrestoIcebergTableForMetricsConfig(schema, spec, properties, sortOrder);
     }
 
     public static Table getHiveIcebergTable(ExtendedHiveMetastore metastore, HdfsEnvironment hdfsEnvironment, IcebergHiveTableOperationsConfig config, ConnectorSession session, SchemaTableName table)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergTableForMetricsConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergTableForMetricsConfig.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DeleteFiles;
+import org.apache.iceberg.ExpireSnapshots;
+import org.apache.iceberg.HistoryEntry;
+import org.apache.iceberg.ManageSnapshots;
+import org.apache.iceberg.OverwriteFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.ReplacePartitions;
+import org.apache.iceberg.ReplaceSortOrder;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.RewriteManifests;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.UpdateLocation;
+import org.apache.iceberg.UpdatePartitionSpec;
+import org.apache.iceberg.UpdateProperties;
+import org.apache.iceberg.UpdateSchema;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.SortOrder.unsorted;
+
+/**
+ * This is a dummy class required for {@link org.apache.iceberg.MetricsConfig#forTable}
+ * */
+public class PrestoIcebergTableForMetricsConfig
+        implements Table
+{
+    private final Schema schema;
+    private final PartitionSpec spec;
+    private final Optional<SortOrder> sortOrder;
+    private final Map<String, String> properties;
+
+    protected PrestoIcebergTableForMetricsConfig(Schema schema, PartitionSpec spec, Map<String, String> properties, Optional<SortOrder> sortOrder)
+    {
+        this.schema = requireNonNull(schema, "schema is null");
+        this.spec = requireNonNull(spec, "partition spec is null");
+        this.sortOrder = requireNonNull(sortOrder, "sortOrder is null");
+        this.properties = requireNonNull(properties, "table properties is null");
+    }
+
+    @Override
+    public void refresh()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public TableScan newScan()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public Schema schema()
+    {
+        return this.schema;
+    }
+
+    @Override
+    public Map<Integer, Schema> schemas()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public PartitionSpec spec()
+    {
+        return this.spec;
+    }
+
+    @Override
+    public Map<Integer, PartitionSpec> specs()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public SortOrder sortOrder()
+    {
+        return this.sortOrder.orElse(unsorted());
+    }
+
+    @Override
+    public Map<Integer, SortOrder> sortOrders()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public Map<String, String> properties()
+    {
+        return this.properties;
+    }
+
+    @Override
+    public String location()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public Snapshot currentSnapshot()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public Snapshot snapshot(long snapshotId)
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public Iterable<Snapshot> snapshots()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public List<HistoryEntry> history()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public UpdateSchema updateSchema()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public UpdatePartitionSpec updateSpec()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public UpdateProperties updateProperties()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public ReplaceSortOrder replaceSortOrder()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public UpdateLocation updateLocation()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public AppendFiles newAppend()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public RewriteFiles newRewrite()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public RewriteManifests rewriteManifests()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public OverwriteFiles newOverwrite()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public RowDelta newRowDelta()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public ReplacePartitions newReplacePartitions()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public DeleteFiles newDelete()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public ExpireSnapshots expireSnapshots()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public ManageSnapshots manageSnapshots()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public Transaction newTransaction()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public FileIO io()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public EncryptionManager encryption()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public LocationProvider locationProvider()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public List<StatisticsFile> statisticsFiles()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+
+    @Override
+    public Map<String, SnapshotRef> refs()
+    {
+        throw new UnsupportedOperationException("Operation is not supported in PrestoIcebergTable");
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -142,7 +142,8 @@ public class IcebergDistributedSmokeTestBase
                         "   format_version = '2',\n" +
                         "   location = '%s',\n" +
                         "   metadata_delete_after_commit = false,\n" +
-                        "   metadata_previous_versions_max = 100\n" +
+                        "   metadata_previous_versions_max = 100,\n" +
+                        "   metrics_max_inferred_column = 100\n" +
                         ")", getLocation("tpch", "orders")));
     }
 
@@ -422,6 +423,7 @@ public class IcebergDistributedSmokeTestBase
                         "   location = '%s',\n" +
                         "   metadata_delete_after_commit = false,\n" +
                         "   metadata_previous_versions_max = 100,\n" +
+                        "   metrics_max_inferred_column = 100,\n" +
                         "   partitioning = ARRAY['order_status','ship_priority','bucket(order_key, 9)']\n" +
                         ")",
                 getSession().getCatalog().get(),
@@ -623,7 +625,8 @@ public class IcebergDistributedSmokeTestBase
                 "   format_version = '2',\n" +
                 "   location = '%s',\n" +
                 "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100\n" +
+                "   metadata_previous_versions_max = 100,\n" +
+                "   metrics_max_inferred_column = 100\n" +
                 ")";
         String createTableSql = format(createTableTemplate, "test table comment", getLocation("tpch", "test_table_comments"));
 
@@ -714,6 +717,7 @@ public class IcebergDistributedSmokeTestBase
                 "   location = '%s',\n" +
                 "   metadata_delete_after_commit = false,\n" +
                 "   metadata_previous_versions_max = 100,\n" +
+                "   metrics_max_inferred_column = 100,\n" +
                 "   partitioning = ARRAY['adate']\n" +
                 ")", getLocation("tpch", "test_create_table_like_original")));
 
@@ -729,7 +733,8 @@ public class IcebergDistributedSmokeTestBase
                 "   format_version = '2',\n" +
                 "   location = '%s',\n" +
                 "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100\n" +
+                "   metadata_previous_versions_max = 100,\n" +
+                "   metrics_max_inferred_column = 100\n" +
                 ")", getLocation("tpch", "test_create_table_like_copy1")));
         dropTable(session, "test_create_table_like_copy1");
 
@@ -740,7 +745,8 @@ public class IcebergDistributedSmokeTestBase
                 "   format_version = '2',\n" +
                 "   location = '%s',\n" +
                 "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100\n" +
+                "   metadata_previous_versions_max = 100,\n" +
+                "   metrics_max_inferred_column = 100\n" +
                 ")", getLocation("tpch", "test_create_table_like_copy2")));
         dropTable(session, "test_create_table_like_copy2");
 
@@ -752,6 +758,7 @@ public class IcebergDistributedSmokeTestBase
                 "   location = '%s',\n" +
                 "   metadata_delete_after_commit = false,\n" +
                 "   metadata_previous_versions_max = 100,\n" +
+                "   metrics_max_inferred_column = 100,\n" +
                 "   partitioning = ARRAY['adate']\n" +
                 ")", catalogType.equals(CatalogType.HIVE) ?
                 getLocation("tpch", "test_create_table_like_original") :
@@ -766,6 +773,7 @@ public class IcebergDistributedSmokeTestBase
                 "   location = '%s',\n" +
                 "   metadata_delete_after_commit = false,\n" +
                 "   metadata_previous_versions_max = 100,\n" +
+                "   metrics_max_inferred_column = 100,\n" +
                 "   partitioning = ARRAY['adate']\n" +
                 ")", catalogType.equals(CatalogType.HIVE) ?
                 getLocation("tpch", "test_create_table_like_original") :
@@ -809,7 +817,8 @@ public class IcebergDistributedSmokeTestBase
                         "   format_version = '%s',\n" +
                         "   location = '%s',\n" +
                         "   metadata_delete_after_commit = false,\n" +
-                        "   metadata_previous_versions_max = 100\n" +
+                        "   metadata_previous_versions_max = 100,\n" +
+                        "   metrics_max_inferred_column = 100\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -35,6 +35,7 @@ import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT
 import static org.apache.iceberg.CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
+import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT;
 
 public class TestIcebergConfig
 {
@@ -64,7 +65,8 @@ public class TestIcebergConfig
                 .setManifestCacheMaxContentLength(IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT)
                 .setSplitManagerThreads(Runtime.getRuntime().availableProcessors())
                 .setMetadataPreviousVersionsMax(METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT)
-                .setMetadataDeleteAfterCommit(METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT));
+                .setMetadataDeleteAfterCommit(METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT)
+                .setMetricsMaxInferredColumn(METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT));
     }
 
     @Test
@@ -94,6 +96,7 @@ public class TestIcebergConfig
                 .put("iceberg.split-manager-threads", "42")
                 .put("iceberg.metadata-previous-versions-max", "1")
                 .put("iceberg.metadata-delete-after-commit", "true")
+                .put("iceberg.metrics-max-inferred-column", "16")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -119,7 +122,8 @@ public class TestIcebergConfig
                 .setManifestCacheMaxContentLength(10485760)
                 .setSplitManagerThreads(42)
                 .setMetadataPreviousVersionsMax(1)
-                .setMetadataDeleteAfterCommit(true);
+                .setMetadataDeleteAfterCommit(true)
+                .setMetricsMaxInferredColumn(16);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -101,6 +101,9 @@ public class TestIcebergSystemTables
 
         assertUpdate("CREATE TABLE test_schema.test_metadata_versions_maintain (_bigint BIGINT)" +
                 " WITH (metadata_previous_versions_max = 1, metadata_delete_after_commit = true)");
+
+        assertUpdate("CREATE TABLE test_schema.test_metrics_max_inferred_column (_bigint BIGINT)" +
+                " WITH (metrics_max_inferred_column = 16)");
     }
 
     @Test
@@ -236,11 +239,11 @@ public class TestIcebergSystemTables
     {
         assertQuery(String.format("SHOW COLUMNS FROM test_schema.\"%s$properties\"", tableName),
                 "VALUES ('key', 'varchar', '', '')," + "('value', 'varchar', '', '')");
-        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 6");
+        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 7");
         List<MaterializedRow> materializedRows = computeActual(getSession(),
                 String.format("SELECT * FROM test_schema.\"%s$properties\"", tableName)).getMaterializedRows();
 
-        assertThat(materializedRows).hasSize(6);
+        assertThat(materializedRows).hasSize(7);
         assertThat(materializedRows)
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.delete.mode", deleteMode)))
@@ -253,18 +256,20 @@ public class TestIcebergSystemTables
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.previous-versions-max", "100")))
                 .anySatisfy(row -> assertThat(row)
-                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.delete-after-commit.enabled", "false")));
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.delete-after-commit.enabled", "false")))
+                .anySatisfy(row -> assertThat(row)
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.metrics.max-inferred-column-defaults", "100")));
     }
 
     protected void checkORCFormatTableProperties(String tableName, String deleteMode)
     {
         assertQuery(String.format("SHOW COLUMNS FROM test_schema.\"%s$properties\"", tableName),
                 "VALUES ('key', 'varchar', '', '')," + "('value', 'varchar', '', '')");
-        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 7");
+        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 8");
         List<MaterializedRow> materializedRows = computeActual(getSession(),
                 String.format("SELECT * FROM test_schema.\"%s$properties\"", tableName)).getMaterializedRows();
 
-        assertThat(materializedRows).hasSize(7);
+        assertThat(materializedRows).hasSize(8);
         assertThat(materializedRows)
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.delete.mode", deleteMode)))
@@ -279,7 +284,9 @@ public class TestIcebergSystemTables
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.previous-versions-max", "100")))
                 .anySatisfy(row -> assertThat(row)
-                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.delete-after-commit.enabled", "false")));
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.delete-after-commit.enabled", "false")))
+                .anySatisfy(row -> assertThat(row)
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.metrics.max-inferred-column-defaults", "100")));
     }
 
     @Test
@@ -320,6 +327,15 @@ public class TestIcebergSystemTables
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.delete-after-commit.enabled", "true")));
     }
 
+    @Test
+    public void testMetricsMaxInferredColumnProperties()
+    {
+        MaterializedResult materializedRows = getQueryRunner().execute("select * from  test_schema.\"test_metrics_max_inferred_column$properties\"");
+        assertThat(materializedRows)
+                .anySatisfy(row -> assertThat(row)
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.metrics.max-inferred-column-defaults", "16")));
+    }
+
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
@@ -330,6 +346,7 @@ public class TestIcebergSystemTables
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_table_drop_column");
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_table_add_column");
         assertUpdate("DROP TABLE IF EXISTS test_schema.test_metadata_versions_maintain");
+        assertUpdate("DROP TABLE IF EXISTS test_schema.test_metrics_max_inferred_column");
         assertUpdate("DROP SCHEMA IF EXISTS test_schema");
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
@@ -89,11 +89,11 @@ public class TestIcebergSystemTablesNessie
     {
         assertQuery(String.format("SHOW COLUMNS FROM test_schema.\"%s$properties\"", tableName),
                 "VALUES ('key', 'varchar', '', '')," + "('value', 'varchar', '', '')");
-        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 8");
+        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 9");
         List<MaterializedRow> materializedRows = computeActual(getSession(),
                 String.format("SELECT * FROM test_schema.\"%s$properties\"", tableName)).getMaterializedRows();
 
-        assertThat(materializedRows).hasSize(8);
+        assertThat(materializedRows).hasSize(9);
         assertThat(materializedRows)
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.delete.mode", deleteMode)))
@@ -108,7 +108,9 @@ public class TestIcebergSystemTablesNessie
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "commit.retry.num-retries", "4")))
                 .anySatisfy(row -> assertThat(row)
-                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.previous-versions-max", "100")));
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.previous-versions-max", "100")))
+                .anySatisfy(row -> assertThat(row)
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.metrics.max-inferred-column-defaults", "100")));
     }
 
     @Override
@@ -116,11 +118,11 @@ public class TestIcebergSystemTablesNessie
     {
         assertQuery(String.format("SHOW COLUMNS FROM test_schema.\"%s$properties\"", tableName),
                 "VALUES ('key', 'varchar', '', '')," + "('value', 'varchar', '', '')");
-        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 9");
+        assertQuery(String.format("SELECT COUNT(*) FROM test_schema.\"%s$properties\"", tableName), "VALUES 10");
         List<MaterializedRow> materializedRows = computeActual(getSession(),
                 String.format("SELECT * FROM test_schema.\"%s$properties\"", tableName)).getMaterializedRows();
 
-        assertThat(materializedRows).hasSize(9);
+        assertThat(materializedRows).hasSize(10);
         assertThat(materializedRows)
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.delete.mode", deleteMode)))
@@ -137,6 +139,8 @@ public class TestIcebergSystemTablesNessie
                 .anySatisfy(row -> assertThat(row)
                         .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "commit.retry.num-retries", "4")))
                 .anySatisfy(row -> assertThat(row)
-                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.previous-versions-max", "100")));
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.previous-versions-max", "100")))
+                .anySatisfy(row -> assertThat(row)
+                        .isEqualTo(new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, "write.metadata.metrics.max-inferred-column-defaults", "100")));
     }
 }


### PR DESCRIPTION
## Description

For a very-wide-table, there will be too much metadata stored as stats in manifest files if we always collect stats for all the columns. It will occupy too much memory when loading the table metadata into memory. To cope with this, Iceberg lib support configuring the max columns that can have metrics for a table, referring to: https://github.com/apache/iceberg/pull/3959, https://github.com/apache/iceberg/pull/5215, https://github.com/apache/iceberg/pull/5916

This PR add an Iceberg table property `metrics_max_inferred_column` to set the max columns number for which metrics are collected, and implement recognizing and supporting `metrics_max_inferred_column` on metrics collection for Iceberg table with `PARQUET` format.

## Motivation and Context

Support setting the max number of columns for which metrics are collected

## Impact

Iceberg tables with `PARQUET` format now only collect statistics information from the first 100 columns by default

## Test Plan

 - Newly added test case to show the behavior of stats collection with columns count limit

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add table property `metrics_max_inferred_column` to configure the max columns number for which metrics are collected, and support `metrics_max_inferred_column` for Iceberg table with `PARQUET` format :pr:`23468`
```
