### PR TITLE
Making configuration manager loaded boolean flag Atomic

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -112,7 +112,7 @@ public final class InternalResourceGroupManager<C>
     private final boolean isResourceManagerEnabled;
     private final QueryManagerConfig queryManagerConfig;
     private final InternalNodeManager nodeManager;
-    private boolean isConfigurationManagerLoaded;
+    private AtomicBoolean isConfigurationManagerLoaded;
 
     @Inject
     public InternalResourceGroupManager(
@@ -137,7 +137,7 @@ public final class InternalResourceGroupManager<C>
         this.isResourceManagerEnabled = requireNonNull(serverConfig, "serverConfig is null").isResourceManagerEnabled();
         this.resourceGroupRuntimeExecutor = new PeriodicTaskExecutor(resourceGroupRuntimeInfoRefreshInterval.toMillis(), refreshExecutor, this::refreshResourceGroupRuntimeInfo);
         configurationManagerFactories.putIfAbsent(LegacyResourceGroupConfigurationManager.NAME, new LegacyResourceGroupConfigurationManager.Factory());
-        this.isConfigurationManagerLoaded = false;
+        this.isConfigurationManagerLoaded = new AtomicBoolean(false);
     }
 
     @Override
@@ -204,7 +204,7 @@ public final class InternalResourceGroupManager<C>
                     MAX_QUEUED_QUERIES, Integer.toString(queryManagerConfig.getMaxQueuedQueries()));
             setConfigurationManager(LegacyResourceGroupConfigurationManager.NAME, legacyProperties);
         }
-        isConfigurationManagerLoaded = true;
+        isConfigurationManagerLoaded.set(true);
     }
 
     private void setConfigurationManager(String name, Map<String, String> properties)
@@ -290,7 +290,7 @@ public final class InternalResourceGroupManager<C>
     @Override
     public boolean isConfigurationManagerLoaded()
     {
-        return isConfigurationManagerLoaded;
+        return isConfigurationManagerLoaded.get();
     }
 
     private void buildResourceGroupRuntimeInfo(ImmutableList.Builder<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos, InternalResourceGroup resourceGroup)


### PR DESCRIPTION
## Description
Given the value is accessed from multiple thread making it atomic so all threads get the right visibility into the value.

## Motivation and Context
Given the isConfigurationManagerLoaded boolean value can be accessed by multiple threads and is mutable, not having atomic value can provide wrong value in concurrent access of the variable.

## Impact
Making thread safe access to isConfigurationManagerLoaded boolean value.

## Test Plan
Existing unit test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== NO RELEASE NOTE ==
```

