### PR TITLE
[native] Add ability to cancel Tasks with stuck Drivers.

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -157,6 +157,8 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kDriverNumCpuThreadsHwMultiplier, 4.0),
           BOOL_PROP(kDriverThreadsBatchSchedulingEnabled, false),
           NUM_PROP(kDriverStuckOperatorThresholdMs, 30 * 60 * 1000),
+          NUM_PROP(
+              kDriverCancelTasksWithStuckOperatorsThresholdMs, 40 * 60 * 1000),
           NUM_PROP(kSpillerNumCpuThreadsHwMultiplier, 1.0),
           STR_PROP(kSpillerFileCreateConfig, ""),
           NONE_PROP(kSpillerSpillPath),
@@ -375,6 +377,12 @@ bool SystemConfig::driverThreadsBatchSchedulingEnabled() const {
 
 size_t SystemConfig::driverStuckOperatorThresholdMs() const {
   return optionalProperty<size_t>(kDriverStuckOperatorThresholdMs).value();
+}
+
+size_t SystemConfig::driverCancelTasksWithStuckOperatorsThresholdMs() const {
+  return optionalProperty<size_t>(
+             kDriverCancelTasksWithStuckOperatorsThresholdMs)
+      .value();
 }
 
 double SystemConfig::spillerNumCpuThreadsHwMultiplier() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -235,6 +235,13 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kDriverStuckOperatorThresholdMs{
       "driver.stuck-operator-threshold-ms"};
 
+  /// Immediately cancels any Task when it is detected that it has at least one
+  /// stuck Operator for at least the time specified by this threshold.
+  /// Use zero to disable canceling.
+  static constexpr std::string_view
+      kDriverCancelTasksWithStuckOperatorsThresholdMs{
+          "driver.cancel-tasks-with-stuck-operators-threshold-ms"};
+
   /// Floating point number used in calculating how many threads we would use
   /// for Spiller CPU executor: hw_concurrency x multiplier.
   /// If 0.0 then spilling is disabled.
@@ -704,6 +711,8 @@ class SystemConfig : public ConfigBase {
   bool driverThreadsBatchSchedulingEnabled() const;
 
   size_t driverStuckOperatorThresholdMs() const;
+
+  size_t driverCancelTasksWithStuckOperatorsThresholdMs() const;
 
   double spillerNumCpuThreadsHwMultiplier() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -44,6 +44,8 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(kCounterNumZombiePrestoTasks, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterNumTasksWithStuckOperator, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterNumCancelledTasksByStuckDriver, facebook::velox::StatType::COUNT);
   DEFINE_METRIC(kCounterNumTasksDeadlock, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterNumTaskManagerLockTimeOut, facebook::velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -67,6 +67,8 @@ constexpr folly::StringPiece kCounterNumZombiePrestoTasks{
     "presto_cpp.num_zombie_presto_tasks"};
 constexpr folly::StringPiece kCounterNumTasksWithStuckOperator{
     "presto_cpp.num_tasks_with_stuck_operator"};
+constexpr folly::StringPiece kCounterNumCancelledTasksByStuckDriver{
+    "presto_cpp.num_cancelled_tasks_by_stuck_driver"};
 constexpr folly::StringPiece kCounterNumTasksDeadlock{
     "presto_cpp.num_tasks_deadlock"};
 constexpr folly::StringPiece kCounterNumTaskManagerLockTimeOut{


### PR DESCRIPTION
## Description
In Prestissimo we detect stuck operators (drivers) for each Task.
This change makes it so that the Task is cancelled after one of its Driver has been stuck for a certain time.
This is to free space for other queries in the cluster.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

