### PR TITLE
[native] Make periodic cache flush incremental

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -87,6 +87,14 @@ Worker Properties
 
 The configuration properties of Presto C++ workers are described here, in alphabetical order. 
 
+``async-cache-persistence-interval``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* **Type:** ``string``
+* **Default value:** ``0s``
+
+  The interval for persisting in-memory cache to SSD. Setting this config
+  to a non-zero value will activate periodic cache persistence.
+
 ``async-data-cache-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -127,11 +127,11 @@ bool isCacheTtlEnabled() {
   return false;
 }
 
-bool isCachePeriodicFullPersistenceEnabled() {
+bool cachePeriodicPersistenceEnabled() {
   const auto* systemConfig = SystemConfig::instance();
   return systemConfig->asyncDataCacheEnabled() &&
       systemConfig->asyncCacheSsdGb() > 0 &&
-      systemConfig->asyncCacheFullPersistenceInterval() >
+      systemConfig->asyncCachePersistenceInterval() >
       std::chrono::seconds::zero();
 }
 
@@ -1008,7 +1008,7 @@ void PrestoServer::addServerPeriodicTasks() {
         "cache_ttl");
   }
 
-  if (isCachePeriodicFullPersistenceEnabled()) {
+  if (cachePeriodicPersistenceEnabled()) {
     PRESTO_STARTUP_LOG(INFO)
         << "Initializing cache periodic full persistence task...";
     auto* cache = velox::cache::AsyncDataCache::getInstance();
@@ -1018,31 +1018,18 @@ void PrestoServer::addServerPeriodicTasks() {
     const auto* systemConfig = SystemConfig::instance();
     const int64_t cacheFullPersistenceIntervalUs =
         std::chrono::duration_cast<std::chrono::microseconds>(
-            systemConfig->asyncCacheFullPersistenceInterval())
+            systemConfig->asyncCachePersistenceInterval())
             .count();
-    const auto asyncCacheSsdCheckpointGb =
-        systemConfig->asyncCacheSsdCheckpointGb();
     periodicTaskManager_->addTask(
-        [asyncCacheSsdCheckpointGb, cache, ssdCache]() {
+        [cache, ssdCache]() {
           try {
             if (!ssdCache->startWrite()) {
               return;
             }
-            LOG(INFO) << "Persisting full cache to SSD...";
-            cache->saveToSsd(true);
+            LOG(INFO) << "Flush in-memory cache to SSD...";
+            cache->saveToSsd();
             ssdCache->waitForWriteToFinish();
-            LOG(INFO) << "Cache full persistence completed.";
-
-            if (asyncCacheSsdCheckpointGb == 0) {
-              return;
-            }
-
-            if (!ssdCache->startWrite()) {
-              return;
-            }
-
-            ssdCache->checkpoint();
-            ssdCache->waitForWriteToFinish();
+            LOG(INFO) << "Flushing in-memory cache to SSD completed.";
           } catch (const std::exception& e) {
             LOG(ERROR) << "Failed to persistent cache to SSD: " << e.what();
           }

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -178,7 +178,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kAsyncCacheMaxSsdWriteRatio, 0.7),
           NUM_PROP(kAsyncCacheSsdSavableRatio, 0.125),
           NUM_PROP(kAsyncCacheMinSsdSavableBytes, 1 << 24 /*16MB*/),
-          STR_PROP(kAsyncCacheFullPersistenceInterval, "0s"),
+          STR_PROP(kAsyncCachePersistenceInterval, "0s"),
           BOOL_PROP(kAsyncCacheSsdDisableFileCow, false),
           BOOL_PROP(kSsdCacheChecksumEnabled, false),
           BOOL_PROP(kSsdCacheReadVerificationEnabled, false),
@@ -465,10 +465,10 @@ int32_t SystemConfig::asyncCacheMinSsdSavableBytes() const {
   return optionalProperty<int32_t>(kAsyncCacheMinSsdSavableBytes).value();
 }
 
-std::chrono::duration<double> SystemConfig::asyncCacheFullPersistenceInterval()
+std::chrono::duration<double> SystemConfig::asyncCachePersistenceInterval()
     const {
   return velox::config::toDuration(
-      optionalProperty(kAsyncCacheFullPersistenceInterval).value());
+      optionalProperty(kAsyncCachePersistenceInterval).value());
 }
 
 bool SystemConfig::asyncCacheSsdDisableFileCow() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -321,10 +321,10 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kAsyncCacheMinSsdSavableBytes{
       "async-cache-min-ssd-savable-bytes"};
 
-  /// The interval for persisting full memory cache to SSD. Setting this config
+  /// The interval for persisting in-memory cache to SSD. Setting this config
   /// to a non-zero value will activate periodic cache persistence.
-  static constexpr std::string_view kAsyncCacheFullPersistenceInterval{
-      "async-cache-full-persistence-interval"};
+  static constexpr std::string_view kAsyncCachePersistenceInterval{
+      "async-cache-persistence-interval"};
 
   /// In file systems, such as btrfs, supporting cow (copy on write), the ssd
   /// cache can use all ssd space and stop working. To prevent that, use this
@@ -747,7 +747,7 @@ class SystemConfig : public ConfigBase {
 
   int32_t asyncCacheMinSsdSavableBytes() const;
 
-  std::chrono::duration<double> asyncCacheFullPersistenceInterval() const;
+  std::chrono::duration<double> asyncCachePersistenceInterval() const;
 
   bool asyncCacheSsdDisableFileCow() const;
 


### PR DESCRIPTION
When flushing the in-memory cache to SSD, perform an incremental flush instead of saving everything forcefully. Additionally, explicit checkpointing is unnecessary, as it will automatically trigger when the written bytes exceed the checkpoint threshold and during shutdown.


```
== RELEASE NOTES ==

General Changes
* Add incremental periodic cache persistence for Presto C++ worker. :pr:`23626`
* Replace configuration property `async-cache-full-persistence-interval` with `async-cache-persistence-interval`. :pr:`23626`
```

