### PR TITLE
[parquet] Support 64-bit RLE-encoded ShortDecimal

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -939,6 +939,23 @@ public abstract class AbstractTestParquetReader
         }
     }
 
+    @Test
+    public void testRLEDecimalBackedByINT64()
+            throws Exception
+    {
+        int[] scales = {9, 9, 9, 9, 9, 9, 9, 9, 9};
+        for (int precision = MAX_PRECISION_INT32 + 1; precision <= MAX_PRECISION_INT64; precision++) {
+            int scale = scales[precision - MAX_PRECISION_INT32 - 1];
+            MessageType parquetSchema = parseMessageType(format("message hive_decimal { optional INT64 test (DECIMAL(%d, %d)); }", precision, scale));
+            ContiguousSet<Long> longValues = longsBetween(1, 1_000);
+            ImmutableList.Builder<SqlDecimal> expectedValues = new ImmutableList.Builder<>();
+            for (Long value : longValues) {
+                expectedValues.add(SqlDecimal.of(value, precision, scale));
+            }
+            tester.testRoundTrip(javaLongObjectInspector, longValues, expectedValues.build(), createDecimalType(precision, scale), Optional.of(parquetSchema));
+        }
+    }
+
     private void testDecimal(int precision, int scale, Optional<MessageType> parquetSchema)
             throws Exception
     {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
@@ -179,6 +179,9 @@ public class Decoders
                     if (isTimeStampMicrosType(columnDescriptor) || isTimeMicrosType(columnDescriptor)) {
                         return new Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder(bitWidth, inputStream, (LongDictionary) dictionary);
                     }
+                    if (isDecimalType(columnDescriptor) && isShortDecimalType(columnDescriptor)) {
+                        return new Int64RLEDictionaryValuesDecoder(bitWidth, inputStream, (LongDictionary) dictionary);
+                    }
                 }
                 case DOUBLE: {
                     return new Int64RLEDictionaryValuesDecoder(bitWidth, inputStream, (LongDictionary) dictionary);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/Int64RLEDictionaryValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/Int64RLEDictionaryValuesDecoder.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.parquet.batchreader.decoders.rle;
 
 import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64ValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.ShortDecimalValuesDecoder;
 import com.facebook.presto.parquet.dictionary.LongDictionary;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.openjdk.jol.info.ClassLayout;
@@ -27,7 +28,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 
 public class Int64RLEDictionaryValuesDecoder
         extends BaseRLEBitPackedDecoder
-        implements Int64ValuesDecoder
+        implements Int64ValuesDecoder, ShortDecimalValuesDecoder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int64RLEDictionaryValuesDecoder.class).instanceSize();
 


### PR DESCRIPTION
## Description

Previously, in the parquet writer short decimals could be written as RLE-encoded with an Int64 primitive type. However we lacked support in the reader to decode this type properly back into a short decimal.

This commit adds support for the RLE-encoded 64-bit short decimals.

## Motivation and Context

Decimals can be stored in three different formats: INT32 (P <= 9), INT64 (9 < P <= 18), and FIXED_LEN_BYTE_ARRAY (P > 18). We were missing read support for RLE-encoded short decimals with 9 < P <= 18. The following sequence of actions leads to failure.

```sql
SET SESSION iceberg.parquet_batch_read_optimization_enabled = true;
SET SESSION iceberg.parquet_writer_version = 'PARQUET_2_0';
CREATE table tmp AS SELECT * FROM (VALUES (1, CAST(15.2 as decimal(15, 2))), (2, 15.2), (3, 15.2), (4, 15.2)) as t(i, j);

presto:tpch> SELECT * FROM tmp;

Query 20240904_171754_00022_5rgwk, FAILED, 2 nodes
Splits: 5 total, 0 done (0.00%)
[Latency: client-side: 0:03, server-side: 0:03] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20240904_171754_00022_5rgwk failed: com.facebook.presto.parquet.batchreader.decoders.rle.Int64RLEDictionaryValuesDecoder cannot be cast to com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder$ShortDecimalValuesDecoder
```

After these changes, this error no longer appears.


## Impact

N/A

## Test Plan

- tests in parquet module

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

