### PR TITLE
SSL enablement for Cassandra Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2127,18 +2127,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.facebook.presto.cassandra</groupId>
-                <artifactId>cassandra-driver</artifactId>
-                <version>3.6.0-1</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-delta</artifactId>
                 <version>${project.version}</version>
@@ -2276,6 +2264,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${dep.commons.compress.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-core</artifactId>
+                <version>3.11.5</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -17,8 +17,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.facebook.presto.cassandra</groupId>
-            <artifactId>cassandra-driver</artifactId>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
         </dependency>
 
         <dependency>
@@ -184,6 +184,17 @@
             <artifactId>security</artifactId>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <!-- This is to fix the upper bound issues arising out of different components-->
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>4.1.107.Final</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
+++ b/presto-cassandra/src/test/java/com/datastax/driver/core/TestHost.java
@@ -20,6 +20,6 @@ public class TestHost
 {
     public TestHost(InetSocketAddress address)
     {
-        super(address, new ConvictionPolicy.DefaultConvictionPolicy.Factory(), Cluster.builder().addContactPoints("localhost").build().manager);
+        super(new TranslatedAddressEndPoint(address), new ConvictionPolicy.DefaultConvictionPolicy.Factory(), Cluster.builder().addContactPoints("localhost").build().manager);
     }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -344,6 +344,7 @@ public class TestCassandraIntegrationSmokeTest
 
     @Test
     public void testTableNameAmbiguity()
+            throws Exception
     {
         session.execute("CREATE KEYSPACE keyspace_4 WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor': 1}");
         assertContainsEventually(() -> execute("SHOW SCHEMAS FROM cassandra"), resultBuilder(getSession(), createUnboundedVarcharType())
@@ -354,6 +355,9 @@ public class TestCassandraIntegrationSmokeTest
         // that have differences only in letters case.
         session.execute("CREATE TABLE keyspace_4.\"TaBlE_4\" (column_4 bigint PRIMARY KEY)");
         session.execute("CREATE TABLE keyspace_4.\"tAbLe_4\" (column_4 bigint PRIMARY KEY)");
+
+        // This is added for Cassandra to refresh its metadata so that we don't encounter a race condition in the forthcoming steps and achieve eventual consistency.
+        Thread.sleep(1000);
 
         // Although in Presto all the schema and table names are always displayed as lowercase
         assertContainsEventually(() -> execute("SHOW TABLES FROM cassandra.keyspace_4"), resultBuilder(getSession(), createUnboundedVarcharType())

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -133,8 +133,15 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.facebook.presto.cassandra</groupId>
-            <artifactId>cassandra-driver</artifactId>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>3.11.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
## Description

Cassandra Version Upgrade for enabling SSL

## Motivation and Context
Presto uses presto cassandra driver (shaded version of datastax driver ) for connections . While non ssl operations work fine , the same does not hold good for SSL functionalities.

While we try to connect to an SSL instance , we get the below error

com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: /52.116.130.195:9042 (com.datastax.driver.core.exceptions.OperationTimedOutException: [/52.116.130.195:9042] Operation timed out))

Presto uses 3.6.0 version of DataStax driver which does not support SSL. Version 3.11.2 or higher version of DataStax driver supports SSL.

https://github.com/prestodb/presto/issues/23506

## Impact
SSL will be enabled and connections can be secured.

## Test Plan

Tested Locally end to end

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

== RELEASE NOTES ==

Cassandra Connector Changes
* Upgrade cassandra-driver-core to 3.11.5 for SSL support :pr:`23493`
