### PR TITLE
Upgrade avro & its dependencies to resolve CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         <dep.guava.version>32.1.0-jre</dep.guava.version>
         <dep.jackson.version>2.11.0</dep.jackson.version>
         <dep.j2objc.version>2.8</dep.j2objc.version>
-        <dep.avro.version>1.11.3</dep.avro.version>
-        <dep.commons.compress.version>1.23.0</dep.commons.compress.version>
+        <dep.avro.version>1.11.4</dep.avro.version>
+        <dep.commons.compress.version>1.26.2</dep.commons.compress.version>
         <dep.protobuf-java.version>3.25.5</dep.protobuf-java.version>
 
         <!--
@@ -314,7 +314,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.16.0</version>
+                <version>2.16.1</version>
             </dependency>
 
             <dependency>
@@ -1742,7 +1742,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.15</version>
+                <version>1.17.0</version>
             </dependency>
 
             <dependency>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.11</version>
+                <version>3.14.0</version>
             </dependency>
 
             <dependency>
@@ -72,12 +72,6 @@
                 <groupId>com.google.auth</groupId>
                 <artifactId>google-auth-library-oauth2-http</artifactId>
                 <version>0.22.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.13</version>
             </dependency>
 
             <dependency>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -340,6 +340,7 @@
                                     <excludes>
                                         <exclude>META-INF/maven/**</exclude>
                                         <exclude>META-INF/services/com.fasterxml.**</exclude>
+                                        <exclude>META-INF.versions.9.module-info</exclude>
                                         <exclude>LICENSE</exclude>
                                     </excludes>
                                 </filter>

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -18,6 +18,16 @@
         <scala.version>2.12.2</scala.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.14.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
## Description
Upgraded avro to version 1.11.4 to resolve CVE-2024-47561
Upgraded commons-compress to version 1.26.2
Upgraded commons-codec to version 1.17.0
Upgraded commons-lang3 to version 3.14.0
Upgraded commons-io to version 2.16.1

This also resolves the issue faced that caused the previous revert: 
https://github.com/prestodb/presto/pull/23931

## Motivation and Context
This upgrade was created to deal with CVEs found in lower versions
## Impact
None

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Upgrade avro to version 1.11.4 in response to `CVE-2024-47561 <https://github.com/advisories/GHSA-r7pg-v2c8-mfg3>`_. :pr:`23868`
```
