### PR TITLE
Centralize dependency versions in parent pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,12 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>4.1.107.Final</version>
+            </dependency>
+            
+            <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-testing-docker</artifactId>
                 <version>${project.version}</version>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -185,17 +185,6 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-        <!-- This is to fix the upper bound issues arising out of different components-->
-        <dependencies>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>4.1.107.Final</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Description
Upgrade dependency version management by centralizing the versions in the parent pom.xml file. Previously, the child module presto-cassandra/pom.xml declared its own dependency versions. Now, the versions are defined once in the parent pom.xml for consistency across modules.

## Motivation and Context
Why is this change required? What problem does it solve?
(1) Consistency: 
By defining dependency versions once in the parent pom.xml, all modules use the same version of the dependencies.

(2) Simplifies Maintenance:
When you need to upgrade a dependency, you only need to change the version in one place (the parent pom.xml) rather than updating each module's pom.xml(presto-cassandra/pom.xml). This reduces the chance of human error and makes upgrades more efficient.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Dependency version updates
* Upgrade to centralize dependency versions in the parent pom.xml from presto-cassandra/pom.xml for consistency and ease of maintenance.  :pr:`23818`

