### PR TITLE
[native] Add Velox query config selective_nimble_reader_enabled

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -853,6 +853,9 @@ BaseVeloxQueryConfig::BaseVeloxQueryConfig() {
           BOOL_PROP(
               QueryConfig::kPrestoArrayAggIgnoreNulls,
               c.prestoArrayAggIgnoreNulls()),
+          BOOL_PROP(
+              QueryConfig::kSelectiveNimbleReaderEnabled,
+              c.selectiveNimbleReaderEnabled()),
           NUM_PROP(QueryConfig::kMaxOutputBufferSize, c.maxOutputBufferSize()),
       };
 }


### PR DESCRIPTION
This is a temporary query config that helps rollout of selective Nimble reader, and will be removed after it is fully rolled out.