### PR TITLE
Fix deprecation of getTypeLength()

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetEncoding.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetEncoding.java
@@ -70,7 +70,7 @@ public enum ParquetEncoding
                 case INT96:
                     return new FixedLenByteArrayPlainValuesReader(INT96_TYPE_LENGTH);
                 case FIXED_LEN_BYTE_ARRAY:
-                    return new FixedLenByteArrayPlainValuesReader(descriptor.getTypeLength());
+                    return new FixedLenByteArrayPlainValuesReader(descriptor.getPrimitiveType().getTypeLength());
                 default:
                     throw new ParquetDecodingException("Plain values reader does not support: " + descriptor.getType());
             }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/dictionary/Dictionaries.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/dictionary/Dictionaries.java
@@ -44,7 +44,7 @@ public class Dictionaries
                 case BINARY:
                     return new BinaryBatchDictionary(dictionaryPage);
                 case FIXED_LEN_BYTE_ARRAY:
-                    return new BinaryBatchDictionary(dictionaryPage, columnDescriptor.getTypeLength());
+                    return new BinaryBatchDictionary(dictionaryPage, columnDescriptor.getPrimitiveType().getTypeLength());
                 case BOOLEAN:
                 default:
                     break;


### PR DESCRIPTION
## Description
getTypeLength() --> getPrimitiveType().getTypeLength() (Inline method)

## Motivation and Context
get ready for eventual parquet upgrade

## Impact
none

## Test Plan
mvn test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

