### PR TITLE
broadcasted --> broadcast

### DIFF
--- a/presto-docs/src/main/sphinx/sql/explain.rst
+++ b/presto-docs/src/main/sphinx/sql/explain.rst
@@ -38,7 +38,7 @@ distributed between fragments:
 
 ``BROADCAST``
     Fragment is executed on a fixed number of nodes with the input data
-    broadcasted to all nodes.
+    broadcast to all nodes.
 
 ``SOURCE``
     Fragment is executed on nodes where input splits are accessed.


### PR DESCRIPTION
broadcasted isn't totally wrong, but broadcast is usually preferred as the past tense

## Description
broadcasted --> broadcast

## Motivation and Context
Grammar pedantry

## Impact
none

## Test Plan
none

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

