### PR TITLE
[Iceberg]Support view on Rest catalog and Nessie catalog

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1134,10 +1134,15 @@ Create an Iceberg table partitioned by ``ts``::
 CREATE VIEW
 ^^^^^^^^^^^
 
-The Iceberg connector supports creating views in Hive and Glue metastores.
+The Iceberg connector supports creating views in Hive, Glue, REST, and Nessie catalogs.
 To create a view named ``view_page_views`` for the ``iceberg.web.page_views`` table created in the `CREATE TABLE`_ example::
 
     CREATE VIEW iceberg.web.view_page_views AS SELECT user_id, country FROM iceberg.web.page_views;
+
+.. note::
+
+    The Iceberg REST catalog may not support view creation depending on the
+    type of the backing catalog.
 
 INSERT INTO
 ^^^^^^^^^^^

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -85,10 +85,12 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
+import org.apache.iceberg.view.View;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -141,6 +143,7 @@ import static com.facebook.presto.iceberg.IcebergUtil.getPartitionSpecsIncluding
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitions;
 import static com.facebook.presto.iceberg.IcebergUtil.getSnapshotIdTimeOperator;
 import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
+import static com.facebook.presto.iceberg.IcebergUtil.getViewComment;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
 import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetLocation;
@@ -216,6 +219,8 @@ public abstract class IcebergAbstractMetadata
     }
 
     protected abstract Table getRawIcebergTable(ConnectorSession session, SchemaTableName schemaTableName);
+
+    protected abstract View getIcebergView(ConnectorSession session, SchemaTableName schemaTableName);
 
     protected abstract boolean tableExists(ConnectorSession session, SchemaTableName schemaTableName);
 
@@ -386,22 +391,31 @@ public abstract class IcebergAbstractMetadata
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) table;
-        return getTableMetadata(session, icebergTableHandle.getSchemaTableName(), icebergTableHandle.getIcebergTableName());
+        return getTableOrViewMetadata(session, icebergTableHandle.getSchemaTableName(), icebergTableHandle.getIcebergTableName());
     }
 
-    protected ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table, IcebergTableName icebergTableName)
+    protected ConnectorTableMetadata getTableOrViewMetadata(ConnectorSession session, SchemaTableName table, IcebergTableName icebergTableName)
     {
-        Table icebergTable = getIcebergTable(session, new SchemaTableName(table.getSchemaName(), icebergTableName.getTableName()));
-        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
-        columns.addAll(getColumnMetadatas(icebergTable));
-        if (icebergTableName.getTableType() == CHANGELOG) {
-            return ChangelogUtil.getChangelogTableMeta(table, typeManager, columns.build());
+        try {
+            Table icebergTable = getIcebergTable(session, new SchemaTableName(table.getSchemaName(), icebergTableName.getTableName()));
+            ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
+            columns.addAll(getColumnMetadata(icebergTable));
+            if (icebergTableName.getTableType() == CHANGELOG) {
+                return ChangelogUtil.getChangelogTableMeta(table, typeManager, columns.build());
+            }
+            else {
+                columns.add(PATH_COLUMN_METADATA);
+                columns.add(DATA_SEQUENCE_NUMBER_COLUMN_METADATA);
+            }
+            return new ConnectorTableMetadata(table, columns.build(), createMetadataProperties(icebergTable), getTableComment(icebergTable));
         }
-        else {
-            columns.add(PATH_COLUMN_METADATA);
-            columns.add(DATA_SEQUENCE_NUMBER_COLUMN_METADATA);
+        catch (NoSuchTableException e) {
+            // Considering that the Iceberg library does not provide an efficient way to determine whether
+            //  it's a view or a table without loading it, we first try to load it as a table directly, and then
+            //  try to load it as a view when getting an `NoSuchTableException`. This will be more efficient.
+            View icebergView = getIcebergView(session, new SchemaTableName(table.getSchemaName(), icebergTableName.getTableName()));
+            return new ConnectorTableMetadata(table, getColumnMetadata(icebergView), createViewMetadataProperties(icebergView), getViewComment(icebergView));
         }
-        return new ConnectorTableMetadata(table, columns.build(), createMetadataProperties(icebergTable), getTableComment(icebergTable));
     }
 
     @Override
@@ -414,7 +428,7 @@ public abstract class IcebergAbstractMetadata
             try {
                 IcebergTableName tableName = IcebergTableName.from(table.getTableName());
                 if (!tableName.isSystemTable()) {
-                    columns.put(table, getTableMetadata(session, table, tableName).getColumns());
+                    columns.put(table, getTableOrViewMetadata(session, table, tableName).getColumns());
                 }
             }
             catch (TableNotFoundException e) {
@@ -529,7 +543,7 @@ public abstract class IcebergAbstractMetadata
         return !isPushdownFilterEnabled(session);
     }
 
-    protected List<ColumnMetadata> getColumnMetadatas(Table table)
+    protected List<ColumnMetadata> getColumnMetadata(Table table)
     {
         Map<String, List<String>> partitionFields = getPartitionFields(table.spec(), ALL);
         return table.schema().columns().stream()
@@ -542,6 +556,18 @@ public abstract class IcebergAbstractMetadata
                                 partitionFields.containsKey(column.name()) ?
                                         columnExtraInfo(partitionFields.get(column.name())) :
                                         null))
+                        .build())
+                .collect(toImmutableList());
+    }
+
+    protected List<ColumnMetadata> getColumnMetadata(View view)
+    {
+        return view.schema().columns().stream()
+                .map(column -> ColumnMetadata.builder()
+                        .setName(column.name())
+                        .setType(toPrestoType(column.type(), typeManager))
+                        .setComment(Optional.ofNullable(column.doc()))
+                        .setHidden(false)
                         .build())
                 .collect(toImmutableList());
     }
