### PR TITLE
CVE-2024-1597 updated postgres version to 42.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1226,7 +1226,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.6.0</version>
+                <version>42.6.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
[CVE-2024-1597](https://nvd.nist.gov/vuln/detail/CVE-2024-1597)
Security fix for postgresql
vulnerable version : 4.6.0
Fixed version : 4.6.1

Updated postgresql version from 4.6.0 to 4.6.1 in root pom.xml

## Motivation and Context

pgjdbc, the PostgreSQL JDBC Driver, allows attacker to inject SQL if using PreferQueryMode=SIMPLE. Note this is not the default. In the default mode there is no vulnerability. A placeholder for a numeric value must be immediately preceded by a minus. There must be a second placeholder for a string value after the first placeholder; both must be on the same line. By constructing a matching string payload, the attacker can inject SQL to alter the query,bypassing the protections that parameterized queries bring against SQL Injection attacks. Versions before 42.7.2, 42.6.1, 42.5.5, 42.4.4, 42.3.9, and 42.2.28 are affected.



## Impact
Image scan report showed the vulnerability has been removed

[correlation-report-ibm-lh-presto-postgres.csv](https://github.com/user-attachments/files/17111857/correlation-report-ibm-lh-presto-postgres.csv)

## Test Plan
<!---Please fill in how you tested your change-->


## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Security Changes
* Upgrade Postgres JDBC Driver to 42.6.1 :pr:`23710`

```

