### PR TITLE
[native] Init UuidParse in TaskManager due to boost UUID non-POD changes

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -1038,8 +1038,7 @@ std::shared_ptr<PrestoTask> TaskManager::findOrCreateTask(
     UuidSplit split;
   };
 
-  UuidParse uuid{};
-  uuid.uuid = boost::uuids::random_generator()();
+  UuidParse uuid = {boost::uuids::random_generator()()};
 
   prestoTask->info.taskStatus.taskInstanceIdLeastSignificantBits =
       uuid.split.lo;

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -1038,7 +1038,7 @@ std::shared_ptr<PrestoTask> TaskManager::findOrCreateTask(
     UuidSplit split;
   };
 
-  UuidParse uuid;
+  UuidParse uuid{};
   uuid.uuid = boost::uuids::random_generator()();
 
   prestoTask->info.taskStatus.taskInstanceIdLeastSignificantBits =


### PR DESCRIPTION
## Description
https://github.com/boostorg/uuid/commit/2bbe9eaec9da43f5debde165a4f5db9f59cac0c2 changed the UUID implementation from `uint8_t[16]` to a struct in the latest `1.86` released last week.

## Motivation and Context
```sh
$ brew info boost
==> boost: stable 1.86.0 (bottled), HEAD
Collection of portable C++ source libraries
https://www.boost.org/
Installed
/opt/homebrew/Cellar/boost/1.86.0 (16,215 files, 518.0MB)

FAILED: presto_cpp/main/CMakeFiles/presto_server_lib.dir/TaskManager.cpp.o
presto/presto-native-execution/presto_cpp/main/TaskManager.cpp:1041:13: error: call to implicitly-deleted default constructor of 'UuidParse'
 1041 |   UuidParse uuid;
      |             ^
presto/presto-native-execution/presto_cpp/main/TaskManager.cpp:1037:24: note: default constructor of 'UuidParse' is implicitly deleted because variant field 'uuid' has a non-trivial default constructor
 1037 |     boost::uuids::uuid uuid;
      |                        ^
1 error generated.
```


```
== NO RELEASE NOTE ==
```

