### PR TITLE
handle null pages when filling in row IDs

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
@@ -145,6 +145,9 @@ public class OrcSelectivePageSource
 
     private Page fillInRowIDs(Page page)
     {
+        if (page == null) {
+            return null;
+        }
         // rowNumbers is always the last block in the page
         Block rowNumbers = page.getBlock(page.getChannelCount() - 1);
         Block rowIDs = coercer.apply(rowNumbers);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
Found this case in a production stack trace. 

## Impact
some row ID queries now work that didn't used to

## Test Plan
mvn test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

