### PR TITLE
Add release notes for 0.290

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    Release-0.290 [2024-11-01] <release/release-0.290>
     Release-0.289 [2024-08-23] <release/release-0.289>
     Release-0.288.1 [2024-08-12] <release/release-0.288.1>
     Release-0.288 [2024-06-13] <release/release-0.288>

--- a/presto-docs/src/main/sphinx/release/release-0.290.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.290.rst
@@ -1,0 +1,116 @@
+=============
+Release 0.290
+=============
+
+**Highlights**
+==============
+* Fix to reduce drop time for Iceberg tables with deleted metadata in S3 storage. :pr:`23510`
+* Fix a data corruption in uncompressed ORC/DWRF files with large values in string/binary columns. :pr:`23760`
+* Improve JoinPrefilter optimizer for wide join keys and multiple join keys. :pr:`23858`
+* Add UUID type support to the Parquet reader and writer. :pr:`23627`
+* Add a configurable-sized cache for Iceberg table puffin files to improve query planning time controlled by the  ``iceberg.max-statistics-file-cache-size`` configuration property. :pr:`23177`
+* Add support of UUID-typed columns. :pr:`23627`
+* Add support to query Iceberg table by branch/tag name. :pr:`23539`
+* Add support for procedure ``fast_forward`` for Iceberg. :pr:`23589`
+* Add support for using named arguments in procedures ``register_table`` and ``unregister_table``. :pr:`23592`
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix :func:`array_intersect` for single parameter array<array<T>> to be deterministic regardless of the order of null input. :pr:`23890`
+* Fix bug in local property calculation when spill is enabled. :pr:`23922`
+* Fix bug to unescape like pattern and validate escape string with no unresolved value. :pr:`23456`
+* Fix to query and filter using Iceberg metadata columns ``$path`` and ``$data_sequence_number``. :pr:`23472`
+* Fix nullability of columns in information schema. :pr:`23577`
+* Fix distinct operator for UUID type. :pr:`23732`
+* Improve ``element_at`` by avoiding pushdown of negative position for ``element_at`` for array.  :pr:`23479`
+* Improve ``GET /v1/info/state`` to return INACTIVE state until the resource group configuration manager is fully initialized. :pr:`23585`
+* Improve JoinPrefilter optimizer for wide join keys and multiple join keys. :pr:`23858`
+* Improve writer scaling in skewed conditions by setting ``optimized_scale_writer_producer_buffer`` to ``on`` by default. :pr:`23774`
+* Add UUID type support to the Parquet reader and writer. :pr:`23627`
+* Add a configurable-sized cache for Iceberg table puffin files to improve query planning time controlled by the  ``iceberg.max-statistics-file-cache-size`` configuration property. :pr:`23177`
+* Add a flag to the Presto CLI which allows skipping SSL certificate verification. :pr:`23780`
+* Add a session property ``native_max_extended_partial_aggregation_memory`` which specifies Presto native max partial aggregation memory when data reduction is optimal. :pr:`23527`
+* Add a session property ``native_max_partial_aggregation_memory`` which specifies Presto native max partial aggregation memory when data reduction is not optimal. :pr:`23527`
+* Add a session property ``native_max_spill_bytes`` which specifies Presto native max allowed spill bytes. :pr:`23527`
+* Add function :func:`is_private_ip` that returns true when the input IP address is private or a reserved IP address. :pr:`23520`
+* Add function :func:`ip_prefix_subnets` that splits the input prefix into subnets the size of the new prefix length. :pr:`23656`
+* Add new configuration property ``eager-plan-validation-enabled`` for eager building of validation of a logical plan before queuing. :pr:`23649`
+* Add session property ``inline_projections_on_values`` and configuration property ``optimizer.inline-projections-on-values`` to evaluate project node on values node. :pr:`23245`
+* Add support in QueuedStatement protocol to accept pre-minted query id and slug. :pr:`23407`
+* Add support to proxy AuthorizedIdentity using JWT. :pr:`23546`
+* Add support for casting ``char`` datatype to various numeric datatypes. :pr:`23792`
+* Replace configuration property ``async-cache-full-persistence-interval`` with ``async-cache-persistence-interval``. :pr:`23626`
+* Remove ``array_dupes`` and ``array_has_dupes`` alias names from functions :func:`array_duplicates` and :func:`array_has_duplicates`. :pr:`23762`
+
+Presto C++ Changes
+______________________________________
+* Fix ``task.writer-count`` and ``task.partitioned-writer-count`` configuration properties in Presto C++ for consistency with Presto. :pr:`23902`
+* Fix a bug where users weren't able to set the ``native_expression.max_array_size_in_reduce`` session property. :pr:`23856`
+* Fix plan validation failures for some join queries running with spill enabled when using Presto C++. :pr:`23595`
+* Fix bug so that proper logical type parameters are now read and written to Parquet files. :pr:`23388`
+* Fix a data corruption in uncompressed ORC/DWRF files with large values in string/binary columns. :pr:`23760`
+* Improve arbitrator configs to use the new string-based format. :pr:`23496`
+* Add ``$path`` and ``$bucket`` to split info, and fixed the split counts in the coordinator UI. :pr:`23755`
+* Add a metric ``presto_cpp.memory_pushback_expected_reduction_bytes`` to track expected reduction in memory after a pushback attempt. :pr:`23872`
+* Add a new counter, ``presto_cpp.memory_pushback_reduction_bytes``, to monitor the actual memory reduction achieved with each memory pushback attempt. :pr:`23813`
+* Add ``native_max_local_exchange_partition_count`` session property which maps to the ``max_local_exchange_partition_count`` velox query property to limit the number of partitions created by a local exchange. :pr:`23910`
+* Add session property: ``native_writer_flush_threshold_bytes`` which specifies the minimum memory footprint size required to reclaim memory from a file writer by flushing its buffered data to disk. :pr:`23891`
+* Add session property: ``native_max_page_partitioning_buffer_size`` which specifies the maximum bytes to buffer per PartitionedOutput operator to avoid creating tiny SerializedPages. :pr:`23853`
+* Add session property: ``native_max_output_buffer_size`` which specifies the maximum size in bytes for the task's buffered output. The buffer is shared among all drivers. :pr:`23853`
+* Add incremental periodic cache persistence for Presto C++ worker. :pr:`23626`
+* Add native system session property provider. :pr:`23045`
+* Remove session property ``native_join_spiller_partition_bits``. :pr:`23906`
+* Revert merging of ``FilterNode`` into ``TableScanNode`` done in :pr:`23755`. :pr:`23855`
+
+Security Changes
+________________
+* Upgrade Postgres JDBC Driver to 42.6.1 in response to `CVE-2024-1597 <https://nvd.nist.gov/vuln/detail/CVE-2024-1597>`_. :pr:`23710`
+* Upgrade the logback-core version to 1.2.13 in response to `CVE-2023-6378 <https://github.com/advisories/GHSA-vmq6-5m68-f53m>`_. :pr:`23735`
+
+Hive Connector Changes
+______________________
+* Fix interpretation of ambiguous timestamps inside array, map, or row types for tables using ``TEXTFILE`` format to interpret the timestamps as the earliest possible unixtime for consistency with the rest of Presto. :pr:`23593`
+* Fix timestamps inside array, map, or row types for tables using ``TEXTFILE`` format to respect the ``hive.time-zone property``. :pr:`23593`
+
+Iceberg Connector Changes
+_________________________
+* Fix time-type columns to return properly when ``iceberg.parquet-batch-read-optimization-enabled`` is set to ``TRUE``. :pr:`23542`
+* Fix to reduce drop time for Iceberg tables with deleted metadata in S3 storage. :pr:`23510`
+* Fix bug so that proper logical type parameters are now read and written to Parquet files. :pr:`23388`
+* Fix a data corruption in uncompressed ORC/DWRF files with large values in string/binary columns. :pr:`23760`
+* Add Iceberg metadata table ``$ref``. :pr:`23503`
+* Add configuration property ``iceberg.rest.auth.oauth2.scope`` for OAUTH2 authentication in Iceberg's REST catalog. :pr:`23884`
+* Add configuration property ``iceberg.rest.auth.oauth2.uri``. :pr:`23739`
+* Add procedure ``rollback_to_timestamp`` to rollback an Iceberg table to a given point in time. :pr:`23559`
+* Add support of UUID-typed columns. :pr:`23627`
+* Add support to query Iceberg table by branch/tag name. :pr:`23539`
+* Add table property ``metrics_max_inferred_column`` to configure the max columns number for which metrics are collected, and support ``metrics_max_inferred_column`` for Iceberg tables with `PARQUET` format. :pr:`23468`
+* Add support for procedure ``fast_forward`` for Iceberg. :pr:`23589`
+* Add support for using named arguments in procedures ``register_table`` and ``unregister_table``. :pr:`23592`
+* Support new procedure ``set_current_snapshot`` for Iceberg. :pr:`23567`
+* Support timestamp without timezone in time travel expressions. :pr:`23714`
+
+MongoDB Connector Changes
+_________________________
+* Add support for ``varbinary`` data type in MongoDB. :pr:`23386`
+* Add support for MongoDB ``ALTER TABLE`` statement. :pr:`23266`
+
+Cassandra Connector Changes
+___________________________
+* Upgrade cassandra-driver-core to 3.11.5 for SSL support. :pr:`23493`
+
+Elasticsearch Connector Changes
+_______________________________
+* Improve handling of exceptions for empty tables in Elasticsearch. :pr:`23850`
+
+SPI Changes
+___________
+* Add ``Partitioning``, ``PartitioningScheme``, ``PartitioningHandle``, ``PlanFragmentId``, ``StageExecutionDescriptor`` and ``SimplePlanFragment`` to the SPI. :pr:`23601`
+
+**Credits**
+===========
+
+Abhisek Saikia, Amit Dutta, Anant Aneja, Ananthu-Nair, Andrii Rosa, Bikramjeet Vig, Bryan Cutler, Chen Yang, Christian Zentgraf, David Tolnay, Deepa-George, Deepak Majeti, Denodo Research Labs, Elbin Pallimalil, Elliotte Rusty Harold, Feilong Liu, Ge Gao, Hazmi, Jalpreet Singh Nanda (:imjalpreet), Jayaprakash Sivaprasad, Jialiang Tan, Jimmy Lu, Joe Abraham, Karnati-Naga-Vivek, Ke, Konjac Huang, Krishna Pai, Linsong Wang, Mahadevuni Naveen Kumar, Matt Calder, Naveen Nitturu, Nikhil Collooru, Pramod, Pratik Joseph Dabre, Rebecca Schlussel, Reetika Agrawal, Richard Barnes, Rohan Pal Sidhu, Sam Partington, Serge Druzkin, Sergey Pershin, Steve Burnett, SthuthiGhosh9400, Swapnil Tailor, Timothy Meehan, Xiaoxuan Meng, Yihong Wang, Ying, Zac Blanco, Zac Wen, Zuyu ZHANG, abhibongale, aditi-pandit, ajay-kharat, auden-woolfson, exxiang, jackychen718, jaystarshot, kiersten-stokes, lingbin, lithinpurushothaman, lukmanulhakkeem, misterjpapa, mohsaka, namya28, oyeliseiev-ua, pratyakshsharma, prithvip, wangd


