### PR TITLE
[native] Add trace session properties to presto native

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -356,10 +356,15 @@ public final class SystemSessionProperties
     public static final String NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_MEMOIZATION = "native_debug_disable_expression_with_memoization";
     public static final String NATIVE_DEBUG_DISABLE_EXPRESSION_WITH_LAZY_INPUTS = "native_debug_disable_expression_with_lazy_inputs";
     public static final String NATIVE_SELECTIVE_NIMBLE_READER_ENABLED = "native_selective_nimble_reader_enabled";
-
     public static final String NATIVE_MAX_PARTIAL_AGGREGATION_MEMORY = "native_max_partial_aggregation_memory";
     public static final String NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY = "native_max_extended_partial_aggregation_memory";
     public static final String NATIVE_MAX_SPILL_BYTES = "native_max_spill_bytes";
+    public static final String NATIVE_QUERY_TRACE_ENABLED = "native_query_trace_enabled";
+    public static final String NATIVE_QUERY_TRACE_DIR = "native_query_trace_dir";
+    public static final String NATIVE_QUERY_TRACE_NODE_IDS = "native_query_trace_node_ids";
+    public static final String NATIVE_QUERY_TRACE_MAX_BYTES = "native_query_trace_max_bytes";
+    public static final String NATIVE_QUERY_TRACE_REG_EXP = "native_query_trace_task_reg_exp";
+
     public static final String DEFAULT_VIEW_SECURITY_MODE = "default_view_security_mode";
     public static final String JOIN_PREFILTER_BUILD_SIDE = "join_prefilter_build_side";
     public static final String OPTIMIZER_USE_HISTOGRAMS = "optimizer_use_histograms";
@@ -1772,6 +1777,26 @@ public final class SystemSessionProperties
                         NATIVE_MAX_SPILL_BYTES,
                         "The max allowed spill bytes",
                         100L << 30,
+                        false),
+                booleanProperty(NATIVE_QUERY_TRACE_ENABLED,
+                        "Enables query tracing.",
+                        false,
+                        false),
+                stringProperty(NATIVE_QUERY_TRACE_DIR,
+                        "Base dir of a query to store tracing data.",
+                        "",
+                        false),
+                stringProperty(NATIVE_QUERY_TRACE_NODE_IDS,
+                        "A comma-separated list of plan node ids whose input data will be traced. Empty string if only want to trace the query metadata.",
+                        "",
+                        false),
+                longProperty(NATIVE_QUERY_TRACE_MAX_BYTES,
+                        "The max trace bytes limit. Tracing is disabled if zero.",
+                        0L,
+                        false),
+                stringProperty(NATIVE_QUERY_TRACE_REG_EXP,
+                        "The regexp of traced task id. We only enable trace on a task if its id matches.",
+                        "",
                         false),
                 booleanProperty(
                         RANDOMIZE_OUTER_JOIN_NULL_KEY,


### PR DESCRIPTION
## Description
Added 5 presto native query trace related session properties to facilitate trace debugging.
```
== NO RELEASE NOTE ==
```

