### PR TITLE
[native] Use row wise encoding in partitioned remote exchanges for wide data sets

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -332,6 +332,7 @@ public final class SystemSessionProperties
     private static final String NATIVE_EXECUTION_EXECUTABLE_PATH = "native_execution_executable_path";
     private static final String NATIVE_EXECUTION_PROGRAM_ARGUMENTS = "native_execution_program_arguments";
     public static final String NATIVE_EXECUTION_PROCESS_REUSE_ENABLED = "native_execution_process_reuse_enabled";
+    public static final String NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING = "native_min_columnar_encoding_channels_to_prefer_row_wise_encoding";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1824,6 +1825,11 @@ public final class SystemSessionProperties
                 booleanProperty(INLINE_PROJECTIONS_ON_VALUES,
                         "Whether to evaluate project node on values node",
                         featuresConfig.getInlineProjectionsOnValues(),
+                        false),
+                integerProperty(
+                        NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING,
+                        "Minimum number of columnar encoding channels to consider row wise encoding for partitioned exchange. Native execution only",
+                        queryManagerConfig.getMinColumnarEncodingChannelsToPreferRowWiseEncoding(),
                         false));
     }
 
@@ -3099,5 +3105,10 @@ public final class SystemSessionProperties
     public static boolean isInlineProjectionsOnValues(Session session)
     {
         return session.getSystemProperty(INLINE_PROJECTIONS_ON_VALUES, Boolean.class);
+    }
+
+    public static int getMinColumnarEncodingChannelsToPreferRowWiseEncoding(Session session)
+    {
+        return session.getSystemProperty(NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING, Integer.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -100,6 +100,8 @@ public class QueryManagerConfig
     private int rateLimiterCacheLimit = 1000;
     private int rateLimiterCacheWindowMinutes = 5;
 
+    private int minColumnarEncodingChannelsToPreferRowWiseEncoding = 1000;
+
     @Min(1)
     public int getScheduleSplitBatchSize()
     {
@@ -735,6 +737,19 @@ public class QueryManagerConfig
     public QueryManagerConfig setEnableWorkerIsolation(boolean enableWorkerIsolation)
     {
         this.enableWorkerIsolation = enableWorkerIsolation;
+        return this;
+    }
+
+    public int getMinColumnarEncodingChannelsToPreferRowWiseEncoding()
+    {
+        return minColumnarEncodingChannelsToPreferRowWiseEncoding;
+    }
+
+    @Config("min-columnar-encoding-channels-to-prefer-row-wise-encoding")
+    @ConfigDescription("Minimum number of columnar encoding channels to consider row wise encoding for partitioned exchange. Native execution only")
+    public QueryManagerConfig setMinColumnarEncodingChannelsToPreferRowWiseEncoding(int minColumnarEncodingChannelsToPreferRowWiseEncoding)
+    {
+        this.minColumnarEncodingChannelsToPreferRowWiseEncoding = minColumnarEncodingChannelsToPreferRowWiseEncoding;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/TemporaryTableUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/TemporaryTableUtil.java
@@ -64,6 +64,7 @@ import static com.facebook.presto.SystemSessionProperties.getTaskPartitionedWrit
 import static com.facebook.presto.SystemSessionProperties.isTableWriterMergeOperatorEnabled;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.plan.ExchangeEncoding.COLUMNAR;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
@@ -284,6 +285,7 @@ public class TemporaryTableUtil
                 outputs,
                 Optional.empty(),
                 false,
+                COLUMNAR,
                 Optional.empty());
 
         ExchangeNode writerRemoteSource = new ExchangeNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -288,6 +288,8 @@ public class FeaturesConfig
     private boolean eagerPlanValidationEnabled;
     private int eagerPlanValidationThreadPoolSize = 20;
 
+    private boolean prestoSparkExecutionEnvironment;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2845,5 +2847,17 @@ public class FeaturesConfig
     public int getEagerPlanValidationThreadPoolSize()
     {
         return this.eagerPlanValidationThreadPoolSize;
+    }
+
+    public boolean isPrestoSparkExecutionEnvironment()
+    {
+        return prestoSparkExecutionEnvironment;
+    }
+
+    @Config("presto-spark-execution-environment")
+    public FeaturesConfig setPrestoSparkExecutionEnvironment(boolean prestoSparkExecutionEnvironment)
+    {
+        this.prestoSparkExecutionEnvironment = prestoSparkExecutionEnvironment;
+        return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -305,7 +305,16 @@ public abstract class BasePlanFragmenter
                 .map(PlanFragment::getId)
                 .collect(toImmutableList());
 
-        return new RemoteSourceNode(exchange.getSourceLocation(), exchange.getId(), exchange.getStatsEquivalentPlanNode(), childrenIds, exchange.getOutputVariables(), exchange.isEnsureSourceOrdering(), exchange.getOrderingScheme(), exchange.getType());
+        return new RemoteSourceNode(
+                exchange.getSourceLocation(),
+                exchange.getId(),
+                exchange.getStatsEquivalentPlanNode(),
+                childrenIds,
+                exchange.getOutputVariables(),
+                exchange.isEnsureSourceOrdering(),
+                exchange.getOrderingScheme(),
+                exchange.getType(),
+                exchange.getPartitioningScheme().getEncoding());
     }
 
     protected void setDistributionForExchange(ExchangeNode.Type exchangeType, PartitioningScheme partitioningScheme, RewriteContext<FragmentProperties> context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -324,11 +324,6 @@ import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZ
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.createSymbolReference;
 import static com.facebook.presto.sql.gen.LambdaBytecodeGenerator.compileLambdaProvider;
 import static com.facebook.presto.sql.planner.RowExpressionInterpreter.rowExpressionInterpreter;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SCALED_WRITER_DISTRIBUTION;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
@@ -539,11 +534,7 @@ public class LocalExecutionPlanner
 
     private OutputFactory createOutputFactory(TaskContext taskContext, PartitioningScheme partitioningScheme, OutputBuffer outputBuffer)
     {
-        if (partitioningScheme.getPartitioning().getHandle().equals(FIXED_BROADCAST_DISTRIBUTION) ||
-                partitioningScheme.getPartitioning().getHandle().equals(FIXED_ARBITRARY_DISTRIBUTION) ||
-                partitioningScheme.getPartitioning().getHandle().equals(SCALED_WRITER_DISTRIBUTION) ||
-                partitioningScheme.getPartitioning().getHandle().equals(SINGLE_DISTRIBUTION) ||
-                partitioningScheme.getPartitioning().getHandle().equals(COORDINATOR_DISTRIBUTION)) {
+        if (partitioningScheme.isSingleOrBroadcastOrArbitrary()) {
             return new TaskOutputFactory(outputBuffer);
         }
 
@@ -557,11 +548,7 @@ public class LocalExecutionPlanner
 
     private Optional<OutputPartitioning> createOutputPartitioning(TaskContext taskContext, PartitioningScheme partitioningScheme)
     {
-        if (partitioningScheme.getPartitioning().getHandle().equals(FIXED_BROADCAST_DISTRIBUTION) ||
-                partitioningScheme.getPartitioning().getHandle().equals(FIXED_ARBITRARY_DISTRIBUTION) ||
-                partitioningScheme.getPartitioning().getHandle().equals(SCALED_WRITER_DISTRIBUTION) ||
-                partitioningScheme.getPartitioning().getHandle().equals(SINGLE_DISTRIBUTION) ||
-                partitioningScheme.getPartitioning().getHandle().equals(COORDINATOR_DISTRIBUTION)) {
+        if (partitioningScheme.isSingleOrBroadcastOrArbitrary()) {
             return Optional.empty();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
@@ -229,6 +229,7 @@ public class PlanFragmenterUtils
                         outputPartitioningScheme.getOutputLayout(),
                         outputPartitioningScheme.getHashColumn(),
                         outputPartitioningScheme.isReplicateNullsAndAny(),
+                        outputPartitioningScheme.getEncoding(),
                         outputPartitioningScheme.getBucketToPartition()),
                 fragment.getStageExecutionDescriptor(),
                 fragment.isOutputTableWriterFragment(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -35,6 +35,7 @@ import com.facebook.presto.sql.planner.iterative.rule.CrossJoinWithArrayNotConta
 import com.facebook.presto.sql.planner.iterative.rule.CrossJoinWithOrFilterToInnerJoin;
 import com.facebook.presto.sql.planner.iterative.rule.DesugarLambdaExpression;
 import com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType;
+import com.facebook.presto.sql.planner.iterative.rule.DetermineRemotePartitionedExchangeEncoding;
 import com.facebook.presto.sql.planner.iterative.rule.DetermineSemiJoinDistributionType;
 import com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroLimit;
@@ -929,7 +930,14 @@ public class PlanOptimizers
 
         // Precomputed hashes - this assumes that partitioning will not change
         builder.add(new HashGenerationOptimizer(metadata.getFunctionAndTypeManager()));
-
+        builder.add(new IterativeOptimizer(
+                metadata,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.of(new DetermineRemotePartitionedExchangeEncoding(
+                        featuresConfig.isNativeExecutionEnabled(),
+                        featuresConfig.isPrestoSparkExecutionEnvironment()))));
         builder.add(new MetadataDeleteOptimizer(metadata));
 
         // TODO: consider adding a formal final plan sanitization optimizer that prepares the plan for transmission/execution/logging

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
@@ -101,13 +101,25 @@ public final class SystemPartitioningHandle
     @Override
     public boolean isSingleNode()
     {
-        return partitioning == SystemPartitioning.COORDINATOR_ONLY || partitioning == SystemPartitioning.SINGLE;
+        return function == SystemPartitionFunction.SINGLE;
     }
 
     @Override
     public boolean isCoordinatorOnly()
     {
         return partitioning == SystemPartitioning.COORDINATOR_ONLY;
+    }
+
+    @Override
+    public boolean isBroadcast()
+    {
+        return function == SystemPartitionFunction.BROADCAST;
+    }
+
+    @Override
+    public boolean isArbitrary()
+    {
+        return function == SystemPartitionFunction.ROUND_ROBIN;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineRemotePartitionedExchangeEncoding.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineRemotePartitionedExchangeEncoding.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.FixedWidthType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.google.common.annotations.VisibleForTesting;
+
+import static com.facebook.presto.SystemSessionProperties.getMinColumnarEncodingChannelsToPreferRowWiseEncoding;
+import static com.facebook.presto.spi.plan.ExchangeEncoding.ROW_WISE;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.sql.planner.plan.Patterns.Exchange.scope;
+import static com.facebook.presto.sql.planner.plan.Patterns.Exchange.type;
+import static com.facebook.presto.sql.planner.plan.Patterns.exchange;
+
+public class DetermineRemotePartitionedExchangeEncoding
+        implements Rule<ExchangeNode>
+{
+    private static final Pattern<ExchangeNode> PATTERN = exchange()
+            .with(scope().equalTo(REMOTE_STREAMING))
+            .with(type().equalTo(REPARTITION));
+
+    private final boolean nativeExecution;
+    private final boolean prestoSparkExecutionEnvironment;
+
+    public DetermineRemotePartitionedExchangeEncoding(boolean nativeExecution, boolean prestoSparkExecutionEnvironment)
+    {
+        this.nativeExecution = nativeExecution;
+        this.prestoSparkExecutionEnvironment = prestoSparkExecutionEnvironment;
+    }
+
+    @Override
+    public Pattern<ExchangeNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return nativeExecution || prestoSparkExecutionEnvironment;
+    }
+
+    @Override
+    public Result apply(ExchangeNode node, Captures captures, Context context)
+    {
+        if (prestoSparkExecutionEnvironment) {
+            // In Presto on Spark, row-wise encoding is always used for non-special shuffles (i.e., excluding broadcast, single, and arbitrary shuffles).
+            // To accurately reflect this in the plan, the exchange encoding is set here.
+            // Presto on Spark does not check the ExchangeEncoding specified in the plan.
+            return determineForPrestoOnSpark(node);
+        }
+        if (nativeExecution) {
+            return determineForNativeExecution(context.getSession(), node);
+        }
+        // Presto Java runtime does not support row-wise encoding
+        return Result.empty();
+    }
+
+    private Result determineForPrestoOnSpark(ExchangeNode node)
+    {
+        // keep columnar for special cases
+        if (node.getPartitioningScheme().isSingleOrBroadcastOrArbitrary()) {
+            return Result.empty();
+        }
+        if (node.getPartitioningScheme().getEncoding() == ROW_WISE) {
+            // leave untouched if already visited
+            return Result.empty();
+        }
+        // otherwise switch to row-wise
+        return Result.ofPlanNode(node.withRowWiseEncoding());
+    }
+
+    private Result determineForNativeExecution(Session session, ExchangeNode node)
+    {
+        // keep columnar for special cases
+        if (node.getPartitioningScheme().isSingleOrBroadcastOrArbitrary()) {
+            return Result.empty();
+        }
+        if (node.getPartitioningScheme().getEncoding() == ROW_WISE) {
+            // leave untouched if already visited
+            return Result.empty();
+        }
+        int minChannelsToPreferRowWiseEncoding = getMinColumnarEncodingChannelsToPreferRowWiseEncoding(session);
+        if (estimateNumberOfOutputColumnarChannels(node) >= minChannelsToPreferRowWiseEncoding) {
+            return Result.ofPlanNode(node.withRowWiseEncoding());
+        }
+        return Result.empty();
+    }
+
+    @VisibleForTesting
+    static long estimateNumberOfOutputColumnarChannels(ExchangeNode node)
+    {
+        return node.getOutputVariables().stream()
+                .map(VariableReferenceExpression::getType)
+                .mapToLong(DetermineRemotePartitionedExchangeEncoding::estimateNumberOfColumnarChannels)
+                .sum();
+    }
+
+    @VisibleForTesting
+    static long estimateNumberOfColumnarChannels(Type type)
+    {
+        if (type instanceof FixedWidthType) {
+            // nulls and values
+            return 2;
+        }
+        if (!type.getTypeParameters().isEmpty()) {
+            // complex type
+            // nulls and offsets
+            long result = 2;
+            for (Type parameter : type.getTypeParameters()) {
+                result += estimateNumberOfColumnarChannels(parameter);
+            }
+            return result;
+        }
+        // nulls, offsets, values
+        return 3;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -233,6 +233,7 @@ public class PushPartialAggregationThroughExchange
                 aggregationOutputs,
                 exchange.getPartitioningScheme().getHashColumn(),
                 exchange.getPartitioningScheme().isReplicateNullsAndAny(),
+                exchange.getPartitioningScheme().getEncoding(),
                 exchange.getPartitioningScheme().getBucketToPartition());
 
         return new ExchangeNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughExchange.java
@@ -146,6 +146,7 @@ public class PushProjectionThroughExchange
                 outputBuilder.build(),
                 exchange.getPartitioningScheme().getHashColumn(),
                 exchange.getPartitioningScheme().isReplicateNullsAndAny(),
+                exchange.getPartitioningScheme().getEncoding(),
                 exchange.getPartitioningScheme().getBucketToPartition());
 
         PlanNode result = new ExchangeNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushRemoteExchangeThroughAssignUniqueId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushRemoteExchangeThroughAssignUniqueId.java
@@ -81,6 +81,7 @@ public final class PushRemoteExchangeThroughAssignUniqueId
                                 removeVariable(partitioningScheme.getOutputLayout(), assignUniqueId.getIdVariable()),
                                 partitioningScheme.getHashColumn(),
                                 partitioningScheme.isReplicateNullsAndAny(),
+                                partitioningScheme.getEncoding(),
                                 partitioningScheme.getBucketToPartition()),
                         ImmutableList.of(assignUniqueId.getSource()),
                         ImmutableList.of(removeVariable(getOnlyElement(node.getInputs()), assignUniqueId.getIdVariable())),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushRemoteExchangeThroughGroupId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushRemoteExchangeThroughGroupId.java
@@ -152,6 +152,7 @@ public final class PushRemoteExchangeThroughGroupId
                                 outputLayout,
                                 partitioningScheme.getHashColumn(),
                                 partitioningScheme.isReplicateNullsAndAny(),
+                                partitioningScheme.getEncoding(),
                                 partitioningScheme.getBucketToPartition()),
                         ImmutableList.of(groupIdNode.getSource()),
                         ImmutableList.of(inputs),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -120,6 +120,7 @@ import static com.facebook.presto.SystemSessionProperties.preferStreamingOperato
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.hasSingleNodeExecutionPreference;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.plan.ExchangeEncoding.COLUMNAR;
 import static com.facebook.presto.spi.plan.LimitNode.Step.PARTIAL;
 import static com.facebook.presto.sql.planner.FragmentTableScanCounter.getNumberOfTableScans;
 import static com.facebook.presto.sql.planner.FragmentTableScanCounter.hasMultipleTableScans;
@@ -1034,6 +1035,7 @@ public class AddExchanges
                                         filteringSource.getNode().getOutputVariables(),
                                         Optional.empty(),
                                         true,
+                                        COLUMNAR,
                                         Optional.empty())),
                                 filteringSource.getProperties());
                     }
@@ -1075,6 +1077,7 @@ public class AddExchanges
                                     filteringSource.getNode().getOutputVariables(),
                                     Optional.empty(),
                                     true,
+                                    COLUMNAR,
                                     Optional.empty())),
                             filteringSource.getProperties());
                 }
