### PR TITLE
[native] Add counter to track effectiveness of memory pushback

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
@@ -209,6 +209,12 @@ void PeriodicMemoryChecker::pushbackMemory() {
   }
   RECORD_HISTOGRAM_METRIC_VALUE(
       kCounterMemoryPushbackLatencyMs, latencyUs / 1000);
-  LOG(INFO) << "Shrunk " << velox::succinctBytes(freedBytes);
+  const auto actualFreedBytes = std::max<int64_t>(
+      0, static_cast<int64_t>(currentMemBytes) - systemUsedMemoryBytes());
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kCounterMemoryPushbackLatencyMs, actualFreedBytes);
+  LOG(INFO) << "Memory pushback shrunk " << velox::succinctBytes(freedBytes)
+            << " Effective bytes shrunk: "
+            << velox::succinctBytes(actualFreedBytes);
 }
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -102,6 +102,15 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(kCounterMemoryPushbackCount, facebook::velox::StatType::COUNT);
   DEFINE_HISTOGRAM_METRIC(
       kCounterMemoryPushbackLatencyMs, 10'000, 0, 100'000, 50, 90, 99, 100);
+  DEFINE_HISTOGRAM_METRIC(
+      kCounterMemoryPushbackLatencyMs,
+      100l * 1024 * 1024, // 100MB
+      0,
+      15l * 1024 * 1024 * 1024, // 15GB
+      50,
+      90,
+      99,
+      100);
 
   // NOTE: Metrics type exporting for file handle cache counters are in
   // PeriodicTaskManager because they have dynamic names. The following counters

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -166,4 +166,9 @@ constexpr folly::StringPiece kCounterMemoryPushbackCount{
 /// reports P50, P90, P99, and P100.
 constexpr folly::StringPiece kCounterMemoryPushbackLatencyMs{
     "presto_cpp.memory_pushback_latency_ms"};
+/// Distribution of reduction in memory usage achieved by each memory pushback
+/// attempt. This is to gauge its effectiveness. In range of [0, 15GB] with 150
+/// buckets and reports P50, P90, P99, and P100.
+constexpr folly::StringPiece kCounterMemoryPushbackReductionBytes{
+    "presto_cpp.memory_pushback_reduction_bytes"};
 } // namespace facebook::presto


### PR DESCRIPTION
Adds a new counter `presto_cpp.memory_pushback_reduction_bytes`
that keeps track of the actual used memory reduction for every
memory pushback attempt.