### PR TITLE
Add Iceberg REST auth server configuration property

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -210,6 +210,9 @@ Property Name                                        Description
                                                      Available values are ``NONE`` or ``OAUTH2`` (default: ``NONE``).
                                                      ``OAUTH2`` requires either a credential or token.
 
+``iceberg.rest.auth.oauth2.uri``                     OAUTH2 server endpoint URI.
+                                                     Example: ``https://localhost:9191``
+
 ``iceberg.rest.auth.oauth2.credential``              The credential to use for OAUTH2 authentication.
                                                      Example: ``key:secret``
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
@@ -35,6 +35,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.CatalogProperties.URI;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.CREDENTIAL;
+import static org.apache.iceberg.rest.auth.OAuth2Properties.OAUTH2_SERVER_URI;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
 
 public class IcebergRestCatalogFactory
@@ -67,6 +68,11 @@ public class IcebergRestCatalogFactory
 
         catalogConfig.getAuthenticationType().ifPresent(type -> {
             if (type == OAUTH2) {
+                // The oauth2/tokens endpoint of the REST catalog spec has been deprecated and will
+                // be removed in Iceberg 2.0 (https://github.com/apache/iceberg/pull/10603)
+                // TODO auth server URI will eventually need to be made a required property
+                catalogConfig.getAuthenticationServerUri().ifPresent(authServerUri -> properties.put(OAUTH2_SERVER_URI, authServerUri));
+
                 if (!catalogConfig.credentialOrTokenExists()) {
                     throw new IllegalStateException("iceberg.rest.auth.oauth2 requires either a credential or a token");
                 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
@@ -25,6 +25,7 @@ public class IcebergRestConfig
     private String serverUri;
     private SessionType sessionType;
     private AuthenticationType authenticationType;
+    private String authenticationServerUri;
     private String credential;
     private String token;
 
@@ -65,6 +66,19 @@ public class IcebergRestConfig
     public IcebergRestConfig setAuthenticationType(AuthenticationType authenticationType)
     {
         this.authenticationType = authenticationType;
+        return this;
+    }
+
+    public Optional<String> getAuthenticationServerUri()
+    {
+        return Optional.ofNullable(authenticationServerUri);
+    }
+
+    @Config("iceberg.rest.auth.oauth2.uri")
+    @ConfigDescription("The URI to connect to the OAUTH2 server")
+    public IcebergRestConfig setAuthenticationServerUri(String authServerUri)
+    {
+        this.authenticationServerUri = authServerUri;
         return this;
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
@@ -32,6 +32,7 @@ public class TestIcebergRestConfig
         assertRecordedDefaults(ConfigAssertions.recordDefaults(IcebergRestConfig.class)
                 .setServerUri(null)
                 .setAuthenticationType(null)
+                .setAuthenticationServerUri(null)
                 .setCredential(null)
                 .setToken(null)
                 .setSessionType(null));
@@ -43,6 +44,7 @@ public class TestIcebergRestConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("iceberg.rest.uri", "http://localhost:xxx")
                 .put("iceberg.rest.auth.type", "OAUTH2")
+                .put("iceberg.rest.auth.oauth2.uri", "http://localhost:yyy")
                 .put("iceberg.rest.auth.oauth2.credential", "key:secret")
                 .put("iceberg.rest.auth.oauth2.token", "SXVLUXUhIExFQ0tFUiEK")
                 .put("iceberg.rest.session.type", "USER")
@@ -51,6 +53,7 @@ public class TestIcebergRestConfig
         IcebergRestConfig expected = new IcebergRestConfig()
                 .setServerUri("http://localhost:xxx")
                 .setAuthenticationType(OAUTH2)
+                .setAuthenticationServerUri("http://localhost:yyy")
                 .setCredential("key:secret")
                 .setToken("SXVLUXUhIExFQ0tFUiEK")
                 .setSessionType(USER);


### PR DESCRIPTION

## Description
This PR adds a new configuration property for an OAUTH2 server uri: `iceberg.rest.auth.oauth2.uri`

## Motivation and Context
Fixes #23491

See linked issue for context

## Impact
Adds a `iceberg.rest.auth.oauth2.uri` configurable property

## Test Plan
Configuration tests have been updated

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add iceberg.rest.auth.oauth2.uri configurable property :pr:`23739` 
```
