### PR TITLE
Add QueryType to AccessControlContext

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/security/ranger/TestRangerBasedAccessControl.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/security/ranger/TestRangerBasedAccessControl.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.assertThrows;
 public class TestRangerBasedAccessControl
 {
     public static final ConnectorTransactionHandle TRANSACTION_HANDLE = new ConnectorTransactionHandle() {};
-    public static final AccessControlContext CONTEXT = new AccessControlContext(new QueryId("query_id"), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats());
+    public static final AccessControlContext CONTEXT = new AccessControlContext(new QueryId("query_id"), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty());
 
     @Test
     public void testTablePriviledgesRolesNotAllowed()

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -15,6 +15,7 @@ package com.facebook.presto;
 
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.cost.PlanCostEstimate;
@@ -99,6 +100,7 @@ public final class Session
     private final Optional<Tracer> tracer;
     private final WarningCollector warningCollector;
     private final RuntimeStats runtimeStats;
+    private final Optional<QueryType> queryType;
 
     private final OptimizerInformationCollector optimizerInformationCollector = new OptimizerInformationCollector();
     private final OptimizerResultCollector optimizerResultCollector = new OptimizerResultCollector();
@@ -131,7 +133,8 @@ public final class Session
             Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions,
             Optional<Tracer> tracer,
             WarningCollector warningCollector,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            Optional<QueryType> queryType)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
@@ -172,7 +175,8 @@ public final class Session
         this.tracer = requireNonNull(tracer, "tracer is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
-        this.context = new AccessControlContext(queryId, clientInfo, clientTags, source, warningCollector, runtimeStats);
+        this.queryType = requireNonNull(queryType, "queryType is null");
+        this.context = new AccessControlContext(queryId, clientInfo, clientTags, source, warningCollector, runtimeStats, queryType);
     }
 
     public QueryId getQueryId()
@@ -353,6 +357,11 @@ public final class Session
         return planNodeCostMap;
     }
 
+    public Optional<QueryType> getQueryType()
+    {
+        return queryType;
+    }
+
     public Session beginTransactionId(TransactionId transactionId, TransactionManager transactionManager, AccessControl accessControl)
     {
         requireNonNull(transactionId, "transactionId is null");
@@ -447,63 +456,8 @@ public final class Session
                 sessionFunctions,
                 tracer,
                 warningCollector,
-                runtimeStats);
-    }
-
-    public Session withDefaultProperties(
-            SystemSessionPropertyConfiguration systemPropertyConfiguration,
-            Map<String, Map<String, String>> catalogPropertyDefaults)
-    {
-        requireNonNull(systemPropertyConfiguration, "systemPropertyConfiguration is null");
-        requireNonNull(catalogPropertyDefaults, "catalogPropertyDefaults is null");
-
-        // to remove this check properties must be authenticated and validated as in beginTransactionId
-        checkState(
-                !this.transactionId.isPresent() && this.connectorProperties.isEmpty(),
-                "Session properties cannot be overridden once a transaction is active");
-
-        Map<String, String> systemProperties = new HashMap<>();
-        systemProperties.putAll(systemPropertyConfiguration.systemPropertyDefaults);
-        systemProperties.putAll(this.systemProperties);
-        systemProperties.putAll(systemPropertyConfiguration.systemPropertyOverrides);
-
-        Map<String, Map<String, String>> connectorProperties = catalogPropertyDefaults.entrySet().stream()
-                .map(entry -> Maps.immutableEntry(entry.getKey(), new HashMap<>(entry.getValue())))
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-        for (Entry<String, Map<String, String>> catalogProperties : this.unprocessedCatalogProperties.entrySet()) {
-            String catalog = catalogProperties.getKey();
-            for (Entry<String, String> entry : catalogProperties.getValue().entrySet()) {
-                connectorProperties.computeIfAbsent(catalog, id -> new HashMap<>())
-                        .put(entry.getKey(), entry.getValue());
-            }
-        }
-
-        return new Session(
-                queryId,
-                transactionId,
-                clientTransactionSupport,
-                identity,
-                source,
-                catalog,
-                schema,
-                traceToken,
-                timeZoneKey,
-                locale,
-                remoteUserAddress,
-                userAgent,
-                clientInfo,
-                clientTags,
-                resourceEstimates,
-                startTime,
-                systemProperties,
-                ImmutableMap.of(),
-                connectorProperties,
-                sessionPropertyManager,
-                preparedStatements,
-                sessionFunctions,
-                tracer,
-                warningCollector,
-                runtimeStats);
+                runtimeStats,
+                queryType);
     }
 
     public ConnectorSession toConnectorSession()