@@ -1250,6 +1253,7 @@ public class AddExchanges
                                                 source.getNode().getOutputVariables(),
                                                 Optional.empty(),
                                                 nullsAndAnyReplicated,
+                                                COLUMNAR,
                                                 Optional.empty())),
                                 source.getProperties());
                     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -587,6 +587,7 @@ public class HashGenerationOptimizer
                             .build(),
                     partitionVariables.map(newHashVariables::get),
                     partitioningScheme.isReplicateNullsAndAny(),
+                    partitioningScheme.getEncoding(),
                     partitioningScheme.getBucketToPartition());
 
             // add hash variables to sources

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergePartialAggregationsWithFilter.java
@@ -356,6 +356,7 @@ public class MergePartialAggregationsWithFilter
                         children.get(children.size() - 1).getOutputVariables(),
                         node.getPartitioningScheme().getHashColumn(),
                         node.getPartitioningScheme().isReplicateNullsAndAny(),
+                        node.getPartitioningScheme().getEncoding(),
                         node.getPartitioningScheme().getBucketToPartition());
 
                 return new ExchangeNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PartitioningUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PartitioningUtils.java
@@ -344,7 +344,7 @@ public class PartitioningUtils
                 .map(oldOutputLayout::indexOf)
                 .map(newOutputLayout::get);
 
-        return new PartitioningScheme(newPartitioning, newOutputLayout, newHashSymbol, partitioningScheme.isReplicateNullsAndAny(), partitioningScheme.getBucketToPartition());
+        return new PartitioningScheme(newPartitioning, newOutputLayout, newHashSymbol, partitioningScheme.isReplicateNullsAndAny(), partitioningScheme.getEncoding(), partitioningScheme.getBucketToPartition());
     }
 
     // Translates VariableReferenceExpression in arguments according to translator, keeps other arguments unchanged.

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -169,6 +169,7 @@ public class PruneUnreferencedOutputs
                     newOutputVariables,
                     node.getPartitioningScheme().getHashColumn(),
                     node.getPartitioningScheme().isReplicateNullsAndAny(),
+                    node.getPartitioningScheme().getEncoding(),
                     node.getPartitioningScheme().getBucketToPartition());
 
             ImmutableList.Builder<PlanNode> rewrittenSources = ImmutableList.builder();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -305,6 +305,7 @@ public class SymbolMapper
                 mapAndDistinctVariable(source.getOutputVariables()),
                 scheme.getHashColumn().map(this::map),
                 scheme.isReplicateNullsAndAny(),
