### PR TITLE
Ensure thread-safe accumulation of timing metrics in AsyncPageTransportServlet

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/AsyncPageTransportServlet.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/AsyncPageTransportServlet.java
@@ -173,7 +173,7 @@ public class AsyncPageTransportServlet
         {
             public void onComplete(AsyncEvent event)
             {
-                resultsRequestTime.add(Duration.nanosSince(start));
+                updateResultsRequestTime(Duration.nanosSince(start));
             }
 
             public void onError(AsyncEvent event)
@@ -213,7 +213,7 @@ public class AsyncPageTransportServlet
                 waitTime,
                 timeoutExecutor);
 
-        bufferResultFuture.addListener(() -> readFromOutputBufferTime.add(Duration.nanosSince(start)), directExecutor());
+        bufferResultFuture.addListener(() -> updateReadFromOutputBufferTime(Duration.nanosSince(start)), directExecutor());
 
         ServletOutputStream out = response.getOutputStream();
         addCallback(bufferResultFuture, new FutureCallback<BufferResult>()
@@ -271,5 +271,15 @@ public class AsyncPageTransportServlet
     public TimeStat getResultsRequestTime()
     {
         return resultsRequestTime;
+    }
+
+    private synchronized void updateReadFromOutputBufferTime(Duration duration)
+    {
+        readFromOutputBufferTime.add(duration);
+    }
+
+    private synchronized void updateResultsRequestTime(Duration duration)
+    {
+        resultsRequestTime.add(duration);
     }
 }


### PR DESCRIPTION
## Description
[CWE - 365](https://cwe.mitre.org/data/definitions/362.html)

This change introduces synchronized methods to handle timing metrics (readFromOutputBufferTime and resultsRequestTime) within AsyncPageTransportServlet, ensuring that cumulative values are safely updated across multiple threads. These variables are instance-level. The update addresses potential race conditions by serializing access to these metrics.

## Motivation and Context
This change is required to address potential race conditions in AsyncPageTransportServlet when updating timing metrics (readFromOutputBufferTime and resultsRequestTime) in a multi-threaded environment. Without synchronization, multiple threads could attempt to modify these shared TimeStat instances simultaneously, leading to inaccurate or corrupted metrics. This can cause issues in tracking performance data and could undermine any monitoring or alerting based on these metrics.

## Impact
No

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
Security Changes
Fix thread-safe updates to prevent race conditions in response to `CWE-362 <https://cwe.mitre.org/data/definitions/362.html>`_.  :pr:`23985`
```

