### PR TITLE
[codemod] Remove unused-variable in /fbcode/github/presto-trunk/presto-native-execution/presto_cpp/main/QueryContextManager.cpp

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -98,8 +98,6 @@ void updateVeloxConnectorConfigs(
     std::unordered_map<
         std::string,
         std::unordered_map<std::string, std::string>>& connectorConfigStrings) {
-  const auto& systemConfig = SystemConfig::instance();
-
   for (auto& entry : connectorConfigStrings) {
     auto& connectorConfig = entry.second;
 


### PR DESCRIPTION
Summary:
[codemod] Remove unused-variable in {filename}


LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient to verify
 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65445391