+                scheme.getEncoding(),
                 scheme.getBucketToPartition());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -334,6 +334,7 @@ public class UnaliasSymbolReferences
                     outputs.build(),
                     canonicalize(node.getPartitioningScheme().getHashColumn()),
                     node.getPartitioningScheme().isReplicateNullsAndAny(),
+                    node.getPartitioningScheme().getEncoding(),
                     node.getPartitioningScheme().getBucketToPartition());
 
             Optional<OrderingScheme> orderingScheme = node.getOrderingScheme().map(this::canonicalizeAndDistinct);
@@ -398,7 +399,8 @@ public class UnaliasSymbolReferences
                     canonicalizeAndDistinct(node.getOutputVariables()),
                     node.isEnsureSourceOrdering(),
                     node.getOrderingScheme().map(this::canonicalizeAndDistinct),
-                    node.getExchangeType());
+                    node.getExchangeType(),
+                    node.getEncoding());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -316,4 +316,17 @@ public class Patterns
             return property("rows", ValuesNode::getRows);
         }
     }
+
+    public static class Exchange
+    {
+        public static Property<ExchangeNode, ExchangeNode.Scope> scope()
+        {
+            return property("scope", ExchangeNode::getScope);
+        }
+
+        public static Property<ExchangeNode, ExchangeNode.Type> type()
+        {
+            return property("type", ExchangeNode::getType);
+        }
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RemoteSourceNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RemoteSourceNode.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.plan.ExchangeEncoding;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanFragmentId;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -28,6 +29,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.spi.plan.ExchangeEncoding.COLUMNAR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -40,6 +42,7 @@ public class RemoteSourceNode
     private final boolean ensureSourceOrdering;
     private final Optional<OrderingScheme> orderingScheme;
     private final ExchangeNode.Type exchangeType; // This is needed to "unfragment" to compute stats correctly.
+    private final ExchangeEncoding encoding;
 
     public RemoteSourceNode(
             Optional<SourceLocation> sourceLocation,
@@ -49,7 +52,8 @@ public class RemoteSourceNode
             List<VariableReferenceExpression> outputVariables,
             boolean ensureSourceOrdering,
             Optional<OrderingScheme> orderingScheme,
-            ExchangeNode.Type exchangeType)
+            ExchangeNode.Type exchangeType,
+            ExchangeEncoding encoding)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
 
@@ -58,6 +62,7 @@ public class RemoteSourceNode
         this.ensureSourceOrdering = ensureSourceOrdering;
         this.orderingScheme = requireNonNull(orderingScheme, "orderingScheme is null");
         this.exchangeType = requireNonNull(exchangeType, "exchangeType is null");
+        this.encoding = requireNonNull(encoding, "encoding is null");
     }
 
     @JsonCreator
@@ -68,9 +73,10 @@ public class RemoteSourceNode
             @JsonProperty("outputVariables") List<VariableReferenceExpression> outputVariables,
             @JsonProperty("ensureSourceOrdering") boolean ensureSourceOrdering,
             @JsonProperty("orderingScheme") Optional<OrderingScheme> orderingScheme,
-            @JsonProperty("exchangeType") ExchangeNode.Type exchangeType)
+            @JsonProperty("exchangeType") ExchangeNode.Type exchangeType,
+            @JsonProperty("encoding") ExchangeEncoding encoding)
     {
-        this(sourceLocation, id, Optional.empty(), sourceFragmentIds, outputVariables, ensureSourceOrdering, orderingScheme, exchangeType);
+        this(sourceLocation, id, Optional.empty(), sourceFragmentIds, outputVariables, ensureSourceOrdering, orderingScheme, exchangeType, encoding);
     }
 
     public RemoteSourceNode(
@@ -82,7 +88,7 @@ public class RemoteSourceNode
             Optional<OrderingScheme> orderingScheme,
             ExchangeNode.Type exchangeType)
     {
-        this(sourceLocation, id, ImmutableList.of(sourceFragmentId), outputVariables, ensureSourceOrdering, orderingScheme, exchangeType);
+        this(sourceLocation, id, ImmutableList.of(sourceFragmentId), outputVariables, ensureSourceOrdering, orderingScheme, exchangeType, COLUMNAR);
     }
 
     @Override
@@ -122,6 +128,12 @@ public class RemoteSourceNode
         return exchangeType;
     }
 
+    @JsonProperty
+    public ExchangeEncoding getEncoding()
+    {
+        return encoding;
+    }
+
     @Override
     public <R, C> R accept(InternalPlanVisitor<R, C> visitor, C context)
     {
@@ -138,6 +150,6 @@ public class RemoteSourceNode
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new RemoteSourceNode(getSourceLocation(), getId(), statsEquivalentPlanNode, sourceFragmentIds, outputVariables, ensureSourceOrdering, orderingScheme, exchangeType);
+        return new RemoteSourceNode(getSourceLocation(), getId(), statsEquivalentPlanNode, sourceFragmentIds, outputVariables, ensureSourceOrdering, orderingScheme, exchangeType, encoding);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -426,6 +426,7 @@ public class PlanPrinter
                     Joiner.on(", ").join(partitioningScheme.getPartitioning().getArguments()),
                     formatHash(partitioningScheme.getHashColumn())));
         }
+        builder.append(indentString(1)).append(format("Output encoding: %s%n", fragment.getPartitioningScheme().getEncoding()));
         builder.append(indentString(1)).append(format("Stage Execution Strategy: %s%n", fragment.getStageExecutionDescriptor().getStageExecutionStrategy()));
 
         TypeProvider typeProvider = TypeProvider.fromVariables(fragment.getVariables());
@@ -1220,8 +1221,9 @@ public class PlanPrinter
             else {
                 addNode(node,
                         format("%sExchange", UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, node.getScope().toString())),
-                        format("[%s%s]%s",
+                        format("[%s - %s%s]%s",
                                 node.getType(),
+                                node.getPartitioningScheme().getEncoding(),
                                 node.getPartitioningScheme().isReplicateNullsAndAny() ? " - REPLICATE NULLS AND ANY" : "",
                                 formatHash(node.getPartitioningScheme().getHashColumn())));
             }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -83,7 +83,8 @@ public class TestQueryManagerConfig
                 .setRateLimiterBucketMaxSize(100)
                 .setRateLimiterCacheLimit(1000)
                 .setRateLimiterCacheWindowMinutes(5)
-                .setEnableWorkerIsolation(false));
+                .setEnableWorkerIsolation(false)
+                .setMinColumnarEncodingChannelsToPreferRowWiseEncoding(1000));
     }
 
     @Test
@@ -137,7 +138,7 @@ public class TestQueryManagerConfig
                 .put("query-manager.rate-limiter-cache-window-minutes", "60")
                 .put("query.cte-partitioning-provider-catalog", "hive")
                 .put("query-manager.enable-worker-isolation", "true")
-
+                .put("min-columnar-encoding-channels-to-prefer-row-wise-encoding", "123")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -188,7 +189,8 @@ public class TestQueryManagerConfig
                 .setRateLimiterCacheLimit(10000)
                 .setRateLimiterCacheWindowMinutes(60)
                 .setCtePartitioningProviderCatalog("hive")
-                .setEnableWorkerIsolation(true);
+                .setEnableWorkerIsolation(true)
+                .setMinColumnarEncodingChannelsToPreferRowWiseEncoding(123);
         ConfigAssertions.assertFullMapping(properties, expected);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.execution.SqlStageExecution.createSqlStageExecution;
 import static com.facebook.presto.execution.buffer.OutputBuffers.BufferType.ARBITRARY;
 import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
+import static com.facebook.presto.spi.plan.ExchangeEncoding.COLUMNAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
@@ -163,7 +164,8 @@ public class TestSqlStageExecution
                 ImmutableList.of(new VariableReferenceExpression(Optional.empty(), "column", VARCHAR)),
                 false,
                 Optional.empty(),
-                REPARTITION);
+                REPARTITION,
+                COLUMNAR);
 
         return new PlanFragment(
                 new PlanFragmentId(0),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
@@ -66,6 +66,7 @@ import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.execution.SqlStageExecution.createSqlStageExecution;
 import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
+import static com.facebook.presto.spi.plan.ExchangeEncoding.COLUMNAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
@@ -183,7 +184,8 @@ public class TestAdaptivePhasedExecutionPolicy
                 ImmutableList.of(new VariableReferenceExpression(Optional.empty(), "column", VARCHAR)),
                 false,
                 Optional.empty(),
-                REPARTITION);
+                REPARTITION,
+                COLUMNAR);
         return planNode;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.plan.ExchangeEncoding.COLUMNAR;
 import static com.facebook.presto.spi.plan.JoinDistributionType.REPLICATED;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
 import static com.facebook.presto.spi.plan.JoinType.RIGHT;
@@ -164,7 +165,8 @@ public class TestPhasedExecutionSchedule
                 fragments[0].getPartitioningScheme().getOutputLayout(),
                 false,
                 Optional.empty(),
-                REPARTITION);
+                REPARTITION,
+                COLUMNAR);
 
         return createFragment(planNode);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -246,7 +246,8 @@ public class TestFeaturesConfig
                 .setUseHistograms(false)
                 .setInlineProjectionsOnValues(false)
                 .setEagerPlanValidationEnabled(false)
-                .setEagerPlanValidationThreadPoolSize(20));
+                .setEagerPlanValidationThreadPoolSize(20)
+                .setPrestoSparkExecutionEnvironment(false));
     }
 
     @Test
@@ -442,6 +443,7 @@ public class TestFeaturesConfig
                 .put("optimizer.inline-projections-on-values", "true")
                 .put("eager-plan-validation-enabled", "true")
                 .put("eager-plan-validation-thread-pool-size", "2")
