### PR TITLE
[native] Revert remaining filter pushdown from FilterNode

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -606,29 +606,6 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
             left->outputType()));
   }
 
-  // For ScanFilter and ScanFilterProject, the planner sometimes put the
-  // remaining filter in a FilterNode after the TableScan.  We need to put it
-  // back to TableScan so that Velox can leverage it to do stripe level
-  // skipping.  Otherwise we only get row level skipping and lose some
-  // optimization opportunity in case of very low selectivity.
-  if (auto tableScan = std::dynamic_pointer_cast<const protocol::TableScanNode>(
-          node->source)) {
-    if (auto* tableLayout = dynamic_cast<protocol::HiveTableLayoutHandle*>(
-            tableScan->table.connectorTableLayout.get())) {
-      auto remainingFilter =
-          exprConverter_.toVeloxExpr(tableLayout->remainingPredicate);
-      if (auto* constant = dynamic_cast<const core::ConstantTypedExpr*>(
-              remainingFilter.get())) {
-        bool value = constant->value().value<bool>();
-        // We should get empty values node instead of table scan if the
-        // remaining filter is constantly false.
-        VELOX_CHECK(value, "Unexpected always-false remaining predicate");
-        tableLayout->remainingPredicate = node->predicate;
-        return toVeloxQueryPlan(tableScan, tableWriteInfo, taskId);
-      }
-    }
-  }
-
   return std::make_shared<core::FilterNode>(
       node->id,
       exprConverter_.toVeloxExpr(node->predicate),

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -143,10 +143,6 @@ TEST_F(PlanConverterTest, scanAgg) {
   ASSERT_EQ(
       tableHandle->dataColumns()->toString(),
       "ROW<nationkey:BIGINT,name:VARCHAR,regionkey:BIGINT,complex_type:ARRAY<MAP<VARCHAR,ROW<id:BIGINT,description:VARCHAR>>>,comment:VARCHAR>");
-  ASSERT_TRUE(tableHandle->remainingFilter());
-  ASSERT_EQ(
-      tableHandle->remainingFilter()->toString(),
-      "presto.default.lt(presto.default.rand(),0.0001)");
 
   auto tableParameters = tableHandle->tableParameters();
   ASSERT_EQ(tableParameters.size(), 6);

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ScanAgg.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ScanAgg.json
@@ -7,209 +7,166 @@
       "@type":".ProjectNode",
       "id":"1",
       "source":{
-        "@type" : ".FilterNode",
-        "id" : "449",
-        "source":{
-          "@type":".TableScanNode",
-          "id":"0",
-          "table":{
-            "connectorId":"hive",
-            "connectorHandle":{
-              "@type":"hive",
-              "schemaName":"tpch",
-              "tableName":"nation"
-            },
-            "transaction":{
-              "@type":"hive",
-              "uuid":"7cc96264-a0fa-45e4-9042-62754ac3a5a0"
-            },
-            "connectorTableLayout":{
-              "@type":"hive",
-              "schemaTableName":{
-                "schema":"tpch",
-                "table":"nation"
-              },
-              "tablePath":"a/path/to/a/table",
-              "partitionColumns":[
-
-              ],
-              "dataColumns":[
-                {
-                  "name":"nationkey",
-                  "type":"bigint"
-                },
-                {
-                  "name":"name",
-                  "type":"varchar(25)"
-                },
-                {
-                  "name":"regionkey",
-                  "type":"bigint"
-                },
-                {
-                  "name":"complex_type",
-                  "type":"array<map<string, row<id:bigint, description:string>>>"
-                },
-                {
-                  "name":"comment",
-                  "type":"varchar(152)"
-                }
-              ],
-              "tableParameters":{
-                "presto_version":"testversion",
-                "presto_query_id":"20200908_214711_00000_7xpqg",
-                "numFiles":"1",
-                "numRows":"25",
-                "rawDataSize":"2734",
-                "totalSize":"1451"
-              },
-              "domainPredicate":{
-                "columnDomains":[
-                  {
-                    "column":"psudo_bool_column",
-                    "domain":{
-                      "values":{
-                        "@type":"sortable",
-                        "type":"boolean",
-                        "ranges":[
-                          {
-                            "low":{
-                              "type":"boolean",
-                              "bound":"ABOVE"
-                            },
-                            "high":{
-                              "type":"boolean",
-                              "valueBlock":"CgAAAEJZVEVfQVJSQVkBAAAAAAE=",
-                              "bound":"BELOW"
-                            }
-                          },
-                          {
-                            "low":{
-                              "type":"boolean",
-                              "valueBlock":"CgAAAEJZVEVfQVJSQVkBAAAAAAE=",
-                              "bound":"ABOVE"
-                            },
-                            "high":{
-                              "type":"boolean",
-                              "bound":"BELOW"
-                            }
-                          }
-                        ]
-                      },
-                      "nullAllowed":false
-                    }
-                  }
-                ]
-              },
-              "remainingPredicate":{
-                "@type":"constant",
-                "valueBlock":"CgAAAEJZVEVfQVJSQVkBAAAAAAE=",
-                "type":"boolean"
-              },
-              "predicateColumns":{
-
-              },
-              "partitionColumnPredicate":{
-                "columnDomains":[
-
-                ]
-              },
-              "pushdownFilterEnabled":true,
-              "layoutString":"tpch.nation{}",
-              "requestedColumns":[
-                {
-                  "@type":"hive",
-                  "name":"regionkey",
-                  "hiveType":"bigint",
-                  "typeSignature":"bigint",
-                  "hiveColumnIndex":2,
-                  "columnType":"REGULAR",
-                  "requiredSubfields":[
-
-                  ]
-                }
-              ],
-              "partialAggregationsPushedDown":false,
-              "appendRowNumber":false,
-              "footerStatsUnreliable":false
-            }
+        "@type":".TableScanNode",
+        "id":"0",
+        "table":{
+          "connectorId":"hive",
+          "connectorHandle":{
+            "@type":"hive",
+            "schemaName":"tpch",
+            "tableName":"nation"
           },
-          "outputVariables":[
-            {
-              "@type":"variable",
-              "name":"regionkey",
-              "type":"bigint"
+          "transaction":{
+            "@type":"hive",
+            "uuid":"7cc96264-a0fa-45e4-9042-62754ac3a5a0"
+          },
+          "connectorTableLayout":{
+            "@type":"hive",
+            "schemaTableName":{
+              "schema":"tpch",
+              "table":"nation"
             },
-            {
-              "@type":"variable",
-              "name":"complex_type",
-              "type":"array(map(varchar, row(id bigint, description varchar)))"
-            }
-          ],
-          "assignments":{
-            "regionkey<bigint>":{
-              "@type":"hive",
-              "name":"regionkey",
-              "hiveType":"bigint",
-              "typeSignature":"bigint",
-              "hiveColumnIndex":2,
-              "columnType":"REGULAR",
-              "requiredSubfields":[
+            "tablePath":"a/path/to/a/table",
+            "partitionColumns":[
+
+            ],
+            "dataColumns":[
+              {
+                "name":"nationkey",
+                "type":"bigint"
+              },
+              {
+                "name":"name",
+                "type":"varchar(25)"
+              },
+              {
+                "name":"regionkey",
+                "type":"bigint"
+              },
+              {
+                "name":"complex_type",
+                "type":"array<map<string, row<id:bigint, description:string>>>"
+              },
+              {
+                "name":"comment",
+                "type":"varchar(152)"
+              }
+            ],
+            "tableParameters":{
+              "presto_version":"testversion",
+              "presto_query_id":"20200908_214711_00000_7xpqg",
+              "numFiles":"1",
+              "numRows":"25",
+              "rawDataSize":"2734",
+              "totalSize":"1451"
+            },
+            "domainPredicate":{
+              "columnDomains":[
+                {
+                  "column":"psudo_bool_column",
+                  "domain":{
+                    "values":{
+                      "@type":"sortable",
+                      "type":"boolean",
+                      "ranges":[
+                        {
+                          "low":{
+                            "type":"boolean",
+                            "bound":"ABOVE"
+                          },
+                          "high":{
+                            "type":"boolean",
+                            "valueBlock":"CgAAAEJZVEVfQVJSQVkBAAAAAAE=",
+                            "bound":"BELOW"
+                          }
+                        },
+                        {
+                          "low":{
+                            "type":"boolean",
+                            "valueBlock":"CgAAAEJZVEVfQVJSQVkBAAAAAAE=",
+                            "bound":"ABOVE"
+                          },
+                          "high":{
+                            "type":"boolean",
+                            "bound":"BELOW"
+                          }
+                        }
+                      ]
+                    },
+                    "nullAllowed":false
+                  }
+                }
+              ]
+            },
+            "remainingPredicate":{
+              "@type":"constant",
+              "valueBlock":"CgAAAEJZVEVfQVJSQVkBAAAAAAE=",
+              "type":"boolean"
+            },
+            "predicateColumns":{
+
+            },
+            "partitionColumnPredicate":{
+              "columnDomains":[
 
               ]
             },
-            "complex_type<array(map(varchar, row(id bigint, description varchar)))>":{
-              "@type":"hive",
-              "name":"complex_type",
-              "hiveType":"array<map<string, struct<id:bigint, description:string>>>",
-              "typeSignature":"array(map(varchar, row(id bigint, description varchar)))",
-              "hiveColumnIndex":3,
-              "columnType":"REGULAR",
-              "requiredSubfields":[
-                "complex_type[1][\"foo\"].id",
-                "complex_type[2][\"bar\"].id"
-              ]
-            }
+            "pushdownFilterEnabled":true,
+            "layoutString":"tpch.nation{}",
+            "requestedColumns":[
+              {
+                "@type":"hive",
+                "name":"regionkey",
+                "hiveType":"bigint",
+                "typeSignature":"bigint",
+                "hiveColumnIndex":2,
+                "columnType":"REGULAR",
+                "requiredSubfields":[
+
+                ]
+              }
+            ],
+            "partialAggregationsPushedDown":false,
+            "appendRowNumber":false,
+            "footerStatsUnreliable":false
           }
         },
-        "predicate": {
-          "@type" : "call",
-          "displayName" : "LESS_THAN",
-          "functionHandle" : {
-            "@type" : "$static",
-            "signature" : {
-              "name" : "presto.default.$operator$less_than",
-              "kind" : "SCALAR",
-              "typeVariableConstraints" : [ ],
-              "longVariableConstraints" : [ ],
-              "returnType" : "boolean",
-              "argumentTypes" : [ "double", "double" ],
-              "variableArity" : false
-            }
+        "outputVariables":[
+          {
+            "@type":"variable",
+            "name":"regionkey",
+            "type":"bigint"
           },
-          "returnType" : "boolean",
-          "arguments" : [ {
-            "@type" : "call",
-            "displayName" : "rand",
-            "functionHandle" : {
-              "@type" : "$static",
-              "signature" : {
-                "name" : "presto.default.rand",
-                "kind" : "SCALAR",
-                "typeVariableConstraints" : [ ],
-                "longVariableConstraints" : [ ],
-                "returnType" : "double",
-                "argumentTypes" : [ ],
-                "variableArity" : false
-              }
-            },
-            "returnType" : "double",
-            "arguments" : [ ]
-          }, {
-            "@type" : "constant",
-            "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAC1DHOviNho/",
-            "type" : "double"
-          } ]
+          {
+            "@type":"variable",
+            "name":"complex_type",
+            "type":"array(map(varchar, row(id bigint, description varchar)))"
+          }
+        ],
+        "assignments":{
+          "regionkey<bigint>":{
+            "@type":"hive",
+            "name":"regionkey",
+            "hiveType":"bigint",
+            "typeSignature":"bigint",
+            "hiveColumnIndex":2,
+            "columnType":"REGULAR",
+            "requiredSubfields":[
+
+            ]
+          },
+          "complex_type<array(map(varchar, row(id bigint, description varchar)))>":{
+            "@type":"hive",
+            "name":"complex_type",
+            "hiveType":"array<map<string, struct<id:bigint, description:string>>>",
+            "typeSignature":"array(map(varchar, row(id bigint, description varchar)))",
+            "hiveColumnIndex":3,
+            "columnType":"REGULAR",
+            "requiredSubfields":[
+              "complex_type[1][\"foo\"].id",
+              "complex_type[2][\"bar\"].id"
+            ]
+          }
         }
       },
       "assignments":{


### PR DESCRIPTION
If there is column renaming happening in-between, this will not work. Handling projection is too complex at worker level, we need to fix this in optimizer.