### PR TITLE
[native] Update metadata for function combinations in FunctionMetadataTest

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/tests/FunctionMetadataTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/FunctionMetadataTest.cpp
@@ -69,7 +69,7 @@ TEST_F(FunctionMetadataTest, arrayFrequency) {
 }
 
 TEST_F(FunctionMetadataTest, combinations) {
-  testFunction("combinations", "Combinations.json", 10);
+  testFunction("combinations", "Combinations.json", 11);
 }
 
 TEST_F(FunctionMetadataTest, covarSamp) {

--- a/presto-native-execution/presto_cpp/main/types/tests/data/Combinations.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/Combinations.json
@@ -3,6 +3,21 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "outputType": "array(array(__user_T1))",
+      "paramTypes": [
+        "array(__user_T1)",
+        "integer"
+      ],
+      "routineCharacteristics": {
+        "determinism": "DETERMINISTIC",
+        "language": "CPP",
+        "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
+      },
+      "schema": "default"
+    },
+    {
+      "docString": "presto.default.combinations",
+      "functionKind": "SCALAR",
       "outputType": "array(array(date))",
       "paramTypes": [
         "array(date)",


### PR DESCRIPTION
## Description
A new function signature was added for `combinations` in Velox to support row types in [this commit](e07a77f4d61cd166edc373e5321a4cc1dfc49ac6). This function signature is not accounted for in `Combinations.json` in `FunctionMetadataTest.cpp`. This PR updates the metadata for function `combinations` to include this signature.

## Motivation and Context
Fixes test failure in presto_function_metadata_test.

## Test Plan
Verified this fixes the test failure on local setup. 

```
== NO RELEASE NOTE ==
```

