### PR TITLE
Add property to enable eager building of plan as part of new native plan checker SPI

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -72,6 +72,17 @@ Number of local parallel table writer threads per worker for partitioned writes.
 set, the number set by ``task_writer_count`` will be used. It is required to be a power
 of two for a Java query engine.
 
+``eager-plan-validation-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+This property enables the eager building and validation of a logical plan.
+When enabled, the logical plan will begin to be built and validated before
+queueing and allocation of cluster resources so that any errors or
+incompatibilities in the query plan will fail quickly and inform the user.
+
 .. _tuning-memory:
 
 Memory Management Properties

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -331,6 +331,7 @@ public final class SystemSessionProperties
     public static final String REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION = "rewrite_expression_with_constant_expression";
     public static final String PRINT_ESTIMATED_STATS_FROM_CACHE = "print_estimated_stats_from_cache";
     public static final String REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT = "remove_cross_join_with_constant_single_row_input";
+    public static final String EAGER_PLAN_VALIDATION_ENABLED = "eager_plan_validation_enabled";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
@@ -2018,6 +2019,11 @@ public final class SystemSessionProperties
                         "If one input of the cross join is a single row with constant value, remove this cross join and replace with a project node",
                         featuresConfig.isRemoveCrossJoinWithSingleConstantRow(),
                         false),
