### PR TITLE
[native] Fix uuid constructor to make presto native work with boost 1.86

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -1037,9 +1037,8 @@ std::shared_ptr<PrestoTask> TaskManager::findOrCreateTask(
     boost::uuids::uuid uuid;
     UuidSplit split;
   };
-
-  UuidParse uuid;
-  uuid.uuid = boost::uuids::random_generator()();
+  
+  UuidParse uuid = {(boost::uuids::random_generator()())};
 
   prestoTask->info.taskStatus.taskInstanceIdLeastSignificantBits =
       uuid.split.lo;


### PR DESCRIPTION
## Description
Preto-Native build is failing with boost 1.86 with the following error:

presto_cpp/main/CMakeFiles/presto_server_lib.dir/TaskManager.cpp.o -c /Users/satadru/gitcode/presto/presto-native-execution/presto_cpp/main/TaskManager.cpp
/Users/satadru/gitcode/presto/presto-native-execution/presto_cpp/main/TaskManager.cpp:1041:13: error: call to implicitly-deleted default constructor of 'UuidParse'
  UuidParse uuid;
            ^
/Users/satadru/gitcode/presto/presto-native-execution/presto_cpp/main/TaskManager.cpp:1037:24: note: default constructor of 'UuidParse' is implicitly deleted because variant field 'uuid' has a non-trivial default constructor
    boost::uuids::uuid uuid;
                       ^
1 error generated.

## Motivation and Context
This diff fixes the constructor for UuidParse union to fix the build with boost 1.86. 

## Impact
Presto-Native should build with boost 1.86

## Test Plan
Build with both boost 1.85 and 1.86 pass. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

