### PR TITLE
[native] Remove sanity check for event base from idle session in GCC

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -462,10 +462,14 @@ folly::SemiFuture<proxygen::HTTPTransaction*> HttpClient::createTransaction(
     }
     VLOG(3) << "Reuse idle connection from different thread to "
             << address_.describe();
+// Skip this check for GCC to prevent SIGSEGV as described in the issue:
+// https://github.com/prestodb/presto/issues/22995
+#if defined(__clang__)
     auto* evb = session->getEventBase();
     // The event base from idle session should not be the current event base,
     // otherwise we should have already got it from the local session pool.
     VELOX_CHECK(!evb || !evb->isInEventBaseThread());
+#endif
     session->attachThreadLocals(
         eventBase_,
         sslContext_,


### PR DESCRIPTION
## Description
We need this to avoid SIGSEGV when exchange.http-client.enable-connection-pool=true
Resolves https://github.com/prestodb/presto/issues/22995

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.


```
== NO RELEASE NOTE ==
```