### PR DESCRIPTION
Fixes #23945

# Missing Release Notes
## Andrii Rosa
- [ ] https://github.com/prestodb/presto/pull/23902 [native] Propagate table writer concurrency settings (Merged by: Andrii Rosa)

## Bikramjeet Vig
- [ ] https://github.com/prestodb/presto/pull/23872 [native] Add a metric to track expected reduction of memory and minor fixes (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/23813 [native] Add counter to track effectiveness of memory pushback (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/23773 [native] Minor refactor of PeriodicMemoryChecker (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/23620 [native] Add session properties for expression evaluation optimizations (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/23621 [native] Advance velox (Merged by: Amit Dutta)

## Chen Yang
- [ ] https://github.com/prestodb/presto/pull/23707 Reduce wasted memory in ChunkedSliceOutput (Merged by: Sergii Druzkin)

## Jialiang Tan
- [ ] https://github.com/prestodb/presto/pull/23891 [native] Add session property native_writer_flush_threshold_bytes (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/23906 [native] Remove native session native_join_spill_partition_bits (Merged by: Xiaoxuan)
- [ ] https://github.com/prestodb/presto/pull/23853 [native] Add partitioned output buffers sessions (Merged by: tanjialiang)
- [ ] https://github.com/prestodb/presto/pull/23496 [native] Switch to use string based arbitrator configs (Merged by: tanjialiang)

## Jimmy Lu
- [ ] https://github.com/prestodb/presto/pull/23855 [native] Revert remaining filter pushdown from FilterNode (Merged by: Jimmy Lu)
- [ ] https://github.com/prestodb/presto/pull/23755 [native] Push down FilterNode into TableScan (Merged by: Aditi Pandit)
- [ ] https://github.com/prestodb/presto/pull/23721 [native] Add native_selective_nimble_reader_enabled session property (Merged by: Amit Dutta)
- [ ] https://github.com/prestodb/presto/pull/23641 [native] Add Velox query config selective_nimble_reader_enabled (Merged by: Jimmy Lu)

## Joe Abraham
- [ ] https://github.com/prestodb/presto/pull/23784 Refactor the ContainerQueryRunner to utilize the JDBC driver for executing queries (Merged by: Timothy Meehan)

## Naveen Nitturu
- [ ] https://github.com/prestodb/presto/pull/23577 Fix for incorrect nullable setting on NOT NULL columns (Merged by: Timothy Meehan)

## Pratik Joseph Dabre
- [ ] https://github.com/prestodb/presto/pull/23045 [native] Adds a native session property provider (Merged by: Timothy Meehan)
- [ ] https://github.com/prestodb/presto/pull/23856 Fix native_expression.max_array_size_in_reduce session property (Merged by: Timothy Meehan)

## Reetika Agrawal
- [ ] https://github.com/prestodb/presto/pull/23567 [Iceberg] Support procedure set_current_snapshot for Iceberg (Merged by: Reetika Agrawal)

## Richard Barnes
- [ ] https://github.com/prestodb/presto/pull/23575 Remove `using namespace` from header files (Merged by: Rebecca Schlussel)

## abhibongale
- [ ] https://github.com/prestodb/presto/pull/23732 Fix UUID distinct operation issue (Merged by: Timothy Meehan)

## ajay-kharat
- [ ] https://github.com/prestodb/presto/pull/23818 Centralize dependency versions in parent pom.xml (Merged by: Timothy Meehan)

## lithinpurushothaman
- [ ] https://github.com/prestodb/presto/pull/23507 SSL enablement for Cassandra Connector (Merged by: Timothy Meehan)

## namya28
- [ ] https://github.com/prestodb/presto/pull/23735 Security Vulnerability fix for logback-core (CVE-2023-6378) (Merged by: Timothy Meehan)

# Extracted Release Notes
- #23177 (Author: Zac Blanco): [Iceberg] Add StatisticsFileCache
  - Add a configurable-sized cache for Iceberg table puffin files to improve query planning time controlled by the  `iceberg.max-statistics-file-cache-size` configuration property. :pr:`23177`.
- #23245 (Author: jackychen718): Evaluate project node on values node
  - Add session property ``inline_projections_on_values`` and configuration property ``optimizer.inline-projections-on-values`` to evaluate project node on values node :pr:`23245`.
