### PR TITLE
Extend join prefilter optimizer to use hash for filter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
@@ -14,6 +14,9 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
@@ -22,6 +25,8 @@ import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -34,17 +39,97 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.SystemSessionProperties.isJoinPrefilterEnabled;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
 import static com.facebook.presto.spi.plan.JoinType.LEFT;
+import static com.facebook.presto.sql.planner.PlannerUtils.addProjections;
 import static com.facebook.presto.sql.planner.PlannerUtils.clonePlanNode;
 import static com.facebook.presto.sql.planner.PlannerUtils.isScanFilterProject;
+import static com.facebook.presto.sql.planner.PlannerUtils.orNullHashCode;
 import static com.facebook.presto.sql.planner.PlannerUtils.projectExpressions;
+import static com.facebook.presto.sql.planner.PlannerUtils.restrictOutput;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.callOperator;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
+
+/**
+ * This optimizer filter the right side of a join with the unique join keys on the left side of the join. When the join key is wide or
+ * there are multiple join keys, we are to do filter on the hash instead of using the keys.
+ * It will convert plan from
+ * <pre>
+ *     - InnerJoin
+ *          leftKey = rightKey
+ *          - scan l
+ *          - scan r
+ * </pre>
+ * into
+ * <pre>
+ *     - InnerJoin
+ *          leftKey = rightKey
+ *          - scan l
+ *          - semiJoin
+ *              r.rightKey in l.leftKey
+ *              - scan r
+ *              - distinct aggregation
+ *                  group by leftKey
+ *                  - scan l
+ * </pre>
+ * And for join with varchar type
+ * <pre>
+ *     - InnerJoin
+ *          leftKey (varchar) = rightKey (varchar)
+ *          - scan l
+ *          - scan r
+ * </pre>
+ * into
+ * <pre>
+ *     - InnerJoin
+ *          leftKey (varchar) = rightKey (varchar)
+ *          - scan l
+ *          - semiJoin
+ *              r.rightKeyHash in l.leftKeyHash
+ *              - project
+ *                  r.rightKeyHash = xx_hash64(r.rightKey)
+ *                  - scan r
+ *              - distinct aggregation
+ *                  group by leftKeyHash
+ *                  - project
+ *                      l.leftKeyHash = xx_hash64(l.leftKey)
+ *                      - scan l
+ * </pre>
+ * And for join with multiple keys
+ * <pre>
+ *     - InnerJoin
+ *          leftKey1 = rightKey1 and leftKey2 = rightKey2
+ *          - scan l
+ *          - scan r
+ * </pre>
+ * into
+ * <pre>
+ *     - InnerJoin
+ *          leftKey1 = rightKey1 and leftKey2 = rightKey2
+ *          - scan l
+ *          - semiJoin
+ *              r.rightKeysHash in l.leftKeysHash
+ *              - project
+ *                  r.rightKeysHash = combine_hash(xx_hash64(rightKey1), xx_hash64(rightKey2))
+ *                  - scan r
+ *              - distinct aggregation
+ *                  group by leftKeysHash
+ *                  - project
+ *                      l.leftKeysHash = combine_hash(xx_hash64(leftKey1), xx_hash64(leftKey2))
+ *                      - scan l
+ * </pre>
+ */
 
 public class JoinPrefilter
         implements PlanOptimizer
@@ -73,7 +158,7 @@ public class JoinPrefilter
     public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
         if (isEnabled(session)) {
-            Rewriter rewriter = new Rewriter(session, metadata, idAllocator, variableAllocator);
+            Rewriter rewriter = new Rewriter(session, metadata, idAllocator, variableAllocator, metadata.getFunctionAndTypeManager());
             PlanNode rewritten = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
             return PlanOptimizerResult.optimizerResult(rewritten, rewriter.isPlanChanged());
         }
@@ -88,14 +173,16 @@ public class JoinPrefilter
         private final Metadata metadata;
         private final PlanNodeIdAllocator idAllocator;
         private final VariableAllocator variableAllocator;
+        private final FunctionAndTypeManager functionAndTypeManager;
         private boolean planChanged;
 
-        private Rewriter(Session session, Metadata metadata, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator)
+        private Rewriter(Session session, Metadata metadata, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, FunctionAndTypeManager functionAndTypeManager)
         {
             this.session = requireNonNull(session, "session is null");
             this.metadata = requireNonNull(metadata, "functionAndTypeManager is null");
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.variableAllocator = requireNonNull(variableAllocator, "idAllocator is null");
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
         }
 
         @Override
@@ -108,21 +195,37 @@ public class JoinPrefilter
             PlanNode rewrittenRight = rewriteWith(this, right);
             List<EquiJoinClause> equiJoinClause = node.getCriteria();
 
