### PR TITLE
[test] Fix flaky test TestQueues.testEagerPlanValidation

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -401,11 +401,12 @@ public class TestQueues
         QueryId secondQuery = createQuery(queryRunner, secondSession, LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, secondQuery, QUEUED);
 
+        // Force failure during plan validation after queuing has begun
+        triggerValidationFailure.set(true);
+
         Session thirdSession = builder.setQueryId(QueryId.valueOf("20240930_203743_00003_33333")).build();
         QueryId thirdQuery = createQuery(queryRunner, thirdSession, LONG_LASTING_QUERY);
 
-        // Force failure during plan validation after queuing has begun
-        triggerValidationFailure.set(true);
         waitForQueryState(queryRunner, thirdQuery, FAILED);
 
         DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

The TestQueues.testEagerPlanValidation is meant to trigger a plan validation failure in an async thread, but a race condition can occur if the query is created and the validation thread manages to complete before the trigger is set. Moving the trigger to be set before the query is created will ensure that it fails during validation.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Flaky test TestQueues.testEagerPlanValidation reported in https://github.com/prestodb/presto/issues/23838

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Manually stopped main thread to simulate load and verified the race condition was fixed by moving the trigger.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

