### PR TITLE
Remove unused usages of SqlParser, TypeProvider, VariableAllocator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -545,7 +545,6 @@ public class SqlQueryExecution
                     metadata,
                     planOptimizers,
                     planChecker,
-                    sqlParser,
                     analyzerContext.getVariableAllocator(),
                     idAllocator,
                     stateMachine.getWarningCollector(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -142,7 +142,6 @@ public class SqlQueryScheduler
     private final Set<StageId> runtimeOptimizedStages = Collections.synchronizedSet(new HashSet<>());
     private final PlanChecker planChecker;
     private final Metadata metadata;
-    private final SqlParser sqlParser;
 
     private final Map<StageId, StageExecutionAndScheduler> stageExecutions = new ConcurrentHashMap<>();
     private final ExecutorService executor;
@@ -237,7 +236,6 @@ public class SqlQueryScheduler
         this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
         this.planChecker = requireNonNull(planChecker, "planChecker is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.sectionExecutionFactory = requireNonNull(sectionExecutionFactory, "sectionExecutionFactory is null");
         this.remoteTaskFactory = requireNonNull(remoteTaskFactory, "remoteTaskFactory is null");
         this.splitSourceFactory = requireNonNull(splitSourceFactory, "splitSourceFactory is null");
@@ -596,7 +594,7 @@ public class SqlQueryScheduler
                 .forEach(currentSubPlan -> {
                     Optional<PlanFragment> newPlanFragment = performRuntimeOptimizations(currentSubPlan);
                     if (newPlanFragment.isPresent()) {
-                        planChecker.validatePlanFragment(newPlanFragment.get().getRoot(), session, metadata, sqlParser, TypeProvider.viewOf(variableAllocator.getVariables()), warningCollector);
+                        planChecker.validatePlanFragment(newPlanFragment.get().getRoot(), session, metadata, warningCollector);
                         oldToNewFragment.put(currentSubPlan.getFragment(), newPlanFragment.get());
                     }
                 });

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -219,7 +219,6 @@ public class QueryExplainer
                 metadata,
                 planOptimizers,
                 planChecker,
-                sqlParser,
                 planVariableAllocator,
                 idAllocator,
                 warningCollector,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -34,7 +34,6 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.MetadataDeleteNode;
@@ -52,7 +51,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -97,11 +95,8 @@ public abstract class BasePlanFragmenter
     private final StatsAndCosts statsAndCosts;
     private final PlanChecker planChecker;
     private final WarningCollector warningCollector;
-    private final SqlParser sqlParser;
     private final Set<PlanNodeId> outputTableWriterNodeIds;
     private final StatisticsAggregationPlanner statisticsAggregationPlanner;
-
-    private Map<String, TableScanNode> cteNameToTableScanMap = new HashMap<>();
 
     public BasePlanFragmenter(
             Session session,
@@ -109,7 +104,6 @@ public abstract class BasePlanFragmenter
             StatsAndCosts statsAndCosts,
             PlanChecker planChecker,
             WarningCollector warningCollector,
-            SqlParser sqlParser,
             PlanNodeIdAllocator idAllocator,
             VariableAllocator variableAllocator,
             Set<PlanNodeId> outputTableWriterNodeIds)
@@ -119,7 +113,6 @@ public abstract class BasePlanFragmenter
         this.statsAndCosts = requireNonNull(statsAndCosts, "statsAndCosts is null");
         this.planChecker = requireNonNull(planChecker, "planChecker is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
-        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
         this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
         this.outputTableWriterNodeIds = ImmutableSet.copyOf(requireNonNull(outputTableWriterNodeIds, "outputTableWriterNodeIds is null"));
@@ -143,7 +136,7 @@ public abstract class BasePlanFragmenter
                 properties.getPartitionedSources());
 
         Set<VariableReferenceExpression> fragmentVariableTypes = extractOutputVariables(root);
-        planChecker.validatePlanFragment(root, session, metadata, sqlParser, TypeProvider.fromVariables(fragmentVariableTypes), warningCollector);
+        planChecker.validatePlanFragment(root, session, metadata, warningCollector);
 
         Set<PlanNodeId> tableWriterNodeIds = PlanFragmenterUtils.getTableWriterNodeIds(root);
         boolean outputTableWriterFragment = tableWriterNodeIds.stream().anyMatch(outputTableWriterNodeIds::contains);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -340,7 +340,7 @@ public final class Partitioning
         return Optional.of(new Partitioning(metadata.isRefinedPartitioningOver(session, other.handle, this.handle) ? this.handle : other.handle, arguments.build()));
     }
 
-    public Optional<Partitioning> translateRowExpression(Map<VariableReferenceExpression, RowExpression> inputToOutputMappings, Map<VariableReferenceExpression, RowExpression> assignments, TypeProvider types)
+    public Optional<Partitioning> translateRowExpression(Map<VariableReferenceExpression, RowExpression> inputToOutputMappings, Map<VariableReferenceExpression, RowExpression> assignments)
     {
         ImmutableList.Builder<RowExpression> newArguments = ImmutableList.builder();
         for (RowExpression argument : arguments) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.BasePlanFragmenter.FragmentProperties;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
@@ -49,17 +48,15 @@ public class PlanFragmenter
     private final Metadata metadata;
     private final NodePartitioningManager nodePartitioningManager;
     private final QueryManagerConfig config;
-    private final SqlParser sqlParser;
     private final PlanChecker distributedPlanChecker;
     private final PlanChecker singleNodePlanChecker;
 
     @Inject
-    public PlanFragmenter(Metadata metadata, NodePartitioningManager nodePartitioningManager, QueryManagerConfig queryManagerConfig, SqlParser sqlParser, FeaturesConfig featuresConfig)
+    public PlanFragmenter(Metadata metadata, NodePartitioningManager nodePartitioningManager, QueryManagerConfig queryManagerConfig, FeaturesConfig featuresConfig)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
         this.config = requireNonNull(queryManagerConfig, "queryManagerConfig is null");
-        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.distributedPlanChecker = new PlanChecker(requireNonNull(featuresConfig, "featuresConfig is null"), false);
         this.singleNodePlanChecker = new PlanChecker(requireNonNull(featuresConfig, "featuresConfig is null"), true);
     }
@@ -78,7 +75,6 @@ public class PlanFragmenter
                 plan.getStatsAndCosts(),
                 forceSingleNode ? singleNodePlanChecker : distributedPlanChecker,
                 warningCollector,
-                sqlParser,
                 idAllocator,
                 variableAllocator,
                 getOutputTableWriterNodeIds(plan.getRoot()));
@@ -100,9 +96,9 @@ public class PlanFragmenter
     {
         private int nextFragmentId = ROOT_FRAGMENT_ID + 1;
 
-        public Fragmenter(Session session, Metadata metadata, StatsAndCosts statsAndCosts, PlanChecker planChecker, WarningCollector warningCollector, SqlParser sqlParser, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, Set<PlanNodeId> outputTableWriterNodeIds)
+        public Fragmenter(Session session, Metadata metadata, StatsAndCosts statsAndCosts, PlanChecker planChecker, WarningCollector warningCollector, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, Set<PlanNodeId> outputTableWriterNodeIds)
         {
-            super(session, metadata, statsAndCosts, planChecker, warningCollector, sqlParser, idAllocator, variableAllocator, outputTableWriterNodeIds);
+            super(session, metadata, statsAndCosts, planChecker, warningCollector, idAllocator, variableAllocator, outputTableWriterNodeIds);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -353,7 +353,7 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.<Rule<?>>builder()
-                                .addAll(new InlineSqlFunctions(metadata, sqlParser).rules())
+                                .addAll(new InlineSqlFunctions(metadata).rules())
                                 .build()),
                 new IterativeOptimizer(
                         metadata,
@@ -568,7 +568,7 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(new LeftJoinNullFilterToSemiJoin(metadata.getFunctionAndTypeManager()))),
-                new KeyBasedSampler(metadata, sqlParser),
+                new KeyBasedSampler(metadata),
                 new IterativeOptimizer(
                         metadata,
                         ruleStats,
@@ -656,7 +656,7 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.<Rule<?>>builder()
-                                .addAll(new InlineSqlFunctions(metadata, sqlParser).rules())
+                                .addAll(new InlineSqlFunctions(metadata).rules())
                                 .build()));
 
         builder.add(new JoinPrefilter(metadata));
