### PR TITLE
Improve how we configure plan checker providers

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -211,6 +211,7 @@ import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManagerConfig;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.Expression;
@@ -801,6 +802,7 @@ public class ServerMainModule
         binder.bind(NodeStatusNotificationManager.class).in(Scopes.SINGLETON);
 
         binder.bind(PlanCheckerProviderManager.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(PlanCheckerProviderManagerConfig.class);
 
         // Worker session property providers
         MapBinder<String, WorkerSessionPropertyProvider> mapBinder =

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanCheckerProviderManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanCheckerProviderManager.java
@@ -13,30 +13,44 @@
  */
 package com.facebook.presto.sql.planner.sanity;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.spi.plan.PlanCheckerProvider;
+import com.facebook.presto.spi.plan.PlanCheckerProviderContext;
 import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
 import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
 
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class PlanCheckerProviderManager
 {
-    private final SimplePlanFragmentSerde simplePlanFragmentSerde;
+    private static final Logger log = Logger.get(PlanCheckerProviderManager.class);
+    private static final String PLAN_CHECKER_PROVIDER_NAME = "plan-checker-provider.name";
+
+    private final PlanCheckerProviderContext planCheckerProviderContext;
     private final Map<String, PlanCheckerProviderFactory> providerFactories = new ConcurrentHashMap<>();
     private final CopyOnWriteArrayList<PlanCheckerProvider> providers = new CopyOnWriteArrayList<>();
+    private final File configDirectory;
 
     @Inject
-    public PlanCheckerProviderManager(SimplePlanFragmentSerde simplePlanFragmentSerde)
+    public PlanCheckerProviderManager(SimplePlanFragmentSerde simplePlanFragmentSerde, PlanCheckerProviderManagerConfig config)
     {
-        this.simplePlanFragmentSerde = requireNonNull(simplePlanFragmentSerde, "planNodeSerde is null");
+        this.planCheckerProviderContext = new PlanCheckerProviderContext(requireNonNull(simplePlanFragmentSerde, "planNodeSerde is null"));
+        requireNonNull(config, "config is null");
+        this.configDirectory = requireNonNull(config.getPlanCheckerConfigurationDir(), "configDirectory is null");
     }
 
     public void addPlanCheckerProviderFactory(PlanCheckerProviderFactory planCheckerProviderFactory)
@@ -48,8 +62,38 @@ public class PlanCheckerProviderManager
     }
 
     public void loadPlanCheckerProviders()
+            throws IOException
     {
-        providers.addAllAbsent(providerFactories.values().stream().map(pc -> pc.create(simplePlanFragmentSerde)).collect(Collectors.toList()));
+        for (File file : listFiles(configDirectory)) {
+            if (file.isFile() && file.getName().endsWith(".properties")) {
+                // unlike function namespaces and connectors, we don't have a concept of catalog
+                // name here (conventionally config file name without the extension)
+                // because plan checkers are never referenced by name.
+                Map<String, String> properties = new HashMap<>(loadProperties(file));
+                checkState(!isNullOrEmpty(properties.get(PLAN_CHECKER_PROVIDER_NAME)),
+                        "Plan checker configuration %s does not contain %s",
+                        file.getAbsoluteFile(),
+                        PLAN_CHECKER_PROVIDER_NAME);
+                String planCheckerProviderName = properties.remove(PLAN_CHECKER_PROVIDER_NAME);
+                log.info("-- Loading plan checker provider %s--", planCheckerProviderName);
+                PlanCheckerProviderFactory providerFactory = providerFactories.get(planCheckerProviderName);
+                checkState(providerFactory != null,
+                        "No planCheckerProviderFactory found for '%s'. Available factories were %s", planCheckerProviderName, providerFactories.keySet());
+                providers.addIfAbsent(providerFactory.create(properties, planCheckerProviderContext));
+                log.info("-- Added plan checker provider [%s] --", planCheckerProviderName);
+            }
+        }
+    }
+
+    private static List<File> listFiles(File dir)
+    {
+        if (dir != null && dir.isDirectory()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                return ImmutableList.copyOf(files);
+            }
+        }
+        return ImmutableList.of();
     }
 
     public List<PlanCheckerProvider> getPlanCheckerProviders()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanCheckerProviderManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanCheckerProviderManagerConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.File;
