### PR TITLE
Add support for printing warnings in EXPLAIN IO output

### DIFF
--- a/presto-docs/src/main/sphinx/sql/explain.rst
+++ b/presto-docs/src/main/sphinx/sql/explain.rst
@@ -152,6 +152,34 @@ IO:
        }
      }
 
+To include warnings in the EXPLAIN (TYPE IO) output, set the configuration property ``print-warnings-for-explain-io`` or session property ``print_warnings_for_explain_io`` to ``true``
+
+.. code-block:: none
+
+    presto> set session print_warnings_for_explain_io=true;
+    SET SESSION
+    presto> EXPLAIN (TYPE IO) SELECT * FROM (SELECT * FROM tpch.sf1.nation order by nationkey) order by regionkey;
+                            Query Plan
+    -----------------------------------------------------------
+     {
+       "inputTableColumnInfos" : [ {
+         "table" : {
+           "catalog" : "tpch",
+           "schemaTable" : {
+             "schema" : "sf1.0",
+             "table" : "nation"
+           }
+         },
+         "columnConstraints" : [ ]
+       } ],
+       "warnings" : [ {
+         "warningCode" : {
+           "code" : 5,
+           "name" : "REDUNDANT_ORDER_BY"
+         },
+         "message" : "ORDER BY in subquery may have no effect"
+       } ]
+     }
 
 See Also
 --------

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -374,6 +374,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZER_USE_HISTOGRAMS = "optimizer_use_histograms";
     public static final String WARN_ON_COMMON_NAN_PATTERNS = "warn_on_common_nan_patterns";
     public static final String INLINE_PROJECTIONS_ON_VALUES = "inline_projections_on_values";
+    public static final String PRINT_WARNINGS_FOR_EXPLAIN_IO = "print_warnings_for_explain_io";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -2096,6 +2097,10 @@ public final class SystemSessionProperties
                 booleanProperty(INLINE_PROJECTIONS_ON_VALUES,
                         "Whether to evaluate project node on values node",
                         featuresConfig.getInlineProjectionsOnValues(),
+                        false),
+                booleanProperty(PRINT_WARNINGS_FOR_EXPLAIN_IO,
+                        "Whether to print warnings in the output for EXPLAIN(TYPE IO)",
+                        featuresConfig.isPrintWarningsForExplainIo(),
                         false));
     }
 
@@ -3432,5 +3437,10 @@ public final class SystemSessionProperties
     public static boolean isInlineProjectionsOnValues(Session session)
     {
         return session.getSystemProperty(INLINE_PROJECTIONS_ON_VALUES, Boolean.class);
+    }
+
+    public static boolean isPrintWarningsForExplainIOEnabled(Session session)
+    {
+        return session.getSystemProperty(PRINT_WARNINGS_FOR_EXPLAIN_IO, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -298,6 +298,7 @@ public class FeaturesConfig
 
     private boolean eagerPlanValidationEnabled;
     private int eagerPlanValidationThreadPoolSize = 20;
+    private boolean printWarningsForExplainIo;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2997,5 +2998,18 @@ public class FeaturesConfig
     public int getEagerPlanValidationThreadPoolSize()
     {
         return this.eagerPlanValidationThreadPoolSize;
+    }
+
+    public boolean isPrintWarningsForExplainIo()
+    {
+        return printWarningsForExplainIo;
+    }
+
+    @Config("print-warnings-for-explain-io")
+    @ConfigDescription("Whether to print warnings in the output for EXPLAIN(TYPE IO)")
+    public FeaturesConfig setPrintWarningsForExplainIo(boolean printWarningsForExplainIo)
+    {
+        this.printWarningsForExplainIo = printWarningsForExplainIo;
+        return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -139,7 +139,7 @@ public class QueryExplainer
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
                 return PlanPrinter.textDistributedPlan(subPlan, metadata.getFunctionAndTypeManager(), session, verbose);
             case IO:
-                return IOPlanPrinter.textIOPlan(getLogicalPlan(session, statement, parameters, warningCollector).getRoot(), metadata, session);
+                return IOPlanPrinter.textIOPlan(getLogicalPlan(session, statement, parameters, warningCollector).getRoot(), metadata, session, warningCollector);
         }
         throw new IllegalArgumentException("Unhandled plan type: " + planType);
     }
@@ -180,7 +180,7 @@ public class QueryExplainer
         switch (planType) {
             case IO:
                 plan = getLogicalPlan(session, statement, parameters, warningCollector);
-                return textIOPlan(plan.getRoot(), metadata, session);
+                return textIOPlan(plan.getRoot(), metadata, session, warningCollector);
             case LOGICAL:
                 plan = getLogicalPlan(session, statement, parameters, warningCollector);
                 return jsonLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionAndTypeManager(), plan.getStatsAndCosts(), session);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -257,7 +257,8 @@ public class TestFeaturesConfig
                 .setUseHistograms(false)
                 .setInlineProjectionsOnValues(false)
                 .setEagerPlanValidationEnabled(false)
-                .setEagerPlanValidationThreadPoolSize(20));
+                .setEagerPlanValidationThreadPoolSize(20)
+                .setPrintWarningsForExplainIo(false));
     }
 
     @Test
