### PR TITLE
[native] Update header for test_json

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/tests/test_json.h
+++ b/presto-native-execution/presto_cpp/main/common/tests/test_json.h
@@ -17,7 +17,7 @@
 #include <ios>
 #include <iosfwd>
 
-#include "presto_cpp/presto_protocol/presto_protocol.h"
+#include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
 
 namespace nlohmann {
 


### PR DESCRIPTION
Update header for test_json to fix tests that no longer depend on the deprecated header presto_protocol.h