### PR TITLE
Upgrade elasticsearch connector from 6 to 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dep.joda.version>2.12.7</dep.joda.version>
         <dep.tempto.version>1.54</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
-        <dep.lucene.version>8.10.0</dep.lucene.version>
+        <dep.lucene.version>8.11.3</dep.lucene.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.13</dep.logback.version>
         <dep.parquet.version>1.13.1</dep.parquet.version>
@@ -72,8 +72,8 @@
         <dep.druid.version>30.0.1</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
         <dep.hudi.version>0.14.0</dep.hudi.version>
-        <dep.testcontainers.version>1.18.3</dep.testcontainers.version>
-        <dep.docker-java.version>3.3.0</dep.docker-java.version>
+        <dep.testcontainers.version>1.20.5</dep.testcontainers.version>
+        <dep.docker-java.version>3.4.1</dep.docker-java.version>
         <dep.jayway.version>2.9.0</dep.jayway.version>
         <dep.ratis.version>3.1.3</dep.ratis.version>
         <dep.errorprone.version>2.36.0</dep.errorprone.version>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
+        <dep.elasticsearch.version>7.17.27</dep.elasticsearch.version>
         <dep.log4j.version>2.24.3</dep.log4j.version>
     </properties>
 
@@ -121,25 +121,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-nio</artifactId>
-            <version>4.4.5</version>
+            <version>4.4.15</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-
             <exclusions>
-                <!-- elasticsearch-rest-high-level-client 6.0.0 brings in httpcore 4.4.5 vs (4.4.4) -->
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-
-                    <!-- elasticsearch-rest-high-level-client 6.0.0 brings in commons-codec 1.10 vs (1.9) -->
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
@@ -155,8 +143,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
-            <version>4.1.2</version>
-
+            <version>4.1.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -359,16 +346,22 @@
         </dependency>
 
         <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-core</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-x-content</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
             <version>${dep.elasticsearch.version}</version>
             <scope>test</scope>
-            <exclusions>
-                 <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                 </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticSearchClientUtils.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticSearchClientUtils.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.ClearScrollResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
+import static org.elasticsearch.client.RequestOptions.DEFAULT;
+
+public class ElasticSearchClientUtils
+{
+    private ElasticSearchClientUtils() {}
+
+    public static void setHosts(RestHighLevelClient client, HttpHost... hosts)
+    {
+        client.getLowLevelClient().setNodes(stream(hosts)
+                .map(Node::new)
+                .collect(toImmutableList()));
+    }
+
+    public static Response performRequest(String method, String endpoint, RestHighLevelClient client, Header... headers)
+            throws IOException
+    {
+        return client.getLowLevelClient().performRequest(toRequest(method, endpoint, headers));
+    }
+
+    public static Response performRequest(String method, String endpoint, Map<String, String> params, HttpEntity entity, RestHighLevelClient client, Header... headers)
+            throws IOException
+    {
+        return client.getLowLevelClient().performRequest(toRequest(method, endpoint, params, entity, headers));
+    }
+
+    public static Request toRequest(String method, String endpoint, Map<String, String> params, HttpEntity entity, Header... headers)
+    {
+        requireNonNull(params, "parameters cannot be null");
+        Request request = toRequest(method, endpoint, headers);
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            request.addParameter(entry.getKey(), entry.getValue());
+        }
+        request.setEntity(entity);
+        return request;
+    }
+
+    public static Request toRequest(String method, String endpoint, Header... headers)
+    {
+        requireNonNull(headers, "headers cannot be null");
+        Request request = new Request(method, endpoint);
+        RequestOptions.Builder options = request.getOptions().toBuilder();
+        for (Header header : headers) {
+            options.addHeader(header.getName(), header.getValue());
+        }
+        request.setOptions(options);
+        return request;
+    }
+
+    public static SearchResponse search(SearchRequest searchRequest, RestHighLevelClient client)
+            throws IOException
+    {
+        return client.search(searchRequest, DEFAULT);
+    }
+
+    public static SearchResponse searchScroll(SearchScrollRequest searchScrollRequest, RestHighLevelClient client)
+            throws IOException
+    {
+        return client.scroll(searchScrollRequest, DEFAULT);
+    }
+
+    public static ClearScrollResponse clearScroll(ClearScrollRequest clearScrollRequest, RestHighLevelClient client)
+            throws IOException
+    {
+        return client.clearScroll(clearScrollRequest, DEFAULT);
+    }
+}

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorTest.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.elasticsearch;
 
