### PR TITLE
[docs] Fix formatting in presto_cpp/properties.rst

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -307,7 +307,7 @@ The LinuxMemoryChecker can be enabled by setting the CMake flag ``PRESTO_MEMORY_
 The following properties for PeriodicMemoryChecker are as follows:
 
 ``system-mem-pushback-enabled``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``


### PR DESCRIPTION
## Description
Fix formatting of a heading in presto_cpp/properties.rst.

## Motivation and Context
Fixing the formatting of the heading reduces the number of warnings in the doc build by 1. 

## Impact
None. 

## Test Plan
Local doc builds before and after the fix. 

Before: 
```
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/properties.rst:310: WARNING: Title underline too short.

``system-mem-pushback-enabled``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^

build succeeded, 30 warnings.
```

After: 
(no warning) 
```
build succeeded, 29 warnings.
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