@@ -630,6 +584,7 @@ public final class Session
         private final SessionPropertyManager sessionPropertyManager;
         private final Map<String, String> preparedStatements = new HashMap<>();
         private final Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions = new HashMap<>();
+        private Optional<QueryType> queryType = Optional.empty();
         private WarningCollector warningCollector = WarningCollector.NOOP;
         private RuntimeStats runtimeStats = new RuntimeStats();
 
@@ -665,6 +620,7 @@ public final class Session
             this.tracer = requireNonNull(session.tracer, "tracer is null");
             this.warningCollector = requireNonNull(session.warningCollector, "warningCollector is null");
             this.runtimeStats = requireNonNull(session.runtimeStats, "runtimeStats is null");
+            this.queryType = requireNonNull(session.queryType, "queryType is null");
         }
 
         public SessionBuilder setQueryId(QueryId queryId)
@@ -821,9 +777,55 @@ public final class Session
             return this;
         }
 
+        public SessionBuilder setQueryType(Optional<QueryType> queryType)
+        {
+            this.queryType = requireNonNull(queryType, "queryType is null");
+            return this;
+        }
+
         public <T> T getSystemProperty(String name, Class<T> type)
         {
             return sessionPropertyManager.decodeSystemPropertyValue(name, systemProperties.get(name), type);
+        }
+
+        public WarningCollector getWarningCollector()
+        {
+            return this.warningCollector;
+        }
+
+        public Map<String, String> getPreparedStatements()
+        {
+            return this.preparedStatements;
+        }
+
+        public Identity getIdentity()
+        {
+            return this.identity;
+        }
+
+        public Optional<String> getSource()
+        {
+            return Optional.ofNullable(this.source);
+        }
+
+        public Set<String> getClientTags()
+        {
+            return this.clientTags;
+        }
+
+        public Optional<String> getClientInfo()
+        {
+            return Optional.ofNullable(this.clientInfo);
+        }
+
+        public Map<String, String> getSystemProperties()
+        {
+            return this.systemProperties;
+        }
+
+        public Map<String, Map<String, String>> getUnprocessedCatalogProperties()
+        {
+            return this.catalogSessionProperties;
         }
 
         public Session build()
@@ -853,7 +855,42 @@ public final class Session
                     sessionFunctions,
                     tracer,
                     warningCollector,
