### PR TITLE
[native] Propagate table writer concurrency settings

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -179,6 +179,9 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kDiscoveryUri{"discovery.uri"};
   static constexpr std::string_view kMaxDriversPerTask{
       "task.max-drivers-per-task"};
+  static constexpr std::string_view kTaskWriterCount{"task.writer-count"};
+  static constexpr std::string_view kTaskPartitionedWriterCount{
+      "task.partitioned-writer-count"};
   static constexpr std::string_view kConcurrentLifespansPerTask{
       "task.concurrent-lifespans-per-task"};
   static constexpr std::string_view kTaskMaxPartialAggregationMemory{
@@ -694,6 +697,10 @@ class SystemConfig : public ConfigBase {
   std::string remoteFunctionServerSerde() const;
 
   int32_t maxDriversPerTask() const;
+
+  folly::Optional<int32_t> taskWriterCount() const;
+
+  folly::Optional<int32_t> taskPartitionedWriterCount() const;
 
   int32_t concurrentLifespansPerTask() const;
 


### PR DESCRIPTION
## Description

- `task.writer-count`
- `task.partitioned-writer-count`

## Motivation and Context

Keep it consistent with Presto

## Test Plan

Use HiveExternalWorkerQueryRunner to validate

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Native
* Respect `task.writer-count` and `task.partitioned-writer-count` configuration properties
```

