### PR TITLE
Function to split an IP prefix into subnets

### DIFF
--- a/presto-docs/src/main/sphinx/functions/ip.rst
+++ b/presto-docs/src/main/sphinx/functions/ip.rst
@@ -60,3 +60,12 @@ IP Functions
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '2620:10d:c090::/48', IPPREFIX '2620:10d:c091::/48']); -- [{2620:10d:c090::/47}]
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '192.168.1.0/24', IPPREFIX '192.168.0.0/24', IPPREFIX '192.168.2.0/24', IPPREFIX '192.168.9.0/24']); -- [{192.168.0.0/23}, {192.168.2.0/24}, {192.168.9.0/24}]
 
+.. function:: ip_prefix_subnets(ip_prefix, prefix_length) -> array(ip_prefix)
+
+    Returns the subnets of ``ip_prefix`` of size ``prefix_length``. ``prefix_length`` must be valid ([0, 32] for IPv4
+    and [0, 128] for IPv6) or the query will fail and raise an error. An empty array is returned if ``prefix_length``
+    is shorter (that is, less specific) than ``ip_prefix``. ::
+
+        SELECT IP_PREFIX_SUBNETS(IPPREFIX '192.168.1.0/24', 25); -- [{192.168.1.0/25}, {192.168.1.128/25}]
+        SELECT IP_PREFIX_SUBNETS(IPPREFIX '2a03:2880:c000::/34', 36); -- [{2a03:2880:c000::/36}, {2a03:2880:d000::/36}, {2a03:2880:e000::/36}, {2a03:2880:f000::/36}]
+

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestIpPrefixFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestIpPrefixFunctions.java
@@ -216,4 +216,56 @@ public class TestIpPrefixFunctions
         assertInvalidFunction("IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '192.168.0.0/22', IPPREFIX '2409:4043:251a:d200::/56'])",
                 "All IPPREFIX elements must be the same IP version.");
     }
+
+    @Test
+    public void testIpPrefixSubnets()
+    {
+        assertFunction("IP_PREFIX_SUBNETS(IPPREFIX '192.168.1.0/24', 25)", new ArrayType(IPPREFIX), ImmutableList.of("192.168.1.0/25", "192.168.1.128/25"));
+        assertFunction("IP_PREFIX_SUBNETS(IPPREFIX '192.168.0.0/24', 26)", new ArrayType(IPPREFIX), ImmutableList.of("192.168.0.0/26", "192.168.0.64/26", "192.168.0.128/26", "192.168.0.192/26"));
+        assertFunction("IP_PREFIX_SUBNETS(IPPREFIX '2A03:2880:C000::/34', 37)",
+                new ArrayType(IPPREFIX),
+                ImmutableList.of("2a03:2880:c000::/37", "2a03:2880:c800::/37", "2a03:2880:d000::/37", "2a03:2880:d800::/37", "2a03:2880:e000::/37", "2a03:2880:e800::/37", "2a03:2880:f000::/37", "2a03:2880:f800::/37"));
+    }
+
+    @Test
+    public void testIpPrefixSubnetsReturnSelf()
+    {
+        assertFunction("IP_PREFIX_SUBNETS(IPPREFIX '192.168.1.0/24', 24)", new ArrayType(IPPREFIX), ImmutableList.of("192.168.1.0/24"));
+        assertFunction("IP_PREFIX_SUBNETS(IPPREFIX '2804:431:b000::/38', 38)", new ArrayType(IPPREFIX), ImmutableList.of("2804:431:b000::/38"));
+    }
+
+    @Test
+    public void testIpPrefixSubnetsNewPrefixLengthLongerReturnsEmpty()
+    {
+        assertFunction("IP_PREFIX_SUBNETS(IPPREFIX '192.168.0.0/24', 23)", new ArrayType(IPPREFIX), ImmutableList.of());
+        assertFunction("IP_PREFIX_SUBNETS(IPPREFIX '64:ff9b::17/64', 48)", new ArrayType(IPPREFIX), ImmutableList.of());
+    }
+
+    @Test
+    public void testIpPrefixSubnetsInvalidPrefixLengths()
+    {
+        assertInvalidFunction("IP_PREFIX_SUBNETS(IPPREFIX '192.168.0.0/24', -1)", "Invalid prefix length for IPv4: -1");
+        assertInvalidFunction("IP_PREFIX_SUBNETS(IPPREFIX '192.168.0.0/24', 33)", "Invalid prefix length for IPv4: 33");
+        assertInvalidFunction("IP_PREFIX_SUBNETS(IPPREFIX '64:ff9b::17/64', -1)", "Invalid prefix length for IPv6: -1");
+        assertInvalidFunction("IP_PREFIX_SUBNETS(IPPREFIX '64:ff9b::17/64', 129)", "Invalid prefix length for IPv6: 129");
+    }
+
+    @Test(dataProvider = "private-ip-provider")
+    public void testIsPrivateTrue(String ipAddress)
+    {
+        assertFunction("IS_PRIVATE_IP(IPADDRESS '" + ipAddress + "')", BOOLEAN, true);
+    }
+
+    @Test(dataProvider = "public-ip-provider")
+    public void testIsPrivateIpFalse(String ipAddress)
+    {
+        assertFunction("IS_PRIVATE_IP(IPADDRESS '" + ipAddress + "')", BOOLEAN, false);
+    }
+
+    @Test
+    public void testIsPrivateIpNull()
+    {
+        assertFunction("IS_PRIVATE_IP(NULL)", BOOLEAN, null);
+    }
+>>>>>>> d73d51d481 (removing whitespace)
 }


### PR DESCRIPTION
## Description
This change introduces a function `ip_prefix_subnets` that, given an input `ip_prefix` and a subnet `prefix_length`, splits the IP prefix into subnets of the input prefix length. The functions return an array of new prefixes of the new input prefix length.

This is a complimentary sister function to the `ip_prefix_collapse` function.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
This change addresses [issue 23514](https://github.com/prestodb/presto/issues/23514).

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
This change introduces a new user-facing function `ip_prefix_subnets`.

## Test Plan
<!---Please fill in how you tested your change-->
Unit tests

`mvn clean install -Dtest=TestIpPrefixFunctions -Dmaven.javadoc.skip=true -DskipUI -T1C -fn -pl presto-main`

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

```
== RELEASE NOTES ==

General Changes
* Add function :func:`ip_prefix_subnets` that splits the input prefix into subnets the size of the new prefix length. ... :pr:`23515`
```

