### PR TITLE
[native] Add partitioned output buffers sessions

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -240,3 +240,21 @@ Native Execution only. Enable window spilling on native engine.
 * **Default value:** ``true``
 
 Native Execution only. Enable writer spilling on native engine.
+
+``native_max_output_buffer_size``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``bigint``
+* **Default value:** ``33554432``
+
+The maximum size in bytes for the task's buffered output. The buffer is shared among all drivers. Default is 32MB.
+
+``native_max_page_partitioning_buffer_size``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``bigint``
+* **Default value:** ``33554432``
+
+The maximum bytes to buffer per PartitionedOutput operator to avoid creating tiny SerializedPages.
+For PartitionedOutputNode::Kind::kPartitioned, PartitionedOutput operator would buffer up to that number of
+bytes / number of destinations for each destination before producing a SerializedPage. Default is 32MB.

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -366,6 +366,8 @@ public final class SystemSessionProperties
     public static final String NATIVE_QUERY_TRACE_NODE_IDS = "native_query_trace_node_ids";
     public static final String NATIVE_QUERY_TRACE_MAX_BYTES = "native_query_trace_max_bytes";
     public static final String NATIVE_QUERY_TRACE_REG_EXP = "native_query_trace_task_reg_exp";
+    public static final String NATIVE_MAX_PAGE_PARTITIONING_BUFFER_SIZE = "native_max_page_partitioning_buffer_size";
+    public static final String NATIVE_MAX_OUTPUT_BUFFER_SIZE = "native_max_output_buffer_size";
 
     public static final String DEFAULT_VIEW_SECURITY_MODE = "default_view_security_mode";
     public static final String JOIN_PREFILTER_BUILD_SIDE = "join_prefilter_build_side";
@@ -1804,6 +1806,17 @@ public final class SystemSessionProperties
                 stringProperty(NATIVE_QUERY_TRACE_REG_EXP,
                         "The regexp of traced task id. We only enable trace on a task if its id matches.",
                         "",
+                        false),
+                longProperty(NATIVE_MAX_OUTPUT_BUFFER_SIZE,
+                        "The maximum size in bytes for the task's buffered output. The buffer is shared among all drivers.",
+                        200L << 20,
+                        false),
+                longProperty(NATIVE_MAX_PAGE_PARTITIONING_BUFFER_SIZE,
+                        "The maximum bytes to buffer per PartitionedOutput operator to avoid creating tiny " +
+                                "SerializedPages. For PartitionedOutputNode::Kind::kPartitioned, PartitionedOutput operator " +
+                                "would buffer up to that number of bytes / number of destinations for each destination before " +
+                                "producing a SerializedPage.",
+                        24L << 20,
                         false),
                 booleanProperty(
                         RANDOMIZE_OUTER_JOIN_NULL_KEY,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -299,10 +299,31 @@ SessionProperties::SessionProperties() {
       kQueryTraceTaskRegExp,
       "The regexp of traced task id. We only enable trace on a task if its id"
       " matches.",
-      BIGINT(),
+      VARCHAR(),
       false,
       QueryConfig::kQueryTraceTaskRegExp,
       c.queryTraceTaskRegExp());
+
+  addSessionProperty(
+      kMaxOutputBufferSize,
+      "The maximum size in bytes for the task's buffered output. The buffer is"
+      " shared among all drivers.",
+      BIGINT(),
+      false,
+      QueryConfig::kMaxOutputBufferSize,
+      std::to_string(c.maxOutputBufferSize()));
+
+  addSessionProperty(
+      kMaxPartitionedOutputBufferSize,
+      "The maximum bytes to buffer per PartitionedOutput operator to avoid"
+      "creating tiny SerializedPages. For "
+      "PartitionedOutputNode::Kind::kPartitioned, PartitionedOutput operator"
+      "would buffer up to that number of bytes / number of destinations for "
+      "each destination before producing a SerializedPage.",
+      BIGINT(),
+      false,
+      QueryConfig::kMaxPartitionedOutputBufferSize,
+      std::to_string(c.maxPartitionedOutputBufferSize()));
 
   // If `legacy_timestamp` is true, the coordinator expects timestamp
   // conversions without a timezone to be converted to the user's

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -205,6 +205,19 @@ class SessionProperties {
   static constexpr const char* kQueryTraceTaskRegExp =
       "native_query_trace_task_reg_exp";
 
+  /// The maximum size in bytes for the task's buffered output. The buffer is
+  /// shared among all drivers.
+  static constexpr const char* kMaxOutputBufferSize =
+      "native_max_output_buffer_size";
+
+  /// The maximum bytes to buffer per PartitionedOutput operator to avoid
+  /// creating tiny SerializedPages. For
+  /// PartitionedOutputNode::Kind::kPartitioned, PartitionedOutput operator
+  /// would buffer up to that number of bytes / number of destinations for each
+  /// destination before producing a SerializedPage.
+  static constexpr const char* kMaxPartitionedOutputBufferSize =
+      "native_max_page_partitioning_buffer_size";
+
   SessionProperties();
 
   const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&


### PR DESCRIPTION
Added 2 native session properties to control partitioned output buffers
```
== RELEASE NOTES ==

Session changes
- Add session property: 'native_max_page_partitioning_buffer_size' :pr:`23853`
- Add session property: 'native_max_output_buffer_size' :pr:`23853`

