### PR TITLE
[iceberg] Fix docs with correct argument names when calling procedure with named args

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -789,7 +789,7 @@ procedure on the catalog's ``system`` schema::
 Rollback to Snapshot
 ^^^^^^^^^^^^^^^^^^^^
 
-Roll back a table to a specific snapshot ID. Iceberg can roll back to a specific snapshot ID by using the ``rollback_to_snapshot`` procedure on Iceberg`s ``system`` schema::
+Rollback a table to a specific snapshot ID. Iceberg can rollback to a specific snapshot ID by using the ``rollback_to_snapshot`` procedure on Iceberg's ``system`` schema::
 
     CALL iceberg.system.rollback_to_snapshot('schema_name', 'table_name', snapshot_id);
 
@@ -798,7 +798,7 @@ The following arguments are available:
 ===================== ========== =============== =======================================================================
 Argument Name         required   type            Description
 ===================== ========== =============== =======================================================================
-``schema_name``       ✔️          string          Schema of the table to update
+``schema``            ✔️          string          Schema of the table to update
 
 ``table_name``        ✔️          string          Name of the table to update
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RollbackToSnapshotProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RollbackToSnapshotProcedure.java
@@ -58,7 +58,7 @@ public class RollbackToSnapshotProcedure
                 "rollback_to_snapshot",
                 ImmutableList.of(
                         new Procedure.Argument("schema", VARCHAR),
-                        new Procedure.Argument("table", VARCHAR),
+                        new Procedure.Argument("table_name", VARCHAR),
                         new Procedure.Argument("snapshot_id", BIGINT)),
                 ROLLBACK_TO_SNAPSHOT.bindTo(this));
     }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
I have updated the docs to match the correct argument names required when calling a procedure with named arguments.

https://github.com/prestodb/presto/blob/913537144b66d783c4300386c17bbae8b92041dc/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RollbackToSnapshotProcedure.java#L60-L62

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Correct Argument names are required when using named arguments while calling a procedure

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
N.A

## Test Plan
<!---Please fill in how you tested your change-->
N.A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

