### PR TITLE
[docs] Add documentation for query plan and plan fragment

### DIFF
--- a/presto-docs/src/main/sphinx/overview/concepts.rst
+++ b/presto-docs/src/main/sphinx/overview/concepts.rst
@@ -183,6 +183,33 @@ that statement. A query encompasses stages, tasks, splits, connectors,
 and other components and data sources working in concert to produce a
 result.
 
+Query Plan
+^^^^^^^^^^
+
+A query plan is a sequence of steps used to access and manipulate data 
+according to the SQL query. It is represented as a tree of nodes, with 
+each node loosely representing an `operator <https://prestodb.io/docs/current/overview/concepts.html#operator>`_. 
+Since SQL is declarative, multiple query plans can be generated to execute 
+a given query. Because query plans can have different performance behavior, 
+Presto uses a query optimizer to choose an efficient plan.
+
+There are two phases of optimization: logical and physical. The logical 
+phase of optimization transforms plans by only considering algorithmic 
+complexity. The logically optimized query plan is then converted into 
+a physical query plan, which is optimized for distributed execution and 
+includes details such as the number and 
+`types <https://prestodb.io/docs/current/overview/concepts.html#server-types>`_ 
+of Presto servers which should process a query plan node, and how data is 
+`exchanged <https://prestodb.io/docs/current/overview/concepts.html#exchange>`_ 
+between them.
+
+Plan Fragment
+^^^^^^^^^^^^^
+
+A plan fragment is a section of the physical query plan executed by 
+`tasks <https://prestodb.io/docs/current/overview/concepts.html#task>`_ on different 
+`Presto servers <https://prestodb.io/docs/current/overview/concepts.html#server-types>`_.
+
 Stage
 ^^^^^
 

--- a/presto-docs/src/main/sphinx/sql/explain.rst
+++ b/presto-docs/src/main/sphinx/sql/explain.rst
@@ -20,10 +20,10 @@ Description
 -----------
 
 Show the logical or distributed execution plan of a statement, or validate the statement.
-Use ``TYPE DISTRIBUTED`` option to display fragmented plan. Each plan fragment is executed by
-a single or multiple Presto nodes. Fragments separation represent the data exchange between Presto nodes.
-Fragment type specifies how the fragment is executed by Presto nodes and how the data is
-distributed between fragments:
+Use ``TYPE DISTRIBUTED`` option to display fragmented plan. Each 
+`plan fragment <https://prestodb.io/docs/current/overview/concepts.html#plan-fragment>`_ 
+is executed by a single or multiple Presto nodes. Fragment type specifies how the fragment 
+is executed by Presto nodes and how the data is distributed between fragments:
 
 ``SINGLE``
     Fragment is executed on a single node.


### PR DESCRIPTION
## Description
* Add definitions for query plan and plan fragment provided by @tdcmeehan in #23675 to the [Presto Concepts](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/overview/concepts.rst) documentation. 

* Add a link to the new plan fragment definition from the [Description](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/sql/explain.rst#description) of [EXPLAIN](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/sql/explain.rst). 

## Motivation and Context
Fixes #23675.

## Impact
Documentation.

## Test Plan
Local doc builds for formatting correctness, and tested new links. See screenshot. 

Note: I decided the best place in [Presto Concepts](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/overview/concepts.rst) for the two new topics was immediately after the `Query` subtopic of `Query Execution Model`. Let me know if either or both of the new topics should be moved to elsewhere on the page. 

<img width="900" alt="Screenshot 2024-10-10 at 5 36 09 PM" src="https://github.com/user-attachments/assets/dffcdfc5-b7a6-4a6e-80bc-41bb1f3c4571">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

