### PR TITLE
[docs] Replace presto-router/README.txt with README.md

### DIFF
--- a/presto-router/README.md
+++ b/presto-router/README.md
@@ -1,0 +1,32 @@
+# Presto Router
+
+Presto Router is a service that sits in front of Presto clusters. It routes requests to Presto clusters, collects statistics from Presto clusters, and shows aggregated results in a UI.
+
+## Running Presto Router in your IDE
+
+After building Presto, load the project into your IDE and run the router. In IntelliJ IDEA, use the following options to create a run configuration:
+
+* Main Class: `com.facebook.presto.router.PrestoRouter`
+* VM Options: `-Drouter.config-file=etc/router-config.json -Dnode.environment=devel`
+* Working directory: `$MODULE_WORKING_DIR$` or `$MODULE_DIR$`(Depends on your version of IntelliJ)
+* Use classpath of module: `presto-router`
+
+The working directory should be the `presto-router` subdirectory.
+
+If necessary, edit the `etc/router-config.json` file and add the Presto clusters' endpoints in the `groups.members` field.
+
+## Building the Web UI
+
+Similar to the Presto Web UI, the router Web UI is also composed of React components and is written in JSX and ES6. To update this folder after making changes, run:
+
+    yarn --cwd presto-router/src/main/resources/router_ui/src install
+
+If no JavaScript dependencies have changed (that is, no changes to `package.json`), it is faster to run:
+
+    yarn --cwd presto-router/src/main/resources/router_ui/src run package
+
+To simplify iteration, you can run in `watch` mode, which automatically re-compiles when changes to source files are detected:
+
+    yarn --cwd presto-router/src/main/resources/router_ui/src run watch
+
+To iterate quickly, re-build the project in IntelliJ after packaging is complete. Project resources are then hot-reloaded and changes are reflected on browser refresh.

--- a/presto-router/README.txt
+++ b/presto-router/README.txt
@@ -1,32 +1,6 @@
 # Presto Router
 
-Presto router is a service sitting in front of Presto clusters. It routes requests to Presto clusters, collects statistics from Presto clusters, and shows aggregated results in a UI.
+Presto router is a service sitting in front of Presto clusters.
 
-## Running Presto router in your IDE
-
-After building Presto, you can load the project into your IDE and run the router. In IntelliJ IDEA, use the following options to create a run configuration:
-
-* Main Class: `com.facebook.presto.router.PrestoRouter`
-* VM Options: `-Drouter.config-file=etc/router-config.json -Dnode.environment=devel`
-* Working directory: `$MODULE_WORKING_DIR$` or `$MODULE_DIR$`(Depends your version of IntelliJ)
-* Use classpath of module: `presto-router`
-
-The working directory should be the `presto-router` subdirectory.
-
-If necessary, edit the `etc/router-config.json` file with the Presto clusters' endpoints in the `groups.members` field.
-
-## Building the Web UI
-
-Similar to the Presto Web UI, the router Web UI is also composed of React components and is written in JSX and ES6. To update this folder after making changes, simply run:
-
-    yarn --cwd presto-router/src/main/resources/router_ui/src install
-
-If no JavaScript dependencies have changed (i.e., no changes to `package.json`), it is faster to run:
-
-    yarn --cwd presto-router/src/main/resources/router_ui/src run package
-
-To simplify iteration, you can also run in `watch` mode, which automatically re-compiles when changes to source files are detected:
-
-    yarn --cwd presto-router/src/main/resources/router_ui/src run watch
-
-To iterate quickly, simply re-build the project in IntelliJ after packaging is complete. Project resources will be hot-reloaded and changes are reflected on browser refresh.
+For more information, see 
+https://github.com/prestodb/presto/blob/master/presto-router/README.md


### PR DESCRIPTION
## Description
* Replace [presto-router/README.txt](https://github.com/prestodb/presto/blob/master/presto-router/README.txt) with README.md. 
* Minor text revisions for readability. 

The file was already formatted as a Markdown file, so conversion was simple. 

## Motivation and Context
Change suggested by @ethanyzhang. 

## Impact
None. 

## Test Plan
Created a README.md in a sandbox GitHub repository with the content of [presto-router/README.txt](https://github.com/prestodb/presto/blob/master/presto-router/README.txt) to check the formatting as it is displayed in GitHub. Deleted the test file afterward. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```