### PR TITLE
[native] Update Prestissimo exchange to use HEAD request

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
@@ -322,8 +322,9 @@ public class TaskResource
     public Response taskResultsHeaders(
             @PathParam("taskId") TaskId taskId,
             @PathParam("bufferId") OutputBufferId bufferId,
-            @PathParam("token") final long unused)
+            @PathParam("token") final long token)
     {
+        taskManager.acknowledgeTaskResults(taskId, bufferId, token);
         return taskResultsHeaders(taskId, bufferId);
     }
 


### PR DESCRIPTION
## Description
Bring `HEAD` request to `/v1/{taskId}/results/{bufferId}` to be in line with the documentation:

> Optionally, a HEAD request can be made to `{taskId}/results/{bufferId}` to retrieve any non-data page sequence related headers. Use this to check if the buffer is finished, or to see how much data is buffered without fetching the data. **Acknowledges the receipt of the previous batch of results.**

## Motivation and Context
https://github.com/prestodb/presto/issues/21926

## Impact
No impact as this endpoint is presently unused

## Test Plan
Tests will be added in a followup commit with Prestissimo (see discussion in this PR).

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