-                    runtimeStats);
+                    runtimeStats,
+                    queryType);
+        }
+
+        public void applyDefaultProperties(SystemSessionPropertyConfiguration systemPropertyConfiguration, Map<String, Map<String, String>> catalogPropertyDefaults)
+        {
+            requireNonNull(systemPropertyConfiguration, "systemPropertyConfiguration is null");
+            requireNonNull(catalogPropertyDefaults, "catalogPropertyDefaults is null");
+
+            // to remove this check properties must be authenticated and validated as in beginTransactionId
+            checkState(
+                    this.transactionId == null && this.connectorProperties.isEmpty(),
+                    "Session properties cannot be overridden once a transaction is active");
+
+            Map<String, String> systemProperties = new HashMap<>();
+            systemProperties.putAll(systemPropertyConfiguration.systemPropertyDefaults);
+            systemProperties.putAll(this.systemProperties);
+            systemProperties.putAll(systemPropertyConfiguration.systemPropertyOverrides);
+            this.systemProperties.putAll(systemProperties);
+
+            Map<String, Map<String, String>> connectorProperties = catalogPropertyDefaults.entrySet().stream()
+                    .map(entry -> Maps.immutableEntry(entry.getKey(), new HashMap<>(entry.getValue())))
+                    .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            for (Entry<String, Map<String, String>> catalogProperties : this.catalogSessionProperties.entrySet()) {
+                String catalog = catalogProperties.getKey();
+                for (Entry<String, String> entry : catalogProperties.getValue().entrySet()) {
+                    connectorProperties.computeIfAbsent(catalog, id -> new HashMap<>()).put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            for (Entry<String, Map<String, String>> catalogProperties : connectorProperties.entrySet()) {
+                String catalog = catalogProperties.getKey();
+                for (Entry<String, String> entry : catalogProperties.getValue().entrySet()) {
+                    setCatalogSessionProperty(catalog, entry.getKey(), entry.getValue());
+                }
+            }
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
@@ -338,6 +338,7 @@ public final class SessionRepresentation
                 Optional.empty(),
                 // we use NOOP to create a session from the representation as worker does not require warning collectors
                 WarningCollector.NOOP,
-                new RuntimeStats());
+                new RuntimeStats(),
+                Optional.empty());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 
+import static com.facebook.presto.Session.SessionBuilder;
 import static com.facebook.presto.SystemSessionProperties.getAnalyzerType;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_TEXT_TOO_LARGE;
 import static com.facebook.presto.util.AnalyzerUtil.createAnalyzerOptions;
@@ -259,6 +260,7 @@ public class DispatchManager
     private <C> void createQueryInternal(QueryId queryId, String slug, int retryCount, SessionContext sessionContext, String query, ResourceGroupManager<C> resourceGroupManager)
     {
         Session session = null;
+        SessionBuilder sessionBuilder = null;
         PreparedQuery preparedQuery;
         try {
             if (query.length() > maxQueryLength) {
@@ -268,16 +270,18 @@ public class DispatchManager
             }
 
             // decode session
-            session = sessionSupplier.createSession(queryId, sessionContext, warningCollectorFactory);
+            sessionBuilder = sessionSupplier.createSessionBuilder(queryId, sessionContext, warningCollectorFactory);
+            session = sessionBuilder.build();
 
             // prepare query
-            AnalyzerOptions analyzerOptions = createAnalyzerOptions(session, session.getWarningCollector());
+            AnalyzerOptions analyzerOptions = createAnalyzerOptions(session, sessionBuilder.getWarningCollector());
             QueryPreparerProvider queryPreparerProvider = queryPreparerProviderManager.getQueryPreparerProvider(getAnalyzerType(session));
-            preparedQuery = queryPreparerProvider.getQueryPreparer().prepareQuery(analyzerOptions, query, session.getPreparedStatements(), session.getWarningCollector());
+            preparedQuery = queryPreparerProvider.getQueryPreparer().prepareQuery(analyzerOptions, query, sessionBuilder.getPreparedStatements(), sessionBuilder.getWarningCollector());
             query = preparedQuery.getFormattedQuery().orElse(query);
 
             // select resource group
             Optional<QueryType> queryType = preparedQuery.getQueryType();
+            sessionBuilder.setQueryType(queryType);
             SelectionContext<C> selectionContext = resourceGroupManager.selectGroup(new SelectionCriteria(
                     sessionContext.getIdentity().getPrincipal().isPresent(),
                     sessionContext.getIdentity().getUser(),
@@ -290,7 +294,12 @@ public class DispatchManager
                     sessionContext.getIdentity().getPrincipal().map(Principal::getName)));
 
             // apply system default session properties (does not override user set properties)
-            session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, queryType.map(Enum::name), Optional.of(selectionContext.getResourceGroupId()));
+            sessionPropertyDefaults.applyDefaultProperties(sessionBuilder, queryType.map(Enum::name), Optional.of(selectionContext.getResourceGroupId()));
+
+            session = sessionBuilder.build();
+            if (sessionContext.getTransactionId().isPresent()) {
+                session = session.beginTransactionId(sessionContext.getTransactionId().get(), transactionManager, accessControl);
+            }
 
             // mark existing transaction as active
             transactionManager.activateTransaction(session, preparedQuery.isTransactionControlStatement(), accessControl);

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlUtils.java
@@ -46,7 +46,8 @@ public class AccessControlUtils
                             sessionContext.getClientTags(),
                             Optional.ofNullable(sessionContext.getSource()),
                             WarningCollector.NOOP,
-                            sessionContext.getRuntimeStats()),
+                            sessionContext.getRuntimeStats(),
+                            Optional.empty()),
                     identity.getPrincipal(),
                     identity.getUser());
         }
