### PR TITLE
[Iceberg]Enable test cases for rename table on REST and NESSIE catalog

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
@@ -67,12 +67,6 @@ public abstract class TestIcebergDistributedQueries
     }
 
     @Override
-    public void testRenameTable()
-    {
-        // Rename table are not supported by the connector
-    }
-
-    @Override
     public void testUpdate()
     {
         // Updates are not supported by the connector

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergHadoopCatalogDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergHadoopCatalogDistributedQueries.java
@@ -29,4 +29,10 @@ public class TestIcebergHadoopCatalogDistributedQueries
     {
         return false;
     }
+
+    @Override
+    public void testRenameTable()
+    {
+        // Rename table are not supported by hadoop catalog
+    }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveCatalogDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveCatalogDistributedQueries.java
@@ -28,4 +28,10 @@ public class TestIcebergHiveCatalogDistributedQueries
     {
         super(HIVE, ImmutableMap.of("iceberg.hive-statistics-merge-strategy", Joiner.on(",").join(NUMBER_OF_DISTINCT_VALUES.name(), TOTAL_SIZE_IN_BYTES.name())));
     }
+
+    @Override
+    public void testRenameTable()
+    {
+        // Rename table are not supported by hive catalog
+    }
 }


### PR DESCRIPTION
## Description

We have already supported rename table on Iceberg connector configured with `REST` and `NESSIE` catalog. This PR enable existing test cases for rename table on them. 

In PR #16612, we introduced `IcebergNativeMetadata`, since then, the catalogs integrated into presto Iceberg connector based on `IcebergNativeMetadata` can support rename table functionality if they originally support this functionality in Iceberg library. This means `REST` and `NESSIE` catalog has already supported the rename table functionality, so we can enable existing test cases for rename table on them directly.


## Motivation and Context

Increase the coverage of code testing

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

