### PR TITLE
Fix REST session bug for Iceberg REST catalogs

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeCatalogFactory.java
@@ -48,7 +48,7 @@ import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
  */
 public class IcebergNativeCatalogFactory
 {
-    private final Cache<String, Catalog> catalogCache;
+    protected final Cache<String, Catalog> catalogCache;
     private final String catalogName;
     protected final CatalogType catalogType;
     private final String catalogWarehouse;
@@ -99,7 +99,7 @@ public class IcebergNativeCatalogFactory
         throw new PrestoException(NOT_SUPPORTED, "Iceberg catalog of type " + catalogType + " does not support namespace operations");
     }
 
-    private String getCacheKey(ConnectorSession session)
+    protected String getCacheKey(ConnectorSession session)
     {
         StringBuilder sb = new StringBuilder();
         sb.append(catalogName);
@@ -112,7 +112,7 @@ public class IcebergNativeCatalogFactory
         return Optional.empty();
     }
 
-    private Map<String, String> getProperties(ConnectorSession session)
+    protected Map<String, String> getProperties(ConnectorSession session)
     {
         Map<String, String> properties = new HashMap<>();
         if (icebergConfig.getManifestCachingEnabled()) {
@@ -134,7 +134,7 @@ public class IcebergNativeCatalogFactory
         return ImmutableMap.of();
     }
 
-    private Configuration getHadoopConfiguration()
+    protected Configuration getHadoopConfiguration()
     {
         Configuration configuration = new Configuration(false);
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
@@ -20,21 +20,35 @@ import com.facebook.presto.iceberg.IcebergCatalogName;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.jsonwebtoken.Jwts;
-import org.apache.iceberg.rest.auth.OAuth2Properties;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
+import org.apache.iceberg.rest.HTTPClient;
+import org.apache.iceberg.rest.RESTCatalog;
 
 import javax.inject.Inject;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
 import static com.facebook.presto.iceberg.rest.AuthenticationType.OAUTH2;
 import static com.facebook.presto.iceberg.rest.SessionType.USER;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 import static org.apache.iceberg.CatalogProperties.URI;
+import static org.apache.iceberg.CatalogUtil.configureHadoopConf;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.CREDENTIAL;
+import static org.apache.iceberg.rest.auth.OAuth2Properties.JWT_TOKEN_TYPE;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.OAUTH2_SERVER_URI;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
 
@@ -43,6 +57,7 @@ public class IcebergRestCatalogFactory
 {
     private final IcebergRestConfig catalogConfig;
     private final NodeVersion nodeVersion;
+    private final String catalogName;
 
     @Inject
     public IcebergRestCatalogFactory(
@@ -56,6 +71,37 @@ public class IcebergRestCatalogFactory
         super(config, catalogName, s3ConfigurationUpdater, gcsConfigurationInitialize);
         this.catalogConfig = requireNonNull(catalogConfig, "catalogConfig is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
+        this.catalogName = requireNonNull(catalogName, "catalogName is null").getCatalogName();
+    }
+
+    @Override
+    public Catalog getCatalog(ConnectorSession session)
+    {
+        try {
+            return catalogCache.get(getCacheKey(session), () -> {
+                RESTCatalog catalog = new RESTCatalog(
+                        convertSession(session),
+                        config -> HTTPClient.builder(config).uri(config.get(URI)).build());
+
+                configureHadoopConf(catalog, getHadoopConfiguration());
+                catalog.initialize(catalogName, getProperties(session));
+                return catalog;
+            });
+        }
+        catch (ExecutionException | UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throwIfUnchecked(e);
+            throw new UncheckedExecutionException(e);
+        }
+    }
+
+    @Override
+    protected Optional<String> getCatalogCacheKey(ConnectorSession session)
+    {
+        StringBuilder sb = new StringBuilder();
+        catalogConfig.getSessionType().filter(type -> type.equals(USER))
+                .ifPresent(type -> sb.append(session.getUser()));
+        return Optional.of(sb.toString());
     }
 
     @Override
@@ -81,24 +127,96 @@ public class IcebergRestCatalogFactory
             }
         });
 
-        catalogConfig.getSessionType().ifPresent(type -> {
-            if (type == USER) {
-                properties.putAll(session.getIdentity().getExtraCredentials());
-
-                String sessionId = format("%s-%s", session.getUser(), session.getSource().orElse("default"));
-                String jwt = Jwts.builder()
-                        .setId(sessionId)
-                        .setSubject(session.getUser())
-                        .setIssuedAt(new Date())
-                        .setIssuer(nodeVersion.toString())
-                        .claim("user", session.getUser())
-                        .claim("source", session.getSource().orElse(""))
-                        .compact();
-
-                properties.put(OAuth2Properties.JWT_TOKEN_TYPE, jwt);
-            }
-        });
+        catalogConfig.getSessionType().filter(type -> type.equals(USER))
+                .ifPresent(type -> properties.put(CatalogProperties.USER, session.getUser()));
 
         return properties.build();
+    }
+
+    protected SessionContext convertSession(ConnectorSession session)
+    {
+        RestSessionBuilder sessionContextBuilder = catalogConfig.getSessionType()
+                .filter(type -> type.equals(USER))
+                .map(type -> {
+                    String sessionId = format("%s-%s", session.getUser(), session.getSource().orElse("default"));
+                    Map<String, String> properties = ImmutableMap.of(
+                            "user", session.getUser(),
+                            "source", session.getSource().orElse(""),
+                            "version", nodeVersion.toString());
+
+                    String jwt = Jwts.builder()
+                            .setSubject(session.getUser())
+                            .setIssuer(nodeVersion.toString())
+                            .setIssuedAt(new Date())
+                            .claim("user", session.getUser())
+                            .claim("source", session.getSource().orElse(""))
+                            .compact();
+
+                    ImmutableMap.Builder<String, String> credentials = ImmutableMap.builder();
+                    credentials.put(JWT_TOKEN_TYPE, jwt).putAll(session.getIdentity().getExtraCredentials());
+
+                    return builder(session).setSessionId(sessionId)
+                            .setIdentity(session.getUser())
+                            .setCredentials(credentials.build())
+                            .setProperties(properties);
+                }).orElse(builder(session).setSessionId(randomUUID().toString()));
+        return sessionContextBuilder.build();
+    }
+
+    protected static class RestSessionBuilder
+    {
+        private String sessionId;
+        private String identity;
+        private Map<String, String> properties;
+        private Map<String, String> credentials;
+        private final ConnectorIdentity wrappedIdentity;
+
+        private RestSessionBuilder(ConnectorSession session)
+        {
+            sessionId = null;
+            identity = null;
+            credentials = null;
+            properties = ImmutableMap.of();
+            wrappedIdentity = session.getIdentity();
+        }
+
+        protected RestSessionBuilder setSessionId(String sessionId)
+        {
+            this.sessionId = sessionId;
+            return this;
+        }
+
+        protected RestSessionBuilder setIdentity(String identity)
+        {
+            this.identity = identity;
+            return this;
+        }
+
+        protected RestSessionBuilder setCredentials(Map<String, String> credentials)
+        {
+            this.credentials = credentials;
+            return this;
+        }
+
+        protected RestSessionBuilder setProperties(Map<String, String> properties)
+        {
+            this.properties = properties;
+            return this;
+        }
+
+        protected SessionContext build()
+        {
+            return new SessionContext(
+                    sessionId,
+                    identity,
+                    credentials,
+                    properties,
+                    wrappedIdentity);
+        }
+    }
+
+    protected static RestSessionBuilder builder(ConnectorSession session)
+    {
+        return new RestSessionBuilder(session);
     }
 }


### PR DESCRIPTION
## Description
By relying on the Iceberg `loadCatalog` utility function for `RESTCatalog`s, there was no way to specify options for a `RESTSessionCatalog`. The result of this is that Iceberg REST user sessions were not being honored. This PR changes the flow for `RESTCatalog`s only, manually creating a `RESTCatalog` instance with the correct `RESTSessionCatalog` context.


## Motivation and Context
Fixes a known bug with REST sessions not working as expected (no related issue).

## Test Plan
Manual testing was done. Working on adding a CI test, which requires changes to the test REST server. I plan on further investigating options for this.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

