### PR TITLE
Prometheus fix for count(*)

### DIFF
--- a/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusRecordCursor.java
+++ b/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusRecordCursor.java
@@ -270,7 +270,7 @@ public class PrometheusRecordCursor
         int columnIndex = fieldToColumnIndex[field];
         switch (columnIndex) {
             case 0:
-                return fields.getLabels();
+                return getBlockFromMap(columnHandles.get(columnIndex).getColumnType(), fields.getLabels());
             case 1:
                 return fields.getTimestamp();
             case 2:
@@ -284,13 +284,12 @@ public class PrometheusRecordCursor
         Type actual = getType(field);
         checkArgument(actual.equals(expected), "Expected field %s to be type %s but is %s", field, expected, actual);
     }
-
     private List<PrometheusStandardizedRow> prometheusResultsInStandardizedForm(List<PrometheusMetricResult> results)
     {
         return results.stream().map(result ->
                 result.getTimeSeriesValues().getValues().stream().map(prometheusTimeSeriesValue ->
                         new PrometheusStandardizedRow(
-                                getBlockFromMap(columnHandles.get(0).getColumnType(), metricHeaderToMap(result.getMetricHeader())),
+                                result.getMetricHeader(),
                                 prometheusTimeSeriesValue.getTimestamp(),
                                 Double.parseDouble(prometheusTimeSeriesValue.getValue())))
                         .collect(Collectors.toList()))

--- a/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusStandardizedRow.java
+++ b/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusStandardizedRow.java
@@ -13,26 +13,25 @@
  */
 package com.facebook.presto.plugin.prometheus;
 
-import com.facebook.presto.common.block.Block;
-
 import java.time.Instant;
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
 public class PrometheusStandardizedRow
 {
-    private final Block labels;
+    private final Map<String, String> labels;
     private final Instant timestamp;
     private final Double value;
 
-    public PrometheusStandardizedRow(Block labels, Instant timestamp, Double value)
+    public PrometheusStandardizedRow(Map<String, String> labels, Instant timestamp, Double value)
     {
         this.labels = requireNonNull(labels, "labels is null");
         this.timestamp = requireNonNull(timestamp, "timestamp is null");
         this.value = requireNonNull(value, "value is null");
     }
 
-    public Block getLabels()
+    public Map<String, String> getLabels()
     {
         return labels;
     }

--- a/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusMetricsIntegration.java
+++ b/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusMetricsIntegration.java
@@ -118,4 +118,13 @@ public class TestPrometheusMetricsIntegration
         MaterializedResult results = runner.execute(session, "SELECT * FROM prometheus.default.up WHERE timestamp > (NOW() - INTERVAL '15' SECOND)").toTestTypes();
         assertEquals(results.getRowCount(), 1);
     }
+    @Test(priority = 3, dependsOnMethods = "testConfirmMetricAvailableAndCheckUp")
+    public void testCountQuery()
+    {
+        MaterializedResult countResult = runner.execute(session, "SELECT COUNT(*) FROM prometheus.default.up").toTestTypes();
+        assertEquals(countResult.getRowCount(), 1);
+        MaterializedRow countRow = countResult.getMaterializedRows().get(0);
+        long countValue = (Long) countRow.getField(0);
+        assert countValue >= 1 : "Expected COUNT(*) to be >= 1, but got " + countValue;
+    }
 }


### PR DESCRIPTION
## Description

In this Presto pull request, we are addressing the issue where an aggregate query with a labels column returns an empty `columnHandles `list, leading to an `ArrayIndexOutOfBoundsException` when the function `columnHandles.get(0).getColumnType()` is called. To handle this, we bypass the conversion from `metricHeader` to a `Block `type (performed by the `getBlockFromMap` function at line 293 in `PrometheusRecordCursor.java`). We are modifying the constructor of PrometheusStandardizedRow to accept a Map type rather than a Block. The conversion to BlockFromMap is now deferred to the getFieldValue function, where getLabels() is used.


Honoring the Trino PR: https://github.com/trinodb/trino/pull/12510
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
https://github.com/prestodb/presto/issues/23702

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

