### PR TITLE
Reduce memory usage in writer by freeing unused buffers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/ChunkedSliceOutput.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ChunkedSliceOutput.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
@@ -61,9 +62,9 @@ public final class ChunkedSliceOutput
      */
     private int bufferPosition;
 
-    public ChunkedSliceOutput(int minChunkSize, int maxChunkSize)
+    public ChunkedSliceOutput(int minChunkSize, int maxChunkSize, boolean resetOutputBuffer)
     {
-        this.chunkSupplier = new ChunkSupplier(minChunkSize, maxChunkSize);
+        this.chunkSupplier = new ChunkSupplier(minChunkSize, maxChunkSize, resetOutputBuffer);
 
         this.buffer = chunkSupplier.get();
         this.slice = Slices.wrappedBuffer(buffer);
@@ -344,14 +345,16 @@ public final class ChunkedSliceOutput
     // reusing the buffers.
     private static class ChunkSupplier
     {
+        private static final Logger log = Logger.get(ChunkSupplier.class);
         private final int maxChunkSize;
+        private boolean resetOutputBuffer;
 
         private final List<byte[]> bufferPool = new ArrayList<>();
         private final List<byte[]> usedBuffers = new ArrayList<>();
 
         private int currentSize;
 
-        public ChunkSupplier(int minChunkSize, int maxChunkSize)
+        public ChunkSupplier(int minChunkSize, int maxChunkSize, boolean resetOutputBuffer)
         {
             checkArgument(minChunkSize >= MINIMUM_CHUNK_SIZE, "minimum chunk size of " + MINIMUM_CHUNK_SIZE + " required");
             checkArgument(maxChunkSize <= MAXIMUM_CHUNK_SIZE, "maximum chunk size of " + MAXIMUM_CHUNK_SIZE + " required");
@@ -359,10 +362,20 @@ public final class ChunkedSliceOutput
 
             this.currentSize = minChunkSize;
             this.maxChunkSize = maxChunkSize;
+            this.resetOutputBuffer = resetOutputBuffer;
         }
 
         public void reset()
         {
+            if (!bufferPool.isEmpty() && resetOutputBuffer) {
+                log.info("Reset unused buffers, used %d chunks (%d bytes), unused %d chunks (%d bytes)",
+                        usedBuffers.size(),
+                        usedBuffers.stream().mapToInt(b -> b.length).sum(),
+                        bufferPool.size(),
+                        bufferPool.stream().mapToInt(b -> b.length).sum());
+                bufferPool.clear();
+                System.setProperty("RESET_OUTPUT_BUFFER", "RESET_OUTPUT_BUFFER");
+            }
             bufferPool.addAll(0, usedBuffers);
             usedBuffers.clear();
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
@@ -28,6 +28,7 @@ import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_OUTPUT_BUFFER
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MIN_OUTPUT_BUFFER_CHUNK_SIZE;
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT;
+import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_RESET_OUTPUT_BUFFER;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.lang.Math.toIntExact;
@@ -50,6 +51,7 @@ public class ColumnWriterOptions
     private final Set<Integer> flattenedNodes;
     private final boolean mapStatisticsEnabled;
     private final int maxFlattenedMapKeyCount;
+    private final boolean resetOutputBuffer;
 
     public ColumnWriterOptions(
             CompressionKind compressionKind,
@@ -66,7 +68,8 @@ public class ColumnWriterOptions
             CompressionBufferPool compressionBufferPool,
             Set<Integer> flattenedNodes,
             boolean mapStatisticsEnabled,
-            int maxFlattenedMapKeyCount)
+            int maxFlattenedMapKeyCount,
+            boolean resetOutputBuffer)
     {
         checkArgument(maxFlattenedMapKeyCount > 0, "maxFlattenedMapKeyCount must be positive: %s", maxFlattenedMapKeyCount);
         requireNonNull(compressionMaxBufferSize, "compressionMaxBufferSize is null");
@@ -86,6 +89,7 @@ public class ColumnWriterOptions
         this.flattenedNodes = requireNonNull(flattenedNodes, "flattenedNodes is null");
         this.mapStatisticsEnabled = mapStatisticsEnabled;
         this.maxFlattenedMapKeyCount = maxFlattenedMapKeyCount;
+        this.resetOutputBuffer = resetOutputBuffer;
     }
 
     public CompressionKind getCompressionKind()
@@ -163,6 +167,10 @@ public class ColumnWriterOptions
         return maxFlattenedMapKeyCount;
     }
 
+    public boolean isResetOutputBuffer()
+    {
+        return resetOutputBuffer;
+    }
     /**
      * Create a copy of this ColumnWriterOptions, but disable string and integer dictionary encodings.
      */
@@ -191,7 +199,8 @@ public class ColumnWriterOptions
                 .setCompressionBufferPool(getCompressionBufferPool())
                 .setFlattenedNodes(getFlattenedNodes())
                 .setMapStatisticsEnabled(isMapStatisticsEnabled())
-                .setMaxFlattenedMapKeyCount(getMaxFlattenedMapKeyCount());
+                .setMaxFlattenedMapKeyCount(getMaxFlattenedMapKeyCount())
+                .setResetOutputBuffer(resetOutputBuffer);
     }
 
     public static Builder builder()