+import com.facebook.presto.elasticsearch.client.ElasticSearchClientUtils;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
@@ -31,6 +32,7 @@ import java.io.IOException;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static com.facebook.presto.elasticsearch.client.ElasticSearchClientUtils.performRequest;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static java.lang.String.format;
@@ -39,9 +41,10 @@ import static java.lang.String.format;
 public class ElasticsearchConnectorTest
         extends AbstractTestIntegrationSmokeTest
 {
-    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0";
+    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch:7.17.27";
     private ElasticsearchServer elasticsearch;
     private RestHighLevelClient client;
+    private ElasticSearchClientUtils elasticSearchClientUtils;
 
     @AfterClass(alwaysRun = true)
     public final void destroy()
@@ -218,7 +221,6 @@ public class ElasticsearchConnectorTest
     private void addAlias(String index, String alias)
             throws IOException
     {
-        client.getLowLevelClient()
-                .performRequest("PUT", format("/%s/_alias/%s", index, alias));
+        performRequest("PUT", format("/%s/_alias/%s", index, alias), client);
     }
 }

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchLoader.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchLoader.java
@@ -25,7 +25,7 @@ import com.facebook.presto.tests.ResultsSession;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -43,7 +43,8 @@ import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.client.RequestOptions.DEFAULT;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 public class ElasticsearchLoader
         extends AbstractTestingPrestoClient<Void>
@@ -102,7 +103,7 @@ public class ElasticsearchLoader
                         dataBuilder.field(columns.get(i).getName(), value);
                     }
                     dataBuilder.endObject();
-                    request.add(new IndexRequest(tableName, "doc").source(dataBuilder));
+                    request.add(new IndexRequest(tableName, "_doc").source(dataBuilder));
                 }
                 catch (IOException e) {
                     throw new UncheckedIOException("Error loading data into Elasticsearch index: " + tableName, e);
@@ -110,7 +111,7 @@ public class ElasticsearchLoader
             }
             request.setRefreshPolicy(IMMEDIATE);
             try {
-                restClient.bulk(request);
+                restClient.bulk(request, DEFAULT);
             }
             catch (IOException e) {
                 throw new RuntimeException(e);

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchNode.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchNode.java
@@ -25,6 +25,10 @@ public class ElasticsearchNode
 {
     public ElasticsearchNode(Settings preparedSettings, Collection<Class<? extends Plugin>> classpathPlugins)
     {
-        super(InternalSettingsPreparer.prepareEnvironment(preparedSettings, null), classpathPlugins);
+        super(InternalSettingsPreparer.prepareEnvironment(preparedSettings, null, null, null), classpathPlugins, false);
+    }
+    public ElasticsearchNode(Settings preparedSettings)
+    {
+        super(InternalSettingsPreparer.prepareEnvironment(preparedSettings, null, null, null));
     }
 }

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -40,17 +40,19 @@ import java.util.Map;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static com.facebook.presto.elasticsearch.client.ElasticSearchClientUtils.performRequest;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.client.RequestOptions.DEFAULT;
 
 @Test(singleThreaded = true)
 public class TestElasticsearchIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
-    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0";
+    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch:7.17.27";
     private ElasticsearchServer elasticsearch;
     private RestHighLevelClient client;
 
@@ -163,7 +165,7 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
+                "    \"_doc\": {" +
                 "      \"_meta\": {" +
                 "        \"presto\": {" +
                 "          \"a\": {" +
@@ -357,7 +359,7 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
+                "    \"_doc\": {" +
                 "      \"properties\": {" +
                 "        \"boolean_column\":   { \"type\": \"boolean\" }," +
                 "        \"float_column\":     { \"type\": \"float\" }," +
@@ -421,7 +423,7 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
+                "    \"_doc\": {" +
                 "      \"properties\": {" +
                 "        \"boolean_column\":   { \"type\": \"boolean\" }," +
                 "        \"float_column\":     { \"type\": \"float\" }," +
@@ -534,7 +536,7 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
+                "    \"_doc\": {" +
                 "      \"properties\": {" +
                 "        \"field\": {" +
                 "          \"properties\": {" +
@@ -604,7 +606,7 @@ public class TestElasticsearchIntegrationSmokeTest
         String mapping = "" +
                 "{" +
                 "  \"mappings\": {" +
-                "    \"doc\": {" +
+                "    \"_doc\": {" +
                 "      \"properties\": {" +
                 "        \"nested_field\": {" +
                 "          \"type\":\"nested\"," +
@@ -752,9 +754,9 @@ public class TestElasticsearchIntegrationSmokeTest
     private void index(String index, Map<String, Object> document)
             throws IOException
     {
-        client.index(new IndexRequest(index, "doc")
+        client.index(new IndexRequest(index, "_doc")
                 .source(document)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE));
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), DEFAULT);
     }
 
     @Test
