### PR TITLE
[iceberg] Add procedure rollback_to_timestamp

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -805,6 +805,27 @@ Argument Name         required   type            Description
 ``snapshot_id``       ✔️          long            Snapshot ID to rollback to
 ===================== ========== =============== =======================================================================
 
+Rollback to Timestamp
+^^^^^^^^^^^^^^^^^^^^^
+
+Rollback a table to a given point in time. Iceberg can rollback to a specific point in time by using the ``rollback_to_timestamp`` procedure on Iceberg's ``system`` schema.
+
+The following arguments are available:
+
+===================== ========== =============== =======================================================================
+Argument Name         required   type            Description
+===================== ========== =============== =======================================================================
+``schema``            ✔️          string          Schema of the table to update
+
+``table_name``        ✔️          string          Name of the table to update
+
+``timestamp``         ✔️          timestamp       Timestamp to rollback to
+===================== ========== =============== =======================================================================
+
+Example::
+
+    CALL iceberg.system.rollback_to_timestamp('schema_name', 'table_name', TIMESTAMP '1995-04-26 00:00:00.000');
+
 Expire Snapshots
 ^^^^^^^^^^^^^^^^
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -43,6 +43,7 @@ import com.facebook.presto.iceberg.procedure.ExpireSnapshotsProcedure;
 import com.facebook.presto.iceberg.procedure.RegisterTableProcedure;
 import com.facebook.presto.iceberg.procedure.RemoveOrphanFiles;
 import com.facebook.presto.iceberg.procedure.RollbackToSnapshotProcedure;
+import com.facebook.presto.iceberg.procedure.RollbackToTimestampProcedure;
 import com.facebook.presto.iceberg.procedure.UnregisterTableProcedure;
 import com.facebook.presto.orc.CachingStripeMetadataSource;
 import com.facebook.presto.orc.DwrfAwareStripeMetadataSourceFactory;
