### PR TITLE
Fix Server Active State Endpoint

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -112,6 +112,7 @@ public final class InternalResourceGroupManager<C>
     private final boolean isResourceManagerEnabled;
     private final QueryManagerConfig queryManagerConfig;
     private final InternalNodeManager nodeManager;
+    private boolean isConfigurationManagerLoaded;
 
     @Inject
     public InternalResourceGroupManager(
@@ -136,6 +137,7 @@ public final class InternalResourceGroupManager<C>
         this.isResourceManagerEnabled = requireNonNull(serverConfig, "serverConfig is null").isResourceManagerEnabled();
         this.resourceGroupRuntimeExecutor = new PeriodicTaskExecutor(resourceGroupRuntimeInfoRefreshInterval.toMillis(), refreshExecutor, this::refreshResourceGroupRuntimeInfo);
         configurationManagerFactories.putIfAbsent(LegacyResourceGroupConfigurationManager.NAME, new LegacyResourceGroupConfigurationManager.Factory());
+        this.isConfigurationManagerLoaded = false;
     }
 
     @Override
@@ -202,6 +204,7 @@ public final class InternalResourceGroupManager<C>
                     MAX_QUEUED_QUERIES, Integer.toString(queryManagerConfig.getMaxQueuedQueries()));
             setConfigurationManager(LegacyResourceGroupConfigurationManager.NAME, legacyProperties);
         }
+        isConfigurationManagerLoaded = true;
     }
 
     private void setConfigurationManager(String name, Map<String, String> properties)
@@ -282,6 +285,12 @@ public final class InternalResourceGroupManager<C>
         ImmutableList.Builder<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos = ImmutableList.builder();
         rootGroups.forEach(resourceGroup -> buildResourceGroupRuntimeInfo(resourceGroupRuntimeInfos, resourceGroup));
         return resourceGroupRuntimeInfos.build();
+    }
+
+    @Override
+    public boolean isConfigurationManagerLoaded()
+    {
+        return isConfigurationManagerLoaded;
     }
 
     private void buildResourceGroupRuntimeInfo(ImmutableList.Builder<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos, InternalResourceGroup resourceGroup)

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/NoOpResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/NoOpResourceGroupManager.java
@@ -76,4 +76,10 @@ public final class NoOpResourceGroupManager
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean isConfigurationManagerLoaded()
+    {
+        return true;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
@@ -49,4 +49,6 @@ public interface ResourceGroupManager<C>
             throws Exception;
 
     List<ResourceGroupRuntimeInfo> getResourceGroupRuntimeInfos();
+
+    boolean isConfigurationManagerLoaded();
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -243,6 +243,7 @@ public class TestingPrestoServer
                 false,
                 false,
                 coordinator,
+                false,
                 properties,
                 environment,
                 discoveryUri,
@@ -259,6 +260,7 @@ public class TestingPrestoServer
             boolean coordinatorSidecar,
             boolean coordinatorSidecarEnabled,
             boolean coordinator,
+            boolean skipLoadingResourceGroupConfigurationManager,
             Map<String, String> properties,
             String environment,
             URI discoveryUri,
@@ -368,7 +370,9 @@ public class TestingPrestoServer
             this.resourceGroupManager = resourceGroupManager instanceof InternalResourceGroupManager
                     ? Optional.of((InternalResourceGroupManager<?>) resourceGroupManager)
                     : Optional.empty();
-            resourceGroupManager.loadConfigurationManager();
+            if (!skipLoadingResourceGroupConfigurationManager) {
+                resourceGroupManager.loadConfigurationManager();
+            }
             nodePartitioningManager = injector.getInstance(NodePartitioningManager.class);
             planOptimizerManager = injector.getInstance(ConnectorPlanOptimizerManager.class);
             clusterMemoryManager = injector.getInstance(ClusterMemoryManager.class);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -141,6 +141,7 @@ public class DistributedQueryRunner
                 false,
                 false,
                 false,
+                false,
                 defaultSession,
                 nodeCount,
                 1,
@@ -166,6 +167,7 @@ public class DistributedQueryRunner
             boolean resourceManagerEnabled,
             boolean catalogServerEnabled,
             boolean coordinatorSidecarEnabled,
+            boolean skipLoadingResourceGroupConfigurationManager,
             Session defaultSession,
             int nodeCount,
             int coordinatorCount,
@@ -232,6 +234,7 @@ public class DistributedQueryRunner
                             false,
                             coordinatorSidecarEnabled,
                             false,
+                            skipLoadingResourceGroupConfigurationManager,
                             workerProperties,
                             parserOptions,
                             environment,
@@ -261,6 +264,7 @@ public class DistributedQueryRunner
                             false,
                             false,
                             false,
+                            skipLoadingResourceGroupConfigurationManager,
                             rmProperties,
                             parserOptions,
                             environment,
@@ -281,6 +285,7 @@ public class DistributedQueryRunner
                         false,
                         false,
                         false,
+                        skipLoadingResourceGroupConfigurationManager,
                         catalogServerProperties,
                         parserOptions,
                         environment,
@@ -299,6 +304,7 @@ public class DistributedQueryRunner
                         true,
                         true,
                         false,
+                        skipLoadingResourceGroupConfigurationManager,
                         coordinatorSidecarProperties,
                         parserOptions,
                         environment,
@@ -317,6 +323,7 @@ public class DistributedQueryRunner
                         false,
                         false,
                         true,
+                        skipLoadingResourceGroupConfigurationManager,
                         extraCoordinatorProperties,
                         parserOptions,
                         environment,
@@ -414,6 +421,7 @@ public class DistributedQueryRunner
             boolean coordinatorSidecar,
             boolean coordinatorSidecarEnabled,
             boolean coordinator,
+            boolean skipLoadingResourceGroupConfigurationManager,
             Map<String, String> extraProperties,
             SqlParserOptions parserOptions,
             String environment,
@@ -444,6 +452,7 @@ public class DistributedQueryRunner
                 coordinatorSidecar,
                 coordinatorSidecarEnabled,
                 coordinator,
+                skipLoadingResourceGroupConfigurationManager,
                 properties,
                 environment,
                 discoveryUri,
@@ -943,6 +952,7 @@ public class DistributedQueryRunner
         private boolean resourceManagerEnabled;
         private boolean catalogServerEnabled;
         private boolean coordinatorSidecarEnabled;
+        private boolean skipLoadingResourceGroupConfigurationManager;
         private List<Module> extraModules = ImmutableList.of();
         private int resourceManagerCount = 1;
 
@@ -1074,6 +1084,12 @@ public class DistributedQueryRunner
             return this;
         }
 
