### PR TITLE
Add ParquetQuickStatsBuilder bean exporter

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -384,13 +384,15 @@ public class HiveClientModule
             FileFormatDataSourceStats fileFormatDataSourceStats,
             MBeanExporter exporter)
     {
+        ParquetQuickStatsBuilder parquetQuickStatsBuilder = new ParquetQuickStatsBuilder(fileFormatDataSourceStats, hdfsEnvironment, hiveClientConfig);
         QuickStatsProvider quickStatsProvider = new QuickStatsProvider(hdfsEnvironment,
                 directoryLister,
                 hiveClientConfig,
                 nameNodeStats,
-                // Ordered list of strategies to apply to decipher quick stats
-                ImmutableList.of(new ParquetQuickStatsBuilder(fileFormatDataSourceStats, hdfsEnvironment, hiveClientConfig)));
+                // Ordered list of strategies to apply to build quick stats
+                ImmutableList.of(parquetQuickStatsBuilder));
         exporter.export(generatedNameOf(QuickStatsProvider.class, connectorId + "_QuickStatsProvider"), quickStatsProvider);
+        exporter.export(generatedNameOf(ParquetQuickStatsBuilder.class, connectorId + "_ParquetQuickStatsBuilder"), parquetQuickStatsBuilder);
         return quickStatsProvider;
     }
 }


### PR DESCRIPTION
## Description
ParquetQuickStatsBuilder exposes JMX metrics that were not registered

## Impact
The ParquetQuickStatsBuilder metrics will now be available via the JMX interfaces

## Test Plan
Manually verified that the JMX metric is registered by running -
```
presto> describe jmx.current."com.facebook.presto.hive.statistics:name=local_hms_parquetquickstatsbuilder,type=parquetquickstatsbuilder";

                            Column                            |  Type   | Extra | Comment 
--------------------------------------------------------------+---------+-------+---------
 executor.activecount                                         | bigint  |       |         
 executor.allowcorethreadtimeout                              | boolean |       |         
 executor.completedtaskcount                                  | bigint  |       |         
...        
 filecountperpartitiondistribution.alltime.avg                | double  |       |         
 filecountperpartitiondistribution.alltime.count              | double  |       |         
 filecountperpartitiondistribution.alltime.max                | bigint  |       |         
...  
 footerbytesizedistribution.alltime.avg                       | double  |       |         
 footerbytesizedistribution.alltime.count                     | double  |       |         
 footerbytesizedistribution.alltime.max                       | bigint  |       |         
 ...    
 footerfetchduration.alltime.avg                              | double  |       |         
 footerfetchduration.alltime.count                            | double  |       |         
 
...        
      
 node                                                         | varchar |       |         
 object_name                                                  | varchar |       |         
(192 rows)
```

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```