### PR TITLE
[WIP] Avoid comparing case value with operand when class types don't match #23324

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -663,6 +663,10 @@ public class RowExpressionInterpreter
                                 simplifiedWhenClauses.add(new SpecialFormExpression(operand.getSourceLocation(), WHEN, whenClause.getType(), toRowExpression(operandValue, operand), toRowExpression(processWithExceptionHandling(result, context), result)));
                             }
                             else if (operandValue != null) {
+                                //Check to avoid class cast exception
+                                if (!value.getClass().isInstance(operandValue)) {
+                                    break;
+                                }
                                 Boolean isEqual = (Boolean) invokeOperator(
                                         EQUAL,
                                         ImmutableList.of(node.getArguments().get(0).getType(), operand.getType()),

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -1589,6 +1589,44 @@ public class TestExpressionInterpreter
         assertEquals(optimize("X'1234'"), Slices.wrappedBuffer((byte) 0x12, (byte) 0x34));
     }
 
+    @Test
+    public void testCaseMixedLongDecimalAndIntegral() {
+        assertRowExpressionEquals(OPTIMIZED, "case 1 " +
+                        "when 0.11111111 then 2 " +
+                        "when 3 then 4 " +
+                        "end",
+                "NULL");
+
+        assertRowExpressionEquals(OPTIMIZED, "case 1 " +
+                        "when 0.111111111 then 2 " +
+                        "when 3 then 4 " +
+                        "end",
+                "NULL");
+
+        assertRowExpressionEquals(OPTIMIZED, "case 0.11111111 " +
+                        "when 0.11111111 then 2 " +
+                        "when 3 then 4 " +
+                        "end",
+                "2");
+
+        assertRowExpressionEquals(OPTIMIZED, "case 0.111111111 " +
+                        "when 0.111111111 then 2 " +
+                        "when 3 then 4 " +
+                        "end",
+                "NULL");
+
+        assertRowExpressionEquals(OPTIMIZED, "case 1 " +
+                        "when 1 then 2 " +
+                        "when 3 then 4 " +
+                        "end",
+                "2");
+        assertRowExpressionEquals(OPTIMIZED, "case 3 " +
+                        "when 1 then 2 " +
+                        "when 3 then 4 " +
+                        "end",
+                "4");
+    }
+
     private static void assertLike(byte[] value, String pattern, boolean expected)
     {
         Expression predicate = new LikePredicate(


### PR DESCRIPTION
## Description
Avoid comparing case value with operand when class types don't match

## Motivation and Context

## Impact

## Test Plan

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

