### PR TITLE
[iceberg] Add UUID type support

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1737,26 +1737,28 @@ Map of Iceberg types to the relevant PrestoDB types:
     - PrestoDB type
   * - ``BOOLEAN``
     - ``BOOLEAN``
-  * - ``BINARY``, ``FIXED``
-    - ``VARBINARY``
-  * - ``DATE``
-    - ``DATE``
-  * - ``DECIMAL``
-    - ``DECIMAL``
-  * - ``DOUBLE``
-    - ``DOUBLE``
+  * - ``INTEGER``
+    - ``INTEGER``
   * - ``LONG``
     - ``BIGINT``
   * - ``FLOAT``
     - ``REAL``
-  * - ``INTEGER``
-    - ``INTEGER``
+  * - ``DOUBLE``
+    - ``DOUBLE``
+  * - ``DECIMAL``
+    - ``DECIMAL``
+  * - ``STRING``
+    - ``VARCHAR``
+  * - ``BINARY``, ``FIXED``
+    - ``VARBINARY``
+  * - ``DATE``
+    - ``DATE``
   * - ``TIME``
     - ``TIME``
   * - ``TIMESTAMP``
     - ``TIMESTAMP``
-  * - ``STRING``
-    - ``VARCHAR``
+  * - ``UUID``
+    - ``UUID``
   * - ``LIST``
     - ``ARRAY``
   * - ``MAP``
@@ -1796,17 +1798,20 @@ Map of PrestoDB types to the relevant Iceberg types:
     - ``BINARY``
   * - ``DATE``
     - ``DATE``
-  * - ``ROW``
-    - ``STRUCT``
-  * - ``ARRAY``
-    - ``LIST``
-  * - ``MAP``
-    - ``MAP``
   * - ``TIME``
     - ``TIME``
   * - ``TIMESTAMP``
     - ``TIMESTAMP WITHOUT ZONE``
   * - ``TIMESTAMP WITH TIMEZONE``
     - ``TIMESTAMP WITH ZONE``
+  * - ``UUID``
+    - ``UUID``
+  * - ``ARRAY``
+    - ``LIST``
+  * - ``MAP``
+    - ``MAP``
+  * - ``ROW``
+    - ``STRUCT``
+
 
 No other types are supported.

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.UuidType;
 import com.facebook.presto.spi.PrestoException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -47,6 +48,7 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.StandardTypes.UUID;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
@@ -58,6 +60,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.binaryTypeInfo;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.booleanTypeInfo;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.byteTypeInfo;
@@ -87,6 +90,47 @@ public final class HiveType
     public static final HiveType HIVE_TIMESTAMP = new HiveType(timestampTypeInfo);
     public static final HiveType HIVE_DATE = new HiveType(dateTypeInfo);
     public static final HiveType HIVE_BINARY = new HiveType(binaryTypeInfo);
+    public static final HiveType HIVE_UUID = new HiveType(new TypeInfo()
+    {
+        @Override
+        public Category getCategory()
+        {
+            return PRIMITIVE;
+        }
+
+        @Override
+        public String getTypeName()
+        {
+            return UUID;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (this == other) {
+                return true;
+            }
+            if (other == null || getClass() != other.getClass()) {
+                return false;
+            }
+
+            TypeInfo ti = (TypeInfo) other;
+
+            return UUID.equals(ti.getTypeName());
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return UUID.hashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return UUID;
+        }
+    });
 
     private final HiveTypeName hiveTypeName;
     private final TypeInfo typeInfo;
@@ -223,6 +267,9 @@ public final class HiveType
         switch (typeInfo.getCategory()) {
             case PRIMITIVE:
                 Type primitiveType = getPrimitiveType((PrimitiveTypeInfo) typeInfo);
+                if (primitiveType == null && typeInfo.getTypeName().equals(UUID)) {
+                    return UuidType.UUID.getTypeSignature();
+                }
                 if (primitiveType == null) {
                     break;
                 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.UuidType.UUID;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.hive.HiveType.HIVE_BINARY;
 import static com.facebook.presto.hive.HiveType.HIVE_BOOLEAN;
@@ -52,6 +53,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_SHORT;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveType.HIVE_TIMESTAMP;
+import static com.facebook.presto.hive.HiveType.HIVE_UUID;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.isArrayType;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.isMapType;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.isRowType;
@@ -90,6 +92,9 @@ public class HiveTypeTranslator
         }
         if (DOUBLE.equals(type)) {
             return HIVE_DOUBLE.getTypeInfo();
+        }
+        if (UUID.equals(type)) {
+            return HIVE_UUID.getTypeInfo();
         }
         if (type instanceof VarcharType) {
             VarcharType varcharType = (VarcharType) type;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
@@ -31,6 +31,7 @@ import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.UuidType;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
 import com.google.common.base.VerifyException;
@@ -41,6 +42,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.facebook.presto.common.predicate.Marker.Bound.ABOVE;
 import static com.facebook.presto.common.predicate.Marker.Bound.BELOW;
@@ -220,6 +222,12 @@ public final class ExpressionConverter
             return new BigDecimal(Decimals.decodeUnscaledValue((Slice) value), decimalType.getScale());
         }
 
+        if (type instanceof UuidType) {
+            UuidType uuidType = (UuidType) type;
+            return marker.getValueBlock()
+                    .map(block -> UUID.fromString((String) uuidType.getObjectValue(null, block, 0)))
+                    .orElseThrow(NullPointerException::new);
+        }
         return marker.getValue();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -33,6 +33,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.UuidType;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.hive.HiveType;
@@ -120,6 +121,8 @@ public final class TypeConverter
                 return TimestampType.TIMESTAMP;
             case STRING:
                 return VarcharType.createUnboundedVarcharType();
+            case UUID:
+                return UuidType.UUID;
             case LIST:
                 Types.ListType listType = (Types.ListType) type;
                 return new ArrayType(toPrestoType(listType.elementType(), typeManager));
@@ -202,6 +205,9 @@ public final class TypeConverter
         }
         if (type instanceof TimestampWithTimeZoneType) {
             return Types.TimestampType.withZone();
+        }
+        if (type instanceof UuidType) {
+            return Types.UUIDType.get();
         }
         throw new PrestoException(NOT_SUPPORTED, "Type not supported for Iceberg: " + type.getDisplayName());
     }

