### PR TITLE
Fix DeleteNode does not have a Graphviz visitor

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -42,6 +42,7 @@ import com.facebook.presto.sql.planner.optimizations.JoinNodeUtils;
 import com.facebook.presto.sql.planner.plan.AbstractJoinNode;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.DeleteNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
@@ -114,6 +115,7 @@ public final class GraphvizPrinter
         SINK,
         WINDOW,
         UNION,
+        DELETE,
 
         SEQUENCE,
         SORT,
@@ -145,6 +147,7 @@ public final class GraphvizPrinter
             .put(NodeType.SINK, "indianred1")
             .put(NodeType.WINDOW, "darkolivegreen4")
             .put(NodeType.UNION, "turquoise4")
+            .put(NodeType.DELETE, "tomato")
             .put(NodeType.SEQUENCE, "turquoise4")
             .put(NodeType.MARK_DISTINCT, "violet")
             .put(NodeType.TABLE_WRITER, "cyan")
@@ -680,6 +683,16 @@ public final class GraphvizPrinter
             node.getProbeSource().accept(this, context);
             node.getIndexSource().accept(this, context);
 
+            return null;
+        }
+
+        @Override
+        public Void visitDelete(DeleteNode node, Void context)
+        {
+            String deleteLabel = format("Delete[%s]", Joiner.on(",").join(node.getOutputVariables()));
+            printNode(node, deleteLabel, NODE_COLORS.get(NodeType.DELETE));
+
+            node.getSource().accept(this, context);
             return null;
         }
 


### PR DESCRIPTION
Reduces stack traces and log spam in tests

## Description

Adds a visitor for Delete nodes in the Graphviz printer

## Motivation and Context

Log spam in tests occur with the following stack trace:

```
2024-08-29T14:49:44.9644936Z 2024-08-29T08:49:44.924-0600	WARN	dispatcher-query-12	com.facebook.presto.event.QueryMonitor	Error creating graphviz plan for query 20240829_144944_00163_9vazg: java.lang.UnsupportedOperationException: Node com.facebook.presto.sql.planner.plan.DeleteNode does not have a Graphviz visitor
2024-08-29T14:49:44.9648748Z java.lang.UnsupportedOperationException: Node com.facebook.presto.sql.planner.plan.DeleteNode does not have a Graphviz visitor
2024-08-29T14:49:44.9650799Z 	at com.facebook.presto.util.GraphvizPrinter$NodePrinter.visitPlan(GraphvizPrinter.java:278)
2024-08-29T14:49:44.9652698Z 	at com.facebook.presto.util.GraphvizPrinter$NodePrinter.visitPlan(GraphvizPrinter.java:256)
2024-08-29T14:49:44.9654567Z 	at com.facebook.presto.sql.planner.plan.InternalPlanVisitor.visitDelete(InternalPlanVisitor.java:92)
2024-08-29T14:49:44.9656607Z 	at com.facebook.presto.sql.planner.plan.DeleteNode.accept(DeleteNode.java:94)
2024-08-29T14:49:44.9658378Z 	at com.facebook.presto.sql.planner.plan.InternalPlanNode.accept(InternalPlanNode.java:36)
2024-08-29T14:49:44.9660170Z 	at com.facebook.presto.util.GraphvizPrinter.printFragmentNodes(GraphvizPrinter.java:250)
2024-08-29T14:49:44.9662438Z 	at com.facebook.presto.util.GraphvizPrinter.printDistributedFromFragments(GraphvizPrinter.java:213)
2024-08-29T14:49:44.9664626Z 	at com.facebook.presto.sql.planner.planPrinter.PlanPrinter.graphvizDistributedPlan(PlanPrinter.java:478)
2024-08-29T14:49:44.9666539Z 	at com.facebook.presto.event.QueryMonitor.createGraphvizQueryPlan(QueryMonitor.java:561)
2024-08-29T14:49:44.9668168Z 	at com.facebook.presto.event.QueryMonitor.createQueryMetadata(QueryMonitor.java:355)
2024-08-29T14:49:44.9669929Z 	at com.facebook.presto.event.QueryMonitor.queryCompletedEvent(QueryMonitor.java:291)
2024-08-29T14:49:44.9671518Z 	at com.facebook.presto.execution.SqlQueryManager.lambda$createQuery$5(SqlQueryManager.java:307)
2024-08-29T14:49:44.9675393Z 	at com.facebook.presto.execution.QueryStateMachine.lambda$addQueryInfoStateChangeListener$18(QueryStateMachine.java:985)
2024-08-29T14:49:44.9677578Z 	at com.facebook.presto.execution.StateMachine.fireStateChangedListener(StateMachine.java:229)
2024-08-29T14:49:44.9679124Z 	at com.facebook.presto.execution.StateMachine.lambda$fireStateChanged$0(StateMachine.java:221)
2024-08-29T14:49:44.9680630Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2024-08-29T14:49:44.9682211Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2024-08-29T14:49:44.9683856Z 	at java.lang.Thread.run(Thread.java:750)
```


## Impact

Delete nodes now work properly in the graphviz printer

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

