### PR TITLE
Enable set_table_property procedure for Iceberg

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -984,6 +984,31 @@ Examples:
 
     CALL iceberg.system.fast_forward('schema_name', 'table_name', 'branch1', 'main');
 
+Set Table Property
+^^^^^^^^^^^^^^^^^^
+
+Iceberg table property can be set from the catalog using the ``set_table_property`` procedure on the catalog's ``system`` schema.
+
+The following arguments are available:
+
+===================== ========== =============== =======================================================================
+Argument Name         required   type            Description
+===================== ========== =============== =======================================================================
+``schema``            ✔️         string          Schema of the table to update
+
+``table_name``        ✔️         string          Name of the table to update
+
+``key``               ✔️         string          Name of the table property
+
+``value``             ✔️         string          Value for the table property
+===================== ========== =============== =======================================================================
+
+Examples:
+
+* Set table property ``commit.retry.num-retries`` to ``10`` for a Iceberg table ::
+
+    CALL iceberg.system.set_table_property('schema_name', 'table_name', 'commit.retry.num-retries', '10');
+
 SQL Support
 -----------
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -46,6 +46,7 @@ import com.facebook.presto.iceberg.procedure.RemoveOrphanFiles;
 import com.facebook.presto.iceberg.procedure.RollbackToSnapshotProcedure;
 import com.facebook.presto.iceberg.procedure.RollbackToTimestampProcedure;
 import com.facebook.presto.iceberg.procedure.SetCurrentSnapshotProcedure;
+import com.facebook.presto.iceberg.procedure.SetTablePropertyProcedure;
 import com.facebook.presto.iceberg.procedure.UnregisterTableProcedure;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCacheKey;