@@ -464,6 +465,7 @@ public class TestFeaturesConfig
                 .put("optimizer.inline-projections-on-values", "true")
                 .put("eager-plan-validation-enabled", "true")
                 .put("eager-plan-validation-thread-pool-size", "2")
+                .put("print-warnings-for-explain-io", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -667,7 +669,8 @@ public class TestFeaturesConfig
                 .setUseHistograms(true)
                 .setInlineProjectionsOnValues(true)
                 .setEagerPlanValidationEnabled(true)
-                .setEagerPlanValidationThreadPoolSize(2);
+                .setEagerPlanValidationThreadPoolSize(2)
+                .setPrintWarningsForExplainIo(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -876,6 +876,18 @@ public class PlanBuilder
         return new ExceptNode(Optional.empty(), idAllocator.getNextId(), sources, ImmutableList.copyOf(mapping.keySet()), mapping);
     }
 
+    public TableFinishNode tableFinish(TableWriterNode.WriterTarget writerTarget, PlanNode source)
+    {
+        return new TableFinishNode(
+                Optional.empty(),
+                idAllocator.getNextId(),
+                source,
+                Optional.of(writerTarget),
+                new VariableReferenceExpression(Optional.empty(), "rowCountVariable", BIGINT),
+                Optional.empty(),
+                Optional.empty());
+    }
+
     public TableWriterNode tableWriter(List<VariableReferenceExpression> columns, List<String> columnNames, PlanNode source)
     {
         return new TableWriterNode(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestIOPlanPrinter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/planPrinter/TestIOPlanPrinter.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.planPrinter;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.WarningHandlingLevel;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.execution.warnings.DefaultWarningCollector;
+import com.facebook.presto.execution.warnings.WarningCollectorConfig;
+import com.facebook.presto.metadata.AbstractMockMetadata;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.StandardWarningCode;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.TableMetadata;
+import com.facebook.presto.spi.TestingColumnHandle;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.TableWriterNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.PRINT_WARNINGS_FOR_EXPLAIN_IO;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestIOPlanPrinter
+{
+    private static final Session WARNINGS_DISABLED_SESSION = testSessionBuilder()
+            .setSystemProperty(PRINT_WARNINGS_FOR_EXPLAIN_IO, "false")
+            .build();
+    private static final Session WARNINGS_ENABLED_SESSION = testSessionBuilder()
+            .setSystemProperty(PRINT_WARNINGS_FOR_EXPLAIN_IO, "true")
+            .build();
+
+    private static final Metadata METADATA = new TestingMetadataManager();
+
+    private static final PlanBuilder PLAN_BUILDER = new PlanBuilder(WARNINGS_ENABLED_SESSION, new PlanNodeIdAllocator(), METADATA);
+    private static final PlanNode TEST_PLAN = PLAN_BUILDER.tableFinish(
+            new TableWriterNode.CreateName(
+                    new ConnectorId("testConnector"),
+                    new ConnectorTableMetadata(new SchemaTableName("test_schema", "test_table"), ImmutableList.of()),
+                    Optional.empty()),
+            PLAN_BUILDER.tableScan("testConnector",
+                    ImmutableList.of(PLAN_BUILDER.variable("c1")),
+                    ImmutableMap.of(PLAN_BUILDER.variable("c1"), new TestingColumnHandle("column1"))));
+
+    @Test
+    public void testIOPlanWithWarningsDisabled()
+    {
+        WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig(), WarningHandlingLevel.NORMAL);
+        warningCollector.add(new PrestoWarning(StandardWarningCode.PARSER_WARNING, "Warning about something"));
+        String actualIOPlan = IOPlanPrinter.textIOPlan(TEST_PLAN, METADATA, WARNINGS_DISABLED_SESSION, warningCollector);
+        String expectedIOPlan = "{\n" +
+                "  \"inputTableColumnInfos\" : [ {\n" +
+                "    \"table\" : {\n" +
+                "      \"catalog\" : \"testConnector\",\n" +
+                "      \"schemaTable\" : {\n" +
+                "        \"schema\" : \"test_schema\",\n" +
+                "        \"table\" : \"test_table\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"columnConstraints\" : [ ]\n" +
+                "  } ],\n" +
+                "  \"outputTable\" : {\n" +
+                "    \"catalog\" : \"testConnector\",\n" +
+                "    \"schemaTable\" : {\n" +
+                "      \"schema\" : \"test_schema\",\n" +
+                "      \"table\" : \"test_table\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        assertEquals(actualIOPlan, expectedIOPlan);
+    }
+
+    @Test
+    public void testIOPlanWithWarningsEnabled()
+    {
+        WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig(), WarningHandlingLevel.NORMAL);
+        warningCollector.add(new PrestoWarning(StandardWarningCode.PARSER_WARNING, "Warning about something"));
+        PlanBuilder planBuilder = new PlanBuilder(WARNINGS_ENABLED_SESSION, new PlanNodeIdAllocator(), METADATA);
+        String actualIOPlan = IOPlanPrinter.textIOPlan(TEST_PLAN, METADATA, WARNINGS_ENABLED_SESSION, warningCollector);
+        String expectedIOPlan = "{\n" +
+                "  \"inputTableColumnInfos\" : [ {\n" +
+                "    \"table\" : {\n" +
+                "      \"catalog\" : \"testConnector\",\n" +
+                "      \"schemaTable\" : {\n" +
+                "        \"schema\" : \"test_schema\",\n" +
+                "        \"table\" : \"test_table\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"columnConstraints\" : [ ]\n" +
+                "  } ],\n" +
+                "  \"outputTable\" : {\n" +
+                "    \"catalog\" : \"testConnector\",\n" +
+                "    \"schemaTable\" : {\n" +
+                "      \"schema\" : \"test_schema\",\n" +
+                "      \"table\" : \"test_table\"\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"warnings\" : [ {\n" +
+                "    \"warningCode\" : {\n" +
+                "      \"code\" : 2,\n" +
+                "      \"name\" : \"PARSER_WARNING\"\n" +
+                "    },\n" +
+                "    \"message\" : \"Warning about something\"\n" +
+                "  } ]\n" +
+                "}";
+        assertEquals(actualIOPlan, expectedIOPlan);
+    }
+
+    @Test
+    public void testIOPlanWithEmptyWarnings()
+    {
+        WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig(), WarningHandlingLevel.NORMAL);
+        String actualIOPlan = IOPlanPrinter.textIOPlan(TEST_PLAN, METADATA, WARNINGS_DISABLED_SESSION, warningCollector);
+        String expectedIOPlan = "{\n" +
+                "  \"inputTableColumnInfos\" : [ {\n" +
+                "    \"table\" : {\n" +
+                "      \"catalog\" : \"testConnector\",\n" +
+                "      \"schemaTable\" : {\n" +
+                "        \"schema\" : \"test_schema\",\n" +
+                "        \"table\" : \"test_table\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"columnConstraints\" : [ ]\n" +
+                "  } ],\n" +
+                "  \"outputTable\" : {\n" +
+                "    \"catalog\" : \"testConnector\",\n" +
+                "    \"schemaTable\" : {\n" +
+                "      \"schema\" : \"test_schema\",\n" +
+                "      \"table\" : \"test_table\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        assertEquals(actualIOPlan, expectedIOPlan);
+    }
+
+    private static class TestingMetadataManager
+            extends AbstractMockMetadata
+    {
+        @Override
+        public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+        {
+            return new TableMetadata(
+                    tableHandle.getConnectorId(),
+                    new ConnectorTableMetadata(
+                            new SchemaTableName("test_schema", "test_table"),
+                            ImmutableList.of(new ColumnMetadata("column1", BIGINT))));
+        }
+
+        @Override
+        public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
+        {
+            return new ColumnMetadata("column1", BIGINT);
+        }
+
+        @Override
+        public TupleDomain<ColumnHandle> toExplainIOConstraints(Session session, TableHandle tableHandle, TupleDomain<ColumnHandle> constraints)
+        {
+            return constraints;
+        }
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesIndexed.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesIndexed.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.planner.planPrinter.IOPlanPrinter;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.tpch.IndexedTpchPlugin;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
@@ -81,6 +82,6 @@ public class TestDistributedQueriesIndexed
 
         assertEquals(
                 jsonCodec(IOPlanPrinter.IOPlan.class).fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
-                new IOPlanPrinter.IOPlan(ImmutableSet.of(lineitem, orders), Optional.empty()));
+                new IOPlanPrinter.IOPlan(ImmutableSet.of(lineitem, orders), Optional.empty(), ImmutableList.of()));
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -27,6 +27,7 @@ import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
@@ -142,6 +143,6 @@ public class TestLocalQueries
                                                         new FormattedMarker(Optional.of("P"), EXACTLY)))))));
         assertEquals(
                 jsonCodec(IOPlan.class).fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
-                new IOPlan(ImmutableSet.of(input), Optional.empty()));
+                new IOPlan(ImmutableSet.of(input), Optional.empty(), ImmutableList.of()));
     }
 }


