### PR TITLE
Fix some toString methods in presto-orc

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/ChunkedSliceOutput.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ChunkedSliceOutput.java
@@ -303,9 +303,9 @@ public final class ChunkedSliceOutput
     @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder("OutputStreamSliceOutputAdapter{");
+        StringBuilder builder = new StringBuilder("ChunkedSliceOutput{");
         builder.append("position=").append(size());
-        builder.append("bufferSize=").append(slice.length());
+        builder.append(", bufferSize=").append(slice.length());
         builder.append('}');
         return builder.toString();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -421,9 +421,9 @@ public class OrcOutputBuffer
     @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder("OutputStreamSliceOutputAdapter{");
+        StringBuilder builder = new StringBuilder("OrcOutputBuffer{");
         builder.append("outputStream=").append(compressedOutputStream);
-        builder.append("bufferSize=").append(slice.length());
+        builder.append(", bufferSize=").append(slice.length());
         builder.append('}');
         return builder.toString();
     }


### PR DESCRIPTION
## Description
Fix some incorrectly formatted toString methods.

## Motivation and Context

## Impact


## Test Plan
mvn test

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

