### PR TITLE
Handle exception for empty tables in elasticsearch

### DIFF
--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
@@ -492,6 +492,10 @@ public class ElasticsearchClient
                     // Older versions of ElasticSearch supported multiple "type" mappings
                     // for a given index. Newer versions support only one and don't
                     // expose it in the document. Here we skip it if it's present.
+
+                    if (!mappings.elements().hasNext()) {
+                        return new IndexMetadata(new IndexMetadata.ObjectType(ImmutableList.of()));
+                    }
                     mappings = mappings.elements().next();
                 }
 

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -805,4 +805,12 @@ public class TestElasticsearchIntegrationSmokeTest
         client.getLowLevelClient()
                 .performRequest("PUT", "/" + indexName, ImmutableMap.of(), new NStringEntity(mapping, ContentType.APPLICATION_JSON));
     }
+
+    @Test
+    public void testEmptyIndexNoMappings()
+            throws IOException
+    {
+        client.getLowLevelClient().performRequest("PUT", "/emptyindex");
+        assertQueryFails("SELECT * FROM emptyindex", "line 1:8: SELECT \\* not allowed from relation that has no columns");
+    }
 }


### PR DESCRIPTION
Add a catch block to handle the exception when a table in Elasticsearch does not have any columns. Previously, this situation would cause an internal error in Presto.

The code iterates through the mappings (columns) but lacks an exception handler for cases where an element is not found. So, catching the NoSuchElementException to throw the appropriate error.


## Motivation and Context
https://github.com/prestodb/presto/issues/23849

## Test Plan
Added the related testcase to the code change.

Tested and working as excepted.
<img width="813" alt="image" src="https://github.com/user-attachments/assets/59f35422-7acb-43e6-8e4f-5dcee0a5d77e">


## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Elasticsearch Changes
* Improve handling of exceptions for empty tables in Elasticsearch :pr:`23850`

