### PR TITLE
Upgraded protobuf-java dependencies to 3.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <dep.j2objc.version>2.8</dep.j2objc.version>
         <dep.avro.version>1.11.3</dep.avro.version>
         <dep.commons.compress.version>1.23.0</dep.commons.compress.version>
+        <dep.protobuf-java.version>3.25.5</dep.protobuf-java.version>
 
         <!--
           America/Bahia_Banderas has:
@@ -551,7 +552,13 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.25.1</version>
+                <version>${dep.protobuf-java.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java-util</artifactId>
+                <version>${dep.protobuf-java.version}</version>
             </dependency>
 
             <dependency>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -27,6 +27,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.9</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.threeten</groupId>
                 <artifactId>threetenbp</artifactId>
                 <version>1.5.1</version>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -319,7 +319,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.21.7</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.21.7</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
## Description
Upgraded protobuf-java dependencies to version 3.25.5
## Motivation and Context
This upgrade was created to deal with CVEs found in lower versions
## Impact
None

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Upgraded protobuf-java to version 3.25.5 :pr:`23797`
* Upgraded protobuf-java-util to version 3.25.5 :pr:`23797`
```