--- a/presto-parquet/.gitignore
+++ b/presto-parquet/.gitignore
@@ -1,0 +1,2 @@
+src/main/java/ParquetFlatColumnReaderGenerator.tdd
+src/main/java/ParquetNestedColumnReaderGenerator.tdd

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -223,8 +223,17 @@
                     <ignoredClassPatterns>
                         <ignoredClassPattern>shaded.parquet.it.unimi.dsi.fastutil.*</ignoredClassPattern>
                         <ignoredClassPattern>module-info</ignoredClassPattern>
-                        <ignoredClassPattern>com.facebook.presto.parquet.batchreader.*BatchReader</ignoredClassPattern>
+                        <ignoredClassPattern>com.facebook.presto.parquet.*</ignoredClassPattern>
+                        <ignoredClassPattern>org.apache.parquet.io.*</ignoredClassPattern>
+                        <ignoredClassPattern>org.apache.parquet.crypto.*</ignoredClassPattern>
                     </ignoredClassPatterns>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <excludes>**/com/facebook/presto/parquet/batchreader/*FlatBatchReader.java,**/com/facebook/presto/parquet/batchreader/*NestedBatchReader.java</excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -241,6 +250,38 @@
                         <configuration>
                             <excludes combine.self="override" />
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>generateParquetReaders</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.googlecode.fmpp-maven-plugin</groupId>
+                        <artifactId>fmpp-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>net.sourceforge.fmpp</groupId>
+                                <artifactId>fmpp</artifactId>
+                                <version>0.9.15</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <cfgFile>${project.basedir}/src/main/resources/freemarker/config.fmpp</cfgFile>
+                            <outputDirectory>${project.build.sourceDirectory}</outputDirectory>
+                            <templateDirectory>${project.basedir}/src/main/resources/freemarker/templates</templateDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.common.type.Decimals.MAX_SHORT_PRECISION;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.stream.Collectors.joining;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
 import static org.apache.parquet.schema.OriginalType.DECIMAL;
 import static org.apache.parquet.schema.OriginalType.TIMESTAMP_MICROS;
 import static org.apache.parquet.schema.OriginalType.TIME_MICROS;
@@ -351,6 +352,11 @@ public final class ParquetTypeUtils
 
         DecimalLogicalTypeAnnotation decimalLogicalTypeAnnotation = (DecimalLogicalTypeAnnotation) logicalTypeAnnotation;
         return decimalLogicalTypeAnnotation.getPrecision() <= MAX_SHORT_PRECISION;
+    }
+
+    public static boolean isUuidType(ColumnDescriptor columnDescriptor)
+    {
+        return uuidType().equals(columnDescriptor.getPrimitiveType().getLogicalTypeAnnotation());
     }
 
     public static boolean isDecimalType(ColumnDescriptor columnDescriptor)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BooleanFlatBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BooleanFlatBatchReader.java
@@ -255,3 +255,4 @@ public class BooleanFlatBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BooleanNestedBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BooleanNestedBatchReader.java
@@ -142,3 +142,4 @@ public class BooleanNestedBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BytesUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/BytesUtils.java
@@ -29,6 +29,13 @@ public class BytesUtils
         return (ch3 << 24) + (ch2 << 16) + (ch1 << 8) + ch0;
     }
 
+    /**
+     * Convert a little-endian formatted value in a bytearray to a long.
+     *
+     * @param byteBuffer source bytes
+     * @param offset offset in byte array to start decoding
+     * @return long value
+     */
     public static long getLong(byte[] byteBuffer, int offset)
     {
         int ch0 = byteBuffer[offset + 0];
@@ -48,6 +55,34 @@ public class BytesUtils
                 ((long) (ch2 & 255) << 16) +
                 ((long) (ch1 & 255) << 8) +
                 ((long) (ch0 & 255) << 0);
+    }
+
+    /**
+     * Convert a big-endian formatted value in a bytearray to a long.
+     *
+     * @param byteBuffer source bytes
+     * @param offset offset in byte array to start decoding
+     * @return long value
+     */
+    public static long getLongBigEndian(byte[] byteBuffer, int offset)
+    {
+        byte ch0 = byteBuffer[offset + 0];
+        byte ch1 = byteBuffer[offset + 1];
+        byte ch2 = byteBuffer[offset + 2];
+        byte ch3 = byteBuffer[offset + 3];
+        byte ch4 = byteBuffer[offset + 4];
+        byte ch5 = byteBuffer[offset + 5];
+        byte ch6 = byteBuffer[offset + 6];
+        byte ch7 = byteBuffer[offset + 7];
+
+        return ((long) (ch0 & 255) << 56) +
+                ((long) (ch1 & 255) << 48) +
+                ((long) (ch2 & 255) << 40) +
+                ((long) (ch3 & 255) << 32) +
+                ((long) (ch4 & 255) << 24) +
+                ((long) (ch5 & 255) << 16) +
+                ((long) (ch6 & 255) << 8) +
+                ((long) (ch7 & 255) << 0);
     }
 
     public static void unpack8Values(byte inByte, byte[] out, int outPos)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int64FlatBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int64FlatBatchReader.java
