### PR TITLE
Upgrade Jackson's dependencies to address PRISMA-2023-0067 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dep.ratis.version>2.2.0</dep.ratis.version>
         <dep.errorprone.version>2.18.0</dep.errorprone.version>
         <dep.guava.version>32.1.0-jre</dep.guava.version>
-        <dep.jackson.version>2.11.0</dep.jackson.version>
+        <dep.jackson.version>2.15.4</dep.jackson.version>
         <dep.j2objc.version>2.8</dep.j2objc.version>
         <dep.avro.version>1.11.4</dep.avro.version>
         <dep.commons.compress.version>1.26.2</dep.commons.compress.version>
@@ -795,6 +795,36 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-afterburner</artifactId>
+                <version>${dep.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${dep.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${dep.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-smile</artifactId>
+                <version>${dep.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${dep.jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
                 <version>${dep.jackson.version}</version>
             </dependency>
 
@@ -2277,6 +2307,14 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.3.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>extra-enforcer-rules</artifactId>
+                            <version>1.6.2</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <rules>
                             <requireUpperBoundDeps>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -353,6 +353,7 @@
                                 <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
                                 <exclude>javax.annotation:javax.annotation-api</exclude>
                                 <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+                                <exclude>com.google.api.grpc:proto-google-common-protos</exclude>
                             </excludes>
                         </requireUpperBoundDeps>
                     </rules>

--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -217,7 +217,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -459,7 +459,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewDefinition.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewDefinition.java
@@ -270,7 +270,7 @@ public final class MaterializedViewDefinition
             return columnName;
         }
 
-        @JsonProperty
+        @JsonProperty(value = "isDirectMapped")
         public Optional<Boolean> isDirectMapped()
         {
             return isDirectMapped;


### PR DESCRIPTION
## Description
This PR upgrades Jackson dependencies to version 2.15.4, addressing the security vulnerabilities identified in [PRISMA-2023-0067](https://www.ibm.com/support/pages/security-bulletin-vulnerability-jackson-core-might-affect-ibm-business-automation-workflow-prisma-2023-0067).

## Motivation and Context
Reasons for upgradation:
The upgrade to Jackson 2.15.4 resolves multiple critical security vulnerabilities, including a Denial of Service (DoS) vulnerability in jackson-core, caused by improper input validation during numeric type conversions. This update ensures enhanced security and system stability.

## Impact
Image Scan showed the vulnerability have been removed.
Image scan report : 
[Image-scan-report-9 Sep.csv](https://github.ibm.com/lakehouse/presto/files/1401872/Image-scan-report-9.Sep.csv)


## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
 == RELEASE NOTES == =

Security Changes
* Upgrade Jackson dependencies to 2.15.4 in response to `PRISMA-2023-0067 <https://www.ibm.com/support/pages/security-bulletin-vulnerability-jackson-core-might-affect-ibm-business-automation-workflow-prisma-2023-0067>`_. :pr:`23753`
```

