### PR TITLE
[native] Remove unnecessary semicolons

### DIFF
--- a/presto-native-execution/presto_cpp/main/SignalHandler.h
+++ b/presto-native-execution/presto_cpp/main/SignalHandler.h
@@ -30,4 +30,4 @@ class SignalHandler : private folly::AsyncSignalHandler {
   PrestoServer* prestoServer_{nullptr};
 };
 
-}; // namespace facebook::presto
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -116,4 +116,4 @@ BroadcastExchangeSource::createExchangeSource(
       fileSystemBroadcast.createReader(std::move(broadcastFileInfo), pool),
       pool);
 }
-}; // namespace facebook::presto::operators
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
@@ -43,7 +43,7 @@ inline std::string createShuffleFileName(
 // reading (acts as a sync point between readers if needed). Mostly used for
 // test purposes.
 const static std::string kReadyForReadFilename = "readyForRead";
-}; // namespace
+} // namespace
 
 LocalPersistentShuffleWriter::LocalPersistentShuffleWriter(
     const std::string& rootPath,

--- a/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/UnsafeRowExchangeSource.cpp
@@ -135,4 +135,4 @@ UnsafeRowExchangeSource::createExchangeSource(
           serializedShuffleInfo.value(), destination, pool),
       pool);
 }
-}; // namespace facebook::presto::operators
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.cpp
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.cpp
@@ -235,4 +235,4 @@ std::string PrometheusStatsReporter::fetchMetrics() {
   return serializer.Serialize(impl_->registry->Collect());
 }
 
-}; // namespace facebook::presto::prometheus
+} // namespace facebook::presto::prometheus

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.h
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.h
@@ -94,5 +94,5 @@ class PrometheusStatsReporter : public facebook::velox::BaseStatsReporter {
   mutable std::unordered_map<std::string, StatsInfo> registeredMetricsMap_;
   VELOX_FRIEND_TEST(PrometheusReporterTest, testCountAndGauge);
   VELOX_FRIEND_TEST(PrometheusReporterTest, testHistogramSummary);
-}; // class PrometheusReporter
-}; // namespace facebook::presto::prometheus
+};
+} // namespace facebook::presto::prometheus


### PR DESCRIPTION
Semicolons at the end of namespace declaration are not necessary, and
should be removed.

No functional change.

```
== NO RELEASE NOTE ==
```

