### PR TITLE
[native] Use new metrics() API in PrestoExchangeSource

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -123,10 +123,17 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   /// already.
   void close() override;
 
-  folly::F14FastMap<std::string, int64_t> stats() const override {
+  bool supportsMetrics() const override {
+    return true;
+  }
+
+  folly::F14FastMap<std::string, velox::RuntimeMetric> metrics()
+      const override {
     return {
-        {"prestoExchangeSource.numPages", numPages_},
-        {"prestoExchangeSource.totalBytes", totalBytes_},
+        {"prestoExchangeSource.numPages", velox::RuntimeMetric(numPages_)},
+        {"prestoExchangeSource.totalBytes",
+         velox::RuntimeMetric(
+             totalBytes_, velox::RuntimeCounter::Unit::kBytes)},
     };
   }
 

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -510,10 +510,10 @@ TEST_P(PrestoExchangeSourceTest, basic) {
   serverWrapper.stop();
   EXPECT_EQ(pool_->usedBytes(), 0);
 
-  const auto stats = exchangeSource->stats();
+  const auto stats = exchangeSource->metrics();
   ASSERT_EQ(stats.size(), 2);
-  ASSERT_EQ(stats.at("prestoExchangeSource.numPages"), pages.size());
-  ASSERT_EQ(stats.at("prestoExchangeSource.totalBytes"), totalBytes(pages));
+  ASSERT_EQ(stats.at("prestoExchangeSource.numPages").sum, pages.size());
+  ASSERT_EQ(stats.at("prestoExchangeSource.totalBytes").sum, totalBytes(pages));
 }
 
 TEST_P(PrestoExchangeSourceTest, retryState) {
@@ -636,10 +636,10 @@ TEST_P(PrestoExchangeSourceTest, earlyTerminatingConsumer) {
   serverWrapper.stop();
   EXPECT_EQ(pool_->usedBytes(), 0);
 
-  const auto stats = exchangeSource->stats();
+  const auto stats = exchangeSource->metrics();
   ASSERT_EQ(stats.size(), 2);
-  ASSERT_EQ(stats.at("prestoExchangeSource.numPages"), 0);
-  ASSERT_EQ(stats.at("prestoExchangeSource.totalBytes"), 0);
+  ASSERT_EQ(stats.at("prestoExchangeSource.numPages").sum, 0);
+  ASSERT_EQ(stats.at("prestoExchangeSource.totalBytes").sum, 0);
 }
 
 TEST_P(PrestoExchangeSourceTest, slowProducer) {
@@ -678,10 +678,10 @@ TEST_P(PrestoExchangeSourceTest, slowProducer) {
   serverWrapper.stop();
   EXPECT_EQ(pool_->usedBytes(), 0);
 
-  const auto stats = exchangeSource->stats();
+  const auto stats = exchangeSource->metrics();
   ASSERT_EQ(stats.size(), 2);
-  ASSERT_EQ(stats.at("prestoExchangeSource.numPages"), pages.size());
-  ASSERT_EQ(stats.at("prestoExchangeSource.totalBytes"), totalBytes(pages));
+  ASSERT_EQ(stats.at("prestoExchangeSource.numPages").sum, pages.size());
+  ASSERT_EQ(stats.at("prestoExchangeSource.totalBytes").sum, totalBytes(pages));
 }
 
 DEBUG_ONLY_TEST_P(


### PR DESCRIPTION
`velox::ExchangeSource` adds a new `metrics()` interface to replace the 
old 'stats()' interface, so that 'units' can be represented in results.

This patch modifies the `PrestoExchangeSource` to use the new interface.

```
== NO RELEASE NOTE ==
```

