### PR TITLE
[native] Use core protocol header in FunctionMetadata

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/FunctionMetadata.cpp
+++ b/presto-native-execution/presto_cpp/main/types/FunctionMetadata.cpp
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/types/FunctionMetadata.h"
-#include "presto_cpp/presto_protocol/presto_protocol.h"
+#include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregateFunctionRegistry.h"
 #include "velox/exec/WindowFunction.h"


### PR DESCRIPTION
The new header file "presto_protocol_core.h", has been created to hold non-connector specific code. FunctionMetadata.cpp was not updated to use this header. We are fixing the same as part of this PR

```
== NO RELEASE NOTE ==
```

