### PR TITLE
Fix flaky testMemoryUsedIsNotAFunctionOfDataPageCount

### DIFF
--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -192,11 +192,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.ehcache</groupId>
-            <artifactId>sizeof</artifactId>
-            <version>0.4.3</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Description
Fix for https://github.com/prestodb/presto/issues/20612
This should also make [fixing this test](https://github.com/orgs/prestodb/projects/31/views/4?pane=issue&itemId=89923046) on JDK 17 redundant

## Fix details
We added detailed memory tracking in #19194 that makes size tracking using ehcache redundant

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

