### PR TITLE
[native] Use Velox namespace explicitly in PrestoServer.cpp

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -76,7 +76,7 @@
 #include <sched.h>
 #endif
 
-using namespace facebook::velox;
+using namespace facebook;
 
 namespace facebook::presto {
 namespace {
@@ -104,7 +104,7 @@ void enableChecksum() {
   velox::exec::OutputBufferManager::getInstance().lock()->setListenerFactory(
       []() {
         return std::make_unique<
-            serializer::presto::PrestoOutputStreamListener>();
+            velox::serializer::presto::PrestoOutputStreamListener>();
       });
 }
 
@@ -237,7 +237,7 @@ void PrestoServer::run() {
       address_ = fmt::format("[{}]", address_);
     }
     nodeLocation_ = nodeConfig->nodeLocation();
-  } catch (const VeloxUserError& e) {
+  } catch (const velox::VeloxUserError& e) {
     PRESTO_STARTUP_LOG(ERROR) << "Failed to start server due to " << e.what();
     exit(EXIT_FAILURE);
   }
@@ -252,8 +252,9 @@ void PrestoServer::run() {
 
   // Register Velox connector factory for iceberg.
   // The iceberg catalog is handled by the hive connector factory.
-  connector::registerConnectorFactory(
-      std::make_shared<connector::hive::HiveConnectorFactory>("iceberg"));
+  velox::connector::registerConnectorFactory(
+      std::make_shared<velox::connector::hive::HiveConnectorFactory>(
+          "iceberg"));
 
   registerPrestoToVeloxConnector(
       std::make_unique<HivePrestoToVeloxConnector>("hive"));
@@ -457,7 +458,7 @@ void PrestoServer::run() {
           const std::string& taskId,
           int destination,
           std::shared_ptr<velox::exec::ExchangeQueue> queue,
-          memory::MemoryPool* pool) {
+          velox::memory::MemoryPool* pool) {
         return PrestoExchangeSource::create(
             taskId,
             destination,
@@ -469,11 +470,11 @@ void PrestoServer::run() {
             sslContext_);
       });
 
-  facebook::velox::exec::ExchangeSource::registerFactory(
+  velox::exec::ExchangeSource::registerFactory(
       operators::UnsafeRowExchangeSource::createExchangeSource);
 
   // Batch broadcast exchange source.
-  facebook::velox::exec::ExchangeSource::registerFactory(
+  velox::exec::ExchangeSource::registerFactory(
       operators::BroadcastExchangeSource::createExchangeSource);
 
   pool_ =
@@ -516,13 +517,13 @@ void PrestoServer::run() {
 
   if (systemConfig->enableVeloxTaskLogging()) {
     if (auto listener = getTaskListener()) {
-      exec::registerTaskListener(listener);
+      velox::exec::registerTaskListener(listener);
     }
   }
 
   if (systemConfig->enableVeloxExprSetLogging()) {
     if (auto listener = getExprSetListener()) {
-      exec::registerExprSetListener(listener);
+      velox::exec::registerExprSetListener(listener);
     }
   }
   prestoServerOperations_ =
@@ -563,7 +564,7 @@ void PrestoServer::run() {
   PRESTO_STARTUP_LOG(INFO) << "Starting all periodic tasks";
 
   auto* memoryAllocator = velox::memory::memoryManager()->allocator();
-  auto* asyncDataCache = cache::AsyncDataCache::getInstance();
+  auto* asyncDataCache = velox::cache::AsyncDataCache::getInstance();
   periodicTaskManager_ = std::make_unique<PeriodicTaskManager>(
       driverExecutor_.get(),
       spillerExecutor_.get(),
@@ -778,7 +779,7 @@ void PrestoServer::initializeThreadPools() {
   }
 }
 
-std::unique_ptr<cache::SsdCache> PrestoServer::setupSsdCache() {
+std::unique_ptr<velox::cache::SsdCache> PrestoServer::setupSsdCache() {
   VELOX_CHECK_NULL(cacheExecutor_);
   auto* systemConfig = SystemConfig::instance();
   if (systemConfig->asyncCacheSsdGb() == 0) {
@@ -787,7 +788,7 @@ std::unique_ptr<cache::SsdCache> PrestoServer::setupSsdCache() {
 
   constexpr int32_t kNumSsdShards = 16;
   cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(kNumSsdShards);
-  cache::SsdCache::Config cacheConfig(
+  velox::cache::SsdCache::Config cacheConfig(
       systemConfig->asyncCacheSsdPath(),
       systemConfig->asyncCacheSsdGb() << 30,
       kNumSsdShards,
@@ -798,7 +799,7 @@ std::unique_ptr<cache::SsdCache> PrestoServer::setupSsdCache() {
       systemConfig->ssdCacheReadVerificationEnabled());
   PRESTO_STARTUP_LOG(INFO) << "Initializing SSD cache with "
                            << cacheConfig.toString();
-  return std::make_unique<cache::SsdCache>(cacheConfig);
+  return std::make_unique<velox::cache::SsdCache>(cacheConfig);
 }
 
 void PrestoServer::initializeVeloxMemory() {
@@ -807,7 +808,7 @@ void PrestoServer::initializeVeloxMemory() {
   PRESTO_STARTUP_LOG(INFO) << "Starting with node memory " << memoryGb << "GB";
 
   // Set up velox memory manager.
-  memory::MemoryManagerOptions options;
+  velox::memory::MemoryManagerOptions options;
   options.allocatorCapacity = memoryGb << 30;
   if (systemConfig->useMmapAllocator()) {
     options.useMmapAllocator = true;
@@ -861,34 +862,38 @@ void PrestoServer::initializeVeloxMemory() {
         {std::string(SharedArbitratorConfig::kCheckUsageLeak),
          folly::to<std::string>(systemConfig->enableMemoryLeakCheck())}};
   }
-  memory::initializeMemoryManager(options);
+  velox::memory::initializeMemoryManager(options);
   PRESTO_STARTUP_LOG(INFO) << "Memory manager has been setup: "
-                           << memory::memoryManager()->toString();
+                           << velox::memory::memoryManager()->toString();
 
   if (systemConfig->asyncDataCacheEnabled()) {
-    std::unique_ptr<cache::SsdCache> ssd = setupSsdCache();
+    std::unique_ptr<velox::cache::SsdCache> ssd = setupSsdCache();
     std::string cacheStr =
         ssd == nullptr ? "AsyncDataCache" : "AsyncDataCache with SSD";
 
-    cache::AsyncDataCache::Options cacheOptions{
+    velox::cache::AsyncDataCache::Options cacheOptions{
         systemConfig->asyncCacheMaxSsdWriteRatio(),
         systemConfig->asyncCacheSsdSavableRatio(),
         systemConfig->asyncCacheMinSsdSavableBytes()};
-    cache_ = cache::AsyncDataCache::create(
-        memory::memoryManager()->allocator(), std::move(ssd), cacheOptions);
-    cache::AsyncDataCache::setInstance(cache_.get());
+    cache_ = velox::cache::AsyncDataCache::create(
+        velox::memory::memoryManager()->allocator(),
+        std::move(ssd),
+        cacheOptions);
+    velox::cache::AsyncDataCache::setInstance(cache_.get());
     PRESTO_STARTUP_LOG(INFO) << cacheStr << " has been setup";
 
     if (isCacheTtlEnabled()) {
-      cache::CacheTTLController::create(*cache_);
+      velox::cache::CacheTTLController::create(*cache_);
       PRESTO_STARTUP_LOG(INFO) << fmt::format(
           "Cache TTL is enabled, with TTL {} enforced every {}.",
-          succinctMillis(std::chrono::duration_cast<std::chrono::milliseconds>(
-                             systemConfig->cacheVeloxTtlThreshold())
-                             .count()),
-          succinctMillis(std::chrono::duration_cast<std::chrono::milliseconds>(
-                             systemConfig->cacheVeloxTtlCheckInterval())
-                             .count()));
+          velox::succinctMillis(
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                  systemConfig->cacheVeloxTtlThreshold())
+                  .count()),
+          velox::succinctMillis(
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                  systemConfig->cacheVeloxTtlCheckInterval())
+                  .count()));
     }
   } else {
     VELOX_CHECK_EQ(
@@ -1108,18 +1113,18 @@ PrestoServer::getAdditionalHttpServerFilters() {
 void PrestoServer::registerConnectorFactories() {
   // These checks for connector factories can be removed after we remove the
   // registrations from the Velox library.
-  if (!connector::hasConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)) {
-    connector::registerConnectorFactory(
-        std::make_shared<connector::hive::HiveConnectorFactory>());
-    connector::registerConnectorFactory(
-        std::make_shared<connector::hive::HiveConnectorFactory>(
+  if (!velox::connector::hasConnectorFactory(
+          velox::connector::hive::HiveConnectorFactory::kHiveConnectorName)) {
+    velox::connector::registerConnectorFactory(
+        std::make_shared<velox::connector::hive::HiveConnectorFactory>());
+    velox::connector::registerConnectorFactory(
+        std::make_shared<velox::connector::hive::HiveConnectorFactory>(
             kHiveHadoop2ConnectorName));
   }
-  if (!connector::hasConnectorFactory(
-          connector::tpch::TpchConnectorFactory::kTpchConnectorName)) {
-    connector::registerConnectorFactory(
-        std::make_shared<connector::tpch::TpchConnectorFactory>());
+  if (!velox::connector::hasConnectorFactory(
+          velox::connector::tpch::TpchConnectorFactory::kTpchConnectorName)) {
+    velox::connector::registerConnectorFactory(
+        std::make_shared<velox::connector::tpch::TpchConnectorFactory>());
   }
 }
 
@@ -1169,7 +1174,7 @@ std::vector<std::string> PrestoServer::registerConnectors(
       getPrestoToVeloxConnector(connectorName);
 
       std::shared_ptr<velox::connector::Connector> connector =
-          facebook::velox::connector::getConnectorFactory(connectorName)
+          velox::connector::getConnectorFactory(connectorName)
               ->newConnector(
                   catalogName,
                   std::move(properties),
@@ -1191,7 +1196,7 @@ void PrestoServer::registerSystemConnector() {
 
 void PrestoServer::unregisterConnectors() {
   PRESTO_SHUTDOWN_LOG(INFO) << "Unregistering connectors";
-  auto connectors = facebook::velox::connector::getAllConnectors();
+  auto connectors = velox::connector::getAllConnectors();
   if (connectors.empty()) {
     PRESTO_SHUTDOWN_LOG(INFO) << "No connectors to unregister";
     return;
@@ -1200,7 +1205,7 @@ void PrestoServer::unregisterConnectors() {
   PRESTO_SHUTDOWN_LOG(INFO)
       << "Unregistering " << connectors.size() << " connectors";
   for (const auto& connectorEntry : connectors) {
-    if (facebook::velox::connector::unregisterConnector(connectorEntry.first)) {
+    if (velox::connector::unregisterConnector(connectorEntry.first)) {
       PRESTO_SHUTDOWN_LOG(INFO)
           << "Unregistered connector: " << connectorEntry.first;
     } else {
@@ -1209,7 +1214,7 @@ void PrestoServer::unregisterConnectors() {
     }
   }
 
-  facebook::velox::connector::unregisterConnector("$system@system");
+  velox::connector::unregisterConnector("$system@system");
   PRESTO_SHUTDOWN_LOG(INFO)
       << "Unregistered " << connectors.size() << " connectors";
 }
@@ -1221,18 +1226,17 @@ void PrestoServer::registerShuffleInterfaceFactories() {
 }
 
 void PrestoServer::registerCustomOperators() {
-  facebook::velox::exec::Operator::registerOperator(
+  velox::exec::Operator::registerOperator(
       std::make_unique<operators::PartitionAndSerializeTranslator>());
-  facebook::velox::exec::Operator::registerOperator(
-      std::make_unique<facebook::presto::operators::ShuffleWriteTranslator>());
-  facebook::velox::exec::Operator::registerOperator(
+  velox::exec::Operator::registerOperator(
+      std::make_unique<operators::ShuffleWriteTranslator>());
+  velox::exec::Operator::registerOperator(
       std::make_unique<operators::ShuffleReadTranslator>());
 
   // Todo - Split Presto & Presto-on-Spark server into different classes
   // which will allow server specific operator registration.
-  facebook::velox::exec::Operator::registerOperator(
-      std::make_unique<
-          facebook::presto::operators::BroadcastWriteTranslator>());
+  velox::exec::Operator::registerOperator(
+      std::make_unique<operators::BroadcastWriteTranslator>());
 }
 
 void PrestoServer::registerFunctions() {
@@ -1281,13 +1285,15 @@ void PrestoServer::registerVectorSerdes() {
   if (!velox::isRegisteredVectorSerde()) {
     velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+  if (!velox::isRegisteredNamedVectorSerde(velox::VectorSerde::Kind::kPresto)) {
     velox::serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+  if (!velox::isRegisteredNamedVectorSerde(
+          velox::VectorSerde::Kind::kCompactRow)) {
     velox::serializer::CompactRowVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+  if (!velox::isRegisteredNamedVectorSerde(
+          velox::VectorSerde::Kind::kUnsafeRow)) {
     velox::serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
 }
@@ -1328,7 +1334,7 @@ void PrestoServer::unregisterFileReadersAndWriters() {
 
 void PrestoServer::registerStatsCounters() {
   registerPrestoMetrics();
-  registerVeloxMetrics();
+  velox::registerVeloxMetrics();
 }
 
 std::string PrestoServer::getLocalIp() const {


### PR DESCRIPTION
The namespace used for most Velox APIs was inconsistent in the PrestoServer.cpp file. This PR makes Velox API usage consistent. This also can avoid issues with ambiguous names if somehow another API introduces a similar naming convention but in a different namespace that could be used by Prestissimo.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