+        public Builder setSkipLoadingResourceGroupConfigurationManager(boolean skipLoadingResourceGroupConfigurationManager)
+        {
+            this.skipLoadingResourceGroupConfigurationManager = skipLoadingResourceGroupConfigurationManager;
+            return this;
+        }
+
         public DistributedQueryRunner build()
                 throws Exception
         {
@@ -1081,6 +1097,7 @@ public class DistributedQueryRunner
                     resourceManagerEnabled,
                     catalogServerEnabled,
                     coordinatorSidecarEnabled,
+                    skipLoadingResourceGroupConfigurationManager,
                     defaultSession,
                     nodeCount,
                     coordinatorCount,

--- a/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
@@ -60,7 +60,7 @@ public final class TpchQueryRunner
             int coordinatorCount)
             throws Exception
     {
-        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorSidecarProperties, coordinatorProperties, extraProperties, coordinatorCount, false, 1);
+        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorSidecarProperties, coordinatorProperties, extraProperties, coordinatorCount, false, 1, false);
     }
 
     public static DistributedQueryRunner createQueryRunnerWithNoClusterReadyCheck(
@@ -69,19 +69,20 @@ public final class TpchQueryRunner
             Map<String, String> coordinatorSidecarProperties,
             Map<String, String> coordinatorProperties,
             Map<String, String> extraProperties,
-            int coordinatorCount)
+            int coordinatorCount,
+            boolean skipLoadingResourceGroupConfigurationManager)
             throws Exception
     {
-        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorSidecarProperties, coordinatorProperties, extraProperties, coordinatorCount, true, 1);
+        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorSidecarProperties, coordinatorProperties, extraProperties, coordinatorCount, true, 1, skipLoadingResourceGroupConfigurationManager);
     }
 
     public static DistributedQueryRunner createQueryRunner(Map<String, String> resourceManagerProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount, int resourceManagerCount)
             throws Exception
     {
-        return createQueryRunner(resourceManagerProperties, ImmutableMap.of(), ImmutableMap.of(), coordinatorProperties, extraProperties, coordinatorCount, false, resourceManagerCount);
+        return createQueryRunner(resourceManagerProperties, ImmutableMap.of(), ImmutableMap.of(), coordinatorProperties, extraProperties, coordinatorCount, false, resourceManagerCount, false);
     }
 
-    public static DistributedQueryRunner createQueryRunner(Map<String, String> resourceManagerProperties, Map<String, String> catalogServerProperties, Map<String, String> coordinatorSidecarProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount, boolean skipClusterReadyCheck, int resourceManagerCount)
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> resourceManagerProperties, Map<String, String> catalogServerProperties, Map<String, String> coordinatorSidecarProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount, boolean skipClusterReadyCheck, int resourceManagerCount, boolean skipLoadingResourceGroupConfigurationManager)
             throws Exception
     {
         DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
@@ -93,6 +94,7 @@ public final class TpchQueryRunner
                 .setResourceManagerEnabled(true)
                 .setCoordinatorCount(coordinatorCount)
                 .setResourceManagerCount(resourceManagerCount)
+                .setSkipLoadingResourceGroupConfigurationManager(skipLoadingResourceGroupConfigurationManager)
                 .build();
         if (!skipClusterReadyCheck) {
             queryRunner.waitForClusterToGetReady();


### PR DESCRIPTION
## Description
GET `/v1/info/state` endpoint to return cluster state `INACTIVE` till resource group configuration manager is not fully loaded.

## Motivation and Context
During start of the cluster, ResourceGroupManagerConfigurationManager is initialized with InitializingConfigurationManager class. And later configuration manager is configured when loadConfigurationManager method is called. But between this time period GET `/v1/info/state` endpoint returns the server state as ACTIVE. And if the server receives any queries during the period, they all fails with SERVER_STARTING_UP error.

## Impact
In this PR, we are addressing that by providing a flag in ResourceGroupConfigurationManager that is been checked and if not true, `/v1/info/state` endpoint return server status as INACTIVE.

## Test Plan
Added unit test to verify the scenario.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* GET `/v1/info/state` to return INACTIVE state until the resource group configuration manager is fully initialized :pr:`23585`

