### PR TITLE
Encode the path in uri

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -387,7 +387,7 @@ public final class QueryResourceUtil
         URI uri = uriInfo.getRequestUriBuilder()
                 .scheme(getScheme(xForwardedProto, uriInfo))
                 .replacePath("ui/query.html")
-                .replaceQuery(queryId.toString())
+                .replaceQuery(urlEncode(queryId.toString()))
                 .build();
         return prependUri(uri, xPrestoPrefixUrl);
     }
@@ -397,10 +397,10 @@ public final class QueryResourceUtil
         UriBuilder uriBuilder = uriInfo.getBaseUriBuilder()
                 .scheme(getScheme(xForwardedProto, uriInfo))
                 .replacePath("/v1/statement/queued")
-                .path(queryId.toString())
-                .path(String.valueOf(token))
+                .path(urlEncode(queryId.toString()))
+                .path(urlEncode(String.valueOf(token)))
                 .replaceQuery("")
-                .queryParam("slug", slug);
+                .queryParam("slug", urlEncode(slug));
         if (binaryResults) {
             uriBuilder.queryParam("binaryResults", "true");
         }


### PR DESCRIPTION
## Description
[CWE-235](https://cwe.mitre.org/data/definitions/235.html)

Fixed Http Parameter Pollution Rule at :

(1) Encoded URI path parameter /v1/taskInfo/{taskId} with UTF_8 encoding : presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedTaskInfoResource.java:72
(2) presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java


## Motivation and Context
Concatenating untrusted input into path, query string, or parameters for HTTP message (in the URL or in the request body) may allow an attacker to override/add unexpected request parameters. Attacker may change the intended HTTP request semantics, and may give him/her access to unauthorized data or bypass web application firewall validations. 

## Impact
No Impact

## Test Plan
Verified existing Unit test case for above fix :
(1) presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedTaskInfoResource.java
(2) presto-tests/src/test/java/com/facebook/presto/server/TestQueryResource.java

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

* Security Changes
 Fixes URI path parameter encoding to handle untrusted input : pr:`23907`
```
