### PR TITLE
Remove redundant check for short decimal type in parquet decoders

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
@@ -170,7 +170,7 @@ public class Decoders
             switch (type) {
                 case INT32:
                 case FLOAT: {
-                    if (isDecimalType(columnDescriptor) && isShortDecimalType(columnDescriptor)) {
+                    if (isShortDecimalType(columnDescriptor)) {
                         return new Int32ShortDecimalRLEDictionaryValuesDecoder(bitWidth, inputStream, (IntegerDictionary) dictionary);
                     }
                     return new Int32RLEDictionaryValuesDecoder(bitWidth, inputStream, (IntegerDictionary) dictionary);
@@ -179,7 +179,7 @@ public class Decoders
                     if (isTimeStampMicrosType(columnDescriptor) || isTimeMicrosType(columnDescriptor)) {
                         return new Int64TimeAndTimestampMicrosRLEDictionaryValuesDecoder(bitWidth, inputStream, (LongDictionary) dictionary);
                     }
-                    if (isDecimalType(columnDescriptor) && isShortDecimalType(columnDescriptor)) {
+                    if (isShortDecimalType(columnDescriptor)) {
                         return new Int64RLEDictionaryValuesDecoder(bitWidth, inputStream, (LongDictionary) dictionary);
                     }
                 }


### PR DESCRIPTION
## Description

As discussed in https://github.com/prestodb/presto/pull/23584#discussion_r1746925799, if a columnDescriptor is of type ShortDecimalType, it must first be of type DecimalType. So the check `if (isDecimalType(columnDescriptor) && isShortDecimalType(columnDescriptor))` is redundant and will cause some confusion for future readers, as readers will wonder if there exists a situation where the type is short decimal type but not decimal type.

This PR remove this redundant check as well as the confusion caused by it.

## Motivation and Context

Remove redundant check for short decimal type in parquet decoders to make the code more clear

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

