### PR TITLE
[native] Update gtest targets for presto_function_metadata_test

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -108,5 +108,5 @@ target_link_libraries(
   velox_aggregates
   velox_functions_prestosql
   velox_window
-  gtest
-  gtest_main)
+  GTest::gtest
+  GTest::gtest_main)


### PR DESCRIPTION
Fixed the gtest targets for #22332.

```
[1/73] Linking CXX executable presto_cpp/main/types/tests/presto_function_metadata_test
FAILED: presto_cpp/main/types/tests/presto_function_metadata_test 
...
ld: library 'gtest' not found
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
...
ninja: build stopped: subcommand failed.
```

```
== NO RELEASE NOTE ==
```

