### PR TITLE
[docs] Add doc for driver.cancel-tasks-with-stuck-operators-threshold-ms

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -32,6 +32,16 @@ Presto C++ workers.
 These Presto coordinator configuration properties are described here, in 
 alphabetical order. 
 
+``driver.cancel-tasks-with-stuck-operators-threshold-ms``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* **Type:** ``string``
+* **Default value:** ``240000`` (40 minutes)
+
+  Cancels any task when at least one operator has been stuck for at 
+  least the time specified by this threshold.
+  
+  Set this property to ``0`` to disable canceling.
+
 ``experimental.table-writer-merge-operator-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description
Add documentation for `driver.cancel-tasks-with-stuck-operators-threshold-ms` property to [Presto C++ Properties Reference](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/presto_cpp/properties.rst). 

## Motivation and Context
Fixes #23668. 

## Impact
Documentation. 

## Test Plan
Local docs build. 

Before: 
`build succeeded, 13 warnings.`
After: 
`build succeeded, 13 warnings.`

Screenshot of new content: 
<img width="798" alt="Screenshot 2024-09-25 at 1 38 24 PM" src="https://github.com/user-attachments/assets/4cfc2ad5-667b-48f2-b9ed-b8971209a1b3">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

