### PR TITLE
Fix textfile ambiguous timestamps and different storage timezones

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -513,7 +513,7 @@ public class GenericHiveRecordCursor<K, V extends Writable>
             nulls[column] = true;
         }
         else {
-            objects[column] = getBlockObject(types[column], fieldData, fieldInspectors[column]);
+            objects[column] = getBlockObject(types[column], fieldData, fieldInspectors[column], hiveStorageTimeZone);
             nulls[column] = false;
         }
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -523,7 +523,8 @@ public abstract class AbstractTestHiveFileFormats
                         pageBuilder.getBlockBuilder(columnNumber),
                         testColumns.get(columnNumber).getWriteValue(),
                         testColumns.get(columnNumber).getObjectInspector(),
-                        false);
+                        false,
+                        DateTimeZone.getDefault());
             }
         }
         Page page = pageBuilder.build();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.cost.StatsAndCosts;
@@ -2778,6 +2779,31 @@ public class TestHiveIntegrationSmokeTest
         assertUpdate(createTableSql);
         actualResult = computeActual("SHOW CREATE TABLE \"test_show_create_table'2\"");
         assertEquals(getOnlyElement(actualResult.getOnlyColumnAsSet()), createTableSql);
+    }
+
+    @Test
+    public void testTextfileAmbiguousTimestamp()
+    {
+        try {
+            // set the session time zone to the same as the system timezone to avoid extra time zone conversions outside of what we are trying to test
+            Session timezoneSession = Session.builder(getSession()).setTimeZoneKey(TimeZoneKey.getTimeZoneKey("America/Bahia_Banderas")).build();
+            @Language("SQL") String createTableSql = format("" +
+                            "CREATE TABLE test_timestamp_textfile \n" +
+                            "WITH (\n" +
+                            "   format = 'TEXTFILE'\n" +
+                            ")\n" +
+                            "AS SELECT TIMESTAMP '2022-10-30 01:16:13.000' ts, ARRAY[TIMESTAMP '2022-10-30 01:16:13.000'] array_ts",
+                    getSession().getCatalog().get(),
+                    getSession().getSchema().get());
+            assertUpdate(timezoneSession, createTableSql, 1);
+            // 2022-10-30 01:16:13.00 is an ambiguous timestamp in America/Bahia_Banderas because
+            // it occurs during a fall DST transition where the hour from 1-2am repeats
+            // Ambiguous timestamps should be interpreted as the earlier of the two possible unixtimes for consistency.
+            assertQuery(timezoneSession, "SELECT to_unixtime(ts), to_unixtime(array_ts[1]) FROM test_timestamp_textfile", "SELECT 1.667110573E9, 1.667110573E9");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS test_timestamp_textfile");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description
For TEXTFILE tables, when structural types (array, map, row) contain timestamp columns, we weren't converting to the hive storage time zone as we were doing for primitive types. Instead the timestamps would be interpreted in the JVM timezone

The conversion to hive storage time zone had a secondary benefit (even when the timezones were the same) of fixing the handling of ambiguous timestamps. Ambiguous timestamps are local times that can have more than one unixtime representation. It happens commonly during the fall DST conversion where the hour from 1-2am repeats. Generally in Presto we use the earlier of thetwo possible times when the unixtime is ambiguous. However, the hive library we use for parsing textfiles uses the later time. The code for adjusting the time based on the hive storage time zone has a secondary benefit of correcting ambiguous timestamps to the earlier unixtime representation.

This change fixes those two issues for the structural type code path.

## Motivation and Context
The motivation for this change is to provide consistent results for ambiguous timestamps regardless of where it is used.  We also want to fix incorrectly not using the storage time zone for timestamps in structural types.

## Impact
Ambiguous timestamps inside structural types in textfiles will now be interpreted in the earliest possible unixtime.
The hive.time-zone property will now be respected for timestamps inside structural types in textfiles

## Test Plan
new tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Fix timestamps inside array, map, or row types for tables using TEXTFILE format to respect the ``hive.time-zone property``.
* Fix interpretation of ambiguous timestamps inside array, map, or row types for tables using TEXTFILE format to interpret the timestamps as the earliest possible unixtime for consistency with the rest of Presto.