-            // We apply this for only left and inner join and the left side of the join is a simple scan and the join is on one key
-            if (equiJoinClause.size() == 1 &&
-                    (node.getType() == LEFT || node.getType() == INNER) &&
-                    isScanFilterProject(rewrittenLeft)) {
-                VariableReferenceExpression leftKey = equiJoinClause.stream().map(x -> x.getLeft()).findFirst().get();
-                VariableReferenceExpression rightKey = equiJoinClause.stream().map(x -> x.getRight()).findFirst().get();
+            // We apply this for only left and inner join and the left side of the join is a simple scan
+            if ((node.getType() == LEFT || node.getType() == INNER) && isScanFilterProject(rewrittenLeft) && !node.getCriteria().isEmpty()) {
+                List<VariableReferenceExpression> leftKeyList = equiJoinClause.stream().map(EquiJoinClause::getLeft).collect(toImmutableList());
+                List<VariableReferenceExpression> rightKeyList = equiJoinClause.stream().map(EquiJoinClause::getRight).collect(toImmutableList());
+                checkState(IntStream.range(0, leftKeyList.size()).boxed().allMatch(i -> leftKeyList.get(i).getType().equals(rightKeyList.get(i).getType())));
+
+                boolean hashJoinKey = leftKeyList.size() > 1 || (leftKeyList.get(0).getType().equals(VARCHAR) || leftKeyList.get(0).getType() instanceof VarcharType);
 
                 // First create a SELECT DISTINCT leftKey FROM left
                 Map<VariableReferenceExpression, VariableReferenceExpression> leftVarMap = new HashMap();
-                PlanNode leftKeys = clonePlanNode(rewrittenLeft, session, metadata, idAllocator, ImmutableList.of(leftKey), leftVarMap);
-                PlanNode projectNode = projectExpressions(leftKeys, idAllocator, variableAllocator, ImmutableList.of(leftVarMap.get(leftKey)), ImmutableList.of());
+                PlanNode leftKeys = clonePlanNode(rewrittenLeft, session, metadata, idAllocator, leftKeyList, leftVarMap);
+                ImmutableList.Builder<RowExpression> expressionsToProject = ImmutableList.builder();
+                if (hashJoinKey) {
+                    RowExpression hashExpression = getVariableHash(leftKeyList);
+                    expressionsToProject.add(hashExpression);
+                }
+                else {
+                    expressionsToProject.add(leftVarMap.get(leftKeyList.get(0)));
+                }
+                PlanNode projectNode = projectExpressions(leftKeys, idAllocator, variableAllocator, expressionsToProject.build(), ImmutableList.of());
 
-                // DISTINCT on the leftkey
+                VariableReferenceExpression rightKeyToFilter = rightKeyList.get(0);
+                if (hashJoinKey) {
+                    RowExpression hashExpression = getVariableHash(rightKeyList);
+                    rightKeyToFilter = variableAllocator.newVariable(hashExpression);
+                    rewrittenRight = addProjections(rewrittenRight, idAllocator, ImmutableMap.of(rightKeyToFilter, hashExpression));
+                }
+
+                // DISTINCT on the leftkey or hash if wide column
                 PlanNode filteringSource = new AggregationNode(
-                        leftKey.getSourceLocation(),
+                        node.getLeft().getSourceLocation(),
                         idAllocator.getNextId(),
                         projectNode,
                         ImmutableMap.of(),
@@ -139,12 +242,12 @@ public class JoinPrefilter
                 // Now we add a semijoin as the right side
                 VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
                 SemiJoinNode semiJoinNode = new SemiJoinNode(
-                        rightKey.getSourceLocation(),
+                        node.getRight().getSourceLocation(),
                         idAllocator.getNextId(),
                         node.getStatsEquivalentPlanNode(),
                         rewrittenRight,
                         filteringSource,
-                        rightKey,
+                        rightKeyToFilter,
                         filteringSource.getOutputVariables().get(0),
                         semiJoinOutput,
                         Optional.empty(),
@@ -153,6 +256,9 @@ public class JoinPrefilter
                         ImmutableMap.of());
 
                 rewrittenRight = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
+                if (rewrittenRight.getOutputVariables().size() > node.getRight().getOutputVariables().size()) {
+                    rewrittenRight = restrictOutput(rewrittenRight, idAllocator, node.getRight().getOutputVariables());
+                }
             }
 
             if (rewrittenLeft != node.getLeft() || rewrittenRight != node.getRight()) {
@@ -166,6 +272,20 @@ public class JoinPrefilter
         public boolean isPlanChanged()
         {
             return planChanged;
+        }
+
+        private RowExpression getVariableHash(List<VariableReferenceExpression> inputVariables)
+        {
+            List<CallExpression> hashExpressionList = inputVariables.stream().map(keyVariable ->
+                    callOperator(functionAndTypeManager.getFunctionAndTypeResolver(), OperatorType.XX_HASH_64, BIGINT, keyVariable)).collect(toImmutableList());
+            RowExpression hashExpression = hashExpressionList.get(0);
+            if (hashExpressionList.size() > 1) {
+                hashExpression = orNullHashCode(hashExpression);
+                for (int i = 1; i < hashExpressionList.size(); ++i) {
+                    hashExpression = call(functionAndTypeManager, "combine_hash", BIGINT, hashExpression, orNullHashCode(hashExpressionList.get(i)));
+                }
+            }
+            return hashExpression;
         }
     }
 }


### PR DESCRIPTION
## Description
JoinPrefilter optimizer was added in https://github.com/prestodb/presto/pull/22667 which shows great improvement for a bunch of queries within Meta. However there are two limits of the current implementation
* When the join key is wide, for example VARCHAR type, the semi join added will have a high memory overhead
* It currently only supports single join key
To solve the above limits, this PR:
* Use the hash of the join key for semi join when the join key is wide. 
* When having multiple join keys, hash each key and combine the hash into a single key for semi join
We can apply the hash as this pre filter is an opportunistic and does not need to be comprehensive.

## Motivation and Context
To apply the join prefilter optimizer to more query shapes

## Impact
Apply join prefilter to more query shapes

## Test Plan
Add to existing plans
Also run [verifier suites](https://our.internmc.facebook.com/intern/presto/verifier/results/?test_id=195176) 
This optimizer is default to be disabled as it's not always beneficial, we are considering using HBO to enable it in the future

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve JoinPrefilter optimizer for wide join keys and multiple join keys :pr:`23858`
```

