### PR TITLE
Avoid confusion between ErrorCode and ErrorCodeSupplier

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/PrestoException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PrestoException.java
@@ -20,14 +20,14 @@ public class PrestoException
 {
     private final ErrorCode errorCode;
 
-    public PrestoException(ErrorCodeSupplier errorCode, String message)
+    public PrestoException(ErrorCodeSupplier errorCodeSupplier, String message)
     {
-        this(errorCode, message, null);
+        this(errorCodeSupplier, message, null);
     }
 
-    public PrestoException(ErrorCodeSupplier errorCode, Throwable throwable)
+    public PrestoException(ErrorCodeSupplier errorCodeSupplier, Throwable throwable)
     {
-        this(errorCode, null, throwable);
+        this(errorCodeSupplier, null, throwable);
     }
 
     public PrestoException(ErrorCodeSupplier errorCodeSupplier, String message, Throwable cause)


### PR DESCRIPTION
## Description
errorCode --> errorCodeSupplier; match names to types

## Motivation and Context
This briefly confused me when I was reading code

## Impact
none

## Test Plan
mvn test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

