### PR TITLE
Upgraded commons-io to version 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,12 @@
             </dependency>
 
             <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.16.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-parquet</artifactId>
                 <version>${project.version}</version>
@@ -2354,6 +2360,17 @@
                                 </excludes>
                             </requireUpperBoundDeps>
                         </rules>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoredClassPatterns combine.children="append">
+                            <!-- Duplicate class is being brought in by commons-io & log4j-api -->
+                            <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                        </ignoredClassPatterns>
                     </configuration>
                 </plugin>
 

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -238,7 +238,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.13.0</version>
         </dependency>
 
         <dependency>

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.13.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
Upgraded commons-io to version 2.16.0
## Motivation and Context
This upgrade was created to deal with CVEs found in lower versions
## Impact
None

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Upgraded commons-io to version 2.16.0 :pr:`23794`
```
