### PR TITLE
Enable logging of Hive catalog configuration properties

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -141,7 +141,6 @@ public class HiveConnectorFactory
             Injector injector = app
                     .doNotInitializeLogging()
                     .setRequiredConfigurationProperties(config)
-                    .quiet()
                     .initialize();
 
             LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);


### PR DESCRIPTION
## Description
Enable logging of Hive catalog configuration properties so that users can check it in Presto logs.


## Motivation and Context
Consistency, since the other types of catalogs logs their configuration properties.

Pull request #13070 disabled several Hive logs, including the configuration properties, to avoid hitting the max log size in Travis. Now Travis is not longer used.


## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

