### PR TITLE
[presto-orc] Fix row index position when compression is disabled

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -290,11 +290,13 @@ public class OrcOutputBuffer
         // write maxBufferSize chunks directly to output
         if (length >= maxBufferSize) {
             flushBufferToOutputStream();
+            int bytesOffsetBefore = bytesOffset;
             while (length >= maxBufferSize) {
                 writeChunkToOutputStream(bytes, bytesOffset, maxBufferSize);
                 length -= maxBufferSize;
                 bytesOffset += maxBufferSize;
             }
+            bufferOffset += bytesOffset - bytesOffsetBefore;
         }
 
         // write the tail smaller than maxBufferSize to the buffer


### PR DESCRIPTION
## Description
Fix a bug in position accounting in the OrcOutputBuffer when doing batched writeBytes. 

This bug results in incorrect row index when the file is not compressed,
and one or more writeBytes calls have an input larger than the size of the
compression buffer, and that stripe has 2+ row groups.

Incorrect row index will result in incorrect reads when using presto-orc
reader.

## Motivation and Context

## Impact
Fix data corruption when an ORC/DWRF file is not compressed and one of the string or binary
column values is larger than the compression buffer size.

## Test Plan
Updated unit tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

ORC/DWRF Changes
* Fix a data corruption in uncompressed ORC/DWRF files with large values in string/binary columns :pr:`23760`
```

