### PR TITLE
[native] Report different thread pool executors' stats

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -44,7 +44,10 @@ class PeriodicTaskManager {
   explicit PeriodicTaskManager(
       folly::CPUThreadPoolExecutor* driverCPUExecutor,
       folly::CPUThreadPoolExecutor* spillerExecutor,
-      folly::IOThreadPoolExecutor* httpExecutor,
+      folly::IOThreadPoolExecutor* httpSrvIoExecutor,
+      folly::CPUThreadPoolExecutor* httpSrvCpuExecutor,
+      folly::IOThreadPoolExecutor* exchangeHttpIoExecutor,
+      folly::CPUThreadPoolExecutor* exchangeHttpCpuExecutor,
       TaskManager* taskManager,
       const velox::memory::MemoryAllocator* memoryAllocator,
       const velox::cache::AsyncDataCache* asyncDataCache,
@@ -96,7 +99,6 @@ class PeriodicTaskManager {
 
  private:
   void addExecutorStatsTask();
-  void updateExecutorStats();
 
   void addTaskStatsTask();
   void updateTaskStats();
@@ -123,9 +125,15 @@ class PeriodicTaskManager {
   void detachWorker(const char* reason);
   void maybeAttachWorker();
 
-  folly::CPUThreadPoolExecutor* driverCPUExecutor_;
-  folly::CPUThreadPoolExecutor* spillerExecutor_;
-  folly::IOThreadPoolExecutor* httpExecutor_;
+  folly::CPUThreadPoolExecutor* driverCPUExecutor_{nullptr};
+  folly::CPUThreadPoolExecutor* spillerExecutor_{nullptr};
+
+  folly::IOThreadPoolExecutor* httpSrvIoExecutor_{nullptr};
+  folly::CPUThreadPoolExecutor* httpSrvCpuExecutor_{nullptr};
+
+  folly::IOThreadPoolExecutor* exchangeHttpIoExecutor_{nullptr};
+  folly::CPUThreadPoolExecutor* exchangeHttpCpuExecutor_{nullptr};
+
   TaskManager* taskManager_;
   const velox::memory::MemoryAllocator* memoryAllocator_;
   const velox::cache::AsyncDataCache* asyncDataCache_;

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -241,7 +241,7 @@ class PrestoServer {
   std::shared_ptr<folly::CPUThreadPoolExecutor> exchangeHttpCpuExecutor_;
 
   // Executor for HTTP request dispatching
-  std::shared_ptr<folly::IOThreadPoolExecutor> httpSrvIOExecutor_;
+  std::shared_ptr<folly::IOThreadPoolExecutor> httpSrvIoExecutor_;
 
   // Executor for HTTP request processing after dispatching
   std::shared_ptr<folly::CPUThreadPoolExecutor> httpSrvCpuExecutor_;

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -121,6 +121,17 @@ void registerPrestoMetrics() {
       99,
       100);
 
+  // NOTE: Metrics type exporting for thread pool executor counters are in
+  // PeriodicTaskManager because they have dynamic names and report configs. The
+  // following counters have their type exported there:
+  // [
+  //  kCounterThreadPoolNumThreadsFormat,
+  //  kCounterThreadPoolNumActiveThreadsFormat,
+  //  kCounterThreadPoolNumPendingTasksFormat,
+  //  kCounterThreadPoolNumTotalTasksFormat,
+  //  kCounterThreadPoolMaxIdleTimeNsFormat
+  // ]
+
   // NOTE: Metrics type exporting for file handle cache counters are in
   // PeriodicTaskManager because they have dynamic names. The following counters
   // have their type exported there:

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -157,6 +157,19 @@ constexpr std::string_view kCounterHiveFileHandleCacheNumHitsFormat{
 constexpr std::string_view kCounterHiveFileHandleCacheNumLookupsFormat{
     "presto_cpp.{}.hive_file_handle_cache_num_lookups"};
 
+/// ================== Thread Pool Counters ====================
+
+constexpr std::string_view kCounterThreadPoolNumThreadsFormat{
+    "presto_cpp.{}.num_threads"};
+constexpr std::string_view kCounterThreadPoolNumActiveThreadsFormat{
+    "presto_cpp.{}.num_active_threads"};
+constexpr std::string_view kCounterThreadPoolNumPendingTasksFormat{
+    "presto_cpp.{}.num_pending_tasks"};
+constexpr std::string_view kCounterThreadPoolNumTotalTasksFormat{
+    "presto_cpp.{}.num_total_tasks"};
+constexpr std::string_view kCounterThreadPoolMaxIdleTimeNsFormat{
+    "presto_cpp.{}.max_idle_time_ns"};
+
 /// ================== Memory Pushback Counters =================
 
 /// Number of times memory pushback mechanism is triggered.


### PR DESCRIPTION
folly::ThreadPoolExecutor::getPoolStats() provides better and more detailed thread pool stats for both cpu thread pool and io thread pool. We shall leverage that API to provide with more accurate metrics instead of having our own estimation by enqueue tasks to the queue.

```
== NO RELEASE NOTE ==
```

