### PR TITLE
Add scope for OAUTH2 authentication in Iceberg's REST catalog

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -219,6 +219,11 @@ Property Name                                        Description
 ``iceberg.rest.auth.oauth2.token``                   The Bearer token to use for OAUTH2 authentication.
                                                      Example: ``SXVLUXUhIExFQ0tFUiEK``
 
+``iceberg.rest.auth.oauth2.scope``                   The scope to use for OAUTH2 authentication.
+                                                     This property is only applicable when using
+                                                     ``iceberg.rest.auth.oauth2.credential``.
+                                                     Example: ``PRINCIPAL_ROLE:ALL``
+
 ``iceberg.rest.session.type``                        The session type to use when communicating with the REST catalog.
                                                      Available values are ``NONE`` or ``USER`` (default: ``NONE``).
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
@@ -50,6 +50,7 @@ import static org.apache.iceberg.CatalogUtil.configureHadoopConf;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.CREDENTIAL;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.JWT_TOKEN_TYPE;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.OAUTH2_SERVER_URI;
+import static org.apache.iceberg.rest.auth.OAuth2Properties.SCOPE;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.TOKEN;
 
 public class IcebergRestCatalogFactory
@@ -124,6 +125,7 @@ public class IcebergRestCatalogFactory
                 }
                 catalogConfig.getCredential().ifPresent(credential -> properties.put(CREDENTIAL, credential));
                 catalogConfig.getToken().ifPresent(token -> properties.put(TOKEN, token));
+                catalogConfig.getScope().ifPresent(scope -> properties.put(SCOPE, scope));
             }
         });
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestConfig.java
@@ -28,6 +28,7 @@ public class IcebergRestConfig
     private String authenticationServerUri;
     private String credential;
     private String token;
+    private String scope;
 
     @NotNull
     public Optional<String> getServerUri()
@@ -105,6 +106,19 @@ public class IcebergRestConfig
     public IcebergRestConfig setToken(String token)
     {
         this.token = token;
+        return this;
+    }
+
+    public Optional<String> getScope()
+    {
+        return Optional.ofNullable(scope);
+    }
+
+    @Config("iceberg.rest.auth.oauth2.scope")
+    @ConfigDescription("The scope to use for OAUTH2 authentication")
+    public IcebergRestConfig setScope(String scope)
+    {
+        this.scope = scope;
         return this;
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestConfig.java
@@ -35,6 +35,7 @@ public class TestIcebergRestConfig
                 .setAuthenticationServerUri(null)
                 .setCredential(null)
                 .setToken(null)
+                .setScope(null)
                 .setSessionType(null));
     }
 
@@ -47,6 +48,7 @@ public class TestIcebergRestConfig
                 .put("iceberg.rest.auth.oauth2.uri", "http://localhost:yyy")
                 .put("iceberg.rest.auth.oauth2.credential", "key:secret")
                 .put("iceberg.rest.auth.oauth2.token", "SXVLUXUhIExFQ0tFUiEK")
+                .put("iceberg.rest.auth.oauth2.scope", "PRINCIPAL_ROLE:ALL")
                 .put("iceberg.rest.session.type", "USER")
                 .build();
 
@@ -56,6 +58,7 @@ public class TestIcebergRestConfig
                 .setAuthenticationServerUri("http://localhost:yyy")
                 .setCredential("key:secret")
                 .setToken("SXVLUXUhIExFQ0tFUiEK")
+                .setScope("PRINCIPAL_ROLE:ALL")
                 .setSessionType(USER);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
## Description
Presto issue #23833

## Motivation and Context
When we configure the `iceberg.rest.auth.oauth2.credential` property to connect to a Polaris catalog we get the error `The scope is invalid`.
Since the Presto code does not set the 'scope' property, the Iceberg code is using 'catalog' as scope and the OAuth2 endpoint is considering it an invalid scope.

## Impact
We cannot connect to the Polaris catalog using the iceberg.rest.auth.oauth2.credential property.

## Test Plan
Modified tests in TestIcebergRestConfig

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add configuration property ``iceberg.rest.auth.oauth2.scope`` for OAUTH2 authentication in Iceberg's REST catalog :pr:`23884`
```