- #23266 (Author: Naveen Nitturu): Add support for ALTER TABLE statement in MongoDB
  - Add support for MongoDB ``ALTER TABLE`` statement. :pr:`23266`.
- #23386 (Author: exxiang): Extend MongoDB connector support binData
  - Support varbinary data type in MongoDB (pr:`23386`).
- #23388 (Author: auden-woolfson): Persist proper logical type parameters in parquet files
  - Fix bug so that proper logical type parameters are now read and written to Parquet files :pr:`23388`.
  - Add test for logical type storage in parquet files :pr:`23388`.
- #23407 (Author: prithvip): Accept query id and slug in QueuedStatement
  - Add support in QueuedStatement protocol to accept pre-minted query id and slug :pr:`23407`.
- #23456 (Author: auden-woolfson): Unescape like pattern, and check for one character escape string when in row expression interpreter
  - Fix bug to unescape like pattern and validate escape string with no unresolved value :pr:`23456`.
- #23468 (Author: wangd): [Iceberg]Support setting the max number of columns for which metrics are collected
  - Add table property `metrics_max_inferred_column` to configure the max columns number for which metrics are collected, and support `metrics_max_inferred_column` for Iceberg table with `PARQUET` format :pr:`23468`.
- #23472 (Author: Mahadevuni Naveen Kumar): Fix querying and filtering using Iceberg metadata columns
  - Fix to query and filter using Iceberg metadata columns "$path" and "$data_sequence_number" :pr:`23472`.
- #23479 (Author: Jayaprakash Sivaprasad): Avoid pushdown of negative position for element_at as subfield pruning for array 
  - Avoid pushdown of negative position for element_at for array  :pr:`23479`.
- #23503 (Author: Reetika Agrawal): [Iceberg] Add Iceberg metadata table $ref
  - Add Iceberg metadata table $ref :pr:`23503`.
- #23510 (Author: Deepa-George): Fix to avoid retrying the metadata loading once a FileNotFoundException is thrown, when trying to drop Iceberg tables, whose metadata is deleted from its S3 storage
  - Fix to reduce drop time for Iceberg tables with deleted metadata in S3 storage. :pr:`23510`.
- #23520 (Author: Matt Calder): Function to check if IP address is private
  - Add function :func: `is_private_ip` that returns true when the input IP address is private or a reserved IP address ... :pr:`23520`.
- #23527 (Author: Ke): [native] Add session property for partial aggregation and spill
  - Add a session property `native_max_partial_aggregation_memory` which specifies presto native max partial aggregation memory when data reduction is not optimal :pr:`23527`.
  - Add a session property `native_max_extended_partial_aggregation_memory` which specifies presto native max partial aggregation memory when data reduction is optimal :pr:`23527`.
  - Add a session property `native_max_spill_bytes ` which specifies presto native max allowed spill bytes :pr:`23527`.
- #23539 (Author: Reetika Agrawal): Add support to query Iceberg table by branch/tag name
  - Add support to query Iceberg table by branch/tag name :pr:`23539`.
- #23542 (Author: Zac Blanco): [parquet] Support us precision Time type in batch reader
  - Fix time-type columns to return properly when ``iceberg.parquet-batch-read-optimization-enabled`` is set to ``TRUE``. :pr:`23542`.
- #23546 (Author: prithvip): Add support for AuthorizedIdentity credentials proxying
  - Add support to proxy AuthorizedIdentity via JWT :pr:`23546`.
- #23559 (Author: Jalpreet Singh Nanda (:imjalpreet)): [iceberg] Add procedure rollback_to_timestamp
  - Add procedure `rollback_to_timestamp` to rollback an iceberg table to a given point in time. :pr:`23559`.
- #23579 (Author: auden-woolfson): Add icon in .idea
  - Add presto icon to .idea :pr:`23579`.
- #23580 (Author: auden-woolfson): make IcebergDistributedSmokeTestBase abstract
  - Make IcebergDistributedSmokeTestBase abstract :pr:`23580`.
- #23585 (Author: Swapnil Tailor): Fix Server Active State Endpoint
  - GET `/v1/info/state` to return INACTIVE state until the resource group configuration manager is fully initialized :pr:`23585`.
- #23589 (Author: Reetika Agrawal): Support procedure fast_forward for iceberg
  - Support procedure fast_forward for iceberg :pr:`23589`.
- #23592 (Author: wangd): Make Iceberg's procedures uniformly support named arguments
  - Support using named arguments in procedure `register_table` and `unregister_table` :pr:`12345`.
- #23593 (Author: Rebecca Schlussel): Fix textfile ambiguous timestamps and different storage timezones
  - Fix timestamps inside array, map, or row types for tables using TEXTFILE format to respect the ``hive.time-zone property``.
  - Fix interpretation of ambiguous timestamps inside array, map, or row types for tables using TEXTFILE format to interpret the timestamps as the earliest possible unixtime for consistency with the rest of Presto.
- #23595 (Author: Rebecca Schlussel): Fix join validation when spill enabled for native
  - Fix plan validation failures for some join queries running with spill enabled when using Presto C++.
- #23601 (Author: Rebecca Schlussel): Add SimplePlanFragment to the SPI
  - Add ``Partitioning``, ``PartitioningScheme``, ``PartitioningHandle``, ``PlanFragmentId``, ``StageExecutionDescriptor`` and ``SimplePlanFragment`` to the SPI . :pr:`23601`.
- #23626 (Author: Zac Wen): [native] Make periodic cache flush incremental
  - Add incremental periodic cache persistence for Presto C++ worker. :pr:`23626`.
  - Replace configuration property `async-cache-full-persistence-interval` with `async-cache-persistence-interval`. :pr:`23626`.
- #23627 (Author: Zac Blanco): [iceberg] Add UUID type support
  - Add UUID type support to the Parquet reader and writer. :pr:`23627`.
  - Add support of UUID-typed columns :pr:`23627`.
- #23649 (Author: Bryan Cutler): Add property to enable eager building of plan as part of new native plan checker SPI
  - Add new property `eager-plan-validation-enabled` for eager building of validation of a logical plan before queuing. :pr:`23649`.
- #23656 (Author: Matt Calder): Function to split an IP prefix into subnets (#2)
  - Add function :func:`ip_prefix_subnets` that splits the input prefix into subnets the size of the new prefix length. ... :pr:`23656`.
- #23710 (Author: ajay-kharat): CVE-2024-1597 updated postgres version to 42.6.1
  - Upgrade Postgres JDBC Driver to 42.6.1 :pr:`23710`.
- #23714 (Author: wangd): [Iceberg]Support timestamp without timezone in time travel expressions
  - Support timestamp without timezone in time travel expressions :pr:`23714`.
- #23739 (Author: kiersten-stokes): Add Iceberg REST auth server configuration property
  - Add iceberg.rest.auth.oauth2.uri configurable property :pr:`23739`.
- #23760 (Author: Serge Druzkin): [presto-orc] Fix row index position when compression is disabled
  - Fix a data corruption in uncompressed ORC/DWRF files with large values in string/binary columns :pr:`23760`.
- #23762 (Author: Amit Dutta): Remove array_dupes and array_has_dupes alias.
  - Remove array_dupes and array_has_dupes alias names from functions :func:`array_duplicates` and :func:`array_has_duplicates`.
- #23774 (Author: jaystarshot): Turn on optimized_scale_writer_producer_buffer by default
  - Improve writer scaling in skewed conditions by setting optimized_scale_writer_producer_buffer to on by default :pr:`23774`.
- #23780 (Author: Zac Blanco): [CLI] Add flag to disable certificate verification
  - Add a flag to the Presto CLI which allows skipping SSL certificate verification `:pr:23780`.