@@ -836,7 +836,7 @@ public class PlanOptimizers
                             ImmutableSet.of(new PushTableWriteThroughUnion()))); // Must run before AddExchanges
             builder.add(new CteProjectionAndPredicatePushDown(metadata)); // must run before PhysicalCteOptimizer
             builder.add(new PhysicalCteOptimizer(metadata)); // Must run before AddExchanges
-            builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(metadata, sqlParser, partitioningProviderManager, featuresConfig.isNativeExecutionEnabled())));
+            builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(metadata, partitioningProviderManager, featuresConfig.isNativeExecutionEnabled())));
         }
 
         //noinspection UnusedAssignment
@@ -872,10 +872,10 @@ public class PlanOptimizers
         // MergeJoinForSortedInputOptimizer can avoid the local exchange for a join operation
         // Should be placed after AddExchanges, but before AddLocalExchange
         // To replace the JoinNode to MergeJoin ahead of AddLocalExchange to avoid adding extra local exchange
-        builder.add(new MergeJoinForSortedInputOptimizer(metadata, sqlParser));
+        builder.add(new MergeJoinForSortedInputOptimizer(metadata));
 
         // Optimizers above this don't understand local exchanges, so be careful moving this.
-        builder.add(new AddLocalExchanges(metadata, sqlParser, featuresConfig.isNativeExecutionEnabled()));
+        builder.add(new AddLocalExchanges(metadata, featuresConfig.isNativeExecutionEnabled()));
 
         // Optimizers above this do not need to care about aggregations with the type other than SINGLE
         // This optimizer must be run after all exchange-related optimizers
@@ -934,7 +934,7 @@ public class PlanOptimizers
                 statsCalculator,
                 costCalculator,
                 ImmutableList.of(),
-                ImmutableSet.of(new RuntimeReorderJoinSides(metadata, sqlParser))));
+                ImmutableSet.of(new RuntimeReorderJoinSides(metadata))));
         this.runtimeOptimizers = runtimeBuilder.build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/VariablesExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/VariablesExtractor.java
@@ -44,26 +44,26 @@ public final class VariablesExtractor
 {
     private VariablesExtractor() {}
 
-    public static Set<VariableReferenceExpression> extractUnique(PlanNode node, TypeProvider types)
+    public static Set<VariableReferenceExpression> extractUnique(PlanNode node)
     {
         ImmutableSet.Builder<VariableReferenceExpression> unique = ImmutableSet.builder();
-        extractExpressions(node).forEach(expression -> unique.addAll(extractUniqueVariableInternal(expression, types)));
+        extractExpressions(node).forEach(expression -> unique.addAll(extractUniqueVariableInternal(expression)));
 
         return unique.build();
     }
 
-    public static Set<VariableReferenceExpression> extractUniqueNonRecursive(PlanNode node, TypeProvider types)
+    public static Set<VariableReferenceExpression> extractUniqueNonRecursive(PlanNode node)
     {
         ImmutableSet.Builder<VariableReferenceExpression> uniqueVariables = ImmutableSet.builder();
-        extractExpressionsNonRecursive(node).forEach(expression -> uniqueVariables.addAll(extractUniqueVariableInternal(expression, types)));
+        extractExpressionsNonRecursive(node).forEach(expression -> uniqueVariables.addAll(extractUniqueVariableInternal(expression)));
 
         return uniqueVariables.build();
     }
 
-    public static Set<VariableReferenceExpression> extractUnique(PlanNode node, Lookup lookup, TypeProvider types)
+    public static Set<VariableReferenceExpression> extractUnique(PlanNode node, Lookup lookup)
     {
         ImmutableSet.Builder<VariableReferenceExpression> unique = ImmutableSet.builder();
-        extractExpressions(node, lookup).forEach(expression -> unique.addAll(extractUniqueVariableInternal(expression, types)));
+        extractExpressions(node, lookup).forEach(expression -> unique.addAll(extractUniqueVariableInternal(expression)));
         return unique.build();
     }
 
@@ -139,7 +139,7 @@ public final class VariablesExtractor
                 .collect(toImmutableSet());
     }
 
