### PR TITLE
Fix correctness bug in EffectivePredicateExtractor

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1669,6 +1669,17 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testUncorrelatedSubqueryWithEmptyResult()
+    {
+        assertQuery(
+                "SELECT regionkey, (select name from nation where false) from region",
+                "SELECT regionkey, NULL from region");
+        assertQuery(
+                "SELECT regionkey, (select name from nation where nationkey = 5 and mod(nationkey,5) = 1) from region",
+                "SELECT regionkey, NULL from region");
+    }
+
+    @Test
     public void testChecksum()
     {
         assertQuery("SELECT to_hex(checksum(0))", "SELECT '0000000000000000'");


### PR DESCRIPTION
## Description
Fixes https://github.com/prestodb/presto/issues/23660

During predicate pushdown through a Join, we were 
- Pulling up a predicate expression that only refers to constant values
- Incorrectly pushing down this predicate between join sides
- This predicate expression gets optimized to `FALSE`, but now is pushed down to both sides of the join

This results in the optimizer Incorrectly assuming no results will be produced

## Fix
Pulling up expressions happens in`EffectivePredicateExtractor#pullExpressionThroughVariables`. This was modified to stop pulling up expressions that only refer to constants since this is logically incorrect

## Test Plan
- New unit and E2E tests added

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

