### PR TITLE
Annotate REST endpoints properly

### DIFF
--- a/presto-proxy/src/main/java/com/facebook/presto/proxy/ProxyResource.java
+++ b/presto-proxy/src/main/java/com/facebook/presto/proxy/ProxyResource.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
 
 import javax.annotation.PreDestroy;
+import javax.annotation.security.PermitAll;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
@@ -87,6 +88,7 @@ import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.noContent;
 
 @Path("/")
+@PermitAll
 public class ProxyResource
 {
     private static final Logger log = Logger.get(ProxyResource.class);

--- a/presto-router/src/main/java/com/facebook/presto/router/RouterResource.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/RouterResource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.router.cluster.ClusterManager;
 import com.facebook.presto.router.cluster.RequestInfo;
 import com.google.inject.Inject;
 
+import javax.annotation.security.PermitAll;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -35,6 +36,7 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
 @Path("/")
+@PermitAll
 public class RouterResource
 {
     private static final Logger log = Logger.get(RouterResource.class);


### PR DESCRIPTION
## Description

If implemented, this will add `@PermitAll` annotations to ambiguous endpoints. `@PermitAll` is the default value if no other annotation is used.

## Motivation and Context
Resolves a static scan security issue:
https://blog.dejavu.sk/filtering-jax-rs-entities-with-standard-security-annotations/

## Impact
None

## Test Plan
UT tests


```
== NO RELEASE NOTE ==
```