- #23792 (Author: Elbin Pallimalil): Add cast functions for char datatype to numeric types
  - Added support for casting char datatype to various numeric datatypes.     :pr:`23792`.
- #23794 (Author: Hazmi): Upgraded commons-io to version 2.16.0
  - Upgraded commons-io to version 2.16.0 :pr:`23794`.
- #23797 (Author: Hazmi): Upgraded protobuf-java dependencies to 3.25.5
  - Upgraded protobuf-java to version 3.25.5 :pr:`23797`.
  - Upgraded protobuf-java-util to version 3.25.5 :pr:`23797`.
- #23850 (Author: Karnati-Naga-Vivek): Handle exception for empty tables in elasticsearch
  - Improve handling of exceptions for empty tables in Elasticsearch :pr:`23850`.
- #23858 (Author: Feilong Liu): Extend join prefilter optimizer to use hash for filter
  - Improve JoinPrefilter optimizer for wide join keys and multiple join keys :pr:`23858`.
- #23863 (Author: Pratik Joseph Dabre): Add sidecars to NodeManager and add PluginNodeManager
  - Adds a new NodeManager : 'PluginNodeManager' :pr:`23863`.
- #23868 (Author: Hazmi): Upgrade avro version
  - Upgraded avro to version 1.11.4 :pr:`23868`.
  - Upgraded commons-compress to version 1.26.2 :pr:`23868`.
  - Upgraded commons-codec to version 1.17.0 :pr:`23868`.
  - Upgraded commons-lang3 to version 3.14.0 :pr:`23868`.
  - Upgraded commons-io to version 2.16.1 :pr:`23868`.
- #23884 (Author: Denodo Research Labs): Add scope for OAUTH2 authentication in Iceberg's REST catalog
  - Add configuration property ``iceberg.rest.auth.oauth2.scope`` for OAUTH2 authentication in Iceberg's REST catalog :pr:`23884`.
- #23890 (Author: Ke): Fix array_intersect for array<array<T>>
  - Fix array_intersect for single parameter array<array<T>> to be deterministic regardless of the order of null input:pr:`23890`.
- #23910 (Author: Andrii Rosa): Add native_max_local_exchange_partition_count session property
  - Add ``native_max_local_exchange_partition_count session`` property. :pr:`23910`.
- #23922 (Author: Feilong Liu): Fix localexchange properties when spill is enabled
  - Fix bug in local property calculation when spill is enabled :pr:`23922`.