+                booleanProperty(
+                        EAGER_PLAN_VALIDATION_ENABLED,
+                        "Enable eager building and validation of logical plan before queueing",
+                        featuresConfig.isEagerPlanValidationEnabled(),
+                        false),
                 new PropertyMetadata<>(
                         DEFAULT_VIEW_SECURITY_MODE,
                         format("Set default view security mode. Options are: %s",
@@ -3342,6 +3348,11 @@ public final class SystemSessionProperties
     public static boolean isRewriteExpressionWithConstantEnabled(Session session)
     {
         return session.getSystemProperty(REWRITE_EXPRESSION_WITH_CONSTANT_EXPRESSION, Boolean.class);
+    }
+
+    public static boolean isEagerPlanValidationEnabled(Session session)
+    {
+        return session.getSystemProperty(EAGER_PLAN_VALIDATION_ENABLED, Boolean.class);
     }
 
     public static CreateView.Security getDefaultViewSecurityMode(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/execution/EagerPlanValidationExecutionMBean.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/EagerPlanValidationExecutionMBean.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.concurrent.ThreadPoolExecutorMBean;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.inject.Inject;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class EagerPlanValidationExecutionMBean
+{
+    private final ThreadPoolExecutorMBean executorMBean;
+
+    @Inject
+    public EagerPlanValidationExecutionMBean(@ForEagerPlanValidation ExecutorService executor)
+    {
+        this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) executor);
+    }
+
+    @Managed
+    @Nested
+    public ThreadPoolExecutorMBean getExecutor()
+    {
+        return executorMBean;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/ForEagerPlanValidation.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ForEagerPlanValidation.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForEagerPlanValidation
+{
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -594,7 +594,7 @@ public class SqlQueryScheduler
                 .forEach(currentSubPlan -> {
                     Optional<PlanFragment> newPlanFragment = performRuntimeOptimizations(currentSubPlan);
                     if (newPlanFragment.isPresent()) {
-                        planChecker.validatePlanFragment(newPlanFragment.get().getRoot(), session, metadata, warningCollector);
+                        planChecker.validatePlanFragment(newPlanFragment.get(), session, metadata, warningCollector);
                         oldToNewFragment.put(currentSubPlan.getFragment(), newPlanFragment.get());
                     }
                 });

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProviderFactory;
+import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
@@ -48,6 +49,7 @@ import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
 import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
 import com.facebook.presto.sql.analyzer.AnalyzerProviderManager;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.tracing.TracerProviderManager;
 import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManager;
@@ -131,6 +133,7 @@ public class PluginManager
     private final AnalyzerProviderManager analyzerProviderManager;
     private final QueryPreparerProviderManager queryPreparerProviderManager;
     private final NodeStatusNotificationManager nodeStatusNotificationManager;
+    private final PlanCheckerProviderManager planCheckerProviderManager;
 
     @Inject
     public PluginManager(
@@ -152,7 +155,8 @@ public class PluginManager
             ClusterTtlProviderManager clusterTtlProviderManager,
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
             TracerProviderManager tracerProviderManager,
-            NodeStatusNotificationManager nodeStatusNotificationManager)
+            NodeStatusNotificationManager nodeStatusNotificationManager,
+            PlanCheckerProviderManager planCheckerProviderManager)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
@@ -184,6 +188,7 @@ public class PluginManager
         this.analyzerProviderManager = requireNonNull(analyzerProviderManager, "analyzerProviderManager is null");
         this.queryPreparerProviderManager = requireNonNull(queryPreparerProviderManager, "queryPreparerProviderManager is null");
         this.nodeStatusNotificationManager = requireNonNull(nodeStatusNotificationManager, "nodeStatusNotificationManager is null");
+        this.planCheckerProviderManager = requireNonNull(planCheckerProviderManager, "planCheckerProviderManager is null");
     }
 
     public void loadPlugins()
@@ -347,6 +352,11 @@ public class PluginManager
         for (NodeStatusNotificationProviderFactory nodeStatusNotificationProviderFactory : plugin.getNodeStatusNotificationProviderFactory()) {
             log.info("Registering node status notification provider %s", nodeStatusNotificationProviderFactory.getName());
             nodeStatusNotificationManager.addNodeStatusNotificationProviderFactory(nodeStatusNotificationProviderFactory);
+        }
+
+        for (PlanCheckerProviderFactory planCheckerProviderFactory : plugin.getPlanCheckerProviderFactories()) {
+            log.info("Registering plan checker provider factory %s", planCheckerProviderFactory.getName());
+            planCheckerProviderManager.addPlanCheckerProviderFactory(planCheckerProviderFactory);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -47,6 +47,7 @@ import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.server.security.ServerSecurityModule;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.storage.TempStorageModule;
 import com.facebook.presto.tracing.TracerProviderManager;
@@ -177,6 +178,7 @@ public class PrestoServer
             injector.getInstance(TracerProviderManager.class).loadTracerProvider();
             injector.getInstance(NodeStatusNotificationManager.class).loadNodeStatusNotificationProvider();
             injector.getInstance(GracefulShutdownHandler.class).loadNodeStatusNotification();
+            injector.getInstance(PlanCheckerProviderManager.class).loadPlanCheckerProviders();
             startAssociatedProcesses(injector);
 
             injector.getInstance(Announcer.class).start();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -146,6 +146,8 @@ import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.plan.SimplePlanFragment;
+import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.PredicateCompiler;
@@ -200,7 +202,9 @@ import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.Expression;
@@ -625,6 +629,8 @@ public class ServerMainModule
         // plan
         jsonBinder(binder).addKeySerializerBinding(VariableReferenceExpression.class).to(VariableReferenceExpressionSerializer.class);
         jsonBinder(binder).addKeyDeserializerBinding(VariableReferenceExpression.class).to(VariableReferenceExpressionDeserializer.class);
+        jsonCodecBinder(binder).bindJsonCodec(SimplePlanFragment.class);
+        binder.bind(SimplePlanFragmentSerde.class).to(JsonCodecSimplePlanFragmentSerde.class).in(Scopes.SINGLETON);
 
         // history statistics
         configBinder(binder).bindConfig(HistoryBasedOptimizationConfig.class);
@@ -785,6 +791,8 @@ public class ServerMainModule
         //Optional Status Detector
         newOptionalBinder(binder, NodeStatusService.class);
         binder.bind(NodeStatusNotificationManager.class).in(Scopes.SINGLETON);
+
+        binder.bind(PlanCheckerProviderManager.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -74,6 +74,7 @@ import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.testing.ProcedureTester;
 import com.facebook.presto.testing.TestingAccessControlManager;
@@ -173,6 +174,7 @@ public class TestingPrestoServer
     private final boolean nodeSchedulerIncludeCoordinator;
     private final ServerInfoResource serverInfoResource;
     private final ResourceManagerClusterStateProvider clusterStateProvider;
+    private final PlanCheckerProviderManager planCheckerProviderManager;
 
     public static class TestShutdownAction
             implements ShutdownAction
@@ -379,6 +381,7 @@ public class TestingPrestoServer
             statsCalculator = injector.getInstance(StatsCalculator.class);
             eventListenerManager = ((TestingEventListenerManager) injector.getInstance(EventListenerManager.class));
             clusterStateProvider = null;
+            planCheckerProviderManager = injector.getInstance(PlanCheckerProviderManager.class);
         }
         else if (resourceManager) {
             dispatchManager = null;
@@ -390,6 +393,7 @@ public class TestingPrestoServer
             statsCalculator = null;
             eventListenerManager = ((TestingEventListenerManager) injector.getInstance(EventListenerManager.class));
             clusterStateProvider = injector.getInstance(ResourceManagerClusterStateProvider.class);
+            planCheckerProviderManager = null;
         }
         else if (coordinatorSidecar) {
             dispatchManager = null;
@@ -401,6 +405,7 @@ public class TestingPrestoServer
             statsCalculator = null;
             eventListenerManager = null;
             clusterStateProvider = null;
+            planCheckerProviderManager = null;
         }
         else if (catalogServer) {
             dispatchManager = null;
@@ -412,6 +417,7 @@ public class TestingPrestoServer
             statsCalculator = null;
             eventListenerManager = null;
             clusterStateProvider = null;
+            planCheckerProviderManager = null;
         }
         else {
             dispatchManager = null;
@@ -423,6 +429,7 @@ public class TestingPrestoServer
             statsCalculator = null;
             eventListenerManager = null;
             clusterStateProvider = null;
+            planCheckerProviderManager = null;
         }
         localMemoryManager = injector.getInstance(LocalMemoryManager.class);
         nodeManager = injector.getInstance(InternalNodeManager.class);
@@ -660,6 +667,11 @@ public class TestingPrestoServer
         checkState(coordinator, "not a coordinator");
         checkState(clusterMemoryManager instanceof ClusterMemoryManager);
         return (ClusterMemoryManager) clusterMemoryManager;
+    }
+
+    public PlanCheckerProviderManager getPlanCheckerProviderManager()
+    {
+        return planCheckerProviderManager;
     }
 
     public GracefulShutdownHandler getGracefulShutdownHandler()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -296,6 +296,9 @@ public class FeaturesConfig
 
     private boolean isInlineProjectionsOnValuesEnabled;
 
+    private boolean eagerPlanValidationEnabled;
+    private int eagerPlanValidationThreadPoolSize = 20;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2968,5 +2971,31 @@ public class FeaturesConfig
     {
         this.isInlineProjectionsOnValuesEnabled = isInlineProjectionsOnValuesEnabled;
         return this;
+    }
+
+    @Config("eager-plan-validation-enabled")
+    @ConfigDescription("Enable eager building and validation of logical plan before queueing")
+    public FeaturesConfig setEagerPlanValidationEnabled(boolean eagerPlanValidationEnabled)
+    {
+        this.eagerPlanValidationEnabled = eagerPlanValidationEnabled;
+        return this;
+    }
+
+    public boolean isEagerPlanValidationEnabled()
+    {
+        return this.eagerPlanValidationEnabled;
+    }
+
+    @Config("eager-plan-validation-thread-pool-size")
+    @ConfigDescription("Size of thread pool to use when eager plan validation is enabled")
+    public FeaturesConfig setEagerPlanValidationThreadPoolSize(int eagerPlanValidationThreadPoolSize)
+    {
+        this.eagerPlanValidationThreadPoolSize = eagerPlanValidationThreadPoolSize;
+        return this;
+    }
+
+    public int getEagerPlanValidationThreadPoolSize()
+    {
+        return this.eagerPlanValidationThreadPoolSize;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -140,8 +140,6 @@ public abstract class BasePlanFragmenter
                 properties.getPartitionedSources());
 
         Set<VariableReferenceExpression> fragmentVariableTypes = extractOutputVariables(root);
-        planChecker.validatePlanFragment(root, session, metadata, warningCollector);
-
         Set<PlanNodeId> tableWriterNodeIds = PlanFragmenterUtils.getTableWriterNodeIds(root);
         boolean outputTableWriterFragment = tableWriterNodeIds.stream().anyMatch(outputTableWriterNodeIds::contains);
         if (outputTableWriterFragment) {
@@ -163,6 +161,8 @@ public abstract class BasePlanFragmenter
                 outputTableWriterFragment,
                 Optional.of(statsAndCosts.getForSubplan(root)),
                 Optional.of(jsonFragmentPlan(root, fragmentVariableTypes, statsAndCosts.getForSubplan(root), metadata.getFunctionAndTypeManager(), session)));
+
+        planChecker.validatePlanFragment(fragment, session, metadata, warningCollector);
 
         return new SubPlan(fragment, properties.getChildren());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -29,6 +29,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.BasePlanFragmenter.FragmentProperties;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
@@ -54,13 +55,13 @@ public class PlanFragmenter
     private final PlanChecker singleNodePlanChecker;
 
     @Inject
-    public PlanFragmenter(Metadata metadata, NodePartitioningManager nodePartitioningManager, QueryManagerConfig queryManagerConfig, FeaturesConfig featuresConfig)
+    public PlanFragmenter(Metadata metadata, NodePartitioningManager nodePartitioningManager, QueryManagerConfig queryManagerConfig, FeaturesConfig featuresConfig, PlanCheckerProviderManager planCheckerProviderManager)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
         this.config = requireNonNull(queryManagerConfig, "queryManagerConfig is null");
-        this.distributedPlanChecker = new PlanChecker(requireNonNull(featuresConfig, "featuresConfig is null"), false);
-        this.singleNodePlanChecker = new PlanChecker(requireNonNull(featuresConfig, "featuresConfig is null"), true);
+        this.distributedPlanChecker = new PlanChecker(requireNonNull(featuresConfig, "featuresConfig is null"), false, planCheckerProviderManager);
+        this.singleNodePlanChecker = new PlanChecker(requireNonNull(featuresConfig, "featuresConfig is null"), true, planCheckerProviderManager);
     }
 
     public SubPlan createSubPlans(Session session, Plan plan, boolean forceSingleNode, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JsonCodecSimplePlanFragmentSerde.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JsonCodecSimplePlanFragmentSerde.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.spi.plan.SimplePlanFragment;
+import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
+import com.google.inject.Inject;
+
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Objects.requireNonNull;
+
+public class JsonCodecSimplePlanFragmentSerde
+        implements SimplePlanFragmentSerde
+{
+    private final JsonCodec<SimplePlanFragment> codec;
+
+    @Inject
+    public JsonCodecSimplePlanFragmentSerde(JsonCodec<SimplePlanFragment> codec)
+    {
+        this.codec = requireNonNull(codec, "SimplePlanFragment JSON codec is null");
+    }
+
+    @Override
+    public String serialize(SimplePlanFragment planFragment)
+    {
+        return new String(codec.toBytes(planFragment), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public SimplePlanFragment deserialize(String value)
+    {
+        return codec.fromBytes(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanCheckerProviderManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanCheckerProviderManager.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.spi.plan.PlanCheckerProvider;
+import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
+import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
+import com.google.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class PlanCheckerProviderManager
+{
+    private final SimplePlanFragmentSerde simplePlanFragmentSerde;
+    private final Map<String, PlanCheckerProviderFactory> providerFactories = new ConcurrentHashMap<>();
+    private final CopyOnWriteArrayList<PlanCheckerProvider> providers = new CopyOnWriteArrayList<>();
+
+    @Inject
+    public PlanCheckerProviderManager(SimplePlanFragmentSerde simplePlanFragmentSerde)
+    {
+        this.simplePlanFragmentSerde = requireNonNull(simplePlanFragmentSerde, "planNodeSerde is null");
+    }
+
+    public void addPlanCheckerProviderFactory(PlanCheckerProviderFactory planCheckerProviderFactory)
+    {
+        requireNonNull(planCheckerProviderFactory, "planCheckerProviderFactory is null");
+        if (providerFactories.putIfAbsent(planCheckerProviderFactory.getName(), planCheckerProviderFactory) != null) {
+            throw new IllegalArgumentException(format("PlanCheckerProviderFactory '%s' is already registered", planCheckerProviderFactory.getName()));
+        }
+    }
+
+    public void loadPlanCheckerProviders()
+    {
+        providers.addAllAbsent(providerFactories.values().stream().map(pc -> pc.create(simplePlanFragmentSerde)).collect(Collectors.toList()));
+    }
+
+    public List<PlanCheckerProvider> getPlanCheckerProviders()
+    {
+        return providers;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -27,6 +27,7 @@ import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.transaction.TransactionManager;
 import org.intellij.lang.annotations.Language;
 
@@ -53,6 +54,8 @@ public interface QueryRunner
     NodePartitioningManager getNodePartitioningManager();
 
     ConnectorPlanOptimizerManager getPlanOptimizerManager();
+
+    PlanCheckerProviderManager getPlanCheckerProviderManager();
 
     StatsCalculator getStatsCalculator();
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.SimplePlanFragment;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -57,7 +58,9 @@ import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.plan.SequenceNode;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.tpch.TpchColumnHandle;
@@ -84,6 +87,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
@@ -123,6 +127,7 @@ public class TestCostCalculator
     private NodeScheduler nodeScheduler;
     private NodePartitioningManager nodePartitioningManager;
     private TestingRowExpressionTranslator translator;
+    private PlanCheckerProviderManager planCheckerProviderManager;
 
     @BeforeClass
     public void setUp()
@@ -151,7 +156,8 @@ public class TestCostCalculator
                 new SimpleTtlNodeSelectorConfig());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
-        planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new FeaturesConfig());
+        planCheckerProviderManager = new PlanCheckerProviderManager(new JsonCodecSimplePlanFragmentSerde(jsonCodec(SimplePlanFragment.class)));
+        planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new FeaturesConfig(), planCheckerProviderManager);
         translator = new TestingRowExpressionTranslator();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -255,7 +255,9 @@ public class TestFeaturesConfig
                 .setPrintEstimatedStatsFromCache(false)
                 .setRemoveCrossJoinWithSingleConstantRow(true)
                 .setUseHistograms(false)
-                .setInlineProjectionsOnValues(false));
+                .setInlineProjectionsOnValues(false)
+                .setEagerPlanValidationEnabled(false)
+                .setEagerPlanValidationThreadPoolSize(20));
     }
 
     @Test
@@ -460,6 +462,8 @@ public class TestFeaturesConfig
                 .put("optimizer.remove-cross-join-with-single-constant-row", "false")
                 .put("optimizer.use-histograms", "true")
                 .put("optimizer.inline-projections-on-values", "true")
+                .put("eager-plan-validation-enabled", "true")
+                .put("eager-plan-validation-thread-pool-size", "2")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -661,7 +665,9 @@ public class TestFeaturesConfig
                 .setPrintEstimatedStatsFromCache(true)
                 .setRemoveCrossJoinWithSingleConstantRow(false)
                 .setUseHistograms(true)
-                .setInlineProjectionsOnValues(true);
+                .setInlineProjectionsOnValues(true)
+                .setEagerPlanValidationEnabled(true)
+                .setEagerPlanValidationThreadPoolSize(2);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -25,6 +25,7 @@ import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
@@ -181,6 +182,12 @@ public class ContainerQueryRunner
 
     @Override
     public ConnectorPlanOptimizerManager getPlanOptimizerManager()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PlanCheckerProviderManager getPlanCheckerProviderManager()
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -136,6 +136,8 @@ import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
+import com.facebook.presto.spi.plan.SimplePlanFragment;
+import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.PredicateCompiler;
@@ -186,7 +188,9 @@ import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanOptimizers;
+import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.tracing.TracerProviderManager;
@@ -292,6 +296,8 @@ public class PrestoSparkModule
         jsonCodecBinder(binder).bindJsonCodec(PrestoSparkLocalShuffleWriteInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(BatchTaskUpdateRequest.class);
         jsonCodecBinder(binder).bindJsonCodec(BroadcastFileInfo.class);
+        jsonCodecBinder(binder).bindJsonCodec(SimplePlanFragment.class);
+        binder.bind(SimplePlanFragmentSerde.class).to(JsonCodecSimplePlanFragmentSerde.class).in(Scopes.SINGLETON);
 
         // smile codecs
         smileCodecBinder(binder).bindSmileCodec(TaskSource.class);
@@ -542,6 +548,8 @@ public class PrestoSparkModule
         // extra credentials and authenticator for Presto-on-Spark
         newSetBinder(binder, PrestoSparkCredentialsProvider.class);
         newSetBinder(binder, PrestoSparkAuthenticatorProvider.class);
+
+        binder.bind(PlanCheckerProviderManager.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -99,6 +99,7 @@ import com.facebook.presto.sql.analyzer.utils.StatementUtils;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.SubPlan;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.transaction.TransactionManager;
@@ -206,6 +207,7 @@ public class PrestoSparkQueryExecutionFactory
     private final HistoryBasedPlanStatisticsTracker historyBasedPlanStatisticsTracker;
     private final AdaptivePlanOptimizers adaptivePlanOptimizers;
     private final FragmentStatsProvider fragmentStatsProvider;
+    private final PlanCheckerProviderManager planCheckerProviderManager;
 
     @Inject
     public PrestoSparkQueryExecutionFactory(
@@ -245,7 +247,8 @@ public class PrestoSparkQueryExecutionFactory
             Optional<ErrorClassifier> errorClassifier,
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
             AdaptivePlanOptimizers adaptivePlanOptimizers,
-            FragmentStatsProvider fragmentStatsProvider)
+            FragmentStatsProvider fragmentStatsProvider,
+            PlanCheckerProviderManager planCheckerProviderManager)
     {
         this.queryIdGenerator = requireNonNull(queryIdGenerator, "queryIdGenerator is null");
         this.sessionSupplier = requireNonNull(sessionSupplier, "sessionSupplier is null");
@@ -284,6 +287,7 @@ public class PrestoSparkQueryExecutionFactory
         this.historyBasedPlanStatisticsTracker = requireNonNull(historyBasedPlanStatisticsManager, "historyBasedPlanStatisticsManager is null").getHistoryBasedPlanStatisticsTracker();
         this.adaptivePlanOptimizers = requireNonNull(adaptivePlanOptimizers, "adaptivePlanOptimizers is null");
         this.fragmentStatsProvider = requireNonNull(fragmentStatsProvider, "fragmentStatsProvider is null");
+        this.planCheckerProviderManager = requireNonNull(planCheckerProviderManager, "planCheckerProviderManager is null");
     }
 
     public static QueryInfo createQueryInfo(
@@ -764,7 +768,8 @@ public class PrestoSparkQueryExecutionFactory
                             variableAllocator,
                             planNodeIdAllocator,
                             fragmentStatsProvider,
-                            bootstrapMetricsCollector);
+                            bootstrapMetricsCollector,
+                            planCheckerProviderManager);
                 }
             }
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkAdaptiveQueryExecution.java
@@ -63,6 +63,7 @@ import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -175,7 +176,8 @@ public class PrestoSparkAdaptiveQueryExecution
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator,
             FragmentStatsProvider fragmentStatsProvider,
-            Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector)
+            Optional<CollectionAccumulator<Map<String, Long>>> bootstrapMetricsCollector,
+            PlanCheckerProviderManager planCheckerProviderManager)
     {
         super(
                 sparkContext,
@@ -219,10 +221,10 @@ public class PrestoSparkAdaptiveQueryExecution
         this.adaptivePlanOptimizers = requireNonNull(adaptivePlanOptimizers, "adaptivePlanOptimizers is null").getAdaptiveOptimizers();
         this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
-        this.iterativePlanFragmenter = createIterativePlanFragmenter();
+        this.iterativePlanFragmenter = createIterativePlanFragmenter(requireNonNull(planCheckerProviderManager, "planCheckerProviderManager is null"));
     }
 
-    private IterativePlanFragmenter createIterativePlanFragmenter()
+    private IterativePlanFragmenter createIterativePlanFragmenter(PlanCheckerProviderManager planCheckerProviderManager)
     {
         boolean forceSingleNode = false;
         Function<PlanFragmentId, Boolean> isFragmentFinished = this.executedFragments::contains;
@@ -232,7 +234,7 @@ public class PrestoSparkAdaptiveQueryExecution
                 this.planAndMore.getPlan(),
                 isFragmentFinished,
                 this.metadata,
-                new PlanChecker(this.featuresConfig, forceSingleNode),
+                new PlanChecker(this.featuresConfig, forceSingleNode, planCheckerProviderManager),
                 this.idAllocator,
                 new PrestoSparkNodePartitioningManager(this.partitioningProviderManager),
                 this.queryManagerConfig,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -67,6 +67,7 @@ import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
@@ -156,6 +157,7 @@ public class PrestoSparkQueryRunner
     private final StatsCalculator statsCalculator;
     private final PluginManager pluginManager;
     private final ConnectorManager connectorManager;
+    private final PlanCheckerProviderManager planCheckerProviderManager;
     private final Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics;
     private final HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager;
 
@@ -334,6 +336,7 @@ public class PrestoSparkQueryRunner
         statsCalculator = injector.getInstance(StatsCalculator.class);
         pluginManager = injector.getInstance(PluginManager.class);
         connectorManager = injector.getInstance(ConnectorManager.class);
+        planCheckerProviderManager = injector.getInstance(PlanCheckerProviderManager.class);
         waitTimeMetrics = injector.getInstance(new Key<Set<PrestoSparkServiceWaitTimeMetrics>>() {});
         historyBasedPlanStatisticsManager = injector.getInstance(HistoryBasedPlanStatisticsManager.class);
 
@@ -475,6 +478,12 @@ public class PrestoSparkQueryRunner
     public ConnectorPlanOptimizerManager getPlanOptimizerManager()
     {
         return connectorPlanOptimizerManager;
+    }
+
+    @Override
+    public PlanCheckerProviderManager getPlanCheckerProviderManager()
+    {
+        return planCheckerProviderManager;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.nodestatus.NodeStatusNotificationProviderFactory;
+import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
@@ -139,6 +140,11 @@ public interface Plugin
     }
 
     default Iterable<NodeStatusNotificationProviderFactory> getNodeStatusNotificationProviderFactory()
+    {
+        return emptyList();
+    }
+
+    default Iterable<PlanCheckerProviderFactory> getPlanCheckerProviderFactories()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanChecker.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanChecker.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.plan;
+
+import com.facebook.presto.spi.WarningCollector;
+
+public interface PlanChecker
+{
+    void validate(PlanNode planNode, WarningCollector warningCollector);
+
+    default void validateFragment(SimplePlanFragment planFragment, WarningCollector warningCollector)
+    {
+        validate(planFragment.getRoot(), warningCollector);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanCheckerProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanCheckerProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.plan;
+
+import java.util.Collections;
+import java.util.List;
+
+public interface PlanCheckerProvider
+{
+    default List<PlanChecker> getIntermediatePlanCheckers()
+    {
+        return Collections.emptyList();
+    }
+
+    default List<PlanChecker> getFinalPlanCheckers()
+    {
+        return Collections.emptyList();
+    }
+
+    default List<PlanChecker> getFragmentPlanCheckers()
+    {
+        return Collections.emptyList();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanCheckerProviderFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanCheckerProviderFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+public interface PlanCheckerProviderFactory
+{
+    String getName();
+
+    PlanCheckerProvider create(SimplePlanFragmentSerde simplePlanFragmentSerde);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/SimplePlanFragmentSerde.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/SimplePlanFragmentSerde.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+public interface SimplePlanFragmentSerde
+{
+    String serialize(SimplePlanFragment planFragment);
+
+    SimplePlanFragment deserialize(String value);
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -572,14 +572,14 @@ public abstract class AbstractTestQueryFramework
                 .getPlanningTimeOptimizers();
         return new QueryExplainer(
                 optimizers,
-                new PlanFragmenter(metadata, queryRunner.getNodePartitioningManager(), new QueryManagerConfig(), featuresConfig),
+                new PlanFragmenter(metadata, queryRunner.getNodePartitioningManager(), new QueryManagerConfig(), featuresConfig, queryRunner.getPlanCheckerProviderManager()),
                 metadata,
                 queryRunner.getAccessControl(),
                 sqlParser,
                 queryRunner.getStatsCalculator(),
                 costCalculator,
                 ImmutableMap.of(),
-                new PlanChecker(featuresConfig, false));
+                new PlanChecker(featuresConfig, false, queryRunner.getPlanCheckerProviderManager()));
     }
 
     protected static void skipTestUnless(boolean requirement)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -46,6 +46,7 @@ import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
@@ -579,6 +580,13 @@ public class DistributedQueryRunner
     {
         checkState(coordinators.size() == 1, "Expected a single coordinator");
         return coordinators.get(0).getAccessControl();
+    }
+
+    @Override
+    public PlanCheckerProviderManager getPlanCheckerProviderManager()
+    {
+        checkState(coordinators.size() == 1, "Expected a single coordinator");
+        return coordinators.get(0).getPlanCheckerProviderManager();
     }
 
     public TestingPrestoServer getCoordinator()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -30,6 +30,7 @@ import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
@@ -161,6 +162,12 @@ public final class StandaloneQueryRunner
     public ConnectorPlanOptimizerManager getPlanOptimizerManager()
     {
         return server.getPlanOptimizerManager();
+    }
+
+    @Override
+    public PlanCheckerProviderManager getPlanCheckerProviderManager()
+    {
+        return server.getPlanCheckerProviderManager();
     }
 
     @Override

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestingPlanCheckerProviderPlugin.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestingPlanCheckerProviderPlugin.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.plan.PlanChecker;
+import com.facebook.presto.spi.plan.PlanCheckerProvider;
+import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
+import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TestingPlanCheckerProviderPlugin
+        implements Plugin, PlanCheckerProviderFactory, PlanCheckerProvider
+{
+    private final AtomicBoolean triggerValidationFailure;
+
+    public TestingPlanCheckerProviderPlugin(AtomicBoolean triggerValidationFailure)
+    {
+        this.triggerValidationFailure = triggerValidationFailure;
+    }
+
+    @Override
+    public Iterable<PlanCheckerProviderFactory> getPlanCheckerProviderFactories()
+    {
+        return ImmutableList.of(this);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "TestPlanCheckers";
+    }
+
+    @Override
+    public PlanCheckerProvider create(SimplePlanFragmentSerde simplePlanFragmentSerde)
+    {
+        return this;
+    }
+
+    @Override
+    public List<PlanChecker> getIntermediatePlanCheckers()
+    {
+        return ImmutableList.of(new TriggerFailurePlanChecker(triggerValidationFailure));
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TriggerFailurePlanChecker.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TriggerFailurePlanChecker.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.StandardErrorCode;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.PlanChecker;
+import com.facebook.presto.spi.plan.PlanNode;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
+
+public class TriggerFailurePlanChecker
+        implements PlanChecker
+{
+    public static final StandardErrorCode FAILURE_ERROR_CODE = QUERY_REJECTED;
+    public static final String FAILURE_MESSAGE = "Plan validation failure triggered";
+    private final AtomicBoolean triggerValidationFailure;
+
+    public TriggerFailurePlanChecker(AtomicBoolean triggerValidationFailure)
+    {
+        this.triggerValidationFailure = triggerValidationFailure;
+    }
+
+    @Override
+    public void validate(PlanNode planNode, WarningCollector warningCollector)
+    {
+        if (triggerValidationFailure.get()) {
+            throw new PrestoException(FAILURE_ERROR_CODE, FAILURE_MESSAGE);
+        }
+    }
+}

--- a/presto-tests/src/test/resources/resource_groups_config_eager_plan_validation.json
+++ b/presto-tests/src/test/resources/resource_groups_config_eager_plan_validation.json
@@ -1,0 +1,32 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "softMemoryLimit": "1MB",
+      "hardConcurrencyLimit": 100,
+      "maxQueued": 1000,
+      "subGroups": [
+        {
+          "name": "user-${USER}",
+          "softMemoryLimit": "1MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 3,
+          "subGroups": [
+            {
+              "name": "eager-${USER}",
+              "softMemoryLimit": "1MB",
+              "hardConcurrencyLimit": 1,
+              "maxQueued": 2
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "source": "(?i).*eager.*",
+      "group": "global.user-${USER}.eager-${USER}"
+    }
+  ]
+}

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
@@ -36,6 +36,7 @@ import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
@@ -227,6 +228,12 @@ public final class ThriftQueryRunner
         public ConnectorPlanOptimizerManager getPlanOptimizerManager()
         {
             return source.getPlanOptimizerManager();
+        }
+
+        @Override
+        public PlanCheckerProviderManager getPlanCheckerProviderManager()
+        {
+            return source.getPlanCheckerProviderManager();
         }
 
         @Override


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This is a prerequisite for the native plan checker SPI being worked on in https://github.com/prestodb/presto/pull/23596 and discussed in https://github.com/prestodb/rfcs/blob/main/RFC-0008-plan-checker.md.

The new property `eager-plan-validation-enabled` will enable the eager building and validation of a logical plan so that any errors or incompatibilities in the plan will cause the query to fail quickly, before queueing and cluster resources are assigned to keep queries with invalid plans from holding slots in the queue. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

The new SPI for a native plan checker, being added in https://github.com/prestodb/presto/pull/23596,  would use this property so that a plan can be sent to the native sidecar and incompatibles with velox would be caught before actually sending the plan to a native worker to start execution. However, there is also benefit in enabling this property for non-native clusters since all plan checkers are run once the plan is built.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Manual testing has been done with the property enabled and verified that queries that get queued up will be allowed to be validated and, if fail, removed from the queue before execution begins.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add new property `eager-plan-validation-enabled` for eager building of validation of a logical plan before queuing. :pr:`23649`

