### PR TITLE
[native] Reduce stuck drivers threshold to detach worker.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -469,10 +469,13 @@ void PeriodicTaskManager::addWatchdogTask() {
         }
         RECORD_METRIC_VALUE(kCounterNumStuckDrivers, stuckOpCalls.size());
 
-        // Detach worker from the cluster if more than half of driver threads
-        // are blocked by stuck operators (one unique operator can only get
-        // stuck on one unique thread).
-        if (stuckOpCalls.size() > numDriverThreads_ / 2) {
+        // Detach worker from the cluster if more than a certain number of
+        // driver threads are blocked by stuck operators (one unique operator
+        // can only get stuck on one unique thread).
+        const auto numStuckOperatorsToDetachWorker = std::min(
+            SystemConfig::instance()->driverNumStuckOperatorsToDetachWorker(),
+            numDriverThreads_);
+        if (stuckOpCalls.size() >= numStuckOperatorsToDetachWorker) {
           detachWorker("detected stuck operators");
         } else if (!deadlockTasks.empty()) {
           detachWorker("starving or deadlocked task");

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -159,6 +159,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kDriverStuckOperatorThresholdMs, 30 * 60 * 1000),
           NUM_PROP(
               kDriverCancelTasksWithStuckOperatorsThresholdMs, 40 * 60 * 1000),
+          NUM_PROP(kDriverNumStuckOperatorsToDetachWorker, 8),
           NUM_PROP(kSpillerNumCpuThreadsHwMultiplier, 1.0),
           STR_PROP(kSpillerFileCreateConfig, ""),
           NONE_PROP(kSpillerSpillPath),
@@ -382,6 +383,11 @@ size_t SystemConfig::driverStuckOperatorThresholdMs() const {
 size_t SystemConfig::driverCancelTasksWithStuckOperatorsThresholdMs() const {
   return optionalProperty<size_t>(
              kDriverCancelTasksWithStuckOperatorsThresholdMs)
+      .value();
+}
+
+size_t SystemConfig::driverNumStuckOperatorsToDetachWorker() const {
+  return optionalProperty<size_t>(kDriverNumStuckOperatorsToDetachWorker)
       .value();
 }
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -242,6 +242,12 @@ class SystemConfig : public ConfigBase {
       kDriverCancelTasksWithStuckOperatorsThresholdMs{
           "driver.cancel-tasks-with-stuck-operators-threshold-ms"};
 
+  /// The number of stuck operators (effectively stuck driver threads) when we
+  /// detach the worker from the cluster in an attempt to keep the cluster
+  /// operational.
+  static constexpr std::string_view kDriverNumStuckOperatorsToDetachWorker{
+      "driver.num-stuck-operators-to-detach-worker"};
+
   /// Floating point number used in calculating how many threads we would use
   /// for Spiller CPU executor: hw_concurrency x multiplier.
   /// If 0.0 then spilling is disabled.
@@ -713,6 +719,8 @@ class SystemConfig : public ConfigBase {
   size_t driverStuckOperatorThresholdMs() const;
 
   size_t driverCancelTasksWithStuckOperatorsThresholdMs() const;
+
+  size_t driverNumStuckOperatorsToDetachWorker() const;
 
   double spillerNumCpuThreadsHwMultiplier() const;
 


### PR DESCRIPTION
## Description
In Prestissimo we detect stuck operators (drivers) and when it reaches a certain number we detach the worker from the cluster (announce to the coordinator that it is unavailable for new queries). This is in attempt to keep the cluster running even if few workers are in trouble.
Initially it was just one stuck driver and we saw that in some loads the cluster losing most of the workers.
Then we changed it to the half of the available driver threads and now we are seeing that the queries start queueing up on the coordinator before we reach that threshold on any worker.
This change is to use the driver thread HW multiplier for that threshold. While this will not fix the problem in all cases, it should make it better.
We are also thinking/planning to roll out the change to fail Tasks when stuck drivers are detected for some time to free slots for new queries. But that would be another change.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