+
+public class PlanCheckerProviderManagerConfig
+{
+    private File planCheckerConfigurationDir = new File("etc/plan-checker-providers/");
+
+    @NotNull
+    public File getPlanCheckerConfigurationDir()
+    {
+        return planCheckerConfigurationDir;
+    }
+
+    @Config("plan-checker.config-dir")
+    public PlanCheckerProviderManagerConfig setPlanCheckerConfigurationDir(File dir)
+    {
+        this.planCheckerConfigurationDir = dir;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -190,6 +190,7 @@ import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManagerConfig;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.AlterFunction;
@@ -439,7 +440,7 @@ public class LocalQueryRunner
                 new AnalyzePropertyManager(),
                 transactionManager);
         this.splitManager = new SplitManager(metadata, new QueryManagerConfig(), nodeSchedulerConfig);
-        this.planCheckerProviderManager = new PlanCheckerProviderManager(new JsonCodecSimplePlanFragmentSerde(jsonCodec(SimplePlanFragment.class)));
+        this.planCheckerProviderManager = new PlanCheckerProviderManager(new JsonCodecSimplePlanFragmentSerde(jsonCodec(SimplePlanFragment.class)), new PlanCheckerProviderManagerConfig());
         this.distributedPlanChecker = new PlanChecker(featuresConfig, false, planCheckerProviderManager);
         this.singleNodePlanChecker = new PlanChecker(featuresConfig, true, planCheckerProviderManager);
         this.planFragmenter = new PlanFragmenter(this.metadata, this.nodePartitioningManager, new QueryManagerConfig(), featuresConfig, planCheckerProviderManager);

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -61,6 +61,7 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.plan.SequenceNode;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManagerConfig;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.tpch.TpchColumnHandle;
@@ -156,7 +157,7 @@ public class TestCostCalculator
                 new SimpleTtlNodeSelectorConfig());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
-        planCheckerProviderManager = new PlanCheckerProviderManager(new JsonCodecSimplePlanFragmentSerde(jsonCodec(SimplePlanFragment.class)));
+        planCheckerProviderManager = new PlanCheckerProviderManager(new JsonCodecSimplePlanFragmentSerde(jsonCodec(SimplePlanFragment.class)), new PlanCheckerProviderManagerConfig());
         planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new FeaturesConfig(), planCheckerProviderManager);
         translator = new TestingRowExpressionTranslator();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestPlanCheckerProviderManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestPlanCheckerProviderManager.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.spi.plan.PlanCheckerProvider;
