### PR TITLE
Automatically link sections in rst

### DIFF
--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -64,7 +64,7 @@ def get_version():
 needs_sphinx = '7.2.6'
 
 extensions = [
-    'sphinx_immaterial', 'sphinx_copybutton', 'download', 'issue', 'pr'
+    'sphinx_immaterial', 'sphinx_copybutton', 'download', 'issue', 'pr', 'sphinx.ext.autosectionlabel'
 ]
 
 copyright = 'The Presto Foundation. All rights reserved. Presto is a registered trademark of LF Projects, LLC'
@@ -94,6 +94,8 @@ rst_epilog = """
 
 # 'xelatex' natively supports Unicode
 latex_engine = 'xelatex'
+
+autosectionlabel_prefix_document = True
 
 # -- Options for HTML output ---------------------------------------------------
 


### PR DESCRIPTION
## Description
This enables the ["Automatically label sections"](https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#automatically-label-sections) feature in RST, which will make it easier to link to individual sections in RST files.

## Motivation and Context
Better documentation, deep linking.

## Impact
N/A

## Test Plan
If it builds it works.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

