### PR TITLE
[native] Removing status message from native worker to support http/2

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -145,7 +145,7 @@ std::unique_ptr<folly::IOBuf> HttpResponse::consumeBody(
 
 void HttpResponse::freeBuffers() {
   if (pool_ != nullptr) {
-    for (auto& iobuf : bodyChain_) {
+    for (const auto& iobuf : bodyChain_) {
       if (iobuf != nullptr) {
         pool_->free(iobuf->writableData(), iobuf->capacity());
       }
@@ -170,7 +170,7 @@ std::string HttpResponse::dumpBodyChain() const {
   std::string responseBody;
   if (!bodyChain_.empty()) {
     std::ostringstream oss;
-    for (auto& buf : bodyChain_) {
+    for (const auto& buf : bodyChain_) {
       oss << std::string((const char*)buf->data(), buf->length());
     }
     responseBody = oss.str();

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -21,9 +21,7 @@
 namespace facebook::presto::http {
 
 void sendOkResponse(proxygen::ResponseHandler* downstream) {
-  proxygen::ResponseBuilder(downstream)
-      .status(http::kHttpOk, "OK")
-      .sendWithEOM();
+  proxygen::ResponseBuilder(downstream).status(http::kHttpOk, "").sendWithEOM();
 }
 
 void sendOkResponse(proxygen::ResponseHandler* downstream, const json& body) {
@@ -49,7 +47,7 @@ void sendOkResponse(
     proxygen::ResponseHandler* downstream,
     const std::string& body) {
   proxygen::ResponseBuilder(downstream)
-      .status(http::kHttpOk, "OK")
+      .status(http::kHttpOk, "")
       .header(
           proxygen::HTTP_HEADER_CONTENT_TYPE, http::kMimeTypeApplicationJson)
       .body(body)
@@ -60,7 +58,7 @@ void sendOkThriftResponse(
     proxygen::ResponseHandler* downstream,
     const std::string& body) {
   proxygen::ResponseBuilder(downstream)
-      .status(http::kHttpOk, "OK")
+      .status(http::kHttpOk, "")
       .header(
           proxygen::HTTP_HEADER_CONTENT_TYPE, http::kMimeTypeApplicationThrift)
       .body(body)
@@ -71,19 +69,8 @@ void sendErrorResponse(
     proxygen::ResponseHandler* downstream,
     const std::string& error,
     uint16_t status) {
-  static const size_t kMaxStatusSize = 1024;
-
-  // Use a prefix of the 'error' as status message. Make sure it doesn't include
-  // new lines. See https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html
-
-  size_t statusSize = kMaxStatusSize;
-  auto pos = error.find('\n');
-  if (pos != std::string::npos && pos < statusSize) {
-    statusSize = pos;
-  }
-
   proxygen::ResponseBuilder(downstream)
-      .status(status, error.substr(0, statusSize))
+      .status(status, "")
       .body(error)
       .sendWithEOM();
 }


### PR DESCRIPTION
HTTP/2 does not use status message. We recently migrated to new jetty server that uses http2 (https://github.com/prestodb/presto/pull/23356). From native worker, passing status message is no op. In some cases we parse the error message and pick the first line as message.  This is not necessary as status message is not used. Proxygen's [RequestBuilder::status](https://www.internalfb.com/code/fbsource/[9b7831f3ce75]/fbcode/proxygen/httpserver/ResponseBuilder.h?lines=84-90) function expects status message and sets http version 1/1 hard coded. However, after discussing with proxygen folks, found that they intentially set it and proxygen does not depend on this version number, instead they use server next protocol/client next protocol.

Extensive testing is done with shadow tests, also existing e2e tests pass.

```
== NO RELEASE NOTE ==
```

