### PR TITLE
[docs] Fix formatting of code example for array_has_duplicates

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -78,10 +78,10 @@ Array Functions
 .. function:: array_has_duplicates(array(T)) -> boolean
 
     Returns a boolean: whether ``array`` has any elements that occur more than once.
-    Throws an exception if any of the elements are rows or arrays that contain nulls. 
+    Throws an exception if any of the elements are rows or arrays that contain nulls. ::
 
-    SELECT array_has_duplicates(ARRAY[1, 2, null, 1, null, 3]) -- true
-    SELECT array_has_duplicates(ARRAY[ROW(1, null), ROW(1, null)]) -- "map key cannot be null or contain nulls"
+        SELECT array_has_duplicates(ARRAY[1, 2, null, 1, null, 3]) -- true
+        SELECT array_has_duplicates(ARRAY[ROW(1, null), ROW(1, null)]) -- "map key cannot be null or contain nulls"
 
 .. function:: array_intersect(x, y) -> array
 


### PR DESCRIPTION
## Description
Fix formatting of code example for `array_has_duplicates` in [functions/array.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/functions/array.rst). 

## Motivation and Context
Bad formatting can confuse a reader. 

## Impact
Documentation. 

## Test Plan
Local doc build. 

Before: 
<img width="790" alt="Screenshot 2024-09-04 at 1 30 04 PM" src="https://github.com/user-attachments/assets/122b1789-76d2-4da3-8878-d06d08a0df02">

After: 
<img width="786" alt="Screenshot 2024-09-04 at 1 32 23 PM" src="https://github.com/user-attachments/assets/010766ea-5234-4c51-a471-4ed602c58140">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

