### PR TITLE
[native] Add native_selective_nimble_reader_enabled session property

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -314,6 +314,16 @@ If set to ``true``, disables the optimization in expression evaluation to delay 
 
 This should only be used for debugging purposes.
 
+``native_selective_nimble_reader_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Temporary flag to control whether selective Nimble reader should be used in this
+query or not.  Will be removed after the selective Nimble reader is fully rolled
+out.
+
 ``native_join_spill_enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -321,8 +321,7 @@ This should only be used for debugging purposes.
 * **Default value:** ``false``
 
 Temporary flag to control whether selective Nimble reader should be used in this
-query or not.  Will be removed after the selective Nimble reader is fully rolled
-out.
+query or not.  
 
 ``native_join_spill_enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -355,6 +355,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_DEBUG_DISABLE_COMMON_SUB_EXPRESSION = "native_debug_disable_common_sub_expressions";
     public static final String NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_MEMOIZATION = "native_debug_disable_expression_with_memoization";
     public static final String NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_LAZY_INPUTS = "native_debug_disable_expression_with_lazy_inputs";
+    public static final String NATIVE_SELECTIVE_NIMBLE_READER_ENABLED = "native_selective_nimble_reader_enabled";
 
     public static final String NATIVE_MAX_PARTIAL_AGGREGATION_MEMORY = "native_max_partial_aggregation_memory";
     public static final String NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY = "native_max_extended_partial_aggregation_memory";
@@ -1748,6 +1749,13 @@ public final class SystemSessionProperties
                         NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_LAZY_INPUTS,
                         "If set to true, disables optimization in expression evaluation to delay loading " +
                                 "of lazy inputs unless required. Should only be used for debugging.",
+                        false,
+                        true),
+                booleanProperty(
+                        NATIVE_SELECTIVE_NIMBLE_READER_ENABLED,
+                        "Temporary flag to control whether selective Nimble reader should be " +
+                        "used in this query or not.  Will be removed after the selective Nimble " +
+                        "reader is fully rolled out.",
                         false,
                         true),
                 longProperty(

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -244,6 +244,16 @@ SessionProperties::SessionProperties() {
       QueryConfig::kDebugDisableExpressionWithLazyInputs,
       boolToString(c.debugDisableExpressionsWithLazyInputs()));
 
+  addSessionProperty(
+      kSelectiveNimbleReaderEnabled,
+      "Temporary flag to control whether selective Nimble reader should be "
+      "used in this query or not.  Will be removed after the selective Nimble "
+      "reader is fully rolled out.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kSelectiveNimbleReaderEnabled,
+      boolToString(c.selectiveNimbleReaderEnabled()));
+
   // If `legacy_timestamp` is true, the coordinator expects timestamp
   // conversions without a timezone to be converted to the user's
   // session_timezone.

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -165,6 +165,12 @@ class SessionProperties {
   static constexpr const char* kDebugDisableExpressionWithLazyInputs =
       "native_debug_disable_expression_with_lazy_inputs";
 
+  /// Temporary flag to control whether selective Nimble reader should be used
+  /// in this query or not.  Will be removed after the selective Nimble reader
+  /// is fully rolled out.
+  static constexpr const char* kSelectiveNimbleReaderEnabled =
+      "native_selective_nimble_reader_enabled";
+
   /// Enable timezone-less timestamp conversions.
   static constexpr const char* kLegacyTimestamp = "legacy_timestamp";
 

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -56,6 +56,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
           {"native_debug_disable_common_sub_expressions", "true"},
           {"native_debug_disable_expression_with_memoization", "true"},
           {"native_debug_disable_expression_with_lazy_inputs", "true"},
+          {"native_selective_nimble_reader_enabled", "true"},
           {"aggregation_spill_all", "true"}}};
   auto queryCtx = taskManager_->getQueryContextManager()->findOrCreateQueryCtx(
       taskId, session);
@@ -67,6 +68,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableCommonSubExpressions());
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithMemoization());
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithLazyInputs());
+  EXPECT_TRUE(queryCtx->queryConfig().selectiveNimbleReaderEnabled());
   EXPECT_EQ(queryCtx->queryConfig().spillWriteBufferSize(), 1024);
 }
 


### PR DESCRIPTION
This is a hidden temporary session property to help controlled rollout of selective Nimble reader.  Will be removed after the selective Nimble reader is fully rolled out.