@@ -165,6 +166,7 @@ public class IcebergCommonModule
         procedures.addBinding().toProvider(RemoveOrphanFiles.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(FastForwardBranchProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(SetCurrentSnapshotProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(SetTablePropertyProcedure.class).in(Scopes.SINGLETON);
 
         // for orc
         binder.bind(EncryptionLibrary.class).annotatedWith(HiveDwrfEncryptionProvider.ForCryptoService.class).to(UnsupportedEncryptionLibrary.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/SetTablePropertyProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/SetTablePropertyProcedure.java
@@ -71,7 +71,7 @@ public class SetTablePropertyProcedure
                 "set_table_property",
                 ImmutableList.of(
                         new Procedure.Argument("schema", VARCHAR),
-                        new Procedure.Argument("table", VARCHAR),
+                        new Procedure.Argument("table_name", VARCHAR),
                         new Procedure.Argument("key", VARCHAR),
                         new Procedure.Argument("value", VARCHAR)),
                 SET_TABLE_PROPERTY.bindTo(this));

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestSetTablePropertyProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestSetTablePropertyProcedure.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.procedure;
+
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestSetTablePropertyProcedure
+        extends AbstractTestQueryFramework
+{
+    public static final String ICEBERG_CATALOG = "test_hadoop";
+    public static final String TEST_SCHEMA = "tpch";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createIcebergQueryRunner(ImmutableMap.of(), HADOOP, ImmutableMap.of());
+    }
+
+    public void createTable(String tableName)
+    {
+        assertUpdate("CREATE TABLE IF NOT EXISTS " + tableName + " (id integer, value VARCHAR)");
+    }
+
+    public void dropTable(String tableName)
+    {
+        assertQuerySucceeds("DROP TABLE IF EXISTS " + TEST_SCHEMA + "." + tableName);
+    }
+
+    @Test
+    public void testSetTablePropertyProcedurePositionalArgs()
+    {
+        String tableName = "table_property_table_test";
+        createTable(tableName);
+        try {
+            String propertyKey = "read.split.target-size";
+            String propertyValue = "268435456";
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a')", 1);
+
+            Table table = loadTable(tableName);
+            table.refresh();
+
+            assertEquals(table.properties().size(), 7);
+            assertEquals(table.properties().get(propertyKey), null);
+
+            assertUpdate(format("CALL system.set_table_property('%s', '%s', '%s', '%s')", TEST_SCHEMA, tableName, propertyKey, propertyValue));
+            table.refresh();
+
+            // now the table property read.split.target-size should have new value
+            assertEquals(table.properties().size(), 8);
+            assertEquals(table.properties().get(propertyKey), propertyValue);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testSetTablePropertyProcedureNamedArgs()
+    {
+        String tableName = "table_property_table_arg_test";
+        createTable(tableName);
+        try {
+            String propertyKey = "read.split.target-size";
+            String propertyValue = "268435456";
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a')", 1);
+
+            Table table = loadTable(tableName);
+            table.refresh();
+
+            assertEquals(table.properties().size(), 7);
+            assertEquals(table.properties().get(propertyKey), null);
+
+            assertUpdate(format("CALL system.set_table_property(schema => '%s', key => '%s', value => '%s', table_name => '%s')",
+                    TEST_SCHEMA, propertyKey, propertyValue, tableName));
+            table.refresh();
+
+            // now the table property read.split.target-size should have new value
+            assertEquals(table.properties().size(), 8);
+            assertEquals(table.properties().get(propertyKey), propertyValue);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testSetTablePropertyProcedureUpdateExisting()
+    {
+        String tableName = "table_property_table_test_update";
+        createTable(tableName);
+        try {
+            String propertyKey = "commit.retry.num-retries";
+            String propertyValue = "10";
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a')", 1);
+
+            Table table = loadTable(tableName);
+            table.refresh();
+
+            assertEquals(table.properties().size(), 7);
+            assertEquals(table.properties().get(propertyKey), "4");
+
+            assertUpdate(format("CALL system.set_table_property('%s', '%s', '%s', '%s')", TEST_SCHEMA, tableName, propertyKey, propertyValue));
+            table.refresh();
+
+            // now the table property commit.retry.num-retries should have new value
+            assertEquals(table.properties().size(), 7);
+            assertEquals(table.properties().get(propertyKey), propertyValue);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testInvalidSetTablePropertyProcedureCases()
+    {
+        assertQueryFails("CALL system.set_table_property('test_table', key => 'key', value => 'value')",
+                "line 1:1: Named and positional arguments cannot be mixed");
+        assertQueryFails("CALL custom.set_table_property('test_table', 'key', 'value')",
+                "Procedure not registered: custom.set_table_property");
+        assertQueryFails("CALL system.set_table_property('schema', 'tablename', 'key')",
+                "line 1:1: Required procedure argument 'value' is missing");
+        assertQueryFails("CALL system.set_table_property('', 'main', 'key')",
+                "line 1:1: Required procedure argument 'value' is missing");
+    }
+
+    private Table loadTable(String tableName)
+    {
+        Catalog catalog = CatalogUtil.loadCatalog(HadoopCatalog.class.getName(), ICEBERG_CATALOG, getProperties(), new Configuration());
+        return catalog.loadTable(TableIdentifier.of(TEST_SCHEMA, tableName));
+    }
+
+    private Map<String, String> getProperties()
+    {
+        File metastoreDir = getCatalogDirectory();
+        return ImmutableMap.of("warehouse", metastoreDir.toString());
+    }
+
+    private File getCatalogDirectory()
+    {
+        Path dataDirectory = getDistributedQueryRunner().getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(dataDirectory, HADOOP.name(), new IcebergConfig().getFileFormat(), false);
+        return catalogDirectory.toFile();
+    }
+}


### PR DESCRIPTION
## Description
Enable `set_table_property` procedure for Iceberg

## Motivation and Context
Enable `set_table_property` procedure for Iceberg

## Impact
New Iceberg procedure to alter default Iceberg table properties

## Test Plan
Added Tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

