### PR TITLE
[codemod] Remove unused-variable in gen_ai/unified_parallelism/up/parallelisms/runtime/collective/MNSendRecv.cpp

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -785,7 +785,6 @@ DEBUG_ONLY_TEST_F(TaskManagerTest, fecthFromArbitraryOutput) {
   const protocol::Duration longWait("10s");
   const auto maxSize = protocol::DataSize("1024MB");
   auto expiredRequestState = http::CallbackRequestHandlerState::create();
-  auto consumeCompleted = false;
   // Consume from destination 0 to simulate the case that the http request has
   // expired while destination has notify setup.
   auto expiredResultWait = taskManager_->getResults(


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65584210


