### PR TITLE
Set splitsize for hadoop InputFormat to Presto max_split_size

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCustomInputSplits.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCustomInputSplits.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.google.common.io.Resources;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.HadoopExtendedFileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.TextInputFormat;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@Test(singleThreaded = true)
+public class TestCustomInputSplits
+{
+    private static final String SPLIT_MINSIZE = "mapreduce.input.fileinputformat.split.minsize";
+    private static final String LOCAL_BLOCK_SIZE = "fs.local.block.size";
+    private static final String DFS_BLOCK_SIZE = "dfs.blocksize";
+
+    @Test
+    public void testCustomSplitSize() throws Exception
+    {
+        long splitSize = 1000;
+        long blockSize = 500;
+        String filePath = Resources.getResource("addressbook.parquet").getFile();
+        Path path = new Path(filePath);
+
+        TextInputFormat targetInputFormat = new DummyTextInputFormat();
+        JobConf jobConf = new JobConf();
+        FileInputFormat.setInputPaths(jobConf, path);
+
+        jobConf.set("fs.defaultFS", "file:///");
+        jobConf.setClass("fs.file.impl", TestingFileSystem.class, FileSystem.class);
+        jobConf.setClass("fs.hdfs.impl", TestingFileSystem.class, FileSystem.class);
+        jobConf.setBoolean("fs.file.impl.disable.cache", true);
+        jobConf.setLong(LOCAL_BLOCK_SIZE, blockSize);
+        jobConf.setLong(DFS_BLOCK_SIZE, blockSize);
+        jobConf.set(SPLIT_MINSIZE, Long.toString(splitSize));
+
+        InputSplit[] targetSplits = targetInputFormat.getSplits(jobConf, 0);
+
+        assertNotNull(targetSplits);
+        assertEquals(targetSplits.length, 4);
+    }
+
+    public class DummyTextInputFormat
+            extends TextInputFormat
+    {
+        protected boolean isSplitable(FileSystem fs, Path file)
+        {
+            return true;
+        }
+    }
+
+    public static class TestingFileSystem
+            extends HadoopExtendedFileSystem
+    {
+        public TestingFileSystem()
+        {
+            super(new LocalFileSystem());
+        }
+    }
+}


### PR DESCRIPTION
## Description
Set splitsize for hadoop InputFormat to Presto max_split_size
Details in https://github.com/prestodb/presto/issues/23608

## Motivation and Context
Make splitsize configurable where hadoop InputForma library is used for split generation.
Resolves https://github.com/prestodb/presto/issues/23608

## Impact
Make splitsize configurable where hadoop InputForma library is used for split generation.
Resolves https://github.com/prestodb/presto/issues/23608

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

