### PR TITLE
misc: Easier scalar func support

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/function/OperatorTranslators.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/function/OperatorTranslators.java
@@ -18,6 +18,9 @@ import com.facebook.presto.plugin.jdbc.optimization.JdbcExpression;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeConstraint;
+import com.facebook.presto.spi.function.TypeConstraints;
+import com.facebook.presto.spi.function.TypeParameterBinding;
 
 import static com.facebook.presto.common.function.OperatorType.ADD;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
@@ -33,29 +36,74 @@ public class OperatorTranslators
     }
 
     @ScalarOperator(ADD)
-    @SqlType(StandardTypes.BIGINT)
-    public static JdbcExpression add(@SqlType(StandardTypes.BIGINT) JdbcExpression left, @SqlType(StandardTypes.BIGINT) JdbcExpression right)
+    @TypeConstraints({
+            @TypeConstraint({
+                    @TypeParameterBinding(parameter = "T", type = StandardTypes.INTEGER),
+                    @TypeParameterBinding(parameter = "U", type = StandardTypes.INTEGER)
+            }),
+            @TypeConstraint({
+                    @TypeParameterBinding(parameter = "T", type = StandardTypes.BIGINT),
+                    @TypeParameterBinding(parameter = "U", type = StandardTypes.INTEGER)
+            }),
+            @TypeConstraint({
+                    @TypeParameterBinding(parameter = "T", type = StandardTypes.BIGINT),
+                    @TypeParameterBinding(parameter = "U", type = StandardTypes.BIGINT)
+            })})
+    @SqlType("T")
+    public static JdbcExpression add(
+            @SqlType("T") JdbcExpression left,
+            @SqlType("U") JdbcExpression right)
     {
         return new JdbcExpression(infixOperation("+", left, right), forwardBindVariables(left, right));
     }
 
     @ScalarOperator(SUBTRACT)
     @SqlType(StandardTypes.BIGINT)
-    public static JdbcExpression subtract(@SqlType(StandardTypes.BIGINT) JdbcExpression left, @SqlType(StandardTypes.BIGINT) JdbcExpression right)
+    public static JdbcExpression subtract(
+            @SqlType(StandardTypes.BIGINT) JdbcExpression left,
+            @SqlType(StandardTypes.BIGINT) JdbcExpression right)
     {
         return new JdbcExpression(infixOperation("-", left, right), forwardBindVariables(left, right));
     }
 
     @ScalarOperator(EQUAL)
+    @TypeConstraints({
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.BIGINT)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.INTEGER)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.SMALLINT)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.TINYINT)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.BOOLEAN)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.DATE)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.DECIMAL)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.REAL)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.DOUBLE)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.VARCHAR)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.TIMESTAMP)})})
     @SqlType(StandardTypes.BOOLEAN)
-    public static JdbcExpression equal(@SqlType(StandardTypes.BIGINT) JdbcExpression left, @SqlType(StandardTypes.BIGINT) JdbcExpression right)
+    public static JdbcExpression equal(
+            @SqlType("T") JdbcExpression left,
+            @SqlType("T") JdbcExpression right)
     {
         return new JdbcExpression(infixOperation("=", left, right), forwardBindVariables(left, right));
     }
 
     @ScalarOperator(NOT_EQUAL)
+    @TypeConstraints({
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.BIGINT)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.INTEGER)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.SMALLINT)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.TINYINT)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.BOOLEAN)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.DATE)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.DECIMAL)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.REAL)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.DOUBLE)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.VARCHAR)}),
+            @TypeConstraint({@TypeParameterBinding(parameter = "T", type = StandardTypes.TIMESTAMP)})})
     @SqlType(StandardTypes.BOOLEAN)
-    public static JdbcExpression notEqual(@SqlType(StandardTypes.BIGINT) JdbcExpression left, @SqlType(StandardTypes.BIGINT) JdbcExpression right)
+    public static JdbcExpression notEqual(
+            @SqlType("T") JdbcExpression left,
+            @SqlType("T") JdbcExpression right)
     {
         return new JdbcExpression(infixOperation("<>", left, right), forwardBindVariables(left, right));
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeConstraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeConstraint.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+public @interface TypeConstraint
+{
+    TypeParameterBinding[] value() default {};
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeConstraints.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeConstraints.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(METHOD)
+public @interface TypeConstraints
+{
+    TypeConstraint[] value() default {};
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeParameterBinding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeParameterBinding.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+public @interface TypeParameterBinding
+{
+    String parameter();
+    String type();
+}


### PR DESCRIPTION
## Description

Fix for issue #23605

Currently in order to add new operator/function mappings a new function needs to be defined for each possible mapping. By introducing some new annotations for functions and handling the case we can re use function definitions with different possible type signatures.

```
== RELEASE NOTES ==
General Changes
* Add SupportedSignatures and SqlSignature annotations. :pr:`23642`
* Update OperatorTranslators and tests to use new annotations. :pr:`23642`
```

