### PR TITLE
[docs] Fix formatting for merge_tdist function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/tdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/tdigest.rst
@@ -97,6 +97,7 @@ Functions
 
     This function is particularly useful for adding externally-created tdigests to Presto.
 
- .. function:: merge_tdigest(array<tdigest<double>>) -> tdigest<double>
-     Returns a merged ``tdigest`` of the T-digests in an array. This is the
-     scalar complement to the aggregation function ``merge``.
+.. function:: merge_tdigest(array<tdigest<double>>) -> tdigest<double>
+
+    Returns a merged ``tdigest`` of the T-digests in an array. This is the
+    scalar complement to the aggregation function ``merge``.


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

PR fixes the formatting for the `merge_tdist` function so that it'll appear on its own line, as right now it appears under the `construct_tdigest` function which isn't correct.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

