### PR TITLE
[native] Add session properties for expression evaluation optimizations

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -273,6 +273,47 @@ It can help identify issues where a malformed vector causes failures or crashes,
 
 Note: This is an expensive check and should only be used for debugging purposes.
 
+``native_debug_disable_expression_with_peeling``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+If set to ``true``, disables the optimization in expression evaluation to peel common dictionary layer from inputs.
+
+This should only be used for debugging purposes.
+
+``native_debug_disable_common_sub_expressions``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+If set to ``true``, disables the optimization in expression evaluation to reuse cached results for common sub-expressions.
+
+This should only be used for debugging purposes.
+
+``native_debug_disable_expression_with_memoization``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+If set to ``true``, disables the optimization in expression evaluation to reuse cached results between subsequent
+input batches that are dictionary encoded and have the same alphabet(underlying flat vector).
+
+This should only be used for debugging purposes.
+
+``native_debug_disable_expression_with_lazy_inputs``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+If set to ``true``, disables the optimization in expression evaluation to delay loading of lazy inputs unless required.
+
+This should only be used for debugging purposes.
+
 ``native_join_spill_enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -351,6 +351,10 @@ public final class SystemSessionProperties
     private static final String NATIVE_EXECUTION_PROGRAM_ARGUMENTS = "native_execution_program_arguments";
     public static final String NATIVE_EXECUTION_PROCESS_REUSE_ENABLED = "native_execution_process_reuse_enabled";
     public static final String NATIVE_DEBUG_VALIDATE_OUTPUT_FROM_OPERATORS = "native_debug_validate_output_from_operators";
+    public static final String NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_PEELING = "native_debug_disable_expression_with_peeling";
+    public static final String NATIVE_DEBUG_DISABLE_COMMON_SUB_EXPRESSION = "native_debug_disable_common_sub_expressions";
+    public static final String NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_MEMOIZATION = "native_debug_disable_expression_with_memoization";
+    public static final String NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_LAZY_INPUTS = "native_debug_disable_expression_with_lazy_inputs";
 
     public static final String NATIVE_MAX_PARTIAL_AGGREGATION_MEMORY = "native_max_partial_aggregation_memory";
     public static final String NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY = "native_max_extended_partial_aggregation_memory";
@@ -1718,6 +1722,32 @@ public final class SystemSessionProperties
                                 "so should only be used for debugging. It can help debug issues where " +
                                 "malformed vector cause failures or crashes by helping identify which " +
                                 "operator is generating them.",
