### PR TITLE
[native] Require semicolon after velox macros, avoid triggering `-Wextra-semi`

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -268,7 +268,7 @@ void PrestoExchangeSource::processDataResponse(
   auto* headers = response->headers();
   VELOX_CHECK(
       !headers->getIsChunked(),
-      "Chunked http transferring encoding is not supported.")
+      "Chunked http transferring encoding is not supported.");
   uint64_t contentLength =
       atol(headers->getHeaders()
                .getSingleOrEmpty(proxygen::HTTP_HEADER_CONTENT_LENGTH)

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -184,7 +184,7 @@ void PrestoServer::run() {
 
       ciphers = systemConfig->httpsSupportedCiphers();
       if (ciphers.empty()) {
-        VELOX_USER_FAIL("Https is enabled without ciphers")
+        VELOX_USER_FAIL("Https is enabled without ciphers");
       }
 
       auto optionalCertPath = systemConfig->httpsCertPath();

--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -342,7 +342,7 @@ protocol::TaskStatus PrestoTask::updateStatusLocked() {
     recordProcessCpuTime();
     return info.taskStatus;
   }
-  VELOX_CHECK_NOT_NULL(task, "task is null when updating status")
+  VELOX_CHECK_NOT_NULL(task, "task is null when updating status");
 
   const auto veloxTaskStats = task->taskStats();
 

--- a/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.cpp
+++ b/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.cpp
@@ -41,7 +41,8 @@ PageFormat fromSerdeString(const std::string_view& serdeName) {
   } else if (serdeName == "spark_unsafe_row") {
     return PageFormat::SPARK_UNSAFE_ROW;
   } else {
-    VELOX_FAIL("Unknown serde name for remote function server: '{}'", serdeName)
+    VELOX_FAIL(
+        "Unknown serde name for remote function server: '{}'", serdeName);
   }
 }
 

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -90,7 +90,7 @@ class HttpResponse {
 
   // Invoked to set the error on the first encountered 'exception'.
   void setError(const std::exception& exception) {
-    VELOX_CHECK(!hasError())
+    VELOX_CHECK(!hasError());
     error_ = exception.what();
     freeBuffers();
   }

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -115,7 +115,7 @@ class TestShuffleWriter : public ShuffleWriter {
   }
 
   void noMoreData(bool success) override {
-    VELOX_CHECK(success, "Unexpected error")
+    VELOX_CHECK(success, "Unexpected error");
     // Flush in-progress buffers.
     for (auto i = 0; i < numPartitions_; ++i) {
       if (inProgressSizes_[i] > 0) {

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -744,7 +744,7 @@ TypedExprPtr VeloxExprConverter::toVeloxExpr(
   }
 
   if (pexpr->form == protocol::Form::NULL_IF) {
-    VELOX_UNREACHABLE("NULL_IF not supported in specialForm")
+    VELOX_UNREACHABLE("NULL_IF not supported in specialForm");
   }
 
   auto form = std::string(json(pexpr->form));


### PR DESCRIPTION
https://github.com/facebookincubator/velox/pull/10914 is going to wrap macros like `VELOX_CHECK` and `VELOX_UNREACHABLE` in `do { ... } while (0)` to enforce the use of a trailing semicolon. Before that change, writing velox macro calls with a trailing semicolon would trigger an needless semicolon warning in some circumstances.