### PR TITLE
[native] Fix bug logging memory pushback metric

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
@@ -212,7 +212,7 @@ void PeriodicMemoryChecker::pushbackMemory() {
   const auto actualFreedBytes = std::max<int64_t>(
       0, static_cast<int64_t>(currentMemBytes) - systemUsedMemoryBytes());
   RECORD_HISTOGRAM_METRIC_VALUE(
-      kCounterMemoryPushbackLatencyMs, actualFreedBytes);
+      kCounterMemoryPushbackReductionBytes, actualFreedBytes);
   LOG(INFO) << "Memory pushback shrunk " << velox::succinctBytes(freedBytes)
             << " Effective bytes shrunk: "
             << velox::succinctBytes(actualFreedBytes);


### PR DESCRIPTION
This change ensure the correct metric is used to log memory pushback effectiveness.