### PR TITLE
Add release notes for 0.289

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    Release-0.289 [2024-08-23] <release/release-0.289>
     Release-0.288.1 [2024-08-12] <release/release-0.288.1>
     Release-0.288 [2024-06-13] <release/release-0.288>
     Release-0.287 [2024-04-16] <release/release-0.287>

--- a/presto-docs/src/main/sphinx/release/release-0.289.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.289.rst
@@ -1,0 +1,98 @@
+=============
+Release 0.289
+=============
+
+**Highlights**
+==============
+* Add support to read tables up to Delta Protocol Version 3,7 through the use of the new Delta-Kernel api. :pr:`22596`
+* Fix an issue where ``array_distinct``, ``array_except``, ``array_intersect``, ``array_union``,  ``set_union``, and ``set_agg`` would return an error if the input was an array of rows with null fields or array of arrays with null elements.  These functions now use full ``IS DISTINCT FROM`` semantics for comparison. :pr:`22938`
+* Fix default Parquet writer version to ``PARQUET_1_0``. Set the hive config ``hive.parquet.writer.version = PARQUET_2_0`` for old behavior. :pr:`23369`
+* Add a REST API in Presto C++ worker to fetch worker stats in Prometheus Data Format. :pr:`22360`
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a bug in the hash code of -0 for double and real types when ``use-new-nan-definition`` is false. :pr:`23060`
+* Fix incorrect results on queries with count over mixed aggregation :pr:`23013`
+* Fix a bug where like predicates would only match a newline when there was no wildcard at the end. :pr:`23404`
+* Fix equijoin over timestamp with timezone types. :pr:`23319`
+* Fix resource group state info endpoint to return current values from the resource groups. :pr:`23178`
+* Fix array_min/array_max when the first element recursively contains an inner array with a null element. :pr:`23323`
+* Fix :func:`map_top_n` function to be deterministic by using keys to break ties. :pr:`22778`
+* Fix stddev and variance functions to always return correct results when input is constant. :pr:`23447`
+* Add an optimization to remove cross join when one side of inputs is a single row of constant values. The optimization is controlled by the session property ``remove_cross_join_with_constant_single_row_input`` (default is ``true```). :pr:`23081`
+* Add configuration property ``warn-on-possible-nans`` and session property ``warn_on_possible_nans`` to produce a warning on division operations or comparison operations involving double or real types. Division operations are common causes of accidental creation of NaNs, and the semantics of comparison operations involving NaNs changed considerably in the most recent Presto release. :pr:`23059`
+* Add function :func:`ip_prefix_collapse`. :pr:`23445`
+* Add function :func:`array_split_into_chunks`. :pr:`23264`
+* Add a warning when an ``IGNORE NULL``` clause is used on any non lag, lead, first, last, or nth value function.  In future releases these queries will fail. :pr:`23325`
+* Add treatment of low confidence, zero estimations as ``UNKNOWN`` during joins, with the ``treat-low-confidence-zero-estimation-as-unknown`` session property :pr:`23047`
+* Add confidence based broadcasting, side of join with highest confidence will be on build side.  This can be enabled with the ``confidence_based_broadcast`` session property :pr:`23016`
+* Add :doc:`/clients/dbeaver` documentation. :pr:`23189`
+* Add :doc:`/clients/superset` documentation. :pr:`23194`
+* Upgrade Joda-Time to 2.12.7 to use 2024a tzdata. Note: a corresponding update to the Java runtime should also be made to ensure consistent timezone data. For example, Oracle JDK 8u381, tzdata2024a rpm for OpenJDK, or use Timezone Updater Tool to apply 2024a tzdata to existing JVM. :pr:`23027`
+* Upgrade Airlift to 0.215. :pr:`23356`
+* Upgrade avro to 1.11.3 due to CVE-2023-39410. :pr:`23142`
+* Upgrade guava to 32.1.0-jre due CVE-2023-2976. :pr:`23127`
+* Upgrade json-path to 2.9.0 due to CVE-2023-1370. :pr:`23104`
+
+Presto C++ Changes
+__________________
+* Add a REST API in Presto C++ worker to fetch worker stats in Prometheus Data Format. :pr:`22360`
+* Add CTE materialization for Presto C++ workers with the configuration properties ``hive.temporary-table-storage-format`` (``DWRF`` or ``PARQUET`` only) and ``hive.temporary-table-compression-codec`` (``ZSTD`` or ``NONE`` only). :pr:`22780`
+* Add support for persisting full memory cache to SSD periodically on Presto C++ worker. This can be enabled by setting ``cache.velox.full-persistence-interval`` to a non-zero value. :pr:`23192`
+* Fix queries that contain timestamp with timezone to fail to avoid correctness issues. :pr:`23200`
+
+JDBC Changes
+____________
+* Fix failure when setting autoCommit from ``false`` to ``true``. :pr:`23453`
+* Fix the ``PrestoDatabaseMetaData.getURL`` method to include the ``jdbc:`` prefix in the returned URL :pr:`23397`
+
+History Based Optimizer Changes
+_______________________________
+* Fix serialization of aggregation node in HBO plan hash to output consistent hash. :pr:`22949`
+* Add session property ``enable_verbose_history_based_optimizer_runtime_stats`` to track latency of HBO optimizer. :pr:`23241`
+* Add session property ``enforce_history_based_optimizer_register_timeout`` to enforce the maximum time HBO query registration can take. :pr:`23354`
+* Add support for query retry when History-Based Optimization can help a failed query, with the ``retry-query-with-history-based-optimization`` session property :pr:`23147`
+
+Hive Connector Changes
+______________________
+* Fix default Parquet writer version to ``PARQUET_1_0``. Set the hive config ``hive.parquet.writer.version = PARQUET_2_0`` for old behavior. :pr:`23369`
+* Fix filtering by info columns ``$file_size`` and ``$file_modified_time``, which were ignored before. :pr:`23411`
+* Fix hash calculation for Timestamp column to be hive compatible when writing to a table bucketed by Timestamp.  :pr:`22980`
+* Add config ``hive.legacy-timestamp-bucketing`` and session property ``hive.legacy_timestamp_bucketing`` to use the original hash function for Timestamp column, which is not hive compatible. :pr:`22980`
+* Add support for setting the max size in bytes for the directory listing cache. This can be set via the new ``hive.file-status-cache.max-retained-size`` configuration property. ``hive.file-status-cache-size`` is now deprecated. :pr:`23176`
+* Add support to skip empty files using configuration property ``hive.skip_empty_files``. :pr:`22727`
+* Add support for decimal batch reader :pr:`22636`
+
+Iceberg Connector Changes
+_________________________
+* Fix default Parquet writer version to ``PARQUET_1_0``. Set the hive config ``hive.parquet.writer.version = PARQUET_2_0`` for old behavior. :pr:`23369`
+* Add procedure ``remove_orphan_files`` to remove orphan files that are not referenced in any metadata files for Iceberg. :pr:`23267`
+* Add table properties ``metadata_previous_versions_max`` and ``metadata_delete_after_commit`` to maintain the previous metadata files. :pr:`23260`
+* Add support for Iceberg with hive catalog to delete old metadata files after commit based on the table properties. :pr:`23260`
+* Add `configuration properties <https://prestodb.io/docs/current/connector/iceberg.html#glue-catalog>` to tune table metadata refresh timeouts for the Iceberg connector when configured with the Hive or Glue catalog. :pr:`23174`
+* Fix Iceberg read failing for Decimal type. :pr:`23305`
+* Improve performance of Iceberg and Delta connectors when used with JDBC client. :pr:`22936`
+
+Delta Connector Changes
+_______________________
+* Add support to read tables up to Delta Protocol Version 3,7 through the use of the new Delta-Kernel api. :pr:`22596`
+* Improve performance of Iceberg and Delta connectors when used with JDBC client. :pr:`22936`
+* Add new boolean configuration parameter delta.case-sensitive-partitions-enabled to be able to query data with partitioned columns with column names in uppercase. This property is set to true by default. :pr:`22596`
+
+Verifier Changes
+________________
+* Add ``control.reuse-table`` and ``test.reuse-table`` configuration properties for the Presto Verifier to reuse the output tables of the source query for control and test. :pr:`22965`
+* Add verifier config ``--validate-string-as-double`` to control applying floating point validation to the column composed of varchar, if the varchar column is derived from casting floating points. :pr:`23312`
+
+SPI Changes
+___________
+* Add ``publishQueryProgress`` to ``EventListener`` to publish regular progress of queries in a Presto cluster.  The ``event.query-progress-publish-interval`` config property can be used to specify the time interval at which progress events should be generated. Default is 0 (disabled). :pr:`23195`
+* Add ``equalValuesAreIdentical`` to ``Type``.  Override this method to return ``false`` when the values of the type may have more than one representation. :pr:`23319`
+
+**Credits**
+===========
+
+Abe Varghese, Abhisek Saikia, Ajay George, Amit Dutta, Andrii Rosa, Anil Gupta Somisetty, Arjun Gupta, Auden Woolfson, Bikramjeet Vig, Christian Zentgraf, Deepak Majeti, Denodo Research Labs, Devesh Agrawal, Elliotte Rusty Harold, Emanuel F., Feilong Liu, Gary Helmling, Ge Gao, Jacob Khaliqi, Jalpreet Singh Nanda (:imjalpreet), Jialiang Tan, Jimmy Lu, Karteekmurthys, Ke, Kevin Wilfong, Krishna Pai, Linsong Wang, Mahadevuni Naveen Kumar, Matt Calder, Miguel Blanco Godón, Nikhil Collooru, Pramod Satya, Pratik Joseph Dabre, Ramesh Kanna S, Rebecca Schlussel, Reetika Agrawal, Sergey Pershin, Sreeni Viswanadha, Steve Burnett, Swapnil Tailor, Tim Meehan, Wills Feng, Yihong Wang, Zac Blanco, Zac Wen, Zuyu ZHANG, abhinavmuk04, aditi-pandit, cvarelad-denodo, jaystarshot, misterjpapa, oyeliseiev-ua, prithvip, wangd, wypb, xiaoxmeng, yingsu00, ymmarissa


### PR DESCRIPTION
# Missing Release Notes
## Abe Varghese
- [ ] https://github.com/prestodb/presto/pull/23382 [native] Enhance CSV Parsing in ContainerQueryRunner to Use MaterializedResult (Merged by: Timothy Meehan)

## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/23263 [native] Advance velox. (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/23259 [native] Fix crash in httpclient when accessing null eventbase (follo… (Merged by: Ge Gao)
- [ ] https://github.com/prestodb/presto/pull/23258 [native] Fix crash in httpclient when accessing null eventbase (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/23117 [native] Advance velox. (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/23036 [native] Advance velox. (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/23007 [native] Advance velox. (Merged by: Amit Dutta)

## Auden Woolfson
- [ ] https://github.com/prestodb/presto/pull/23325 Add warning for IGNORE NULL with Window agggregates (Merged by: Auden Woolfson)

## Bikramjeet Vig
- [ ] https://github.com/prestodb/presto/pull/23289 [native] Handle scan filter with NaN limits during plan conversion (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/23046 [native] Remove spark specific query config from BaseVeloxQueryConfig (Merged by: Ge Gao)
- [ ] https://github.com/prestodb/presto/pull/23025 [native] Include additional context from velox exception (Merged by: Aditi Pandit)

## Deepak Majeti
- [ ] https://github.com/prestodb/presto/pull/23290 [native] Add CMake options to enable GCS and ABFS (Merged by: Deepak Majeti)

## Elliotte Rusty Harold
- [ ] https://github.com/prestodb/presto/pull/23168 Decouple from HiveErrorCode.HIVE_TOO_MANY_OPEN_PARTITIONS (Merged by: Elliotte Rusty Harold)

## Jialiang Tan
- [ ] https://github.com/prestodb/presto/pull/23422 [native] Add metrics for memory pushback mechanism (Merged by: Xiaoxuan)

## Jimmy Lu
- [ ] https://github.com/prestodb/presto/pull/23321 [native] Fix HTTP client connection pool shutdown order (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/23286 [native] Fix exchange HTTP executors shutdown order (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/23028 [native] Implement bucket conversion for Hive splits (Merged by: Xiaoxuan)

## Karteekmurthys
- [ ] https://github.com/prestodb/presto/pull/22360 [native] Expose REST API to fetch worker stats in Prometheus format (Merged by: Deepak Majeti)

## Ke
- [ ] https://github.com/prestodb/presto/pull/23480 [native] Refactor TaskManagerTest to not create common::WriterOptions instance (Merged by: Ke)

## Kevin Wilfong
- [ ] https://github.com/prestodb/presto/pull/23323 array_min/array_max throw if first element is an inner Array with a null (Merged by: Xiaoxuan)

## Miguel Blanco Godón
- [ ] https://github.com/prestodb/presto/pull/22596 Add support to be able to query new Delta protocols (Merged by: Timothy Meehan)

## Pratik Joseph Dabre
- [ ] https://github.com/prestodb/presto/pull/23144 Introduce a new CoordinatorPlugin interface for native clusters (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/22854 Add coordinator sidecar process (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/23035 [native] Add e2e tests for normalize scalar function (Merged by: Amit Dutta)

## Yiqun (Ethan) Zhang
- [ ] 815012f55906d5dbc659b96f2d6b7de58bcb9470 Update .gitignore to include more IDE generated files

## abhinavmuk04
- [ ] https://github.com/prestodb/presto/pull/23147 Support query retry for HBO (Merged by: abhinavmuk04)
- [ ] https://github.com/prestodb/presto/pull/23264 Add a function for splitting array into slices of given length (Merged by: abhinavmuk04)
- [ ] https://github.com/prestodb/presto/pull/23047 Treat Low Confidence, 0 estimations as unknown during joins (Merged by: feilong-liu)
- [ ] https://github.com/prestodb/presto/pull/23016 Prioritize high confidence stats during broadcast joins (Merged by: abhinavmuk04)

## aditi-pandit
- [ ] https://github.com/prestodb/presto/pull/22780 [Native] Add missing plumbing for Cte support (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/23078 [Native] Advance Velox (Merged by: Amit Dutta)

## misterjpapa
- [ ] https://github.com/prestodb/presto/pull/23397 Prepend jdbc: to DatabaseMetaData.getURL result (Merged by: Timothy Meehan)

## wypb
- [ ] https://github.com/prestodb/presto/pull/23305 Fix Iceberg read failing for Decimal type (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/22636 Add support for decimal batch reader (Merged by: Ying)

# Extracted Release Notes
- #22727 (Author: cvarelad-denodo): Add property to skip empty files in Hive Connector
  - Add support to skip empty files using configuration property ``hive.skip_empty_files`` :pr:`22727`.
- #22936 (Author: Denodo Research Labs): Pass full session to avoid Unknown connector errors
  - Pass full session to avoid Unknown connector errors :pr:`22936`.
- #22938 (Author: Rebecca Schlussel): Use distinct semantics for distincting array functions
  - Fix an issue where ``array_distinct``,``array_except``, ``array_intersect``, ``array_union``,  ``set_union``, and ``set_agg`` would return an error if the input was an array of rows with null fields or array of arrays with null elements.  These functions now use full "IS DISTINCT FROM" semantics for comparison.
- #22949 (Author: Feilong Liu): Fix serialization of aggregation node for HBO
  - * Fix serialization of aggregation node in HBO plan hash to output consistent hash :pr:`22949 `.
- #22965 (Author: Ge Gao): [Verifier] Wrap checksum queries with partition predicate for reused output table
  - Add `control.reuse-table` and `test.reuse-table` configuration properties for the Presto Verifier to reuse the output tables of the source query for control and test.
- #22979 (Author: Krishna Pai): Fix map_top_n to use keys to break ties on NULL values. 
  - Make map_top_n function more deterministic by using keys to break ties.
- #22980 (Author: Ke): Fix hash calculation for Timestamp in HiveBucketing to be Hive Compatible
  - Fix hash calculation for Timestamp column to be hive compatible when writing to a table bucketed by Timestamp.  :pr:`22890`.
  - Add config `hive.legacy-timestamp-bucketing` and session property ``hive.legacy_timestamp_bucketing`` to use the original hash function for Timestamp column, which is not hive compatible. :pr:`22890`.
- #23013 (Author: Rebecca Schlussel): Fix wrong results bug with count over mixed aggregation
  - Fix a bug where count queries on top of aggregations with mixed global and grouped grouping sets could return wrong results.
- #23027 (Author: Amit Dutta): Update Joda-Time to 2.12.7
  - Update Joda-Time to 2.12.7 to use 2024a tzdata. Note: a corresponding update to the Java runtime should also be made to ensure consistent timezone data. For example, Oracle JDK 8u381, tzdata2024a rpm for OpenJDK, or use Timezone Updater Tool to apply 2024a tzdata to existing JVM. :pr:`23027`.
- #23059 (Author: Rebecca Schlussel): Add analyzer warning for common NaN pitfalls
  - Add configuration property ``warn-on-possible-nans`` and session property ``warn_on_possible_nans`` to produce a warning on division operations or comparison operations involving double or real types. Division operations are common causes of accidental creation of nans, and the semantics of comparison operations involving nans changed considerably in the most recent Presto release.
- #23060 (Author: Rebecca Schlussel): Fix hash for double and real types when new nan is disabled
  - Fix a bug in the hash code of -0 for double and real types when ``use-new-nan-definition`` is false :pr:`23060`.
- #23081 (Author: Feilong Liu): Remove cross join if one side of input is single row constant
  - Add an optimization to remove cross join when one side of inputs is single row of constant values. The optimization is controlled by session property `remove_cross_join_with_constant_single_row_input` :pr:`23081`.
- #23104 (Author: Denodo Research Labs): Upgrade json-path to 2.9.0 due CVE-2023-1370
  - Upgrade json-path to 2.9.0 due CVE-2023-1370 :pr:`23104`.
- #23127 (Author: Denodo Research Labs): Upgrade guava to 32.1.0-jre due CVE-2023-2976
  - Upgrade guava to 32.1.0-jre due CVE-2023-2976 :pr:`23127`.
- #23142 (Author: Denodo Research Labs): Upgrade avro to 1.11.3 due CVE-2023-39410
  - Upgrade avro to 1.11.3 due CVE-2023-39410 :pr:`23142`.
- #23174 (Author: Zac Blanco): [Iceberg] Add table refresh retry configurations
  - The Iceberg connector when configured with Hive, can now configure table metadata refresh timeouts. See documentation for details.
- #23176 (Author: Nikhil Collooru): Use data size for directory listing cache
  - Add support for setting the max size in bytes for directory listing cache. This can be set via the new `hive.file-status-cache.max-retained-size` configuration property. `hive.file-status-cache-size` is now deprecated :pr:`23176`.
- #23178 (Author: Swapnil Tailor): Fix Resource Group State Info
  - Fix resource group state info endpoint to return correct value when caching is disabled. :pr:`23178`.
- #23189 (Author: Steve Burnett): [docs] Add DBeaver documentation to /clients/
  - ... Add :doc:`/clients/dbeaver` documentation :pr:`23189`.
- #23192 (Author: Zac Wen): [native] Add support for cache periodic full persistence
  - Add support for persisting full memory cache to SSD periodically on Presto C++ worker. This can be enabled by setting `cache.velox.full-persistence-interval` to a non-zero value. :pr:`23192`.
- #23194 (Author: Steve Burnett): [docs] Add Superset documentation to /clients/
  - ... Add :doc:`/clients/superset` documentation :pr:`23194`.
- #23195 (Author: Arjun Gupta): Send periodic query progress events
  - Add a new configuration property ``event.query-progress-publish-interval`` to specify the time interval at which progress events should be generated. Default is every 1 minute. :pr:`23195`.
- #23200 (Author: Feilong Liu): Add plan validator for timestamp with timezone check for prestissimo
  - Add a plan checker so that queries having timestamp with timezone type will fail in prestissimo :pr:`23200`.
- #23241 (Author: Feilong Liu): Add session property to track latency breakdown for HBO optimizer
  - Add a session property `enable_verbose_history_based_optimizer_runtime_stats` to track latency of HBO optimizer :pr:`23241`.
- #23260 (Author: wangd): Add iceberg table properties for maintenance of previous metadata files
  - Add table properties `metadata_previous_versions_max` and `metadata_delete_after_commit` to maintain the previous metadata files :pr:`23260`.
  - Enable Iceberg with hive catalog to support deleting old metadata files after commit based on the table properties :pr:`23260`.
- #23267 (Author: wangd): [Iceberg] Support procedure `remove_orphan_files`
  - Add procedure `remove_orphan_files` to remove orphan files that are not referenced in any metadata files for Iceberg. :pr:`23267`.
- #23312 (Author: Ge Gao): Allow Verifier to validate varchar as floating point
  - Add verifier config --validate-string-as-double to control applying floating point validation to the column composed of varchar, if it is detected that the varchar column is derived from casting floating points. :pr:`23312`.
- #23319 (Author: Tim Meehan): Fix assignments for equijoin on TimestampWithTimeZone
  - Fix equijoin over timestamp with timezone types (:pr:`23319`).
  - Add ``equalValuesAreIdentical`` to ``Type``.  Override this method to return ``false`` when the values of the type may have more than one canonical representation.
- #23354 (Author: Feilong Liu): Add session property to enforce timeout for query registration in HBO
  - Add session property `enforce_history_based_optimizer_register_timeout` to enforce the maximum time HBO query registration can take :pr:`23354 `.
- #23356 (Author: Nikhil Collooru): Upgrade Airlift to 0.215
  - Upgrade Airlift to 0.215 :pr:`23356`.
- #23369 (Author: Deepak Majeti): Switch default Parquet writer version to PARQUET_1_0
  - Switch default Parquet writer version to PARQUET_1_0. Please set the hive config `hive.parquet.writer.version = PARQUET_2_0` for old behavior. :pr:`23369`.
- #23374 (Author: Feilong Liu): Move timezone with timestamp plan checker to intermediate plan stage
  - Improve the plan check for timestamp with timezone type to cover filter pushdown :pr:`12345`.
- #23404 (Author: Rebecca Schlussel): Fix like matching with newlines and no wildcard
  - Fix a bug where like predicates would only match to a newline when there was no wildcard at the end. :pr:`23404`.
- #23411 (Author: Mahadevuni Naveen Kumar): Apply info column filters during split generation
  - Fix filtering by info columns $file_size and $file_modified_time, which were ignored before. :pr:`23411`.
- #23445 (Author: Matt Calder): Function to aggregate IP prefixes
  - Add function :func:`ip_prefix_collapse` ... :pr:`23445`.
- #23447 (Author: Rebecca Schlussel): Improve correctness of stddev and variance with partial aggregation
  - Improve stddev and variance functions to always return correct results when input is constant. :pr:`23447`.
- #23453 (Author: Rebecca Schlussel): Fix failure with enabling JDBC autocommit
  - Fix failure when setting autoCommit from false to true :pr:`23453`.

# All Commits
- b2974a7d21a298092690b2a4130b434bcf3e41d6 [native] Advance velox. (Amit Dutta)
- 797019c5d05fd8ab752135a7b08544b64036d161 [native] Refactor TaskManagerTest to not create common::WriterOptions instance (Ke)
- 67e423a7672cb011251cdff94789c0a580504c82 [Iceberg]Fix cleanup files behavior on expiring snapshots (wangd)
- 1ab72db57eb8ab439140c6a056b69b6635767625 [native] Fix docker-compose and add etc config into native worker docker image (wypb)
- 81066131c0e6c9f4185fa4d22d3fbc10bd2b91bf Fix analyze table whose column name ends with `_<number>` (wangd)
- d69f1f8a09e643b5260dd28eb325ce545db8bddc Refactor dead links in the documents (Reetika Agrawal)
- 171e57de961ed865926f6b049dfb1dc10a9e9653 Fix sql block in Iceberg document (Reetika Agrawal)
- 73f58cc1a749d78045bc6739168b0c8c8ceee7fb [native] Minor renames and spell fixes. (Amit Dutta)
- 14da6b7754aba39b5aae3203c94b1e0dabedfba3 [native] Advance velox. (Amit Dutta)
- 7cb9526e4b5ffa69871a6a94deefb57251efef1c [native] Add a sample plan validator and e2e tests. (Amit Dutta)
- 6530afc68a9f0dc36d0479b9f58872847ece74eb [native] Fix Velox connector configs update (Zac Wen)
- a8684698417bc1421df610c723137f4204fc4d8d Init w/ a random UUID (Zuyu ZHANG)
- 0e6d3ae2b5e1a5356182cb04ea1f449ba7e2f1dd [native] Init UuidParse in TaskManager due to boost UUID non-POD changes (Zuyu ZHANG)
- dec6c145692ac37c1d8f51bc2bec4a8f80d86d65 [native] Prestissimo worker metrics documentation (Karteekmurthys)
- 61a01f4b1d0ca1217420f00073d8e5cf484c237a initial commit for ip_prefix_collapse function (Matt Calder)
- a37fea2286f2e24a6c22362a9a2468eb2da542c5 Prefer assertSame (Elliotte Rusty Harold)
- fdd20597fba2ce9b6993a5b4e82e3c46f93d7e77 [native] Retrieve presto native session properties (Pramod Satya)
- 56223ebbe21fc60d5aa4cbffbaa5050cb3ff0a24 Aggressively prune statistics from query info after completion (Zac Blanco)
- c4e1ab3d85619fd6bfbb5903467f6a1af9769431 [native] Advance velox. (Amit Dutta)
- a707af8d11c917d5bc1b001b386ee27bcaba40b3 Fix a build link in README.md (zuyu)
- ae870326df4abda6dec73434014477f14594cd3e [native] Add new shared arbitrator configs (Jialiang Tan)
- b4eca42ff679282b58f09d6e5e688cdecad991a0 [native] Add new arbitration configs (Jialiang Tan)
- 34e73df05b3d960a3ddb84140d37ba9867d0b680 Reenabling recently disabled E2E tests. (Sergey Pershin)
- c75087f144ccba5e1c8f642f2eaa4331bcb51afb [native] Add Velox factory registrations (Deepak Majeti)
- 0f7aa2eda11b5c22ff3cd42e70e962efb9233f65 [native] Fill protocol::TaskStats::completedDrivers with finished splits (Jialiang Tan)
- bd444ec9e0c44cd0f41fcbed2de04e7ba837d533 Fix failure with enabling JDBC autocommit (Rebecca Schlussel)
- 4dab5836ba5ab99dc718584083d7b64f4a5de9d3 [native] Comment out failing tests temporarely. (Sergey Pershin)
- ddc33d6ab6ec78688e1c10e8b0c01dfebb024165 Move QueuedStatementResource helpers to QueryResourceUtil (prithvip)
- 6072d373184ba802eb0a3fd6a4e0d211114c6956 Separate ExecutingStatement response from QueuedStatement (prithvip)
- 0c273df259fc2589e330102712c31fd2775d4d4d Separate QueryPreparer from QueryAnalyzer (prithvip)
- bdf89f9982a34d79c643ae5bb6f83e9842f99e5c Extract interface from FailedDispatchQueryFactory (prithvip)
- 330fa47d6f31b9161ebe69b163835458fe772933 array_min/array_max throw if first element is an inner Array with a null element (Kevin Wilfong)
- be299743bf1b2feaaf0fbfaa3d09ce052908a22b [native]Advance velox version (xiaoxmeng)
- 0d0c2ea3c74e1cb7e87f70be0b88f0bd61be94b4 Make hashCode consistent with equals (Elliotte Rusty Harold)
- 4f74f52f36709944ba9eea18b0559ec7dd691d36 Improve correctness of stddev and variance with partial aggregation (Rebecca Schlussel)
- c969f304eacb2faf49f2d8dc226afa497634ffab Update airlift to 0.215 (Nikhil Collooru)
- 7cf06c3a962221207a56e6f8f16180923db97c06 [native] Update gtest targets (Zuyu ZHANG)
- d3dd60a52a7686ce5b57a16295bb727cab299296 Fix formatting in rest/node.rst and statement.rst (Steve Burnett)
- c8a4c55d0d28c33f6f64e5b8d1de714df69dd467 Apply info column filters during split generation (Mahadevuni Naveen Kumar)
- 78a8d18ebd294788b666da641fd46919d03da8d7 Use assertEquals instead of assertTrue when testing equality (Elliotte Rusty Harold)
- c624968cb28791cdaa8fec385360f778a4fbe7ae [native] Cleanup dependencies from old velox::core::Config (Jialiang Tan)
- 868e7217a516b260749f6b4da103451f847d5f85 [native] Advance velox. (Amit Dutta)
- fbc0af38f5440003482c1e21b83803219c51f059 Clean up language (Elliotte Rusty Harold)
- cef7fc6037900be7ddea8bd18d0f71e08a541e87 Apply suggestions from code review (Linsong Wang)
- ee89abedc2ca43f3a91950071831d318cea620c4 Minor changes in Iceberg Connector Docs (Jalpreet Singh Nanda (:imjalpreet))
- 045a80cc3baf056449d56841f932d5d64d696654 [native] Fix Meta internal build caused by folly::StringPiece (Jialiang Tan)
- 03e5e50dcf9a21197f9381fe6df4425c57cd34fa [native] Advance velox. (Amit Dutta)
- 4b920caf6ed7af503f62b00aa9e18293df9cff6f [native] Add hook for Velox plan validation. (Amit Dutta)
- 64219fb751906e793734b0e1b64877bc8501dd77 Clean up exception handling and avoid shadowing mutable field (Elliotte Rusty Harold)
- 28e84a0a1e1fa53b7e3f71ef6c5d646d0bba310d Refine the CircleCI criteria (Yihong Wang)
- fba1b89e5bffbd0b7f9246a544c5e664bd51adc6 [native] Advance velox (Amit Dutta)
- e782f021f1abf0dee4c6698b313d4f161ae03035 [native] Add metrics for memory pushback mechanism (Jialiang Tan)
- 9db7e1b3acd9bb5c53a4ac7c517419690bb2a393 Fix like matching with newlines and no wildcard (Rebecca Schlussel)
- 4e6678c33f82fac71509e11deec40671f154b37e Fix formatting in admin/verifier.rst (Steve Burnett)
- 6c8fd1fc75595bb0669bb5a5bd1b22d31b8d71d5 Fix issue with identifying column nullability (Ramesh Kanna S)
- 88ef79dc43769199aa4969ffd706b8e2f8c5f3d2 [native] Enhance CSV Parsing in ContainerQueryRunner to Use MaterializedResult (Abe Varghese)
- 54dbe5678ba7d07808a2d288440030dbd593b20e [native] Switch to use new config base class from Velox (Jialiang Tan)
- 2855762422bfb3e84ec86dae7a101a978a5db3d3 [native] Advance velox. (Amit Dutta)
- 5e75ca7a44a031c726ca45a8def109cbcb95d0de [native] Advance velox. (Amit Dutta)
- d51207060326ad05891e0a04383c050f39c5ac01 [native] Advance velox. (Amit Dutta)
- 23477ad5b5af45ab21c95d97b1129c71777bf7c4 Warn when a non-window value function is specified to ignore nulls (Auden Woolfson)
- c61eade9a1ea91f77efa7b609043d5ec39000088 [native] Fix node select condition for cache retention (Zac Wen)
- 6d55f58081a5ee4fda759b0dd58e6f62a9699671 [iceberg] Refactor IcebergWritableTableHandle's schema and partitionSpec fields (Jalpreet Singh Nanda (:imjalpreet))
- 6566e7f45cdf59c0037b62780b77eb7aa41b37a0 [iceberg] Add wrapper class PrestoIcebergPartitionSpec for org.apache.iceberg.PartitionSpec (Jalpreet Singh Nanda (:imjalpreet))
- 31e815171de7661b5aae3e7ae1219391cb7ed2ba [iceberg] Add wrapper classes for org.apache.iceberg.Schema and Types.NestedField (Jalpreet Singh Nanda (:imjalpreet))
- fedb846bcccafdc94ffe686447f48b870d98e4fa [native] Disable cache retention with NO_PREFERENCE node selection (Zac Wen)
- 39e74ccfbf398edc41770c9240be26a897946b52 Add session property to enforce timeout for query register in HBO optimizer (Feilong Liu)
- f8f4a83dd8e7e2c6e6cf11415bcd273975480fc5 Add presto-openapi module and QueryResource definition (ymmarissa)
- 9ce424c448d21d939a4fc3cacccabdd7933c6e03 Send periodic query progress events (Arjun Gupta)
- 6e4896ddc4ed078cce1f81186e6986ecca94a141 Prepend jdbc: to DatabaseMetaData.getURL result (misterjpapa)
- fb100f34ef8e6343b1a06237a7efed62bd1cb88f [native] Add e2e tests for corelated subqueries. (Amit Dutta)
- 83a82cde9131accb4a4805544c958dde56254198 [native] Advance velox. (Amit Dutta)
- 937e8638998964c06d31d6c3f4f7cc7cfa0fb4f3 Allow Verifier to validate varchar as floating point (Ge Gao)
- 768efa34ba5a48815a7eb151391b7d654c24cb43 Upgrade avro to 1.11.3 due CVE-2023-39410 (Denodo Research Labs)
- 31aad379da1ecb600e1a8fd610615254c1be9b0b Improve CTE materialization execution tests (Christian Zentgraf)
- 71addc763f90a794b90b027abdd7158d64927479 Add array_split_into_chunks query tests (abhinavmuk04)
- 46f9545534a0f6ed34570136692ae4369ccf10c5 Switch default Parquet writer version to PARQUET_1_0 (Deepak Majeti)
- ce85e975d2a650f25d1d4ddadd23888882ced995 Move timezone with timestamp check to intermediate stage (Feilong Liu)
- 45a52a710569869826e08e342c12a8e8400d216a Introduce a new CoordinatorPlugin interface for native clusters (Pratik Joseph Dabre)
- 62c5791541af2ced44d7a18d8d2c8d047a265033 [native] Add support for running functional tests on Mac M1/ARM64. (Abe Varghese)
- 1fb7e92e29a149adb0738a6845fa31166fdc9d20 Fix assignments for equijoin on TimestampWithTimeZone (Tim Meehan)
- 580988b498b68736c3245e037800f6a0e32a165e [native] Advance velox (Amit Dutta)
- b94cca55abfb4a018116c017e2dbc8f3bf06d6c6 [Native] Disable recording http.client.presto_exchange_source.on_body_bytes metric (Karteekmurthys)
- 106cc4b792ea573e347d6ee54a46990e9c10d476 Support query retry for HBO (abhinavmuk04)
- 27a3384e37f46b3216e227ab9b322153a6b1934b Fix formatting for map_key_exists in functions/map.rst (Steve Burnett)
- 4f5c431ba6a2984000fcc5717d1b1c5b440d1b8f Update docker compose scripts for docker compose v2 (Rebecca Schlussel)
- d41ba1ce1bd3c86468bb13182b22ba08ee06951b Clean up arraysql functions tests (abhinavmuk04)
- 052c5d9cf1718d7eb21a70162ef5cc5a4e794a48 Fix a typo of windowFunctions (Zac Wen)
- d2efd893bcc462c75b4dfd086d5608362ce3929c [Native] Keep presto_protocol files consistent (Abhisek Saikia)
- 8e9521854e56a4c2d621961dc3853ceccca40935 Fix error message for invalid real cast (Rebecca Schlussel)
- 97eed74d30febe2015861be70a8b9a3537ced175 Provide info about new HBO retry feature (abhinavmuk04)
- 1e5d099eb751c7f042d1a700a7c71e79c0ee0009 Include relevant retry info in hbo rst (abhinavmuk04)
- c2290c754d36b5eda9d805dd13f0989c493d33b0 [native] Add AbstractTestNativeTpchConnectorQueries (Joe Abraham)
- 438b3b53f834d8a60a03bed782d18e28d3d309de [native] Add initial basic native container test cases (Joe Abraham)
- 7f01d04686f427bb3dd9a13b61252fd27fff51cb [native] Create ContainerQueryRunner and utility class (Joe Abraham)
- eebcb2590da18ce72e61b12e97e3d5394797da6e [native] Added functional testing framework using TestContainers (Abe Varghese)
- 7640fe6c8533594979bebe104b0f93acb5e64080 [Iceberg]Fix tests failure caused by concurrently handle the same table (wangd)
- 90d1c0db17f409b3201c47e5db8d9b2e9b14af7a Refractor Throwable Catch (abhinavmuk04)
- 703e739cc20f2a4dbe09e9530f4a082567f58be2 [native] Advance velox. (Amit Dutta)
- 5f76bb5d070d94d2f9431c698e17c7965f5eef5c Add query tests for array_sum function (abhinavmuk04)
- 78c41ff401dbbed132442358ffe601a44826ad68 Fix round for input out of long range (Zac Wen)
- 39d419e8a13b4ff6ec372e91e8cb82bbc36be926 [Native] Add runtime metric for bytes processed (Jacob Khaliqi)
- 86fc085a2ff352f7fac02358f579b75e949bd22d [Iceberg] Support procedure `remove_orphan_files` (wangd)
- 23844022b9232ab7e999131ead1fa664981cb067 Add support to read uppercase partition columns (Miguel Blanco Godón)
- 2dc0a9459d69f7e05e309bdc02a03749f107abf4 Add support to be able to query new Delta protocols (Miguel Blanco Godón)
- 1289eb058a97228c017a7a08feafe172a51609c6 [native] Fix build break for file not found in Utils.cpp (Christian Zentgraf)
- c9d1e8a382cf0ad25e28f94b8f81821b65769e0a Fix cross join with constant input optimizer (Feilong Liu)
- 772213c4f93bc77b22ffa1c5ae9f781697f86933 Add additional type support for KLL Sketches (Zac Blanco)
- 9d38c40996262ee3e87f5d4d2a5d9a93896ac0b9 Fix Iceberg read failing for Decimal type (wypb)
- 5e9baaf8b57a801a860cb9f23512b2ac7a815249 [native] Fix HTTP client connection pool shutdown order (Jimmy Lu)
- 980ca70e0b5c325642d0c5193000d83a818f648c [native] Switch to Velox based signal handler for Linux (Christian Zentgraf)
- 28d711116d0768d9faf923280cc3f13a8838d5e7 Support delete old metadata files after commit for HiveTableOperations (wangd)
- 21ee3ae2d58f89991b315baf337b62968c24ce87 Add iceberg table properties for maintenance of previous metadata files (wangd)
- a1152bf58284048a7a9f4267236c777a92b8712e Disable cross join with constant input optimizer (Feilong Liu)
- cf79ae9b0376f907b4492395638c9fdf1f08aaec Fix for Pull request 23127 (Devesh Agrawal)
- 0467afb88a18c3dc3d5dd309ab6f47390bd0335f Add additional scheduler instrumentation (Andrii Rosa)
- 03a2bd8bd31dcc51e0f61b389e32d63dde0f807a Fix explain plan to include materialized info for CTEs when verbose optimizer is enabled (jaystarshot)
- 72e771bb5cf1aa62ea2d708e3501ed42b13ab59d Fixing NAN in coordinator UI on load (Anil Gupta Somisetty)
- 64eedc30e2d446d37f08822b128df873fc6cab34 Provide various updates with new properties to optimizer (abhinavmuk04)
- 8c4fe23379ebf82d3931da7b1cfe424ff11acf33 Add documentation on temp table compression codec (jaystarshot)
- 9a3c695b1403a14e9e4b80f60920f1675115aec2 Improve clarity of function behavior and potential usecases (abhinavmuk04)
- 0a4f2c561272dd0e6bbf237e90bc5337dd010906 [native] Advance velox. (Amit Dutta)
- 506fee22381d592b372e0504377f0830ebfc5708 [native] Add CMake options for GCS and ABFS (Deepak Majeti)
- e63a57a15d46004b4cc3fab0e2d8330c34997237 [native] Handle scan filter with NaN limits during plan conversion (Bikramjeet Vig)
- 31d3bd4bb0e0a77f074d161f7a12701372af5eb6 Fix CODEOWNERS (Timothy Meehan)
- 578aec4a4b941a310e013d29af91336894ab74b1 Upgrade guava to 32.1.0-jre due CVE-2023-2976 (Denodo Research Labs)
- dd86e0c8b11c1376b7a23ef95a9aaf5808b06c1d Upgrade json-path to 2.9.0 due CVE-2023-1370 (Denodo Research Labs)
- 1caebcc79ee358b6f99fe022a6a7e2dfb45710a5 Create and test array split udf (abhinavmuk04)
- ca11b2f0c95b131351f945cd904c4b2fbc9e1db8 [native] Fix exchange HTTP executors shutdown order (Jimmy Lu)
- 9d55bdafb6d7abc2d90c89488d66cb6cef5b6ebc [native] Advance velox. (Amit Dutta)
- 9a364cd8d7938535b095b853e29cd3f6ff047bae Add worker type to query context (Zac Wen)
- 51d3f69ffda41ef80ce5101ab96742e4b210b3bf Add support for cache periodic full persistence (Zac Wen)
- e884a445f27fb86337bdb9e5a9ea8f4e413fb5ba Add session property to track latency breakdown for HBO optimizer (Feilong Liu)
- 06e7d50ecc57b7fe8f479bcda36773474b9daee7 [native] Advance velox. (Amit Dutta)
- 30c48042b8aba3dbd9bc947d8afefe41033a683a fix thrift remote funciton (Wills Feng)
- 7bd2b822c05274774333b504a272b86c2a5ffc53 [Docs] Fix typo in iceberg configuration property `iceberg.file-format` (wangd)
- c24aab36b7ab889693fa40149ebfe081dfecd159 Remove some debugging printlns from tests (Elliotte Rusty Harold)
- 08eb0574995486b751526b55c2e974625cae0fba Resolved performance problem with the grammar. (Emanuel F.)
- d2d864289c96a7d2086af1e12809018d8ff1da33 Add Sql-invoked function support for column statistics (Zac Blanco)
- 00646ac9ae5d7b5ad4df575e0bccd0baa5decd7c [native] Fix crash in httpclient when accessing null eventbase (follow up) (Amit Dutta)
- 2fdbc69e7b1299cdcb24c88a154b6a6b939a93b9 [native] Fix crash in httpclient when accessing null eventbase (Amit Dutta)
- 632eb585dccf539f9da6e90154762edb95a3a717 [Verifier] Wrap checksum queries with partition predicate for reused output table (Ge Gao)
- 753e8e1f5a7c96f9fc121c88566344d1d1cd4374 [iceberg] Add IcebergInsertTableHandle and IcebergOutputTableHandle (Jalpreet Singh Nanda (:imjalpreet))
- 637024f3e2f4b822560e4093e66426d796cb8663 [iceberg] Add compression codec in IcebergWritableTableHandle (Jalpreet Singh Nanda (:imjalpreet))
- 72b768918e138bc20896973419d22a571d0f45ee Do not capitalize version and environment on web UI (Andrii Rosa)
- 96c03612572ed2b06cceef74f2cc7056368730cc Update exchange protocol documentation (Andrii Rosa)
- 05217403bed3c01ea59eb36d683b62598f37ef1e Use data size for directory listing cache (Nikhil Collooru)
- 1a08d3402cc96b798e0b5e9f5857e2f8dced3b53 Use path string as cache key instead of Path (Nikhil Collooru)
- 26d6738bc4ace62f4f8719a55a04ddbff62678b8 [native] Ensure inheritance of fbos version for proxygen (Christian Zentgraf)
- d292e13cf3abbe50dd6ea0f7cdc9aa4449d973fd Fix bug when property exist in both connector,catalog session properties (Nikhil Collooru)
- a38da7aa86d260bbc494d1f9e9ed15f404bf79a0 [native] Advance velox. (Amit Dutta)
- e789515f75409983f3b4250ee7682623b5f46bc6 Add cost calculation for cte reference node (jaystarshot)
- 538fb0e67a1f8151cb88f9077fd1a362b94db088 Fix cte consumer cost calculation (jaystarshot)
- b3746ef9a091c2e674c466d3ecd4636a386cfa78 More precise language (Elliotte Rusty Harold)
- 19bb370c8b0c6003ebceaf4ff0926957e9700c36 update user info with geospatial type (abhinavmuk04)
- 904f9a18ca87a55a2f577b59ec3f4e75bb2fe837 [native] Update presto protocol for adding ConfidenceLevel in PlanNodeStatsEstimate (Jalpreet Singh Nanda (:imjalpreet))
- 90c27cf7415fa13d4a117660019cb7a5d94ca032 [native] Fix path for CacheQuotaRequirement and CacheQuotaScope java classes (Jalpreet Singh Nanda (:imjalpreet))
- 68c6fb92ffbedeeec1a332e2ecfaadf5df8496ce Introduce feature config for low confidence and zero estimations (abhinavmuk04)
- 43b89cd97ff16551c5d79e21eea208542ffeabfd Remove public from non-public classes (Elliotte Rusty Harold)
- bc8b6ff1fc8355448481340aec14e071cd385960 [native] Default to dummy reporter when prometheus is disabled (Karteekmurthys)
- 6fbfc31b3791242552d85e1d97fa7c9fc571c6a4 [native] Add files for clang format and header checks from Velox (Deepak Majeti)
- 0a802515952119344a475d294ec46c2fa761d82b Prefer more explicit assert methods (Elliotte Rusty Harold)
- 69d28c05726b360a0afce2fb3f7536f3047836f8 Fix docs links (Elliotte Rusty Harold)
- 66a632be7e05802a7635203b37c179e7c79c18ff [native] Fix driver count reporting from worker (Jialiang Tan)
- d3393a2bb0dcc562fc873d332c5142dde9ade066 [native] Update clang check CI image (Deepak Majeti)
- 96711d66864b1415e63f65e69f9ec697fe450893 Fix formatting in clients/superset.rst (Steve Burnett)
- 051c1d6f93716a635ad7d21dfeb0ae84c1c710be [native] Add support for Ubuntu aarch64 build on Mac M1 (Deepak Majeti)
- 991e5088e1751e2d20e9d9fb22c8463ccb4b04f8 Fix @VisibleForTesting method visibility (Ajay George)
- 6c7abcbef37c5a741b5750ea3f723243aa140aa6 [docs] Supplement the descriptions for configuration properties in HBO (wangd)
- bb9e2cd3a64d78f1769a796549159ecb551800ff Add new join property to documentation (abhinavmuk04)
- 1c8b69531d9fdbd6f1c5bb8ecc1d2b7696e0598c Treat low confidence, zero estimations as unknown during joins (abhinavmuk04)
- 3d25cd9fa7c4f26a769ab06cc248226e714ca958 Fix doc links in READMEs (Steve Burnett)
- fd5ba48956a0e2d1c3f3dc32bdf1b9cadcdb861b Fix testcase name (Joe Abraham)
- 14e4fe53a15b3a2eda0847538cd8e8ab613efeec Remove cross join if one side of input is single row constant (Feilong Liu)
- 6d6c8d28033524be8015f1976ae6dfd949f12bfa Ensure connector specific session properties be valid in test framework (wangd)
- 3095fac6e10f4c5e5ac18d685e25add788a37700 Fix javadoc pointing to itself (Ajay George)
- b745e76375704a5d4df849973eee2cb8cc2c5a27 Fix multiple properties error handling (Ajay George)
- 3f778e928c6208fa25341a16d54bfc80505da68a Fix doc build error in release-0.288.rst (Steve Burnett)
- 6b77a1b3b7eb43f47aad6ba1a42bbf8d30df5c29 Use specified strategy to get input table statistics (wangd)
- 4ca9f8b68df6e651f199311455c8fb492701e583 [native] Advance velox. (Amit Dutta)
- b693975a14e934234ded6a94663ed18f0350311b Add plan validator for timestamp with timezone check for prestissimo (Feilong Liu)
- 0e7a3364e82893a44335be4c97f9b932a77ecd41 Return predicate columns in table statistics (Zac Blanco)
- ba080362360e661d334e5ef6f06e7b32b331956b Pluralize parenthesis (Elliotte Rusty Harold)
- d5094e33928c424bb512fb4a3d7e58badd40948d [native] Advance velox. (Amit Dutta)
- bfe68e6a1cc9f5a2c4b8fac1d838625644b1de11 Fix typo in LifespanAndStageStateTracker (wangd)
- 9cd54a059d065005988436ae9385d997ee156ce5 Add Superset documentation to /clients/ (Steve Burnett)
- caa35d8aa96f235353c2ce3dc394af5fc7989d32 [Native] Add missing plumbing for CTE support (aditi-pandit)
- f3f060f9fb8a158461f1f6d7c491d8f072da8b8f [Iceberg] Add table refresh retry configurations (Zac Blanco)
- d76c2d355f72735b7d3eea8e74c74daa3f865754 Add support for decimal batch reader. (wypb)
- 66a7fc9f3ec7ea5b59b11ef7f71127a1b72d78f4 Update CODEOWNERS (Timothy Meehan)
- 960138f45e634e582c009ad422e7131c4d481396 [native] Limit format and header checks to presto-native-execution (Deepak Majeti)
- ae788f3156d7f1078084ebfa7509dea638addf7e Fix invalid limit clause (Ajay George)
- 8022abdba429a643ec5134eb6fddf980f4a7ea53 Add DBeaver documentation to /clients/ (Steve Burnett)
- 852432ddbf3d1d7a477aee768f17806a20c81730 Fix Resource Group State Info (Swapnil Tailor)
- 98988861d4f11295ef88549a7d4c254d47b9ac0e Integrate config and session property for history matching threshold (wangd)
- 683dd61d64380b37d286b1f4c4348930dbad3d71 Remove unused `SecurityConfig` from `SystemSessionProperties` (wangd)
- 8babf0ae303621859a9e10fa3ee4ca04d3241b8c Decouple from com.facebook.presto.hive.HiveErrorCode.HIVE_TOO_MANY_OPEN_PARTITIONS (Elliotte Rusty Harold)
- 9c2d18a0384920ee8458a211c60dd7b92faf33bb [native] Make ssd save behavior system config (Zac Wen)
- affcc943ed3a26eda7b1519d7ce851eb6721c5b8 [native] Advance Velox (Jialiang Tan)
- e0b76e6e56684fc5621090eb0823977846427f54 Add more time for query runner to start (Elliotte Rusty Harold)
- 07d6f77348e5520f3cdb0bd55517c299fa535d94 Use property to deactivate UI profile (Zac Blanco)
- 366a7fa73a81f2f9b409ea7798d0d77096b65d35 Convert cast to substr when target is capped varchar (Ge Gao)
- bd47c2a6c2149141d47b83064ec70af8853cd798 Add confidence based broadcast to feature config (abhinavmuk04)
- cd68435ca74ca23eba4ab3683c9d9fd37b9389c5 Fix View not found error classification (Ajay George)
- 6a0b1940e393e933471ec667a42dcc7b66913092 Fix map_top_n to use keys to break ties on NULL values. #22778 (Krishna Pai)
- b73ab7df31e4d969c44fd953e5cb8e36a18eb55b [native]Add data cache related server operations (xiaoxmeng)
- 72f4af6945fcc6f2bc9dfb24ab5c74b44db53501 Improve the documentation for two memory counters (yingsu00)
- 01b70e0ccd030034b100ca8470dd37401a96984b [native] Revert coordinator and native process logs merging in e2e tests. (Amit Dutta)
- eb53161d40c15aa349fe42142d4b75342584cb48 Add positional deletes to Iceberg native tpcds e2e tests (Mahadevuni Naveen Kumar)
- 3a31ddc894a8ce99f170fc0dae19254abede480a Fix bug in selective page source when row IDs are needed but row numbers aren't (Elliotte Rusty Harold)
- fd57488cea000f39c0ca9214d48bcf59cbbc5df8 [native] Expose REST API to fetch worker stats in Prometheus format (Karteekmurthys)
- 68c86e82c69ad86863a99f48486a72944c1dda8e Let connector metadata existing in presto-main utilize newer SPI method (wangd)
- 8991db7743c0d21e08b9eb8aaf08e168c9d09071 Remove json serialization annotation for `TableWriterNode.UpdateTarget` (wangd)
- 37a9cb395fd320c41896fee0b0a9fb432998d63a [native] Minor cosmetic changes. (Amit Dutta)
- 6fe54eacff732f2c1c7f6872acc39cf81c2d129b Use buffered bytes in parquet written bytes metric (Zac Blanco)
- 27ece7e2d3d24ee14728360648686f35fb2569ab Pass full session to avoid Unknown connector errors (Denodo Research Labs)
- 7e199c8752f64f3215b400ca2232a18abd84e66d Delete unused Docker class (Elliotte Rusty Harold)
- c9e3b0634a75de8542529b4f7dfbe1577e32136c [native] Advance velox. (Amit Dutta)
- 5b1cde74a562548971fa23b7146c017764b4f961 Update Properties documentation with new Optimizer property (abhinavmuk04)
- 461a31ad4a0f6e8a9b2a23e5b5050c2dcea9cc4e Prioritize high confidence stats during broadcast joins (abhinavmuk04)
- bccb13cbbf72026a926266fbad31657e8c597045 Upgrade maven-shade-plugin to 3.6.0 (Elliotte Rusty Harold)
- 9ea981fbceb35a38857c8479a38ec923af9724ad Remvoe outdated workaround (Elliotte Rusty Harold)
- cd3968a3feb36afccd56fe1dcbfde2c17f28158f Modify and sync DATA_DIR for IcebergQueryRunner (Reetika Agrawal)
- d022fdb43b361fdd15dbb2475fa7641ce1d778a3 Correct application name for HiveExternalWorkerQueryRunner (Reetika Agrawal)
- 3adf9758374549c19af3230b43a751732517e157 Enable ifNotExists flag while tpch copy in IcebergQueryRunner (Reetika Agrawal)
- e123d5ebcabeb1758b41c493b020da68a3c1a685 [native] Merge coordinator and native process logs in e2e tests. (Amit Dutta)
- dd42f2605ab763aec1e48f3f29197566c9be700e [native] Fix TaskManagerTest.buildSpillDirectoryFailure (Sergey Pershin)
- 0a17a67c59738770d00cc16a6b328d7771ebd2ff [native] Increase default request timeout for Exchange (Andrii Rosa)
- 0d480412f6e8bdbed99e91f30954e361f4b97782 [native] Send explicit ack only when PrestoExchangeSource is paused (Andrii Rosa)
- d011944bdbf77853c52ab4ecb63abf6c4508dda0 [Native] Advance Velox (Andrii Rosa)
- c3e4c8ee8af94fa97ef4c5845aafd14cb2dde843 Prioritize Facts over HBO stats (abhinavmuk04)
- a150ea60b16815b9ad286670f1e754ba9aa555dd Update SingleStore image tag. (oyeliseiev-ua)
- 5e92be3f810da9519572e3ffb476ccfb0829f05d Fix SingleStore tests. Add metrics. (oyeliseiev-ua)
- d07c874947f996f0ed57a0d67422fc11e78373ba Fix doc build errors (Steve Burnett)
- dcb4ed50bc228b268b021e6a43473bcdeaf2fde6 [native] Allow running Driver threads with SCHED_BATCH policy (Andrii Rosa)
- 74fb8cee624af51dc9e63cc5458ed8373e05e74e [native] Use dedicated thread pool for Exchange requests (Andrii Rosa)
- 2344876a5b90ae7390f1740864f7aa8ab5c4ce57 Add analyzer warning for common NaN pitfalls (Rebecca Schlussel)
- c70fd3c92fd528d486b994cd052fbc03ec0c8a98 Remove hard-coded values from TestNodeMemoryConfig to make tests independent of runtime heap size (Gary Helmling)
- 1d28c05feec72cebafa01ed74aeb0e49360ddfbe Fix error in 0.287 release notes (Steve Burnett)
- b7905c7af2ec4b925e6b9889dfb5716d2932722f Exclude presto-ui from shaded jar (Elliotte Rusty Harold)
- 1947f9e10d8c5e26ac3703b21964c93a95ed677c [Native] Advance Velox (aditi-pandit)
- d412d86da0f35a0ae57497e5cf294b969fdce2d6 Fix doc build errors (Steve Burnett)
- 3b03849a8bb3f14687454be588ab049f4b3f924a Fix doc build errors (Steve Burnett)
- ae7d90aca0ae0a5b45eef8581e6692e63352a73c Simplify code (Elliotte Rusty Harold)
- 45e31283e77e1d23f944c054176256d502211541 Fix typo in `HiveSplitManager` (wangd)
- e979ef03a66982118279bd24bf4890f9be44e6d4 Add coordinator sidecar process (Pratik Joseph Dabre)
- 435e1779d775d06a200fd5748b2fe3690f1c60b4 Improve array function documentation (Rebecca Schlussel)
- 6d2e8cb53bedb9e7e245971c8668441ab75c493f Use distinct semantics for set_agg and set_union (Rebecca Schlussel)
- 0c8fbb7405a0b713f84332f32f05c990d23c4589 Use distinct for array_intersect, array_except, array_union (Rebecca Schlussel)
- 1722ea726c1638d96d48c50cffbdc4c2691ba48d Move array_union tests to TestArrayUnionFunction (Rebecca Schlussel)
- e7eb016977350a2d9d7c5c63ff4676db2fdd3299 Consolidate array_intersect tests (Rebecca Schlussel)
- 01f5c65ac4466d0a73d204b0f9a508d1f3d45f00 Use distinct semantics for array_distinct (Rebecca Schlussel)
- dbfb6ac80b519f306c997f9884114130b4195d36 [native]Add to config largest size class pages (xiaoxmeng)
- 95da85b204a89c40f0910c77c442ba88d0fdc334 [native] Remove spark specific query config from BaseVeloxQueryConfig (Bikramjeet Vig)
- 30bd7fe7a1d386df14d39a095cd8f4788d94fad5 Fix serialization of HBO plan nodes to output consistent hash (Feilong Liu)
- 50084588fa98ab9b9dbb98485247ea37453c419c Rename split --> splitRunner (Elliotte Rusty Harold)
- 5ed9da6e4268670da1c66845356bc3e4465f02df Fix hash for double and real types when new nan is disabled (Rebecca Schlussel)
- 794cbae38e7a313a4842976576c9cc84c357ce7c [native] Add e2e tests for normalize scalar function (Pratik Joseph Dabre)
- 289ecb9b12fae0cb3827e496cfc99196c117558d [Native] Advance velox (Karteekmurthys)
- 210876eba66e128a6915bb2092a84ae7361d24cf [native] add entrypoint script into native worker docker image (Linsong Wang)
- 8f26ac6548ff738940ffa4e9b34fed209878a22e Fix for previous correctness issue with TableScanConfidence (abhinavmuk04)
- 3fd0a02b6d21c08132b39091260c9902492cc1dd Update Iceberg documentation with SQL queries (Reetika Agrawal)
- b7204ee1e710869cf194e8fac212b5158f342075 [native]Add system config for global memory arbitration in velox (xiaoxmeng)
- 21667e266a9d6b11a630b91d3c3c03291933ebed [native] Advance velox. (Amit Dutta)
- 815012f55906d5dbc659b96f2d6b7de58bcb9470 Update .gitignore to include more IDE generated files (Yiqun (Ethan) Zhang)
- c3e41145aedb64998a7f80cf9bbb35a5d09e39e4 [native]Simplify test error message check (xiaoxmeng)
- 7d7d89d50b9284286f546b0a6647d3da8e948828 [native]Support no shuffle data copy to speedup query execution (xiaoxmeng)
- 0168e16e94f2f07483050fae65693c4467b53e6c [native] Implement bucket conversion for Hive splits (Jimmy Lu)
- c60f472099edf820e68a67121113177a2b852e9f [native] Advance Velox (Jimmy Lu)
- 61104566130156da809aeb31e0f6eab5f2e7da68 Update Joda-Time to 2.12.7 (Amit Dutta)
- c542429ba989887de6208daaed4d7b4e34b49b3b [native] Update CI dependency image to latest (Christian Zentgraf)
- 7727beb51cf2159e60848613c6369268d52db16d Fix wrong results bug with count over mixed aggregation (Rebecca Schlussel)
- 1286ae4392bea27ad173c7778e8b943a159862fb [native] Include additional context from velox exception (Bikramjeet Vig)
- 1ab45c2b8a3938cbde5e0f99f0e293c75c2eeb5a Change getExpectedOrdersTableDescription() back to protected (Jialiang Tan)
- 5acdcd54d8092c2ca3a0ff5e9877955fae35685a Update Jenkins pipeline per dockerfile name update (Linsong Wang)
- 35eab5d9bbd68771cac887ab5e1fc62ffd407e56 Add more documentation on Presto committers (Tim Meehan)
- 7164087d6560f710f7dce5188d0ef92a56652a39 [native] Update dockerfiles to use Centos9 (Christian Zentgraf)
- 1e80972b373b7133ebd5c29e4987e3265638ae69 Implement array_sum function in Java from SQL (abhinavmuk04)
- fd8d57299e5de5377ebcd86756616778c3768f20 Fix hash calculation for Timestamp in HiveBucketing to be Hive Compatible (Ke)
- c55dad662ea3af6cb47221303114d2607b390f66 [native] Advance velox. (Amit Dutta)
- 7f8ff9596367ee37be3efe956285b225bf32deb3 [docs] remove method toc icons (Zac Blanco)
- 416d3b54aa8b17c7ab157e92bd7025eb8ef2460b Make private temporaryDirectory variable in TestHiveSkipEmptyFiles (cvarelad-denodo)
- 2597e6018f9075f339f5359c278ae2b6e5335619 Resolve TestHiveClientConfig conflicts (cvarelad-denodo)
- 6ed1e6fa415353aac015a72d33c408bf56e65d6a Fix TestHiveSkipEmptyFiles methods refactor (cvarelad-denodo)
- 24d3b6cc7fe5d6fdd7f0c1dcb80bd48ef8f0bffe Fix TestHiveSkipEmptyFiles temporal files and directories creation (cvarelad-denodo)
- b712b344b698911f4c11f4a5dd3a9bcf39e687ce Add tests for bucketed tables in TestHiveSkipEmptyFiles (cvarelad-denodo)
- 4ac8108266c66aa1cb741932dd703622122c7e5f Fixes in TesHiveSkipEmptyFiles and HiveClientConfig (cvarelad-denodo)
- 27bd90ee00cca08a9a09f58fda1e48372a92b4ce Add property hive.skip_empty_files to session properties in TestQuickStatsProvider (cvarelad-denodo)
- da3d7c26e276933a58b42bd231cf97f03058f9ff Fix code style in TestHiveSkipEmptyFiles (cvarelad-denodo)
- 176acba1b57eda39de07f9990cad948035494f9d Add property to skip empty files in Hive Connector (cvarelad-denodo)
- 2ef2ba82c948f73c7581fdd18e081f6bb12c2c5e [Verifier] Support reuse of source query output table (Ge Gao)
- 4cbd3f4d56c3db9bcfd0a8e4240cf69ef2f57c65 Fix precedence (Elliotte Rusty Harold)
- 364d5bafe0290414900a36f9c2944bbe0e5d3964 Fill in missing spaces (Elliotte Rusty Harold)
- 0f99fe49a042b4a55b91a1651c474c8d8c1489f5 Remove unneeded suppression (Elliotte Rusty Harold)
- 7fec8c35352f3c2e36478eb31b824375dca04ce1 [native] Advance Velox (Christian Zentgraf)