### PR TITLE
Fix querying and filtering using Iceberg metadata columns

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -45,6 +45,8 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.getMinimumAss
 import static com.facebook.presto.iceberg.IcebergTableType.CHANGELOG;
 import static com.facebook.presto.iceberg.IcebergTableType.EQUALITY_DELETES;
 import static com.facebook.presto.iceberg.IcebergUtil.getIcebergTable;
+import static com.facebook.presto.iceberg.IcebergUtil.getMetadataColumnConstraints;
+import static com.facebook.presto.iceberg.IcebergUtil.getNonMetadataColumnConstraints;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplitManager
@@ -81,7 +83,8 @@ public class IcebergSplitManager
             return new FixedSplitSource(ImmutableList.of());
         }
 
-        TupleDomain<IcebergColumnHandle> predicate = layoutHandle.getValidPredicate();
+        TupleDomain<IcebergColumnHandle> predicate = getNonMetadataColumnConstraints(layoutHandle
+                .getValidPredicate());
         Table icebergTable = getIcebergTable(transactionManager.get(transaction), session, table.getSchemaTableName());
 
         if (table.getIcebergTableName().getTableType() == CHANGELOG) {
@@ -114,7 +117,8 @@ public class IcebergSplitManager
                     session,
                     tableScan,
                     TableScanUtil.splitFiles(tableScan.planFiles(), tableScan.targetSplitSize()),
-                    getMinimumAssignedSplitWeight(session));
+                    getMinimumAssignedSplitWeight(session),
+                    getMetadataColumnConstraints(layoutHandle.getValidPredicate()));
             return splitSource;
         }
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
@@ -27,6 +27,7 @@ import com.facebook.presto.iceberg.IcebergTableLayoutHandle;
 import com.facebook.presto.iceberg.IcebergTableName;
 import com.facebook.presto.iceberg.IcebergTableType;
 import com.facebook.presto.iceberg.IcebergTransactionManager;
+import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.ConnectorPlanRewriter;
@@ -180,6 +181,7 @@ public class IcebergEqualityDeleteAsJoin
 
             TupleDomain<IcebergColumnHandle> predicate = icebergTableLayoutHandle
                     .map(IcebergTableLayoutHandle::getValidPredicate)
+                    .map(IcebergUtil::getNonMetadataColumnConstraints)
                     .orElse(TupleDomain.all());
 
             // Collect info about each unique delete schema to join by

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
@@ -1354,6 +1354,12 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
     deletes.emplace_back(icebergDeleteFile);
   }
 
+  std::unordered_map<std::string, std::string> metadataColumns;
+  metadataColumns.reserve(1);
+  metadataColumns.insert(
+      {"$data_sequence_number",
+       std::to_string(icebergSplit->dataSequenceNumber)});
+
   return std::make_unique<connector::hive::iceberg::HiveIcebergSplit>(
       catalogId,
       icebergSplit->path,
@@ -1364,7 +1370,8 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
       std::nullopt,
       customSplitInfo,
       nullptr,
-      deletes);
+      deletes,
+      metadataColumns);
 }
 
 std::unique_ptr<velox::connector::ColumnHandle>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -109,20 +109,19 @@ public class NativeQueryRunnerUtils
 
     public static void createLineitem(QueryRunner queryRunner, boolean castDateToVarchar)
     {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "lineitem")) {
-            String shipDate = castDateToVarchar ? "cast(shipdate as varchar) as shipdate" : "shipdate";
-            String commitDate = castDateToVarchar ? "cast(commitdate as varchar) as commitdate" : "commitdate";
-            String receiptDate = castDateToVarchar ? "cast(receiptdate as varchar) as receiptdate" : "receiptdate";
-            queryRunner.execute("CREATE TABLE lineitem AS " +
-                    "SELECT orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, " +
-                    "   returnflag, linestatus, " + shipDate + ", " + commitDate + ", " + receiptDate + ", " +
-                    "   shipinstruct, shipmode, comment, " +
-                    "   linestatus = 'O' as is_open, returnflag = 'R' as is_returned, " +
-                    "   cast(tax as real) as tax_as_real, cast(discount as real) as discount_as_real, " +
-                    "   cast(linenumber as smallint) as linenumber_as_smallint, " +
-                    "   cast(linenumber as tinyint) as linenumber_as_tinyint " +
-                    "FROM tpch.tiny.lineitem");
-        }
+        queryRunner.execute("DROP TABLE IF EXISTS lineitem");
+        String shipDate = castDateToVarchar ? "cast(shipdate as varchar) as shipdate" : "shipdate";
+        String commitDate = castDateToVarchar ? "cast(commitdate as varchar) as commitdate" : "commitdate";
+        String receiptDate = castDateToVarchar ? "cast(receiptdate as varchar) as receiptdate" : "receiptdate";
+        queryRunner.execute("CREATE TABLE lineitem AS " +
+                "SELECT orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, " +
+                "   returnflag, linestatus, " + shipDate + ", " + commitDate + ", " + receiptDate + ", " +
+                "   shipinstruct, shipmode, comment, " +
+                "   linestatus = 'O' as is_open, returnflag = 'R' as is_returned, " +
+                "   cast(tax as real) as tax_as_real, cast(discount as real) as discount_as_real, " +
+                "   cast(linenumber as smallint) as linenumber_as_smallint, " +
+                "   cast(linenumber as tinyint) as linenumber_as_tinyint " +
+                "FROM tpch.tiny.lineitem");
     }
 
     public static void createLineitemForIceberg(QueryRunner queryRunner)
