### PR TITLE
Change quick stats classes to use ExtendedHiveMetastore

### DIFF
--- a/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
+++ b/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
@@ -176,7 +176,7 @@ public class S3SelectTestHelper
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 columnConverterProvider,
-                new QuickStatsProvider(hdfsEnvironment, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new QuickStatsProvider(metastoreClient, hdfsEnvironment, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
                 new HiveTableWritabilityChecker(config));
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -24,6 +24,7 @@ import com.facebook.presto.hive.HiveDwrfEncryptionProvider.ForUnknown;
 import com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration;
 import com.facebook.presto.hive.datasink.DataSinkFactory;
 import com.facebook.presto.hive.datasink.OutputStreamDataSinkFactory;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
 import com.facebook.presto.hive.metastore.MetastoreCacheStats;
@@ -377,7 +378,9 @@ public class HiveClientModule
 
     @Singleton
     @Provides
-    public QuickStatsProvider createQuickStatsProvider(HdfsEnvironment hdfsEnvironment,
+    public QuickStatsProvider createQuickStatsProvider(
+            ExtendedHiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment,
             DirectoryLister directoryLister,
             HiveClientConfig hiveClientConfig,
             NamenodeStats nameNodeStats,
@@ -385,7 +388,8 @@ public class HiveClientModule
             MBeanExporter exporter)
     {
         ParquetQuickStatsBuilder parquetQuickStatsBuilder = new ParquetQuickStatsBuilder(fileFormatDataSourceStats, hdfsEnvironment, hiveClientConfig);
-        QuickStatsProvider quickStatsProvider = new QuickStatsProvider(hdfsEnvironment,
+        QuickStatsProvider quickStatsProvider = new QuickStatsProvider(metastore,
+                hdfsEnvironment,
                 directoryLister,
                 hiveClientConfig,
                 nameNodeStats,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
@@ -140,7 +140,7 @@ public class MetastoreHiveStatisticsProvider
             PartitionStatistics tableStatistics = metastore.getTableStatistics(metastoreContext, table.getSchemaName(), table.getTableName());
             if (isQuickStatsEnabled(session) &&
                     (tableStatistics.equals(empty()) || tableStatistics.getColumnStatistics().isEmpty())) {
-                tableStatistics = quickStatsProvider.getQuickStats(session, metastore, table, metastoreContext, UNPARTITIONED_ID.getPartitionName());
+                tableStatistics = quickStatsProvider.getQuickStats(session, table, metastoreContext, UNPARTITIONED_ID.getPartitionName());
             }
             return ImmutableMap.of(UNPARTITIONED_ID.getPartitionName(), tableStatistics);
         }
@@ -156,7 +156,7 @@ public class MetastoreHiveStatisticsProvider
                     .map(Map.Entry::getKey)
                     .collect(toImmutableList());
 
-            Map<String, PartitionStatistics> partitionQuickStats = quickStatsProvider.getQuickStats(session, metastore, table, metastoreContext, partitionsWithNoStats);
+            Map<String, PartitionStatistics> partitionQuickStats = quickStatsProvider.getQuickStats(session, table, metastoreContext, partitionsWithNoStats);
 
             HashMap<String, PartitionStatistics> mergedMap = new HashMap<>(partitionStatistics);
             mergedMap.putAll(partitionQuickStats);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/ParquetQuickStatsBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/ParquetQuickStatsBuilder.java
@@ -27,9 +27,9 @@ import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.HiveFileContext;
 import com.facebook.presto.hive.HiveFileInfo;
 import com.facebook.presto.hive.PartitionNameWithVersion;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
 import com.facebook.presto.hive.metastore.Partition;
-import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
 import com.facebook.presto.hive.metastore.StorageFormat;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.parquet.ParquetDataSource;
@@ -283,7 +283,7 @@ public class ParquetQuickStatsBuilder
     }
 
     @Override
-    public PartitionQuickStats buildQuickStats(ConnectorSession session, SemiTransactionalHiveMetastore metastore,
+    public PartitionQuickStats buildQuickStats(ConnectorSession session, ExtendedHiveMetastore metastore,
             SchemaTableName table, MetastoreContext metastoreContext, String partitionId, Iterator<HiveFileInfo> files)
     {
         requireNonNull(session);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/QuickStatsBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/QuickStatsBuilder.java
@@ -15,8 +15,8 @@
 package com.facebook.presto.hive.statistics;
 
 import com.facebook.presto.hive.HiveFileInfo;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
-import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
 
@@ -25,6 +25,6 @@ import java.util.Iterator;
 @FunctionalInterface
 public interface QuickStatsBuilder
 {
-    PartitionQuickStats buildQuickStats(ConnectorSession session, SemiTransactionalHiveMetastore metastore, SchemaTableName table,
+    PartitionQuickStats buildQuickStats(ConnectorSession session, ExtendedHiveMetastore metastore, SchemaTableName table,
             MetastoreContext metastoreContext, String partitionId, Iterator<HiveFileInfo> files);
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1042,7 +1042,7 @@ public abstract class AbstractTestHiveClient
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 DEFAULT_COLUMN_CONVERTER_PROVIDER,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new QuickStatsProvider(metastoreClient, HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
                 new HiveTableWritabilityChecker(false));
 
         transactionManager = new HiveTransactionManager();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -224,7 +224,7 @@ public abstract class AbstractTestHiveFileSystem
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 columnConverterProvider,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new QuickStatsProvider(metastoreClient, HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
                 new HiveTableWritabilityChecker(config));
 
         transactionManager = new HiveTransactionManager();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
@@ -259,7 +259,7 @@ public class TestHiveCommitHandleOutput
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new QuickStatsProvider(metastore, HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
                 new HiveTableWritabilityChecker(false));
         return hiveMetadataFactory.get();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -140,7 +140,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, HiveTestUtils.DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new QuickStatsProvider(metastore, HDFS_ENVIRONMENT, HiveTestUtils.DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
                 new HiveTableWritabilityChecker(false));
 
         metastore.createDatabase(METASTORE_CONTEXT, Database.builder()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -499,8 +499,9 @@ public class TestHiveSplitManager
                 new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, new MetastoreClientConfig()), ImmutableSet.of(), hiveClientConfig),
                 new MetastoreClientConfig(),
                 new NoHdfsAuthentication());
+        TestingExtendedHiveMetastore metastore = new TestingExtendedHiveMetastore(TEST_TABLE, partitionWithStatistics);
         HiveMetadataFactory metadataFactory = new HiveMetadataFactory(
-                new TestingExtendedHiveMetastore(TEST_TABLE, partitionWithStatistics),
+                metastore,
                 hdfsEnvironment,
                 new HivePartitionManager(FUNCTION_AND_TYPE_MANAGER, hiveClientConfig),
                 DateTimeZone.forOffsetHours(1),
@@ -531,7 +532,7 @@ public class TestHiveSplitManager
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new QuickStatsProvider(metastore, HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
                 new HiveTableWritabilityChecker(false));
 
         HiveSplitManager splitManager = new HiveSplitManager(
@@ -646,8 +647,9 @@ public class TestHiveSplitManager
                 new NoHdfsAuthentication());
         HiveEncryptionInformationProvider encryptionInformationProvider = new HiveEncryptionInformationProvider(ImmutableList.of(new TestDwrfEncryptionInformationSource()));
 
+        TestingExtendedHiveMetastore metastore = new TestingExtendedHiveMetastore(testTable, partitionWithStatistics);
         HiveMetadataFactory metadataFactory = new HiveMetadataFactory(
-                new TestingExtendedHiveMetastore(testTable, partitionWithStatistics),
+                metastore,
                 hdfsEnvironment,
                 new HivePartitionManager(FUNCTION_AND_TYPE_MANAGER, hiveClientConfig),
                 DateTimeZone.forOffsetHours(1),
@@ -678,7 +680,7 @@ public class TestHiveSplitManager
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
-                new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
+                new QuickStatsProvider(metastore, HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
                 new HiveTableWritabilityChecker(false));
 
         HiveSplitManager splitManager = new HiveSplitManager(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestMetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestMetastoreHiveStatisticsProvider.java
@@ -26,6 +26,7 @@ import com.facebook.presto.hive.NamenodeStats;
 import com.facebook.presto.hive.OrcFileWriterConfig;
 import com.facebook.presto.hive.ParquetFileWriterConfig;
 import com.facebook.presto.hive.PartitionNameWithVersion;
+import com.facebook.presto.hive.TestingExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.DateStatistics;
 import com.facebook.presto.hive.metastore.DecimalStatistics;
 import com.facebook.presto.hive.metastore.DoubleStatistics;
@@ -107,7 +108,7 @@ public class TestMetastoreHiveStatisticsProvider
     private static final HiveColumnHandle PARTITION_COLUMN_1 = new HiveColumnHandle("p1", HIVE_STRING, VARCHAR.getTypeSignature(), 0, PARTITION_KEY, Optional.empty(), Optional.empty());
     private static final HiveColumnHandle PARTITION_COLUMN_2 = new HiveColumnHandle("p2", HIVE_LONG, BIGINT.getTypeSignature(), 1, PARTITION_KEY, Optional.empty(), Optional.empty());
 
-    private static final QuickStatsProvider quickStatsProvider = new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of());
+    private static final QuickStatsProvider quickStatsProvider = new QuickStatsProvider(new TestingExtendedHiveMetastore(), HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of());
 
     @Test
     public void testGetPartitionsSample()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestParquetQuickStatsBuilder.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestParquetQuickStatsBuilder.java
@@ -23,11 +23,12 @@ import com.facebook.presto.hive.HiveColumnConverterProvider;
 import com.facebook.presto.hive.HiveFileInfo;
 import com.facebook.presto.hive.HiveHdfsConfiguration;
 import com.facebook.presto.hive.MetastoreClientConfig;
-import com.facebook.presto.hive.TestingSemiTransactionalHiveMetastore;
+import com.facebook.presto.hive.TestingExtendedHiveMetastore;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
-import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
+import com.facebook.presto.hive.metastore.PrincipalPrivileges;
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.spi.ConnectorSession;
@@ -36,6 +37,7 @@ import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.airlift.units.Duration;
@@ -80,7 +82,7 @@ public class TestParquetQuickStatsBuilder
     public static final String TEST_TABLE = "quick_stats";
     private ParquetQuickStatsBuilder parquetQuickStatsBuilder;
     private MetastoreContext metastoreContext;
-    private SemiTransactionalHiveMetastore metastore;
+    private ExtendedHiveMetastore metastore;
     private HdfsEnvironment hdfsEnvironment;
     private HiveClientConfig hiveClientConfig;
     private MetastoreClientConfig metastoreClientConfig;
@@ -203,10 +205,6 @@ public class TestParquetQuickStatsBuilder
                 Optional.empty(),
                 Optional.empty());
 
-        TestingSemiTransactionalHiveMetastore mock = TestingSemiTransactionalHiveMetastore.create();
-        mock.addTable(TEST_SCHEMA, TEST_TABLE, table, ImmutableList.of());
-        metastore = mock;
-
         metastoreContext = new MetastoreContext(SESSION.getUser(),
                 SESSION.getQueryId(),
                 Optional.empty(),
@@ -217,6 +215,10 @@ public class TestParquetQuickStatsBuilder
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
                 SESSION.getWarningCollector(),
                 SESSION.getRuntimeStats());
+        ExtendedHiveMetastore mock = new TestingExtendedHiveMetastore();
+        mock.createTable(metastoreContext, table, new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of()), ImmutableList.of());
+        metastore = mock;
+
         hiveClientConfig = new HiveClientConfig();
         metastoreClientConfig = new MetastoreClientConfig();
         // Use HiveUtils#createTestHdfsEnvironment to ensure that PrestoS3FileSystem is used for s3a paths

--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestQuickStatsProvider.java
@@ -13,38 +13,28 @@
  */
 package com.facebook.presto.hive.statistics;
 
-import com.facebook.presto.hive.ColumnConverterProvider;
 import com.facebook.presto.hive.DirectoryLister;
-import com.facebook.presto.hive.HdfsConfiguration;
-import com.facebook.presto.hive.HdfsConfigurationInitializer;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HiveClientConfig;
-import com.facebook.presto.hive.HiveColumnConverterProvider;
-import com.facebook.presto.hive.HiveHdfsConfiguration;
 import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.NamenodeStats;
-import com.facebook.presto.hive.PartitionNameWithVersion;
-import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.TestingExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
-import com.facebook.presto.hive.metastore.HivePartitionMutator;
 import com.facebook.presto.hive.metastore.MetastoreContext;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
-import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
+import com.facebook.presto.hive.metastore.PartitionWithStatistics;
+import com.facebook.presto.hive.metastore.PrincipalPrivileges;
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.hive.metastore.Table;
-import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
-import com.facebook.presto.hive.metastore.thrift.HiveCluster;
-import com.facebook.presto.hive.metastore.thrift.TestingHiveCluster;
-import com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.units.Duration;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -56,10 +46,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.hive.HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER;
 import static com.facebook.presto.hive.HiveSessionProperties.QUICK_STATS_BACKGROUND_BUILD_TIMEOUT;
@@ -75,12 +63,9 @@ import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
 import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
 import static com.facebook.presto.hive.statistics.PartitionQuickStats.convertToPartitionStatistics;
 import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static java.util.Collections.emptyIterator;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
-import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.ForkJoinPool.commonPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -130,7 +115,7 @@ public class TestQuickStatsProvider
     private final HiveClientConfig hiveClientConfig = new HiveClientConfig().setRecursiveDirWalkerEnabled(true);
     private HdfsEnvironment hdfsEnvironment;
     private DirectoryLister directoryListerMock;
-    private SemiTransactionalHiveMetastore metastoreMock;
+    private ExtendedHiveMetastore metastoreMock;
     private MetastoreContext metastoreContext;
     private PartitionQuickStats mockPartitionQuickStats;
     private PartitionStatistics expectedPartitionStats;
@@ -190,7 +175,9 @@ public class TestQuickStatsProvider
                 Optional.empty(),
                 Optional.empty());
 
-        metastoreMock = MockSemiTransactionalHiveMetastore.create(mockTable, mockPartition);
+        metastoreMock = new TestingExtendedHiveMetastore();
+        metastoreMock.createTable(metastoreContext, mockTable, new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of()), ImmutableList.of());
+        metastoreMock.addPartitions(metastoreContext, TEST_SCHEMA, TEST_TABLE, ImmutableList.of(new PartitionWithStatistics(mockPartition, "TEST_PARTITION", empty())));
 
         directoryListerMock = (fileSystem, table2, path, partition, namenodeStats, hiveDirectoryContext) -> emptyIterator();
 
@@ -210,12 +197,12 @@ public class TestQuickStatsProvider
     {
         QuickStatsBuilder quickStatsBuilderMock = (session, metastore, table, metastoreContext, partitionId, files) -> mockPartitionQuickStats;
 
-        QuickStatsProvider quickStatsProvider = new QuickStatsProvider(hdfsEnvironment, directoryListerMock, hiveClientConfig, new NamenodeStats(),
+        QuickStatsProvider quickStatsProvider = new QuickStatsProvider(metastoreMock, hdfsEnvironment, directoryListerMock, hiveClientConfig, new NamenodeStats(),
                 ImmutableList.of(quickStatsBuilderMock));
 
         // Execute
         ImmutableList<String> testPartitions1 = ImmutableList.of("partition1", "partition2", "partition3");
-        Map<String, PartitionStatistics> quickStats = quickStatsProvider.getQuickStats(SESSION, metastoreMock,
+        Map<String, PartitionStatistics> quickStats = quickStatsProvider.getQuickStats(SESSION,
                 new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitions1);
 
         // Verify only one call was made for each test partition
@@ -224,14 +211,14 @@ public class TestQuickStatsProvider
         quickStats.values().forEach(ps -> assertEquals(ps, expectedPartitionStats));
 
         // For subsequent calls for the same partitions that are already cached, no new calls are mode to the quick stats builder
-        quickStatsProvider.getQuickStats(SESSION, metastoreMock,
+        quickStatsProvider.getQuickStats(SESSION,
                 new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitions1);
 
         // For subsequent calls with a mix of old and new partitions, we only see calls to the quick stats builder for the new partitions
         ImmutableList<String> testPartitions2 = ImmutableList.of("partition4", "partition5", "partition6");
         ImmutableList<String> testPartitionsMix = ImmutableList.<String>builder().addAll(testPartitions1).addAll(testPartitions2).build();
 
-        quickStats = quickStatsProvider.getQuickStats(SESSION, metastoreMock,
+        quickStats = quickStatsProvider.getQuickStats(SESSION,
                 new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitionsMix);
         assertEquals(quickStats.entrySet().size(), testPartitionsMix.size());
         assertTrue(quickStats.keySet().containsAll(testPartitionsMix));
@@ -254,7 +241,7 @@ public class TestQuickStatsProvider
             return mockPartitionQuickStats;
         };
 
-        QuickStatsProvider quickStatsProvider = new QuickStatsProvider(hdfsEnvironment, directoryListerMock, hiveClientConfig, new NamenodeStats(),
+        QuickStatsProvider quickStatsProvider = new QuickStatsProvider(metastoreMock, hdfsEnvironment, directoryListerMock, hiveClientConfig, new NamenodeStats(),
                 ImmutableList.of(longRunningQuickStatsBuilderMock));
 
         List<String> testPartitions = ImmutableList.of("partition1", "partition2", "partition3");
@@ -265,10 +252,10 @@ public class TestQuickStatsProvider
 
             ConnectorSession session = getSession("600ms", "0ms");
             // Execute two concurrent calls for the same partitions; wait for them to complete
-            CompletableFuture<Map<String, PartitionStatistics>> future1 = supplyAsync(() -> quickStatsProvider.getQuickStats(session, metastoreMock,
+            CompletableFuture<Map<String, PartitionStatistics>> future1 = supplyAsync(() -> quickStatsProvider.getQuickStats(session,
                     new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitions), commonPool());
 
-            CompletableFuture<Map<String, PartitionStatistics>> future2 = supplyAsync(() -> quickStatsProvider.getQuickStats(session, metastoreMock,
+            CompletableFuture<Map<String, PartitionStatistics>> future2 = supplyAsync(() -> quickStatsProvider.getQuickStats(session,
                     new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitions), commonPool());
 
             allOf(future1, future2).join();
@@ -300,7 +287,7 @@ public class TestQuickStatsProvider
             }
 
             // Future calls for the same partitions will return from cached partition stats with valid values
-            Map<String, PartitionStatistics> quickStats = quickStatsProvider.getQuickStats(session, metastoreMock,
+            Map<String, PartitionStatistics> quickStats = quickStatsProvider.getQuickStats(session,
                     new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitions);
 
             // Verify only one call was made for each test partition
@@ -315,10 +302,10 @@ public class TestQuickStatsProvider
 
             ConnectorSession session = getSession("300ms", "300ms");
             // Execute two concurrent calls for the same partitions; wait for them to complete
-            CompletableFuture<Map<String, PartitionStatistics>> future1 = supplyAsync(() -> quickStatsProvider.getQuickStats(session, metastoreMock,
+            CompletableFuture<Map<String, PartitionStatistics>> future1 = supplyAsync(() -> quickStatsProvider.getQuickStats(session,
                     new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitions), commonPool());
 
-            CompletableFuture<Map<String, PartitionStatistics>> future2 = supplyAsync(() -> quickStatsProvider.getQuickStats(session, metastoreMock,
+            CompletableFuture<Map<String, PartitionStatistics>> future2 = supplyAsync(() -> quickStatsProvider.getQuickStats(session,
                     new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitions), commonPool());
 
             allOf(future1, future2).join();
@@ -350,12 +337,12 @@ public class TestQuickStatsProvider
         };
 
         {
-            QuickStatsProvider quickStatsProvider = new QuickStatsProvider(hdfsEnvironment, directoryListerMock, hiveClientConfig, new NamenodeStats(),
+            QuickStatsProvider quickStatsProvider = new QuickStatsProvider(metastoreMock, hdfsEnvironment, directoryListerMock, hiveClientConfig, new NamenodeStats(),
                     ImmutableList.of(longRunningQuickStatsBuilderMock));
             // Create a session where an inline build will occur for any newly requested partition
             ConnectorSession session = getSession("300ms", "0ms");
             List<String> testPartitions = ImmutableList.copyOf(mockPerPartitionStatsFetchTimes.keySet());
-            Map<String, PartitionStatistics> quickStats = quickStatsProvider.getQuickStats(session, metastoreMock,
+            Map<String, PartitionStatistics> quickStats = quickStatsProvider.getQuickStats(session,
                     new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, testPartitions);
             Map<String, Instant> inProgressBuildsSnapshot = quickStatsProvider.getInProgressBuildsSnapshot();
 
@@ -376,10 +363,10 @@ public class TestQuickStatsProvider
             // Create a session where no inline builds will occur for any requested partition; empty() quick stats will be returned
             ConnectorSession session = getSession("0ms", "0ms");
 
-            QuickStatsProvider quickStatsProvider = new QuickStatsProvider(hdfsEnvironment, directoryListerMock, hiveClientConfig, new NamenodeStats(),
+            QuickStatsProvider quickStatsProvider = new QuickStatsProvider(metastoreMock, hdfsEnvironment, directoryListerMock, hiveClientConfig, new NamenodeStats(),
                     ImmutableList.of((session1, metastore, table, metastoreContext, partitionId, files) -> mockPartitionQuickStats));
 
-            Map<String, PartitionStatistics> quickStats = quickStatsProvider.getQuickStats(session, metastoreMock,
+            Map<String, PartitionStatistics> quickStats = quickStatsProvider.getQuickStats(session,
                     new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, ImmutableList.of("p5", "p6"));
 
             assertEquals(quickStats.size(), 2);
@@ -392,7 +379,7 @@ public class TestQuickStatsProvider
                     .maxAttempts(10)
                     .exponentialBackoff(new Duration(20D, MILLISECONDS), new Duration(500D, MILLISECONDS), new Duration(2, SECONDS), 2.0)
                     .run("waitForQuickStatsBuild", () -> {
-                        Map<String, PartitionStatistics> quickStatsAfter = quickStatsProvider.getQuickStats(session, metastoreMock,
+                        Map<String, PartitionStatistics> quickStatsAfter = quickStatsProvider.getQuickStats(session,
                                 new SchemaTableName(TEST_SCHEMA, TEST_TABLE), metastoreContext, ImmutableList.of("p5", "p6"));
 
                         try {
@@ -405,63 +392,6 @@ public class TestQuickStatsProvider
                             throw new RuntimeException(e);
                         }
                     });
-        }
-    }
-
-    public static class MockSemiTransactionalHiveMetastore
-            extends SemiTransactionalHiveMetastore
-    {
-        private final Table mockTable;
-        private final Partition mockPartition;
-
-        private MockSemiTransactionalHiveMetastore(HdfsEnvironment hdfsEnvironment,
-                ExtendedHiveMetastore delegate,
-                ListeningExecutorService renameExecutor,
-                boolean skipDeletionForAlter,
-                boolean skipTargetCleanupOnRollback,
-                boolean undoMetastoreOperationsEnabled,
-                ColumnConverterProvider columnConverterProvider,
-                Table mockTable, Partition mockPartition)
-        {
-            super(hdfsEnvironment, delegate, renameExecutor, skipDeletionForAlter, skipTargetCleanupOnRollback, undoMetastoreOperationsEnabled, columnConverterProvider);
-            this.mockPartition = mockPartition;
-            this.mockTable = mockTable;
-        }
-
-        public static MockSemiTransactionalHiveMetastore create(Table mockTable, Partition mockPartition)
-        {
-            // none of these values matter, as we never use them
-            HiveClientConfig config = new HiveClientConfig();
-            MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-            HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, metastoreClientConfig), ImmutableSet.of(), config);
-            HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
-            HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, "dummy", 1000);
-            ColumnConverterProvider columnConverterProvider = HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER;
-            ExtendedHiveMetastore delegate = new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig, hdfsEnvironment), new HivePartitionMutator());
-            ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
-            ListeningExecutorService renameExecutor = listeningDecorator(executor);
-
-            return new MockSemiTransactionalHiveMetastore(hdfsEnvironment, delegate, renameExecutor, false, false, true,
-                    columnConverterProvider, mockTable, mockPartition);
-        }
-
-        @Override
-        public synchronized Optional<Partition> getPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionValues)
-        {
-            return Optional.of(mockPartition);
-        }
-
-        @Override
-        public synchronized Map<String, Optional<Partition>> getPartitionsByNames(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionNameWithVersion> partitionNames)
-        {
-            checkArgument(partitionNames.size() == 1, "Expected caller to only pass in a single partition to fetch");
-            return ImmutableMap.of(partitionNames.get(0).getPartitionName(), Optional.of(mockPartition));
-        }
-
-        @Override
-        public Optional<Table> getTable(MetastoreContext metastoreContext, String databaseName, String tableName)
-        {
-            return Optional.of(mockTable);
         }
     }
 }


### PR DESCRIPTION
## Description
Fix for https://github.com/prestodb/presto/issues/23767

## Motivation and Context
Observed errors during operationalizing Quick stats. See linked issue for details

## Impact
No user facing impact

## Test Plan
Existing tests pass

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