+                .put("presto-spark-execution-environment", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -634,7 +636,8 @@ public class TestFeaturesConfig
                 .setUseHistograms(true)
                 .setInlineProjectionsOnValues(true)
                 .setEagerPlanValidationEnabled(true)
-                .setEagerPlanValidationThreadPoolSize(2);
+                .setEagerPlanValidationThreadPoolSize(2)
+                .setPrestoSparkExecutionEnvironment(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
@@ -346,7 +346,7 @@ public class TestCanonicalPlanGenerator
                         .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
-                ImmutableSet.of("partitioning", "outputLayout", "hashColumn", "replicateNullsAndAny", "bucketToPartition"));
+                ImmutableSet.of("partitioning", "outputLayout", "hashColumn", "replicateNullsAndAny", "encoding", "bucketToPartition"));
         assertEquals(
                 Arrays.stream(Partitioning.class.getDeclaredFields())
                         .filter(f -> !f.isSynthetic())

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineRemotePartitionedExchangeEncoding.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineRemotePartitionedExchangeEncoding.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.ExchangeEncoding;
+import com.facebook.presto.spi.plan.Partitioning;
+import com.facebook.presto.spi.plan.PartitioningHandle;
+import com.facebook.presto.spi.plan.PartitioningScheme;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.assertions.MatchResult;
+import com.facebook.presto.sql.planner.assertions.Matcher;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.assertions.SymbolAliases;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.SystemSessionProperties.NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.plan.ExchangeEncoding.ROW_WISE;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.iterative.rule.DetermineRemotePartitionedExchangeEncoding.estimateNumberOfColumnarChannels;
+import static com.facebook.presto.sql.planner.iterative.rule.DetermineRemotePartitionedExchangeEncoding.estimateNumberOfOutputColumnarChannels;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.partitionedExchange;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestDetermineRemotePartitionedExchangeEncoding
+{
+    private static final int MIN_COLUMNAR_STREAMS = 100;
+
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        tester.close();
+        tester = null;
+    }
+
+    @Test
+    public void testPrestoOnSpark()
+    {
+        // special exchanges are always columnar
+        assertForPrestoOnSpark()
+                .on(p -> createExchange(FIXED_ARBITRARY_DISTRIBUTION, MIN_COLUMNAR_STREAMS))
+                .doesNotFire();
+        // do not fire twice
+        assertForPrestoOnSpark()
+                .on(p -> createExchange(FIXED_HASH_DISTRIBUTION, MIN_COLUMNAR_STREAMS).withRowWiseEncoding())
+                .doesNotFire();
+        // hash based exchanges are always row wise in Presto on Spark
+        assertForPrestoOnSpark()
+                .on(p -> createExchange(FIXED_HASH_DISTRIBUTION, MIN_COLUMNAR_STREAMS - 1))
+                .matches(exchangeEncoding(ROW_WISE));
+    }
+
+    @Test
+    public void testPresto()
+    {
+        // exchanges are always columnar in Presto
+        assertForPresto()
+                .on(p -> createExchange(FIXED_ARBITRARY_DISTRIBUTION, MIN_COLUMNAR_STREAMS))
+                .doesNotFire();
+        assertForPresto()
+                .on(p -> createExchange(FIXED_HASH_DISTRIBUTION, MIN_COLUMNAR_STREAMS - 1))
+                .doesNotFire();
+        assertForPresto()
+                .on(p -> createExchange(FIXED_HASH_DISTRIBUTION, MIN_COLUMNAR_STREAMS + 1))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNative()
+    {
+        // special exchanges are always columnar
+        assertForNative()
+                .on(p -> createExchange(FIXED_ARBITRARY_DISTRIBUTION, MIN_COLUMNAR_STREAMS))
+                .doesNotFire();
+        // hash based exchange with the total number of output columnar streams lower than threshold is columnar
+        assertForNative()
+                .on(p -> createExchange(FIXED_HASH_DISTRIBUTION, MIN_COLUMNAR_STREAMS - 1))
+                .doesNotFire();
+        // otherwise row wise
+        assertForNative()
+                .on(p -> createExchange(FIXED_HASH_DISTRIBUTION, MIN_COLUMNAR_STREAMS))
+                .matches(exchangeEncoding(ROW_WISE));
+    }
+
+    private RuleAssert assertForPrestoOnSpark()
+    {
+        return createAssert(false, true);
+    }
+
+    private RuleAssert assertForNative()
+    {
+        return createAssert(true, false);
+    }
+
+    private RuleAssert assertForPresto()
+    {
+        return createAssert(false, false);
+    }
+
+    private RuleAssert createAssert(boolean nativeExecution, boolean prestoSparkExecutionEnvironment)
+    {
+        return tester.assertThat(new DetermineRemotePartitionedExchangeEncoding(nativeExecution, prestoSparkExecutionEnvironment))
+                .setSystemProperty(NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING, MIN_COLUMNAR_STREAMS + "");
+    }
+
+    private static ExchangeNode createExchange(PartitioningHandle handle, int numberOfOutputColumnarStreams)
+    {
+        int numberOfBigintColumns = numberOfOutputColumnarStreams / 2;
+        List<Type> types = IntStream.range(0, numberOfBigintColumns)
+                .mapToObj(i -> BIGINT)
+                .collect(toImmutableList());
+        ExchangeNode exchangeNode = createExchangeNode(handle, types, types);
+        assertEquals(estimateNumberOfOutputColumnarChannels(exchangeNode), numberOfBigintColumns * 2);
+        return exchangeNode;
+    }
+
+    private static PlanMatchPattern exchangeEncoding(ExchangeEncoding encoding)
+    {
+        return node(ExchangeNode.class, node(ValuesNode.class)).with(new ExchangeEncodingMatcher(encoding));
+    }
+
+    @Test
+    public void testEstimateNumberOfOutputColumnarChannels()
+    {
+        assertEquals(estimateNumberOfOutputColumnarChannels(createExchangeNode(FIXED_HASH_DISTRIBUTION, ImmutableList.of(BIGINT), ImmutableList.of(BIGINT))), 2);
+        assertEquals(estimateNumberOfOutputColumnarChannels(createExchangeNode(FIXED_HASH_DISTRIBUTION, ImmutableList.of(BIGINT, VARCHAR), ImmutableList.of(BIGINT))), 2);
+    }
+
+    private static ExchangeNode createExchangeNode(PartitioningHandle handle, List<Type> inputTypes, List<Type> outputTypes)
+    {
+        return partitionedExchange(
+                new PlanNodeId("exchange"),
+                REMOTE_STREAMING,
+                new ValuesNode(
+                        Optional.empty(),
+                        new PlanNodeId("values"),
+                        createExpressions(inputTypes),
+                        ImmutableList.of(),
+                        Optional.empty()),
+                new PartitioningScheme(
+                        Partitioning.create(handle, ImmutableList.of()),
+                        createExpressions(outputTypes)));
+    }
+
+    private static List<VariableReferenceExpression> createExpressions(List<Type> types)
+    {
+        ImmutableList.Builder<VariableReferenceExpression> result = ImmutableList.builder();
+        for (int i = 0; i < types.size(); i++) {
+            result.add(new VariableReferenceExpression(Optional.empty(), "exp_" + i, types.get(i)));
+        }
+        return result.build();
+    }
+
+    @Test
+    public void testEstimateNumberOfColumnarChannels()
+    {
+        assertEquals(estimateNumberOfColumnarChannels(BIGINT), 2);
+        assertEquals(estimateNumberOfColumnarChannels(REAL), 2);
+        assertEquals(estimateNumberOfColumnarChannels(VARCHAR), 3);
+        assertEquals(estimateNumberOfColumnarChannels(createVarcharType(10)), 3);
+        assertEquals(estimateNumberOfColumnarChannels(createDecimalType(3, 2)), 2);
+        assertEquals(estimateNumberOfColumnarChannels(createDecimalType(30, 2)), 2);
+        assertEquals(estimateNumberOfColumnarChannels(new ArrayType(BIGINT)), 4);
+        assertEquals(estimateNumberOfColumnarChannels(new ArrayType(VARCHAR)), 5);
+        assertEquals(estimateNumberOfColumnarChannels(RowType.anonymous(ImmutableList.of(BIGINT, VARCHAR))), 7);
+    }
+
+    private static class ExchangeEncodingMatcher
+            implements Matcher
+    {
+        private final ExchangeEncoding encoding;
+
+        private ExchangeEncodingMatcher(ExchangeEncoding encoding)
+        {
+            this.encoding = requireNonNull(encoding, "encoding is null");
+        }
+
+        @Override
+        public boolean shapeMatches(PlanNode node)
+        {
+            return node instanceof ExchangeNode;
+        }
+
+        @Override
+        public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+        {
+            ExchangeNode exchangeNode = (ExchangeNode) node;
+            return exchangeNode.getPartitioningScheme().getEncoding() == encoding ? match() : NO_MATCH;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -110,6 +110,7 @@ import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_FIRST;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.plan.ExchangeEncoding.COLUMNAR;
 import static com.facebook.presto.spi.plan.LimitNode.Step.FINAL;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
@@ -331,7 +332,7 @@ public class PlanBuilder
 
     public RemoteSourceNode remoteSource(PlanNodeId planNodeId, List<PlanFragmentId> sourceFragmentIds, List<VariableReferenceExpression> outputVariables)
     {
-        return new RemoteSourceNode(Optional.empty(), planNodeId, sourceFragmentIds, outputVariables, false, Optional.empty(), REPARTITION);
+        return new RemoteSourceNode(Optional.empty(), planNodeId, sourceFragmentIds, outputVariables, false, Optional.empty(), REPARTITION, COLUMNAR);
     }
 
     public RemoteSourceNode remoteSource(List<PlanFragmentId> sourceFragmentIds, PlanNode statsEquivalentPlanNode)
@@ -343,7 +344,8 @@ public class PlanBuilder
                 sourceFragmentIds, ImmutableList.of(),
                 false,
                 Optional.empty(),
-                REPARTITION);
+                REPARTITION,
+                COLUMNAR);
     }
 
     public CallExpression binaryOperation(OperatorType operatorType, RowExpression left, RowExpression right)

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -144,6 +144,7 @@ TEST_F(PlanConverterTest, partitionedOutput) {
   ASSERT_EQ(keys.size(), 2);
   ASSERT_EQ(keys[0]->toString(), "1 elements starting at 0 {cluster_label_v2}");
   ASSERT_EQ(keys[1]->toString(), "\"expr_181\"");
+  ASSERT_EQ(partitionedOutput->serdeKind(), VectorSerde::Kind::kCompactRow);
 }
 
 // Final Agg stage plan for select regionkey, sum(1) from nation group by 1

--- a/presto-native-execution/presto_cpp/main/types/tests/data/FinalAgg.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/FinalAgg.json
@@ -47,7 +47,8 @@
           "name":"$hashvalue",
           "type":"bigint"
         },