@@ -71,7 +72,8 @@ public class AccessControlUtils
                             sessionContext.getClientTags(),
                             Optional.ofNullable(sessionContext.getSource()),
                             WarningCollector.NOOP,
-                            sessionContext.getRuntimeStats()),
+                            sessionContext.getRuntimeStats(),
+                            Optional.empty()),
                     identity.getUser(),
                     sessionContext.getCertificates());
             return Optional.of(authorizedIdentity);

--- a/presto-main/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
@@ -17,6 +17,8 @@ import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
 
+import static com.facebook.presto.Session.SessionBuilder;
+
 /**
  * Used on workers.
  */
@@ -25,6 +27,12 @@ public class NoOpSessionSupplier
 {
     @Override
     public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionSupplier.java
@@ -17,7 +17,11 @@ import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollectorFactory;
 import com.facebook.presto.spi.QueryId;
 
+import static com.facebook.presto.Session.SessionBuilder;
+
 public interface SessionSupplier
 {
     Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
+
+    SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -549,7 +549,8 @@ public class LocalQueryRunner
                 defaultSession.getSessionFunctions(),
                 defaultSession.getTracer(),
                 defaultSession.getWarningCollector(),
-                defaultSession.getRuntimeStats());
+                defaultSession.getRuntimeStats(),
+                defaultSession.getQueryType());
 
         dataDefinitionTask = ImmutableMap.<Class<? extends Statement>, DataDefinitionTask<?>>builder()
                 .put(CreateTable.class, new CreateTableTask())

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -82,7 +82,7 @@ public class TestAccessControlManager
         AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
         accessControlManager.checkCanSetUser(
                 new Identity(USER_NAME, Optional.of(PRINCIPAL)),
-                new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats()),
+                new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty()),
                 Optional.empty(),
                 "foo");
     }
@@ -94,7 +94,7 @@ public class TestAccessControlManager
         accessControlManager.setSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
         accessControlManager.checkCanSetUser(
                 new Identity(USER_NAME, Optional.of(PRINCIPAL)),
-                new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats()),
+                new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty()),
                 Optional.empty(),
                 USER_NAME);
     }
@@ -106,7 +106,7 @@ public class TestAccessControlManager
         QualifiedObjectName tableName = new QualifiedObjectName("catalog", "schema", "table");
         TransactionManager transactionManager = createTestTransactionManager();
         AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
-        AccessControlContext context = new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats());
+        AccessControlContext context = new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty());
 
         accessControlManager.setSystemAccessControl(ReadOnlySystemAccessControl.NAME, ImmutableMap.of());
         accessControlManager.checkCanSetUser(identity, context, Optional.of(PRINCIPAL), USER_NAME);
@@ -149,7 +149,7 @@ public class TestAccessControlManager
 
         accessControlManager.checkCanSetUser(
                 new Identity(USER_NAME, Optional.of(PRINCIPAL)),
-                new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats()),
+                new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty()),
                 Optional.of(PRINCIPAL),
                 USER_NAME);
         assertEquals(accessControlFactory.getCheckedUserName(), USER_NAME);
