### PR TITLE
Fix the length of offsets array in parquet short decimal value decoders

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/delta/BinaryShortDecimalDeltaValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/delta/BinaryShortDecimalDeltaValuesDecoder.java
@@ -47,7 +47,7 @@ public class BinaryShortDecimalDeltaValuesDecoder
         BinaryValuesDecoder.ValueBuffer valueBuffer = delegate.readNext(length);
         int bufferSize = valueBuffer.getBufferSize();
         byte[] byteBuffer = new byte[bufferSize];
-        int[] offsets = new int[bufferSize + 1];
+        int[] offsets = new int[length + 1];
         delegate.readIntoBuffer(byteBuffer, 0, offsets, 0, valueBuffer);
 
         for (int i = 0; i < length; i++) {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/BinaryShortDecimalPlainValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/BinaryShortDecimalPlainValuesDecoder.java
@@ -41,7 +41,7 @@ public class BinaryShortDecimalPlainValuesDecoder
         ValueBuffer valueBuffer = delegate.readNext(length);
         int bufferSize = valueBuffer.getBufferSize();
         byte[] byteBuffer = new byte[bufferSize];
-        int[] offsets = new int[bufferSize + 1];
+        int[] offsets = new int[length + 1];
         delegate.readIntoBuffer(byteBuffer, 0, offsets, 0, valueBuffer);
 
         for (int i = 0; i < length; i++) {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/ShortDecimalRLEDictionaryValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/ShortDecimalRLEDictionaryValuesDecoder.java
@@ -44,7 +44,7 @@ public class ShortDecimalRLEDictionaryValuesDecoder
         ValueBuffer valueBuffer = delegate.readNext(length);
         int bufferSize = valueBuffer.getBufferSize();
         byte[] byteBuffer = new byte[bufferSize];
-        int[] offsets = new int[bufferSize + 1];
+        int[] offsets = new int[length + 1];
         delegate.readIntoBuffer(byteBuffer, 0, offsets, 0, valueBuffer);
 
         for (int i = 0; i < length; i++) {


### PR DESCRIPTION
## Description

This PR fix the length of offsets array in parquet short decimal value decoders. Currently, a larger but unnecessary array length has been set for the offsets array.

## Motivation and Context

N/A

## Impact

N/A

## Test Plan

 - Make sure this change do not affect existing test cases

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

