### PR TITLE
Fix round for float value when input out of long range

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -1136,7 +1136,7 @@ public final class MathFunctions
         catch (ArithmeticException e) {
             // Use BigDecimal if the value is out of the range of long.
             BigDecimal bigDecimal = new BigDecimal(numInFloat);
-            return floatToRawIntBits(bigDecimal.setScale((int) decimals, HALF_UP).longValue());
+            return floatToRawIntBits(bigDecimal.setScale((int) decimals, HALF_UP).floatValue());
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -710,6 +710,19 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testRoundForUnderlyingValueOutOfRange()
+    {
+        // Round data of `REAL` type with underlying value out of long range should work well.
+        // See issue https://github.com/prestodb/presto/issues/23763
+        assertFunction("round(REAL '1.0E19', 1)", REAL, 1.0E19f);
+        assertFunction("round(REAL '1.0E19', 10)", REAL, 1.0E19f);
+        assertFunction("round(REAL '1.0E19', 100)", REAL, 1.0E19f);
+        assertFunction("round(REAL '9999999999999999999.9', 1)", REAL, 9999999999999999999.9f);
+        assertFunction("round(REAL '9999999999999999999.99', 10)", REAL, 9999999999999999999.99f);
+        assertFunction("round(REAL '9999999999999999999.999', 100)", REAL, 9999999999999999999.999f);
+    }
+
+    @Test
     public void testRound()
     {
         assertFunction("round(TINYINT '3')", TINYINT, (byte) 3);


### PR DESCRIPTION
## Description

Fixes #23763 

## Motivation and Context

Fix issue: #23763 

## Impact

N/A

## Test Plan

 - Newly added test case in `TestMathFuntions.testRoundForUnderlyingValueOutOfRange()` to cover the scenario mentioned in issue #23763 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