@@ -143,13 +142,12 @@ public class NativeQueryRunnerUtils
 
     public static void createOrders(QueryRunner queryRunner, boolean castDateToVarchar)
     {
-        if (!queryRunner.tableExists(queryRunner.getDefaultSession(), "orders")) {
-            String orderDate = castDateToVarchar ? "cast(orderdate as varchar) as orderdate" : "orderdate";
-            queryRunner.execute("CREATE TABLE orders AS " +
-                    "SELECT orderkey, custkey, orderstatus, totalprice, " + orderDate + ", " +
-                    "   orderpriority, clerk, shippriority, comment " +
-                    "FROM tpch.tiny.orders");
-        }
+        queryRunner.execute("DROP TABLE IF EXISTS orders");
+        String orderDate = castDateToVarchar ? "cast(orderdate as varchar) as orderdate" : "orderdate";
+        queryRunner.execute("CREATE TABLE orders AS " +
+                "SELECT orderkey, custkey, orderstatus, totalprice, " + orderDate + ", " +
+                "   orderpriority, clerk, shippriority, comment " +
+                "FROM tpch.tiny.orders");
     }
 
     public static void createOrdersEx(QueryRunner queryRunner)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergGeneralQueries.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestPrestoNativeIcebergGeneralQueries
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner(false, true);
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner(true);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        createTableToTestHiddenColumns();
+    }
+
+    private void createTableToTestHiddenColumns()
+    {
+        QueryRunner javaQueryRunner = ((QueryRunner) getExpectedQueryRunner());
+        if (!javaQueryRunner.tableExists(getSession(), "test_hidden_columns")) {
+            javaQueryRunner.execute("CREATE TABLE test_hidden_columns AS SELECT * FROM tpch.tiny.region WHERE regionkey=0");
+            javaQueryRunner.execute("INSERT INTO test_hidden_columns SELECT * FROM tpch.tiny.region WHERE regionkey=1");
+        }
+    }
+
+    @Test
+    public void testPathHiddenColumn()
+    {
+        assertQuery("SELECT \"$path\", * FROM test_hidden_columns");
+
+        // Fetch one of the file paths and use it in a filter
+        String filePath = (String) computeActual("SELECT \"$path\" from test_hidden_columns LIMIT 1").getOnlyValue();
+        assertQuery(format("SELECT * from test_hidden_columns WHERE \"$path\"='%s'", filePath));
+
+        assertEquals(
+                (Long) computeActual(format("SELECT count(*) from test_hidden_columns WHERE \"$path\"='%s'", filePath))
+                        .getOnlyValue(),
+                1L);
+
+        // Filter for $path that doesn't exist.
+        assertEquals(
+                (Long) computeActual(format("SELECT count(*) from test_hidden_columns WHERE \"$path\"='%s'", "non-existent-path"))
+                        .getOnlyValue(),
+                0L);
+    }
+
+    @Test
+    public void testDataSequenceNumberHiddenColumn()
+    {
+        assertQuery("SELECT \"$data_sequence_number\", * FROM test_hidden_columns");
+
+        // Fetch one of the data sequence numbers and use it in a filter
+        Long dataSequenceNumber = (Long) computeActual("SELECT \"$data_sequence_number\" from test_hidden_columns LIMIT 1").getOnlyValue();
+        assertQuery(format("SELECT * from test_hidden_columns WHERE \"$data_sequence_number\"=%d", dataSequenceNumber));
+
+        assertEquals(
+                (Long) computeActual(format("SELECT count(*) from test_hidden_columns WHERE \"$data_sequence_number\"=%d", dataSequenceNumber))
+                        .getOnlyValue(),
+                1L);
+
+        // Filter for $data_sequence_number that doesn't exist.
+        assertEquals(
+                (Long) computeActual(format("SELECT count(*) from test_hidden_columns WHERE \"$data_sequence_number\"=%d", 1000))
+                        .getOnlyValue(),
+                0L);
+    }
+}


### PR DESCRIPTION
## Description
Fix to query and filter using Iceberg metadata columns "$path" and "$data_sequence_number".

## Motivation and Context
Previously wasn't able to query these metadata columns.

## Impact
No impact

## Test Plan
Added new test file to test querying and filtering by metadata columns.

```
== RELEASE NOTES ==

General Changes
* Fix to query and filter using Iceberg metadata columns "$path" and "$data_sequence_number" :pr:`23472`
```

