### PR TITLE
make IcebergDistributedSmokeTestBase abstract

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -56,7 +56,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-public class IcebergDistributedSmokeTestBase
+public abstract class IcebergDistributedSmokeTestBase
         extends AbstractTestIntegrationSmokeTest
 {
     private final CatalogType catalogType;


### PR DESCRIPTION
This class should be abstract since it errors (cannot be instantiated) if the tests are run from it, and can only be used by sub classes anyway. 

```
== RELEASE NOTES ==
General Changes
* Make IcebergDistributedSmokeTestBase abstract :pr:`23580`
```

