### PR TITLE
Allow InternalPlanNodes to accept a PlanVisitor

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanNode.java
@@ -20,8 +20,6 @@ import com.facebook.presto.spi.plan.PlanVisitor;
 
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 public abstract class InternalPlanNode
         extends PlanNode
 {
@@ -32,8 +30,10 @@ public abstract class InternalPlanNode
 
     public final <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
-        checkArgument(visitor instanceof InternalPlanVisitor, "PlanVisitor is only for connector to use; InternalPlanNode should never use it");
-        return accept((InternalPlanVisitor<R, C>) visitor, context);
+        if (visitor instanceof InternalPlanVisitor) {
+            return accept((InternalPlanVisitor<R, C>) visitor, context);
+        }
+        return visitor.visitPlan(this, context);
     }
 
     public <R, C> R accept(InternalPlanVisitor<R, C> visitor, C context)


### PR DESCRIPTION

## Description
Previously, we would fail if an InternalPlanNode tried to accept a PlanVisitor that was not an InternalPlanVisitor. This was useful to tell developers to use InternalPlanVisitor when operating in presto-main. However, it prevented plugins from being able to traverse a plan that contains InternalPlanNodes. Allowing plugins to traverse the plan has become critical since adding support for plugin PlanCheckers. Without this change, plugin plan checkers become almost useless.

## Motivation and Context
The motivation for this change is to allow plugin PlanCheckers to traverse the plan

## Impact
InternalPlanNodes are now able to accept a PlanVisitor

## Test Plan
CI
## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

