### PR TITLE
[native] Fix cmake target name

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -114,7 +114,7 @@ if(PRESTO_STATS_REPORTER_TYPE)
   add_compile_definitions(PRESTO_STATS_REPORTER_TYPE)
   if(PRESTO_STATS_REPORTER_TYPE STREQUAL "PROMETHEUS")
     add_subdirectory(runtime-metrics)
-    target_link_libraries(presto_server prometheus_reporter)
+    target_link_libraries(presto_server presto_prometheus_reporter)
   else()
     message(
       FATAL_ERROR

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/CMakeLists.txt
@@ -16,8 +16,9 @@
 find_package(prometheus-cpp CONFIG REQUIRED)
 
 # Prepare a static library to link with prometheus_reporter_test
-add_library(prometheus_reporter OBJECT PrometheusStatsReporter.cpp)
-target_link_libraries(prometheus_reporter presto_common prometheus-cpp::core)
+add_library(presto_prometheus_reporter OBJECT PrometheusStatsReporter.cpp)
+target_link_libraries(presto_prometheus_reporter presto_common
+                      prometheus-cpp::core)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/tests/CMakeLists.txt
@@ -16,4 +16,4 @@ add_test(
   COMMAND prometheus_reporter_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(prometheus_reporter_test velox_exec_test_lib
-                      prometheus_reporter GTest::gtest GTest::gtest_main)
+                      presto_prometheus_reporter GTest::gtest GTest::gtest_main)


### PR DESCRIPTION
All targets under presto_cpp should use "presto_" as the prefix, so
rename the "prometheus_reporter" target to
"presto_prometheus_reporter".

No functional change.

```
== NO RELEASE NOTE ==
```

