### PR TITLE
Fix localexchange properties when spill is enabled

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -47,7 +47,6 @@ import static com.facebook.presto.sql.planner.optimizations.PartitioningUtils.is
 import static com.facebook.presto.sql.planner.optimizations.PartitioningUtils.isRepartitionEffective;
 import static com.facebook.presto.sql.planner.optimizations.PartitioningUtils.translatePartitioningRowExpression;
 import static com.facebook.presto.sql.planner.optimizations.PartitioningUtils.translateToCoalesce;
-import static com.facebook.presto.util.MoreLists.filteredCopy;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.transform;
@@ -323,7 +322,16 @@ public class ActualProperties
         {
             List<LocalProperty<VariableReferenceExpression>> localProperties = this.localProperties;
             if (unordered) {
-                localProperties = filteredCopy(this.localProperties, property -> !property.isOrderSensitive());
+                ImmutableList.Builder<LocalProperty<VariableReferenceExpression>> newLocalProperties = ImmutableList.builder();
+                for (LocalProperty<VariableReferenceExpression> property : this.localProperties) {
+                    if (!property.isOrderSensitive()) {
+                        newLocalProperties.add(property);
+                    }
+                    else {
+                        break;
+                    }
+                }
+                localProperties = newLocalProperties.build();
             }
             return new ActualProperties(global, localProperties, constants);
         }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
@@ -18,6 +18,7 @@ import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.nio.file.Paths;
@@ -74,5 +75,22 @@ public class TestDistributedSpilledQueries
     {
         // TODO: disabled until https://github.com/prestodb/presto/issues/8926 is resolved
         //       due to long running query test created many spill files on disk.
+    }
+
+    @Test
+    public void testQueriesWithSpill()
+    {
+        // Test double filtered left, right, full and inner joins with right constant equality.
+        @Language("SQL") String query = "with t1 as (select max(totalprice) maxprice, min(totalprice) minprice, custkey ckey from orders group by custkey), " +
+                "t2 as (select custkey, totalprice, (select maxprice from t1 where ckey = custkey) maxprice, " +
+                "(select minprice from t1 where ckey=custkey) minprice from orders) select custkey from t2 where " +
+                "(totalprice between minprice and maxprice) group by custkey";
+        Session enableSpill = Session.builder(getSession())
+                .setSystemProperty("spill_enabled", "true")
+                .build();
+        Session disableSpill = Session.builder(getSession())
+                .setSystemProperty("spill_enabled", "true")
+                .build();
+        assertQueryWithSameQueryRunner(disableSpill, query, enableSpill);
     }
 }


### PR DESCRIPTION
## Description
This is discovered by a bug, which can be replayed with the following query:
```
WITH t1 AS (
    SELECT
        MAX(totalprice) maxprice,
        MIN(totalprice) minprice,
        custkey ckey
    FROM orders
    GROUP BY
        custkey
),
t2 AS (
    SELECT
        custkey,
        totalprice,
        (
            SELECT
                maxprice
            FROM t1
            WHERE
                ckey = custkey
        ) maxprice,
        (
            SELECT
                minprice
            FROM t1
            WHERE
                ckey = custkey
        ) minprice
    FROM orders
)
SELECT
    custkey
FROM t2
WHERE
    (
        totalprice BETWEEN minprice AND maxprice
    )
GROUP BY
    custkey;
```