@@ -160,7 +160,7 @@ public class TestAccessControlManager
     public void testCheckQueryIntegrity()
     {
         AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
-        AccessControlContext context = new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats());
+        AccessControlContext context = new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty());
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
@@ -210,7 +210,7 @@ public class TestAccessControlManager
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
                     accessControlManager.checkCanSelectFromColumns(transactionId, new Identity(USER_NAME, Optional.of(PRINCIPAL)),
-                            new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats()),
+                            new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty()),
                             new QualifiedObjectName("catalog", "schema", "table"), ImmutableSet.of(new Subfield("column")));
                 });
     }
@@ -232,7 +232,7 @@ public class TestAccessControlManager
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
                     accessControlManager.checkCanSelectFromColumns(transactionId, new Identity(USER_NAME, Optional.of(PRINCIPAL)),
-                            new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats()),
+                            new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty()),
                             new QualifiedObjectName("catalog", "schema", "table"), ImmutableSet.of(new Subfield("column")));
                 });
     }
@@ -254,7 +254,7 @@ public class TestAccessControlManager
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
                     accessControlManager.checkCanSelectFromColumns(transactionId, new Identity(USER_NAME, Optional.of(PRINCIPAL)),
-                            new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats()),
+                            new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty()),
                             new QualifiedObjectName("secured_catalog", "schema", "table"), ImmutableSet.of(new Subfield("column")));
                 });
     }

--- a/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
@@ -70,7 +70,7 @@ public class TestFileBasedSystemAccessControl
     private static final QualifiedObjectName aliceTable = new QualifiedObjectName("alice-catalog", "schema", "table");
     private static final QualifiedObjectName aliceView = new QualifiedObjectName("alice-catalog", "schema", "view");
     private static final CatalogSchemaName aliceSchema = new CatalogSchemaName("alice-catalog", "schema");