@@ -255,3 +255,4 @@ public class Int64FlatBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int64NestedBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int64NestedBatchReader.java
@@ -142,3 +142,4 @@ public class Int64NestedBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int64TimeAndTimestampMicrosFlatBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int64TimeAndTimestampMicrosFlatBatchReader.java
@@ -255,3 +255,4 @@ public class Int64TimeAndTimestampMicrosFlatBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int64TimeAndTimestampMicrosNestedBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/Int64TimeAndTimestampMicrosNestedBatchReader.java
@@ -142,3 +142,4 @@ public class Int64TimeAndTimestampMicrosNestedBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/LongDecimalFlatBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/LongDecimalFlatBatchReader.java
@@ -256,3 +256,4 @@ public class LongDecimalFlatBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/ShortDecimalFlatBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/ShortDecimalFlatBatchReader.java
@@ -255,3 +255,4 @@ public class ShortDecimalFlatBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/TimestampFlatBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/TimestampFlatBatchReader.java
@@ -255,3 +255,4 @@ public class TimestampFlatBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/TimestampNestedBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/TimestampNestedBatchReader.java
@@ -142,3 +142,4 @@ public class TimestampNestedBatchReader
         }
     }
 }
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/UuidFlatBatchReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/UuidFlatBatchReader.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.batchreader;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.Int128ArrayBlock;
+import com.facebook.presto.common.block.RunLengthEncodedBlock;
+import com.facebook.presto.parquet.ColumnReader;
+import com.facebook.presto.parquet.DataPage;
+import com.facebook.presto.parquet.DictionaryPage;
+import com.facebook.presto.parquet.Field;
+import com.facebook.presto.parquet.RichColumnDescriptor;
+import com.facebook.presto.parquet.batchreader.decoders.Decoders.FlatDecoders;
+import com.facebook.presto.parquet.batchreader.decoders.FlatDefinitionLevelDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.UuidValuesDecoder;
+import com.facebook.presto.parquet.batchreader.dictionary.Dictionaries;
+import com.facebook.presto.parquet.dictionary.Dictionary;
+import com.facebook.presto.parquet.reader.ColumnChunk;
+import com.facebook.presto.parquet.reader.PageReader;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.parquet.internal.filter2.columnindex.RowRanges;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.facebook.presto.parquet.ParquetErrorCode.PARQUET_IO_READ_ERROR;
+import static com.facebook.presto.parquet.batchreader.decoders.Decoders.readFlatPage;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class UuidFlatBatchReader
+        implements ColumnReader
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(UuidFlatBatchReader.class).instanceSize();
+
+    private final RichColumnDescriptor columnDescriptor;
+
+    protected Field field;
+    protected int nextBatchSize;
+    protected FlatDefinitionLevelDecoder definitionLevelDecoder;
+    protected UuidValuesDecoder valuesDecoder;
+    protected int remainingCountInPage;
+
+    private Dictionary dictionary;
+    private int readOffset;
+    private PageReader pageReader;
+
+    public UuidFlatBatchReader(RichColumnDescriptor columnDescriptor)
+    {
+        this.columnDescriptor = requireNonNull(columnDescriptor, "columnDescriptor is null");
+    }
+
+    @Override
+    public boolean isInitialized()
+    {
+        return pageReader != null && field != null;
+    }
+
+    @Override
+    public void init(PageReader pageReader, Field field, RowRanges rowRanges)
+    {
+        checkArgument(!isInitialized(), "Parquet batch reader already initialized");
+        this.pageReader = requireNonNull(pageReader, "pageReader is null");
+        checkArgument(pageReader.getValueCountInColumnChunk() > 0, "page is empty");
+        this.field = requireNonNull(field, "field is null");
+
+        DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
+        if (dictionaryPage != null) {
+            dictionary = Dictionaries.createDictionary(columnDescriptor, dictionaryPage);
+        }
+    }
+
+    @Override
+    public void prepareNextRead(int batchSize)
+    {
+        readOffset = readOffset + nextBatchSize;
+        nextBatchSize = batchSize;
+    }
+
+    @Override
+    public ColumnChunk readNext()
+    {
+        ColumnChunk columnChunk = null;
+        try {
+            seek();
+            if (field.isRequired()) {
+                columnChunk = readWithoutNull();
+            }
+            else {
+                columnChunk = readWithNull();
+            }
+        }
+        catch (IOException exception) {
+            throw new PrestoException(PARQUET_IO_READ_ERROR, "Error reading Parquet column " + columnDescriptor, exception);
+        }
+
+        readOffset = 0;
+        nextBatchSize = 0;
+        return columnChunk;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                (definitionLevelDecoder == null ? 0 : definitionLevelDecoder.getRetainedSizeInBytes()) +
+                (valuesDecoder == null ? 0 : valuesDecoder.getRetainedSizeInBytes()) +
+                (dictionary == null ? 0 : dictionary.getRetainedSizeInBytes()) +
+                (pageReader == null ? 0 : pageReader.getRetainedSizeInBytes());
+    }
+
+    protected boolean readNextPage()
+    {
+        definitionLevelDecoder = null;
+        valuesDecoder = null;
+        remainingCountInPage = 0;
+
+        DataPage page = pageReader.readPage();
+        if (page == null) {
+            return false;
+        }
+
+        FlatDecoders flatDecoders = readFlatPage(page, columnDescriptor, dictionary);
+        definitionLevelDecoder = flatDecoders.getDefinitionLevelDecoder();
+        valuesDecoder = (UuidValuesDecoder) flatDecoders.getValuesDecoder();
+
+        remainingCountInPage = page.getValueCount();
+        return true;
+    }
+
+    private ColumnChunk readWithNull()
+            throws IOException
+    {
+        long[] values = new long[nextBatchSize * 2];
+        boolean[] isNull = new boolean[nextBatchSize];
+
+        int totalNonNullCount = 0;
+        int remainingInBatch = nextBatchSize;
+        int startOffset = 0;
+        while (remainingInBatch > 0) {
+            if (remainingCountInPage == 0) {
+                if (!readNextPage()) {
+                    break;
+                }
+            }
+
+            int chunkSize = min(remainingCountInPage, remainingInBatch);
+            int nonNullCount = definitionLevelDecoder.readNext(isNull, startOffset, chunkSize);
+            totalNonNullCount += nonNullCount;
+
+            if (nonNullCount > 0) {
+                valuesDecoder.readNext(values, startOffset, nonNullCount);
+
+                int valueDestinationIndex = startOffset + chunkSize - 1;
+                int valueSourceIndex = startOffset + nonNullCount - 1;
+
+                while (valueDestinationIndex >= startOffset) {
+                    if (!isNull[valueDestinationIndex]) {
+                        values[valueDestinationIndex * 2 + 1] = values[valueSourceIndex * 2 + 1];
+                        values[valueDestinationIndex * 2] = values[valueSourceIndex * 2];
+                        valueSourceIndex--;
+                    }
+                    valueDestinationIndex--;
+                }
+            }
+
+            startOffset += chunkSize;
+            remainingInBatch -= chunkSize;
+            remainingCountInPage -= chunkSize;
+        }
+
+        if (remainingInBatch != 0) {
+            throw new ParquetDecodingException("Still remaining to be read in current batch.");
+        }
+
+        if (totalNonNullCount == 0) {
+            Block block = RunLengthEncodedBlock.create(field.getType(), null, nextBatchSize);
+            return new ColumnChunk(block, new int[0], new int[0]);
+        }
+
+        boolean hasNoNull = totalNonNullCount == nextBatchSize;
+        Block block = new Int128ArrayBlock(nextBatchSize, hasNoNull ? Optional.empty() : Optional.of(isNull), values);
+        return new ColumnChunk(block, new int[0], new int[0]);
+    }
+
+    private ColumnChunk readWithoutNull()
+            throws IOException
+    {
+        long[] values = new long[nextBatchSize * 2];
+        int remainingInBatch = nextBatchSize;
+        int startOffset = 0;
+        while (remainingInBatch > 0) {
+            if (remainingCountInPage == 0) {
+                if (!readNextPage()) {
+                    break;
+                }
+            }
+
+            int chunkSize = min(remainingCountInPage, remainingInBatch);
+
+            valuesDecoder.readNext(values, startOffset, chunkSize);
+            startOffset += chunkSize;
+            remainingInBatch -= chunkSize;
+            remainingCountInPage -= chunkSize;
+        }
+
+        if (remainingInBatch != 0) {
+            throw new ParquetDecodingException(format("Corrupted Parquet file: extra %d values to be consumed when scanning current batch", remainingInBatch));
+        }
+
+        Block block = new Int128ArrayBlock(nextBatchSize, Optional.empty(), values);
+        return new ColumnChunk(block, new int[0], new int[0]);
+    }
+
+    private void seek()
+            throws IOException
+    {
+        if (readOffset == 0) {
+            return;
+        }
+
+        int remainingInBatch = readOffset;
+        int startOffset = 0;
+        while (remainingInBatch > 0) {
+            if (remainingCountInPage == 0) {
+                if (!readNextPage()) {
+                    break;
+                }
+            }
+
+            int chunkSize = min(remainingCountInPage, remainingInBatch);
+            int skipSize = chunkSize;
+            if (!columnDescriptor.isRequired()) {
+                boolean[] isNull = new boolean[readOffset];
+                int nonNullCount = definitionLevelDecoder.readNext(isNull, startOffset, chunkSize);
+                skipSize = nonNullCount;
+                startOffset += chunkSize;
+            }
+            valuesDecoder.skip(skipSize);
+            remainingInBatch -= chunkSize;
+            remainingCountInPage -= chunkSize;
+        }
+    }
+}
+

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
@@ -23,6 +23,7 @@ import com.facebook.presto.parquet.batchreader.decoders.delta.BinaryLongDecimalD
 import com.facebook.presto.parquet.batchreader.decoders.delta.BinaryShortDecimalDeltaValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.delta.FixedLenByteArrayLongDecimalDeltaValueDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.delta.FixedLenByteArrayShortDecimalDeltaValueDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.delta.FixedLenByteArrayUuidDeltaValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.delta.Int32DeltaBinaryPackedValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.delta.Int32ShortDecimalDeltaValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.delta.Int64DeltaBinaryPackedValuesDecoder;
