### PR TITLE
Update asm.version to fix upper bound dependencies error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.parquet.version>1.13.1</dep.parquet.version>
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
-        <dep.asm.version>9.0</dep.asm.version>
+        <dep.asm.version>9.2</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
         <dep.alluxio.version>313</dep.alluxio.version>
         <dep.slf4j.version>1.7.32</dep.slf4j.version>


### PR DESCRIPTION
## Description
Update asm.version to fix upper bound dependencies error

## Motivation and Context
Builds were failing with the following error : 
```
Require upper bound dependencies error for org.ow2.asm:asm:9.0 paths to dependency are:
+-com.facebook.presto:presto-cassandra:0.290-SNAPSHOT
  +-com.facebook.presto:presto-main:0.290-SNAPSHOT
    +-org.ow2.asm:asm:9.0 (managed) <-- org.ow2.asm:asm:9.2
and
+-com.facebook.presto:presto-cassandra:0.290-SNAPSHOT
  +-com.datastax.cassandra:cassandra-driver-core:3.11.5
    +-com.github.jnr:jnr-ffi:2.2.10
      +-org.ow2.asm:asm:9.0 (managed) <-- org.ow2.asm:asm:9.2
and
+-com.facebook.presto:presto-cassandra:0.290-SNAPSHOT
  +-com.facebook.presto:presto-main:0.290-SNAPSHOT
    +-com.facebook.presto:presto-bytecode:0.290-SNAPSHOT
      +-org.ow2.asm:asm:9.0 (managed) <-- org.ow2.asm:asm:9.2
and
+-com.facebook.presto:presto-cassandra:0.290-SNAPSHOT
  +-com.facebook.presto:presto-tests:0.290-SNAPSHOT
    +-com.facebook.presto:presto-main:0.290-SNAPSHOT
      +-org.ow2.asm:asm:9.0 (managed) <-- org.ow2.asm:asm:9.2
and
+-com.facebook.presto:presto-cassandra:0.290-SNAPSHOT
  +-com.datastax.cassandra:cassandra-driver-core:3.11.5
    +-com.github.jnr:jnr-ffi:2.2.10
      +-org.ow2.asm:asm-commons:9.2
        +-org.ow2.asm:asm:9.0 (managed) <-- org.ow2.asm:asm:9.2
and
+-com.facebook.presto:presto-cassandra:0.290-SNAPSHOT
  +-com.datastax.cassandra:cassandra-driver-core:3.11.5
    +-com.github.jnr:jnr-ffi:2.2.10
      +-org.ow2.asm:asm-tree:9.0
        +-org.ow2.asm:asm:9.0 (managed) <-- org.ow2.asm:asm:9.2
and
+-com.facebook.presto:presto-cassandra:0.290-SNAPSHOT
  +-com.datastax.cassandra:cassandra-driver-core:3.11.5
    +-com.github.jnr:jnr-ffi:2.2.10
      +-org.ow2.asm:asm-util:9.0 (managed) <-- org.ow2.asm:asm-util:9.2
        +-org.ow2.asm:asm:9.0 (managed) <-- org.ow2.asm:asm:9.2
and
+-com.facebook.presto:presto-cassandra:0.290-SNAPSHOT
  +-com.facebook.presto:presto-main:0.290-SNAPSHOT
    +-com.facebook.drift:drift-codec:1.38
      +-com.facebook.airlift:bytecode:1.3

```
## Impact
Fix build


```
== NO RELEASE NOTE ==
```

