### PR TITLE
[native] Add session property native_writer_flush_threshold_bytes

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -233,13 +233,14 @@ Native Execution only. Enable topN row number spilling on native engine.
 
 Native Execution only. Enable window spilling on native engine.
 
-``native_writer_spill_enabled``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``native_writer_flush_threshold_bytes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* **Type:** ``boolean``
-* **Default value:** ``true``
+* **Type:** ``bigint``
+* **Default value:** ``100663296``
 
-Native Execution only. Enable writer spilling on native engine.
+Minimum memory footprint size required to reclaim memory from a file writer by flushing its buffered data to disk.
+Default is 96MB.
 
 ``native_max_output_buffer_size``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -41,6 +41,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_JOIN_SPILL_ENABLED = "native_join_spill_enabled";
     public static final String NATIVE_WINDOW_SPILL_ENABLED = "native_window_spill_enabled";
     public static final String NATIVE_WRITER_SPILL_ENABLED = "native_writer_spill_enabled";
+    public static final String NATIVE_WRITER_FLUSH_THRESHOLD_BYTES = "native_writer_flush_threshold_bytes";
     public static final String NATIVE_ROW_NUMBER_SPILL_ENABLED = "native_row_number_spill_enabled";
     public static final String NATIVE_TOPN_ROW_NUMBER_SPILL_ENABLED = "native_topn_row_number_spill_enabled";
     public static final String NATIVE_SPILLER_NUM_PARTITION_BITS = "native_spiller_num_partition_bits";
@@ -122,6 +123,12 @@ public class NativeWorkerSessionPropertyProvider
                         "Native Execution only. Enable writer spilling on native engine",
                         false,
                         !nativeExecution),
+                longProperty(
+                        NATIVE_WRITER_FLUSH_THRESHOLD_BYTES,
+                        "Native Execution only. Minimum memory footprint size required to reclaim memory from a file " +
+                        "writer by flushing its buffered data to disk.",
+                        96L << 20,
+                        false),
                 booleanProperty(
                         NATIVE_ROW_NUMBER_SPILL_ENABLED,
                         "Native Execution only. Enable row number spilling on native engine",

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -168,6 +168,16 @@ SessionProperties::SessionProperties() {
       boolToString(c.writerSpillEnabled()));
 
   addSessionProperty(
+      kWriterFlushThresholdBytes,
+      "Native Execution only. Minimum memory footprint size required "
+      "to reclaim memory from a file writer by flushing its buffered data to "
+      "disk.",
+      BIGINT(),
+      false,
+      QueryConfig::kWriterFlushThresholdBytes,
+      std::to_string(c.writerFlushThresholdBytes()));
+
+  addSessionProperty(
       kRowNumberSpillEnabled,
       "Native Execution only. Enable row number spilling on native engine",
       BOOLEAN(),

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -131,6 +131,11 @@ class SessionProperties {
   static constexpr const char* kWriterSpillEnabled =
       "native_writer_spill_enabled";
 
+  /// Minimum memory footprint size required to reclaim memory from a file
+  /// writer by flushing its buffered data to disk.
+  static constexpr const char* kWriterFlushThresholdBytes =
+      "native_writer_flush_threshold_bytes";
+
   /// The number of bits (N) used to calculate the spilling partition number for
   /// hash join and RowNumber: 2 ^ N
   static constexpr const char* kSpillerNumPartitionBits =


### PR DESCRIPTION
```
== RELEASE NOTES ==

Session changes
- Add session property: 'native_writer_flush_threshold_bytes' :pr:`23891 `
```

