### PR TITLE
[native] Update protocol for iceberg writes

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergSchema.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergSchema.java
@@ -45,7 +45,7 @@ public class PrestoIcebergSchema
         this.schemaId = schemaId;
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.columnNameToIdMapping = ImmutableMap.copyOf(requireNonNull(columnNameToIdMapping, "columnNameToIdMapping is null"));
-        this.aliases = aliases != null ? ImmutableMap.copyOf(aliases) : null;
+        this.aliases = aliases != null ? ImmutableMap.copyOf(aliases) : ImmutableMap.of();
         this.identifierFieldIds = ImmutableSet.copyOf(requireNonNull(identifierFieldIds, "identifierFieldIds is null"));
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SchemaConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SchemaConverter.java
@@ -45,7 +45,7 @@ public final class SchemaConverter
                 schema.getColumns().stream()
                         .map(nestedField -> toIcebergNestedField(nestedField, schema.getColumnNameToIdMapping()))
                         .collect(toImmutableList()),
-                schema.getAliases(),
+                schema.getAliases().isEmpty() ? null : schema.getAliases(),
                 schema.getIdentifierFieldIds());
     }
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.cpp
@@ -7897,6 +7897,534 @@ void from_json(const json& j, HiveTransactionHandle& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<IcebergTableType, json> IcebergTableType_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {IcebergTableType::DATA, "DATA"},
+        {IcebergTableType::HISTORY, "HISTORY"},
+        {IcebergTableType::SNAPSHOTS, "SNAPSHOTS"},
+        {IcebergTableType::MANIFESTS, "MANIFESTS"},
+        {IcebergTableType::PARTITIONS, "PARTITIONS"},
+        {IcebergTableType::FILES, "FILES"},
+        {IcebergTableType::REFS, "REFS"},
+        {IcebergTableType::PROPERTIES, "PROPERTIES"},
+        {IcebergTableType::CHANGELOG, "CHANGELOG"},
+        {IcebergTableType::EQUALITY_DELETES, "EQUALITY_DELETES"},
+        {IcebergTableType::DATA_WITHOUT_EQUALITY_DELETES,
+         "DATA_WITHOUT_EQUALITY_DELETES"}};
+void to_json(json& j, const IcebergTableType& e) {
+  static_assert(
+      std::is_enum<IcebergTableType>::value,
+      "IcebergTableType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(IcebergTableType_enum_table),
+      std::end(IcebergTableType_enum_table),
+      [e](const std::pair<IcebergTableType, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(IcebergTableType_enum_table))
+           ? it
+           : std::begin(IcebergTableType_enum_table))
+          ->second;
+}
+void from_json(const json& j, IcebergTableType& e) {
+  static_assert(
+      std::is_enum<IcebergTableType>::value,
+      "IcebergTableType must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(IcebergTableType_enum_table),
+      std::end(IcebergTableType_enum_table),
+      [&j](const std::pair<IcebergTableType, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(IcebergTableType_enum_table))
+           ? it
+           : std::begin(IcebergTableType_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const IcebergTableName& p) {
+  j = json::object();
+  to_json_key(
+      j, "tableName", p.tableName, "IcebergTableName", "String", "tableName");
+  to_json_key(
+      j,
+      "tableType",
+      p.tableType,
+      "IcebergTableName",
+      "IcebergTableType",
+      "tableType");
+  to_json_key(
+      j, "snapshotId", p.snapshotId, "IcebergTableName", "Long", "snapshotId");
+  to_json_key(
+      j,
+      "changelogEndSnapshot",
+      p.changelogEndSnapshot,
+      "IcebergTableName",
+      "Long",
+      "changelogEndSnapshot");
+}
+
+void from_json(const json& j, IcebergTableName& p) {
+  from_json_key(
+      j, "tableName", p.tableName, "IcebergTableName", "String", "tableName");
+  from_json_key(
+      j,
+      "tableType",
+      p.tableType,
+      "IcebergTableName",
+      "IcebergTableType",
+      "tableType");
+  from_json_key(
+      j, "snapshotId", p.snapshotId, "IcebergTableName", "Long", "snapshotId");
+  from_json_key(
+      j,
+      "changelogEndSnapshot",
+      p.changelogEndSnapshot,
+      "IcebergTableName",
+      "Long",
+      "changelogEndSnapshot");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const PrestoIcebergNestedField& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "optional",
+      p.optional,
+      "PrestoIcebergNestedField",
+      "bool",
+      "optional");
+  to_json_key(j, "id", p.id, "PrestoIcebergNestedField", "int", "id");
+  to_json_key(j, "name", p.name, "PrestoIcebergNestedField", "String", "name");
+  to_json_key(
+      j,
+      "prestoType",
+      p.prestoType,
+      "PrestoIcebergNestedField",
+      "Type",
+      "prestoType");
+  to_json_key(j, "doc", p.doc, "PrestoIcebergNestedField", "String", "doc");
+}
+
+void from_json(const json& j, PrestoIcebergNestedField& p) {
+  from_json_key(
+      j,
+      "optional",
+      p.optional,
+      "PrestoIcebergNestedField",
+      "bool",
+      "optional");
+  from_json_key(j, "id", p.id, "PrestoIcebergNestedField", "int", "id");
+  from_json_key(
+      j, "name", p.name, "PrestoIcebergNestedField", "String", "name");
+  from_json_key(
+      j,
+      "prestoType",
+      p.prestoType,
+      "PrestoIcebergNestedField",
+      "Type",
+      "prestoType");
+  from_json_key(j, "doc", p.doc, "PrestoIcebergNestedField", "String", "doc");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const PrestoIcebergSchema& p) {
+  j = json::object();
+  to_json_key(
+      j, "schemaId", p.schemaId, "PrestoIcebergSchema", "int", "schemaId");
+  to_json_key(
+      j,
+      "columns",
+      p.columns,
+      "PrestoIcebergSchema",
+      "List<PrestoIcebergNestedField>",
+      "columns");
+  to_json_key(
+      j,
+      "columnNameToIdMapping",
+      p.columnNameToIdMapping,
+      "PrestoIcebergSchema",
+      "Map<String, Integer>",
+      "columnNameToIdMapping");
+  to_json_key(
+      j,
+      "aliases",
+      p.aliases,
+      "PrestoIcebergSchema",
+      "Map<String, Integer>",
+      "aliases");
+  to_json_key(
+      j,
+      "identifierFieldIds",
+      p.identifierFieldIds,
+      "PrestoIcebergSchema",
+      "List<Integer>",
+      "identifierFieldIds");
+}
+
+void from_json(const json& j, PrestoIcebergSchema& p) {
+  from_json_key(
+      j, "schemaId", p.schemaId, "PrestoIcebergSchema", "int", "schemaId");
+  from_json_key(
+      j,
+      "columns",
+      p.columns,
+      "PrestoIcebergSchema",
+      "List<PrestoIcebergNestedField>",
+      "columns");
+  from_json_key(
+      j,
+      "columnNameToIdMapping",
+      p.columnNameToIdMapping,
+      "PrestoIcebergSchema",
+      "Map<String, Integer>",
+      "columnNameToIdMapping");
+  from_json_key(
+      j,
+      "aliases",
+      p.aliases,
+      "PrestoIcebergSchema",
+      "Map<String, Integer>",
+      "aliases");
+  from_json_key(
+      j,
+      "identifierFieldIds",
+      p.identifierFieldIds,
+      "PrestoIcebergSchema",
+      "List<Integer>",
+      "identifierFieldIds");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const PrestoIcebergPartitionSpec& p) {
+  j = json::object();
+  to_json_key(
+      j, "specId", p.specId, "PrestoIcebergPartitionSpec", "int", "specId");
+  to_json_key(
+      j,
+      "schema",
+      p.schema,
+      "PrestoIcebergPartitionSpec",
+      "PrestoIcebergSchema",
+      "schema");
+  to_json_key(
+      j,
+      "fields",
+      p.fields,
+      "PrestoIcebergPartitionSpec",
+      "List<String>",
+      "fields");
+}
+
+void from_json(const json& j, PrestoIcebergPartitionSpec& p) {
+  from_json_key(
+      j, "specId", p.specId, "PrestoIcebergPartitionSpec", "int", "specId");
+  from_json_key(
+      j,
+      "schema",
+      p.schema,
+      "PrestoIcebergPartitionSpec",
+      "PrestoIcebergSchema",
+      "schema");
+  from_json_key(
+      j,
+      "fields",
+      p.fields,
+      "PrestoIcebergPartitionSpec",
+      "List<String>",
+      "fields");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+IcebergInsertTableHandle::IcebergInsertTableHandle() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergInsertTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(
+      j,
+      "schemaName",
+      p.schemaName,
+      "IcebergInsertTableHandle",
+      "String",
+      "schemaName");
+  to_json_key(
+      j,
+      "tableName",
+      p.tableName,
+      "IcebergInsertTableHandle",
+      "IcebergTableName",
+      "tableName");
+  to_json_key(
+      j,
+      "schema",
+      p.schema,
+      "IcebergInsertTableHandle",
+      "PrestoIcebergSchema",
+      "schema");
+  to_json_key(
+      j,
+      "partitionSpec",
+      p.partitionSpec,
+      "IcebergInsertTableHandle",
+      "PrestoIcebergPartitionSpec",
+      "partitionSpec");
+  to_json_key(
+      j,
+      "inputColumns",
+      p.inputColumns,
+      "IcebergInsertTableHandle",
+      "List<IcebergColumnHandle>",
+      "inputColumns");
+  to_json_key(
+      j,
+      "outputPath",
+      p.outputPath,
+      "IcebergInsertTableHandle",
+      "String",
+      "outputPath");
+  to_json_key(
+      j,
+      "fileFormat",
+      p.fileFormat,
+      "IcebergInsertTableHandle",
+      "FileFormat",
+      "fileFormat");
+  to_json_key(
+      j,
+      "compressionCodec",
+      p.compressionCodec,
+      "IcebergInsertTableHandle",
+      "HiveCompressionCodec",
+      "compressionCodec");
+  to_json_key(
+      j,
+      "storageProperties",
+      p.storageProperties,
+      "IcebergInsertTableHandle",
+      "Map<String, String>",
+      "storageProperties");
+}
+
+void from_json(const json& j, IcebergInsertTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "schemaName",
+      p.schemaName,
+      "IcebergInsertTableHandle",
+      "String",
+      "schemaName");
+  from_json_key(
+      j,
+      "tableName",
+      p.tableName,
+      "IcebergInsertTableHandle",
+      "IcebergTableName",
+      "tableName");
+  from_json_key(
+      j,
+      "schema",
+      p.schema,
+      "IcebergInsertTableHandle",
+      "PrestoIcebergSchema",
+      "schema");
+  from_json_key(
+      j,
+      "partitionSpec",
+      p.partitionSpec,
+      "IcebergInsertTableHandle",
+      "PrestoIcebergPartitionSpec",
+      "partitionSpec");
+  from_json_key(
+      j,
+      "inputColumns",
+      p.inputColumns,
+      "IcebergInsertTableHandle",
+      "List<IcebergColumnHandle>",
+      "inputColumns");
+  from_json_key(
+      j,
+      "outputPath",
+      p.outputPath,
+      "IcebergInsertTableHandle",
+      "String",
+      "outputPath");
+  from_json_key(
+      j,
+      "fileFormat",
+      p.fileFormat,
+      "IcebergInsertTableHandle",
+      "FileFormat",
+      "fileFormat");
+  from_json_key(
+      j,
+      "compressionCodec",
+      p.compressionCodec,
+      "IcebergInsertTableHandle",
+      "HiveCompressionCodec",
+      "compressionCodec");
+  from_json_key(
+      j,
+      "storageProperties",
+      p.storageProperties,
+      "IcebergInsertTableHandle",
+      "Map<String, String>",
+      "storageProperties");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+IcebergOutputTableHandle::IcebergOutputTableHandle() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergOutputTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(
+      j,
+      "schemaName",
+      p.schemaName,
+      "IcebergOutputTableHandle",
+      "String",
+      "schemaName");
+  to_json_key(
+      j,
+      "tableName",
+      p.tableName,
+      "IcebergOutputTableHandle",
+      "IcebergTableName",
+      "tableName");
+  to_json_key(
+      j,
+      "schema",
+      p.schema,
+      "IcebergOutputTableHandle",
+      "PrestoIcebergSchema",
+      "schema");
+  to_json_key(
+      j,
+      "partitionSpec",
+      p.partitionSpec,
+      "IcebergOutputTableHandle",
+      "PrestoIcebergPartitionSpec",
+      "partitionSpec");
+  to_json_key(
+      j,
+      "inputColumns",
+      p.inputColumns,
+      "IcebergOutputTableHandle",
+      "List<IcebergColumnHandle>",
+      "inputColumns");
+  to_json_key(
+      j,
+      "outputPath",
+      p.outputPath,
+      "IcebergOutputTableHandle",
+      "String",
+      "outputPath");
+  to_json_key(
+      j,
+      "fileFormat",
+      p.fileFormat,
+      "IcebergOutputTableHandle",
+      "FileFormat",
+      "fileFormat");
+  to_json_key(
+      j,
+      "compressionCodec",
+      p.compressionCodec,
+      "IcebergOutputTableHandle",
+      "HiveCompressionCodec",
+      "compressionCodec");
+  to_json_key(
+      j,
+      "storageProperties",
+      p.storageProperties,
+      "IcebergOutputTableHandle",
+      "Map<String, String>",
+      "storageProperties");
+}
+
+void from_json(const json& j, IcebergOutputTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "schemaName",
+      p.schemaName,
+      "IcebergOutputTableHandle",
+      "String",
+      "schemaName");
+  from_json_key(
+      j,
+      "tableName",
+      p.tableName,
+      "IcebergOutputTableHandle",
+      "IcebergTableName",
+      "tableName");
+  from_json_key(
+      j,
+      "schema",
+      p.schema,
+      "IcebergOutputTableHandle",
+      "PrestoIcebergSchema",
+      "schema");
+  from_json_key(
+      j,
+      "partitionSpec",
+      p.partitionSpec,
+      "IcebergOutputTableHandle",
+      "PrestoIcebergPartitionSpec",
+      "partitionSpec");
+  from_json_key(
+      j,
+      "inputColumns",
+      p.inputColumns,
+      "IcebergOutputTableHandle",
+      "List<IcebergColumnHandle>",
+      "inputColumns");
+  from_json_key(
+      j,
+      "outputPath",
+      p.outputPath,
+      "IcebergOutputTableHandle",
+      "String",
+      "outputPath");
+  from_json_key(
+      j,
+      "fileFormat",
+      p.fileFormat,
+      "IcebergOutputTableHandle",
+      "FileFormat",
+      "fileFormat");
+  from_json_key(
+      j,
+      "compressionCodec",
+      p.compressionCodec,
+      "IcebergOutputTableHandle",
+      "HiveCompressionCodec",
+      "compressionCodec");
+  from_json_key(
+      j,
+      "storageProperties",
+      p.storageProperties,
+      "IcebergOutputTableHandle",
+      "Map<String, String>",
+      "storageProperties");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 IcebergSplit::IcebergSplit() noexcept {
   _type = "hive-iceberg";
 }
