### PR TITLE
Enable verbose runtime stats for connector optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/OptimizerRuntimeTrackUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/OptimizerRuntimeTrackUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
+import com.facebook.presto.sql.planner.optimizations.StatsRecordingPlanOptimizer;
+import com.google.common.base.Splitter;
+
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.getOptimizersToEnableVerboseRuntimeStats;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+
+public class OptimizerRuntimeTrackUtil
+{
+    private OptimizerRuntimeTrackUtil()
+    {
+    }
+
+    public static String getOptimizerNameForLog(Object optimizer)
+    {
+        checkArgument(optimizer instanceof PlanOptimizer || optimizer instanceof ConnectorPlanOptimizer);
+        String optimizerName = optimizer.getClass().getSimpleName();
+        if (optimizer instanceof StatsRecordingPlanOptimizer) {
+            optimizerName = format("%s:%s", optimizerName, ((StatsRecordingPlanOptimizer) optimizer).getDelegate().getClass().getSimpleName());
+        }
+        return optimizerName;
+    }
+
+    public static boolean trackOptimizerRuntime(Session session, Object optimizer)
+    {
+        String optimizerString = getOptimizersToEnableVerboseRuntimeStats(session);
+        if (optimizerString.isEmpty()) {
+            return false;
+        }
+        List<String> optimizers = Splitter.on(",").trimResults().splitToList(optimizerString);
+        return optimizers.contains(getOptimizerNameForLog(optimizer));
+    }
+}


### PR DESCRIPTION
## Description
Connector optimizer is a wrapper which will run multiple individual optimizers.
When verbose runtime is enabled, the latency of each individual connector optimizer is not logged (we only log the overall latency of the connector optimizer, but for each individual optimizer included in the connector optimizer we do not log). This change will enable recording each individual connector optimizer.

## Motivation and Context
As above

## Impact
To track latency of each individual connector optimizer

## Test Plan
Easy change. Test locally end to end

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