-    private static Set<VariableReferenceExpression> extractUniqueVariableInternal(RowExpression expression, TypeProvider types)
+    private static Set<VariableReferenceExpression> extractUniqueVariableInternal(RowExpression expression)
     {
         return extractUnique(expression);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
@@ -215,7 +215,7 @@ public class AddIntermediateAggregations
             if (!(aggregation.getArguments().size() == 1 && !aggregation.getOrderBy().isPresent() && !aggregation.getFilter().isPresent())) {
                 return ImmutableMap.of();
             }
-            VariableReferenceExpression input = getOnlyElement(extractAggregationUniqueVariables(entry.getValue(), types));
+            VariableReferenceExpression input = getOnlyElement(extractAggregationUniqueVariables(entry.getValue()));
             // Return type of intermediate aggregation is the same as the input type.
             RowExpression argumentExpr = aggregation.getCall().getArguments().get(0);
             Type returnType = argumentExpr.getType();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineSqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineSqlFunctions.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.SqlInvokedScalarFunctionImplementation;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.google.common.collect.ImmutableSet;
 
@@ -38,15 +37,14 @@ import static java.util.Objects.requireNonNull;
 public class InlineSqlFunctions
         extends RowExpressionRewriteRuleSet
 {
-    public InlineSqlFunctions(Metadata metadata, SqlParser sqlParser)
+    public InlineSqlFunctions(Metadata metadata)
     {
-        super(createRewrite(metadata, sqlParser));
+        super(createRewrite(metadata));
     }
 
-    private static PlanRowExpressionRewriter createRewrite(Metadata metadata, SqlParser sqlParser)
+    private static PlanRowExpressionRewriter createRewrite(Metadata metadata)
     {
         requireNonNull(metadata, "metadata is null");
-        requireNonNull(sqlParser, "sqlParser is null");
 
         return (expression, context) -> InlineSqlFunctionsRewriter.rewrite(
                 expression,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
@@ -60,7 +60,7 @@ public class PruneAggregationSourceColumns
     private static Stream<VariableReferenceExpression> getAggregationInputs(AggregationNode.Aggregation aggregation, TypeProvider types)
     {
         return Streams.concat(
-                AggregationNodeUtils.extractAggregationUniqueVariables(aggregation, types).stream(),
+                AggregationNodeUtils.extractAggregationUniqueVariables(aggregation).stream(),
                 aggregation.getMask().map(Stream::of).orElse(Stream.empty()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneWindowColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneWindowColumns.java
@@ -17,7 +17,6 @@ import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.optimizations.WindowNodeUtil;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.google.common.collect.ImmutableSet;
@@ -60,7 +59,7 @@ public class PruneWindowColumns
         windowNode.getHashVariable().ifPresent(referencedInputs::add);
 
         for (WindowNode.Function windowFunction : referencedFunctions.values()) {
-            referencedInputs.addAll(WindowNodeUtil.extractWindowFunctionUniqueVariables(windowFunction, TypeProvider.viewOf(variableAllocator.getVariables())));
+            referencedInputs.addAll(WindowNodeUtil.extractWindowFunctionUniqueVariables(windowFunction));
             windowFunction.getFrame().getStartValue().ifPresent(referencedInputs::add);
             windowFunction.getFrame().getEndValue().ifPresent(referencedInputs::add);
             windowFunction.getFrame().getSortKeyCoercedForFrameStartComparison().ifPresent(referencedInputs::add);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -108,7 +108,7 @@ public class PushPartialAggregationThroughJoin
     {
         Set<VariableReferenceExpression> inputs = aggregations.values()
                 .stream()
-                .map(aggregation -> extractAggregationUniqueVariables(aggregation, types))
+                .map(aggregation -> extractAggregationUniqueVariables(aggregation))
                 .flatMap(Set::stream)
                 .collect(toImmutableSet());
         return variables.containsAll(inputs);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RuntimeReorderJoinSides.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RuntimeReorderJoinSides.java
@@ -20,7 +20,6 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.plan.TableScanNode;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -45,12 +44,10 @@ public class RuntimeReorderJoinSides
     private static final Pattern<JoinNode> PATTERN = join();
 
     private final Metadata metadata;
-    private final SqlParser parser;
 
-    public RuntimeReorderJoinSides(Metadata metadata, SqlParser parser)
+    public RuntimeReorderJoinSides(Metadata metadata)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.parser = requireNonNull(parser, "parser is null");
     }
 
     @Override
@@ -100,7 +97,7 @@ public class RuntimeReorderJoinSides
             return Result.empty();
         }
 
-        Optional<JoinNode> rewrittenNode = createRuntimeSwappedJoinNode(joinNode, metadata, parser, context.getLookup(), context.getSession(), context.getVariableAllocator(), context.getIdAllocator());
+        Optional<JoinNode> rewrittenNode = createRuntimeSwappedJoinNode(joinNode, metadata, context.getLookup(), context.getSession(), context.getIdAllocator());
         if (rewrittenNode.isPresent()) {
             log.debug(format("Probe size: %.2f is smaller than Build size: %.2f => invoke runtime join swapping on JoinNode ID: %s.", leftOutputSizeInBytes, rightOutputSizeInBytes, joinNode.getId()));
             return Result.ofPlanNode(rewrittenNode.get());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -390,7 +390,7 @@ public class TransformCorrelatedInPredicateToJoin
 
         private boolean isCorrelatedShallowly(PlanNode node)
         {
-            return VariablesExtractor.extractUniqueNonRecursive(node, types).stream().anyMatch(correlation::contains);
+            return VariablesExtractor.extractUniqueNonRecursive(node).stream().anyMatch(correlation::contains);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningHandle;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -203,7 +202,7 @@ public class ActualProperties
                 .build();
     }
 
-    public ActualProperties translateRowExpression(Map<VariableReferenceExpression, RowExpression> assignments, TypeProvider types)
+    public ActualProperties translateRowExpression(Map<VariableReferenceExpression, RowExpression> assignments)
     {
         Map<VariableReferenceExpression, VariableReferenceExpression> inputToOutputVariables = new HashMap<>();
         for (Map.Entry<VariableReferenceExpression, RowExpression> assignment : assignments.entrySet()) {
@@ -226,7 +225,7 @@ public class ActualProperties
                 .filter(entry -> !inputToOutputVariables.containsKey(entry.getKey()))
                 .forEach(inputToOutputMappings::put);
         return builder()
-                .global(global.translateRowExpression(inputToOutputMappings.build(), assignments, types))
+                .global(global.translateRowExpression(inputToOutputMappings.build(), assignments))
                 .local(LocalProperties.translate(localProperties, variable -> Optional.ofNullable(inputToOutputVariables.get(variable))))
                 .constants(translatedConstants)
                 .build();
@@ -568,11 +567,11 @@ public class ActualProperties
                     nullsAndAnyReplicated);
         }
 
-        private Global translateRowExpression(Map<VariableReferenceExpression, RowExpression> inputToOutputMappings, Map<VariableReferenceExpression, RowExpression> assignments, TypeProvider types)
+        private Global translateRowExpression(Map<VariableReferenceExpression, RowExpression> inputToOutputMappings, Map<VariableReferenceExpression, RowExpression> assignments)
         {
             return new Global(
-                    nodePartitioning.flatMap(partitioning -> partitioning.translateRowExpression(inputToOutputMappings, assignments, types)),
-                    streamPartitioning.flatMap(partitioning -> partitioning.translateRowExpression(inputToOutputMappings, assignments, types)),
+                    nodePartitioning.flatMap(partitioning -> partitioning.translateRowExpression(inputToOutputMappings, assignments)),
+                    streamPartitioning.flatMap(partitioning -> partitioning.translateRowExpression(inputToOutputMappings, assignments)),
                     nullsAndAnyReplicated);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -47,7 +47,6 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialMergePushdownStrategy;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningHandle;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
@@ -157,15 +156,13 @@ import static java.util.stream.Collectors.toList;
 public class AddExchanges
         implements PlanOptimizer
 {
-    private final SqlParser parser;
     private final Metadata metadata;
     private final PartitioningProviderManager partitioningProviderManager;
     private final boolean nativeExecution;
 
-    public AddExchanges(Metadata metadata, SqlParser parser, PartitioningProviderManager partitioningProviderManager, boolean nativeExecution)
+    public AddExchanges(Metadata metadata, PartitioningProviderManager partitioningProviderManager, boolean nativeExecution)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.parser = requireNonNull(parser, "parser is null");
         this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
         this.nativeExecution = nativeExecution;
     }
@@ -1449,7 +1446,7 @@ public class AddExchanges
         private ActualProperties deriveProperties(PlanNode result, List<ActualProperties> inputProperties)
         {
             // TODO: move this logic to PlanChecker once PropertyDerivations.deriveProperties fully supports local exchanges
-            ActualProperties outputProperties = PropertyDerivations.deriveProperties(result, inputProperties, metadata, session, types, parser);
+            ActualProperties outputProperties = PropertyDerivations.deriveProperties(result, inputProperties, metadata, session);
             verify(result instanceof SemiJoinNode || inputProperties.stream().noneMatch(ActualProperties::isNullsAndAnyReplicated) || outputProperties.isNullsAndAnyReplicated(),
                     "SemiJoinNode is the only node that can strip null replication");
             return outputProperties;
@@ -1457,7 +1454,7 @@ public class AddExchanges
 
         private ActualProperties derivePropertiesRecursively(PlanNode result)
         {
-            return PropertyDerivations.derivePropertiesRecursively(result, metadata, session, types, parser);
+            return PropertyDerivations.derivePropertiesRecursively(result, metadata, session);
         }
 
         private PlanWithProperties accept(PlanNode plan, PreferredProperties context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AggregationNodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AggregationNodeUtils.java
@@ -56,17 +56,17 @@ public class AggregationNodeUtils
                 Optional.empty());
     }
 
-    public static Set<VariableReferenceExpression> extractAggregationUniqueVariables(AggregationNode.Aggregation aggregation, TypeProvider types)
+    public static Set<VariableReferenceExpression> extractAggregationUniqueVariables(AggregationNode.Aggregation aggregation)
     {
         // types will be no longer needed once everything is RowExpression.
         ImmutableSet.Builder<VariableReferenceExpression> builder = ImmutableSet.builder();
-        aggregation.getArguments().forEach(argument -> builder.addAll(extractAll(argument, types)));
-        aggregation.getFilter().ifPresent(filter -> builder.addAll(extractAll(filter, types)));
+        aggregation.getArguments().forEach(argument -> builder.addAll(extractAll(argument)));
+        aggregation.getFilter().ifPresent(filter -> builder.addAll(extractAll(filter)));
         aggregation.getOrderBy().ifPresent(orderingScheme -> builder.addAll(orderingScheme.getOrderByVariables()));
         return builder.build();
     }
 
-    private static List<VariableReferenceExpression> extractAll(RowExpression expression, TypeProvider types)
+    private static List<VariableReferenceExpression> extractAll(RowExpression expression)
     {
         return VariablesExtractor.extractAll(expression)
                 .stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
@@ -34,7 +34,6 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
@@ -71,7 +70,7 @@ public class KeyBasedSampler
     private final Metadata metadata;
     private boolean isEnabledForTesting;
 
-    public KeyBasedSampler(Metadata metadata, SqlParser sqlParser)
+    public KeyBasedSampler(Metadata metadata)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinForSortedInputOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinForSortedInputOptimizer.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.MergeJoinNode;
@@ -40,13 +39,11 @@ public class MergeJoinForSortedInputOptimizer
         implements PlanOptimizer
 {
     private final Metadata metadata;
-    private final SqlParser parser;
     private boolean isEnabledForTesting;
 
-    public MergeJoinForSortedInputOptimizer(Metadata metadata, SqlParser parser)
+    public MergeJoinForSortedInputOptimizer(Metadata metadata)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.parser = requireNonNull(parser, "parser is null");
     }
 
     @Override
@@ -141,8 +138,8 @@ public class MergeJoinForSortedInputOptimizer
         private boolean meetsDataRequirement(PlanNode left, PlanNode right, JoinNode node)
         {
             // Acquire data properties for both left and right side
-            StreamPropertyDerivations.StreamProperties leftProperties = StreamPropertyDerivations.derivePropertiesRecursively(left, metadata, session, types, parser);
-            StreamPropertyDerivations.StreamProperties rightProperties = StreamPropertyDerivations.derivePropertiesRecursively(right, metadata, session, types, parser);
+            StreamPropertyDerivations.StreamProperties leftProperties = StreamPropertyDerivations.derivePropertiesRecursively(left, metadata, session);
+            StreamPropertyDerivations.StreamProperties rightProperties = StreamPropertyDerivations.derivePropertiesRecursively(right, metadata, session);
 
             List<VariableReferenceExpression> leftJoinColumns = node.getCriteria().stream().map(EquiJoinClause::getLeft).collect(toImmutableList());
             List<VariableReferenceExpression> rightJoinColumns = node.getCriteria().stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -30,7 +30,6 @@ import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.VariablesExtractor;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
@@ -549,7 +548,7 @@ public class PlanNodeDecorrelator
 
     private boolean containsCorrelation(PlanNode node, List<VariableReferenceExpression> correlation)
     {
-        return Sets.union(VariablesExtractor.extractUnique(node, lookup, TypeProvider.viewOf(variableAllocator.getVariables())), VariablesExtractor.extractOutputVariables(node, lookup)).stream().anyMatch(correlation::contains);
+        return Sets.union(VariablesExtractor.extractUnique(node, lookup), VariablesExtractor.extractOutputVariables(node, lookup)).stream().anyMatch(correlation::contains);
     }
 
     public static class DecorrelatedNode

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowNodeUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowNodeUtil.java
@@ -15,7 +15,6 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.VariablesExtractor;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.planner.plan.WindowNode.Frame.BoundType;
@@ -74,7 +73,7 @@ public final class WindowNodeUtil
 
     // Explicitly limit the following functions for WindowNode.
     // TODO: Once the arguments in CallExpression are pure RowExpressions, move the method to VariablesExtractor
-    public static Set<VariableReferenceExpression> extractWindowFunctionUniqueVariables(WindowNode.Function function, TypeProvider types)
+    public static Set<VariableReferenceExpression> extractWindowFunctionUniqueVariables(WindowNode.Function function)
     {
         ImmutableSet.Builder<VariableReferenceExpression> builder = ImmutableSet.builder();
         for (RowExpression argument : function.getFunctionCall().getArguments()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/CheckUnsupportedExternalFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/CheckUnsupportedExternalFunctions.java
@@ -21,9 +21,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.PlanNode;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.optimizations.ExternalCallExpressionChecker;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -38,7 +36,7 @@ public class CheckUnsupportedExternalFunctions
         implements PlanChecker.Checker
 {
     @Override
-    public void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode planNode, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         planNode.accept(new Visitor(metadata.getFunctionAndTypeManager()), null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/CheckUnsupportedPrestissimoTypes.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/CheckUnsupportedPrestissimoTypes.java
@@ -34,9 +34,7 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 
 import java.util.List;
@@ -61,7 +59,7 @@ public class CheckUnsupportedPrestissimoTypes
     }
 
     @Override
-    public void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode planNode, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         planNode.accept(new Visitor(), null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/DynamicFiltersChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/DynamicFiltersChecker.java
@@ -22,8 +22,6 @@ import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.relation.RowExpression;
-import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.AbstractJoinNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -51,7 +49,7 @@ public class DynamicFiltersChecker
         implements PlanChecker.Checker
 {
     @Override
-    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode plan, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         plan.accept(new InternalPlanVisitor<Set<String>, Void>()
         {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoDuplicatePlanNodeIdsChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoDuplicatePlanNodeIdsChecker.java
@@ -18,8 +18,6 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
-import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.TypeProvider;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +31,7 @@ public class NoDuplicatePlanNodeIdsChecker
         implements PlanChecker.Checker
 {
     @Override
-    public void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode planNode, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         Map<PlanNodeId, PlanNode> planNodeIds = new HashMap<>();
         searchFrom(planNode)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
@@ -18,8 +18,6 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 
@@ -77,24 +75,24 @@ public final class PlanChecker
         checkers = builder.build();
     }
 
-    public void validateFinalPlan(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validateFinalPlan(PlanNode planNode, Session session, Metadata metadata, WarningCollector warningCollector)
     {
-        checkers.get(Stage.FINAL).forEach(checker -> checker.validate(planNode, session, metadata, sqlParser, types, warningCollector));
+        checkers.get(Stage.FINAL).forEach(checker -> checker.validate(planNode, session, metadata, warningCollector));
     }
 
-    public void validateIntermediatePlan(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validateIntermediatePlan(PlanNode planNode, Session session, Metadata metadata, WarningCollector warningCollector)
     {
-        checkers.get(Stage.INTERMEDIATE).forEach(checker -> checker.validate(planNode, session, metadata, sqlParser, types, warningCollector));
+        checkers.get(Stage.INTERMEDIATE).forEach(checker -> checker.validate(planNode, session, metadata, warningCollector));
     }
 
-    public void validatePlanFragment(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validatePlanFragment(PlanNode planNode, Session session, Metadata metadata, WarningCollector warningCollector)
     {
-        checkers.get(Stage.FRAGMENT).forEach(checker -> checker.validate(planNode, session, metadata, sqlParser, types, warningCollector));
+        checkers.get(Stage.FRAGMENT).forEach(checker -> checker.validate(planNode, session, metadata, warningCollector));
     }
 
     public interface Checker
     {
-        void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector);
+        void validate(PlanNode planNode, Session session, Metadata metadata, WarningCollector warningCollector);
     }
 
     private enum Stage

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
@@ -29,9 +29,7 @@ import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 
 import java.util.List;
@@ -51,27 +49,19 @@ public final class TypeValidator
     public TypeValidator() {}
 
     @Override
-    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode plan, Session session, Metadata metadata, WarningCollector warningCollector)
     {
-        plan.accept(new Visitor(session, metadata, sqlParser, types, warningCollector), null);
+        plan.accept(new Visitor(metadata), null);
     }
 
     private static class Visitor
             extends SimplePlanVisitor<Void>
     {
-        private final Session session;
         private final Metadata metadata;
-        private final SqlParser sqlParser;
-        private final TypeProvider types;
-        private final WarningCollector warningCollector;
 
-        public Visitor(Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+        public Visitor(Metadata metadata)
         {
-            this.session = requireNonNull(session, "session is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
-            this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
-            this.types = requireNonNull(types, "types is null");
-            this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoFilteredAggregations.java
@@ -18,8 +18,6 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.PlanNode;
-import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.TypeProvider;
 
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 
@@ -27,7 +25,7 @@ public final class VerifyNoFilteredAggregations
         implements PlanChecker.Checker
 {
     @Override
-    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode plan, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         searchFrom(plan)
                 .where(AggregationNode.class::isInstance)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoIntermediateFormExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoIntermediateFormExpression.java
@@ -20,9 +20,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.relation.IntermediateFormExpression;
 import com.facebook.presto.spi.relation.RowExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.ExpressionExtractor;
-import com.facebook.presto.sql.planner.TypeProvider;
 
 import java.util.List;
 
@@ -33,7 +31,7 @@ public final class VerifyNoIntermediateFormExpression
         implements PlanChecker.Checker
 {
     @Override
-    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode plan, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         List<RowExpression> expressions = ExpressionExtractor.extractExpressions(plan)
                 .stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoUnresolvedSymbolExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoUnresolvedSymbolExpression.java
@@ -20,9 +20,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.UnresolvedSymbolExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.ExpressionExtractor;
-import com.facebook.presto.sql.planner.TypeProvider;
 
 import java.util.List;
 
@@ -34,7 +32,7 @@ public final class VerifyNoUnresolvedSymbolExpression
         implements PlanChecker.Checker
 {
     @Override
-    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode plan, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         List<RowExpression> expressions = ExpressionExtractor.extractExpressions(plan)
                 .stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyOnlyOneOutputNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyOnlyOneOutputNode.java
@@ -18,8 +18,6 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
-import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.TypeProvider;
 
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.google.common.base.Preconditions.checkState;
@@ -28,7 +26,7 @@ public final class VerifyOnlyOneOutputNode
         implements PlanChecker.Checker
 {
     @Override
-    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode plan, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         int outputPlanNodesCount = searchFrom(plan)
                 .where(OutputNode.class::isInstance)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyProjectionLocality.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyProjectionLocality.java
@@ -21,9 +21,7 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.optimizations.ExternalCallExpressionChecker;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -34,7 +32,7 @@ public class VerifyProjectionLocality
         implements PlanChecker.Checker
 {
     @Override
-    public void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode planNode, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         planNode.accept(new Visitor(metadata.getFunctionAndTypeManager()), null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/WarnOnScanWithoutPartitionPredicate.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/WarnOnScanWithoutPartitionPredicate.java
@@ -22,8 +22,6 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 
@@ -44,7 +42,7 @@ public final class WarnOnScanWithoutPartitionPredicate
     }
 
     @Override
-    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    public void validate(PlanNode plan, Session session, Metadata metadata, WarningCollector warningCollector)
     {
         for (TableScanNode scan : searchFrom(plan)
                 .where(TableScanNode.class::isInstance)

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -432,7 +432,7 @@ public class LocalQueryRunner
         this.splitManager = new SplitManager(metadata, new QueryManagerConfig(), nodeSchedulerConfig);
         this.distributedPlanChecker = new PlanChecker(featuresConfig, false);
         this.singleNodePlanChecker = new PlanChecker(featuresConfig, true);
-        this.planFragmenter = new PlanFragmenter(this.metadata, this.nodePartitioningManager, new QueryManagerConfig(), sqlParser, featuresConfig);
+        this.planFragmenter = new PlanFragmenter(this.metadata, this.nodePartitioningManager, new QueryManagerConfig(), featuresConfig);
         this.joinCompiler = new JoinCompiler(metadata);
         this.pageIndexerFactory = new GroupByHashPageIndexerFactory(joinCompiler);
         this.statsNormalizer = new StatsNormalizer();
@@ -1137,7 +1137,6 @@ public class LocalQueryRunner
                 metadata,
                 optimizers,
                 singleNodePlanChecker,
-                sqlParser,
                 analyzerContext.getVariableAllocator(),
                 idAllocator,
                 warningCollector,

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -49,7 +49,6 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.Plan;
@@ -152,7 +151,7 @@ public class TestCostCalculator
                 new SimpleTtlNodeSelectorConfig());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
-        planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser(), new FeaturesConfig());
+        planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new FeaturesConfig());
         translator = new TestingRowExpressionTranslator();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -507,7 +507,7 @@ public class TestTypeValidator
 
     private void assertTypesValid(PlanNode node)
     {
-        TYPE_VALIDATOR.validate(node, TEST_SESSION, createTestMetadataManager(), SQL_PARSER, TypeProvider.viewOf(variableAllocator.getVariables()), WarningCollector.NOOP);
+        TYPE_VALIDATOR.validate(node, TEST_SESSION, createTestMetadataManager(), WarningCollector.NOOP);
     }
 
     private static PlanNodeId newId()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineSqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineSqlFunctions.java
@@ -177,7 +177,7 @@ public class TestInlineSqlFunctions
     {
         RowExpression inputExpression = new TestingRowExpressionTranslator(tester.getMetadata()).translate(inputExpressionStr, ImmutableMap.of(variable, type));
 
-        tester().assertThat(new InlineSqlFunctions(tester.getMetadata(), tester.getSqlParser()).projectRowExpressionRewriteRule())
+        tester().assertThat(new InlineSqlFunctions(tester.getMetadata()).projectRowExpressionRewriteRule())
                 .on(p -> p.project(assignment(p.variable("var"), inputExpression), p.values(p.variable(variable, type))))
                 .matches(project(ImmutableMap.of("var", expression(expectedExpressionStr)), values(variable)));
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRuntimeReorderJoinSides.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRuntimeReorderJoinSides.java
@@ -276,6 +276,6 @@ public class TestRuntimeReorderJoinSides
 
     private RuleAssert assertReorderJoinSides()
     {
-        return tester.assertThat(new RuntimeReorderJoinSides(tester.getMetadata(), tester.getSqlParser()));
+        return tester.assertThat(new RuntimeReorderJoinSides(tester.getMetadata()));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -15,7 +15,6 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.block.SortOrder;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
@@ -141,8 +140,8 @@ public class TestEliminateSorts
                         getQueryRunner().getStatsCalculator(),
                         getQueryRunner().getCostCalculator(),
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())),
-                new AddExchanges(getQueryRunner().getMetadata(), new SqlParser(), new PartitioningProviderManager(), false),
-                new AddLocalExchanges(getMetadata(), new SqlParser(), false),
+                new AddExchanges(getQueryRunner().getMetadata(), new PartitioningProviderManager(), false),
+                new AddLocalExchanges(getMetadata(), false),
                 new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -25,7 +25,6 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
@@ -247,7 +246,7 @@ public class TestRemoveUnsupportedDynamicFilters
             // metadata.getCatalogHandle() registers the catalog for the transaction
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
             PlanNode rewrittenPlan = new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()).optimize(root, session, TypeProvider.empty(), new VariableAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP).getPlanNode();
-            new DynamicFiltersChecker().validate(rewrittenPlan, session, metadata, new SqlParser(), TypeProvider.empty(), WarningCollector.NOOP);
+            new DynamicFiltersChecker().validate(rewrittenPlan, session, metadata, WarningCollector.NOOP);
             return rewrittenPlan;
         });
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestCheckUnsupportedPrestissimoTypes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestCheckUnsupportedPrestissimoTypes.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
@@ -43,7 +42,6 @@ public class TestCheckUnsupportedPrestissimoTypes
 {
     private Session testSession;
     private Metadata metadata;
-    private SqlParser sqlParser;
     private PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
     private FeaturesConfig featuresConfig = new FeaturesConfig();
 
@@ -55,7 +53,6 @@ public class TestCheckUnsupportedPrestissimoTypes
                 .setSchema("tiny");
         testSession = sessionBuilder.build();
         metadata = getQueryRunner().getMetadata();
-        sqlParser = getQueryRunner().getSqlParser();
     }
 
     @AfterClass(alwaysRun = true)
@@ -63,7 +60,6 @@ public class TestCheckUnsupportedPrestissimoTypes
     {
         testSession = null;
         metadata = null;
-        sqlParser = null;
         idAllocator = null;
     }
 
@@ -154,7 +150,7 @@ public class TestCheckUnsupportedPrestissimoTypes
         TypeProvider types = builder.getTypes();
         getQueryRunner().inTransaction(testSession, session -> {
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            new CheckUnsupportedPrestissimoTypes(featuresConfig).validate(planNode, session, metadata, sqlParser, types, WarningCollector.NOOP);
+            new CheckUnsupportedPrestissimoTypes(featuresConfig).validate(planNode, session, metadata, WarningCollector.NOOP);
             return null;
         });
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestDynamicFiltersChecker.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestDynamicFiltersChecker.java
@@ -23,8 +23,6 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.sql.relational.FunctionResolution;
@@ -174,7 +172,7 @@ public class TestDynamicFiltersChecker
         getQueryRunner().inTransaction(session -> {
             // metadata.getCatalogHandle() registers the catalog for the transaction
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            new DynamicFiltersChecker().validate(root, session, metadata, new SqlParser(), TypeProvider.empty(), WarningCollector.NOOP);
+            new DynamicFiltersChecker().validate(root, session, metadata, WarningCollector.NOOP);
             return null;
         });
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateAggregationsWithDefaultValues.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateAggregationsWithDefaultValues.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.testing.TestingTransactionHandle;
@@ -50,8 +49,6 @@ import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION
 public class TestValidateAggregationsWithDefaultValues
         extends BasePlanTest
 {
-    private static final SqlParser SQL_PARSER = new SqlParser();
-
     private Metadata metadata;
     private PlanBuilder builder;
     private VariableReferenceExpression variable;
@@ -191,7 +188,7 @@ public class TestValidateAggregationsWithDefaultValues
         getQueryRunner().inTransaction(session -> {
             // metadata.getCatalogHandle() registers the catalog for the transaction
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            new ValidateAggregationsWithDefaultValues(forceSingleNode).validate(root, session, metadata, SQL_PARSER, builder.getTypes(), WarningCollector.NOOP);
+            new ValidateAggregationsWithDefaultValues(forceSingleNode).validate(root, session, metadata, WarningCollector.NOOP);
             return null;
         });
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingAggregations.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
@@ -45,7 +44,6 @@ public class TestValidateStreamingAggregations
         extends BasePlanTest
 {
     private Metadata metadata;
-    private SqlParser sqlParser;
     private PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
     private TableHandle nationTableHandle;
 
@@ -53,7 +51,6 @@ public class TestValidateStreamingAggregations
     public void setup()
     {
         metadata = getQueryRunner().getMetadata();
-        sqlParser = getQueryRunner().getSqlParser();
 
         TpchTableHandle nationTpchTableHandle = new TpchTableHandle("nation", 1.0);
         ConnectorId connectorId = getCurrentConnectorId();
@@ -115,7 +112,7 @@ public class TestValidateStreamingAggregations
         getQueryRunner().inTransaction(session -> {
             // metadata.getCatalogHandle() registers the catalog for the transaction
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            new ValidateStreamingAggregations().validate(planNode, session, metadata, sqlParser, types, WarningCollector.NOOP);
+            new ValidateStreamingAggregations().validate(planNode, session, metadata, WarningCollector.NOOP);
             return null;
         });
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingJoins.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
@@ -51,7 +50,6 @@ public class TestValidateStreamingJoins
 {
     private Session testSession;
     private Metadata metadata;
-    private SqlParser sqlParser;
     private PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
     private TableHandle nationTableHandle;
     private TableHandle supplierTableHandle;
@@ -66,7 +64,6 @@ public class TestValidateStreamingJoins
                 .setSchema("tiny");
         testSession = sessionBuilder.build();
         metadata = getQueryRunner().getMetadata();
-        sqlParser = getQueryRunner().getSqlParser();
 
         TpchTableHandle nationTpchTableHandle = new TpchTableHandle("nation", 1.0);
         TpchTableHandle supplierTpchTableHandle = new TpchTableHandle("supplier", 1.0);
@@ -90,7 +87,6 @@ public class TestValidateStreamingJoins
     {
         testSession = null;
         metadata = null;
-        sqlParser = null;
         idAllocator = null;
         nationTableHandle = null;
         supplierTableHandle = null;
@@ -134,7 +130,7 @@ public class TestValidateStreamingJoins
         TypeProvider types = builder.getTypes();
         getQueryRunner().inTransaction(testSession, session -> {
             session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
-            new ValidateStreamingJoins().validate(planNode, session, metadata, sqlParser, types, WarningCollector.NOOP);
+            new ValidateStreamingJoins().validate(planNode, session, metadata, WarningCollector.NOOP);
             return null;
         });
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyOnlyOneOutputNode.java
@@ -51,7 +51,7 @@ public class TestVerifyOnlyOneOutputNode
                                         Optional.empty()),
                                 Assignments.of()
                         ), ImmutableList.of(), ImmutableList.of());
-        new VerifyOnlyOneOutputNode().validate(root, null, null, null, null, WarningCollector.NOOP);
+        new VerifyOnlyOneOutputNode().validate(root, null, null, WarningCollector.NOOP);
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
@@ -71,6 +71,6 @@ public class TestVerifyOnlyOneOutputNode
                                 false,
                                 ExplainFormat.Type.TEXT),
                         ImmutableList.of(), ImmutableList.of());
-        new VerifyOnlyOneOutputNode().validate(root, null, null, null, null, WarningCollector.NOOP);
+        new VerifyOnlyOneOutputNode().validate(root, null, null, WarningCollector.NOOP);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -53,7 +53,6 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.storage.TempStorage;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.SubPlan;
@@ -234,7 +233,6 @@ public class PrestoSparkAdaptiveQueryExecution
                 isFragmentFinished,
                 this.metadata,
                 new PlanChecker(this.featuresConfig, forceSingleNode),
-                new SqlParser(),
                 this.idAllocator,
                 new PrestoSparkNodePartitioningManager(this.partitioningProviderManager),
                 this.queryManagerConfig,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/IterativePlanFragmenter.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/IterativePlanFragmenter.java
@@ -36,7 +36,6 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.BasePlanFragmenter;
 import com.facebook.presto.sql.planner.BasePlanFragmenter.FragmentProperties;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
@@ -87,7 +86,6 @@ public class IterativePlanFragmenter
     private final Plan originalPlan;
     private final Metadata metadata;
     private final PlanChecker planChecker;
-    private final SqlParser sqlParser;
     private final PlanNodeIdAllocator idAllocator;
     private final VariableAllocator variableAllocator;
     private final NodePartitioningManager nodePartitioningManager;
@@ -112,7 +110,6 @@ public class IterativePlanFragmenter
             Function<PlanFragmentId, Boolean> isFragmentFinished,
             Metadata metadata,
             PlanChecker planChecker,
-            SqlParser sqlParser,
             PlanNodeIdAllocator idAllocator,
             NodePartitioningManager nodePartitioningManager,
             QueryManagerConfig queryManagerConfig,
@@ -124,7 +121,6 @@ public class IterativePlanFragmenter
         this.isFragmentFinished = requireNonNull(isFragmentFinished, "isSourceReady is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.planChecker = requireNonNull(planChecker, "planChecker is null");
-        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
         this.variableAllocator = new VariableAllocator(originalPlan.getTypes().allVariables());
         this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
@@ -149,7 +145,6 @@ public class IterativePlanFragmenter
                 originalPlan.getStatsAndCosts(),
                 planChecker,
                 warningCollector,
-                sqlParser,
                 idAllocator,
                 variableAllocator,
                 getOutputTableWriterNodeIds(plan));
@@ -244,12 +239,11 @@ public class IterativePlanFragmenter
                 StatsAndCosts statsAndCosts,
                 PlanChecker planChecker,
                 WarningCollector warningCollector,
-                SqlParser sqlParser,
                 PlanNodeIdAllocator idAllocator,
                 VariableAllocator variableAllocator,
                 Set<PlanNodeId> outputTableWriterNodeIds)
         {
-            super(session, metadata, statsAndCosts, planChecker, warningCollector, sqlParser, idAllocator, variableAllocator, outputTableWriterNodeIds);
+            super(session, metadata, statsAndCosts, planChecker, warningCollector, idAllocator, variableAllocator, outputTableWriterNodeIds);
         }
 
         @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
@@ -136,7 +136,6 @@ public class PrestoSparkQueryPlanner
                 metadata,
                 optimizers.getPlanningTimeOptimizers(),
                 planChecker,
-                sqlParser,
                 variableAllocator,
                 idAllocator,
                 warningCollector,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/AdaptivePlanOptimizers.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/AdaptivePlanOptimizers.java
@@ -17,7 +17,6 @@ package com.facebook.presto.spark.planner.optimizers;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.OptimizerStatsRecorder;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
@@ -47,12 +46,11 @@ public class AdaptivePlanOptimizers
     public AdaptivePlanOptimizers(
             MBeanExporter exporter,
             Metadata metadata,
-            SqlParser sqlParser,
             StatsCalculator statsCalculator,
             CostCalculator costCalculator)
     {
         this.exporter = exporter;
-        this.adaptiveOptimizers = ImmutableList.of(new IterativeOptimizer(metadata, ruleStats, statsCalculator, costCalculator, ImmutableSet.of(new PickJoinSides(metadata, sqlParser))));
+        this.adaptiveOptimizers = ImmutableList.of(new IterativeOptimizer(metadata, ruleStats, statsCalculator, costCalculator, ImmutableSet.of(new PickJoinSides(metadata))));
     }
 
     @PostConstruct

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/PickJoinSides.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/optimizers/PickJoinSides.java
@@ -33,7 +33,6 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 
@@ -73,12 +72,10 @@ public class PickJoinSides
                     && !(joinNode.getCriteria().isEmpty() && (joinNode.getType() == LEFT || joinNode.getType() == RIGHT)));
 
     private Metadata metadata;
-    private SqlParser sqlParser;
 
-    public PickJoinSides(Metadata metadata, SqlParser sqlParser)
+    public PickJoinSides(Metadata metadata)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
     }
 
     @Override
@@ -104,7 +101,7 @@ public class PickJoinSides
         // if we don't have exact costs for the join, but based on source tables we think the left side
         // is very small or much smaller than the right, then flip the join.
         if (rightSize > leftSize || (isSizeBasedJoinDistributionTypeEnabled(context.getSession()) && (Double.isNaN(leftSize) || Double.isNaN(rightSize)) && isLeftSideSmall(joinNode, context))) {
-            rewrittenNode = createRuntimeSwappedJoinNode(joinNode, metadata, sqlParser, context.getLookup(), context.getSession(), context.getVariableAllocator(), context.getIdAllocator());
+            rewrittenNode = createRuntimeSwappedJoinNode(joinNode, metadata, context.getLookup(), context.getSession(), context.getIdAllocator());
         }
 
         return rewrittenNode.map(Result::ofPlanNode).orElseGet(Result::empty);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
@@ -61,7 +61,6 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.security.AllowAllAccessControl;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PartitioningHandle;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
@@ -158,7 +157,7 @@ public class TestIterativePlanFragmenter
                 new SimpleTtlNodeSelectorConfig());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
-        planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser(), new FeaturesConfig());
+        planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new FeaturesConfig());
     }
 
     @AfterClass(alwaysRun = true)
@@ -226,7 +225,6 @@ public class TestIterativePlanFragmenter
                 testingFragmentTracker::isFragmentFinished,
                 metadata,
                 new PlanChecker(new FeaturesConfig()),
-                new SqlParser(),
                 new PlanNodeIdAllocator(),
                 nodePartitioningManager,
                 new QueryManagerConfig(),

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
@@ -379,7 +379,7 @@ public class TestPickJoinSides
     {
         int aSize = 100;
         int bSize = 10_000;
-        tester.assertThat(new PickJoinSides(tester.getMetadata(), tester.getSqlParser()))
+        tester.assertThat(new PickJoinSides(tester.getMetadata()))
                 .setSystemProperty(ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED, "false")
                 .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
                         .setTotalSize(aSize)
@@ -470,7 +470,7 @@ public class TestPickJoinSides
 
     private RuleAssert assertPickJoinSides()
     {
-        return tester.assertThat(new PickJoinSides(tester.getMetadata(), tester.getSqlParser()))
+        return tester.assertThat(new PickJoinSides(tester.getMetadata()))
                 .setSystemProperty(JOIN_MAX_BROADCAST_TABLE_SIZE, "100MB")
                 .setSystemProperty(ADAPTIVE_JOIN_SIDE_SWITCHING_ENABLED, "true");
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -572,7 +572,7 @@ public abstract class AbstractTestQueryFramework
                 .getPlanningTimeOptimizers();
         return new QueryExplainer(
                 optimizers,
-                new PlanFragmenter(metadata, queryRunner.getNodePartitioningManager(), new QueryManagerConfig(), sqlParser, featuresConfig),
+                new PlanFragmenter(metadata, queryRunner.getNodePartitioningManager(), new QueryManagerConfig(), featuresConfig),
                 metadata,
                 queryRunner.getAccessControl(),
                 sqlParser,

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
@@ -101,7 +101,7 @@ public class TestChecksumValidator
             .put("row.r._col1$sum", 0.0)
             .put("row.r.b$checksum", new SqlVarbinary(new byte[] {0xe}))
             .build();
-    private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
 
     private final ChecksumValidator checksumValidator = createChecksumValidator(new VerifierConfig()
             .setRelativeErrorMargin(RELATIVE_ERROR_MARGIN)
@@ -132,7 +132,7 @@ public class TestChecksumValidator
                         MAP_NON_ORDERABLE_COLUMN,
                         ROW_COLUMN),
                 Optional.empty());
-        Statement expectedChecksumQuery = sqlParser.createStatement(
+        Statement expectedChecksumQuery = SQL_PARSER.createStatement(
                 "SELECT\n" +
                         "  \"count\"(*)\n" +
                         ", \"checksum\"(\"bigint\") \"bigint$checksum\"\n" +
@@ -212,7 +212,7 @@ public class TestChecksumValidator
                 ImmutableList.of(
                         VARCHAR_COLUMN, VARCHAR_ARRAY_COLUMN, MAP_VARCHAR_VARCHAR_COLUMN),
                 Optional.empty());
-        Statement expectedChecksumQuery = sqlParser.createStatement(
+        Statement expectedChecksumQuery = SQL_PARSER.createStatement(
                 "SELECT\n" +
                         "  \"count\"(*)\n" +
                         ", \"checksum\"(\"varchar\") \"varchar$checksum\"\n" +

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
@@ -51,7 +51,7 @@ public class TestDeterminismAnalyzer
 {
     private static final String SUITE = "test-suite";
     private static final String NAME = "test-query";
-    private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
     private static final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager();
 
     @Test
@@ -64,7 +64,7 @@ public class TestDeterminismAnalyzer
 
     private static boolean isMutableCatalogReferenced(DeterminismAnalyzer determinismAnalyzer, String query)
     {
-        return determinismAnalyzer.isNonDeterministicCatalogReferenced(sqlParser.createStatement(query, ParsingOptions.builder().build()));
+        return determinismAnalyzer.isNonDeterministicCatalogReferenced(SQL_PARSER.createStatement(query, ParsingOptions.builder().build()));
     }
 
     private static DeterminismAnalyzer createDeterminismAnalyzer(String mutableCatalogPattern)
@@ -87,7 +87,7 @@ public class TestDeterminismAnalyzer
                 retryConfig,
                 new DefaultClientInfoFactory(verifierConfig));
         QueryRewriter queryRewriter = new QueryRewriter(
-                sqlParser,
+                SQL_PARSER,
                 typeManager,
                 blockEncodingSerde,
                 prestoAction,

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestLimitQueryDeterminismAnalyzer.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestLimitQueryDeterminismAnalyzer.java
@@ -83,7 +83,7 @@ public class TestLimitQueryDeterminismAnalyzer
             Optional.of(new QueryStats("id", "", false, false, false, 1, 2, 3, 4, 5, 0, 7, 8, 9, 10, 11, 12, 0, 0, 0, Optional.empty())),
             Optional.empty());
     private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build();
-    private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
 
     private static final String ORDER_BY_LIMIT_QUERY = "INSERT INTO test\n" +
             "SELECT\n" +
@@ -229,7 +229,7 @@ public class TestLimitQueryDeterminismAnalyzer
         LimitQueryDeterminismAnalysis analysis = new LimitQueryDeterminismAnalyzer(
                 prestoAction,
                 true,
-                sqlParser.createStatement(query, PARSING_OPTIONS),
+                SQL_PARSER.createStatement(query, PARSING_OPTIONS),
                 controlRowCount,
                 determinismAnalysisDetailsBuilder).analyze();
         DeterminismAnalysisDetails determinismAnalysisDetails = determinismAnalysisDetailsBuilder.build(NON_DETERMINISTIC_LIMIT_CLAUSE);
@@ -240,7 +240,7 @@ public class TestLimitQueryDeterminismAnalyzer
 
     private static void assertAnalyzerQuery(MockPrestoAction prestoAction, String expectedQuery)
     {
-        Statement expectedStatement = sqlParser.createStatement(expectedQuery, PARSING_OPTIONS);
+        Statement expectedStatement = SQL_PARSER.createStatement(expectedQuery, PARSING_OPTIONS);
         Statement actualStatement = prestoAction.getLastStatement();
         assertEquals(formatSql(actualStatement, Optional.empty()), formatSql(expectedStatement, Optional.empty()));
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestJdbcPrestoAction.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestJdbcPrestoAction.java
@@ -57,7 +57,7 @@ public class TestJdbcPrestoAction
     private static final String NAME = "test-query";
     private static final QueryStage QUERY_STAGE = CONTROL_MAIN;
     private static final QueryConfiguration CONFIGURATION = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-    private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
     private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DECIMAL).build();
 
     private static StandaloneQueryRunner queryRunner;
@@ -99,13 +99,13 @@ public class TestJdbcPrestoAction
     {
         assertEquals(
                 prestoAction.execute(
-                        sqlParser.createStatement("SELECT 1", PARSING_OPTIONS),
+                        SQL_PARSER.createStatement("SELECT 1", PARSING_OPTIONS),
                         QUERY_STAGE).getQueryStats().map(QueryStats::getState).orElse(null),
                 FINISHED.name());
 
         assertEquals(
                 prestoAction.execute(
-                        sqlParser.createStatement("CREATE TABLE test_table (x int)", PARSING_OPTIONS),
+                        SQL_PARSER.createStatement("CREATE TABLE test_table (x int)", PARSING_OPTIONS),
                         QUERY_STAGE).getQueryStats().map(QueryStats::getState).orElse(null),
                 FINISHED.name());
     }
@@ -114,7 +114,7 @@ public class TestJdbcPrestoAction
     public void testQuerySucceededWithConverter()
     {
         QueryResult<Integer> result = prestoAction.execute(
-                sqlParser.createStatement("SELECT x FROM (VALUES (1), (2), (3)) t(x)", PARSING_OPTIONS),
+                SQL_PARSER.createStatement("SELECT x FROM (VALUES (1), (2), (3)) t(x)", PARSING_OPTIONS),
                 QUERY_STAGE,
                 resultSet -> Optional.of(resultSet.getInt("x") * resultSet.getInt("x")));
         assertEquals(result.getQueryActionStats().getQueryStats().map(QueryStats::getState).orElse(null), FINISHED.name());
@@ -126,7 +126,7 @@ public class TestJdbcPrestoAction
     {
         try {
             prestoAction.execute(
-                    sqlParser.createStatement("SELECT * FROM test_table", PARSING_OPTIONS),
+                    SQL_PARSER.createStatement("SELECT * FROM test_table", PARSING_OPTIONS),
                     QUERY_STAGE);
             fail("Expect QueryException");
         }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
@@ -35,7 +35,7 @@ import static com.facebook.presto.verifier.resolver.FailureResolverTestUtil.crea
 public class TestIgnoredFunctionsMismatchResolver
         extends AbstractTestResultMismatchResolver
 {
-    private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON));
+    private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON));
 
     public TestIgnoredFunctionsMismatchResolver()
     {
@@ -68,7 +68,7 @@ public class TestIgnoredFunctionsMismatchResolver
         return new QueryObjectBundle(
                 QualifiedName.of("test"),
                 ImmutableList.of(),
-                sqlParser.createStatement(query, PARSING_OPTIONS),
+                SQL_PARSER.createStatement(query, PARSING_OPTIONS),
                 ImmutableList.of(),
                 CONTROL,
                 Optional.empty(),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
@@ -85,7 +85,7 @@ public class TestQueryRewriter
             .setTablePrefix("local.tmp")
             .setTableProperties("{\"p_int\": 30, \"p_long\": 4294967297, \"p_double\": 1.5, \"p_varchar\": \"test\", \"p_bool\": true}");
     private static final VerifierConfig VERIFIER_CONFIG = new VerifierConfig();
-    private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
     private static final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager();
 
     private static StandaloneQueryRunner queryRunner;
@@ -646,14 +646,14 @@ public class TestQueryRewriter
     {
         assertTrue(statement instanceof CreateTableAsSelect);
         Query query = ((CreateTableAsSelect) statement).getQuery();
-        assertEquals(formatSql(query, Optional.empty()), formatSql(sqlParser.createStatement(selectQuery, PARSING_OPTIONS), Optional.empty()));
+        assertEquals(formatSql(query, Optional.empty()), formatSql(SQL_PARSER.createStatement(selectQuery, PARSING_OPTIONS), Optional.empty()));
     }
 
     private static List<Statement> templateToStatements(List<String> templates, String tableName)
     {
         return templates.stream()
                 .map(template -> format(template, tableName))
-                .map(query -> sqlParser.createStatement(query, PARSING_OPTIONS))
+                .map(query -> SQL_PARSER.createStatement(query, PARSING_OPTIONS))
                 .collect(toImmutableList());
     }
 
@@ -675,6 +675,6 @@ public class TestQueryRewriter
 
     private QueryRewriter getQueryRewriter(QueryRewriteConfig rewriteConfig, VerifierConfig verifierConfig)
     {
-        return new VerificationQueryRewriterFactory(sqlParser, createTypeManager(), blockEncodingSerde, rewriteConfig, rewriteConfig, verifierConfig).create(prestoAction);
+        return new VerificationQueryRewriterFactory(SQL_PARSER, createTypeManager(), blockEncodingSerde, rewriteConfig, rewriteConfig, verifierConfig).create(prestoAction);
     }
 }


### PR DESCRIPTION
## Description
Remove unused usages of SqlParser, TypeProvider, VariableAllocator

## Motivation and Context
Code cleanup

## Impact
none

## Test Plan
build/CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

