### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -125,7 +125,6 @@ CODEOWNERS @prestodb/team-tsc
 
 # Iceberg connector
 /presto-iceberg @hantangwangd @ZacBlanco @prestodb/committers
-/presto-docs/src/**/connector/iceberg.rst @hantangwangd @ZacBlanco @prestodb/committers
 
 # Ranger Hive plugin
 /presto-hive/**/com/facebook/presto/hive/security/ranger @agrawalreetika @prestodb/committers
@@ -154,4 +153,5 @@ CODEOWNERS @prestodb/team-tsc
 # Presto documentation
 /presto-docs @steveburnett @elharo @prestodb/committers
 /**/*.md @steveburnett @prestodb/committers
+/presto-docs/src/**/connector/iceberg.rst @steveburnett @elharo @hantangwangd @ZacBlanco @prestodb/committers
 


### PR DESCRIPTION
## Description

The recently added codeowner rule about Iceberg documents are not working, because under github's matching rules, the last matching pattern takes the most precedence and will override the previous matching patterns. In this way, the matching pattern for the entire `/presto-docs` override the previous defined matching pattern for iceberg document.

This PR fix the problem, put the matching pattern for iceberg document at the end, add @hantangwangd and @ZacBlanco  after @steveburnett and @elharo as code owners. This way, @hantangwangd and @ZacBlanco have the permission to approval Iceberg document as well besides @steveburnett and @elharo.

## Motivation and Context

Make the matching pattern of adding @hantangwangd and @ZacBlanco as Iceberg document code owners effective

## Impact

See above.

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

