### PR TITLE
[Iceberg]Fix cleanup files behavior on expiring snapshots

### DIFF
--- a/presto-iceberg/src/main/java/org/apache/iceberg/IcebergLibUtils.java
+++ b/presto-iceberg/src/main/java/org/apache/iceberg/IcebergLibUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergLibUtils
+{
+    private IcebergLibUtils()
+    {}
+
+    /**
+     * Call the method in Iceberg lib's protected class to set explicitly
+     *  whether to use incremental cleanup when expiring snapshots
+     * */
+    public static ExpireSnapshots withIncrementalCleanup(ExpireSnapshots expireSnapshots, boolean incrementalCleanup)
+    {
+        requireNonNull(expireSnapshots, "expireSnapshots is null");
+        checkArgument(expireSnapshots instanceof RemoveSnapshots, "expireSnapshots is not an instance of RemoveSnapshots");
+        return ((RemoveSnapshots) expireSnapshots).withIncrementalCleanup(incrementalCleanup);
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Test
 public class TestIcebergDistributedNessie
@@ -75,5 +76,14 @@ public class TestIcebergDistributedNessie
             throws Exception
     {
         return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+    }
+
+    @Override
+    public void testExpireSnapshotWithDeletedEntries()
+    {
+        // Nessie do not support expire snapshots as it set table property `gc.enabled` to `false` by default
+        assertThatThrownBy(() -> super.testExpireSnapshotWithDeletedEntries())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageMatching("Cannot expire snapshots: GC is disabled .*");
     }
 }


### PR DESCRIPTION
## Description

This PR fix the problem which will lead in useful data files being mistakenly cleaned up on expiring a specified snapshot. The problem is caused by a bug in Iceberg lib, see: https://github.com/apache/iceberg/issues/10982

For example, if we have a table with actions as follows:

```
create table test_table (a int, b varchar) with (partitioning = ARRAY['a']);
insert into test_table values(1, '1001'), (2, '2002')";   // snapshotID1: 665253674228182135
delete from test_table where a = 1;                             // snapshotID2: 8747165359269122672
insert into test_table values(1, '1003'), (3, '3003');	// snapshotID3
```

Now we want to expire the specified snapshot `snapshotID2`:

```
call iceberg.system.expire_snapshots(schema => 'test_schema', table_name => 'test_table', snapshot_ids => ARRAY[8747165359269122672]);
```

After that, when we want to do a Time Travel query on `snapshotID1`, we will fail because a data file do not exist any more:

```
presto:default> select * from "aat@665253674228182135";

Query 20240820_134750_00015_iskqd failed: Error opening Iceberg split file:/Users/wangd/work/data/iceberg/data/default/aat/data/a=2/57e1e6ad-eccf-44dc-b951-678dfbdb7e51.parquet (offset=0, length=302): File file:/Users/wangd/work/data/iceberg/data/default/aat/data/a=2/57e1e6ad-eccf-44dc-b951-678dfbdb7e51.parquet does not exist
```

## Motivation and Context
Fix the problem which will lead in useful data files being mistakenly cleaned up on expiring a specified snapshot

## Impact

N/A

## Test Plan

 - Newly added test case in `IcebergDistributedTestBase` to show the scenario described above

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