@@ -576,6 +602,16 @@ public abstract class IcebergAbstractMetadata
         properties.put(METADATA_DELETE_AFTER_COMMIT, IcebergUtil.isMetadataDeleteAfterCommit(icebergTable));
         properties.put(METRICS_MAX_INFERRED_COLUMN, IcebergUtil.getMetricsMaxInferredColumn(icebergTable));
 
+        return properties.build();
+    }
+
+    protected ImmutableMap<String, Object> createViewMetadataProperties(View view)
+    {
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        if (view.properties() != null) {
+            view.properties().entrySet().stream()
+                    .forEach(entry -> properties.put(entry.getKey(), entry.getValue()));
+        }
         return properties.build();
     }
 
@@ -719,7 +755,7 @@ public abstract class IcebergAbstractMetadata
         Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
         Schema schema;
         if (table.getIcebergTableName().getTableType() == CHANGELOG) {
-            schema = ChangelogUtil.changelogTableSchema(getRowTypeFromColumnMeta(getColumnMetadatas(icebergTable)));
+            schema = ChangelogUtil.changelogTableSchema(getRowTypeFromColumnMeta(getColumnMetadata(icebergTable)));
         }
         else {
             schema = icebergTable.schema();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -73,6 +73,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.view.View;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -179,6 +180,12 @@ public class IcebergHiveMetadata
     protected org.apache.iceberg.Table getRawIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
         return getHiveIcebergTable(metastore, hdfsEnvironment, hiveTableOeprationsConfig, session, schemaTableName);
+    }
+
+    @Override
+    protected View getIcebergView(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "Iceberg Hive catalog does not support native Iceberg views.");
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -24,31 +24,46 @@ import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.relation.RowExpressionService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewBuilder;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
 import static com.facebook.presto.iceberg.IcebergTableType.DATA;
+import static com.facebook.presto.iceberg.IcebergUtil.VIEW_OWNER;
+import static com.facebook.presto.iceberg.IcebergUtil.createIcebergViewProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
+import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergView;
 import static com.facebook.presto.iceberg.IcebergUtil.populateTableProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.verifyTypeSupported;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
