### PR TITLE
[native] Move queryCtx in TaskManager::createOrUpdateTask

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -13,6 +13,9 @@
  */
 
 #include "presto_cpp/main/TaskManager.h"
+
+#include <utility>
+
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <folly/container/F14Set.h>
@@ -434,7 +437,7 @@ std::unique_ptr<protocol::TaskInfo> TaskManager::createOrUpdateTask(
       planFragment,
       updateRequest.sources,
       updateRequest.outputIds,
-      queryCtx,
+      std::move(queryCtx),
       startProcessCpuTime);
 }
 


### PR DESCRIPTION
## Description
A follow-up PR for #19923 that only moved `queryCtx` for `TaskManager::createOrUpdateBatchTask`

## Motivation and Context
Avoid a copy of a shared_ptr in `TaskManager::createOrUpdateTask`.

```
== NO RELEASE NOTE ==
```