-        "replicateNullsAndAny":false
+        "replicateNullsAndAny":false,
+        "encoding":"COLUMNAR"
       },
       "sources":[
         {
@@ -74,7 +75,8 @@
             }
           ],
           "ensureSourceOrdering":false,
-          "exchangeType":"REPARTITION"
+          "exchangeType":"REPARTITION",
+          "encoding":"COLUMNAR"
         }
       ],
       "inputs":[
@@ -239,6 +241,7 @@
       }
     ],
     "replicateNullsAndAny":false,
+    "encoding":"COLUMNAR",
     "bucketToPartition":[
       0
     ]

--- a/presto-native-execution/presto_cpp/main/types/tests/data/OffsetLimit.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/OffsetLimit.json
@@ -51,7 +51,8 @@
               "type":"bigint"
             }
           ],
-          "replicateNullsAndAny":false
+          "replicateNullsAndAny":false,
+          "encoding":"COLUMNAR"
         },
         "sources":[
           {
@@ -102,7 +103,8 @@
                     "type":"bigint"
                   }
                 ],
-                "replicateNullsAndAny":false
+                "replicateNullsAndAny":false,
+                "encoding":"COLUMNAR"
               },
               "sources":[
                 {
@@ -153,7 +155,8 @@
                           "type":"bigint"
                         }
                       ],
-                      "replicateNullsAndAny":false
+                      "replicateNullsAndAny":false,
+                      "encoding":"COLUMNAR"
                     },
                     "sources":[
                       {
@@ -200,7 +203,8 @@
                               }
                             ]
                           },
-                          "exchangeType":"GATHER"
+                          "exchangeType":"GATHER",
+                          "encoding":"COLUMNAR"
                         },
                         "partitionBy":[
 
@@ -476,6 +480,7 @@
       }
     ],
     "replicateNullsAndAny":false,
+    "encoding":"COLUMNAR",
     "bucketToPartition":[
       0
     ]

--- a/presto-native-execution/presto_cpp/main/types/tests/data/Output.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/Output.json
@@ -22,7 +22,8 @@
         }
       ],
       "ensureSourceOrdering":false,
-      "exchangeType":"GATHER"
+      "exchangeType":"GATHER",
+      "encoding":"COLUMNAR"
     },
     "columnNames":[
       "regionkey",
@@ -89,6 +90,7 @@
       }
     ],
     "replicateNullsAndAny":false,
+    "encoding":"COLUMNAR",
     "bucketToPartition":[
       0
     ]

--- a/presto-native-execution/presto_cpp/main/types/tests/data/PartitionedOutput.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/PartitionedOutput.json
@@ -463,7 +463,8 @@
       1,
       2,
       3
-    ]
+    ],
+    "encoding":"ROW_WISE"
   },
   "stageExecutionDescriptor":{
     "stageExecutionStrategy":"UNGROUPED_EXECUTION",

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ScanAgg.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ScanAgg.json
@@ -320,6 +320,7 @@
       }
     ],
     "replicateNullsAndAny":false,
+    "encoding":"COLUMNAR",
     "bucketToPartition":[
       0
     ]

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ScanAggBatch.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ScanAggBatch.json
@@ -299,6 +299,7 @@
       }
     ],
     "replicateNullsAndAny":false,
+    "encoding":"COLUMNAR",
     "bucketToPartition":[
       0,
       1,

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ScanAggCustomConnectorId.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ScanAggCustomConnectorId.json
@@ -266,6 +266,7 @@
       }
     ],
     "replicateNullsAndAny":false,
+    "encoding":"COLUMNAR",
     "bucketToPartition":[
       0
     ]

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ValuesPipeTest.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ValuesPipeTest.json
@@ -34,7 +34,8 @@
 	              "type": "varchar(1)"
 	            }
 	          ],
-	          "replicateNullsAndAny": false
+	          "replicateNullsAndAny": false,
+              "encoding":"COLUMNAR"
 	        },
 	        "sources": [
 	          {
@@ -202,6 +203,7 @@
 	      }
 	    ],
 	    "replicateNullsAndAny": false,
+		"encoding":"COLUMNAR",
 	    "bucketToPartition": [
 	      0
 	    ]

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -4635,6 +4635,45 @@ void from_json(const json& j, ExchangeNodeType& e) {
           ->first;
 }
 } // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<ExchangeEncoding, json> ExchangeEncoding_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {ExchangeEncoding::COLUMNAR, "COLUMNAR"},
