### PR TITLE
Fix native_expression.max_array_size_in_reduce session property

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -335,7 +335,7 @@ public final class SystemSessionProperties
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "native_simplified_expression_evaluation_enabled";
-    public static final String NATIVE_EXPRESSION_MAX_ARRAY_SIZE_IN_REDUCE = "native_expression.max_array_size_in_reduce";
+    public static final String NATIVE_EXPRESSION_MAX_ARRAY_SIZE_IN_REDUCE = "native_expression_max_array_size_in_reduce";
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
     public static final String NATIVE_MAX_SPILL_LEVEL = "native_max_spill_level";
     public static final String NATIVE_MAX_SPILL_FILE_SIZE = "native_max_spill_file_size";

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -80,7 +80,7 @@ class SessionProperties {
   /// Reduce() function will throw an error if it encounters an array of size
   /// greater than this value.
   static constexpr const char* kExprMaxArraySizeInReduce =
-      "native_expression.max_array_size_in_reduce";
+      "native_expression_max_array_size_in_reduce";
 
   /// The maximum memory used by partial aggregation when data reduction is not
   /// optimal.

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -58,7 +58,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
           {"native_debug_disable_expression_with_lazy_inputs", "true"},
           {"native_selective_nimble_reader_enabled", "true"},
           {"aggregation_spill_all", "true"},
-          {"native_expression.max_array_size_in_reduce", "99999"},
+          {"native_expression_max_array_size_in_reduce", "99999"},
       }};
   auto queryCtx = taskManager_->getQueryContextManager()->findOrCreateQueryCtx(
       taskId, session);


### PR DESCRIPTION
Fixes a bug where users weren't able to set `native_expression.max_array_size_in_reduce` session property.
If there are two parts in the session property name, the first part is considered as the catalog.
```
presto> show session like 'native_expression%';
                    Name                    | Value  | Default |  Type   |                                                       Description                             >
--------------------------------------------+--------+---------+---------+----------------------------------------------------------------------------------------------->
 native_expression.max_array_size_in_reduce | 100000 | 100000  | integer | Native Execution only. Reduce() function will throw an error if it encounters an array of size>
(1 row)

presto> set session native_expression.max_array_size_in_reduce=50000;
Query 20241018_045451_00001_vgykq failed: line 1:1: Catalog native_expression does not exist
set session native_expression.max_array_size_in_reduce=50000
```

After fixing: 
```
presto> show session like 'native_expression%';
                    Name                    | Value  | Default |  Type   |                                                       Description                             >
--------------------------------------------+--------+---------+---------+----------------------------------------------------------------------------------------------->
 native_expression_max_array_size_in_reduce | 100000 | 100000  | integer | Native Execution only. Reduce() function will throw an error if it encounters an array of size>
(1 row)

presto> set session native_expression_max_array_size_in_reduce=50000;
SET SESSION
presto> show session like 'native_expression%';
                    Name                    | Value | Default |  Type   |                                                       Description                              >
--------------------------------------------+-------+---------+---------+------------------------------------------------------------------------------------------------>
 native_expression_max_array_size_in_reduce | 50000 | 100000  | integer | Native Execution only. Reduce() function will throw an error if it encounters an array of size >
(1 row)
presto>
```
