### PR TITLE
Allow hbo stats for failed stages with local memory

### DIFF
--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderPlugin.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderPlugin.java
@@ -50,8 +50,8 @@ public class RedisProviderPlugin
     public Iterable<HistoryBasedPlanStatisticsProvider> getHistoryBasedPlanStatisticsProviders()
     {
         if (this.propertyMap == null) {
-            log.info("Redis Provider Plugin returned an empty instance");
-            return ImmutableList.of(EmptyPlanStatisticsProvider.getInstance());
+            log.error("Redis Provider Plugin returned an empty instance");
+            throw new RedisProviderInitializationException("Unable to retrieve RedisProviderPlugin");
         }
         if (!(propertyMap.getOrDefault(RedisProviderConfig.COORDINATOR_PROPERTY_NAME, "false").equals("true") &&
                 propertyMap.getOrDefault(RedisProviderConfig.HBO_PROVIDER_ENABLED_NAME, "false").equals("true"))) {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