@@ -8044,100 +8572,6 @@ void from_json(const json& j, IcebergSplit& p) {
       "IcebergSplit",
       "int64_t",
       "dataSequenceNumber");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<IcebergTableType, json> IcebergTableType_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {IcebergTableType::DATA, "DATA"},
-        {IcebergTableType::HISTORY, "HISTORY"},
-        {IcebergTableType::SNAPSHOTS, "SNAPSHOTS"},
-        {IcebergTableType::MANIFESTS, "MANIFESTS"},
-        {IcebergTableType::PARTITIONS, "PARTITIONS"},
-        {IcebergTableType::FILES, "FILES"},
-        {IcebergTableType::REFS, "REFS"},
-        {IcebergTableType::PROPERTIES, "PROPERTIES"},
-        {IcebergTableType::CHANGELOG, "CHANGELOG"},
-        {IcebergTableType::EQUALITY_DELETES, "EQUALITY_DELETES"},
-        {IcebergTableType::DATA_WITHOUT_EQUALITY_DELETES,
-         "DATA_WITHOUT_EQUALITY_DELETES"}};
-void to_json(json& j, const IcebergTableType& e) {
-  static_assert(
-      std::is_enum<IcebergTableType>::value,
-      "IcebergTableType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(IcebergTableType_enum_table),
-      std::end(IcebergTableType_enum_table),
-      [e](const std::pair<IcebergTableType, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(IcebergTableType_enum_table))
-           ? it
-           : std::begin(IcebergTableType_enum_table))
-          ->second;
-}
-void from_json(const json& j, IcebergTableType& e) {
-  static_assert(
-      std::is_enum<IcebergTableType>::value,
-      "IcebergTableType must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(IcebergTableType_enum_table),
-      std::end(IcebergTableType_enum_table),
-      [&j](const std::pair<IcebergTableType, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(IcebergTableType_enum_table))
-           ? it
-           : std::begin(IcebergTableType_enum_table))
-          ->first;
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const IcebergTableName& p) {
-  j = json::object();
-  to_json_key(
-      j, "tableName", p.tableName, "IcebergTableName", "String", "tableName");
-  to_json_key(
-      j,
-      "tableType",
-      p.tableType,
-      "IcebergTableName",
-      "IcebergTableType",
-      "tableType");
-  to_json_key(
-      j, "snapshotId", p.snapshotId, "IcebergTableName", "Long", "snapshotId");
-  to_json_key(
-      j,
-      "changelogEndSnapshot",
-      p.changelogEndSnapshot,
-      "IcebergTableName",
-      "Long",
-      "changelogEndSnapshot");
-}
-
-void from_json(const json& j, IcebergTableName& p) {
-  from_json_key(
-      j, "tableName", p.tableName, "IcebergTableName", "String", "tableName");
-  from_json_key(
-      j,
-      "tableType",
-      p.tableType,
-      "IcebergTableName",
-      "IcebergTableType",
-      "tableType");
-  from_json_key(
-      j, "snapshotId", p.snapshotId, "IcebergTableName", "Long", "snapshotId");
-  from_json_key(
-      j,
-      "changelogEndSnapshot",
-      p.changelogEndSnapshot,
-      "IcebergTableName",
-      "Long",
-      "changelogEndSnapshot");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.h
@@ -2121,27 +2121,6 @@ void to_json(json& j, const HiveTransactionHandle& p);
 void from_json(const json& j, HiveTransactionHandle& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct IcebergSplit : public ConnectorSplit {
-  String path = {};
-  int64_t start = {};
-  int64_t length = {};
-  FileFormat fileFormat = {};
-  List<HostAddress> addresses = {};
-  Map<Integer, HivePartitionKey> partitionKeys = {};
-  String partitionSpecAsJson = {};
-  std::shared_ptr<String> partitionDataJson = {};
-  NodeSelectionStrategy nodeSelectionStrategy = {};
-  SplitWeight splitWeight = {};
-  List<DeleteFile> deletes = {};
-  std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo = {};
-  int64_t dataSequenceNumber = {};
-
-  IcebergSplit() noexcept;
-};
-void to_json(json& j, const IcebergSplit& p);
-void from_json(const json& j, IcebergSplit& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 enum class IcebergTableType {
   DATA,
   HISTORY,
@@ -2167,6 +2146,92 @@ struct IcebergTableName {
 };
 void to_json(json& j, const IcebergTableName& p);
 void from_json(const json& j, IcebergTableName& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PrestoIcebergNestedField {
+  bool optional = {};
+  int id = {};
+  String name = {};
+  Type prestoType = {};
+  std::shared_ptr<String> doc = {};
+};
+void to_json(json& j, const PrestoIcebergNestedField& p);
+void from_json(const json& j, PrestoIcebergNestedField& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PrestoIcebergSchema {
+  int schemaId = {};
+  List<PrestoIcebergNestedField> columns = {};
+  Map<String, Integer> columnNameToIdMapping = {};
+  Map<String, Integer> aliases = {};
+  List<Integer> identifierFieldIds = {};
+};
+void to_json(json& j, const PrestoIcebergSchema& p);
+void from_json(const json& j, PrestoIcebergSchema& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct PrestoIcebergPartitionSpec {
+  int specId = {};
+  PrestoIcebergSchema schema = {};
+  List<String> fields = {};
+};
+void to_json(json& j, const PrestoIcebergPartitionSpec& p);
+void from_json(const json& j, PrestoIcebergPartitionSpec& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+
+  IcebergInsertTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergInsertTableHandle& p);
+void from_json(const json& j, IcebergInsertTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct IcebergOutputTableHandle : public ConnectorOutputTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+
+  IcebergOutputTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergOutputTableHandle& p);
+void from_json(const json& j, IcebergOutputTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct IcebergSplit : public ConnectorSplit {
+  String path = {};
+  int64_t start = {};
+  int64_t length = {};
+  FileFormat fileFormat = {};
+  List<HostAddress> addresses = {};
+  Map<Integer, HivePartitionKey> partitionKeys = {};
+  String partitionSpecAsJson = {};
+  std::shared_ptr<String> partitionDataJson = {};
+  NodeSelectionStrategy nodeSelectionStrategy = {};
+  SplitWeight splitWeight = {};
+  List<DeleteFile> deletes = {};
+  std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo = {};
+  int64_t dataSequenceNumber = {};
+
+  IcebergSplit() noexcept;
+};
+void to_json(json& j, const IcebergSplit& p);
+void from_json(const json& j, IcebergSplit& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct IcebergTableHandle : public ConnectorTableHandle {

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -73,11 +73,13 @@ AbstractClasses:
       super: JsonEncodedSubclass
       subclasses:
         - { name: HiveOutputTableHandle,          key: hive }
+        - { name: IcebergOutputTableHandle,       key: hive-iceberg }
 
     ConnectorInsertTableHandle:
       super: JsonEncodedSubclass
       subclasses:
         - { name: HiveInsertTableHandle,          key: hive }
+        - { name: IcebergInsertTableHandle,       key: hive-iceberg }
 
     ConnectorTransactionHandle:
       super: JsonEncodedSubclass
@@ -250,13 +252,18 @@ JavaClasses:
   - presto-hive/src/main/java/com/facebook/presto/hive/HiveTransactionHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergSchema.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableName.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableType.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOutputTableHandle.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergPartitionSpec.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergNestedField.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogOperation.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitInfo.java


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This PR includes the Presto Protocol Changes required for implementing Iceberg Writes in Presto C++.

This PR includes two commits:
- `Make com.facebook.presto.iceberg.PrestoIcebergSchema.aliases not null`: This is a small change required because when it is null, aliases are not serialized as part of the object. This leads to failures when we try to deserialize the objects in Prestissimo since Prestissimo expects it. Due to this, I made a small change to send an empty map rather than setting it as null aligning with how we do it for other similar fields. 
- The second commit includes the required protocol changes.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
As part of the ongoing effort to support Iceberg Writes with Presto C++.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