+import com.facebook.presto.spi.plan.PlanCheckerProviderContext;
+import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
+import com.facebook.presto.spi.plan.SimplePlanFragment;
+import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import static com.facebook.presto.sql.planner.sanity.TestPlanCheckerProviderManager.TestingPlanCheckerProvider.TESTING_PLAN_CHECKER_PROVIDER;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+
+public class TestPlanCheckerProviderManager
+{
+    @Test
+    public void testLoadPlanCheckerProviders()
+            throws IOException
+    {
+        PlanCheckerProviderManagerConfig planCheckerProviderManagerConfig = new PlanCheckerProviderManagerConfig()
+                .setPlanCheckerConfigurationDir(new File("src/test/resources/plan-checkers"));
+        PlanCheckerProviderManager planCheckerProviderManager = new PlanCheckerProviderManager(new JsonCodecSimplePlanFragmentSerde(JsonCodec.jsonCodec(SimplePlanFragment.class)), planCheckerProviderManagerConfig);
+        planCheckerProviderManager.addPlanCheckerProviderFactory(new TestingPlanCheckerProviderFactory());
+        planCheckerProviderManager.loadPlanCheckerProviders();
+        assertEquals(planCheckerProviderManager.getPlanCheckerProviders(), ImmutableList.of(TESTING_PLAN_CHECKER_PROVIDER));
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "No planCheckerProviderFactory found for 'test'. Available factories were \\[]")
+    public void testLoadUnregisteredPlanCheckerProvider()
+            throws IOException
+    {
+        PlanCheckerProviderManagerConfig planCheckerProviderManagerConfig = new PlanCheckerProviderManagerConfig()
+                .setPlanCheckerConfigurationDir(new File("src/test/resources/plan-checkers"));
+        PlanCheckerProviderManager planCheckerProviderManager = new PlanCheckerProviderManager(new JsonCodecSimplePlanFragmentSerde(JsonCodec.jsonCodec(SimplePlanFragment.class)), planCheckerProviderManagerConfig);
+        planCheckerProviderManager.loadPlanCheckerProviders();
+    }
+
+    public static class TestingPlanCheckerProviderFactory
+            implements PlanCheckerProviderFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "test";
+        }
+
+        @Override
+        public PlanCheckerProvider create(Map<String, String> properties, PlanCheckerProviderContext planCheckerProviderContext)
+        {
+            return TESTING_PLAN_CHECKER_PROVIDER;
+        }
+    }
+
+    public static class TestingPlanCheckerProvider
+            implements PlanCheckerProvider
+    {
+        public static final TestingPlanCheckerProvider TESTING_PLAN_CHECKER_PROVIDER = new TestingPlanCheckerProvider();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestPlanCheckerProviderManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestPlanCheckerProviderManagerConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.sanity;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestPlanCheckerProviderManagerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(PlanCheckerProviderManagerConfig.class)
+                .setPlanCheckerConfigurationDir(new File("etc/plan-checker-providers")));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("plan-checker.config-dir", "/foo")
+                .build();
+
+        PlanCheckerProviderManagerConfig expected = new PlanCheckerProviderManagerConfig()
+                .setPlanCheckerConfigurationDir(new File("/foo"));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/test/resources/plan-checkers/test-plan-checker.properties
+++ b/presto-main/src/test/resources/plan-checkers/test-plan-checker.properties
@@ -1,0 +1,1 @@
+plan-checker-provider.name=test

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -192,6 +192,7 @@ import com.facebook.presto.sql.planner.PlanOptimizers;
 import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManagerConfig;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.tracing.TracerProviderManager;
@@ -276,6 +277,7 @@ public class PrestoSparkModule
         configBinder(binder).bindConfig(NativeExecutionSystemConfig.class);
         configBinder(binder).bindConfig(NativeExecutionNodeConfig.class);
         configBinder(binder).bindConfig(NativeExecutionConnectorConfig.class);
+        configBinder(binder).bindConfig(PlanCheckerProviderManagerConfig.class);
 
         // json codecs
         jsonCodecBinder(binder).bindJsonCodec(ViewDefinition.class);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
@@ -77,6 +77,7 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.JsonCodecSimplePlanFragmentSerde;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
+import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManagerConfig;
 import com.facebook.presto.tpch.TpchColumnHandle;
 import com.facebook.presto.tpch.TpchTableHandle;
 import com.facebook.presto.tpch.TpchTableLayoutHandle;
@@ -162,7 +163,7 @@ public class TestIterativePlanFragmenter
                 new SimpleTtlNodeSelectorConfig());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
-        planCheckerProviderManager = new PlanCheckerProviderManager(new JsonCodecSimplePlanFragmentSerde(jsonCodec(SimplePlanFragment.class)));
+        planCheckerProviderManager = new PlanCheckerProviderManager(new JsonCodecSimplePlanFragmentSerde(jsonCodec(SimplePlanFragment.class)), new PlanCheckerProviderManagerConfig());
         planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new FeaturesConfig(), planCheckerProviderManager);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanCheckerProviderContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanCheckerProviderContext.java
@@ -11,13 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.facebook.presto.spi.plan;
 
-import java.util.Map;
+import static java.util.Objects.requireNonNull;
 