# All Commits
- c16711ae7b94794ea95c425cceb48ca98a8fc067 Handle empty tables with no mappings (Karnati-Naga-Vivek)
- 7805ba5ef86d53f2f806aaeb1af49471cdee55af Revert "Upgrade avro & its dependencies to resolve CVEs" (Konjac Huang)
- 9e0c295a8315b2eb04adc7842d64cca6ec29c20c Fix localexchange propertie when spill is enabled (Feilong Liu)
- be973ccac64311949082452b9c19c81f0aa7ca54 Fix formatting in presto_cpp/properties.rst (Steve Burnett)
- c3abe54a59e87191a563475927df1c4be33d46b3 Add Comments in PRs to CONTRIBUTING.md (Steve Burnett)
- f02bf22c5b202cebde459c07024b295877f54ca1 [native] Allow new Velox GCS changes (Deepak Majeti)
- 68aea2fdbdcb1936aba43eaa396d842ba67a1d90 [native] Fix table writer to use the actual storage format (Ke)
- 8f630f909715244e554019be4566797cbe498f38 Update HiveWriterFactory to use actualStorageFormat (Ke)
- 4391c9b82b38c94cd46e04dee26eadd373336f33 [native] Advance velox. (Amit Dutta)
- fcac3b42b03000f5e17d6e395c281890855d56cb [native] Use new metrics() API in PrestoExchangeSource (lingbin)
- 600b7bc476f7508aa52cab38faf39dfc1b6320f1 [native] Add Linux Memory Manager (mohsaka)
- 636a663eb99807cd1db5fb0da52e715f325e49c9 [native] Advance velox. (Amit Dutta)
- d3051d69e5235f08ee297d43c4f97a63eabafb78 Fix array_intersect for array<array<T>> (Ke)
- 0d04e9788aeafdc6ac04c7001bd3f5c21ef66e8b Fix depenedency version issue (Konjac Huang)
- 09977dc1b3f1ce8a74da5bba5241170d88234fe1 Add native_writer_spill_enabled session doc back (Jialiang Tan)
- 2834ecc6973a594fd9177ee7b0d7879822c1a22c Add native_max_local_exchange_partition_count session property (Andrii Rosa)
- a4fe9243ef5a82262ed1835e565a10334b327dab Propagate underlying exception in NativeSystemSessionPropertyProvider (Andrii Rosa)
- b1ab1e42ffb16d6f8094879a795c63179a93e258 Unblock TestPrestoNativeHiveExternalTableTpchQueriesParquet (Andrii Rosa)
- afccfedeff85cfedebc852f090695d911a2d1c17 Advance Velox (Andrii Rosa)
- 4d0df87d801656d154d58388d97b6dbbf91e9e0f [native] Add session property native_writer_flush_threshold_bytes (Jialiang Tan)
- dd638db573e620f4402250f74d1675c23a955bbf [native] Fix typos in ProtocolToThrift README (Zuyu ZHANG)
- 38ca2ec4488f6112ff3d9f01974d20471c344171 [native] Propagate table writer concurrency settings (Andrii Rosa)
- 189e817cb39473e59f62c00e5ccb269a896f2bcc [native] Remove native session native_join_spill_partition_bits (Jialiang Tan)
- 1c0fc175a73f60ababb6fba26472c3d5df7ebadf Upgrade avro & its dependencies to resolve CVEs (Hazmi)
- 5ed9da172336f90cb9f8cdf58f522f6a22c7360d Add OpenAPI documentation for /v1/properties/session (Pratik Joseph Dabre)
- 2b9e483f6d08619d21b84eafc4a4093e5ed25be0 [native] Add e2e native session property provider tests with sidecar (Pratik Joseph Dabre)
- 4f7fad71798c00724da0e092325ef28fb2331f7e Integrate session property plugin with sidecar (Pratik Joseph Dabre)
- ebbfdacb23b7cbd0eae219a78cc9bb8569d2f85b Integrate session property SPI with Presto engine (Pratik Joseph Dabre)
- 524fbea48d449769d2f139527d1aa9cffb4f7455 Introduce session properties SPI (Pratik Joseph Dabre)
- cee51f5c9d00de3a0164372363871140aac1249d Separate out worker session properties and introduce JavaFeaturesConfig (Pratik Joseph Dabre)
- b936b6d1d0a1ac7c966da37e9996800e1f009ae4 Allow workers to act as coordinator sidecars (Pratik Joseph Dabre)
- 1640594fc0f0d691728aadbf97259c0a082fde9f [native] Use core protocol header in FunctionMetadata (Abhisek Saikia)
- 8abe0c9609dd6c82a01a542499a9def0d9e81ea4 [native] split protocol header (Abhisek Saikia)
- d384ccab8a2d25b4200b0d122d6dd1c8bc7374c3 Add admin/properties-session.rst (Steve Burnett)
- fe3b95971de165d7b798d42b41dac486c790569f Add documentation for properties (Timothy Meehan)
- 52cdfff12cfc8acba704d376bdcc1f343da7056d Automatically link sections in rst (Tim Meehan)
- 88a35dbbf63832aed7cc264ca67bf3c22a3b48b3 Add scope for OAUTH2 authentication in Iceberg's REST catalog (Denodo Research Labs)
- 0ef5f820f5a8e934078cefb08a3156eea4cd6984 [native] Symlink table mapping for Delta table access. (Reetika Agrawal)
- c8a90e5f492c7323280c7b4f9c3c07323e531913 Allow InternalPlanNodes to accept a PlanVisitor (Rebecca Schlussel)
- 758205af5429e7c422f6e6787d5eeb480b5a9f62 Upgraded commons-io (Hazmi)
- 855ac732c5941d78078bbe67bbf89ae48d6e0830 Added gson to dependency management in bigquery (Hazmi)
- ed9e2254ddcc84961469a8460f67994aab98a400 Upgraded protobuf-java dependencies to 3.25.5 (Hazmi)
- b324cf06f2eaa5464a2592ec3778fe1c32c31882 Fix error in sql/update.rst (Steve Burnett)
- c2dad16b3599265b48bb90a6c0ccad9087fcdb58 [native]Update TaskManagerTest to create new file in local file sink (Xiaoxuan Meng)
- 65374855ffa389a3b64efb23d74f9ee5292d16dc [native] Add a metric to track expected reduction of memory and minor fixes (Bikramjeet Vig)
- 96b716d51eb23fb712cd8e80a2a6fb7df38f5c35 [native] Update gtest targets for presto_function_metadata_test (zuyu)
- e1c2db8e41c220d7a1a978092429e203469d2c3b Rename enabledOptimizedReader -> enableBatchReader (Zac Blanco)
- 6909c855c8589a3f9cc178b77b9cabacd41be89c [iceberg] Add UUID type support (Zac Blanco)
- 342ceb00ccf4631c92956c5470cafaf928f52941 [parquet] Add a profile to re-generate batch readers (Zac Blanco)
- 1512671dedca30e8f0c772afb9301f53deaf5e44 Extend join prefilter optimizer to use hash (Feilong Liu)
- b0a9144fc413e6125cd68f1875c7369cc6039c02 [native]Advance velox version with flaky test fix (Xiaoxuan Meng)
- 90fe610759c1199665536e7441a102486bdc9345 [native] Update metadata for function combinations in FunctionMetadataTest (Pramod)
- 7e6691dfb83513ac7d78b1bdee0ad2d290c1bf61 Add sidecars to NodeManager and add PluginNodeManager (Tim Meehan)
- 38e977e121aee5552c6171639b6423d4c4799aea [native] Add partitioned output buffers sessions (Jialiang Tan)
- bba64ad4630af400609917ab90d598acabd2f015 [native] Retrieve Json function metadata (Pramod)
- d00cbe878ff4f24c726b2d815608c3eb94e2bb3b [native] Update presto_protocol (Pramod)
- a4e7d3f06b2448ac6adab6a25df890b81bc3d17b [native] Advance velox. (Amit Dutta)
- 0c19d4f64bc5821fc63d500262f31768cbd4a539 Fix native_expression.max_array_size_in_reduce session property (Pratik Joseph Dabre)
- 47e37307b43129a997c0547f724ce5c00abea2ed Add more tests for ArrayNormalizeFunction. (Amit Dutta)
- 3d62b27cbb6208fbe014fee4fcf08e19577a7730 Add presto_cpp/properties-session.rst (Steve Burnett)
- 8cceea2600f16c75c4955760fc2f64f509736f10 [native] Include glog for thrift artifact build (Christian Zentgraf)
- f73097fa1afd0607acbcd4847ffac05ba381b7e8 Pass extra credentials to system connector (SthuthiGhosh9400)
- f6c3abe9114ceb2317156a4debfc1865cf80451e [native] Revert remaining filter pushdown from FilterNode (Jimmy Lu)
- 85a0fa443bcf4f1e0feb9876c7cf4f47f34e7092 [native] Fix periodic memory checker reporting metrics (Jialiang Tan)
- 8c69bcb9ac42344cc7082eb047b061b4ba574caa Use JDBC for ContainerQueryRunner (Joe Abraham)
- 61f5c3eef0e3a0aa774c2fc19408c8432a65ef03 Add "native_expression.max_array_size_in_reduce" session property. (Sergey Pershin)
- 86ae5241e330013040866ff9f45d42c9da98bc27 Add documentation for query plan and plan fragment (Steve Burnett)
- 90742a47c6497b6cac5336ffdeadc40ed56e48ef Fix flaky test TestQueues.testEagerPlanValidation (Bryan Cutler)
- 9f542077cbf6e4f9fa6fc6fee5c58bf3dad7d22d Fix aggregate queries with labels column in prometheus (lukmanulhakkeem)
- e4c7e05c96f181232ff227d9081af92f63ea0c38 [native] Advance velox. (Amit Dutta)
- 87277f87c8787cf9c209815f5975d3e87cb39444 [native] Add the native isBlockedTiming stat to operator stats (Zuyu ZHANG)
- f1058ccdddaae07888e7cb1077a9264a0cbd5917 [Iceberg]Enable test cases for rename table on REST and NESSIE catalog (wangd)
- 5f3835ef76afe93f966b25f502ba503924e21068 [native] Advance Velox version. (Sergey Pershin)
- d280efccd3358f53eaec4dd83fd31cde412d8a8b [native] Install all adapter dependencies in dependency dockerfiles (Deepak Majeti)
- 6efcf0f4567c2e1f249ee96051e81feb76dd7af8 Centralize dependency versions in parent pom.xml (ajay-kharat)
- bee3c6e20fa27e0068d5ae84842527654c3f06b2 fix the multi-level subgroup issue (Yihong Wang)
- 27eb6663a0b6a5e5587fce5b2f00b1aa19345bf8 [native] Add query trace session properties to native session (Jialiang Tan)
- 3236937a64879f0908c5b4c5e06d884805d7b161 [native] Advance velox. (Amit Dutta)
- 10227bbe57921f90a89bfbd5b22db036aa6018c7 [native] Add counter to track effectiveness of memory pushback (Bikramjeet Vig)
- 4799dd2f739ebfd074d01571bf413fcfa71749c1 Enable verbose runtime stats for connector optimizer (Feilong Liu)
- 6bf9e3ca513324aea271afc8c87c50b255ade7a5 Replace presto-router/README.txt with README.md (Steve Burnett)
- fb3a00f51de7446e103aeaa4e7ec515a5c7269c5 [native]Prestissimo exception error code conversion fix (Xiaoxuan Meng)
- 9c4e018d2fb35feb882729c01cac6c0bbd651361 [prestissimo] Fix memory push back latency unit (Jialiang Tan)
- b7814dfecc8ba055aac0a32a48297217eae0bc35 Add SPI to support plugin for custom plan checkers (Bryan Cutler)
- 4b0ab664bfc090838db38212ad84b8a6603b6344 Add property for eager building of plan (Bryan Cutler)
- 8ce4ccd69f660a94ce779805001077b5edf0a509 Update presto-docs/src/main/sphinx/connector/singlestore.rst (oyeliseiev-ua)
- ac954c259a53ecd5f4af924ae8b441670b6ff8eb Update presto-docs/src/main/sphinx/connector/singlestore.rst (oyeliseiev-ua)
- 44e6604ebe74520f855694e7226131807be422f3 Update presto-docs/src/main/sphinx/connector/singlestore.rst (oyeliseiev-ua)
- 01354d643db48d369fd451762299e1bcdb135379 Update SingleStore docs (oyeliseiev-ua)
- cbd1a11d634dacfc75fb0d6c8cb057be7797986d Fix round for float value when input out of long range (wangd)
- 9fa4aee94c0942c962acd7df46996bc925006dd6 Add cast functions for char datatype to numeric types (Elbin Pallimalil)
- 48f0a0c1d380b1155dfd7c99b134a350627c7260 [native] Update velox (Christian Zentgraf)
- 7deadd1dc2ba0bce4f345c1394e67a5aa1fd7893 Upgrade the logback-core version to 1.2.13 (namya28)
- f9f884dc749b0cee899685a9b93193360ea797ee [native] Add support for DEPENDENCY_DIR, INSTALL_PREFIX, PYTHON_VENV (Deepak Majeti)
- 96c58c916f344df810e2fc783a1c8ef4d2bcbe5f [CLI] Add flag to disable certificate verification (Zac Blanco)
- 64be0e3188921ed5e5dc110f6d4bceaec352bb12 Add trace session properties to presto native (Jialiang Tan)
- 11926329467d60f71c3c4747b9a40f83afad4ee8 Read dataDirectory from system/env variables (pratyakshsharma)
- 66f34de3fb919e84514544f45d47b43b677d90a3 [native] Advance velox. (Amit Dutta)
- 6d096e5ee93a99a6573b32c63aa7dabfff4186f0 [native] Minor refactor of PeriodicMemoryChecker (Bikramjeet Vig)
- 152e64dbebf2d8c9deedaae833d4ebfcaa4a531f Turn on optimized_scale_writer_producer_buffer by default (jaystarshot)
- 6f603558869153bd249836004e9c78af7d3fd5fd Fix the length of offsets array in parquet long decimal value decoders (wangd)
- 88c03ab6ffb3f10eba7caa3c2bab692106d0b599 Fix distinct operator for UUID (abhibongale)
- 832b071b3c74f65a6fe8386dc296b61f17192a7a [native] Advance velox. (Amit Dutta)
- 7c814aeeb5ab35e351f181fc465a92cca59d66de Don't generate code for Parquet readers; Make batchreader code available and findable in the source repository (Elliotte Rusty Harold)
- 751768a544ec65ce4bbfd474907b01afab2dff1c Fix some toString methods in presto-orc (#23750) (Serge Druzkin)
- 64b5ebfef5f800d6e1a4594c7c7e5fb002284bcf Fix REST session bug for Iceberg REST catalogs (kiersten-stokes)
- 1a8c27d95ee2cef49d624474a7eba7056be078b0 Fix formatting problem. (Krishna Pai)
- ceeab87b46d3b6193b5c1dbaad1e96dac938e53a Register dwrf reader/writer factories. (Krishna Pai)
- 8bd65b058e0bf7932c79ae2cf25a112106b448a8 Disable streaming aggregations. (Krishna Pai)
- 8c264599aa87b230c5b74d4548440afcb10d2248 Expand block documentation (Elliotte Rusty Harold)
- 8a026e5a734d01f69fae591983cbb364f29193ac Remove array_dupes and array_has_dupes alias. (Amit Dutta)
- 699a808d0a5ca3d4a7ad11e1b437ca5cb9950cdc [presto-orc] Fix row index position when compression is disabled (Serge Druzkin)
- 176e8867cd254bb428a5ab8b58118a5be2b8b4d8 [native] Push down FilterNode into TableScan (Jimmy Lu)
- c4c02f8fe85cc1a8ceccf2cc7109388ba6e1d8b8 [native]Remove bucket property set in table write node (Xiaoxuan Meng)
- af8852255b1cb1eca69625434403b97c95eb4aeb [native] Advance velox. (Amit Dutta)
- 266ccecd6aa89362699bf0815c85ed7d9833f35c Add Iceberg REST auth server configuration property (kiersten-stokes)
- 83cb0f6ffbfeffa74a027ad5f5ec73b39adaf36c Fix typo in TupleDomainFilterUtils (Rebecca Schlussel)
- 24a488bb41b568e9323085873f24d82eaf861ade Allow task writer counts to be non-power of two for native engine (Xiaoxuan Meng)
- bd07a0e15f7ca5e35879b4ad847f3f73b7388c64 Remove use of deprecated getTypeLength method (Elliotte Rusty Harold)
- 9e2ed296ec08dababcd0d1625acbec3f25c68498 [native] Advance velox. (Amit Dutta)
- 489acf684cc2facaec6f2c2e90b7c40560a45443 Add doc requirement for new methods to CONTRIBUTING.md (Steve Burnett)
- ffb7643f0694a5828f3e37817827a6dc0f8afb56 orc_output_buffer_chunk_size (Chen Yang)
- 092ba79b7c38a5a1df6aaae3d25c7ae9a1f02d19 Add a PR link in release-0.282.rst (Steve Burnett)
- 83851634590467292d6b870b779af89201ed9bc8 Add QueryType to AccessControlContext (Rohan Pal Sidhu)
- 375dd5a460343cf4bceeaffb5c276875cab26c2c Add TLS support for Prometheus connector (Ananthu-Nair)
- a8c1ee397a2ab74e5e673edaef156baf2c900114 Add doc for driver.cancel-tasks-with-stuck-operators-threshold-ms (Steve Burnett)
- 6c57a3e3c299f016bab7ba7481f188d58f2ace83 [Iceberg]Support timestamp without timezone in time travel expressions (wangd)
- 27d38bf0f807b6ba70889283d94cbcb0b2180da7 Remove format() calls for constant strings with no arguments (Elliotte Rusty Harold)
- 4bdd580a186bf8e802b912d192e0dfba64475ea8 Delete unused code (Elliotte Rusty Harold)
- 2c57ef3e701d80ec6369ae16cd86c7db1bd7d791 [native]Add to set bucket property flag in table write plan node (Xiaoxuan Meng)
- 12afd2664b7e33b82332dbe7e4d81878470cc449 [native] Remove memory transfer capacity (Jialiang Tan)
- 2242d6c76621d7cb4b9c3fd7e65dddd19f6c0300 Upgrade Postgres JDBC Driver to 42.6.1 (Ajay Kharat)
- a93eafca41c14100d70ea6f1a7bbc2cea15552bc [native] Advance velox. (Amit Dutta)
- 62ca0801fba8448b162fe89f8dab10e0c14158e1 Apply suggestions from code review (Jimmy Lu)
- 6f4d3cca45560c63a7144af8fe47aa9a039363db [native] Add native_selective_nimble_reader_enabled session property (Jimmy Lu)
- 9bbfbaf869107f36ae3b62aa9a89d1a37433b797 [native] Add native e2e tests for unicode in JSON (Ge Gao)
- 7d9a0b0ae10a9e78b38d458cb0fafa04088b70d1 Remove redundant check for short decimal type in parquet decoders (wangd)
- 98ff012587bc57bf87aad5a67adaea2dc98e5bdb Avoid confusion between ErrorCode and ErrorCodeSupplier (Elliotte Rusty Harold)
- 2f4ea64d3bf3fa8c89b3e805d5d0987ac6d971c2 Use semantic asserts (Elliotte Rusty Harold)
- 87e2beb53a0e55c0974482185bcd74bfb148572a Remove test-jar dependency (Elliotte Rusty Harold)
- 649b45a0f40b4cd8a31fcfef91a06a5d3b5303a1 Fix formatting in functions/json.rst (Steve Burnett)
- 30d6a8d116d5f51da26924603205e95ba8a87593 [native] Advance velox. (Amit Dutta)
- 8b6b9db32ad78afe0a616c3eec3ff7c509292e97 Update sqlserver docker image version (Reetika Agrawal)
- 95d24399ac931c236986acbe24285849ca557f22 Fix EffectivePredicateExtractor (Anant Aneja)
- 33ff9521dbd25e2b7b1181cf01391cb899857d65 initial commit for ip_prefix_subnets (Matt Calder)
- 79a5802a336404110c86f144e24699dd4b1e1134 [native] Remove dependencies of old arbitrator config (Jialiang Tan)
- 1a4339ef9b38ab2ddd3b5fefc542c654b7e73a42 Fix case to map optimization (Tim Meehan)
- bf5928e04a844ecc1594f6a4c6f174a7d31ee715 Add presto-server to maven-checks (Timothy Meehan)
- 52081acf54c7e27a7b3a103a04a250b2e82b23c0 Add missing article (Elliotte Rusty Harold)
- 240948137669b685b806a5b9018c58302221259f [native] Advance velox. (Amit Dutta)
- c00f8af3595bc36eef10cdc79c66008cf0871a77 Use Provisio plugin for packaging (Tim Meehan)
- 46eacc3888e1d4e5605015a52cd0a04262c5f183 [native] Removing status message from native worker to support http/2 (Amit Dutta)
- 0b10149ee03f571ba8bab13a4e3d67b03defcd21 Acknowledge results in HEAD request to output buffer (Tim Meehan)
- 26fd8dbd976e2b4341558c953e54bcfbad0a6198 broadcasted --> broadcast (Elliotte Rusty Harold)
- ba811b9f6a9fec15dddb1457fefb1281fb54f335 [native] Fix recording of SUM type in PrometheusStatsReporter (lingbin)
- fd2615e89562047daa004851015270007c6de746 Add support for AuthorizedIdentity JWT claim (prithvip)
- bcb2431fd3958f0e879d37ee8f3cc3ddeb0e1337 Move JWT Authentication from airlift to presto (prithvip)
- d7c6d4ed7b84910e71c1afc2a90efd47d7ccd2d3 Move impersonation authorization to SessionSupplier (prithvip)
- 5a6542c78571eb36f4952f601a9c701989a7948b [native] Update Presto Protocol for Iceberg Writes (Jalpreet Singh Nanda (:imjalpreet))
- f21f15e8fcc6719ce196bebfb70888bf0629482d [iceberg] Make com.facebook.presto.iceberg.PrestoIcebergSchema.aliases not null (Jalpreet Singh Nanda (:imjalpreet))
- cefb7ab9d7603dc42051e9103b090dad284ca44c [native] Advance velox. (Amit Dutta)
- 9c229297922707e28593a7a049c5998fa8d6d902 [native] Reduce stuck drivers threashold to detach worker. (Sergey Pershin)
- 7c0f20b7d7afdac261cb02f781427569986d3466 [Iceberg]Ensure concurrently executed tests use different table names (wangd)
- 64d1a6616f257dbce0d255ff4ee523f590903626 handle null pages when filling in row IDs (Elliotte Rusty Harold)
- 626bb99edeb0bae7dc6078649e36feb243f4fcbb [Native] Add HiveConnectorFactory registration to tests (Deepak Majeti)
- d7a9118b7722816c672e762b6fdca869a8f880a1 [native] Remove unused includes. (Amit Dutta)
- b09edc1a82f3d56d00ff139fe73cbe2341841da2 [native] Advance velox. (Amit Dutta)
- 7c2993f72fb08119c8983f4b9d4bb2e218acc8a3 Fix nullability of columns in information schema (Naveen Nitturu)
- a85138e5f5fe52a5c5a80ee278ea792e7166ec36 Enable set_table_property procedure for Iceberg (Reetika Agrawal)
- 030e1204eb925f6f47fea6599dd23765129f9d6b [native] Add ability to cancel Tasks with stuck Drivers. (Sergey Pershin)
- d849304bcc7265cbef2e4639cfc26a36eee4dcfa [native] Update presto protocol (Jalpreet Singh Nanda (:imjalpreet))
- f834af09029a030899677e2e92059437db083e06 [native] Add Velox query config selective_nimble_reader_enabled (Jimmy Lu)
- 1ab2cbc0f4d4e5da3aa2133c59caecfcce4fa8c5 [native] Advance velox. (Jimmy Lu)
- 251fe6f540ab8b577f6c6fe0f50ca140510dc6a3 Modify CREATE TABLE sql in iceberg tests (Reetika Agrawal)
- 4bedf5e6a06b5032eb4728b9dc8f99a90b286e6c [native] Make periodic cache flush incremental (Zac Wen)
- 7b6820738beee53d2e0123c2e6e3d94b64577dab Standardize on Guava for VisibleForTesting annotation (Elliotte Rusty Harold)
- 7727df83eecf6ff31f81f8533e0654f82992d221 [native] Advance velox. (Amit Dutta)
- 1167b1e91b855c54193fae6fe63a7abea00dbe83 fix formatting in presto-cpp/features.rst (Steve Burnett)
- 3b36ffe696d35e5a93c92261c592431e2824ea96 Update asm.version to fix upper bound dependencies error (aditi-pandit)
- ac510c24c4a04406e90f5052fbd0bcb99cb4f34b [native] Add session properties for expression evaluation optimizations (Bikramjeet Vig)
- e4b8abb1eba532ee024da1b09bd50cde7a0eab3a Persist logical type parameters in parquet files (auden-woolfson)
- d020f10df6316d49071b0c14c967867a51a31dde [native] Advance velox (Bikramjeet Vig)
- 84bd2010d9831b4f7013f4f8875f41d96fc633b7 [Iceberg] Clean up unclosed resources from library (Zac Blanco)
- 52c090ed3634ef7f3454835381e8a1598e68773a [parquet] Support 64-bit RLE-encoded ShortDecimal (Zac Blanco)
- 97d88cfdebb553b5c7fb0e217b0211573df3d190 Make TaskUpdate size exceeded message succinct (misterjpapa)
- 0902cb330c8b0a96aa8f6dc590c4db7f051fc2b7 Add support for microsecond precision Time type (Zac Blanco)
- 1a2228dc8a79f491f79ed4a1677a86d91d873c10 Fix Iceberg procedures to uniformly support named arguments (wangd)
- ca6a9786031f3e9a96f2b91a0c8e332a569c62de [Doc]Supplement explanations on named and positional arguments in CALL (wangd)
- 73fd8c2c19e57536c3b445d499aab2c2d5508f70 initial commit for is_private_ip (Matt Calder)
- 9d463405b35de42dc8e46ac2a453f666d077c30d Add SimplePlanFragment to the SPI (Rebecca Schlussel)
- 07bf13ae09618ea51e34f74d8678d7aa19e2d2bc [Iceberg] Add statistics file caching (Zac Blanco)
- 68bac8959a9e396b79b3351854961f28ac54493a Fix textfile ambiguous timestamps and different storage timezones (Rebecca Schlussel)
- 1f74d4d96191775abde662e64a246ff1f2dd56bf Fix interpreting like expressions with escape (Rebecca Schlussel)
- 8e3710b654851bcf35c31113d65c69d24ea0759f [native] Advance velox. (Amit Dutta)
- 0c394bf682a1fe1f913f2e0563d7af2bb1431161 Fix type signature with whitespace in parameters (Tim Meehan)
- 8964fedcf5693925cb5b307f36ec4021c7d8e66e Support procedure fast_forward for iceberg (Reetika Agrawal)
- e789025411b77097e843821f537f1837e8e02bea Add presto icon to .idea (auden-woolfson)
- b7f0bf1cacea22df9e8156c34585a6008a24806b Fix formatting in functions/array.rst (Steve Burnett)
- f393c602230bd30f0934557ec908e3c29aee72fb Remove `using namespace` from header files (#23575) (Richard Barnes)
- a0e97589d630001bb448994ab88ce71f1a0d00fb Support procedure set_current_snapshot for Iceberg (Reetika Agrawal)
- 8f8f690d31646d775ed70d7e36d3f52543e2446f Terminate all Velox macro calls with semicolon (David Tolnay)
- 5b10fba579d19262774d6fb61e73648de74fa6c1 Fix join validation when spill enabled for native (Rebecca Schlussel)
- 5b78cc853c50f4867f71e9d0a3396f1dadff4d64 Making configuration manager loaded boolean flag Atomic (Swapnil Tailor)
- 6f28f37e81cd5f1bd08b7563522d705de130cf4f Prepare function guidelines (Elliotte Rusty Harold)
- 62d264108733bea012bdd944e1fec2f553965306 Fix formatting of code example for array_has_duplicates (Steve Burnett)
- eb7ef887528416c7ed6c8b945e6623caa4f3e581 SSL enablement for Cassandra connector (lithinpurushothaman)
- 7b14c7a0792499f3a4ada0e21e523cec86259c1b Fix Server Active State Endpoint (Swapnil Tailor)
- c7787045e2f75bbb0f0c0dde0fa62782e3435a81 [native] fix openssl not found on Ubuntu (Christian Zentgraf)
- 92b27b6c54bd8f28fb411f59eba0038023730a2f Add ParquetQuickStatsBuilder bean exporter (Anant Aneja)
- a0d25e2b623136581bcde6610e6e5a5490cbda3d Clarify top N array function (Elliotte Rusty Harold)
- fce4ddfbe137a997da50e41c1f9d7eb26a349aa9 [native] Fix cmake target name (lingbin)
- 22b6b09fcb978278f2575b1c443ff6e170a80f2f make IcebergDistributedSmokeTestBase abstract (auden-woolfson)
- 7bb59d36dddf561686fede59dc83400ce7a30401 [iceberg] Add procedure rollback_to_timestamp (Jalpreet Singh Nanda (:imjalpreet))
- ffd30da1ae2e97638b25856b7b576f07812cd5e7 Add support to query Iceberg table by branch/tag name (Reetika Agrawal)
- 4974aeb3b5f8d0c8811ea911f8e6e79130093a94 Add VARCHAR support with SYSTEM_VERSION AS OF (Reetika Agrawal)
- c40897514e277f0702b27b13619c529ce8744eb6 Adding alter support for mongodb (Naveen Nitturu)
- 87db58c2b92383db6b86c0ab1536a640cea95920 Fix CODEOWNERS (wangd)
- 721d71fc365dba5dfa43d477ee361e5ceabf3c88 Remove unneeded local variable (Elliotte Rusty Harold)
- c4dbb21b7b8d17026c2b4183ddfd92a439abdce4 [iceberg] Rename `table` to `table_name` and update docs with correct argument names (Jalpreet Singh Nanda (:imjalpreet))
- 848b373e5454c84cbc3ed1e599c2d96ba780937c [native] Advance velox. (Amit Dutta)
- b1f849e0eccc2124a6ab8915abe36c5c75e35411 [native] Remove unnecessary semicolons (lingbin)
- 2bceaa02b982f2b10d4d577fac9b3c8944c36ace Avoid retrying once a FileNotFoundException is thrown (Deepa-George)
- 1eafe7d8748132d097a7a7d30c72a138f2220be9 Revert "[native] Fill protocol::TaskStats::completedDrivers with finished splits" (Zac Wen)
- cac668268193ab901d95d9b7c0e3d973955b3c63 Split functions configuration from FeaturesConfig (Tim Meehan)
- cd2fb54fc2fc18bfbfe415013af1a42beff97f0d Add more code owners for Iceberg document (wangd)
- 175f177a075768bd6bb70040435271af06a03828 Make legacy_json_cast hidden (Timothy Meehan)
- 4dd678d77826672ee39561c51c7ac286b64198ba Fix NPE when pruning info from query plan (Zac Blanco)
- d6a42fcfdc4d6b0f0e9ce7148c531f223acfdd16 Remove unused usages of SqlParser, TypeProvider, VariableAllocator (Rebecca Schlussel)
- 539a448e27dab5eb8c759177d88c7dc19df57153 Evaluate project node on values node (jackychen718)
- 838293cabda81f765f32a057288bac09450c05cc Add doc for field_names_in_json_cast_enabled (Steve Burnett)
- b24ddb143e2c18e14936645948d029500600fc3b Fix DeleteNode does not have a Graphviz visitor (Zac Blanco)
- d16bf86050ad214aa70c3d248b9abcf45e4209ea [Iceberg] Use remainingPredicate in filter stats calc (Zac Blanco)
- 72c07cc084bef2fc368ea90ac0395ad1916808a0 Accept query id and slug in QueuedStatement (prithvip)
- c111f7981bf210afab0906c4ab2a015f086c06d6 [native] Advance velox. (Amit Dutta)
- c66fa3572977252ffdd52d6869f57d817c83988e Add Iceberg table property to set the max columns number for which metrics are collected (wangd)
- 3544e0e3d5a8fd3d503305a39be8a8a776811a2b [Iceberg]Support identifying max columns number on metrics collection (wangd)
- 8b5c969f72e17abea2e418e1587ef782ef889078 Remove unused fields (Elliotte Rusty Harold)
- 7fde59ba527d11c4eda8bf51ce656d1d957bf0ea Add session property for partial aggregation and spill (Ke)
- bc2f280e0b21062be45dccff7378a6ef7c16ff5b Use isLeaf to figure out if plan fragment is a leaf stage (Nikhil Collooru)
- 940d2d84a324e17b9819b2fece0a6feab58be1c5 Fix Iceberg document (Reetika Agrawal)
- 225b206d5c1559925cc0ea4d06701f2d26bfe860 Add Iceberg metadata table $refs (Reetika Agrawal)
- 030f25f31b880329b174a5e7733f5d84bc14e760 [native] Remove sanity check for event base from idle session in GCC (Deepak Majeti)
- 8af5d11caf7b945489f55218fbe1f3f208d185bd [native] Update readme (Christian Zentgraf)
- 7b0456658bdc74bf48183233cb140e6858a92030 Drop test tables to make CTE and other native tests run correctly (Mahadevuni Naveen Kumar)
- d270495d6c864e7bc99575381c527392a2c63d05 Fix querying and filtering using Iceberg metadata columns (Mahadevuni Naveen Kumar)
- 581eb87017d5766279184817bdb55a7479121a7f Extend MongoDB connector support binData (exxiang)
- 428cee2d3e278372c30740bb41a92fc36f6d8860 [native] Fix conversion of partitining const keys. (Sergey Pershin)
- 410d3eca0caeb325df5e7226fd82d7915d8093b6 Update version of maven-gpg-plugin (Linsong Wang)
- 6c4ee5555f9d663145a14b490d81c402785b4862 [native] Advance velox. (Amit Dutta)
- 961ff8a185d66b31b42c22c2024d26b1a5cac972 [Iceberg]Refactor test classes to avoid them growing too large (wangd)
- d6f85880573b468f8d706df8918c066015bddac2 Skip exception type check for dwrf reader internal check change (xiaoxmeng)
- 6b54b7d0a0091a1f35af660cf05e5df7b6868d5b Validate all like patterns can only use one character escape strings (auden-woolfson)
- 6634b7a2e152f6a820131e7eb292a1de2d88a2c9 Distinguish scheduler runtime stats for scan stage (Nikhil Collooru)
- ab162e7a401380f76f7170b48b5821dc8a09ab90 [native] Fix a typo in LocalPersistentShuffleReader ctor. (Zuyu ZHANG)
- d7ca7af192d3647ed1ef93a6b008f9158f3ce847 [native] Switch to use string based arbitrator configs (Jialiang Tan)
- febecd61fcababe05c744ddd9f231b96c355fccb [native] Advance velox. (Amit Dutta)
- 7d3e06e8f4ba2ece0edc1dd2949aca059ae1a04d Use efficient empty string test (Sam Partington)
- 9ede2669191764db20d4ae6b0a22d5579714541e Avoid pushdown of negative position for element_at for array (Jayaprakash Sivaprasad)
- 64f9455c13aba7e8ac04ff2f308fb9efe282b42c [native] Advance velox. (Amit Dutta)
- 63a472b8d44b6bc36bc962a0cfbe0153c6cd529f Block ipaddress type in prestissimo (mohsaka)