### PR TITLE
Fix NPE when pruning info from query plan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -754,10 +754,12 @@ public class SqlQueryExecution
     @Override
     public void pruneFinishedQueryInfo()
     {
-        queryPlan.getAndUpdate(plan -> new Plan(
-                plan.getRoot(),
-                plan.getTypes(),
-                pruneHistogramsFromStatsAndCosts(plan.getStatsAndCosts())));
+        queryPlan.getAndUpdate(nullablePlan -> Optional.ofNullable(nullablePlan)
+                .map(plan -> new Plan(
+                        plan.getRoot(),
+                        plan.getTypes(),
+                        pruneHistogramsFromStatsAndCosts(plan.getStatsAndCosts())))
+                .orElse(null));
         // drop the reference to the scheduler since execution is finished
         queryScheduler.set(null);
         stateMachine.pruneQueryInfoFinished();


### PR DESCRIPTION
## Description

Fix an NPE when pruning happens when a query plan wasn't set for an execution. Mostly prevents log spam.

## Motivation and Context

I noticed some frequent NPE messages in logs after merging #23257:

```
2024-08-29T03:37:16.5026254Z 2024-08-28T21:37:16.479-0600	ERROR	dispatcher-query-18	com.facebook.presto.execution.StateMachine	Error notifying state change listener for finalQueryInfo-20240829_033716_00316_5xfqn
2024-08-29T03:37:16.5027920Z java.lang.NullPointerException
2024-08-29T03:37:16.5029154Z 	at com.facebook.presto.execution.SqlQueryExecution.lambda$pruneFinishedQueryInfo$7(SqlQueryExecution.java:758)
2024-08-29T03:37:16.5031493Z 	at java.util.concurrent.atomic.AtomicReference.getAndUpdate(AtomicReference.java:160)
2024-08-29T03:37:16.5033058Z 	at com.facebook.presto.execution.SqlQueryExecution.pruneFinishedQueryInfo(SqlQueryExecution.java:757)
2024-08-29T03:37:16.5034631Z 	at com.facebook.presto.execution.QueryTracker.lambda$expireQuery$2(QueryTracker.java:201)
2024-08-29T03:37:16.5035718Z 	at java.util.Optional.ifPresent(Optional.java:159)
2024-08-29T03:37:16.5036990Z 	at com.facebook.presto.execution.QueryTracker.expireQuery(QueryTracker.java:200)
2024-08-29T03:37:16.5038406Z 	at com.facebook.presto.execution.SqlQueryManager.lambda$createQuery$5(SqlQueryManager.java:311)
2024-08-29T03:37:16.5040287Z 	at com.facebook.presto.execution.QueryStateMachine.lambda$addQueryInfoStateChangeListener$18(QueryStateMachine.java:985)
2024-08-29T03:37:16.5042362Z 	at com.facebook.presto.execution.StateMachine.fireStateChangedListener(StateMachine.java:229)
2024-08-29T03:37:16.5044309Z 	at com.facebook.presto.execution.StateMachine.lambda$fireStateChanged$0(StateMachine.java:221)
2024-08-29T03:37:16.5046020Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2024-08-29T03:37:16.5047354Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2024-08-29T03:37:16.5048354Z 	at java.lang.Thread.run(Thread.java:750)
```

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

