### PR TITLE
[Iceberg] Clean up unclosed resources from iceberg lib

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -274,6 +274,8 @@ public final class IcebergQueryRunner
         logging.setLevel("org.glassfish.jersey.internal.inject.Providers", ERROR);
         logging.setLevel("parquet.hadoop", WARN);
         logging.setLevel("org.apache.iceberg", WARN);
+        logging.setLevel("com.facebook.airlift.bootstrap", WARN);
+        logging.setLevel("org.apache.hadoop.io.compress", WARN);
     }
 
     public static void main(String[] args)


### PR DESCRIPTION
## Description

Perform better housekeeping to prevent leaving waiting for GC to clean up some unclosed resources.

## Motivation and Context

Some log message spam indicating unclosed resources.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

