### PR TITLE
Remove `using namespace` from header files

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -71,6 +71,8 @@
 #include <sched.h>
 #endif
 
+using namespace facebook::velox;
+
 namespace facebook::presto {
 namespace {
 

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -13,6 +13,9 @@
  */
 #include "presto_cpp/main/http/tests/HttpTestBase.h"
 
+using namespace facebook::presto;
+using namespace facebook::velox;
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::Init init{&argc, &argv};

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -17,6 +17,8 @@
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/operators/BroadcastExchangeSource.h"
 
+using namespace facebook::velox;
+
 namespace facebook::presto::operators {
 
 namespace {

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastFactory.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastFactory.h
@@ -18,8 +18,6 @@
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/VectorStream.h"
 
-using namespace facebook::velox;
-
 namespace facebook::presto::operators {
 
 /// Struct for single broadcast file info.]
@@ -48,7 +46,7 @@ class BroadcastFileWriter {
   virtual ~BroadcastFileWriter() = default;
 
   /// Write to file.
-  void collect(const RowVectorPtr& input);
+  void collect(const velox::RowVectorPtr& input);
 
   /// Flush the data.
   void noMoreData();
@@ -110,8 +108,8 @@ class BroadcastFactory {
   virtual ~BroadcastFactory() = default;
 
   std::unique_ptr<BroadcastFileWriter> createWriter(
-      memory::MemoryPool* pool,
-      const RowTypePtr& inputType);
+      velox::memory::MemoryPool* pool,
+      const velox::RowTypePtr& inputType);
 
   std::shared_ptr<BroadcastFileReader> createReader(
       const std::unique_ptr<BroadcastFileInfo> fileInfo,


### PR DESCRIPTION
Removes `using namespace` from header files to align with Velox C++ codestyle guidelines ([link](https://github.com/facebookincubator/velox/blob/main/CODING_STYLE.md#namespaces)).