@@ -34,6 +35,7 @@ import com.facebook.presto.parquet.batchreader.decoders.plain.BinaryShortDecimal
 import com.facebook.presto.parquet.batchreader.decoders.plain.BooleanPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.FixedLenByteArrayLongDecimalPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.FixedLenByteArrayShortDecimalPlainValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.plain.FixedLenByteArrayUuidPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int32PlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int32ShortDecimalPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int64PlainValuesDecoder;
@@ -49,6 +51,7 @@ import com.facebook.presto.parquet.batchreader.decoders.rle.Int64TimeAndTimestam
 import com.facebook.presto.parquet.batchreader.decoders.rle.LongDecimalRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.ShortDecimalRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.TimestampRLEDictionaryValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.rle.UuidRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.dictionary.BinaryBatchDictionary;
 import com.facebook.presto.parquet.batchreader.dictionary.TimestampDictionary;
 import com.facebook.presto.parquet.dictionary.Dictionary;
@@ -81,6 +84,7 @@ import static com.facebook.presto.parquet.ParquetTypeUtils.isDecimalType;
 import static com.facebook.presto.parquet.ParquetTypeUtils.isShortDecimalType;
 import static com.facebook.presto.parquet.ParquetTypeUtils.isTimeMicrosType;
 import static com.facebook.presto.parquet.ParquetTypeUtils.isTimeStampMicrosType;
