### PR TITLE
Allow task_partitioned_writer_count to be non-power of two for native engine

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -53,6 +53,25 @@ output data set is not skewed in order to avoid the overhead of hashing and
 redistributing all the data across the network. This can also be specified
 on a per-query basis using the ``redistribute_writes`` session property.
 
+``task_writer_count``
+^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``1``
+
+Default number of local parallel table writer threads per worker. It is required
+to be a power of two for a Java query engine.
+
+``task_partitioned_writer_count``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``task_writer_count``
+
+Number of local parallel table writer threads per worker for partitioned writes. If not
+set, the number set by ``task_writer_count`` will be used. It is required to be a power
+of two for a Java query engine.
+
 .. _tuning-memory:
 
 Memory Management Properties

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -520,7 +520,7 @@ public final class SystemSessionProperties
                         Integer.class,
                         taskManagerConfig.getWriterCount(),
                         false,
-                        value -> validateValueIsPowerOfTwo(requireNonNull(value, "value is null"), TASK_WRITER_COUNT),
+                        featuresConfig.isNativeExecutionEnabled() ? value -> validateNullablePositiveIntegerValue(value, TASK_WRITER_COUNT) : value -> validateValueIsPowerOfTwo(value, TASK_WRITER_COUNT),
                         value -> value),
                 new PropertyMetadata<>(
                         TASK_PARTITIONED_WRITER_COUNT,
@@ -529,7 +529,7 @@ public final class SystemSessionProperties
                         Integer.class,
                         taskManagerConfig.getPartitionedWriterCount(),
                         false,
-                        value -> validateValueIsPowerOfTwo(value, TASK_PARTITIONED_WRITER_COUNT),
+                        featuresConfig.isNativeExecutionEnabled() ? value -> validateNullablePositiveIntegerValue(value, TASK_PARTITIONED_WRITER_COUNT) : value -> validateValueIsPowerOfTwo(value, TASK_PARTITIONED_WRITER_COUNT),
                         value -> value),
                 booleanProperty(
                         REDISTRIBUTE_WRITES,

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -428,14 +428,14 @@ public class TaskManagerConfig
     }
 
     @Min(1)
-    @PowerOfTwo
     public int getWriterCount()
     {
         return writerCount;
     }
 
+    // NOTE: writer count needs to be a power of two for java query engine.
     @Config("task.writer-count")
-    @ConfigDescription("Number of writers per task")
+    @ConfigDescription("Number of writer threads per task")
     public TaskManagerConfig setWriterCount(int writerCount)
     {
         this.writerCount = writerCount;
@@ -443,14 +443,14 @@ public class TaskManagerConfig
     }
 
     @Min(1)
-    @PowerOfTwo
     public Integer getPartitionedWriterCount()
     {
         return partitionedWriterCount;
     }
 
+    // NOTE: partitioned writer count needs to be a power of two for java query engine.
     @Config("task.partitioned-writer-count")
-    @ConfigDescription("Number of writers per task for partitioned writes. If not set, the number set by task.writer-count will be used")
+    @ConfigDescription("Number of writer threads per task for partitioned writes. If not set, the number set by task.writer-count will be used")
     public TaskManagerConfig setPartitionedWriterCount(Integer partitionedWriterCount)
     {
         this.partitionedWriterCount = partitionedWriterCount;


### PR DESCRIPTION
task_partitioned_writer_count is used to configure the number of drivers at worker size
which doesn't have to be power of two. In Prestissimo we need to configure this to avoid
the number of table writer workers is a multiple of the number of table writer threads per
worker. As Presto java engine still requires table writer threads to be power of two so
keep the check for non-native engine scenario.

```
== NO RELEASE NOTE ==
```

