### PR TITLE
Removing class objects comparison using getName(),getSimpleName()

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -56,7 +56,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
 import org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
@@ -442,8 +444,7 @@ public final class HiveUtil
 
     public static boolean isSplittable(InputFormat<?, ?> inputFormat, FileSystem fileSystem, Path path)
     {
-        if ("OrcInputFormat".equals(inputFormat.getClass().getSimpleName()) ||
-                "RCFileInputFormat".equals(inputFormat.getClass().getSimpleName())) {
+        if (inputFormat instanceof OrcInputFormat || inputFormat instanceof RCFileInputFormat) {
             return true;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -388,11 +388,11 @@ public class QueryStats
 
                 if (plan.isOutputTableWriterFragment()) {
                     writtenOutputPositions += stageExecutionStats.getOperatorSummaries().stream()
-                            .filter(stats -> stats.getOperatorType().equals(TableWriterOperator.class.getSimpleName()))
+                            .filter(stats -> stats.getOperatorType().equals(TableWriterOperator.OPERATOR_TYPE))
                             .mapToLong(OperatorStats::getInputPositions)
                             .sum();
                     writtenOutputLogicalDataSize += stageExecutionStats.getOperatorSummaries().stream()
-                            .filter(stats -> stats.getOperatorType().equals(TableWriterOperator.class.getSimpleName()))
+                            .filter(stats -> stats.getOperatorType().equals(TableWriterOperator.OPERATOR_TYPE))
                             .mapToLong(stats -> stats.getInputDataSize().toBytes())
                             .sum();
                     writtenOutputPhysicalDataSize += stageExecutionStats.getPhysicalWrittenDataSize().toBytes();

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
@@ -95,7 +95,7 @@ public class TaskExecutor
     // Interrupt a split if it is running longer than this AND it's blocked on something known
     private static final Predicate<List<StackTraceElement>> DEFAULT_INTERRUPTIBLE_SPLIT_PREDICATE = elements ->
                     elements.stream()
-                            .anyMatch(element -> element.getClassName().equals(JoniRegexpFunctions.class.getName()));
+                            .anyMatch(element -> element.getClassName().equals(JoniRegexpFunctions.CLASS_NAME));
     private static final Duration DEFAULT_INTERRUPT_SPLIT_INTERVAL = new Duration(60, SECONDS);
 
     private static final AtomicLong NEXT_RUNNER_ID = new AtomicLong();

--- a/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
@@ -35,6 +35,8 @@ import static java.util.Objects.requireNonNull;
 public class AggregationOperator
         implements Operator
 {
+    public static final String OPERATOR_TYPE = "AggregationOperator";
+
     public static class AggregationOperatorFactory
             implements OperatorFactory
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -57,6 +57,7 @@ public class HashAggregationOperator
         implements Operator
 {
     private static final double MERGE_WITH_MEMORY_RATIO = 0.9;
+    public static final String OPERATOR_TYPE = "HashAggregationOperator";
 
     public static class HashAggregationOperatorFactory
             implements OperatorFactory

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -57,6 +57,7 @@ public class HashBuilderOperator
         implements Operator
 {
     private static final Logger log = Logger.get(HashBuilderOperator.class);
+    public static final String OPERATOR_TYPE = "HashBuilderOperator";
 
     public static class HashBuilderOperatorFactory
             implements OperatorFactory

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
@@ -78,6 +78,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class TableWriterOperator
         implements Operator
 {
+    public static final String OPERATOR_TYPE = "TableWriterOperator";
     public static class TableWriterOperatorFactory
             implements OperatorFactory
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -717,7 +717,7 @@ public class TaskContext
             return Optional.empty();
         }
 
-        if (context.getOperatorType().equals(HashBuilderOperator.class.getSimpleName())) {
+        if (context.getOperatorType().equals(HashBuilderOperator.OPERATOR_TYPE)) {
             Optional<JoinNode> planNode = findPlanNode(context.getPlanNodeId(), JoinNode.class);
             if (!planNode.isPresent()) {
                 return Optional.empty();
@@ -729,8 +729,8 @@ public class TaskContext
             return Optional.of(info);
         }
 
-        if (context.getOperatorType().equals(HashAggregationOperator.class.getSimpleName()) ||
-                context.getOperatorType().equals(AggregationOperator.class.getSimpleName())) {
+        if (context.getOperatorType().equals(HashAggregationOperator.OPERATOR_TYPE) ||
+                context.getOperatorType().equals(AggregationOperator.OPERATOR_TYPE)) {
             Optional<AggregationNode> planNode = findPlanNode(context.getPlanNodeId(), AggregationNode.class);
             if (!planNode.isPresent()) {
                 return Optional.empty();

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpFunctions.java
@@ -47,6 +47,7 @@ import static java.lang.String.format;
 
 public final class JoniRegexpFunctions
 {
+    public static final String CLASS_NAME = "JoniRegexpFunctions";
     private static final Block EMPTY_BLOCK = VarcharType.VARCHAR.createBlockBuilder(null, 0).build();
     private JoniRegexpFunctions()
     {


### PR DESCRIPTION
## Description
Changes to remove class objects comparison using the methods getName(),getSimpleName() to improve security.
Made changes in
presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpFunctions.java

## Motivation and Context
Do not compare class objects using the getName() or getSimpleName() method which may causes multiple security vulnerabilities includes String manipulations,class spoofing and namespace collisions

## Impact
No impact

## Test Plan
Verified existing Unit test case for above fix
presto-hive/src/test/java/com/facebook/presto/hive/TestHiveUtil.java
presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
presto-main/src/test/java/com/facebook/presto/execution/executor/TestTaskExecutor.java
presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java

## Release Notes

```
== NO RELEASE NOTE ==
```