+import static com.facebook.presto.parquet.ParquetTypeUtils.isUuidType;
 import static com.facebook.presto.parquet.ValuesType.VALUES;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
@@ -153,6 +157,10 @@ public class Decoders
                         int typeLength = columnDescriptor.getPrimitiveType().getTypeLength();
                         return new FixedLenByteArrayLongDecimalPlainValuesDecoder(typeLength, buffer, offset, length);
                     }
+                    else if (isUuidType(columnDescriptor)) {
+                        int typeLength = columnDescriptor.getPrimitiveType().getTypeLength();
+                        return new FixedLenByteArrayUuidPlainValuesDecoder(typeLength, buffer, offset, length);
+                    }
                 default:
                     throw new PrestoException(PARQUET_UNSUPPORTED_COLUMN_TYPE, format("Column: %s, Encoding: %s", columnDescriptor, encoding));
             }
@@ -198,6 +206,9 @@ public class Decoders
                             return new ShortDecimalRLEDictionaryValuesDecoder(bitWidth, inputStream, (BinaryBatchDictionary) dictionary);
                         }
                         return new LongDecimalRLEDictionaryValuesDecoder(bitWidth, inputStream, (BinaryBatchDictionary) dictionary);
+                    }
+                    else if (isUuidType(columnDescriptor)) {
+                        return new UuidRLEDictionaryValuesDecoder(bitWidth, inputStream, (BinaryBatchDictionary) dictionary);
                     }
                 default:
                     throw new PrestoException(PARQUET_UNSUPPORTED_COLUMN_TYPE, format("Column: %s, Encoding: %s", columnDescriptor, encoding));
@@ -255,6 +266,11 @@ public class Decoders
                 }
 
                 return new FixedLenByteArrayLongDecimalDeltaValueDecoder(parquetReader);
+            }
+            else if (isUuidType(columnDescriptor)) {
+                ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ByteBuffer.wrap(buffer, offset, length));
+                ValuesReader parquetReader = getParquetReader(encoding, columnDescriptor, valueCount, inputStream);
+                return new FixedLenByteArrayUuidDeltaValuesDecoder(parquetReader);
             }
         }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/ValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/ValuesDecoder.java
@@ -102,5 +102,15 @@ public interface ValuesDecoder
                 throws IOException;
     }
 
