### PR TITLE
Make Iceberg's procedures uniformly support named arguments

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -732,7 +732,7 @@ example uses the earliest snapshot ID: ``2423571386296047175``
 Procedures
 ----------
 
-Use the CALL statement to perform data manipulation or administrative tasks. Procedures are available in the ``system`` schema of the catalog.
+Use the :doc:`/sql/call` statement to perform data manipulation or administrative tasks. Procedures are available in the ``system`` schema of the catalog.
 
 Register Table
 ^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -739,20 +739,41 @@ Register Table
 
 Iceberg tables for which table data and metadata already exist in the
 file system can be registered with the catalog. Use the ``register_table``
-procedure on the catalog's ``system`` schema and supply the target schema,
-desired table name, and the location of the table metadata::
+procedure on the catalog's ``system`` schema to register a table which
+already exists but does not known by the catalog.
+
+The following arguments are available:
+
+===================== ========== =============== =======================================================================
+Argument Name         required   type            Description
+===================== ========== =============== =======================================================================
+``schema``            ✔️         string          Schema of the table to register
+
+``table_name``        ✔️         string          Name of the table to register
+
+``metadata_location`` ✔️         string          The location of the table metadata which is to be registered
+
+``metadata_file``                string          An optionally specified metadata file which is to be registered
+===================== ========== =============== =======================================================================
+
+Examples:
+
+* Register a table through supplying the target schema, desired table name, and the location of the table metadata::
 
     CALL iceberg.system.register_table('schema_name', 'table_name', 'hdfs://localhost:9000/path/to/iceberg/table/metadata/dir')
+
+    CALL iceberg.system.register_table(table_name => 'table_name', schema => 'schema_name', metadata_location => 'hdfs://localhost:9000/path/to/iceberg/table/metadata/dir')
 
 .. note::
 
     If multiple metadata files of the same version exist at the specified
     location, the most recently modified one is used.
 
-A metadata file can optionally be included as an argument to ``register_table``
-where a specific metadata file contains the targeted table state::
+* Register a table through additionally supplying a specific metadata file::
 
     CALL iceberg.system.register_table('schema_name', 'table_name', 'hdfs://localhost:9000/path/to/iceberg/table/metadata/dir', '00000-35a08aed-f4b0-4010-95d2-9d73ef4be01c.metadata.json')
+
+    CALL iceberg.system.register_table(table_name => 'table_name', schema => 'schema_name', metadata_location => 'hdfs://localhost:9000/path/to/iceberg/table/metadata/dir', metadata_file => '00000-35a08aed-f4b0-4010-95d2-9d73ef4be01c.metadata.json')
 
 .. note::
 
@@ -775,9 +796,23 @@ Unregister Table
 ^^^^^^^^^^^^^^^^
 
 Iceberg tables can be unregistered from the catalog using the ``unregister_table``
-procedure on the catalog's ``system`` schema::
+procedure on the catalog's ``system`` schema.
+
+The following arguments are available:
+
+===================== ========== =============== ===================================
+Argument Name         required   type            Description
+===================== ========== =============== ===================================
+``schema``            ✔️         string          Schema of the table to unregister
+
+``table_name``        ✔️         string          Name of the table to unregister
+===================== ========== =============== ===================================
+
+Examples::
 
     CALL iceberg.system.unregister_table('schema_name', 'table_name')
+
+    CALL iceberg.system.unregister_table(table_name => 'table_name', schema => 'schema_name')
 
 .. note::
 

--- a/presto-docs/src/main/sphinx/sql/call.rst
+++ b/presto-docs/src/main/sphinx/sql/call.rst
@@ -18,6 +18,22 @@ Procedures can be provided by connectors to perform data manipulation or
 administrative tasks. For example, the :doc:`/connector/system` defines a
 procedure for killing a running query.
 
+CALL statement supports passing arguments by name or by position. Mixing position and named arguments is not supported.
+
+* Named arguments
+
+Procedure arguments all have a name. When passing arguments by name, arguments can be in any order
+and any optional argument can be omitted::
+
+    CALL catalog_name.system.procedure_name(arg_name_2 => arg_2, arg_name_1 => arg_1);
+
+* Positional arguments
+
+When passing arguments by position, only the ending arguments may be omitted if they are optional.
+Intermediate parameters cannot be omitted::
+
+    CALL catalog_name.system.procedure_name(arg_1, arg_2, ... arg_n);
+
 Some connectors, such as the :doc:`/connector/postgresql`, are for systems
 that have their own stored procedures. These stored procedures are separate
 from the connector-defined procedures discussed here and thus are not

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RegisterTableProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RegisterTableProcedure.java
@@ -84,9 +84,9 @@ public class RegisterTableProcedure
                 "register_table",
                 ImmutableList.of(
                         new Procedure.Argument("schema", VARCHAR),
-                        new Procedure.Argument("table", VARCHAR),
-                        new Procedure.Argument("metadataLocation", VARCHAR),
-                        new Procedure.Argument("metadataFile", VARCHAR, false, null)),
+                        new Procedure.Argument("table_name", VARCHAR),
+                        new Procedure.Argument("metadata_location", VARCHAR),
+                        new Procedure.Argument("metadata_file", VARCHAR, false, null)),
                 REGISTER_TABLE.bindTo(this));
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/UnregisterTableProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/UnregisterTableProcedure.java
@@ -57,7 +57,7 @@ public class UnregisterTableProcedure
                 "unregister_table",
                 ImmutableList.of(
                         new Procedure.Argument("schema", VARCHAR),
-                        new Procedure.Argument("table", VARCHAR)),
+                        new Procedure.Argument("table_name", VARCHAR)),
                 UNREGISTER_TABLE.bindTo(this));
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -42,7 +42,7 @@ import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.iceberg.IcebergUtil.MIN_FORMAT_VERSION_FOR_DELETE;
 import static com.facebook.presto.iceberg.procedure.RegisterTableProcedure.METADATA_FOLDER_NAME;
-import static com.facebook.presto.iceberg.procedure.TestIcebergRegisterProcedure.getMetadataFileLocation;
+import static com.facebook.presto.iceberg.procedure.TestIcebergRegisterAndUnregisterProcedure.getMetadataFileLocation;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;


### PR DESCRIPTION
## Description

This PR enables existing procedures which do not yet support named arguments to support named arguments, ensures consistency in the naming of arguments across procedures, and supplements the document with explanations for named arguments and sequential arguments.

Besides, this PR removes a procedure `set_table_property` which is completely unused.

## Motivation and Context

Make Iceberg's procedures uniformly support named arguments

## Impact

After this change, Iceberg procedures `register_table` and `unregister_table` support named arguments as well

## Test Plan

 - Newly added test cases to show the support of using named arguments in procedure `register_table` and `unregister_table`

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Support using named arguments in procedure `register_table` and `unregister_table` :pr:`12345`
```
