### PR TITLE
[parquet] Support us precision Time type in batch reader

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
@@ -139,6 +139,13 @@ public final class TimeOperators
     }
 
     @ScalarOperator(CAST)
+    @SqlType(StandardTypes.BIGINT)
+    public static long castToBigint(@SqlType(StandardTypes.TIME) long value)
+    {
+        return value;
+    }
+
+    @ScalarOperator(CAST)
     @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE)
     public static long castToTimestampWithTimeZone(SqlFunctionProperties properties, @SqlType(StandardTypes.TIME) long value)
     {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
@@ -42,6 +42,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.stream.Collectors.joining;
 import static org.apache.parquet.schema.OriginalType.DECIMAL;
 import static org.apache.parquet.schema.OriginalType.TIMESTAMP_MICROS;
+import static org.apache.parquet.schema.OriginalType.TIME_MICROS;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 
 public final class ParquetTypeUtils
@@ -334,6 +335,11 @@ public final class ParquetTypeUtils
     public static boolean isTimeStampMicrosType(ColumnDescriptor descriptor)
     {
         return TIMESTAMP_MICROS.equals(descriptor.getPrimitiveType().getOriginalType());
+    }
+
+    public static boolean isTimeMicrosType(ColumnDescriptor descriptor)
+    {
+        return TIME_MICROS.equals(descriptor.getPrimitiveType().getOriginalType());
     }
 
     public static boolean isShortDecimalType(ColumnDescriptor descriptor)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
@@ -27,7 +27,7 @@ import com.facebook.presto.parquet.batchreader.decoders.delta.Int32DeltaBinaryPa
 import com.facebook.presto.parquet.batchreader.decoders.delta.Int32ShortDecimalDeltaValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.delta.Int64DeltaBinaryPackedValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.delta.Int64ShortDecimalDeltaValuesDecoder;
-import com.facebook.presto.parquet.batchreader.decoders.delta.Int64TimestampMicrosDeltaBinaryPackedValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.delta.Int64TimeAndTimestampMicrosDeltaBinaryPackedValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.BinaryLongDecimalPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.BinaryPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.BinaryShortDecimalPlainValuesDecoder;
@@ -38,14 +38,14 @@ import com.facebook.presto.parquet.batchreader.decoders.plain.Int32PlainValuesDe
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int32ShortDecimalPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int64PlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int64ShortDecimalPlainValuesDecoder;
-import com.facebook.presto.parquet.batchreader.decoders.plain.Int64TimestampMicrosPlainValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.plain.Int64TimeAndTimestampMicrosPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.TimestampPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.BinaryRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.BooleanRLEValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int32RLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int32ShortDecimalRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int64RLEDictionaryValuesDecoder;
-import com.facebook.presto.parquet.batchreader.decoders.rle.Int64TimestampMicrosRLEDictionaryValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.rle.Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.LongDecimalRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.ShortDecimalRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.TimestampRLEDictionaryValuesDecoder;
@@ -79,6 +79,7 @@ import static com.facebook.presto.parquet.ParquetErrorCode.PARQUET_UNSUPPORTED_C
 import static com.facebook.presto.parquet.ParquetErrorCode.PARQUET_UNSUPPORTED_ENCODING;
 import static com.facebook.presto.parquet.ParquetTypeUtils.isDecimalType;
 import static com.facebook.presto.parquet.ParquetTypeUtils.isShortDecimalType;
+import static com.facebook.presto.parquet.ParquetTypeUtils.isTimeMicrosType;
 import static com.facebook.presto.parquet.ParquetTypeUtils.isTimeStampMicrosType;
 import static com.facebook.presto.parquet.ValuesType.VALUES;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -123,8 +124,8 @@ public class Decoders
                 case FLOAT:
                     return new Int32PlainValuesDecoder(buffer, offset, length);
                 case INT64: {
-                    if (isTimeStampMicrosType(columnDescriptor)) {
-                        return new Int64TimestampMicrosPlainValuesDecoder(buffer, offset, length);
+                    if (isTimeStampMicrosType(columnDescriptor) || isTimeMicrosType(columnDescriptor)) {
+                        return new Int64TimeAndTimestampMicrosPlainValuesDecoder(buffer, offset, length);
                     }
 
                     if (isShortDecimalType(columnDescriptor)) {
@@ -175,8 +176,8 @@ public class Decoders
                     return new Int32RLEDictionaryValuesDecoder(bitWidth, inputStream, (IntegerDictionary) dictionary);
                 }
                 case INT64: {
-                    if (isTimeStampMicrosType(columnDescriptor)) {
-                        return new Int64TimestampMicrosRLEDictionaryValuesDecoder(bitWidth, inputStream, (LongDictionary) dictionary);
+                    if (isTimeStampMicrosType(columnDescriptor) || isTimeMicrosType(columnDescriptor)) {
+                        return new Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder(bitWidth, inputStream, (LongDictionary) dictionary);
                     }
                 }
                 case DOUBLE: {
@@ -212,8 +213,8 @@ public class Decoders
                     return new Int32DeltaBinaryPackedValuesDecoder(valueCount, inputStream);
                 }
                 case INT64: {
-                    if (isTimeStampMicrosType(columnDescriptor)) {
-                        return new Int64TimestampMicrosDeltaBinaryPackedValuesDecoder(valueCount, inputStream);
+                    if (isTimeStampMicrosType(columnDescriptor) || isTimeMicrosType(columnDescriptor)) {
+                        return new Int64TimeAndTimestampMicrosDeltaBinaryPackedValuesDecoder(valueCount, inputStream);
                     }
 
                     if (isShortDecimalType(columnDescriptor)) {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/ValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/ValuesDecoder.java
@@ -54,7 +54,7 @@ public interface ValuesDecoder
                 throws IOException;
     }
 
-    interface Int64TimestampMicrosValuesDecoder
+    interface Int64TimeAndTimestampMicrosValuesDecoder
             extends ValuesDecoder
     {
         void readNext(long[] values, int offset, int length)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/delta/Int64TimeAndTimestampMicrosDeltaBinaryPackedValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/delta/Int64TimeAndTimestampMicrosDeltaBinaryPackedValuesDecoder.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.parquet.batchreader.decoders.delta;
 
-import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimestampMicrosValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimeAndTimestampMicrosValuesDecoder;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
 import org.openjdk.jol.info.ClassLayout;
@@ -27,14 +27,14 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
  * is not a common one, just use the existing one provided by Parquet library and add a wrapper around it that satisfies the
  * {@link Int64ValuesDecoder} interface.
  */
-public class Int64TimestampMicrosDeltaBinaryPackedValuesDecoder
-        implements Int64TimestampMicrosValuesDecoder
+public class Int64TimeAndTimestampMicrosDeltaBinaryPackedValuesDecoder
+        implements Int64TimeAndTimestampMicrosValuesDecoder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int64TimestampMicrosDeltaBinaryPackedValuesDecoder.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int64TimeAndTimestampMicrosDeltaBinaryPackedValuesDecoder.class).instanceSize();
 
     private final DeltaBinaryPackingValuesReader innerReader;
 
-    public Int64TimestampMicrosDeltaBinaryPackedValuesDecoder(int valueCount, ByteBufferInputStream bufferInputStream)
+    public Int64TimeAndTimestampMicrosDeltaBinaryPackedValuesDecoder(int valueCount, ByteBufferInputStream bufferInputStream)
             throws IOException
     {
         innerReader = new DeltaBinaryPackingValuesReader();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/Int64TimeAndTimestampMicrosPlainValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/Int64TimeAndTimestampMicrosPlainValuesDecoder.java
@@ -14,24 +14,24 @@
 package com.facebook.presto.parquet.batchreader.decoders.plain;
 
 import com.facebook.presto.parquet.batchreader.BytesUtils;
-import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimestampMicrosValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimeAndTimestampMicrosValuesDecoder;
 import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
-public class Int64TimestampMicrosPlainValuesDecoder
-        implements Int64TimestampMicrosValuesDecoder
+public class Int64TimeAndTimestampMicrosPlainValuesDecoder
+        implements Int64TimeAndTimestampMicrosValuesDecoder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int64TimestampMicrosPlainValuesDecoder.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int64TimeAndTimestampMicrosPlainValuesDecoder.class).instanceSize();
 
     private final byte[] byteBuffer;
     private final int bufferEnd;
 
     private int bufferOffset;
 
-    public Int64TimestampMicrosPlainValuesDecoder(byte[] byteBuffer, int bufferOffset, int length)
+    public Int64TimeAndTimestampMicrosPlainValuesDecoder(byte[] byteBuffer, int bufferOffset, int length)
     {
         this.byteBuffer = byteBuffer;
         this.bufferOffset = bufferOffset;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/TimestampPlainValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/TimestampPlainValuesDecoder.java
@@ -23,7 +23,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 public class TimestampPlainValuesDecoder
         implements TimestampValuesDecoder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int64TimestampMicrosPlainValuesDecoder.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TimestampPlainValuesDecoder.class).instanceSize();
 
     private final byte[] byteBuffer;
     private final int bufferEnd;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.parquet.batchreader.decoders.rle;
 
-import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimestampMicrosValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimeAndTimestampMicrosValuesDecoder;
 import com.facebook.presto.parquet.dictionary.LongDictionary;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.openjdk.jol.info.ClassLayout;
@@ -26,15 +26,15 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
-public class Int64TimestampMicrosRLEDictionaryValuesDecoder
+public class Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder
         extends BaseRLEBitPackedDecoder
-        implements Int64TimestampMicrosValuesDecoder
+        implements Int64TimeAndTimestampMicrosValuesDecoder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int64TimestampMicrosRLEDictionaryValuesDecoder.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder.class).instanceSize();
 
     private final LongDictionary dictionary;
 
-    public Int64TimestampMicrosRLEDictionaryValuesDecoder(int bitWidth, InputStream inputStream, LongDictionary dictionary)
+    public Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder(int bitWidth, InputStream inputStream, LongDictionary dictionary)
     {
         super(Integer.MAX_VALUE, bitWidth, inputStream);
         this.dictionary = dictionary;

--- a/presto-parquet/src/main/resources/freemarker/data/ParquetTypes.tdd
+++ b/presto-parquet/src/main/resources/freemarker/data/ParquetTypes.tdd
@@ -19,9 +19,9 @@
             primitiveType: "byte"
         },
         {
-            classNamePrefix: "Int64TimestampMicros",
+            classNamePrefix: "Int64TimeAndTimestampMicros",
             blockType: "LongArrayBlock",
-            valuesDecoder: "Int64TimestampMicrosValuesDecoder",
+            valuesDecoder: "Int64TimeAndTimestampMicrosValuesDecoder",
             primitiveType: "long"
         },
         {

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/batchreader/decoders/TestValuesDecoders.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/batchreader/decoders/TestValuesDecoders.java
@@ -17,20 +17,20 @@ import com.facebook.presto.parquet.DictionaryPage;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.BinaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.BooleanValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int32ValuesDecoder;
-import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimestampMicrosValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimeAndTimestampMicrosValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64ValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.TimestampValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.BinaryPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.BooleanPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int32PlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int64PlainValuesDecoder;
-import com.facebook.presto.parquet.batchreader.decoders.plain.Int64TimestampMicrosPlainValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.plain.Int64TimeAndTimestampMicrosPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.TimestampPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.BinaryRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.BooleanRLEValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int32RLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int64RLEDictionaryValuesDecoder;
-import com.facebook.presto.parquet.batchreader.decoders.rle.Int64TimestampMicrosRLEDictionaryValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.rle.Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.TimestampRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.dictionary.BinaryBatchDictionary;
 import com.facebook.presto.parquet.batchreader.dictionary.TimestampDictionary;
@@ -83,9 +83,9 @@ public class TestValuesDecoders
         return new Int64PlainValuesDecoder(pageBytes, 0, pageBytes.length);
     }
 
-    private static Int64TimestampMicrosValuesDecoder int64TimestampMicrosPlain(byte[] pageBytes)
+    private static Int64TimeAndTimestampMicrosValuesDecoder int64TimestampMicrosPlain(byte[] pageBytes)
     {
-        return new Int64TimestampMicrosPlainValuesDecoder(pageBytes, 0, pageBytes.length);
+        return new Int64TimeAndTimestampMicrosPlainValuesDecoder(pageBytes, 0, pageBytes.length);
     }
 
     private static Int64ValuesDecoder int64Dictionary(byte[] pageBytes, int dictionarySize, LongDictionary dictionary)
@@ -93,9 +93,9 @@ public class TestValuesDecoders
         return new Int64RLEDictionaryValuesDecoder(getWidthFromMaxInt(dictionarySize), new ByteArrayInputStream(pageBytes), dictionary);
     }
 
-    private static Int64TimestampMicrosValuesDecoder int64TimestampMicrosDictionary(byte[] pageBytes, int dictionarySize, LongDictionary dictionary)
+    private static Int64TimeAndTimestampMicrosValuesDecoder int64TimestampMicrosDictionary(byte[] pageBytes, int dictionarySize, LongDictionary dictionary)
     {
-        return new Int64TimestampMicrosRLEDictionaryValuesDecoder(getWidthFromMaxInt(dictionarySize), new ByteArrayInputStream(pageBytes), dictionary);
+        return new Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder(getWidthFromMaxInt(dictionarySize), new ByteArrayInputStream(pageBytes), dictionary);
     }
 
     private static TimestampValuesDecoder timestampPlain(byte[] pageBytes)
@@ -167,7 +167,7 @@ public class TestValuesDecoders
         }
     }
 
-    private static void int64BatchReadWithSkipHelper(int batchSize, int skipSize, int valueCount, Int64TimestampMicrosValuesDecoder decoder, List<Object> expectedValues)
+    private static void int64BatchReadWithSkipHelper(int batchSize, int skipSize, int valueCount, Int64TimeAndTimestampMicrosValuesDecoder decoder, List<Object> expectedValues)
             throws IOException
     {
         long[] actualValues = new long[valueCount];


### PR DESCRIPTION
## Description

Iceberg timestamps are written with microsecond precision as defined by the spec. Before this change, the parquet batch reader optimization did not properly support reading microsecond-precision `time` types. Presto returned results which differed depending on whether the optimization was enabled

This change adds proper support in the batch reader.

## Motivation and Context

Previously Presto would return wrong results in the Iceberg connector when parquet batch read optimizations are enabled.

<details><summary>Behavior before this change:</summary>
<p>


```sql
CREATE TABLE t(i time);
INSERT INTO t VALUES time '1:00';
-- without batch optimization
presto:tpch> SET SESSION iceberg.parquet_batch_read_optimization_enabled = false;
presto:tpch> SELECT CAST(i as bigint) FROM t;
  _col0
----------
 32400000 -- (5 trailing zeroes)
(1 row)


-- with batch optimization
presto:tpch> SET SESSION iceberg.parquet_batch_read_optimization_enabled = true;
SET SESSION
presto:tpch> SELECT CAST(i as bigint) FROM t;
    _col0
-------------
 32400000000 -- (8 trailing zeroes)
(1 row)
```

</p>
</details> 

<details><summary>Behavior after this change:</summary>
<p>


```sql
CREATE TABLE t(i time);
INSERT INTO t VALUES time '1:00';
-- without batch optimization
presto:tpch> SET SESSION iceberg.parquet_batch_read_optimization_enabled = false;
presto:tpch> SELECT CAST(i as bigint) FROM t;
  _col0
----------
 32400000 -- (5 trailing zeroes)
(1 row)


-- with batch optimization
presto:tpch> SET SESSION iceberg.parquet_batch_read_optimization_enabled = true;
SET SESSION
presto:tpch> SELECT CAST(i as bigint) FROM t;
    _col0
-------------
 32400000 -- (5 trailing zeroes)
(1 row)
```

</p>
</details> 




## Impact

Proper `time` type support.

## Test Plan

Added test to verify equivalent return values with and without the optimization in the Iceberg connector.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix time-type columns to return properly when ``iceberg.parquet-batch-read-optimization-enabled`` is set to ``TRUE``. :pr:`23542`
```


