### PR TITLE
[docs] Add doc for field_names_in_json_cast_enabled

### DIFF
--- a/presto-docs/src/main/sphinx/functions/json.rst
+++ b/presto-docs/src/main/sphinx/functions/json.rst
@@ -38,6 +38,20 @@ Cast to JSON
     than a JSON object. This is because positions are more important than
     names for rows in SQL.
 
+.. note::
+
+    Set the session property ``field_names_in_json_cast_enabled`` to ``true`` to preserve the row field names as JSON field names. With ``field_names_in_json_cast_enabled=false``, the result of::
+
+        SELECT CAST(CAST(ROW(123, 'abc', true) AS ROW(v1 BIGINT, v2 VARCHAR, v3 BOOLEAN)) AS JSON);
+    
+    is::
+    
+        JSON '[123,"abc",true]'
+    
+    With ``field_names_in_json_cast_enabled=true``, the result is::
+
+        JSON '{"v1":123,"v2":"abc","v3":true}'
+
 Cast from JSON
 --------------
 


### PR DESCRIPTION
## Description
Add documentation for ``field_names_in_json_cast_enabled`` to [functions/json.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/functions/json.rst). 

## Motivation and Context
Fixes #23540. 

## Impact
Documentation. 

## Test Plan
1. Ran local Presto server and CLI to confirm behavior as described in #23540. 

```
presto> SELECT CAST(CAST(ROW(123, 'abc', true) AS ROW(v1 BIGINT, v2 VARCHAR, v3 BOOLEAN)) AS JSON);
      _col0       
------------------
 [123,"abc",true] 
(1 row)

Query 20240829_173810_00002_pwfxu, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:01, server-side: 457ms] [0 rows, 0B] [0 rows/s, 0B/s]

presto> set session field_names_in_json_cast_enabled=true;
SET SESSION
presto> SELECT CAST(CAST(ROW(123, 'abc', true) AS ROW(v1 BIGINT, v2 VARCHAR, v3 BOOLEAN)) AS JSON);
              _col0              
---------------------------------
 {"v1":123,"v2":"abc","v3":true} 
(1 row)
```

2. For the documentation, local doc build. Screenshot: 
<img width="798" alt="Screenshot 2024-08-29 at 1 54 18 PM" src="https://github.com/user-attachments/assets/0b929c47-6df2-4543-bc7d-8e93b82a9437">

I chose to break from the format of the code block above because the results were hidden by the single-line code blocks running off the page on the right. This shows the results to the reader without them having to copy the lines and paste them into a document. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