When executing this query in Presto CPP (i.e. native execution is true) and with `set session spill_enabled=true`, it will produce a wrong query plan, where the Aggregation on the top is a streaming aggregation which is wrong.
```
presto:tpch> explain (type distributed) with t1 as (select max(totalprice) maxprice, min(totalprice) minprice, custkey ckey from orders group by custkey), t2 as (select custkey, totalprice, (select maxprice from t1 where ckey = custkey) maxprice, (select minprice from t1 where ckey=custkey) minprice from orders) select custkey from t2 where (totalprice between minprice and maxprice) group by custkey;
                                                                                                                                                           >
----------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                       >
     Output layout: [custkey]                                                                                                                              >
     Output partitioning: SINGLE []                                                                                                                        >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - Output[PlanNodeId 74][custkey] => [custkey:bigint]                                                                                                  >
         - RemoteSource[1] => [custkey:bigint]                                                                                                             >
                                                                                                                                                           >
 Fragment 1 [HASH]                                                                                                                                         >
     Output layout: [custkey]                                                                                                                              >
     Output partitioning: SINGLE []                                                                                                                        >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - Aggregate(STREAMING)[custkey][PlanNodeId 69] => [custkey:bigint]                                                                                    >
         - FilterProject[PlanNodeId 912,693][filterPredicate = (SWITCH(is_distinct, WHEN(BOOLEAN'true', BOOLEAN'true'), CAST(fail(INTEGER'28', VARCHAR'Scal>
             - MarkDistinct[PlanNodeId 691][distinct=unique:bigint marker=is_distinct] => [custkey:bigint, totalprice:double, max:double, unique:bigint, mi>
                 - LeftJoin[PlanNodeId 702][("custkey" = "custkey_34")][$hashvalue_108, $hashvalue_112] => [custkey:bigint, totalprice:double, max:double, >
                         Distribution: PARTITIONED                                                                                                         >
                     - AssignUniqueId[PlanNodeId 690] => [custkey:bigint, totalprice:double, max:double, $hashvalue_108:bigint, unique:bigint]             >
                         - FilterProject[PlanNodeId 909,711][filterPredicate = SWITCH(is_distinct_97, WHEN(BOOLEAN'true', BOOLEAN'true'), CAST(fail(INTEGER>
                                 $hashvalue_108 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:294)                      >
                             - Project[PlanNodeId 1763][projectLocality = LOCAL] => [custkey:bigint, totalprice:double, unique_96:bigint, max:double, is_di>
                                 - MarkDistinct[PlanNodeId 709][distinct=custkey:bigint, totalprice:double, unique_96:bigint marker=is_distinct_97][$hashva>
                                     - LocalExchange[PlanNodeId 1619][HASH][$hashvalue] (custkey) => [custkey:bigint, totalprice:double, unique_96:bigint, >
                                         - Project[PlanNodeId 1762][projectLocality = LOCAL] => [custkey:bigint, totalprice:double, $hashvalue_101:bigint, >
                                                 $hashvalue_107 := combine_hash(combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey),>
                                             - LeftJoin[PlanNodeId 720][("custkey" = "custkey_1")][$hashvalue_101, $hashvalue_106] => [custkey:bigint, tota>
                                                     Distribution: PARTITIONED                                                                             >
                                                 - AssignUniqueId[PlanNodeId 708] => [custkey:bigint, totalprice:double, $hashvalue_101:bigint, unique_96:b>
                                                         Estimates: {source: CostBasedSourceInfo, rows: 15,000 (131.84kB), cpu: 1,215,000.00, memory: 0.00,>
                                                     - RemoteSource[2] => [custkey:bigint, totalprice:double, $hashvalue_101:bigint]                       >
                                                 - Project[PlanNodeId 1761][projectLocality = LOCAL] => [custkey_1:bigint, max:double, $hashvalue_106:bigin>
                                                         $hashvalue_106 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_1), BIGINT'0')) (1:>
                                                     - Aggregate(FINAL)[custkey_1][PlanNodeId 4] => [custkey_1:bigint, max:double]                         >
                                                             max := "presto.default.max"((max_98)) (1:47)                                                  >
                                                         - LocalExchange[PlanNodeId 1650][HASH][$hashvalue_103] (custkey_1) => [custkey_1:bigint, max_98:do>
                                                             - RemoteSource[3] => [custkey_1:bigint, max_98:double, $hashvalue_104:bigint]                 >
                     - Project[PlanNodeId 1765][projectLocality = LOCAL] => [custkey_34:bigint, min_51:double, $hashvalue_112:bigint]                      >
                             $hashvalue_112 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_34), BIGINT'0')) (1:100)                       >
                         - Aggregate(FINAL)[custkey_34][PlanNodeId 34] => [custkey_34:bigint, min_51:double]                                               >
                                 min_51 := "presto.default.min"((min_99)) (1:73)                                                                           >
                             - LocalExchange[PlanNodeId 1666][HASH][$hashvalue_109] (custkey_34) => [custkey_34:bigint, min_99:double, $hashvalue_109:bigin>
                                 - RemoteSource[4] => [custkey_34:bigint, min_99:double, $hashvalue_110:bigint]                                            >
                                                                                                                                                           >
 Fragment 2 [SOURCE]                                                                                                                                       >
     Output layout: [custkey, totalprice, $hashvalue_102]                                                                                                  >
     Output partitioning: HASH [custkey][$hashvalue_102]                                                                                                   >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - ScanProject[PlanNodeId 0,1759][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzeP>
             Estimates: {source: CostBasedSourceInfo, rows: 15,000 (395.51kB), cpu: 270,000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, >
             $hashvalue_102 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:294)                                          >
             LAYOUT: tpch.orders{}                                                                                                                         >
             custkey := custkey:bigint:1:REGULAR (1:294)                                                                                                   >
             totalprice := totalprice:double:3:REGULAR (1:294)                                                                                             >
                                                                                                                                                           >
 Fragment 3 [SOURCE]                                                                                                                                       >
     Output layout: [custkey_1, max_98, $hashvalue_105]                                                                                                    >
     Output partitioning: HASH [custkey_1][$hashvalue_105]                                                                                                 >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - Project[PlanNodeId 1760][projectLocality = LOCAL] => [custkey_1:bigint, max_98:double, $hashvalue_105:bigint]                                       >
             $hashvalue_105 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_1), BIGINT'0')) (1:133)                                        >
         - Aggregate(PARTIAL)[custkey_1][PlanNodeId 1654] => [custkey_1:bigint, max_98:double]                                                             >
                 max_98 := "presto.default.max"((totalprice_3)) (1:47)                                                                                     >
             - TableScan[PlanNodeId 1][TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartitio>
                     Estimates: {source: CostBasedSourceInfo, rows: 15,000 (395.51kB), cpu: 270,000.00, memory: 0.00, network: 0.00}                       >
                     LAYOUT: tpch.orders{}                                                                                                                 >
                     custkey_1 := custkey:bigint:1:REGULAR (1:117)                                                                                         >
                     totalprice_3 := totalprice:double:3:REGULAR (1:117)                                                                                   >
                                                                                                                                                           >
 Fragment 4 [SOURCE]                                                                                                                                       >
     Output layout: [custkey_34, min_99, $hashvalue_111]                                                                                                   >
     Output partitioning: HASH [custkey_34][$hashvalue_111]                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - Project[PlanNodeId 1764][projectLocality = LOCAL] => [custkey_34:bigint, min_99:double, $hashvalue_111:bigint]                                      >
             $hashvalue_111 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_34), BIGINT'0')) (1:133)                                       >
         - Aggregate(PARTIAL)[custkey_34][PlanNodeId 1670] => [custkey_34:bigint, min_99:double]                                                           >
                 min_99 := "presto.default.min"((totalprice_36)) (1:73)                                                                                    >
             - TableScan[PlanNodeId 31][TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartiti>
                     Estimates: {source: CostBasedSourceInfo, rows: 15,000 (395.51kB), cpu: 270,000.00, memory: 0.00, network: 0.00}                       >
                     LAYOUT: tpch.orders{}                                                                                                                 >
                     totalprice_36 := totalprice:double:3:REGULAR (1:117)                                                                                  >
                     custkey_34 := custkey:bigint:1:REGULAR (1:117)                                                                                        >
                                                                                                                                                           >
                                                                                                                                                           >
(1 row)
```