### PR DESCRIPTION
## Description
If warnings are present when generating the query plan and
print_warnings_for_explain_io is set to true, then include
warnings in the explain output for EXPLAIN (TYPE IO).

With warnings disabled:

```
presto> EXPLAIN (TYPE IO) SELECT * FROM (SELECT * FROM tpch.sf1.nation order by nationkey) order by regionkey;
           Query Plan
---------------------------------
 {
   "inputTableColumnInfos" : [ {
     "table" : {
       "catalog" : "tpch",
       "schemaTable" : {
         "schema" : "sf1.0",
         "table" : "nation"
       }
     },
     "columnConstraints" : [ ]
   } ]
 }
```

With warnings enabled:
```
presto> set session print_warnings_for_explain_io=true;
SET SESSION
presto> EXPLAIN (TYPE IO) SELECT * FROM (SELECT * FROM tpch.sf1.nation order by nationkey) order by regionkey;
                        Query Plan
-----------------------------------------------------------
 {
   "inputTableColumnInfos" : [ {
     "table" : {
       "catalog" : "tpch",
       "schemaTable" : {
         "schema" : "sf1.0",
         "table" : "nation"
       }
     },
     "columnConstraints" : [ ]
   } ],
   "warnings" : [ {
     "warningCode" : {
       "code" : 5,
       "name" : "REDUNDANT_ORDER_BY"
     },
     "message" : "ORDER BY in subquery may have no effect"
   } ]
 }
```
## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/23864

## Impact
If print_warnings_for_explain_io is set to true, then include warnings in the output for EXPLAIN(TYPE IO)

## Test Plan
added tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for printing warnings in `EXPLAIN(TYPE IO)` output when ``print_warnings_for_explain_io`` is set to true
```

