### PR TITLE
Distinguish scheduler runtime stats for scan stage

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -41,9 +41,15 @@ public class RuntimeMetricName
     public static final String GET_PARTITIONS_BY_NAMES_TIME_NANOS = "getPartitionsByNamesTimeNanos";
     public static final String GET_TABLE_TIME_NANOS = "getTableTimeNanos";
     public static final String GET_SPLITS_TIME_NANOS = "getSplitsTimeNanos";
+    // CPU time taken to schedule a given stage
     public static final String SCHEDULER_CPU_TIME_NANOS = "schedulerCpuTimeNanos";
+    // Wall time taken to schedule a given stage
     public static final String SCHEDULER_WALL_TIME_NANOS = "schedulerWallTimeNanos";
+    // Blocked time of the scheduler during scheduling a given stage
     public static final String SCHEDULER_BLOCKED_TIME_NANOS = "schedulerBlockedTimeNanos";
+    public static final String SCAN_STAGE_SCHEDULER_CPU_TIME_NANOS = "scanStageSchedulerCpuTimeNanos";
+    public static final String SCAN_STAGE_SCHEDULER_WALL_TIME_NANOS = "scanStageSchedulerWallTimeNanos";
+    public static final String SCAN_STAGE_SCHEDULER_BLOCKED_TIME_NANOS = "scanStageSchedulerBlockedTimeNanos";
     public static final String LOGICAL_PLANNER_TIME_NANOS = "logicalPlannerTimeNanos";
     public static final String OPTIMIZER_TIME_NANOS = "optimizerTimeNanos";
     public static final String GET_CANONICAL_INFO_TIME_NANOS = "getCanonicalInfoTimeNanos";

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -26,6 +26,7 @@ import com.facebook.presto.metadata.RemoteTransactionHandle;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.server.remotetask.HttpRemoteTask;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.split.RemoteSplit;
 import com.facebook.presto.sql.planner.PlanFragment;
@@ -573,12 +574,27 @@ public final class SqlStageExecution
 
     public void recordSchedulerRunningTime(long cpuTimeNanos, long wallTimeNanos)
     {
+        if (isLeafStage(planFragment.getRoot())) {
+            stateMachine.recordLeafStageSchedulerRunningTime(cpuTimeNanos, wallTimeNanos);
+        }
         stateMachine.recordSchedulerRunningTime(cpuTimeNanos, wallTimeNanos);
     }
 
     public void recordSchedulerBlockedTime(ScheduleResult.BlockedReason reason, long nanos)
     {
+        if (isLeafStage(planFragment.getRoot())) {
+            stateMachine.recordLeafStageSchedulerBlockedTime(reason, nanos);
+        }
         stateMachine.recordSchedulerBlockedTime(reason, nanos);
+    }
+
+    private boolean isLeafStage(PlanNode root)
+    {
+        PlanNode leafNode = root;
+        while (!leafNode.getSources().isEmpty()) {
+            leafNode = leafNode.getSources().get(0);
+        }
+        return leafNode.getSources().isEmpty();
     }
 
     private static Split createRemoteSplitFor(TaskId taskId, URI remoteSourceTaskLocation, TaskId remoteSourceTaskId)

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
@@ -39,6 +39,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.common.RuntimeMetricName.GET_SPLITS_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.SCAN_STAGE_SCHEDULER_BLOCKED_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.SCAN_STAGE_SCHEDULER_CPU_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.SCAN_STAGE_SCHEDULER_WALL_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.SCHEDULER_BLOCKED_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.SCHEDULER_CPU_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.SCHEDULER_WALL_TIME_NANOS;
@@ -379,6 +382,18 @@ public class StageExecutionStateMachine
     {
         requireNonNull(reason, "reason is null");
         runtimeStats.addMetricValue(SCHEDULER_BLOCKED_TIME_NANOS + "-" + reason, NANO, max(nanos, 0));
+    }
+
+    public void recordLeafStageSchedulerRunningTime(long cpuTimeNanos, long wallTimeNanos)
+    {
+        runtimeStats.addMetricValue(SCAN_STAGE_SCHEDULER_CPU_TIME_NANOS, NANO, max(cpuTimeNanos, 0));
+        runtimeStats.addMetricValue(SCAN_STAGE_SCHEDULER_WALL_TIME_NANOS, NANO, max(wallTimeNanos, 0));
+    }
+
+    public void recordLeafStageSchedulerBlockedTime(ScheduleResult.BlockedReason reason, long nanos)
+    {
+        requireNonNull(reason, "reason is null");
+        runtimeStats.addMetricValue(SCAN_STAGE_SCHEDULER_BLOCKED_TIME_NANOS + "-" + reason, NANO, max(nanos, 0));
     }
 
     @Override


### PR DESCRIPTION
## Description
Distinguish scheduler runtime stats for scan stage scheduling

## Motivation and Context
We want to identify the slowness if any in the scan stage scheduling (split scheduling). So we want to have a different name, so that its easy to identify.

## Impact
None

## Test Plan
run hive query runner and confirm
<img width="648" alt="Screenshot 2024-08-22 at 11 25 17 AM" src="https://github.com/user-attachments/assets/71fb4196-ed7a-44d8-b527-3f6c63a3afa9">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