@@ -152,6 +153,7 @@ public class IcebergCommonModule
 
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(RollbackToSnapshotProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(RollbackToTimestampProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(RegisterTableProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(UnregisterTableProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(ExpireSnapshotsProcedure.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RollbackToTimestampProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RollbackToTimestampProcedure.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.procedure;
+
+import com.facebook.presto.common.type.SqlTimestamp;
+import com.facebook.presto.iceberg.IcebergMetadataFactory;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.iceberg.IcebergUtil.getIcebergTable;
+import static java.util.Objects.requireNonNull;
+
+public class RollbackToTimestampProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle ROLLBACK_TO_TIMESTAMP = methodHandle(
+            RollbackToTimestampProcedure.class,
+            "rollbackToTimestamp",
+            ConnectorSession.class,
+            String.class,
+            String.class,
+            SqlTimestamp.class);
+
+    private final IcebergMetadataFactory metadataFactory;
+
+    @Inject
+    public RollbackToTimestampProcedure(IcebergMetadataFactory metadataFactory)
+    {
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "rollback_to_timestamp",
+                ImmutableList.of(
+                        new Procedure.Argument("schema", VARCHAR),
+                        new Procedure.Argument("table_name", VARCHAR),
+                        new Procedure.Argument("timestamp", TIMESTAMP)),
+                ROLLBACK_TO_TIMESTAMP.bindTo(this));
+    }
+
+    public void rollbackToTimestamp(ConnectorSession clientSession, String schema, String tableName, SqlTimestamp timestamp)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doRollbackToTimestamp(clientSession, schema, tableName, timestamp);
+        }
+    }
+
+    private void doRollbackToTimestamp(ConnectorSession clientSession, String schema, String tableName, SqlTimestamp timestamp)
+    {
+        SchemaTableName schemaTableName = new SchemaTableName(schema, tableName);
+        ConnectorMetadata metadata = metadataFactory.create();
+        getIcebergTable(metadata, clientSession, schemaTableName)
+                .manageSnapshots()
+                .rollbackToTime(timestamp.isLegacyTimestamp() ? timestamp.getMillisUtc() : timestamp.getMillis())
+                .commit();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRollbackToTimestampProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRollbackToTimestampProcedure.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.procedure;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.Session.SessionBuilder;
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+import static com.facebook.presto.SystemSessionProperties.LEGACY_TIMESTAMP;
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+
+public class TestRollbackToTimestampProcedure
+        extends AbstractTestQueryFramework
+{
+    public static final String ICEBERG_CATALOG = "iceberg";
+    public static final String TEST_SCHEMA = "tpch";
+    public static final String TEST_TABLE = "test_rollback_to_timestamp_table";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), HADOOP, ImmutableMap.of());
+    }
+
+    @DataProvider(name = "timezones")
+    public Object[][] timezones()
+    {
+        return new Object[][] {
+                {"UTC", true},
+                {"America/Los_Angeles", true},
+                {"Asia/Kolkata", true},
+                {"UTC", false}};
+    }
+
+    private void createTable()
+    {
+        assertUpdate("CREATE TABLE " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE + " (id integer, value varchar)");
+    }
+
+    @Test(dataProvider = "timezones")
+    public void testRollbackToTimestampUsingPositionalArgs(String zoneId, boolean legacyTimestamp)
+    {
+        createTable();
+        Session session = sessionForTimezone(zoneId, legacyTimestamp);
+
+        try {
+            assertUpdate(session, "INSERT INTO " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE + " VALUES(1, 'a')", 1);
+
+            Table table = loadTable();
+            Snapshot firstSnapshot = table.currentSnapshot();
+            String firstSnapshotTimestampString = getTimestampString(System.currentTimeMillis(), zoneId);
+
+            waitUntilAfter(firstSnapshot.timestampMillis());
+
+            assertUpdate(session, "INSERT INTO " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE + " VALUES(2, 'b')", 1);
+            assertQuery(session, "select * from " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE, "values(1, 'a'), (2, 'b')");
+
+            table.refresh();
+
+            // Rollback to first snapshot timestamp
+            @Language("SQL") String callProcedureString = format(
+                    "CALL " + ICEBERG_CATALOG + ".system.rollback_to_timestamp('%s', '%s', TIMESTAMP '%s')",
+                    TEST_SCHEMA,
+                    TEST_TABLE,
+                    firstSnapshotTimestampString);
+
+            assertUpdate(session, callProcedureString);
+
+            // Rollback should be successful
+            assertQuery(session, "select * from " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE, "values(1, 'a')");
+        }
+        finally {
+            dropTable();
+        }
+    }
+
+    @Test(dataProvider = "timezones")
+    public void testRollbackToTimestampUsingNamedArgs(String zoneId, boolean legacyTimestamp)
+    {
+        createTable();
+        Session session = sessionForTimezone(zoneId, legacyTimestamp);
+
+        try {
+            assertUpdate(session, "INSERT INTO " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE + " VALUES(1, 'a')", 1);
+
+            Table table = loadTable();
+            Snapshot firstSnapshot = table.currentSnapshot();
+            String firstSnapshotTimestampString = getTimestampString(System.currentTimeMillis(), zoneId);
+
+            waitUntilAfter(firstSnapshot.timestampMillis());
+
+            assertUpdate(session, "INSERT INTO " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE + " VALUES(2, 'b')", 1);
+            assertQuery(session, "select * from " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE, "values(1, 'a'), (2, 'b')");
+
+            table.refresh();
+
+            // Rollback to first snapshot timestamp
+            @Language("SQL") String callProcedureString = format(
+                    "CALL " + ICEBERG_CATALOG + ".system.rollback_to_timestamp(timestamp => TIMESTAMP '%s', table_name => '%s', schema => '%s')",
+                    firstSnapshotTimestampString,
+                    TEST_TABLE,
+                    TEST_SCHEMA);
+
+            assertUpdate(session, callProcedureString);
+
+            // Rollback should be successful
+            assertQuery(session, "select * from " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE, "values(1, 'a')");
+        }
+        finally {
+            dropTable();
+        }
+    }
+
+    @Test
+    public void testNoValidSnapshotFound()
+    {
+        createTable();
+        Session session = sessionForTimezone("UTC", false);
+
+        try {
+            assertUpdate(session, "INSERT INTO " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE + " VALUES(1, 'a')", 1);
+
+            Table table = loadTable();
+            Snapshot firstSnapshot = table.currentSnapshot();
+
+            waitUntilAfter(firstSnapshot.timestampMillis());
+
+            assertUpdate(session, "INSERT INTO " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE + " VALUES(2, 'b')", 1);
+            assertQuery(session, "select * from " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE, "values(1, 'a'), (2, 'b')");
+
+            table.refresh();
+
+            // Try to roll back to snapshot older than first snapshot
+            String olderThamfirstSnapshotTimestampString = "TIMESTAMP '1995-04-26 10:15:30.000'";
+
+            @Language("SQL") String callProcedureString = format(
+                    "CALL " + ICEBERG_CATALOG + ".system.rollback_to_timestamp(timestamp => %s, table_name => '%s', schema => '%s')",
+                    olderThamfirstSnapshotTimestampString,
+                    TEST_TABLE,
+                    TEST_SCHEMA);
+
+            assertQueryFails(callProcedureString, ".*Cannot roll back, no valid snapshot older than.*");
+        }
+        finally {
+            dropTable();
+        }
+    }
+
+    @Test
+    public void testInvalidRollbackToTimestampCases()
+    {
+        String timestamp = "TIMESTAMP '1995-04-26 10:15:30.000'";
+
+        assertQueryFails(
+                format("CALL system.rollback_to_timestamp('n', table_name => 't', %s)", timestamp),
+                ".*Named and positional arguments cannot be mixed");
+
+        assertQueryFails(
+                format("CALL custom.rollback_to_timestamp('n', 't', %s)", timestamp),
+                "Procedure not registered: custom.rollback_to_timestamp");
+
+        assertQueryFails(
+                "CALL system.rollback_to_timestamp('n', 't')",
+                ".*Required procedure argument 'timestamp' is missing");
+
+        assertQueryFails(
+                format("CALL system.rollback_to_timestamp(table_name => 't', timestamp => %s)", timestamp),
+                ".*Required procedure argument 'schema' is missing");
+
+        assertQueryFails(
+                format("CALL system.rollback_to_timestamp('n', 't', %s, 'extra')", timestamp),
+                ".*Too many arguments for procedure");
+
+        assertQueryFails(
+                "CALL system.rollback_to_timestamp('s', 't', 2.2)",
+                ".*Cannot cast type decimal\\(2,1\\) to timestamp");
+
+        assertQueryFails(
+                format("CALL system.rollback_to_timestamp('', 't', %s)", timestamp),
+                "schemaName is empty");
+
+        assertQueryFails(
+                format("CALL system.rollback_to_timestamp('s', '', %s)", timestamp),
+                "tableName is empty");
+    }
+
+    private void dropTable()
+    {
+        assertQuerySucceeds("DROP TABLE IF EXISTS " + ICEBERG_CATALOG + "." + TEST_SCHEMA + "." + TEST_TABLE);
+    }
+
+    private Session sessionForTimezone(String zoneId, boolean legacyTimestamp)
+    {
+        SessionBuilder sessionBuilder = Session.builder(getSession())
+                .setSystemProperty(LEGACY_TIMESTAMP, String.valueOf(legacyTimestamp));
+        if (legacyTimestamp) {
+            sessionBuilder.setTimeZoneKey(TimeZoneKey.getTimeZoneKey(zoneId));
+        }
+        return sessionBuilder.build();
+    }
+
+    private static String getTimestampString(long timeMillsUtc, String zoneId)
+    {
+        Instant instant = Instant.ofEpochMilli(timeMillsUtc);
+        LocalDateTime localDateTime = instant
+                .atZone(ZoneId.of(zoneId))
+                .toLocalDateTime();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+        formatter = formatter.withZone(ZoneId.of(zoneId));
+        return localDateTime.format(formatter);
+    }
+
+    private Table loadTable()
+    {
+        Catalog catalog = CatalogUtil.loadCatalog(HADOOP.getCatalogImpl(), ICEBERG_CATALOG, getProperties(), new Configuration());
+        return catalog.loadTable(TableIdentifier.of(TEST_SCHEMA, TEST_TABLE));
+    }
+
+    private Map<String, String> getProperties()
+    {
+        File metastoreDir = getCatalogDirectory();
+        return ImmutableMap.of("warehouse", metastoreDir.toString());
+    }
+
+    private File getCatalogDirectory()
+    {
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(dataDirectory, HADOOP.name(), new IcebergConfig().getFileFormat(), false);
+        return catalogDirectory.toFile();
+    }
+
+    private static long waitUntilAfter(long snapshotTimeMillis)
+    {
+        long currentTimeMillis = System.currentTimeMillis();
+        assertTrue(snapshotTimeMillis - currentTimeMillis <= 10,
+                format("Snapshot time %s is greater than the current time %s by more than 10ms", snapshotTimeMillis, currentTimeMillis));
+
+        while (currentTimeMillis <= snapshotTimeMillis) {
+            currentTimeMillis = System.currentTimeMillis();
+        }
+        return currentTimeMillis;
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This PR adds a procedure to rollback a table to a given point in time.

Example:

```
CALL iceberg.system.rollback_to_timestamp('schema_name', 'table_name', TIMESTAMP '1995-04-26 00:00:00.000');
```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Ability to rollback a table to a given point in time

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
New Procedure `rollback_to_timestamp` added


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add procedure `rollback_to_timestamp` to rollback an iceberg table to a given point in time. :pr:`23559`
```
