### PR TITLE
Reduce size of Presto distribution

### DIFF
--- a/presto-server/src/main/assembly/presto.xml
+++ b/presto-server/src/main/assembly/presto.xml
@@ -89,14 +89,6 @@
             <outputDirectory>plugin/pinot</outputDirectory>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/dependency/presto-example-http-${project.version}</directory>
-            <outputDirectory>plugin/example-http</outputDirectory>
-        </fileSet>
-        <fileSet>
-            <directory>${project.build.directory}/dependency/presto-hana-${project.version}</directory>
-            <outputDirectory>plugin/hana</outputDirectory>
-        </fileSet>
-        <fileSet>
             <directory>${project.build.directory}/dependency/presto-hive-hadoop2-${project.version}</directory>
             <outputDirectory>plugin/hive-hadoop2</outputDirectory>
         </fileSet>
@@ -105,24 +97,12 @@
             <outputDirectory>plugin/memory</outputDirectory>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/dependency/presto-blackhole-${project.version}</directory>
-            <outputDirectory>plugin/blackhole</outputDirectory>
-        </fileSet>
-        <fileSet>
             <directory>${project.build.directory}/dependency/presto-kafka-${project.version}</directory>
             <outputDirectory>plugin/kafka</outputDirectory>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/dependency/presto-kudu-${project.version}</directory>
-            <outputDirectory>plugin/kudu</outputDirectory>
-        </fileSet>
-        <fileSet>
             <directory>${project.build.directory}/dependency/presto-atop-${project.version}</directory>
             <outputDirectory>plugin/atop</outputDirectory>
-        </fileSet>
-        <fileSet>
-            <directory>${project.build.directory}/dependency/presto-ml-${project.version}</directory>
-            <outputDirectory>plugin/ml</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/dependency/presto-mysql-${project.version}</directory>
@@ -165,20 +145,12 @@
             <outputDirectory>plugin/tpcds</outputDirectory>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/dependency/presto-teradata-functions-${project.version}</directory>
-            <outputDirectory>plugin/teradata-functions</outputDirectory>
-        </fileSet>
-        <fileSet>
             <directory>${project.build.directory}/dependency/presto-mongodb-${project.version}</directory>
             <outputDirectory>plugin/mongodb</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/dependency/presto-local-file-${project.version}</directory>
             <outputDirectory>plugin/localfile</outputDirectory>
-        </fileSet>
-        <fileSet>
-            <directory>${project.build.directory}/dependency/presto-accumulo-${project.version}</directory>
-            <outputDirectory>plugin/accumulo</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/dependency/presto-thrift-connector-${project.version}</directory>
@@ -199,10 +171,6 @@
         <fileSet>
             <directory>${project.build.directory}/dependency/presto-iceberg-${project.version}</directory>
             <outputDirectory>plugin/iceberg</outputDirectory>
-        </fileSet>
-        <fileSet>
-            <directory>${project.build.directory}/dependency/presto-hive-function-namespace-${project.version}</directory>
-            <outputDirectory>plugin/hive-function-namespace</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/dependency/presto-delta-${project.version}</directory>


### PR DESCRIPTION
Remove presto-example-http, presto-hana, presto-blackhole, presto-kudu, presto-ml, presto-teradata-functions, presto-accumulo and presto-hive-function-namespace from the default distribution.  Users can add these plugins to their deployments manually if these plugins are desired.

## Description
Presto 0.289 cannot be downloaded due to the size of the distribution.  Remove uncommon plugins from the default distribution (these can always be added manually).

## Motivation and Context
Fix 0.289

## Impact
Certain plugins will now need to be manually included.

## Test Plan
Product tests should be sufficient

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

