### PR TITLE
Add "native_expression.max_array_size_in_reduce" session property.

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -395,6 +395,14 @@ Native Execution only. Enable row number spilling on native engine.
 
 Native Execution only. Enable simplified path in expression evaluation.
 
+``native_expression.max_array_size_in_reduce``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``100000``
+
+Native Execution only. The `reduce <https://prestodb.io/docs/current/functions/array.html#reduce-array-T-initialState-S-inputFunction-S-T-S-outputFunction-S-R-R>`_ function will throw an error if it encounters an array of size greater than this value.
+
 ``native_spill_compression_codec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -335,6 +335,7 @@ public final class SystemSessionProperties
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
+    public static final String NATIVE_EXPRESSION_MAX_ARRAY_SIZE_IN_REDUCE = "native_expression.max_array_size_in_reduce";
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
     public static final String NATIVE_MAX_SPILL_LEVEL = "native_max_spill_level";
     public static final String NATIVE_MAX_SPILL_FILE_SIZE = "native_max_spill_file_size";
@@ -1647,6 +1648,11 @@ public final class SystemSessionProperties
                         NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED,
                         "Native Execution only. Enable simplified path in expression evaluation",
                         false,
+                        false),
+                integerProperty(
+                        NATIVE_EXPRESSION_MAX_ARRAY_SIZE_IN_REDUCE,
+                        "Native Execution only. Reduce() function will throw an error if it encounters an array of size greater than this value.",
+                        100000,
                         false),
                 booleanProperty(
                         NATIVE_AGGREGATION_SPILL_ALL,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -65,6 +65,14 @@ SessionProperties::SessionProperties() {
       boolToString(c.exprEvalSimplified()));
 
   addSessionProperty(
+      kExprMaxArraySizeInReduce,
+      "Reduce() function will throw an error if it encounters an array of size greater than this value.",
+      BIGINT(),
+      false,
+      QueryConfig::kExprMaxArraySizeInReduce,
+      std::to_string(c.exprMaxArraySizeInReduce()));
+
+  addSessionProperty(
       kMaxPartialAggregationMemory,
       "The max partial aggregation memory when data reduction is not optimal.",
       BIGINT(),

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -77,6 +77,11 @@ class SessionProperties {
   static constexpr const char* kExprEvalSimplified =
       "native_simplified_expression_evaluation_enabled";
 
+  /// Reduce() function will throw an error if it encounters an array of size
+  /// greater than this value.
+  static constexpr const char* kExprMaxArraySizeInReduce =
+      "native_expression.max_array_size_in_reduce";
+
   /// The maximum memory used by partial aggregation when data reduction is not
   /// optimal.
   static constexpr const char* kMaxPartialAggregationMemory =

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -57,7 +57,9 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
           {"native_debug_disable_expression_with_memoization", "true"},
           {"native_debug_disable_expression_with_lazy_inputs", "true"},
           {"native_selective_nimble_reader_enabled", "true"},
-          {"aggregation_spill_all", "true"}}};
+          {"aggregation_spill_all", "true"},
+          {"native_expression.max_array_size_in_reduce", "99999"},
+      }};
   auto queryCtx = taskManager_->getQueryContextManager()->findOrCreateQueryCtx(
       taskId, session);
   EXPECT_EQ(queryCtx->queryConfig().maxSpillLevel(), 2);
@@ -70,6 +72,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithLazyInputs());
   EXPECT_TRUE(queryCtx->queryConfig().selectiveNimbleReaderEnabled());
   EXPECT_EQ(queryCtx->queryConfig().spillWriteBufferSize(), 1024);
+  EXPECT_EQ(queryCtx->queryConfig().exprMaxArraySizeInReduce(), 99999);
 }
 
 TEST_F(QueryContextManagerTest, defaultSessionProperties) {


### PR DESCRIPTION
## Description
Add "native_expression.max_array_size_in_reduce" session property.
It can be used to control the limitation of Prestissimo's implementation of reduce() function.

```
== NO RELEASE NOTE ==
```

