### PR TITLE
[docs] Fix error in sql/update.rst

### DIFF
--- a/presto-docs/src/main/sphinx/sql/update.rst
+++ b/presto-docs/src/main/sphinx/sql/update.rst
@@ -7,7 +7,7 @@ Synopsis
 
 .. code-block:: none
 
-    UPDATE table_name SET [ ( column = expression [, ... ] ) ] [ WHERE condition ]
+    UPDATE table_name SET [ column = expression [, ... ] ] [ WHERE condition ]
 
 Description
 -----------


### PR DESCRIPTION
## Description
Fix erroneous parentheses in [sql/update.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/sql/update.rst) as described in #23870. 

## Motivation and Context
Fixes #23870.

## Impact
Documentation.

## Test Plan
Local doc build. Screenshot after fix: 
<img width="793" alt="Screenshot 2024-10-22 at 3 13 57 PM" src="https://github.com/user-attachments/assets/54eea87c-814a-4cad-a5ff-a11e6f46571f">

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