After fix with this PR
```
presto:tpch> explain (type distributed) with t1 as (select max(totalprice) maxprice, min(totalprice) minprice, custkey ckey from orders group by custkey), t2 as (select custkey, totalprice, (select maxprice from t1 where ckey = custkey) maxprice, (select minprice from t1 where ckey=custkey) minprice from orders) select custkey from t2 where (totalprice between minprice and maxprice) group by custkey;
                                                                                                                                                           >
----------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                       >
     Output layout: [custkey]                                                                                                                              >
     Output partitioning: SINGLE []                                                                                                                        >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - Output[PlanNodeId 74][custkey] => [custkey:bigint]                                                                                                  >
         - RemoteSource[1] => [custkey:bigint]                                                                                                             >
                                                                                                                                                           >
 Fragment 1 [HASH]                                                                                                                                         >
     Output layout: [custkey]                                                                                                                              >
     Output partitioning: SINGLE []                                                                                                                        >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - Aggregate[custkey][PlanNodeId 69] => [custkey:bigint]                                                                                               >
         - FilterProject[PlanNodeId 912,693][filterPredicate = (SWITCH(is_distinct, WHEN(BOOLEAN'true', BOOLEAN'true'), CAST(fail(INTEGER'28', VARCHAR'Scal>
             - Project[PlanNodeId 1767][projectLocality = LOCAL] => [custkey:bigint, totalprice:double, max:double, unique:bigint, min_51:double, is_distin>
                 - MarkDistinct[PlanNodeId 691][distinct=custkey:bigint, totalprice:double, max:double, unique:bigint marker=is_distinct][$hashvalue_113] =>
                     - Project[PlanNodeId 1766][projectLocality = LOCAL] => [custkey:bigint, totalprice:double, max:double, unique:bigint, min_51:double, $>
                             $hashvalue_113 := combine_hash(combine_hash(combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT>
                         - LeftJoin[PlanNodeId 702][("custkey" = "custkey_34")][$hashvalue_108, $hashvalue_112] => [custkey:bigint, totalprice:double, max:>
                                 Distribution: PARTITIONED                                                                                                 >
                             - AssignUniqueId[PlanNodeId 690] => [custkey:bigint, totalprice:double, max:double, $hashvalue_108:bigint, unique:bigint]     >
                                 - FilterProject[PlanNodeId 909,711][filterPredicate = SWITCH(is_distinct_97, WHEN(BOOLEAN'true', BOOLEAN'true'), CAST(fail>
                                         $hashvalue_108 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:294)              >
                                     - Project[PlanNodeId 1763][projectLocality = LOCAL] => [custkey:bigint, totalprice:double, unique_96:bigint, max:doubl>
                                         - MarkDistinct[PlanNodeId 709][distinct=custkey:bigint, totalprice:double, unique_96:bigint marker=is_distinct_97]>
                                             - LocalExchange[PlanNodeId 1619][HASH][$hashvalue] (custkey) => [custkey:bigint, totalprice:double, unique_96:>
                                                 - Project[PlanNodeId 1762][projectLocality = LOCAL] => [custkey:bigint, totalprice:double, $hashvalue_101:>
                                                         $hashvalue_107 := combine_hash(combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(c>
                                                     - LeftJoin[PlanNodeId 720][("custkey" = "custkey_1")][$hashvalue_101, $hashvalue_106] => [custkey:bigi>
                                                             Distribution: PARTITIONED                                                                     >
                                                         - AssignUniqueId[PlanNodeId 708] => [custkey:bigint, totalprice:double, $hashvalue_101:bigint, uni>
                                                                 Estimates: {source: CostBasedSourceInfo, rows: 15,000 (131.84kB), cpu: 1,215,000.00, memor>
                                                             - RemoteSource[2] => [custkey:bigint, totalprice:double, $hashvalue_101:bigint]               >
                                                         - Project[PlanNodeId 1761][projectLocality = LOCAL] => [custkey_1:bigint, max:double, $hashvalue_1>
                                                                 $hashvalue_106 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_1), BIGINT'>
                                                             - Aggregate(FINAL)[custkey_1][PlanNodeId 4] => [custkey_1:bigint, max:double]                 >
                                                                     max := "presto.default.max"((max_98)) (1:47)                                          >
                                                                 - LocalExchange[PlanNodeId 1650][HASH][$hashvalue_103] (custkey_1) => [custkey_1:bigint, m>
                                                                     - RemoteSource[3] => [custkey_1:bigint, max_98:double, $hashvalue_104:bigint]         >
                             - Project[PlanNodeId 1765][projectLocality = LOCAL] => [custkey_34:bigint, min_51:double, $hashvalue_112:bigint]              >
                                     $hashvalue_112 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_34), BIGINT'0')) (1:100)               >
                                 - Aggregate(FINAL)[custkey_34][PlanNodeId 34] => [custkey_34:bigint, min_51:double]                                       >
                                         min_51 := "presto.default.min"((min_99)) (1:73)                                                                   >
                                     - LocalExchange[PlanNodeId 1666][HASH][$hashvalue_109] (custkey_34) => [custkey_34:bigint, min_99:double, $hashvalue_1>
                                         - RemoteSource[4] => [custkey_34:bigint, min_99:double, $hashvalue_110:bigint]                                    >
                                                                                                                                                           >
 Fragment 2 [SOURCE]                                                                                                                                       >
     Output layout: [custkey, totalprice, $hashvalue_102]                                                                                                  >
     Output partitioning: HASH [custkey][$hashvalue_102]                                                                                                   >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - ScanProject[PlanNodeId 0,1759][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzeP>
             Estimates: {source: CostBasedSourceInfo, rows: 15,000 (395.51kB), cpu: 270,000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, >
             $hashvalue_102 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:294)                                          >
             LAYOUT: tpch.orders{}                                                                                                                         >
             custkey := custkey:bigint:1:REGULAR (1:294)                                                                                                   >
             totalprice := totalprice:double:3:REGULAR (1:294)                                                                                             >
                                                                                                                                                           >
 Fragment 3 [SOURCE]                                                                                                                                       >
     Output layout: [custkey_1, max_98, $hashvalue_105]                                                                                                    >
     Output partitioning: HASH [custkey_1][$hashvalue_105]                                                                                                 >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - Project[PlanNodeId 1760][projectLocality = LOCAL] => [custkey_1:bigint, max_98:double, $hashvalue_105:bigint]                                       >
             $hashvalue_105 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_1), BIGINT'0')) (1:133)                                        >
         - Aggregate(PARTIAL)[custkey_1][PlanNodeId 1654] => [custkey_1:bigint, max_98:double]                                                             >
                 max_98 := "presto.default.max"((totalprice_3)) (1:47)                                                                                     >
             - TableScan[PlanNodeId 1][TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartitio>
                     Estimates: {source: CostBasedSourceInfo, rows: 15,000 (395.51kB), cpu: 270,000.00, memory: 0.00, network: 0.00}                       >
                     LAYOUT: tpch.orders{}                                                                                                                 >
                     custkey_1 := custkey:bigint:1:REGULAR (1:117)                                                                                         >
                     totalprice_3 := totalprice:double:3:REGULAR (1:117)                                                                                   >
                                                                                                                                                           >
 Fragment 4 [SOURCE]                                                                                                                                       >
     Output layout: [custkey_34, min_99, $hashvalue_111]                                                                                                   >
     Output partitioning: HASH [custkey_34][$hashvalue_111]                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                         >
     - Project[PlanNodeId 1764][projectLocality = LOCAL] => [custkey_34:bigint, min_99:double, $hashvalue_111:bigint]                                      >
             $hashvalue_111 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_34), BIGINT'0')) (1:133)                                       >
         - Aggregate(PARTIAL)[custkey_34][PlanNodeId 1670] => [custkey_34:bigint, min_99:double]                                                           >
                 min_99 := "presto.default.min"((totalprice_36)) (1:73)                                                                                    >
             - TableScan[PlanNodeId 31][TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=orders, analyzePartiti>
                     Estimates: {source: CostBasedSourceInfo, rows: 15,000 (395.51kB), cpu: 270,000.00, memory: 0.00, network: 0.00}                       >
                     LAYOUT: tpch.orders{}                                                                                                                 >
                     totalprice_36 := totalprice:double:3:REGULAR (1:117)                                                                                  >
                     custkey_34 := custkey:bigint:1:REGULAR (1:117)                                                                                        >
                                                                                                                                                           >
                                                                                                                                                           >
(1 row)

```

After debugging, it's due to the fact that when spill is enabled, the order sensitive local properties will be removed. However, the local properties has hierarchy and cannot be simply removed. In this example, the properties are G(unique), C(custkey), C(totalprice) where unique is the unique key generated by the AssignUniqueId operator. Current logic will simply remove the G(unique) property and keeping the rest of the two. This is not right as the rest will not hold true after the first is removed.
This PR fix it by discarding the rest of properties if any previous properties are removed.

## Motivation and Context
Bug fix

## Impact
Fix potential incorrect plan

## Test Plan
Add unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix bug in local property calculation when spill is enabled :pr:`23922`
```

