### PR TITLE
[native] Include glog for thrift artifact build

### DIFF
--- a/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
@@ -32,11 +32,13 @@ thrift_library(
 target_link_libraries(presto_thrift-cpp2 ${THRIFT_PROTOCOL} ${THRIFT_METADATA}
                       ${THRIFT_CORE} ${THRIFT_TRANSPORT})
 set(presto_thrift_INCLUDES ${CMAKE_CURRENT_BINARY_DIR})
-target_include_directories(presto_thrift-cpp2 PUBLIC ${presto_thrift_INCLUDES})
-target_include_directories(presto_thrift-cpp2-obj PUBLIC ${THRIFT_INCLUDES})
+target_include_directories(presto_thrift-cpp2 PUBLIC ${presto_thrift_INCLUDES}
+                                                     ${GLOG_INCLUDE_DIR})
+target_include_directories(presto_thrift-cpp2-obj PUBLIC ${THRIFT_INCLUDES}
+                                                         ${GLOG_INCLUDE_DIR})
 
 add_library(presto_thrift_extra ProtocolToThrift.cpp)
-target_include_directories(presto_thrift_extra PUBLIC ${presto_thrift_INCLUDES}
-                                                      ${THRIFT_INCLUDES})
-target_include_directories(presto_thrift_extra PUBLIC ${presto_thrift_INCLUDES})
+target_include_directories(
+  presto_thrift_extra PUBLIC ${presto_thrift_INCLUDES} ${THRIFT_INCLUDES}
+                             ${GLOG_INCLUDE_DIR})
 add_dependencies(presto_thrift_extra presto_thrift-cpp2)


### PR DESCRIPTION
An upgrade to folly introduces the glog headers into the build of thrift artifacts. This commit adds the glog include directory when building the targets.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

