### PR TITLE
Revert "Upgrade avro & its dependencies to resolve CVEs"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         <dep.guava.version>32.1.0-jre</dep.guava.version>
         <dep.jackson.version>2.11.0</dep.jackson.version>
         <dep.j2objc.version>2.8</dep.j2objc.version>
-        <dep.avro.version>1.11.4</dep.avro.version>
-        <dep.commons.compress.version>1.26.2</dep.commons.compress.version>
+        <dep.avro.version>1.11.3</dep.avro.version>
+        <dep.commons.compress.version>1.23.0</dep.commons.compress.version>
         <dep.protobuf-java.version>3.25.5</dep.protobuf-java.version>
 
         <!--
@@ -314,7 +314,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.16.1</version>
+                <version>2.16.0</version>
             </dependency>
 
             <dependency>
@@ -1742,7 +1742,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.17.0</version>
+                <version>1.15</version>
             </dependency>
 
             <dependency>
@@ -1999,12 +1999,6 @@
                 <groupId>redis.clients</groupId>
                 <artifactId>jedis</artifactId>
                 <version>2.6.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.14.0</version>
             </dependency>
 
             <dependency>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -232,6 +232,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
         </dependency>
 
         <dependency>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.14.0</version>
+                <version>3.11</version>
             </dependency>
 
             <dependency>
@@ -72,6 +72,12 @@
                 <groupId>com.google.auth</groupId>
                 <artifactId>google-auth-library-oauth2-http</artifactId>
                 <version>0.22.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.13</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This reverts commit 1c0fc175a73f60ababb6fba26472c3d5df7ebadf.

## Description
<!---Describe your changes in detail-->

This commit, 1c0fc17, has caused a break in Meta's internal Maven module. To resolve the issue and unblock the pipeline, we need to revert this commit before investigating its root cause.

Error message: 

```
[WARNING] Found duplicate and different classes in [com.facebook.presto.hive:hive-apache:3.0.0-10, com.facebook.presto:presto-jdbc:0.290-SNAPSHOT]:
[WARNING]   META-INF.versions.9.module-info
[WARNING] Found duplicate classes/resources in runtime classpath.
[WARNING] Found duplicate and different classes in [com.facebook.presto.hive:hive-apache:3.0.0-10, com.facebook.presto:presto-jdbc:0.290-SNAPSHOT]:
[WARNING]   META-INF.versions.9.module-info
[WARNING] Found duplicate classes/resources in test classpath.
[WARNING] We have a duplicate module-info.class in /var/twsvcscm/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.11.0/jackson-core-2.11.0.jar
```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

As above 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

Local build with maven passed

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

