### PR TITLE
Security Fix for Lucene-core PRISMA-2021-0081

### DIFF
--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -30,6 +30,10 @@
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## Description
Security fix for Lucene-core
Fixed - 1 High
vulnerable version : 8.2.0
Fixed version : 8.10.0
excluded the higher version because local source build was breaking.



## Motivation and Context
Reasons to exclude:

1. Apache Lucene is vulnerable to ReDos, the regex engine in Lucene can take long time and high CPU usage before
determining the total count for the states of a regex.

## Impact
[Image scan](http://9.30.122.186:8080/job/multiscanner-scan-on-demand/1697/) showed the vulnerability has been removed
Image scan report :
[correlation-report-ibm-lh-presto lucene 10th.csv](https://github.ibm.com/lakehouse/presto/files/1405394/correlation-report-ibm-lh-presto.lucene.10th.csv)

## Test Plan
Tested in 3 form factor : Cpd,Dev and SaaS

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

