### PR TITLE
Fix ARRAYS_OVERLAP function bug

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -1295,6 +1295,8 @@ public class TestArrayOperators
         assertFunction("ARRAYS_OVERLAP(ARRAY [NULL, 3], ARRAY [2, 1])", BooleanType.BOOLEAN, null);
         assertFunction("ARRAYS_OVERLAP(ARRAY [3, NULL], ARRAY [2, 1])", BooleanType.BOOLEAN, null);
         assertFunction("ARRAYS_OVERLAP(ARRAY [3, NULL], ARRAY [2, 1, NULL])", BooleanType.BOOLEAN, null);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [ARRAY [1, 2], ARRAY [1, NULL]], ARRAY [ARRAY [1, 2]])", BooleanType.BOOLEAN, true);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [ARRAY [1, NULL], ARRAY [1, 2]], ARRAY [ARRAY [1, 2]])", BooleanType.BOOLEAN, true);
 
         assertFunction("ARRAYS_OVERLAP(ARRAY [CAST(1 AS BIGINT), 2], ARRAY [NULL, CAST(2 AS BIGINT)])", BooleanType.BOOLEAN, true);
         assertFunction("ARRAYS_OVERLAP(ARRAY [CAST(1 AS BIGINT), 2], ARRAY [CAST(2 AS BIGINT), NULL])", BooleanType.BOOLEAN, true);
@@ -1405,8 +1407,8 @@ public class TestArrayOperators
         assertFunction("ARRAY [1, 2, null] != ARRAY [1, 2, null]", BOOLEAN, null);
         assertFunction("ARRAY [1, 2, null] != ARRAY [1, null]", BOOLEAN, true);
         assertFunction("ARRAY [1, 3, null] != ARRAY [1, 2, null]", BOOLEAN, true);
-        assertFunction("ARRAY [ARRAY[1], ARRAY[null], ARRAY[2]] != ARRAY [ARRAY[1], ARRAY[2], ARRAY[3]]", BOOLEAN, true);
-        assertFunction("ARRAY [ARRAY[1], ARRAY[null], ARRAY[3]] != ARRAY [ARRAY[1], ARRAY[2], ARRAY[3]]", BOOLEAN, null);
+        assertFunction("ARRAY [ARRAY [1], ARRAY [null], ARRAY [2]] != ARRAY [ARRAY [1], ARRAY [2], ARRAY [3]]", BOOLEAN, true);
+        assertFunction("ARRAY [ARRAY [1], ARRAY [null], ARRAY [3]] != ARRAY [ARRAY [1], ARRAY [2], ARRAY [3]]", BOOLEAN, null);
 
         assertFunction("ARRAY [10, 20, 30] < ARRAY [10, 20, 40, 50]", BOOLEAN, true);
         assertFunction("ARRAY [10, 20, 30] >= ARRAY [10, 20, 40, 50]", BOOLEAN, false);


### PR DESCRIPTION
## Description

In some arrays containing arrays that contain null values, arrays_overlap was not properly comparing values. Switch array_overlap to set based implementation.


## Motivation and Context

Fixes  #23730

## Impact
None

## Test Plan
Added the failing functions to unit tests and ran testArraysOverlap to confirm the functionality for the other queries remains the same.

<img width="282" alt="Screenshot 2024-10-16 at 5 12 35 PM" src="https://github.com/user-attachments/assets/d461ce4f-5ef9-44e9-b2bb-356a4c72c5de">

== RELEASE NOTES ==
```
General Changes
* Fix a bug where a mirrored :func:`arrays_overlap(x, y) -> boolean` function does not return the correct value.
```
