### PR TITLE
[docs] fix formatting in presto-cpp/features.rst

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -274,7 +274,7 @@ It can help identify issues where a malformed vector causes failures or crashes,
 Note: This is an expensive check and should only be used for debugging purposes.
 
 ``native_debug_disable_expression_with_peeling``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``
@@ -294,7 +294,7 @@ If set to ``true``, disables the optimization in expression evaluation to reuse 
 This should only be used for debugging purposes.
 
 ``native_debug_disable_expression_with_memoization``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``
@@ -305,7 +305,7 @@ input batches that are dictionary encoded and have the same alphabet(underlying 
 This should only be used for debugging purposes.
 
 ``native_debug_disable_expression_with_lazy_inputs``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``


### PR DESCRIPTION
## Description
Fix formatting errors in presto-cpp/features.rst that create the following warnings in local doc build: 

```
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/features.rst:277: WARNING: Title underline too short.

``native_debug_disable_expression_with_peeling``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/features.rst:277: WARNING: Title underline too short.

``native_debug_disable_expression_with_peeling``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/features.rst:297: WARNING: Title underline too short.

``native_debug_disable_expression_with_memoization``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/features.rst:297: WARNING: Title underline too short.

``native_debug_disable_expression_with_memoization``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/features.rst:308: WARNING: Title underline too short.

``native_debug_disable_expression_with_lazy_inputs``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/features.rst:308: WARNING: Title underline too short.

``native_debug_disable_expression_with_lazy_inputs``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
``` 

## Motivation and Context
Builds on work in https://github.com/prestodb/presto/pull/23210, https://github.com/prestodb/presto/pull/23090, https://github.com/prestodb/presto/pull/23033, https://github.com/prestodb/presto/pull/22876, and https://github.com/prestodb/presto/pull/22985.

Like the doc build errors I fixed in the other PRs, these errors don't stop the build but they're annoying, and these are easy and low-risk fixes.

## Impact
Reduces warnings in doc builds, making them run faster. 

## Test Plan
Local doc builds. 

Before: 
Six errors above display, and total `build succeeded, 19 warnings`. 

After: The six errors are not displayed, and total `build succeeded, 13 warnings`. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