+                        false,
+                        true),
+                booleanProperty(
+                        NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_PEELING,
+                        "If set to true, disables optimization in expression evaluation to peel common " +
+                                "dictionary layer from inputs. Should only be used for debugging.",
+                        false,
+                        true),
+                booleanProperty(
+                        NATIVE_DEBUG_DISABLE_COMMON_SUB_EXPRESSION,
+                        "If set to true, disables optimization in expression evaluation to reuse cached " +
+                                "results for common sub-expressions. Should only be used for debugging.",
+                        false,
+                        true),
+                booleanProperty(
+                        NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_MEMOIZATION,
+                        "If set to true, disables optimization in expression evaluation to reuse cached " +
+                                "results between subsequent input batches that are dictionary encoded and " +
+                                "have the same alphabet(underlying flat vector). Should only be used for " +
+                                "debugging.",
+                        false,
+                        true),
+                booleanProperty(
+                        NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_LAZY_INPUTS,
+                        "If set to true, disables optimization in expression evaluation to delay loading " +
+                                "of lazy inputs unless required. Should only be used for debugging.",
                         false,
                         true),
                 longProperty(

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -204,6 +204,46 @@ SessionProperties::SessionProperties() {
       QueryConfig::kValidateOutputFromOperators,
       boolToString(c.validateOutputFromOperators()));
 
+  addSessionProperty(
+      kDebugDisableExpressionWithPeeling,
+      "If set to true, disables optimization in expression evaluation to peel "
+      "common dictionary layer from inputs. Should only be used for debugging.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kDebugDisableExpressionWithPeeling,
+      boolToString(c.debugDisableExpressionsWithPeeling()));
+
+  addSessionProperty(
+      kDebugDisableCommonSubExpressions,
+      "If set to true, disables optimization in expression evaluation to "
+      "re-use cached results for common sub-expressions. Should only be "
+      "used for debugging.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kDebugDisableCommonSubExpressions,
+      boolToString(c.debugDisableCommonSubExpressions()));
+
+  addSessionProperty(
+      kDebugDisableExpressionWithMemoization,
+      "If set to true, disables optimization in expression evaluation to "
+      "re-use cached results between subsequent input batches that are "
+      "dictionary encoded and have the same alphabet(underlying flat vector). "
+      "Should only be used for debugging.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kDebugDisableExpressionWithMemoization,
+      boolToString(c.debugDisableExpressionsWithMemoization()));
+
+  addSessionProperty(
+      kDebugDisableExpressionWithLazyInputs,
+      "If set to true, disables optimization in expression evaluation to delay "
+      "loading of lazy inputs unless required. Should only be used for "
+      "debugging.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kDebugDisableExpressionWithLazyInputs,
+      boolToString(c.debugDisableExpressionsWithLazyInputs()));
+
   // If `legacy_timestamp` is true, the coordinator expects timestamp
   // conversions without a timezone to be converted to the user's
   // session_timezone.

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -144,6 +144,27 @@ class SessionProperties {
   static constexpr const char* kValidateOutputFromOperators =
       "native_debug_validate_output_from_operators";
 
+  /// Disable optimization in expression evaluation to peel common dictionary
+  /// layer from inputs.
+  static constexpr const char* kDebugDisableExpressionWithPeeling =
+      "native_debug_disable_expression_with_peeling";
+
+  /// Disable optimization in expression evaluation to reuse cached results for
+  /// common sub-expressions.
+  static constexpr const char* kDebugDisableCommonSubExpressions =
+      "native_debug_disable_common_sub_expressions";
+
+  /// Disable optimization in expression evaluation to reuse cached results
+  /// between subsequent input batches that are dictionary encoded and have the
+  /// same alphabet(underlying flat vector).
+  static constexpr const char* kDebugDisableExpressionWithMemoization =
+      "native_debug_disable_expression_with_memoization";
+
+  /// Disable optimization in expression evaluation to delay loading of lazy
+  /// inputs unless required.
+  static constexpr const char* kDebugDisableExpressionWithLazyInputs =
+      "native_debug_disable_expression_with_lazy_inputs";
+
   /// Enable timezone-less timestamp conversions.
   static constexpr const char* kLegacyTimestamp = "legacy_timestamp";
 

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -52,6 +52,10 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
           {"native_join_spill_enabled", "false"},
           {"native_spill_write_buffer_size", "1024"},
           {"native_debug_validate_output_from_operators", "true"},
+          {"native_debug_disable_expression_with_peeling", "true"},
+          {"native_debug_disable_common_sub_expressions", "true"},
+          {"native_debug_disable_expression_with_memoization", "true"},
+          {"native_debug_disable_expression_with_lazy_inputs", "true"},
           {"aggregation_spill_all", "true"}}};
   auto queryCtx = taskManager_->getQueryContextManager()->findOrCreateQueryCtx(
       taskId, session);
@@ -59,6 +63,10 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
   EXPECT_EQ(queryCtx->queryConfig().spillCompressionKind(), "NONE");
   EXPECT_FALSE(queryCtx->queryConfig().joinSpillEnabled());
   EXPECT_TRUE(queryCtx->queryConfig().validateOutputFromOperators());
+  EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithPeeling());
+  EXPECT_TRUE(queryCtx->queryConfig().debugDisableCommonSubExpressions());
+  EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithMemoization());
+  EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithLazyInputs());
   EXPECT_EQ(queryCtx->queryConfig().spillWriteBufferSize(), 1024);
 }
 


### PR DESCRIPTION
This change adds session properties that are eventually translate to
velox query configs to toggle optimization in expression evaluation.
These are debug only configs and should not be used in production.
The configs added are:
`native_debug_disable_expression_with_peeling`,
`native_debug_disable_common_sub_expressions`,
`native_debug_disable_expression_with_memoization`,
`native_debug_disable_expression_with_lazy_inputs`.

Test Plan:
Updated and added unit tests