@@ -216,6 +225,7 @@ public class ColumnWriterOptions
         private Set<Integer> flattenedNodes = ImmutableSet.of();
         private boolean mapStatisticsEnabled;
         private int maxFlattenedMapKeyCount = DEFAULT_MAX_FLATTENED_MAP_KEY_COUNT;
+        private boolean resetOutputBuffer = DEFAULT_RESET_OUTPUT_BUFFER;
 
         private Builder() {}
 
@@ -309,6 +319,12 @@ public class ColumnWriterOptions
             return this;
         }
 
+        public Builder setResetOutputBuffer(boolean resetOutputBuffer)
+        {
+            this.resetOutputBuffer = resetOutputBuffer;
+            return this;
+        }
+
         public ColumnWriterOptions build()
         {
             return new ColumnWriterOptions(
@@ -326,7 +342,8 @@ public class ColumnWriterOptions
                     compressionBufferPool,
                     flattenedNodes,
                     mapStatisticsEnabled,
-                    maxFlattenedMapKeyCount);
+                    maxFlattenedMapKeyCount,
+                    resetOutputBuffer);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -57,6 +57,7 @@ public class OrcOutputBuffer
     private final int minOutputBufferChunkSize;
     private final int maxOutputBufferChunkSize;
     private final int minCompressibleSize;
+    private final boolean resetOutputBuffer;
 
     private final CompressionBufferPool compressionBufferPool;
     private final Optional<DwrfDataEncryptor> dwrfEncryptor;
@@ -87,6 +88,7 @@ public class OrcOutputBuffer
         this.maxBufferSize = compressionKind == CompressionKind.NONE ? maxBufferSize : maxBufferSize - PAGE_HEADER_SIZE;
         this.minOutputBufferChunkSize = columnWriterOptions.getMinOutputBufferChunkSize();
         this.maxOutputBufferChunkSize = columnWriterOptions.getMaxOutputBufferChunkSize();
+        this.resetOutputBuffer = columnWriterOptions.isResetOutputBuffer();
         this.minCompressibleSize = compressionKind.getMinCompressibleSize();
 
         this.buffer = new byte[INITIAL_BUFFER_SIZE];
@@ -473,7 +475,7 @@ public class OrcOutputBuffer
     private void initCompressedOutputStream()
     {
         checkState(compressedOutputStream == null, "compressedOutputStream is already initialized");
-        compressedOutputStream = new ChunkedSliceOutput(minOutputBufferChunkSize, maxOutputBufferChunkSize);
+        compressedOutputStream = new ChunkedSliceOutput(minOutputBufferChunkSize, maxOutputBufferChunkSize, resetOutputBuffer);
     }
 
     private void writeChunkToOutputStream(byte[] chunk, int offset, int length)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -236,6 +236,7 @@ public class OrcWriter
                 .setFlattenedNodes(flattenedNodes)
                 .setMapStatisticsEnabled(options.isMapStatisticsEnabled())
                 .setMaxFlattenedMapKeyCount(options.getMaxFlattenedMapKeyCount())
+                .setResetOutputBuffer(options.isResetOutputBuffer())
                 .build();
         recordValidation(validation -> validation.setCompression(compressionKind));
         recordValidation(validation -> validation.setFlattenedNodes(flattenedNodes));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -49,6 +49,7 @@ public class OrcWriterOptions
     public static final boolean DEFAULT_INTEGER_DICTIONARY_ENCODING_ENABLED = false;
     public static final boolean DEFAULT_STRING_DICTIONARY_ENCODING_ENABLED = true;
     public static final boolean DEFAULT_STRING_DICTIONARY_SORTING_ENABLED = true;
+    public static final boolean DEFAULT_RESET_OUTPUT_BUFFER = false;
 
     private final OrcWriterFlushPolicy flushPolicy;
     private final int rowGroupMaxRowCount;
@@ -74,6 +75,7 @@ public class OrcWriterOptions
     private final int preserveDirectEncodingStripeCount;
     private final boolean mapStatisticsEnabled;
     private final int maxFlattenedMapKeyCount;
