### PR TITLE
[native] Add session property for bucket write

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -359,6 +359,7 @@ public final class SystemSessionProperties
 
     public static final String NATIVE_MAX_PARTIAL_AGGREGATION_MEMORY = "native_max_partial_aggregation_memory";
     public static final String NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY = "native_max_extended_partial_aggregation_memory";
+    public static final String NATIVE_TASK_BUCKETED_WRITER_COUNT = "native_task_bucketed_writer_count";
     public static final String NATIVE_MAX_SPILL_BYTES = "native_max_spill_bytes";
     public static final String DEFAULT_VIEW_SECURITY_MODE = "default_view_security_mode";
     public static final String JOIN_PREFILTER_BUILD_SIDE = "join_prefilter_build_side";
@@ -1767,6 +1768,11 @@ public final class SystemSessionProperties
                         NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY,
                         "The max partial aggregation memory when data reduction is optimal.",
                         1L << 26,
+                        false),
+                integerProperty(
+                        NATIVE_TASK_BUCKETED_WRITER_COUNT,
+                        "Number of writers per task for bucketed writes.",
+                        7,
                         false),
                 longProperty(
                         NATIVE_MAX_SPILL_BYTES,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -245,6 +245,14 @@ SessionProperties::SessionProperties() {
       boolToString(c.debugDisableExpressionsWithLazyInputs()));
 
   addSessionProperty(
+      kNativeTaskBucketedWriterCount,
+      "Number of writers per task for bucketed writes.",
+      INTEGER(),
+      false,
+      QueryConfig::kTaskBucketedWriterCount,
+      std::to_string(c.taskBucketedWriterCount()));
+
+  addSessionProperty(
       kSelectiveNimbleReaderEnabled,
       "Temporary flag to control whether selective Nimble reader should be "
       "used in this query or not.  Will be removed after the selective Nimble "

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -171,6 +171,9 @@ class SessionProperties {
   static constexpr const char* kSelectiveNimbleReaderEnabled =
       "native_selective_nimble_reader_enabled";
 
+  static constexpr const char* kNativeTaskBucketedWriterCount =
+      "native_task_bucketed_writer_count";
+
   /// Enable timezone-less timestamp conversions.
   static constexpr const char* kLegacyTimestamp = "legacy_timestamp";
 


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Add a session property `native_task_bucketed_writer_count` which specifies number of writers per task for bucketed writes for Prestissimo. :pr:`23741`
```