### PR TITLE
Reorder test-jar dependency

### DIFF
--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -261,13 +261,13 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-resource-group-managers</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-resource-group-managers</artifactId>
-            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Description
Move test-jar dependency first on presto-resource-group-managers to help IntelliJ build

## Motivation and Context
Depending on both the module and the test-jar of the module is strange, and is possibly breaking my IntelliJ build. This seems to fix the problem, though it's tricky to untangle all the ways IntelliJ misunderstands the presto Maven build. 

There are also split package issues here that could cause us problems down the road in Java 11+. 

## Impact
None. This is all test code and test infrastructure. If tests pass, we're good.


## Test Plan
mvn test-compile
CI
Rebukld module in IntelliJ

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