-public interface PlanCheckerProviderFactory
+public class PlanCheckerProviderContext
 {
-    String getName();
+    private final SimplePlanFragmentSerde simplePlanFragmentSerde;
 
-    PlanCheckerProvider create(Map<String, String> properties, PlanCheckerProviderContext planCheckerProviderContext);
+    public PlanCheckerProviderContext(SimplePlanFragmentSerde simplePlanFragmentSerde)
+    {
+        this.simplePlanFragmentSerde = requireNonNull(simplePlanFragmentSerde, "simplePlanFragmentSerde is null");
+    }
+
+    public SimplePlanFragmentSerde getSimplePlanFragmentSerde()
+    {
+        return simplePlanFragmentSerde;
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -42,6 +42,7 @@ import org.testng.annotations.Test;
 import javax.ws.rs.core.Response.Status;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -59,7 +60,9 @@ import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.execution.TestQueryRunnerUtil.cancelQuery;
 import static com.facebook.presto.execution.TestQueryRunnerUtil.createQuery;
 import static com.facebook.presto.execution.TestQueryRunnerUtil.waitForQueryState;
-import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getSimpleQueryRunner;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.createQueryRunner;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDao;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDbConfigUrl;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.spi.StandardErrorCode.ADMINISTRATIVELY_KILLED;
 import static com.facebook.presto.spi.StandardErrorCode.ADMINISTRATIVELY_PREEMPTED;
@@ -88,7 +91,9 @@ public class TestQueues
     public void setup()
             throws Exception
     {
-        queryRunner = getSimpleQueryRunner();
+        Map<String, String> coordinatorProperties = ImmutableMap.of("plan-checker.config-dir", "src/test/resources/plan-checker-providers");
+        String dbConfigUrl = getDbConfigUrl();
+        queryRunner = createQueryRunner(dbConfigUrl, getDao(dbConfigUrl), coordinatorProperties, 1);
         queryRunner.installPlugin(new BlackHolePlugin());
         queryRunner.createCatalog("blackhole", "blackhole");
         queryRunner.execute(

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestingPlanCheckerProviderPlugin.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestingPlanCheckerProviderPlugin.java
@@ -16,11 +16,12 @@ package com.facebook.presto.execution;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.plan.PlanChecker;
 import com.facebook.presto.spi.plan.PlanCheckerProvider;
+import com.facebook.presto.spi.plan.PlanCheckerProviderContext;
 import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
-import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TestingPlanCheckerProviderPlugin
@@ -46,7 +47,7 @@ public class TestingPlanCheckerProviderPlugin
     }
 
     @Override
-    public PlanCheckerProvider create(SimplePlanFragmentSerde simplePlanFragmentSerde)
+    public PlanCheckerProvider create(Map<String, String> properties, PlanCheckerProviderContext planCheckerProviderContext)
     {
         return this;
     }

--- a/presto-tests/src/test/resources/plan-checker-providers/trigger-failure-provider.properties
+++ b/presto-tests/src/test/resources/plan-checker-providers/trigger-failure-provider.properties
@@ -1,0 +1,1 @@
+plan-checker-provider.name=TestPlanCheckers


### PR DESCRIPTION
## Description
Plan checker configurations go in the configured plan checker
configuration directory.  We load the configuration files to figure out
which plan checkers to register, and pass any configuration properties
to the PlanCheckerProviderFactory.

This change also wraps SimplePlanFragmentSerde into a
PlanCheckerProviderContext so that if plan checkers need other things
arguments added we can add them to that wrapper class. That way we won't
break anyone's plan checker provider plugins by changing the
PlanCheckerProviderFactory SPI.

## Motivation and Context
This change makes the configuration of plan checkers more standard, both in that each plan checker won't need to manage it's own configuration loading code, and in that it aligns with how other plugin configurations work in Presto

This change also ensures that plan checker plugins are only loaded when they are configured.

Finally, it makes the PlanCheckerProviderFactory SPI more robust by making it less likely to need to be changed in the future.

## Impact
Plan checker plugin configurations should all go in the directory set by `plan-checker.config-dir`. The default is `etc/plan-checker-providers`. 

All plan checker provider configurations should include the property "plan-checker-provider.name", which should be set to the name of the PlanCheckerProviderFactory to use to create the PlanCheckerProvider (the name is as defined by PlanCheckerProviderFactory.getName()).

Modifies the PlanCheckerProviderFactory.create() SPI to pass in configuration properties and to wrap other arguments in PlanCheckerProviderContext

## Test Plan
Added unit test. Also, deployed a custom plan checker to a test cluster using this change.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
General Changes
* Add a configuration property ``plan-checker.config-dir`` to set the configuration directory for PlanCheckerProvider configurations. :pr:`23955`

SPI Changes
* Modify the signature of ``PlanCheckerProviderFactory.create`` to pass in a map of configuration properties and replace ``SimplePlanFragmentSerde`` with a ``PlanCheckerProviderContext``. :pr:`23955`

```