+    interface UuidValuesDecoder
+            extends ValuesDecoder
+    {
+        void readNext(long[] values, int offset, int length)
+                throws IOException;
+
+        void skip(int length)
+                throws IOException;
+    }
+
     public long getRetainedSizeInBytes();
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/delta/FixedLenByteArrayUuidDeltaValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/delta/FixedLenByteArrayUuidDeltaValuesDecoder.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.batchreader.decoders.delta;
+
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.UuidValuesDecoder;
+import org.apache.parquet.column.values.ValuesReader;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.facebook.presto.parquet.batchreader.BytesUtils.getLongBigEndian;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Note: this is not an optimized values decoder. It makes use of the existing Parquet decoder. Given that this type encoding
+ * is not a common one, just use the existing one provided by Parquet library and add a wrapper around it that satisfies the
+ * {@link UuidValuesDecoder} interface.
+ */
+public class FixedLenByteArrayUuidDeltaValuesDecoder
+        implements UuidValuesDecoder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(FixedLenByteArrayUuidDeltaValuesDecoder.class).instanceSize();
+
+    private final ValuesReader delegate;
+
+    public FixedLenByteArrayUuidDeltaValuesDecoder(ValuesReader delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public void readNext(long[] values, int offset, int length)
+    {
+        int endOffset = (offset + length) * 2;
+        for (int currentOutputOffset = offset * 2; currentOutputOffset < endOffset; currentOutputOffset += 2) {
+            byte[] inputBytes = delegate.readBytes().getBytes();
+            values[currentOutputOffset] = getLongBigEndian(inputBytes, 0);
+            values[currentOutputOffset + 1] = getLongBigEndian(inputBytes, Long.BYTES);
+        }
+    }
+
+    @Override
+    public void skip(int length)
+    {
+        delegate.skip(length);
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/FixedLenByteArrayUuidPlainValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/FixedLenByteArrayUuidPlainValuesDecoder.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.batchreader.decoders.plain;
+
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.UuidValuesDecoder;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.nio.ByteOrder.BIG_ENDIAN;
+
+public class FixedLenByteArrayUuidPlainValuesDecoder
+        implements UuidValuesDecoder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(FixedLenByteArrayUuidPlainValuesDecoder.class).instanceSize();
+
+    private final int typeLength;
+    private final int bufferEnd;
+    private final ByteBuffer buffer;
+
+    public FixedLenByteArrayUuidPlainValuesDecoder(int typeLength, byte[] buffer, int baseOffset, int length)
+    {
+        checkArgument(typeLength == 16, "typeLength %s should be 16 for a UUID", typeLength);
+        this.typeLength = typeLength;
+        this.buffer = ByteBuffer.wrap(buffer).order(BIG_ENDIAN);
+        this.buffer.position(baseOffset);
+        this.bufferEnd = baseOffset + length;
+    }
+
+    /**
+     * @param values array containing decoded values
+     * @param offset offset to start writing in the values argument
+     * @param length number of values to write
+     */
+    @Override
+    public void readNext(long[] values, int offset, int length)
+    {
+        int readEndOffset = (offset + length) * 2;
+
+        for (int currentOutputOffset = offset * 2; currentOutputOffset < readEndOffset; currentOutputOffset += 2) {
+            values[currentOutputOffset] = buffer.getLong();
+            values[currentOutputOffset + 1] = buffer.getLong();
+        }
+    }
+
+    @Override
+    public void skip(int length)
+    {
+        checkArgument(buffer.position() + (length * typeLength) <= bufferEnd, "End of stream: invalid read request");
+        checkArgument(length >= 0, "invalid length %s", length);
+        buffer.position(buffer.position() + (length * typeLength));
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(buffer.array());
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/UuidRLEDictionaryValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/UuidRLEDictionaryValuesDecoder.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.batchreader.decoders.rle;
+
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.BinaryValuesDecoder.ValueBuffer;
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.UuidValuesDecoder;
+import com.facebook.presto.parquet.batchreader.dictionary.BinaryBatchDictionary;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.facebook.presto.parquet.batchreader.BytesUtils.getLongBigEndian;
+import static java.util.Objects.requireNonNull;
+
+public class UuidRLEDictionaryValuesDecoder
+        extends BaseRLEBitPackedDecoder
+        implements UuidValuesDecoder
+{
+    private final BinaryRLEDictionaryValuesDecoder delegate;
+
+    public UuidRLEDictionaryValuesDecoder(int bitWidth, InputStream inputStream, BinaryBatchDictionary dictionary)
+    {
+        super(Integer.MAX_VALUE, bitWidth, inputStream);
+        requireNonNull(dictionary, "dictionary is null");
+        delegate = new BinaryRLEDictionaryValuesDecoder(bitWidth, inputStream, dictionary);
+    }
+
+    @Override
+    public void readNext(long[] values, int offset, int length)
+            throws IOException
+    {
+        ValueBuffer valueBuffer = delegate.readNext(length);
+        int bufferSize = valueBuffer.getBufferSize();
+        byte[] byteBuffer = new byte[bufferSize];
+        int[] offsets = new int[length + 1];
+        delegate.readIntoBuffer(byteBuffer, 0, offsets, 0, valueBuffer);
+
+        for (int i = 0; i < length; i++) {
+            int positionOffset = offsets[i];
+            values[(i + offset) * 2] = getLongBigEndian(byteBuffer, positionOffset);
+            values[((i + offset) * 2) + 1] = getLongBigEndian(byteBuffer, positionOffset + Long.BYTES);
+        }
+    }
+
+    @Override
+    public void skip(int length)
+            throws IOException
+    {
+        delegate.skip(length);
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
@@ -373,14 +373,15 @@ public final class MetadataReader
                 }
                 typeBuilder = primitiveBuilder;
             }
-            if (element.isSetConverted_type()) {
+
+            if (element.isSetLogicalType()) {
+                getLogicalTypeAnnotationWithParameters(element.getLogicalType())
+                        .ifPresent(typeBuilder::as);
+            }
+            else if (element.isSetConverted_type()) {
                 typeBuilder.as(getOriginalType(element.converted_type));
             }
-            if (element.isSetLogicalType()) {
-                LogicalType type = element.getLogicalType();
-                Optional<LogicalTypeAnnotation> annotationWithParams = getLogicalTypeAnnotationWithParameters(type);
-                annotationWithParams.ifPresent(typeBuilder::as);
-            }
+
             if (element.isSetField_id()) {
                 typeBuilder.id(element.field_id);
             }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetSchemaConverter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetSchemaConverter.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.UuidType;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.PrestoException;
@@ -144,6 +145,13 @@ public class ParquetSchemaConverter
         }
         if (type instanceof VarcharType || type instanceof CharType || type instanceof VarbinaryType) {
             return Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition).named(name);
+        }
+        if (type instanceof UuidType) {
+            LogicalTypeAnnotation logicalTypeAnnotation = LogicalTypeAnnotation.uuidType();
+            Types.PrimitiveBuilder<PrimitiveType> builder = Types.primitive(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, repetition)
+                    .length(16);
+            builder = builder.as(logicalTypeAnnotation);
+            return builder.named(name);
         }
         throw new PrestoException(NOT_SUPPORTED, format("Unsupported primitive type: %s", type));
     }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriters.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriters.java
@@ -29,6 +29,7 @@ import com.facebook.presto.parquet.writer.valuewriter.PrimitiveValueWriter;
 import com.facebook.presto.parquet.writer.valuewriter.RealValueWriter;
 import com.facebook.presto.parquet.writer.valuewriter.TimeValueWriter;
 import com.facebook.presto.parquet.writer.valuewriter.TimestampValueWriter;
+import com.facebook.presto.parquet.writer.valuewriter.UuidValuesWriter;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
 import org.apache.parquet.column.ColumnDescriptor;
@@ -57,6 +58,7 @@ import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimeType.TIME;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.UuidType.UUID;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -211,6 +213,9 @@ class ParquetWriters
         }
         if (TIME.equals(type)) {
             return new TimeValueWriter(valuesWriter, type, parquetType);
+        }
+        if (UUID.equals(type)) {
+            return new UuidValuesWriter(valuesWriter, parquetType);
         }
         if (type instanceof VarcharType || type instanceof CharType || type instanceof VarbinaryType) {
             return new CharValueWriter(valuesWriter, type, parquetType);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/UuidValuesWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/UuidValuesWriter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.writer.valuewriter;
+
+import com.facebook.presto.common.block.Block;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.PrimitiveType;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+
+@NotThreadSafe
+public class UuidValuesWriter
+        extends PrimitiveValueWriter
+{
+    private final ByteBuffer writeBuffer = ByteBuffer.allocate(2 * SIZE_OF_LONG)
+            .order(ByteOrder.BIG_ENDIAN);
+
+    public UuidValuesWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
+    {
+        super(parquetType, valuesWriter);
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (!block.isNull(i)) {
+                writeBuffer.clear();
+                writeBuffer.putLong(block.getLong(i, 0));
+                writeBuffer.putLong(block.getLong(i, SIZE_OF_LONG));
+                writeBuffer.flip();
+                Binary data = Binary.fromReusedByteBuffer(writeBuffer);
+                getValueWriter().writeBytes(data);
+                getStatistics().updateStats(data);
+            }
+        }
+    }
+}

