### PR TITLE
Changes to make clone method final to increase security

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/UnweightedDoubleReservoirSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/UnweightedDoubleReservoirSample.java
@@ -121,7 +121,7 @@ public class UnweightedDoubleReservoirSample
     }
 
     @Override
-    public UnweightedDoubleReservoirSample clone()
+    public final UnweightedDoubleReservoirSample clone()
     {
         return new UnweightedDoubleReservoirSample(this);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/WeightedDoubleReservoirSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/WeightedDoubleReservoirSample.java
@@ -107,7 +107,7 @@ public class WeightedDoubleReservoirSample
     }
 
     @Override
-    public WeightedDoubleReservoirSample clone()
+    public final WeightedDoubleReservoirSample clone()
     {
         return new WeightedDoubleReservoirSample(this);
     }


### PR DESCRIPTION
## Description
Improve Cloneable interface by making clone method final to increase security
Made the changes in
presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/WeightedDoubleReservoirSample.java:110
presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/UnweightedDoubleReservoirSample.java:124

## Motivation and Context
All classes implementing the Cloneable interface must have a final clone() method. A class with a clone() method that is not declared final allows an object to be created without calling the constructor. This can cause the object to be in an unexpected state.

## Impact
no impact

## Test Plan
Verified existing Unit test case for above fix :
(1) presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestWeightedDoubleReservoirSample.java
(2) presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestUnweightedDoubleReservoirSample.java


## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

== NO RELEASE NOTE ==