+    private final boolean resetOutputBuffer;
 
     /**
      * Contains indexes of columns (not nodes!) for which writer should use flattened encoding, e.g. flat maps.
@@ -101,7 +103,8 @@ public class OrcWriterOptions
             int preserveDirectEncodingStripeCount,
             Set<Integer> flattenedColumns,
             boolean mapStatisticsEnabled,
-            int maxFlattenedMapKeyCount)
+            int maxFlattenedMapKeyCount,
+            boolean resetOutputBuffer)
     {
         requireNonNull(flushPolicy, "flushPolicy is null");
         checkArgument(rowGroupMaxRowCount >= 1, "rowGroupMaxRowCount must be at least 1");
@@ -139,6 +142,7 @@ public class OrcWriterOptions
         this.flattenedColumns = flattenedColumns;
         this.mapStatisticsEnabled = mapStatisticsEnabled;
         this.maxFlattenedMapKeyCount = maxFlattenedMapKeyCount;
+        this.resetOutputBuffer = resetOutputBuffer;
     }
 
     public OrcWriterFlushPolicy getFlushPolicy()
@@ -246,6 +250,11 @@ public class OrcWriterOptions
         return maxFlattenedMapKeyCount;
     }
 
+    public boolean isResetOutputBuffer()
+    {
+        return resetOutputBuffer;
+    }
+
     @Override
     public String toString()
     {
@@ -269,6 +278,7 @@ public class OrcWriterOptions
                 .add("flattenedColumns", flattenedColumns)
                 .add("mapStatisticsEnabled", mapStatisticsEnabled)
                 .add("maxFlattenedMapKeyCount", maxFlattenedMapKeyCount)
+                .add("resetOutputBuffer", resetOutputBuffer)
                 .toString();
     }
 
@@ -307,6 +317,7 @@ public class OrcWriterOptions
         private Set<Integer> flattenedColumns = ImmutableSet.of();
         private boolean mapStatisticsEnabled;
         private int maxFlattenedMapKeyCount = DEFAULT_MAX_FLATTENED_MAP_KEY_COUNT;
+        private boolean resetOutputBuffer = DEFAULT_RESET_OUTPUT_BUFFER;
 
         public Builder withFlushPolicy(OrcWriterFlushPolicy flushPolicy)
         {
@@ -448,6 +459,12 @@ public class OrcWriterOptions
             return this;
         }
 
+        public Builder withResetOutputBuffer(boolean resetOutputBuffer)
+        {
+            this.resetOutputBuffer = resetOutputBuffer;
+            return this;
+        }
+
         public OrcWriterOptions build()
         {
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
@@ -479,7 +496,8 @@ public class OrcWriterOptions
                     preserveDirectEncodingStripeCount,
                     flattenedColumns,
                     mapStatisticsEnabled,
-                    maxFlattenedMapKeyCount);
+                    maxFlattenedMapKeyCount,
+                    resetOutputBuffer);
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -160,6 +160,7 @@ public class TestOrcWriterOptions
         int preserveDirectEncodingStripeCount = 0;
         boolean mapStatisticsEnabled = true;
         int maxFlattenedMapKeyCount = 27;
+        boolean resetOutputBuffer = false;
 
         OrcWriterOptions writerOptions = OrcWriterOptions.builder()
                 .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
@@ -185,6 +186,7 @@ public class TestOrcWriterOptions
                 .withFlattenedColumns(ImmutableSet.of(4))
                 .withMapStatisticsEnabled(mapStatisticsEnabled)
                 .withMaxFlattenedMapKeyCount(maxFlattenedMapKeyCount)
+                .withResetOutputBuffer(resetOutputBuffer)
                 .build();
 
         String expectedString = "OrcWriterOptions{flushPolicy=DefaultOrcWriterFlushPolicy{stripeMaxRowCount=1100000, " +
@@ -195,7 +197,7 @@ public class TestOrcWriterOptions
                 "stringDictionarySortingEnabled=true, stringDictionaryEncodingEnabled=true, " +
                 "dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], " +
                 "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0, flattenedColumns=[4], mapStatisticsEnabled=true, " +
-                "maxFlattenedMapKeyCount=27}";
+                "maxFlattenedMapKeyCount=27, resetOutputBuffer=false}";
         assertEquals(expectedString, writerOptions.toString());
     }
 }


### PR DESCRIPTION
## Description
Currently ChunkedSliceOutput keep buffers in bufferPool and usedBuffers, it never free those buffer, even with reset(), leads to extra memory usage and OOM.

This PR avoid those extra memory usage by freeing unused buffer in chunk supplier during reset. This behavior is controlled by resetOutputBuffer in OrcWriterOptions, and it's disabled by default.

Example ChunkedSliceOutput behaviour before and after the change
Assume first batch of output is large, it used 3.75M
after writing those output, and before we call reset()
the usedBuffers contains a list of buffer with increasing sizes  (assuming min buffer is 256k, max buffer is 1M for illustration purpose)
256k, 512k, 1M, 1M, 1M

The second batch of output is smaller, it will only used 1.75M
after writing those output, and before we call reset()
usedBuffers have 256k, 512k, 1M,
bufferPool have 1M, 1M

before the change
we will keep all 5 buffers, and will never free them
after the change
we will keep the 3 buffer which are used (256k, 512k, 1M) and free up the 2 buffer which are unused (1M, 1M)

In other word, previous behaviour only scale up number of buffers, new behaviour also can scale down number of buffer based on memory usage

## Impact
Reduce memory usage in writer.

## Test Plan
Tested with Spark workload

Example output showing unused buffer getting freed after the change
```
Reset unused buffers, used 17 chunks (8387584 bytes), unused 65 chunks (68157440 bytes)
Reset unused buffers, used 82 chunks (76545024 bytes), unused 4 chunks (4194304 bytes)
```

```
== RELEASE NOTES ==
General change
* Improve memory usage in writer by feeing unused buffers.
```