--- a/presto-parquet/src/main/resources/freemarker/data/ParquetTypes.tdd
+++ b/presto-parquet/src/main/resources/freemarker/data/ParquetTypes.tdd
@@ -36,5 +36,11 @@
             valuesDecoder: "LongDecimalValuesDecoder",
             primitiveType: "long"
         },
+        {
+            classNamePrefix: "Uuid",
+            blockType: "Int128ArrayBlock",
+            valuesDecoder: "UuidValuesDecoder",
+            primitiveType: "long"
+        },
     ]
 }

--- a/presto-parquet/src/main/resources/freemarker/templates/ParquetFlatColumnReaderGenerator.tdd
+++ b/presto-parquet/src/main/resources/freemarker/templates/ParquetFlatColumnReaderGenerator.tdd
@@ -4,7 +4,7 @@
 <#assign updatedTemplate = updatedTemplate?replace("com.facebook.presto.common.block.IntArrayBlock", "com.facebook.presto.common.block.${type.blockType}")>
 <#assign updatedTemplate = updatedTemplate?replace("IntArrayBlock", "${type.blockType}")>
 <#assign updatedTemplate = updatedTemplate?replace("Int32ValuesDecoder", "${type.valuesDecoder}")>
-<#if !type.classNamePrefix?starts_with("LongDecimal")>
+<#if !type.classNamePrefix?starts_with("LongDecimal") && !type.classNamePrefix?starts_with("Uuid")>
 <#assign updatedTemplate = updatedTemplate?replace("int[] values = new int[nextBatchSize]", "${type.primitiveType}[] values = new ${type.primitiveType}[nextBatchSize]")>
 <#else>
 <#assign updatedTemplate = updatedTemplate?replace("int[] values = new int[nextBatchSize]", "${type.primitiveType}[] values = new ${type.primitiveType}[nextBatchSize * 2]")>

--- a/presto-parquet/src/main/resources/freemarker/templates/ParquetNestedColumnReaderGenerator.tdd
+++ b/presto-parquet/src/main/resources/freemarker/templates/ParquetNestedColumnReaderGenerator.tdd
@@ -1,5 +1,5 @@
 <#list parquetTypes.flatTypes as type>
-<#if !type.classNamePrefix?ends_with("Decimal")>
+<#if !type.classNamePrefix?ends_with("Decimal") && !type.classNamePrefix?starts_with("Uuid")>
 <@pp.changeOutputFile name="/com/facebook/presto/parquet/batchreader/${type.classNamePrefix}NestedBatchReader.java" />
 <#assign updatedTemplate = nestedTypeTemplate?replace("Int32NestedBatchReader", "${type.classNamePrefix}NestedBatchReader")>
 <#assign updatedTemplate = updatedTemplate?replace("com.facebook.presto.common.block.IntArrayBlock", "com.facebook.presto.common.block.${type.blockType}")>

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/batchreader/decoders/TestParquetUtils.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/batchreader/decoders/TestParquetUtils.java
@@ -144,6 +144,16 @@ public class TestParquetUtils
                 }
                 break;
             }
+            case 128:
+                for (int i = 0; i < valueCount; i++) {
+                    long value = random.nextLong();
+                    writer.writeLong(value);
+                    addedValues.add(value);
+                    value = random.nextLong();
+                    writer.writeLong(value);
+                    addedValues.add(value);
+                }
+                break;
             default:
                 throw new IllegalArgumentException("invalid value size (expected: 4, 8 or 12)");
         }

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/AbstractColumnReaderBenchmark.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/AbstractColumnReaderBenchmark.java
@@ -85,7 +85,7 @@ public abstract class AbstractColumnReaderBenchmark<T>
     @Param({
             "true", "false",
     })
-    public boolean enableOptimizedReader;
+    public boolean batchReaderEnabled;
 
     protected abstract PrimitiveField createPrimitiveField();
 
@@ -95,7 +95,7 @@ public abstract class AbstractColumnReaderBenchmark<T>
 
     protected abstract void writeValue(ValuesWriter writer, T batch, int index);
 
-    protected abstract boolean getEnableOptimizedReader();
+    protected abstract boolean getBatchReaderEnabled();
 
     @Setup
     public void setup()
@@ -126,7 +126,7 @@ public abstract class AbstractColumnReaderBenchmark<T>
     public int read()
             throws IOException
     {
-        ColumnReader columnReader = ColumnReaderFactory.createReader(field.getDescriptor(), getEnableOptimizedReader());
+        ColumnReader columnReader = ColumnReaderFactory.createReader(field.getDescriptor(), getBatchReaderEnabled());
         columnReader.init(new PageReader(UNCOMPRESSED, new LinkedList<>(dataPages).listIterator(), MAX_VALUES, null, null, Optional.empty(), null, -1, -1), field, null);
 
         ColumnReader reader = null;

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkLongDecimalColumnReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkLongDecimalColumnReader.java
@@ -79,9 +79,9 @@ public class BenchmarkLongDecimalColumnReader
     }
 
     @Override
-    protected boolean getEnableOptimizedReader()
+    protected boolean getBatchReaderEnabled()
     {
-        return enableOptimizedReader;
+        return batchReaderEnabled;
     }
 
     @Override

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkShortDecimalColumnReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkShortDecimalColumnReader.java
@@ -78,9 +78,9 @@ public class BenchmarkShortDecimalColumnReader
     }
 
     @Override
-    protected boolean getEnableOptimizedReader()
+    protected boolean getBatchReaderEnabled()
     {
-        return enableOptimizedReader;
+        return batchReaderEnabled;
     }
 
     @Override

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkUuidColumnReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkUuidColumnReader.java
@@ -79,9 +79,9 @@ public class BenchmarkUuidColumnReader
     }
 
     @Override
