### PR TITLE
Fix type signature with whitespace in parameters

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
@@ -657,7 +657,7 @@ public class TypeSignature
             Map<Integer, DistinctTypeParsingData> parsedDistinctTypes)
     {
         String parameterName = signature.substring(begin, end).trim();
-        if (isDigit(signature.charAt(begin))) {
+        if (isDigit(parameterName.charAt(0))) {
             return TypeSignatureParameter.of(Long.parseLong(parameterName));
         }
         else if (literalCalculationParameters.contains(parameterName)) {

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeSignature.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeSignature.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.common.type.ParameterKind.LONG;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
@@ -313,6 +314,17 @@ public class TestTypeSignature
         assertFalse(parseTypeSignature("map(decimal(2, 1),decimal(3, 1))").isCalculated());
         assertTrue(parseTypeSignature("row(a decimal(p1,s1),b decimal(p2,s2))", ImmutableSet.of("p1", "s1", "p2", "s2")).isCalculated());
         assertFalse(parseTypeSignature("row(a decimal(2,1),b decimal(3,2))").isCalculated());
+    }
+
+    @Test
+    public void testParseTypeSignatureWithNumericParameters()
+    {
+        TypeSignature typeSignature = parseTypeSignature("DECIMAL(1, 0)");
+        assertEquals(typeSignature.getParameters().size(), 2);
+        assertEquals(typeSignature.getParameters().get(0).getLongLiteral(), 1L);
+        assertEquals(typeSignature.getParameters().get(0).getKind(), LONG);
+        assertEquals(typeSignature.getParameters().get(1).getLongLiteral(), 0L);
+        assertEquals(typeSignature.getParameters().get(1).getKind(), LONG);
     }
 
     @Test


### PR DESCRIPTION
If the type signature contained a whitespace, numeric parameters would erroneously be treated as variable parameters instead of numeric parameters.

## Description
This makes the TypeSignature format more robust

## Motivation and Context
During testing of expression optimization in the Presto sidecar, I found that `DECIMAL(1, 0)` would be treated as having two parameters, a `LONG` parameter and a `VARIABLE` parameter.  `DECIMAL(1,0)` would have two `LONG` parameters.  This is because the second had a space, and that space was causing the parsing to treat that as a variable.

## Impact
No present production impact, since only Presto Java makes these TypeSignatures at the moment.  But it will make it more robust for when TypeSignatures can be created remotely.

## Test Plan
Included a unit test.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

