### PR TITLE
[native] Fix Velox connector configs update

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -101,7 +101,7 @@ void updateVeloxConnectorConfigs(
   const auto& systemConfig = SystemConfig::instance();
 
   for (auto& entry : connectorConfigStrings) {
-    auto connectorConfig = entry.second;
+    auto& connectorConfig = entry.second;
 
     // Do not retain cache if `node_selection_strategy` is explicitly set to
     // `NO_PREFERENCE`.


### PR DESCRIPTION
The variable needs to be a reference instead of a copy. This is necessary to ensure that changes made to the config are reflected in the query context.

```
== NO RELEASE NOTE ==
```