+        {ExchangeEncoding::ROW_WISE, "ROW_WISE"}};
+void to_json(json& j, const ExchangeEncoding& e) {
+  static_assert(
+      std::is_enum<ExchangeEncoding>::value,
+      "ExchangeEncoding must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(ExchangeEncoding_enum_table),
+      std::end(ExchangeEncoding_enum_table),
+      [e](const std::pair<ExchangeEncoding, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(ExchangeEncoding_enum_table))
+           ? it
+           : std::begin(ExchangeEncoding_enum_table))
+          ->second;
+}
+void from_json(const json& j, ExchangeEncoding& e) {
+  static_assert(
+      std::is_enum<ExchangeEncoding>::value,
+      "ExchangeEncoding must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(ExchangeEncoding_enum_table),
+      std::end(ExchangeEncoding_enum_table),
+      [&j](const std::pair<ExchangeEncoding, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(ExchangeEncoding_enum_table))
+           ? it
+           : std::begin(ExchangeEncoding_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4791,6 +4830,13 @@ void to_json(json& j, const PartitioningScheme& p) {
       "replicateNullsAndAny");
   to_json_key(
       j,
+      "encoding",
+      p.encoding,
+      "PartitioningScheme",
+      "ExchangeEncoding",
+      "encoding");
+  to_json_key(
+      j,
       "bucketToPartition",
       p.bucketToPartition,
       "PartitioningScheme",
@@ -4827,6 +4873,13 @@ void from_json(const json& j, PartitioningScheme& p) {
       "PartitioningScheme",
       "bool",
       "replicateNullsAndAny");
+  from_json_key(
+      j,
+      "encoding",
+      p.encoding,
+      "PartitioningScheme",
+      "ExchangeEncoding",
+      "encoding");
   from_json_key(
       j,
       "bucketToPartition",
@@ -7997,6 +8050,13 @@ void to_json(json& j, const RemoteSourceNode& p) {
       "RemoteSourceNode",
       "ExchangeNodeType",
       "exchangeType");
+  to_json_key(
+      j,
+      "encoding",
+      p.encoding,
+      "RemoteSourceNode",
+      "ExchangeEncoding",
+      "encoding");
 }
 
 void from_json(const json& j, RemoteSourceNode& p) {
@@ -8037,6 +8097,13 @@ void from_json(const json& j, RemoteSourceNode& p) {
       "RemoteSourceNode",
       "ExchangeNodeType",
       "exchangeType");
+  from_json_key(
+      j,
+      "encoding",
+      p.encoding,
+      "RemoteSourceNode",
+      "ExchangeEncoding",
+      "encoding");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1281,6 +1281,11 @@ extern void to_json(json& j, const ExchangeNodeType& e);
 extern void from_json(const json& j, ExchangeNodeType& e);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+enum class ExchangeEncoding { COLUMNAR, ROW_WISE };
+extern void to_json(json& j, const ExchangeEncoding& e);
+extern void from_json(const json& j, ExchangeEncoding& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 struct PartitioningHandle {
   std::shared_ptr<ConnectorId> connectorId = {};
   std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
@@ -1303,6 +1308,7 @@ struct PartitioningScheme {
   List<VariableReferenceExpression> outputLayout = {};
   std::shared_ptr<VariableReferenceExpression> hashColumn = {};
   bool replicateNullsAndAny = {};
+  ExchangeEncoding encoding = {};
   std::shared_ptr<List<int>> bucketToPartition = {};
 };
 void to_json(json& j, const PartitioningScheme& p);
@@ -1889,6 +1895,7 @@ struct RemoteSourceNode : public PlanNode {
   bool ensureSourceOrdering = {};
   std::shared_ptr<OrderingScheme> orderingScheme = {};
   ExchangeNodeType exchangeType = {};
+  ExchangeEncoding encoding = {};
 
   RemoteSourceNode() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -17,6 +17,7 @@ EnumMap:
   ExchangeNode:
     Type: ExchangeNodeType
     Scope: ExchangeNodeScope
+    Encoding: ExchangeEncoding
 
   LimitNode:
     Step: LimitNodeStep
@@ -314,3 +315,4 @@ JavaClasses:
   - presto-main/src/main/java/com/facebook/presto/connector/system/SystemTransactionHandle.java
   - presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionMetadata.java
   - presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonBasedUdfFunctionMetadata.java
+  - presto-spi/src/main/java/com/facebook/presto/spi/plan/ExchangeEncoding.java

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/data/ExchangeNode.json
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/data/ExchangeNode.json
@@ -26,7 +26,8 @@
         "type": "varchar(1)"
       }
     ],
-    "replicateNullsAndAny": false
+    "replicateNullsAndAny": false,
+    "encoding":"COLUMNAR"
   },
   "sources": [],
   "inputs": [

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/data/FilterNode.json
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/data/FilterNode.json
@@ -29,7 +29,8 @@
           "type": "varchar(1)"
         }
       ],
-      "replicateNullsAndAny": false
+      "replicateNullsAndAny": false,
+      "encoding":"COLUMNAR"
     },
     "sources": [],
     "inputs": [

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/data/OutputNode.json
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/data/OutputNode.json
@@ -29,7 +29,8 @@
           "type": "varchar(1)"
         }
       ],
-      "replicateNullsAndAny": false
+      "replicateNullsAndAny": false,
+      "encoding":"COLUMNAR"
     },
     "sources": [],
     "inputs": [

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -16,8 +16,10 @@ package com.facebook.presto.nativeworker;
 import com.facebook.presto.Session;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.SystemSessionProperties.NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_DISTINCT_AGGREGATIONS;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
@@ -42,87 +44,87 @@ public abstract class AbstractTestNativeAggregations
         createRegion(queryRunner);
     }
 
-    @Test
-    public void testAggregations()
+    @Test(dataProvider = "exchangeEncodingProvider")
+    public void testAggregations(String exchangeEncoding)
     {
-        assertQuery("SELECT count(*) FROM nation");
-        assertQuery("SELECT regionkey, count(*) FROM nation GROUP BY regionkey");
+        assertQuery(getSession(exchangeEncoding), "SELECT count(*) FROM nation");
+        assertQuery(getSession(exchangeEncoding), "SELECT regionkey, count(*) FROM nation GROUP BY regionkey");
 
-        assertQuery("SELECT avg(discount), avg(quantity) FROM lineitem");
-        assertQuery(
+        assertQuery(getSession(exchangeEncoding), "SELECT avg(discount), avg(quantity) FROM lineitem");
+        assertQuery(getSession(exchangeEncoding),
                 "SELECT linenumber, avg(discount), avg(quantity) FROM lineitem GROUP BY linenumber");
 
-        assertQuery("SELECT sum(totalprice) FROM orders");
-        assertQuery("SELECT orderpriority, sum(totalprice) FROM orders GROUP BY orderpriority");
+        assertQuery(getSession(exchangeEncoding), "SELECT sum(totalprice) FROM orders");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderpriority, sum(totalprice) FROM orders GROUP BY orderpriority");
 
-        assertQuery("SELECT custkey, min(totalprice), max(orderkey) FROM orders GROUP BY custkey");
+        assertQuery(getSession(exchangeEncoding), "SELECT custkey, min(totalprice), max(orderkey) FROM orders GROUP BY custkey");
 
-        assertQuery("SELECT bitwise_and_agg(orderkey), bitwise_and_agg(suppkey), bitwise_or_agg(partkey), bitwise_or_agg(linenumber) FROM lineitem");
-        assertQuery("SELECT orderkey, bitwise_and_agg(orderkey), bitwise_and_agg(suppkey) FROM lineitem GROUP BY orderkey");
-        assertQuery("SELECT bitwise_and_agg(custkey), bitwise_or_agg(orderkey) FROM orders");
-        assertQuery("SELECT shippriority, bitwise_and_agg(orderkey), bitwise_or_agg(custkey) FROM orders GROUP BY shippriority");
+        assertQuery(getSession(exchangeEncoding), "SELECT bitwise_and_agg(orderkey), bitwise_and_agg(suppkey), bitwise_or_agg(partkey), bitwise_or_agg(linenumber) FROM lineitem");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, bitwise_and_agg(orderkey), bitwise_and_agg(suppkey) FROM lineitem GROUP BY orderkey");
+        assertQuery(getSession(exchangeEncoding), "SELECT bitwise_and_agg(custkey), bitwise_or_agg(orderkey) FROM orders");
+        assertQuery(getSession(exchangeEncoding), "SELECT shippriority, bitwise_and_agg(orderkey), bitwise_or_agg(custkey) FROM orders GROUP BY shippriority");
 
-        assertQuery("SELECT sum(custkey), clerk FROM orders GROUP BY clerk HAVING sum(custkey) > 10000");
+        assertQuery(getSession(exchangeEncoding), "SELECT sum(custkey), clerk FROM orders GROUP BY clerk HAVING sum(custkey) > 10000");
 
-        assertQuery("SELECT orderkey, array_sort(array_agg(linenumber)) FROM lineitem GROUP BY 1");
-        assertQuery("SELECT orderkey, map_agg(linenumber, discount) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, array_sort(array_agg(linenumber)) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, map_agg(linenumber, discount) FROM lineitem GROUP BY 1");
 
-        assertQuery("SELECT array_agg(nationkey ORDER BY name) FROM nation");
-        assertQuery("SELECT orderkey, array_agg(quantity ORDER BY linenumber DESC) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT array_agg(nationkey ORDER BY name) FROM nation");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, array_agg(quantity ORDER BY linenumber DESC) FROM lineitem GROUP BY 1");
 
-        assertQuery("SELECT array_sort(map_keys(map_union(quantity_by_linenumber))) FROM orders_ex");
+        assertQuery(getSession(exchangeEncoding), "SELECT array_sort(map_keys(map_union(quantity_by_linenumber))) FROM orders_ex");
 
-        assertQuery("SELECT orderkey, count_if(linenumber % 2 > 0) FROM lineitem GROUP BY 1");
-        assertQuery("SELECT orderkey, bool_and(linenumber % 2 = 1) FROM lineitem GROUP BY 1");
-        assertQuery("SELECT orderkey, bool_or(linenumber % 2 = 0) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, count_if(linenumber % 2 > 0) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, bool_and(linenumber % 2 = 1) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, bool_or(linenumber % 2 = 0) FROM lineitem GROUP BY 1");
 
-        assertQuery("SELECT linenumber = 2 AND quantity > 10, sum(quantity / 7) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT linenumber = 2 AND quantity > 10, sum(quantity / 7) FROM lineitem GROUP BY 1");
 
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, 0.25) FROM orders");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, 0.25) FROM orders");
-        assertQuerySucceeds("SELECT clerk, approx_percentile(totalprice, 0.25) FROM orders GROUP BY 1");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, 0.25, 0.005) FROM orders");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, 0.25, 0.005) FROM orders");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, 0.25), approx_percentile(totalprice, 0.5) FROM orders");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, 0.25), approx_percentile(totalprice, orderkey, 0.5) FROM orders");
-        assertQuerySucceeds("SELECT clerk, approx_percentile(totalprice, 0.25), approx_percentile(totalprice, 0.5) FROM orders GROUP BY 1");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, 0.25, 0.005), approx_percentile(totalprice, 0.5, 0.005) FROM orders");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, 0.25, 0.005), approx_percentile(totalprice, orderkey, 0.5, 0.005) FROM orders");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, ARRAY[0.25, 0.5]) FROM orders");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, ARRAY[0.25, 0.5]) FROM orders");
-        assertQuerySucceeds("SELECT clerk, approx_percentile(totalprice, ARRAY[0.25, 0.5]) FROM orders GROUP BY 1");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, ARRAY[0.25, 0.5], 0.005) FROM orders");
-        assertQuerySucceeds("SELECT approx_percentile(totalprice, orderkey, ARRAY[0.25, 0.5], 0.005) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, 0.25) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, orderkey, 0.25) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT clerk, approx_percentile(totalprice, 0.25) FROM orders GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, 0.25, 0.005) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, orderkey, 0.25, 0.005) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, 0.25), approx_percentile(totalprice, 0.5) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, orderkey, 0.25), approx_percentile(totalprice, orderkey, 0.5) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT clerk, approx_percentile(totalprice, 0.25), approx_percentile(totalprice, 0.5) FROM orders GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, 0.25, 0.005), approx_percentile(totalprice, 0.5, 0.005) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, orderkey, 0.25, 0.005), approx_percentile(totalprice, orderkey, 0.5, 0.005) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, ARRAY[0.25, 0.5]) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, orderkey, ARRAY[0.25, 0.5]) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT clerk, approx_percentile(totalprice, ARRAY[0.25, 0.5]) FROM orders GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, ARRAY[0.25, 0.5], 0.005) FROM orders");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_percentile(totalprice, orderkey, ARRAY[0.25, 0.5], 0.005) FROM orders");
 
         // count is not using any channel or mask.
         // sum1 and sum3 are using different channels, but the same mask.
         // sum2 and sum1 are using the same channel, but different masks.
-        assertQuery("SELECT count(1), sum(IF(linenumber = 7, partkey)), sum(IF(linenumber = 5, partkey)), sum(IF(linenumber = 7, orderkey)) FROM lineitem");
-        assertQuery("SELECT count(1), sum(partkey) FILTER (where linenumber = 7), sum(partkey) FILTER (where linenumber = 5), sum(orderkey) FILTER (where linenumber = 7) FROM lineitem");
-        assertQuery("SELECT shipmode, count(1), sum(IF(linenumber = 7, partkey)), sum(IF(linenumber = 5, partkey)), sum(IF(linenumber = 7, orderkey)) FROM lineitem group by 1");
-        assertQuery("SELECT shipmode, count(1), sum(partkey) FILTER (where linenumber = 7), sum(partkey) FILTER (where linenumber = 5), sum(orderkey) FILTER (where linenumber = 7) FROM lineitem group by 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT count(1), sum(IF(linenumber = 7, partkey)), sum(IF(linenumber = 5, partkey)), sum(IF(linenumber = 7, orderkey)) FROM lineitem");
+        assertQuery(getSession(exchangeEncoding), "SELECT count(1), sum(partkey) FILTER (where linenumber = 7), sum(partkey) FILTER (where linenumber = 5), sum(orderkey) FILTER (where linenumber = 7) FROM lineitem");
+        assertQuery(getSession(exchangeEncoding), "SELECT shipmode, count(1), sum(IF(linenumber = 7, partkey)), sum(IF(linenumber = 5, partkey)), sum(IF(linenumber = 7, orderkey)) FROM lineitem group by 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT shipmode, count(1), sum(partkey) FILTER (where linenumber = 7), sum(partkey) FILTER (where linenumber = 5), sum(orderkey) FILTER (where linenumber = 7) FROM lineitem group by 1");
 
         // distinct limit
         assertQueryResultCount("SELECT orderkey FROM lineitem GROUP BY 1 LIMIT 17", 17);
 
         // aggregation with no grouping keys and no aggregates
