### PR TITLE
Fix join validation when spill enabled for native

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
@@ -53,7 +53,7 @@ public final class PlanChecker
                         new TypeValidator(),
                         new VerifyNoFilteredAggregations(),
                         new VerifyNoIntermediateFormExpression(),
-                        new ValidateStreamingJoins())
+                        new ValidateStreamingJoins(featuresConfig))
                 .putAll(
                         Stage.FINAL,
                         new CheckUnsupportedExternalFunctions(),


### PR DESCRIPTION
## Description
ValidateStreamingJoins tests that a join node has the necessary stream properties.  When spill is enabled for Java, we need the probe side to have a fixed parallelism, but native does not have that requirement.. Fix ValidateStreamingJoins to not require an extra local exchange for spilling when using native execution.

## Motivation and Context
Fix query failures like "java.lang.IllegalArgumentException: Probe side needs an additional local exchange for join: 17" when running with native execution with spill enabled

## Impact
Fixes query failures for some join queries when spill and native execution are both enabled.

## Test Plan
new tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix plan validation failures for some join queries running with spill enabled when using Presto C++
```

