### PR TITLE
Fix interpreting like expressions with escape

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -148,6 +148,7 @@ public class RowExpressionInterpreter
     {
         this(expression, metadata.getFunctionAndTypeManager(), session, optimizationLevel);
     }
+
     public RowExpressionInterpreter(RowExpression expression, FunctionAndTypeManager functionAndTypeManager, ConnectorSession session, Level optimizationLevel)
     {
         this.expression = requireNonNull(expression, "expression is null");
@@ -922,8 +923,7 @@ public class RowExpressionInterpreter
                 // this corresponds to ExpressionInterpreter::getConstantPattern
                 if (hasEscape) {
                     // like_pattern(pattern, escape)
-                    Slice unescapedPattern = unescapeLiteralLikePattern((Slice) nonCompiledPattern, (Slice) escape);
-                    possibleCompiledPattern = functionInvoker.invoke(((CallExpression) possibleCompiledPattern).getFunctionHandle(), session.getSqlFunctionProperties(), unescapedPattern, escape);
+                    possibleCompiledPattern = functionInvoker.invoke(((CallExpression) possibleCompiledPattern).getFunctionHandle(), session.getSqlFunctionProperties(), nonCompiledPattern, escape);
                 }
                 else {
                     // like_pattern(pattern)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestLikeQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestLikeQueries.java
@@ -23,7 +23,8 @@ public class TestLikeQueries
         extends AbstractTestQueryFramework
 {
     @Override
-    protected QueryRunner createQueryRunner() throws Exception
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
         Session session = testSessionBuilder()
                 .setCatalog("test")
@@ -35,8 +36,13 @@ public class TestLikeQueries
     @Test
     public void testLikeQueriesWithEscape()
     {
-        assertQuerySucceeds("SELECT IF('_T' LIKE '#_T' ESCAPE '#', c0, c1) FROM (values (true, false)) t(c0, c1)");
-        assertQuerySucceeds("SELECT IF(c2 LIKE 'T' ESCAPE '#', c0, c1) FROM (values (true, false, 'T')) t(c0, c1, c2)");
+        assertQuery("SELECT IF('xT' LIKE '#_T' ESCAPE '#', c0, c1) FROM (values (true, false)) t(c0, c1)", "SELECT false");
+        assertQuery("SELECT IF(c2 LIKE 'T' ESCAPE '#', c0, c1) FROM (values (true, false, 'T')) t(c0, c1, c2)", "SELECT true");
+    }
+
+    @Test
+    public void testLikeQueriesWithInvalidEscape()
+    {
         assertQueryFails("SELECT IF('T' LIKE '###T' ESCAPE '##', c0, c1) FROM (values (true, false)) t(c0, c1)", ".*Escape string must be a single character$");
         assertQueryFails("SELECT IF(c2 LIKE '' ESCAPE '', c0, c1) FROM (values (true, false, 'T')) t(c0, c1, c2)", ".*Escape string must be a single character$");
     }


### PR DESCRIPTION
## Description

Fix a bug with interpreting escaped like patterns in some cases where all arguments to the like predicate are constants 

## Motivation and Context
https://github.com/prestodb/presto/pull/23456 incorrectly changed the invocation of the like function to use the unescaped pattern for a call that expects the pattern to still contain the escape characters. As a result, any escaped characters were treated as though they were not escaped.  This affects certain queries when all arguments to the like predicate are constants.

## Impact
Fix a bug with interpreting escaped like patterns in some cases where all arguments to the like predicate are constants 

## Test Plan
new tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

* No release note because the bug and fix are all within the 0.290 release * 

```
== NO RELEASE NOTE ==
```

