### PR TITLE
Enable extra credentials for the system connector.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
@@ -34,7 +34,7 @@ public final class SystemConnectorSessionUtil
     {
         TransactionId transactionId = ((GlobalSystemTransactionHandle) transactionHandle).getTransactionId();
         ConnectorIdentity connectorIdentity = session.getIdentity();
-        Identity identity = new Identity(connectorIdentity.getUser(), connectorIdentity.getPrincipal());
+        Identity identity = new Identity(connectorIdentity.getUser(), connectorIdentity.getPrincipal(), connectorIdentity.getExtraCredentials());
         return Session.builder(new SessionPropertyManager(SYSTEM_SESSION_PROPERTIES))
                 .setQueryId(new QueryId(session.getQueryId()))
                 .setTransactionId(transactionId)

--- a/presto-main/src/test/java/com/facebook/presto/connector/system/TestSystemSession.java
+++ b/presto-main/src/test/java/com/facebook/presto/connector/system/TestSystemSession.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.security.ConnectorIdentity;
+import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestSystemSession
+{
+    @Test
+    public void testSystemSessionForExtraCredentials()
+    {
+        Map<String, String> extraCredentials = ImmutableMap.of("key1", "value1", "key2", "value2");
+        String user = "user";
+        String principal = "principal";
+
+        ConnectorTransactionHandle transactionHandle = new GlobalSystemTransactionHandle("connector-id", new TransactionId(UUID.randomUUID()));
+
+        ConnectorIdentity connectorIdentity = new ConnectorIdentity(
+                user,
+                Optional.of(() -> principal),
+                Optional.empty(),
+                extraCredentials,
+                ImmutableMap.of(),
+                Optional.of("selectedUserName"),
+                Optional.of("reasonForSelection"));
+
+        TestingConnectorSession testingConnectorSession = new TestingConnectorSession(connectorIdentity,
+                ImmutableList.of(new PropertyMetadata<>("property-name",
+                        "This is a description",
+                        VarcharType.createUnboundedVarcharType(),
+                        String.class,
+                        "defaultValue",
+                        false,
+                        Object::toString,
+                        value -> value)));
+
+        Session resultSession = SystemConnectorSessionUtil.toSession(transactionHandle, testingConnectorSession);
+
+        assertNotNull(resultSession);
+        assertEquals(resultSession.getIdentity().getUser(), "user");
+        assertEquals(resultSession.getIdentity().getPrincipal().get().getName(), principal);
+        assertEquals(resultSession.getIdentity().getExtraCredentials(), extraCredentials);
+    }
+}


### PR DESCRIPTION
## Description
It was identified that extra credentials were not being passed into the connector session when running queries against system.jdbc.tables. 
**fix:**
Modified the constructor call for the Identity class to pass extra credentials.

A use case is that `system.jdbc.tables` should not fail for any connectors (e.g., the Arrow Flight connector)

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

