### PR TITLE
Function to check if IP address is private

### DIFF
--- a/presto-docs/src/main/sphinx/functions/ip.rst
+++ b/presto-docs/src/main/sphinx/functions/ip.rst
@@ -60,3 +60,13 @@ IP Functions
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '2620:10d:c090::/48', IPPREFIX '2620:10d:c091::/48']); -- [{2620:10d:c090::/47}]
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '192.168.1.0/24', IPPREFIX '192.168.0.0/24', IPPREFIX '192.168.2.0/24', IPPREFIX '192.168.9.0/24']); -- [{192.168.0.0/23}, {192.168.2.0/24}, {192.168.9.0/24}]
 
+.. function:: is_private_ip(ip_address) -> boolean
+
+    Returns whether ``ip_address`` of type ``IPADDRESS`` is a private or reserved IP address
+    that is not considered globally reachable by IANA. For more information, see `IANA IPv4 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_ and `IANA IPv6 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml>`_. `Null` inputs return `null`. ::
+
+        SELECT is_private_ip(IPADDRESS '10.0.0.1'); -- true
+        SELECT is_private_ip(IPADDRESS '192.168.0.1'); -- true
+        SELECT is_private_ip(IPADDRESS '157.240.200.99'); -- false
+        SELECT is_private_ip(IPADDRESS '2a03:2880:f031:12:face:b00c:0:2'); -- false
+

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestIpPrefixFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestIpPrefixFunctions.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.common.type.ArrayType;
 import com.google.common.collect.ImmutableList;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -24,6 +25,58 @@ import static com.facebook.presto.type.IpPrefixType.IPPREFIX;
 public class TestIpPrefixFunctions
         extends AbstractTestFunctions
 {
+    @DataProvider(name = "public-ip-provider")
+    public Object[] publicIpProvider()
+    {
+        return new Object[] {
+                "6.7.8.9",
+                "157.240.200.99",
+                "8.8.8.8",
+                "128.1.2.8",
+                "2a03:2880:f031:12:face:b00c:0:2",
+                "2600:1406:6c00::173c:ad43",
+                "2607:f8b0:4007:818::2004"
+        };
+    }
+
+    @DataProvider(name = "private-ip-provider")
+    public Object[][] privateIpProvider()
+    {
+        return new Object[][] {
+                // The first and last IP address in each private range
+                {"0.0.0.0"}, {"0.255.255.255"},         // 0.0.0.0/8 RFC1122: "This host on this network"
+                {"10.0.0.0"}, {"10.255.255.255"},       // 10.0.0.0/8 RFC1918: Private-Use
+                {"100.64.0.0"}, {"100.127.255.255"},    // 100.64.0.0/10 RFC6598: Shared Address Space
+                {"127.0.0.0"}, {"127.255.255.255"},     // 127.0.0.0/8 RFC1122: Loopback
+                {"169.254.0.0"}, {"169.254.255.255"},   // 169.254.0.0/16 RFC3927: Link Local
+                {"172.16.0.0"}, {"172.31.255.255"},     // 172.16.0.0/12 RFC1918: Private-Use
+                {"192.0.0.0"}, {"192.0.0.255"},         // 192.0.0.0/24 RFC6890: IETF Protocol Assignments
+                {"192.0.2.0"}, {"192.0.2.255"},         // 192.0.2.0/24 RFC5737: Documentation (TEST-NET-1)
+                {"192.88.99.0"}, {"192.88.99.255"},     // 192.88.99.0/24 RFC3068: 6to4 Relay anycast
+                {"192.168.0.0"}, {"192.168.255.255"},   // 192.168.0.0/16 RFC1918: Private-Use
+                {"198.18.0.0"}, {"198.19.255.255"},     // 198.18.0.0/15 RFC2544: Benchmarking
+                {"198.51.100.0"}, {"198.51.100.255"},   // 198.51.100.0/24 RFC5737: Documentation (TEST-NET-2)
+                {"203.0.113.0"}, {"203.0.113.255"},     // 203.0.113.0/24 RFC5737: Documentation (TEST-NET-3)
+                {"240.0.0.0"}, {"255.255.255.255"},     // 240.0.0.0/4 RFC1112: Reserved
+                {"::"}, {"::"},                         // ::/128 RFC4291: Unspecified address
+                {"::1"}, {"::1"},                       // ::1/128 RFC4291: Loopback address
+                {"100::"}, {"100::ffff:ffff:ffff:ffff"},                        // 100::/64 RFC6666: Discard-Only Address Block
+                {"64:ff9b:1::"}, {"64:ff9b:1:ffff:ffff:ffff:ffff:ffff"},        // 64:ff9b:1::/48 RFC8215: IPv4-IPv6 Translation
+                {"2001:2::"}, {"2001:2:0:ffff:ffff:ffff:ffff:ffff"},            // 2001:2::/48 RFC5180,RFC Errata 1752: Benchmarking
+                {"2001:db8::"}, {"2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"},     // 2001:db8::/32 RFC3849: Documentation
+                {"2001::"}, {"2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff"},         // 2001::/23 RFC2928: IETF Protocol Assignments
+                {"5f00::"}, {"5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},        // 5f00::/16 RFC-ietf-6man-sids-06: Segment Routing (SRv6)
+                {"fe80::"}, {"febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},        // fe80::/10 RFC4291: Link-Local Unicast
+                {"fc00::"}, {"fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},        // fc00::/7 RFC4193, RFC8190: Unique Local
+                // some IPs in the middle of ranges
+                {"10.1.2.3"},
+                {"100.64.3.2"},
+                {"192.168.55.99"},
+                {"2001:0DB8:0000:0000:face:b00c:0000:0000"},
+                {"0100:0000:0000:0000:ffff:ffff:0000:0000"}
+        };
+    }
+
     @Test
     public void testIpAddressIpPrefix()
     {
@@ -215,5 +268,23 @@ public class TestIpPrefixFunctions
     {
         assertInvalidFunction("IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '192.168.0.0/22', IPPREFIX '2409:4043:251a:d200::/56'])",
                 "All IPPREFIX elements must be the same IP version.");
+    }
+
+    @Test (dataProvider = "private-ip-provider")
+    public void testIsPrivateTrue(String ipAddress)
+    {
+        assertFunction("IS_PRIVATE_IP(IPADDRESS '" + ipAddress + "')", BOOLEAN, true);
+    }
+
+    @Test (dataProvider = "public-ip-provider")
+    public void testIsPrivateIpFalse(String ipAddress)
+    {
+        assertFunction("IS_PRIVATE_IP(IPADDRESS '" + ipAddress + "')", BOOLEAN, false);
+    }
+
+    @Test
+    public void testIsPrivateIpNull()
+    {
+        assertFunction("IS_PRIVATE_IP(NULL)", BOOLEAN, null);
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Adding the `is_private_ip` function that checks whether an IP address is within private or reserved range that is not globally reachable. We take our definitions from what IANA considers not "globally reachable" in
[https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) and
[https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml](https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml).

This is a follow-up to a [previous PR](https://github.com/prestodb/presto/pull/23243) which used an inefficient SQL-function approach. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
When working with network data, filtering private IP address space is a common requirement. Without a standard function to handle it, it has led to numerous instances of:
* Incorrect/partial detection because of the scattered nature of Internet RFCs.
* Code duplication and general clutter to handle ~25 IP address block conditions.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Adds a new user facing function `is_private_ip`.

## Test Plan
<!---Please fill in how you tested your change-->

Added unit tests that check that the boundaries of all include private ranges return `true` while non-private ranges return `false`.

`mvn clean install -Dtest=TestIpPrefixFunctions -Dmaven.javadoc.skip=true -DskipUI -T1C -fn -pl presto-main`

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== RELEASE NOTES ==

General Changes
* Add function :func: `is_private_ip` that returns true when the input IP address is private or a reserved IP address ... :pr:`23520`
```