-        assertQuery("with a as (select sum(nationkey) from nation) select x from a, unnest(array[1, 2,3]) as t(x)");
+        assertQuery(getSession(exchangeEncoding), "with a as (select sum(nationkey) from nation) select x from a, unnest(array[1, 2,3]) as t(x)");
     }
 
-    @Test
-    public void testGroupingSets()
+    @Test(dataProvider = "exchangeEncodingProvider")
+    public void testGroupingSets(String exchangeEncoding)
     {
-        assertQuery("SELECT orderstatus, orderpriority, count(1), min(orderkey) FROM orders GROUP BY GROUPING SETS ((orderstatus), (orderpriority))");
-        assertQuery("SELECT orderstatus, orderpriority, count(1), min(orderkey) FROM orders GROUP BY CUBE (orderstatus, orderpriority)");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderstatus, orderpriority, count(1), min(orderkey) FROM orders GROUP BY GROUPING SETS ((orderstatus), (orderpriority))");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderstatus, orderpriority, count(1), min(orderkey) FROM orders GROUP BY CUBE (orderstatus, orderpriority)");
         assertQuery("SELECT orderstatus, orderpriority, count(1), min(orderkey) FROM orders GROUP BY ROLLUP (orderstatus, orderpriority)");
 
         // With grouping expression.
-        assertQuery("SELECT orderstatus, orderpriority, grouping(orderstatus), grouping(orderpriority), grouping(orderstatus, orderpriority), count(1), min(orderkey) FROM orders GROUP BY GROUPING SETS ((orderstatus), (orderpriority))");
-        assertQuery("SELECT orderstatus, orderpriority, grouping(orderstatus), grouping(orderpriority), grouping(orderstatus, orderpriority), count(1), min(orderkey) FROM orders GROUP BY CUBE (orderstatus, orderpriority)");
-        assertQuery("SELECT orderstatus, orderpriority, grouping(orderstatus), grouping(orderpriority), grouping(orderstatus, orderpriority), count(1), min(orderkey) FROM orders GROUP BY ROLLUP (orderstatus, orderpriority)");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderstatus, orderpriority, grouping(orderstatus), grouping(orderpriority), grouping(orderstatus, orderpriority), count(1), min(orderkey) FROM orders GROUP BY GROUPING SETS ((orderstatus), (orderpriority))");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderstatus, orderpriority, grouping(orderstatus), grouping(orderpriority), grouping(orderstatus, orderpriority), count(1), min(orderkey) FROM orders GROUP BY CUBE (orderstatus, orderpriority)");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderstatus, orderpriority, grouping(orderstatus), grouping(orderpriority), grouping(orderstatus, orderpriority), count(1), min(orderkey) FROM orders GROUP BY ROLLUP (orderstatus, orderpriority)");
 
         // With aliased columns.
-        assertQuery("SELECT lna, lnb, SUM(quantity) FROM (SELECT linenumber lna, linenumber lnb, CAST(quantity AS BIGINT) quantity FROM lineitem) GROUP BY GROUPING SETS ((lna, lnb), (lna), (lnb), ())");
+        assertQuery(getSession(exchangeEncoding), "SELECT lna, lnb, SUM(quantity) FROM (SELECT linenumber lna, linenumber lnb, CAST(quantity AS BIGINT) quantity FROM lineitem) GROUP BY GROUPING SETS ((lna, lnb), (lna), (lnb), ())");
     }
 
     @Test
@@ -135,27 +137,27 @@ public abstract class AbstractTestNativeAggregations
         assertQuery(session, "SELECT max(orderstatus), COUNT(orderkey), sum(DISTINCT orderkey) FROM orders");
     }
 
-    @Test
-    public void testEmptyGroupingSets()
+    @Test(dataProvider = "exchangeEncodingProvider")
+    public void testEmptyGroupingSets(String exchangeEncoding)
     {
         // Returns  a single row with the global aggregation.
-        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS (())");
+        assertQuery(getSession(exchangeEncoding), "SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS (())");
 
         // Returns 2 rows with global aggregation for the global grouping sets.
-        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS ((), ())");
+        assertQuery(getSession(exchangeEncoding), "SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS ((), ())");
 
         // Returns a single row with the global aggregation. There are no rows for the orderkey group.
-        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS ((orderkey), ())");
+        assertQuery(getSession(exchangeEncoding), "SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS ((orderkey), ())");
 
         // This is a shorthand for the above query. Returns a single row with the global aggregation.
-        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY CUBE (orderkey)");
+        assertQuery(getSession(exchangeEncoding), "SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY CUBE (orderkey)");
 
-        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY ROLLUP (orderkey)");
+        assertQuery(getSession(exchangeEncoding), "SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY ROLLUP (orderkey)");
 
         // Returns a single row with NULL orderkey.
-        assertQuery("SELECT orderkey FROM orders WHERE orderkey < 0 GROUP BY CUBE (orderkey)");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey FROM orders WHERE orderkey < 0 GROUP BY CUBE (orderkey)");
 
-        assertQuery("SELECT orderkey FROM orders WHERE orderkey < 0 GROUP BY ROLLUP (orderkey)");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey FROM orders WHERE orderkey < 0 GROUP BY ROLLUP (orderkey)");
     }
 
     @Test
@@ -164,33 +166,33 @@ public abstract class AbstractTestNativeAggregations
         assertQuery("SELECT name, (SELECT max(name) FROM region WHERE regionkey = nation.regionkey AND length(name) > length(nation.name)) FROM nation");
     }
 
-    @Test
-    public void testApproxDistinct()
+    @Test(dataProvider = "exchangeEncodingProvider")
+    public void testApproxDistinct(String exchangeEncoding)
     {
         // low cardinality -> expect exact results
-        assertQuery("SELECT approx_distinct(linenumber) FROM lineitem");
-        assertQuery("SELECT orderkey, approx_distinct(linenumber) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT approx_distinct(linenumber) FROM lineitem");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, approx_distinct(linenumber) FROM lineitem GROUP BY 1");
 
         // high cardinality -> results may not be exact
-        assertQuerySucceeds("SELECT approx_distinct(orderkey) FROM lineitem");
-        assertQuerySucceeds("SELECT linenumber, approx_distinct(orderkey) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_distinct(orderkey) FROM lineitem");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT linenumber, approx_distinct(orderkey) FROM lineitem GROUP BY 1");
 
         // approx_set + cardinality
-        assertQuery("SELECT cardinality(approx_set(linenumber)) FROM lineitem");
-        assertQuery("SELECT orderkey, cardinality(approx_set(linenumber)) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT cardinality(approx_set(linenumber)) FROM lineitem");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, cardinality(approx_set(linenumber)) FROM lineitem GROUP BY 1");
 
         // Verify that Velox can read HLL binaries written by Java Presto.
-        assertQuery("SELECT cardinality(cast(hll as hyperloglog)) FROM orders_hll");
-        assertQuery("SELECT cardinality(merge(cast(hll as hyperloglog))) FROM orders_hll");
+        assertQuery(getSession(exchangeEncoding), "SELECT cardinality(cast(hll as hyperloglog)) FROM orders_hll");
+        assertQuery(getSession(exchangeEncoding), "SELECT cardinality(merge(cast(hll as hyperloglog))) FROM orders_hll");
     }
 
-    @Test
-    public void testApproxMostFrequent()
+    @Test(dataProvider = "exchangeEncodingProvider")
+    public void testApproxMostFrequent(String exchangeEncoding)
     {
-        assertQuery("SELECT approx_most_frequent(3, linenumber, 1000) FROM lineitem");
-        assertQuerySucceeds("SELECT orderkey, approx_most_frequent(3, linenumber, 10) FROM lineitem GROUP BY 1");
-        assertQuerySucceeds("SELECT approx_most_frequent(3, orderkey, 1000) FROM lineitem");
-        assertQuerySucceeds("SELECT linenumber, approx_most_frequent(3, orderkey, 10) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT approx_most_frequent(3, linenumber, 1000) FROM lineitem");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT orderkey, approx_most_frequent(3, linenumber, 10) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT approx_most_frequent(3, orderkey, 1000) FROM lineitem");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT linenumber, approx_most_frequent(3, orderkey, 10) FROM lineitem GROUP BY 1");
     }
 
     @Test
@@ -242,23 +244,23 @@ public abstract class AbstractTestNativeAggregations
                 ".*Aggregate function signature is not supported.*");
     }
 
