### PR TITLE
Remove array_dupes and array_has_dupes alias.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -69,7 +69,7 @@ public class ArraySqlFunctions
                 "m -> m)";
     }
 
-    @SqlInvokedScalarFunction(value = "array_duplicates", alias = {"array_dupes"}, deterministic = true, calledOnNullInput = false)
+    @SqlInvokedScalarFunction(value = "array_duplicates", deterministic = true, calledOnNullInput = false)
     @Description("Returns set of elements that have duplicates")
     @SqlParameter(name = "input", type = "array(T)")
     @TypeParameter("T")
@@ -81,7 +81,7 @@ public class ArraySqlFunctions
                 "map_keys(map_filter(array_frequency(input), (k, v) -> v > 1)))";
     }
 
-    @SqlInvokedScalarFunction(value = "array_has_duplicates", alias = {"array_has_dupes"}, deterministic = true, calledOnNullInput = false)
+    @SqlInvokedScalarFunction(value = "array_has_duplicates", deterministic = true, calledOnNullInput = false)
     @Description("Returns whether array has any duplicate element")
     @TypeParameter("T")
     @SqlParameter(name = "input", type = "array(T)")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
@@ -196,9 +196,6 @@ public class TestArraySqlFunctions
         assertFunction("array_has_duplicates(array[0, null])", BOOLEAN, false);
         assertFunction("array_has_duplicates(array[0, null, null])", BOOLEAN, true);
 
-        // Test legacy name.
-        assertFunction("array_has_dupes(array[varchar 'a', varchar 'b', varchar 'a'])", BOOLEAN, true);
-
         assertFunction("array_has_duplicates(array[array[1], array[2], array[]])", BOOLEAN, false);
         assertFunction("array_has_duplicates(array[array[1], array[2], array[2]])", BOOLEAN, true);
         assertFunction("array_has_duplicates(array[(1, 2), (1, 2)])", BOOLEAN, true);
@@ -223,9 +220,6 @@ public class TestArraySqlFunctions
 
         assertFunction("array_duplicates(array[0, null])", new ArrayType(INTEGER), ImmutableList.of());
         assertFunction("array_duplicates(array[0, null, null])", new ArrayType(INTEGER), singletonList(null));
-
-        // Test legacy name.
-        assertFunction("array_dupes(array[1, 2, 1])", new ArrayType(INTEGER), ImmutableList.of(1));
 
         RowType rowType = RowType.from(ImmutableList.of(RowType.field(INTEGER), RowType.field(INTEGER)));
         assertFunction("array_duplicates(array[array[1], array[2], array[]])", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of());


### PR DESCRIPTION
## Description
Removing non-standard alias names array_dupes and array_has_dupes. [These were moved to alias and removed from documentation in 2021](https://github.com/prestodb/presto/pull/16891).

## Motivation and Context
Keeping function names standard.

## Impact
If there is any legacy usage of these aliases, those needs to be migrated to standard names. Standard name `array_duplicates` and `array_has_duplicates` are already available and no change is done there.

## Test Plan
Existing tests and removed test with alias.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Remove array_dupes and array_has_dupes alias names from functions :func:`array_duplicates` and :func:`array_has_duplicates`.

