### PR TITLE
Add javadoc on internal UUID format

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/UuidType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/UuidType.java
@@ -31,6 +31,27 @@ import static io.airlift.slice.Slices.wrappedLongArray;
 import static java.lang.Long.reverseBytes;
 import static java.lang.String.format;
 
+/**
+ * The value of a UUID is stored as two longs in little-endian
+ * format in the order of [MSB, LSB] when executing within Presto:
+ * <br>
+ *
+ *  0 1 2 3 4 5 6 7 8 0 1 2 3 4 5 6 7 8
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |     MSB (LE)    |     LSB (LE)    |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * <br>
+ * The MSB and LSB are stored in little-endian format because the {@code slice}
+ * library assumes that longs used in byte-wise comparisons are stored in
+ * little-endian format. This requires us to store the bytes in little-endian
+ * too.
+ * <br>
+ * On-disk storage specifications such as Parquet or ORC may require different
+ * endianness or ordering of the MSB and LSB. Such conversions should be done in
+ * the code responsible for reading and writing the UUID.
+ *
+ */
 public class UuidType
         extends AbstractPrimitiveType
         implements FixedWidthType


### PR DESCRIPTION
## Description

Adds a javadoc for presto-native developers to reference the internal format of UUIDs

## Motivation and Context

Helps better specify the format to maintain compatibility

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