-    protected boolean getEnableOptimizedReader()
+    protected boolean getBatchReaderEnabled()
     {
-        return enableOptimizedReader;
+        return batchReaderEnabled;
     }
 
     @Override

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkUuidColumnReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkUuidColumnReader.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import com.facebook.presto.common.type.UuidType;
+import com.facebook.presto.parquet.PrimitiveField;
+import com.facebook.presto.parquet.RichColumnDescriptor;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
+import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+
+import java.util.Random;
+
+import static com.facebook.presto.parquet.reader.TestData.randomBigInteger;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+
+public class BenchmarkUuidColumnReader
+        extends AbstractColumnReaderBenchmark<long[]>
+{
+    private static final int LENGTH = 2 * SIZE_OF_LONG;
+
+    private static final Random random = new Random(1);
+
+    @Override
+    protected PrimitiveField createPrimitiveField()
+    {
+        PrimitiveType parquetType = Types.optional(FIXED_LEN_BYTE_ARRAY)
+                .length(LENGTH)
+                .as(LogicalTypeAnnotation.uuidType())
+                .named("name");
+
+        return new PrimitiveField(
+                UuidType.UUID,
+                -1,
+                -1,
+                true,
+                new RichColumnDescriptor(new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0), parquetType),
+                0);
+    }
+
+    @Override
+    protected ValuesWriter createValuesWriter(int bufferSize)
+    {
+        switch (parquetEncoding) {
+            case PLAIN:
+                return new FixedLenByteArrayPlainValuesWriter(LENGTH, bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+            case DELTA_BYTE_ARRAY:
+                return new DeltaByteArrayWriter(bufferSize, bufferSize, HeapByteBufferAllocator.getInstance());
+            default:
+                throw new RuntimeException("Cannot parse parquetEncoding:" + parquetEncoding);
+        }
+    }
+
+    @Override
+    protected void writeValue(ValuesWriter writer, long[] batch, int index)
+    {
+        Slice slice = Slices.wrappedLongArray(batch, index * 2, 2);
+        writer.writeBytes(Binary.fromConstantByteArray(slice.getBytes()));
+    }
+
+    @Override
+    protected boolean getEnableOptimizedReader()
+    {
+        return enableOptimizedReader;
+    }
+
+    @Override
+    protected long[] generateDataBatch(int size)
+    {
+        long[] batch = new long[size * 2];
+        for (int i = 0; i < size; i++) {
+            Slice slice = randomBigInteger(random);
+            batch[i * 2] = slice.getLong(0);
+            batch[(i * 2) + 1] = slice.getLong(SIZE_OF_LONG);
+        }
+        return batch;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        run(BenchmarkUuidColumnReader.class);
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/writer/TestParquetWriter.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/writer/TestParquetWriter.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.UuidType.UUID;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.io.Files.createTempDir;
@@ -127,6 +128,7 @@ public class TestParquetWriter
                 {DATE, LogicalTypeAnnotation.DateLogicalTypeAnnotation.class, "INT32"},
                 {TIMESTAMP, LogicalTypeAnnotation.TimestampLogicalTypeAnnotation.class, "INT64"},
                 {MAP, LogicalTypeAnnotation.MapLogicalTypeAnnotation.class, null},
+                {UUID, LogicalTypeAnnotation.UUIDLogicalTypeAnnotation.class, "FIXED_LEN_BYTE_ARRAY"},
                 {ROW, null, null}
         };
     }


### PR DESCRIPTION
## Description

This PR adds support for reading and writing UUIDs on Iceberg tables with all available catalogs. In order to support this we also needed improvements to the parquet reader and writer for [Parquet's UUID logical type](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#uuid).

## Motivation and Context

Presto has type support for UUIDs. We should support reading and writing them in some of the connectors.

## Impact

- Iceberg tables can now be created with UUID types.

## Test Plan

-  Basic tests inside of the Iceberg module for round-trip UUID reading and writing.
- Additional tests in the parquet module for reading and writing UUID values

I also added a benchmark for reading and writing UUID types and compared it to our current LongDecimal benchmark to see the performance difference for another type which uses `FIXED_LENGTH_BYTE_ARRAY` as the underlying physical type.

These were the microbenchmarks from my local machine on ARM using a build of Corretto JDK11 and with reader verification disabled

```
Benchmark                       (batchReaderEnabled)  (parquetEncoding)   Mode  Cnt    Score   Error  Units
BenchmarkUuidColumnReader.read                  true              PLAIN  thrpt   20  265.542 ± 3.891  ops/s
BenchmarkUuidColumnReader.read                  true   DELTA_BYTE_ARRAY  thrpt   20   35.511 ± 0.598  ops/s
BenchmarkUuidColumnReader.read                 false              PLAIN  thrpt   20   27.316 ± 1.222  ops/s
BenchmarkUuidColumnReader.read                 false   DELTA_BYTE_ARRAY  thrpt   20   20.883 ± 0.521  ops/s


Benchmark                              (enableOptimizedReader)  (parquetEncoding)   Mode  Cnt   Score   Error  Units
BenchmarkLongDecimalColumnReader.read                     true              PLAIN  thrpt   20  10.926 ± 0.178  ops/s
BenchmarkLongDecimalColumnReader.read                     true   DELTA_BYTE_ARRAY  thrpt   20   8.948 ± 0.180  ops/s
BenchmarkLongDecimalColumnReader.read                    false              PLAIN  thrpt   20   8.632 ± 0.129  ops/s
BenchmarkLongDecimalColumnReader.read                    false   DELTA_BYTE_ARRAY  thrpt   20   7.771 ± 0.066  ops/s
```


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add UUID type support to the Parquet reader and writer. :pr:`23627`

Iceberg Connector Changes
* Add support of UUID-typed columns :pr:`23627`
```