-    private static final AccessControlContext context = new AccessControlContext(new QueryId("query_id"), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats());
+    private static final AccessControlContext context = new AccessControlContext(new QueryId("query_id"), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty());
     @Test
     public void testCanSetUserOperations() throws IOException
     {

--- a/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.Session.SessionBuilder;
 import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
@@ -59,33 +60,32 @@ public class TestSessionPropertyDefaults
         sessionPropertyDefaults.addConfigurationManagerFactory(factory);
         sessionPropertyDefaults.setConfigurationManager(factory.getName(), ImmutableMap.of());
 
-        Session session = Session.builder(new SessionPropertyManager())
+        SessionBuilder sessionBuilder = Session.builder(new SessionPropertyManager())
                 .setQueryId(new QueryId("test_query_id"))
                 .setIdentity(new Identity("testUser", Optional.empty()))
                 .setSystemProperty(QUERY_MAX_MEMORY, "1GB")
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
                 .setSystemProperty(HASH_PARTITION_COUNT, "43")
                 .setSystemProperty("override", "should be overridden")
-                .setCatalogSessionProperty("testCatalog", "explicit_set", "explicit_set")
-                .build();
+                .setCatalogSessionProperty("testCatalog", "explicit_set", "explicit_set");
 
-        assertEquals(session.getSystemProperties(), ImmutableMap.<String, String>builder()
+        assertEquals(sessionBuilder.getSystemProperties(), ImmutableMap.<String, String>builder()
                 .put(QUERY_MAX_MEMORY, "1GB")
                 .put(JOIN_DISTRIBUTION_TYPE, "partitioned")
                 .put(HASH_PARTITION_COUNT, "43")
                 .put("override", "should be overridden")
                 .build());
         assertEquals(
-                session.getUnprocessedCatalogProperties(),
+                sessionBuilder.getUnprocessedCatalogProperties(),
                 ImmutableMap.of(
                         "testCatalog",
                         ImmutableMap.<String, String>builder()
                                 .put("explicit_set", "explicit_set")
                                 .build()));
 
-        session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, Optional.empty(), Optional.of(TEST_RESOURCE_GROUP_ID));
+        sessionPropertyDefaults.applyDefaultProperties(sessionBuilder, Optional.empty(), Optional.of(TEST_RESOURCE_GROUP_ID));
 
-        assertEquals(session.getSystemProperties(), ImmutableMap.<String, String>builder()
+        assertEquals(sessionBuilder.getSystemProperties(), ImmutableMap.<String, String>builder()
                 .put(QUERY_MAX_MEMORY, "1GB")
                 .put(JOIN_DISTRIBUTION_TYPE, "partitioned")
                 .put(HASH_PARTITION_COUNT, "43")
@@ -93,7 +93,7 @@ public class TestSessionPropertyDefaults
                 .put("override", "overridden")
                 .build());
         assertEquals(
-                session.getUnprocessedCatalogProperties(),
+                sessionBuilder.getUnprocessedCatalogProperties(),
                 ImmutableMap.of(
                         "testCatalog",
                         ImmutableMap.<String, String>builder()

--- a/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.assertThrows;
 public class TestFileBasedAccessControl
 {
     public static final ConnectorTransactionHandle TRANSACTION_HANDLE = new ConnectorTransactionHandle() {};
-    public static final AccessControlContext CONTEXT = new AccessControlContext(new QueryId("query_id"), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats());
+    public static final AccessControlContext CONTEXT = new AccessControlContext(new QueryId("query_id"), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty());
 
     @Test
     public void testSchemaRules()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControlContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControlContext.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.security;
 
 import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCollector;
 
@@ -30,8 +31,9 @@ public class AccessControlContext
     private final Optional<String> source;
     private final WarningCollector warningCollector;
     private final RuntimeStats runtimeStats;
+    private final Optional<QueryType> queryType;
 
-    public AccessControlContext(QueryId queryId, Optional<String> clientInfo, Set<String> clientTags, Optional<String> source, WarningCollector warningCollector, RuntimeStats runtimeStats)
+    public AccessControlContext(QueryId queryId, Optional<String> clientInfo, Set<String> clientTags, Optional<String> source, WarningCollector warningCollector, RuntimeStats runtimeStats, Optional<QueryType> queryType)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
@@ -39,6 +41,7 @@ public class AccessControlContext
         this.source = requireNonNull(source, "source is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
+        this.queryType = requireNonNull(queryType, "queryType is null");
     }
 
     public QueryId getQueryId()
@@ -69,5 +72,10 @@ public class AccessControlContext
     public RuntimeStats getRuntimeStats()
     {
         return runtimeStats;
+    }
+
+    public Optional<QueryType> getQueryType()
+    {
+        return queryType;
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3072,7 +3072,8 @@ public abstract class AbstractTestQueries
                 ImmutableMap.of(),
                 getSession().getTracer(),
                 getSession().getWarningCollector(),
-                getSession().getRuntimeStats());
+                getSession().getRuntimeStats(),
+                getSession().getQueryType());
         MaterializedResult result = computeActual(session, "SHOW SESSION");
 
         ImmutableMap<String, MaterializedRow> properties = Maps.uniqueIndex(result.getMaterializedRows(), input -> {


### PR DESCRIPTION
## Description
Adding a QueryType field into the AccessControlContext object to allow for this information to be available when making access control related decisions.

## Motivation and Context
The addition of QueryType allows for downstream function calls to access this context which can be used to alter decision making if needed.

## Impact
Minor performance enhancement as rebuilding Session is no longer needed. If additional context needs to be added into Session, we can utilize SessionBuilder to add additional/edit material.

## Test Plan
Tested code change by running sample queries and followed the call stack to ensure queryType was present.
<img width="1195" alt="Screenshot 2024-09-16 at 13 10 19" src="https://github.com/user-attachments/assets/25b94acf-4cdc-442a-946f-39106e173b42">
Also verified the context was present in the AccessControlContext through unit tests under AbstractTestQueries.

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```