@@ -788,29 +790,26 @@ public class TestElasticsearchIntegrationSmokeTest
     private void addAlias(String index, String alias)
             throws IOException
     {
-        client.getLowLevelClient()
-                .performRequest("PUT", format("/%s/_alias/%s", index, alias));
+        performRequest("PUT", format("/%s/_alias/%s", index, alias), client);
     }
 
     private void removeAlias(String index, String alias)
             throws IOException
     {
-        client.getLowLevelClient()
-                .performRequest("DELETE", format("/%s/_alias/%s", index, alias));
+        performRequest("DELETE", format("/%s/_alias/%s", index, alias), client);
     }
 
     private void createIndex(String indexName, @Language("JSON") String mapping)
             throws IOException
     {
-        client.getLowLevelClient()
-                .performRequest("PUT", "/" + indexName, ImmutableMap.of(), new NStringEntity(mapping, ContentType.APPLICATION_JSON));
+        performRequest("PUT", "/" + indexName, ImmutableMap.of("include_type_name", "true"), new NStringEntity(mapping, ContentType.APPLICATION_JSON), client);
     }
 
     @Test
     public void testEmptyIndexNoMappings()
             throws IOException
     {
-        client.getLowLevelClient().performRequest("PUT", "/emptyindex");
+        performRequest("PUT", "/emptyindex", client);
         assertQueryFails("SELECT * FROM emptyindex", "line 1:8: SELECT \\* not allowed from relation that has no columns");
     }
 }

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestPasswordAuthentication.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestPasswordAuthentication.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static com.facebook.presto.elasticsearch.client.ElasticSearchClientUtils.performRequest;
 import static com.google.common.io.Resources.getResource;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -92,12 +93,12 @@ public class TestPasswordAuthentication
                 .put("value", 42L)
                 .build());
 
-        client.getLowLevelClient()
-                .performRequest(
+        performRequest(
                         "POST",
                         "/test/_doc?refresh",
                         ImmutableMap.of(),
                         new NStringEntity(json, ContentType.APPLICATION_JSON),
+                        client,
                         new BasicHeader("Authorization", format("Basic %s", Base64.encodeAsString(format("%s:%s", USER, PASSWORD).getBytes(StandardCharsets.UTF_8)))));
 
         assertions.assertQuery("SELECT * FROM test",


### PR DESCRIPTION
## Description
If implemented, this will upgrade the elasticsearch module to 7.17.27 by bringing in IBM presto commits.

## Motivation and Context
Resolves 
[CVE-2024-43709](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-43709)
[CVE-2024-23444](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-23444)
[CVE-2023-49921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-49921)
[CVE-2023-31418](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-31418)
[CVE-2021-22144](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22144)
[CVE-2021-22137](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22137)
[CVE-2021-22135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22135)
[CVE-2020-7021](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7021)
[CVE-2020-7020](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7020)
[CVE-2020-7019](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7019)
[CVE-2019-7614](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-7614)
[CVE-2019-7611](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-7611)
[CVE-2018-3831](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3831)
[CVE-2018-3824](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3824)
## Impact
Due to upgrading the elasticsearch API from to 7.17.27, there might be some compatibility issues interacting with clusters of a lower version. 
https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.17/java-rest-high-compatibility.html

## Test Plan
Unit tests & tested in IBM lakehouse
## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes

```
== RELEASE NOTES ==
Elasticsearch Connector Changes
* Upgrade elasticsearch to 7.17.27 in response to `CVE-2024-43709 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-43709>`_.
```

