### PR TITLE
[native] Fix a typo in LocalPersistentShuffleReader ctor

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -125,7 +125,7 @@ class LocalPersistentShuffleReader : public ShuffleReader {
   LocalPersistentShuffleReader(
       const std::string& rootPath,
       const std::string& queryId,
-      std::vector<std::string> partitionIds_,
+      std::vector<std::string> partitionIds,
       velox::memory::MemoryPool* FOLLY_NONNULL pool);
 
   folly::SemiFuture<velox::BufferPtr> next() override;


### PR DESCRIPTION
## Description
Fixed a typo from #19304.

```
== NO RELEASE NOTE ==
```