@@ -68,9 +83,11 @@ public class IcebergNativeMetadata
         extends IcebergAbstractMetadata
 {
     private static final String INFORMATION_SCHEMA = "information_schema";
+    private static final String VIEW_DIALECT = "presto";
 
     private final IcebergNativeCatalogFactory catalogFactory;
     private final CatalogType catalogType;
+    private final ConcurrentMap<SchemaTableName, View> icebergViews = new ConcurrentHashMap<>();
 
     public IcebergNativeMetadata(
             IcebergNativeCatalogFactory catalogFactory,
@@ -92,6 +109,14 @@ public class IcebergNativeMetadata
     protected Table getRawIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
         return getNativeIcebergTable(catalogFactory, session, schemaTableName);
+    }
+
+    @Override
+    protected View getIcebergView(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        return icebergViews.computeIfAbsent(
+                schemaTableName,
+                ignored -> getNativeIcebergView(catalogFactory, session, schemaTableName));
     }
 
     @Override
@@ -156,6 +181,102 @@ public class IcebergNativeMetadata
     public void renameSchema(ConnectorSession session, String source, String target)
     {
         throw new PrestoException(NOT_SUPPORTED, format("Iceberg %s catalog does not support rename namespace", catalogType.name()));
+    }
+
+    @Override
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        Catalog catalog = catalogFactory.getCatalog(session);
+        if (!(catalog instanceof ViewCatalog)) {
+            throw new PrestoException(NOT_SUPPORTED, "This connector does not support creating views");
+        }
+        Schema schema = toIcebergSchema(viewMetadata.getColumns());
+        ViewBuilder viewBuilder = ((ViewCatalog) catalog).buildView(TableIdentifier.of(viewMetadata.getTable().getSchemaName(), viewMetadata.getTable().getTableName()))
+                .withSchema(schema)
+                .withDefaultNamespace(Namespace.of(viewMetadata.getTable().getSchemaName()))
+                .withQuery(VIEW_DIALECT, viewData)
+                .withProperties(createIcebergViewProperties(session, nodeVersion.toString()));
+        if (replace) {
+            viewBuilder.createOrReplace();
+        }
+        else {
+            viewBuilder.create();
+        }
+    }
+
+    @Override
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
+        Catalog catalog = catalogFactory.getCatalog(session);
+        if (catalog instanceof ViewCatalog) {
+            for (String schema : listSchemas(session, schemaName.orElse(null))) {
+                try {
+                    for (TableIdentifier tableIdentifier : ((ViewCatalog) catalog).listViews(Namespace.of(schema))) {
+                        tableNames.add(new SchemaTableName(schema, tableIdentifier.name()));
+                    }
+                }
+                catch (NoSuchNamespaceException e) {
+                    // ignore
+                }
+            }
+        }
+        return tableNames.build();
+    }
+
+    private List<String> listSchemas(ConnectorSession session, String schemaNameOrNull)
+    {
+        if (schemaNameOrNull == null) {
+            return listSchemaNames(session);
+        }
+        return ImmutableList.of(schemaNameOrNull);
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
+        Catalog catalog = catalogFactory.getCatalog(session);
+        if (catalog instanceof ViewCatalog) {
+            List<SchemaTableName> tableNames;
+            if (prefix.getTableName() != null) {
+                tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+            }
+            else {
+                tableNames = listViews(session, Optional.of(prefix.getSchemaName()));
+            }
+
+            for (SchemaTableName schemaTableName : tableNames) {
+                try {
+                    if (((ViewCatalog) catalog).viewExists(TableIdentifier.of(schemaTableName.getSchemaName(), schemaTableName.getTableName()))) {
+                        View view = ((ViewCatalog) catalog).loadView(TableIdentifier.of(schemaTableName.getSchemaName(), schemaTableName.getTableName()));
+                        verifyAndPopulateViews(view, schemaTableName, view.sqlFor(VIEW_DIALECT).sql(), views);
+                    }
+                }
+                catch (IllegalArgumentException e) {
+                    // Ignore illegal view names
+                }
+            }
+        }
+        return views.build();
+    }
+
+    @Override
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        Catalog catalog = catalogFactory.getCatalog(session);
+        if (!(catalog instanceof ViewCatalog)) {
+            throw new PrestoException(NOT_SUPPORTED, "This connector does not support dropping views");
+        }
+        ((ViewCatalog) catalog).dropView(TableIdentifier.of(viewName.getSchemaName(), viewName.getTableName()));
+    }
+
+    private void verifyAndPopulateViews(View view, SchemaTableName schemaTableName, String viewData, ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views)
+    {
+        views.put(schemaTableName, new ConnectorViewDefinition(
+                schemaTableName,
+                Optional.ofNullable(view.properties().get(VIEW_OWNER)),
+                viewData));
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieCatalogDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieCatalogDistributedQueries.java
@@ -62,6 +62,6 @@ public class TestIcebergNessieCatalogDistributedQueries
     @Override
     protected boolean supportsViews()
     {
-        return false;
+        return true;
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestTestUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestTestUtil.java
@@ -70,6 +70,7 @@ public class IcebergRestTestUtil
                 .put(WAREHOUSE_LOCATION, location)
                 .put("jdbc.username", "user")
                 .put("jdbc.password", "password")
+                .put("jdbc.schema-version", "V1")
                 .build();
         backingCatalog.initialize("rest_jdbc_backend", properties);
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCatalogDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCatalogDistributedQueries.java
@@ -86,6 +86,6 @@ public class TestIcebergRestCatalogDistributedQueries
     @Override
     protected boolean supportsViews()
     {
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
## Description

Iceberg's `RestCatalog` and `NessieCatalog` have implemented `ViewCatalog` interface, that means we can support operations on `view` for Iceberg connector configured with these catalogs. This PR refactor `IcebergNativeMetadata`, so that catalogs like `REST` and `NESSIE` that implements interface `ViewCatalog` can now support operations on `view`.

## Motivation and Context

Support `view` for Iceberg connector on as many catalog types as possible

## Impact

Iceberg connector configured with `REST` and `NESSIE` catalogs can now support operations on `view`

## Test Plan

 - Enable existing test cases for views on REST and NESSIE

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support of ``view`` for Iceberg connector when configured with ``REST`` and ``NESSIE``. :pr:`23793`
```
