### PR TITLE
[docs] Fix formatting in functions/array.rst

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -227,8 +227,8 @@ Array Functions
 
 .. function:: array_top_n(array(T), int) -> array(T)
 
-    Returns an array of the top n elements from a given ``array``, sorted according to its natural descending order.
-    If n is smaller than the size of the given ``array``, the returned list will be the same size as the input instead of n.::
+    Returns an array of the top ``n`` elements from a given ``array``, sorted according to its natural descending order.
+    If ``n`` is larger than the size of the given ``array``, the returned list will be the same size as the input instead of ``n``. ::
 
         SELECT array_top_n(ARRAY [1, 100, 2, 5, 3], 3); -- [100, 5, 3]
         SELECT array_top_n(ARRAY [1, 100], 5); -- [100, 1]


### PR DESCRIPTION
## Description
Fix formatting in [functions/array.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/functions/array.rst) for the ``array_top_n`` function. 

The end of the final sentence looked like `n.:` when it should be `n.` because there was no space between `n.` (the text) and `::` (the formatting instruction for the code block in the following lines). I also fixed missing formatting in the paragraph. 

## Motivation and Context
Fix display text in the documentation. 

## Impact
Documentation. 

## Test Plan
Local doc builds. 

Before: 
<img width="787" alt="Screenshot 2024-09-05 at 11 09 42 AM" src="https://github.com/user-attachments/assets/e1fd67bd-8c5a-41be-a875-419b98238a7c">

After: 
<img width="786" alt="Screenshot 2024-09-05 at 11 11 06 AM" src="https://github.com/user-attachments/assets/cbf28a7c-977c-4e32-92c4-2ae2b44c6d25">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

