### PR TITLE
[native] Add session property for partial aggregation and spill

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -142,6 +142,16 @@ The configuration properties of Presto C++ workers are described here, in alphab
   worker node. Memory for system usage such as disk spilling and cache prefetch are
   not counted in it.
 
+``max_spill_bytes``
+^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``100UL << 30``
+
+  Specifies the max spill bytes limit set for each query. This is used to cap the
+  storage used for spilling. If it is zero, then there is no limit and spilling
+  might exhaust the storage or takes too long to run.
+
 ``shared-arbitrator.reserved-capacity``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -350,6 +350,10 @@ public final class SystemSessionProperties
     private static final String NATIVE_EXECUTION_PROGRAM_ARGUMENTS = "native_execution_program_arguments";
     public static final String NATIVE_EXECUTION_PROCESS_REUSE_ENABLED = "native_execution_process_reuse_enabled";
     public static final String NATIVE_DEBUG_VALIDATE_OUTPUT_FROM_OPERATORS = "native_debug_validate_output_from_operators";
+
+    public static final String NATIVE_MAX_PARTIAL_AGGREGATION_MEMORY = "native_max_partial_aggregation_memory";
+    public static final String NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY = "native_max_extended_partial_aggregation_memory";
+    public static final String NATIVE_MAX_SPILL_BYTES = "native_max_spill_bytes";
     public static final String DEFAULT_VIEW_SECURITY_MODE = "default_view_security_mode";
     public static final String JOIN_PREFILTER_BUILD_SIDE = "join_prefilter_build_side";
     public static final String OPTIMIZER_USE_HISTOGRAMS = "optimizer_use_histograms";
@@ -1712,6 +1716,21 @@ public final class SystemSessionProperties
                                 "operator is generating them.",
                         false,
                         true),
+                longProperty(
+                        NATIVE_MAX_PARTIAL_AGGREGATION_MEMORY,
+                        "The max partial aggregation memory when data reduction is not optimal.",
+                        1L << 24,
+                        false),
+                longProperty(
+                        NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY,
+                        "The max partial aggregation memory when data reduction is optimal.",
+                        1L << 26,
+                        false),
+                longProperty(
+                        NATIVE_MAX_SPILL_BYTES,
+                        "The max allowed spill bytes",
+                        100L << 30,
+                        false),
                 booleanProperty(
                         RANDOMIZE_OUTER_JOIN_NULL_KEY,
                         "(Deprecated) Randomize null join key for outer join",

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -65,6 +65,22 @@ SessionProperties::SessionProperties() {
       boolToString(c.exprEvalSimplified()));
 
   addSessionProperty(
+      kMaxPartialAggregationMemory,
+      "The max partial aggregation memory when data reduction is not optimal.",
+      BIGINT(),
+      false,
+      QueryConfig::kMaxPartialAggregationMemory,
+      std::to_string(c.maxPartialAggregationMemoryUsage()));
+
+  addSessionProperty(
+      kMaxExtendedPartialAggregationMemory,
+      "The max partial aggregation memory when data reduction is optimal.",
+      BIGINT(),
+      false,
+      QueryConfig::kMaxExtendedPartialAggregationMemory,
+      std::to_string(c.maxExtendedPartialAggregationMemoryUsage()));
+
+  addSessionProperty(
       kMaxSpillLevel,
       "Native Execution only. The maximum allowed spilling level for hash join "
       "build. 0 is the initial spilling level, -1 means unlimited.",
@@ -80,6 +96,14 @@ SessionProperties::SessionProperties() {
       false,
       QueryConfig::kMaxSpillFileSize,
       std::to_string(c.maxSpillFileSize()));
+
+  addSessionProperty(
+      kMaxSpillBytes,
+      "The max allowed spill bytes.",
+      BIGINT(),
+      false,
+      QueryConfig::kMaxSpillBytes,
+      std::to_string(c.maxSpillBytes()));
 
   addSessionProperty(
       kSpillCompressionCodec,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -77,6 +77,18 @@ class SessionProperties {
   static constexpr const char* kExprEvalSimplified =
       "native_simplified_expression_evaluation_enabled";
 
+  /// The maximum memory used by partial aggregation when data reduction is not
+  /// optimal.
+  static constexpr const char* kMaxPartialAggregationMemory =
+      "native_max_partial_aggregation_memory";
+
+  /// The max partial aggregation memory when data reduction is optimal.
+  /// When good data reduction is achieved through partial aggregation, more
+  /// memory would be given even when we reach limit of
+  /// kMaxPartialAggregationMemory.
+  static constexpr const char* kMaxExtendedPartialAggregationMemory =
+      "native_max_extended_partial_aggregation_memory";
+
   /// Enable join spilling on native engine.
   static constexpr const char* kJoinSpillEnabled = "native_join_spill_enabled";
 
@@ -85,6 +97,8 @@ class SessionProperties {
 
   /// The maximum allowed spill file size.
   static constexpr const char* kMaxSpillFileSize = "native_max_spill_file_size";
+
+  static constexpr const char* kMaxSpillBytes = "native_max_spill_bytes";
 
   /// Enable row number spilling on native engine.
   static constexpr const char* kRowNumberSpillEnabled =


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Add a session property `native_max_partial_aggregation_memory` which specifies presto native max partial aggregation memory when data reduction is not optimal :pr:`23527`
* Add a session property `native_max_extended_partial_aggregation_memory` which specifies presto native max partial aggregation memory when data reduction is optimal :pr:`23527`
* Add a session property `native_max_spill_bytes ` which specifies presto native max allowed spill bytes :pr:`23527`

```

