### PR TITLE
[docs] Add Comments in PRs topic to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -479,6 +479,13 @@ We use the [Fork and Pull model](https://docs.github.com/en/pull-requests/collab
     * Instead, review the related code, then draft initial documentation as a separate commit
 * Submit without test cases or clear justification for lack thereof
 
+### Comments in Pull Requests
+Comments should help move the PR toward completion. 
+
+Presto PRs - especially those written by people new to open source or new to Presto - can have a surprisingly high number of comments. This is a general tendency of open source projects and is because members of the Presto community want to help you succeed with your PR and also maintain the quality, and follow the existing standards of, the Presto project.
+
+Do not take the presence of many comments as a sign that the PR, or the work in it, is bad. 
+
 ## <a id="codereviews">Code Reviews</a>
 #### What to do
 * Provide explicit feedback on what is needed or what would be better


### PR DESCRIPTION
## Description
Adapted remarks by @tdcmeehan to add to CONTRIBUTING.md. 

## Motivation and Context
By stating that many comments on a PR are not a reflection of low quality work in the PR, this addition to CONTRIBUTING.md helps avoid contributors, especially new ones, perceiving the quantity of comments as an inherent criticism of their contribution. 

## Impact
Contributors' perception of feedback about their PRs. 

## Test Plan
View file in GitHub for typos and bad formatting. 

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```