-    @Test
-    public void testMinMaxBy()
+    @Test(dataProvider = "exchangeEncodingProvider")
+    public void testMinMaxBy(String exchangeEncoding)
     {
         // We use filters to make queries deterministic.
-        assertQuery("SELECT max_by(partkey, orderkey), max_by(quantity, orderkey), max_by(tax_as_real, orderkey) FROM lineitem where shipmode='MAIL'");
-        assertQuery("SELECT min_by(partkey, orderkey), min_by(quantity, orderkey), min_by(tax_as_real, orderkey) FROM lineitem where shipmode='MAIL'");
+        assertQuery(getSession(exchangeEncoding), "SELECT max_by(partkey, orderkey), max_by(quantity, orderkey), max_by(tax_as_real, orderkey) FROM lineitem where shipmode='MAIL'");
+        assertQuery(getSession(exchangeEncoding), "SELECT min_by(partkey, orderkey), min_by(quantity, orderkey), min_by(tax_as_real, orderkey) FROM lineitem where shipmode='MAIL'");
 
-        assertQuery("SELECT max_by(orderkey, extendedprice), max_by(orderkey, cast(extendedprice as REAL)) FROM lineitem");
-        assertQuery("SELECT min_by(orderkey, extendedprice), min_by(orderkey, cast(extendedprice as REAL)) FROM lineitem where shipmode='MAIL'");
+        assertQuery(getSession(exchangeEncoding), "SELECT max_by(orderkey, extendedprice), max_by(orderkey, cast(extendedprice as REAL)) FROM lineitem");
+        assertQuery(getSession(exchangeEncoding), "SELECT min_by(orderkey, extendedprice), min_by(orderkey, cast(extendedprice as REAL)) FROM lineitem where shipmode='MAIL'");
 
         // 3 argument variant of max_by, min_by
-        assertQuery("SELECT max_by(orderkey, linenumber, 5), min_by(orderkey, linenumber, 5) FROM lineitem GROUP BY orderkey");
+        assertQuery(getSession(exchangeEncoding), "SELECT max_by(orderkey, linenumber, 5), min_by(orderkey, linenumber, 5) FROM lineitem GROUP BY orderkey");
 
         // Non-numeric arguments
-        assertQuery("SELECT max_by(row(orderkey, custkey), orderkey, 5), min_by(row(orderkey, custkey), orderkey, 5) FROM orders");
-        assertQuery("SELECT max_by(row(orderkey, linenumber), linenumber, 5), min_by(row(orderkey, linenumber), linenumber, 5) FROM lineitem GROUP BY orderkey");
-        assertQuery("SELECT orderkey, MAX_BY(v, c, 5), MIN_BY(v, c, 5) FROM " +
+        assertQuery(getSession(exchangeEncoding), "SELECT max_by(row(orderkey, custkey), orderkey, 5), min_by(row(orderkey, custkey), orderkey, 5) FROM orders");
+        assertQuery(getSession(exchangeEncoding), "SELECT max_by(row(orderkey, linenumber), linenumber, 5), min_by(row(orderkey, linenumber), linenumber, 5) FROM lineitem GROUP BY orderkey");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, MAX_BY(v, c, 5), MIN_BY(v, c, 5) FROM " +
                 "(SELECT orderkey, 'This is a long line ' || CAST(orderkey AS VARCHAR) AS v, 'This is also a really long line ' || CAST(linenumber AS VARCHAR) AS c FROM lineitem) " +
                 "GROUP BY 1");
     }
@@ -334,16 +336,16 @@ public abstract class AbstractTestNativeAggregations
         assertQuery("SELECT checksum(a), checksum(b) FROM (VALUES (CAST('999999999999999999' AS DECIMAL(18, 0)), CAST('99999999999999999999999999999999999999' AS DECIMAL(38, 0))), (CAST('-999999999999999999' as DECIMAL(18, 0)), CAST('-99999999999999999999999999999999999999' AS DECIMAL(38, 0)))) AS t(a, b)");
     }
 
-    @Test
-    public void testArbitrary()
+    @Test(dataProvider = "exchangeEncodingProvider")
+    public void testArbitrary(String exchangeEncoding)
     {
         // Non-deterministic queries
-        assertQuerySucceeds("SELECT orderkey, any_value(comment) FROM lineitem GROUP BY 1");
-        assertQuerySucceeds("SELECT orderkey, arbitrary(discount) FROM lineitem GROUP BY 1");
-        assertQuerySucceeds("SELECT orderkey, any_value(linenumber) FROM lineitem GROUP BY 1");
-        assertQuerySucceeds("SELECT orderkey, arbitrary(linenumber_as_smallint) FROM lineitem GROUP BY 1");
-        assertQuerySucceeds("SELECT orderkey, any_value(linenumber_as_tinyint) FROM lineitem GROUP BY 1");
-        assertQuerySucceeds("SELECT orderkey, arbitrary(tax_as_real) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT orderkey, any_value(comment) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT orderkey, arbitrary(discount) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT orderkey, any_value(linenumber) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT orderkey, arbitrary(linenumber_as_smallint) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT orderkey, any_value(linenumber_as_tinyint) FROM lineitem GROUP BY 1");
+        assertQuerySucceeds(getSession(exchangeEncoding), "SELECT orderkey, arbitrary(tax_as_real) FROM lineitem GROUP BY 1");
     }
 
     @Test
@@ -352,11 +354,11 @@ public abstract class AbstractTestNativeAggregations
         assertQuery("SELECT orderkey, multimap_agg(linenumber % 3, discount) FROM lineitem GROUP BY 1");
     }
 
-    @Test
-    public void testMarkDistinct()
+    @Test(dataProvider = "exchangeEncodingProvider")
+    public void testMarkDistinct(String exchangeEncoding)
     {
-        assertQuery("SELECT count(distinct orderkey), count(distinct linenumber) FROM lineitem");
-        assertQuery("SELECT orderkey, count(distinct comment), sum(distinct linenumber) FROM lineitem GROUP BY 1");
+        assertQuery(getSession(exchangeEncoding), "SELECT count(distinct orderkey), count(distinct linenumber) FROM lineitem");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, count(distinct comment), sum(distinct linenumber) FROM lineitem GROUP BY 1");
     }
 
     @Test
@@ -371,12 +373,12 @@ public abstract class AbstractTestNativeAggregations
                 ".*Aggregations over sorted unique values are not supported yet");
     }
 
-    @Test
-    public void testReduceAgg()
+    @Test(dataProvider = "exchangeEncodingProvider")
+    public void testReduceAgg(String exchangeEncoding)
     {
-        assertQuery("SELECT reduce_agg(orderkey, 0, (x, y) -> x + y, (x, y) -> x + y) FROM orders");
-        assertQuery("SELECT orderkey, reduce_agg(linenumber, 0, (x, y) -> x + y, (x, y) -> x + y) FROM lineitem GROUP BY orderkey");
-        assertQuery("SELECT orderkey, array_sort(reduce_agg(linenumber, array[], (s, x) -> s || x, (s, s2) -> s || s2)) FROM lineitem GROUP BY orderkey");
+        assertQuery(getSession(exchangeEncoding), "SELECT reduce_agg(orderkey, 0, (x, y) -> x + y, (x, y) -> x + y) FROM orders");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, reduce_agg(linenumber, 0, (x, y) -> x + y, (x, y) -> x + y) FROM lineitem GROUP BY orderkey");
+        assertQuery(getSession(exchangeEncoding), "SELECT orderkey, array_sort(reduce_agg(linenumber, array[], (s, x) -> s || x, (s, s2) -> s || s2)) FROM lineitem GROUP BY orderkey");
     }
 
     @Test
@@ -397,5 +399,21 @@ public abstract class AbstractTestNativeAggregations
     private void assertQueryResultCount(String sql, int expectedResultCount)
     {
         assertEquals(getQueryRunner().execute(sql).getRowCount(), expectedResultCount);
+    }
+
+    @DataProvider(name = "exchangeEncodingProvider")
+    public Object[][] exchangeEncodingProvider()
+    {
+        return new Object[][] {
+                {"with_columnar_exchange_encoding"},
+                {"with_row_wise_exchange_encoding"},
+        };
+    }
+
+    private Session getSession(String encoding)
+    {
+        return Session.builder(getSession())
+                .setSystemProperty(NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING, "with_row_wise_exchange_encoding".equals(encoding) ? "1" : "1000")
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -67,4 +67,8 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testSetSessionJavaWorkerSessionProperty() {}
+
+    @Override
+    @Ignore
+    public void testRowWiseExchange() {}
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
@@ -97,6 +97,7 @@ public class PrestoSparkSettingsRequirements
         config.setEnforceFixedDistributionForOutputOperator(true);
         config.setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(true);
         config.setTrackPartialAggregationHistory(false);
+        config.setPrestoSparkExecutionEnvironment(true);
     }
 
     public static void setDefaults(QueryManagerConfig config)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/ExchangeEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/ExchangeEncoding.java
@@ -11,27 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spi.connector;
+package com.facebook.presto.spi.plan;
 
-public interface ConnectorPartitioningHandle
+public enum ExchangeEncoding
 {
-    default boolean isSingleNode()
-    {
-        return false;
-    }
-
-    default boolean isCoordinatorOnly()
-    {
-        return false;
-    }
-
-    default boolean isBroadcast()
-    {
-        return false;
-    }
-
-    default boolean isArbitrary()
-    {
-        return false;
-    }
+    COLUMNAR,
+    ROW_WISE,
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/Partitioning.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/Partitioning.java
@@ -72,6 +72,11 @@ public final class Partitioning
         return arguments;
     }
 
+    public boolean isSingleOrBroadcastOrArbitrary()
+    {
+        return handle.isSingleOrBroadcastOrArbitrary();
+    }
+
     public Set<VariableReferenceExpression> getVariableReferences()
     {
         return arguments.stream()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PartitioningHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PartitioningHandle.java
@@ -71,6 +71,21 @@ public class PartitioningHandle
         return connectorHandle.isCoordinatorOnly();
     }
 
+    public boolean isBroadcast()
+    {
+        return connectorHandle.isBroadcast();
+    }
+
+    public boolean isArbitrary()
+    {
+        return connectorHandle.isArbitrary();
+    }
+
+    public boolean isSingleOrBroadcastOrArbitrary()
+    {
+        return isSingleNode() || isBroadcast() || isArbitrary();
+    }
+
     @Override
     public boolean equals(Object o)
     {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Pick row wise exchange encoding when columnar encoding becomes inefficient.

This PR only contains planner changes. Execution path will be provided as a separate PR and will be provided for native execution only.

## Motivation and Context

Columnar partitioning can get inefficient when the number of output partitions and the number of columns is high.

For example an exchange of 1000 VARCHAR columns into 300 partitions requires 900,000 buffers to be allocated. Even when the allocations are as small as 128B per buffer the amount of memory allocated can be considerable (110MB) and can be far exceeding the PartitionedOutput operator budget (usually ~32MB for ~300 partitions).

CPU wise it can also be extremely inefficient. For the example above, for every record 300,000 buffers have to be updated.


## Impact

Improved efficiency for exchanges of more than 500 columns.

## Test Plan

Unit, Integration and e2e tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Improve partitioned remote exchanges for wide data sets (more than 500 columns) to use row wise encoding. :pr:`23929 `
```

