### PR TITLE
Make testQueryHeartbeat deterministic

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -112,7 +112,7 @@ public class TestResourceManagerClusterStatusSender
                 format("Expect number of heartbeats to fall within target range (%s), +/- 50%%.  Was: %s", TARGET_HEARTBEATS, nodeHeartbeats));
     }
 
-    @Test(timeOut = 6_000)
+    @Test(timeOut = 10_000)
     public void testQueryHeartbeat()
             throws Exception
     {
@@ -122,8 +122,14 @@ public class TestResourceManagerClusterStatusSender
         Thread.sleep(SLEEP_DURATION);
 
         int queryHeartbeats = resourceManagerClient.getQueryHeartbeats();
-        assertTrue(queryHeartbeats > TARGET_HEARTBEATS * 0.5 && queryHeartbeats <= TARGET_HEARTBEATS * 1.5,
-                format("Expect number of heartbeats to fall within target range (%s), +/- 50%%.  Was: %s", TARGET_HEARTBEATS, queryHeartbeats));
+        assertTrue(queryHeartbeats > 0, "Expected at least one query heartbeat");
+
+        Thread.sleep(SLEEP_DURATION);
+
+        int newQueryHeartbeats = resourceManagerClient.getQueryHeartbeats();
+        assertTrue(
+                newQueryHeartbeats > queryHeartbeats,
+                format("Expected at least one subsequent query heartbeat, previous: %s, current: %s", queryHeartbeats, newQueryHeartbeats));
 
         // Completing the query stops the heartbeats
         queryExecution.complete();


### PR DESCRIPTION
## Description
We only need to check that the heartbeats are being regularly sent.

## Motivation and Context
Fixes #23235

## Impact
Less flaky tests

## Test Plan
Green CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

