### PR TITLE
Fix for incorrect nullable setting on NOT NULL columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -164,7 +164,7 @@ public class InformationSchemaPageSourceProvider
                             column.getName(),
                             ordinalPosition,
                             null,
-                            "YES",
+                            column.isNullable() ? "YES" : "NO",
                             column.getType().getDisplayName(),
                             column.getComment(),
                             column.getExtraInfo());

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -299,4 +299,11 @@ public class TestMySqlIntegrationSmokeTest
             statement.execute(sql);
         }
     }
+
+    @Test
+    public void testSelectInformationSchemaColumnIsNullable()
+    {
+        assertUpdate("CREATE TABLE test_column (name VARCHAR NOT NULL, email VARCHAR)");
+        assertQuery("SELECT is_nullable FROM information_schema.columns WHERE table_name = 'test_column'", "VALUES 'NO','YES'");
+    }
 }


### PR DESCRIPTION
## Description
The Information schema was returning NULLABLE as YES irrespective of what is been set actually while creating the table.
This PR will fetch the columns details (is NULLABLE ?) details based on how the table was created.

## Motivation and Context
This change is essential to address a specific issue on the information schema tables. The problem revolves around the occurrence of default YES in NULLABLE field while querying the information.schema tables to get the metadata details.

## Impact
Added fix to fetch the columns details (is NULLABLE ?) details based on how the table was created.
## Test Plan
Tested the fix by creating a table having column with NULLABLE and NOT NULLABLE columns.
Tried querying the metadata of the table from the information schema and the details were populated correctly.
**Before Fix:**
<img width="1172" alt="Screenshot 2024-09-03 at 11 57 04 PM" src="https://github.com/user-attachments/assets/9e5139b7-a151-41a2-b27f-29d8a9cbeb9d">

**After Fix:**
<img width="1167" alt="Screenshot 2024-09-04 at 12 00 02 AM" src="https://github.com/user-attachments/assets/00035df3-a821-4443-b943-edcb8de31f4d">


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Information Schema

* Fix nullability of columns in information schema :pr:`23577`
```


