### PR TITLE
[docs] Add a PR link in release-0.282.rst

### DIFF
--- a/presto-docs/src/main/sphinx/release/release-0.282.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.282.rst
@@ -7,7 +7,7 @@ Release 0.282
 
 General Changes
 _______________
-* Fix ``TEMPORARY`` definition :doc:`/sql/create-function` and :doc:`/sql/drop-function`.
+* Fix ``TEMPORARY`` definition :doc:`/sql/create-function` and :doc:`/sql/drop-function`. :pr:`19429`
 * Fix a bug where ``cardinality(map_keys(x))`` and ``cardinality(map_values(x))`` would return wrong results.
 * Improve performance of ``Explain (TYPE VALIDATE)`` by returning immediately after analysis and ACL checks complete without executing a dummy query. The output column is now called ``result`` rather than ``valid``.
 * Improve error handling when using custom ``FunctionNamespaceManagers``.


### PR DESCRIPTION
## Description
Add a link to the relevant PR for a release note entry in [release-0.282.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/release/release-0.282.rst). 

## Motivation and Context
Captures the work done to answer #23672 into the Presto documentation.

Note: adding PR links to the release note entries began with the [0.283 Release Notes](https://prestodb.io/docs/current/release/release-0.283.html). Not currently planning to add PR links throughout for all release note entries in [release-0.282.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/release/release-0.282.rst), or earlier. 

Because this was asked in #23672 it seemed reasonable to update the 0.282 release notes.

## Impact
Documentation. 

## Test Plan
Local doc build, reviewed built page for correct formatting, tested the new link to verify it takes the reader to the correct destination. See screenshot: 
<img width="652" alt="Screenshot 2024-09-27 at 2 21 13 PM" src="https://github.com/user-attachments/assets/4358744b-df11-4a88-a2e2-1c5aa0fd258e">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

