### PR TITLE
Fix client-tag selector rule. 

### DIFF
--- a/presto-router/src/main/java/com/facebook/presto/router/spec/SelectorRuleSpec.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/spec/SelectorRuleSpec.java
@@ -84,7 +84,7 @@ public class SelectorRuleSpec
             }
         }
 
-        if (clientTags.isPresent() && requestInfo.getClientTags().containsAll(clientTags.get())) {
+        if (clientTags.isPresent() && !requestInfo.getClientTags().containsAll(clientTags.get())) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
## Description
When the client-tags matches the request, the selector should choose the target group. The bug in the code doesn't do that. In th current code, when all the client-tags match incoming request, the selector is not matched.

## Motivation and Context
When the client-tags matches the request, the selector should choose the target group. The bug in the code doesn't do that. In th current code, when all the client-tags match incoming request, the selector is not matched.

## Impact
None

## Test Plan
Verified manually by passing client-tags in the request and tried to match the client-tags configured in the selector. After the fix, it matches and the right target group is used

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

