### PR TITLE
[native] Implement Graceful Shutdown in Native worker

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -26,6 +26,7 @@
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Counters.h"
 #include "presto_cpp/main/common/Utils.h"
+#include "presto_cpp/main/http/HttpConstants.h"
 #include "presto_cpp/main/http/filters/AccessLogFilter.h"
 #include "presto_cpp/main/http/filters/HttpEndpointLatencyFilter.h"
 #include "presto_cpp/main/http/filters/InternalAuthenticationFilter.h"
@@ -372,6 +373,14 @@ void PrestoServer::run() {
           proxygen::ResponseHandler* downstream) {
         json infoStateJson = convertNodeState(server->nodeState());
         http::sendOkResponse(downstream, infoStateJson);
+      });
+  httpServer_->registerPut(
+      "/v1/info/state",
+      [server = this](
+          proxygen::HTTPMessage* /*message*/,
+          const std::vector<std::unique_ptr<folly::IOBuf>>& body,
+          proxygen::ResponseHandler* downstream) {
+        server->handleGracefulShutdown(body, downstream);
       });
   httpServer_->registerGet(
       "/v1/status",
@@ -911,7 +920,6 @@ void PrestoServer::stop() {
   PRESTO_SHUTDOWN_LOG(INFO)
       << "Waiting for " << shutdownOnsetSec
       << " second(s) before proceeding with the shutdown...";
-
   // Give coordinator some time to receive our new node state and stop sending
   // any tasks.
   std::this_thread::sleep_for(std::chrono::seconds(shutdownOnsetSec));
@@ -1433,6 +1441,27 @@ void PrestoServer::reportServerInfo(proxygen::ResponseHandler* downstream) {
 
 void PrestoServer::reportNodeStatus(proxygen::ResponseHandler* downstream) {
   http::sendOkResponse(downstream, json(fetchNodeStatus()));
+}
+
+void PrestoServer::handleGracefulShutdown(
+    const std::vector<std::unique_ptr<folly::IOBuf>>& body,
+    proxygen::ResponseHandler* downstream) {
+  std::string bodyContent =
+      folly::trimWhitespace(body[0]->moveToFbString()).toString();
+  if (body.size() == 1 && bodyContent == http::kShuttingDown) {
+    LOG(INFO) << "Shutdown requested";
+    if (nodeState() == NodeState::kActive) {
+      // Run stop() in a separate thread to avoid blocking the main HTTP handler
+      // and ensure a timely 200 OK response to the client.
+      std::thread([this]() { this->stop(); }).detach();
+    } else {
+      LOG(INFO) << "Node is inactive or shutdown is already requested";
+    }
+    http::sendOkResponse(downstream);
+  } else {
+    LOG(ERROR) << "Bad Request. Received body content: " << bodyContent;
+    http::sendErrorResponse(downstream, "Bad Request", http::kHttpBadRequest);
+  }
 }
 
 void PrestoServer::registerSidecarEndpoints() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -211,6 +211,10 @@ class PrestoServer {
 
   void reportNodeStatus(proxygen::ResponseHandler* downstream);
 
+  void handleGracefulShutdown(
+      const std::vector<std::unique_ptr<folly::IOBuf>>& body,
+      proxygen::ResponseHandler* downstream);
+
   protocol::NodeStatus fetchNodeStatus();
 
   void populateMemAndCPUInfo();

--- a/presto-native-execution/presto_cpp/main/http/HttpConstants.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpConstants.h
@@ -17,11 +17,13 @@ namespace facebook::presto::http {
 const uint16_t kHttpOk = 200;
 const uint16_t kHttpAccepted = 202;
 const uint16_t kHttpNoContent = 204;
+const uint16_t kHttpBadRequest = 400;
 const uint16_t kHttpUnauthorized = 401;
 const uint16_t kHttpNotFound = 404;
 const uint16_t kHttpInternalServerError = 500;
 
 const char kMimeTypeApplicationJson[] = "application/json";
 const char kMimeTypeApplicationThrift[] = "application/x-thrift+binary";
+const char kShuttingDown[] = "\"SHUTTING_DOWN\"";
 static const char kPrestoInternalBearer[] = "X-Presto-Internal-Bearer";
 } // namespace facebook::presto::http

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGracefulShutdown.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGracefulShutdown.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.spi.NodeState;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.NodeState.SHUTTING_DOWN;
+import static org.testng.Assert.assertEquals;
+
+public class TestPrestoNativeGracefulShutdown
+{
+    @Test
+    public void testGracefulShutdown() throws Exception
+    {
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
+        DistributedQueryRunner distributedQueryRunner = (DistributedQueryRunner) queryRunner;
+
+        int responseCode = distributedQueryRunner.sendWorkerRequest(0, "INVALID_BODY");
+        assertEquals(responseCode, 400, "Expected a 400 Bad Request response for invalid body");
+
+        responseCode = distributedQueryRunner.sendWorkerRequest(0, "");
+        assertEquals(responseCode, 400, "Expected a 400 Bad Request response for empty body");
+
+        responseCode = distributedQueryRunner.sendWorkerRequest(0, "\"SHUTTING_DOWN\"");
+        assertEquals(responseCode, 200, "Expected a 200 OK response for valid shutdown request");
+        NodeState state = distributedQueryRunner.getWorkerInfoState(0);
+        assertEquals(state.getValue(), SHUTTING_DOWN.getValue());
+
+        queryRunner.close();
+    }
+}


### PR DESCRIPTION
## Description
Added PUT method in /v1/info/state for transitioning the server to the SHUTTING_DOWN state for graceful shutdown

Resolves https://github.com/prestodb/presto/issues/18617

## Motivation and Context
The Prestissimo project currently lacks support for transitioning the server to the SHUTTING_DOWN state via the PUT method in the /v1/info/state endpoint. Implementing this feature allows for a graceful shutdown of the server, ensuring that ongoing processes are completed without abrupt termination.

## Impact
This implementation introduces a new feature that enables the server to handle a graceful shutdown when the SHUTTING_DOWN state is triggered via a PUT request. By supporting this functionality, the server can now properly manage ongoing requests before shutting down, reducing the risk of data loss or inconsistency.

## Test Plan


## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

