### PR TITLE
[native] Remove dependencies of old arbitrator config

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -739,7 +739,7 @@ void PrestoServer::initializeThreadPools() {
 #ifdef __linux__
     threadFactory = std::make_shared<BatchThreadFactory>("Driver");
 #else
-    VELOX_FAIL("Batch scheduling policy can only be enabled on Linux")
+    VELOX_FAIL("Batch scheduling policy can only be enabled on Linux");
 #endif
   } else {
     threadFactory = std::make_shared<folly::NamedThreadFactory>("Driver");

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -198,7 +198,10 @@ class TaskManagerTest : public testing::Test {
     velox::memory::MemoryManagerOptions options;
     options.allocatorCapacity = 8L << 30;
     options.arbitratorCapacity = 6L << 30;
-    options.memoryPoolInitCapacity = 512 << 20;
+    options.extraArbitratorConfigs = {
+        {std::string(velox::memory::SharedArbitrator::ExtraConfig::
+                         kMemoryPoolInitialCapacity),
+         "512MB"}};
     options.arbitratorKind = "SHARED";
     options.checkUsageLeak = true;
     options.arbitrationStateCheckCb = memoryArbitrationStateCheck;


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

