### PR TITLE
Fix CVEs about h2database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
+
         <dep.drift.version>1.38</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
@@ -1180,7 +1181,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.200</version>
+                <version>2.2.220</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1180,7 +1180,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>2.2.220</version>
+                <version>1.4.200</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1180,7 +1180,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.199</version>
+                <version>2.2.220</version>
             </dependency>
 
             <dependency>

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
@@ -50,7 +50,7 @@ final class TestingDatabase
     public TestingDatabase()
             throws SQLException
     {
-        String connectionUrl = "jdbc:h2:mem:test" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt() + ";LOCK_TIMEOUT=" + LOCK_TIMEOUT.toMillis();
+        String connectionUrl = "jdbc:h2:mem:test" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt() + ";LOCK_TIMEOUT=" + LOCK_TIMEOUT.toMillis() + ";NON_KEYWORDS=KEY,VALUE"; // key and value are reserved keywords in H2 2.x
         jdbcClient = new BaseJdbcClient(
                 new JdbcConnectorId(CONNECTOR_ID),
                 new BaseJdbcConfig(),

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingH2JdbcModule.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingH2JdbcModule.java
@@ -42,7 +42,7 @@ class TestingH2JdbcModule
     public static Map<String, String> createProperties()
     {
         return ImmutableMap.<String, String>builder()
-                .put("connection-url", format("jdbc:h2:mem:test%s;DB_CLOSE_DELAY=-1", System.nanoTime()))
+                .put("connection-url", format("jdbc:h2:mem:test%s;DB_CLOSE_DELAY=-1;NON_KEYWORDS=KEY,VALUE", System.nanoTime())) // key and value are reserved keywords in H2 2.x
                 .build();
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -81,27 +81,27 @@ public class TestHivePushdownFilterQueries
             "   CASE WHEN orderkey % 5 = 0 THEN null ELSE CAST(discount AS REAL) END AS discount_real, \n" +
             "   CASE WHEN orderkey % 43  = 0 THEN null ELSE discount END as discount, \n" +
             "   CASE WHEN orderkey % 7 = 0 THEN null ELSE CAST(tax AS REAL) END AS tax_real, \n" +
-            "   CASE WHEN linenumber % 2 = 0 THEN null ELSE (CAST(day(shipdate) AS TINYINT) , CAST(month(shipdate) AS TINYINT)) END AS ship_day_month, " +
+            "   CASE WHEN linenumber % 2 = 0 THEN null ELSE ARRAY[CAST(day(shipdate) AS TINYINT) , CAST(month(shipdate) AS TINYINT)] END AS ship_day_month, " +
             "   CASE WHEN orderkey % 37 = 0 THEN null ELSE CAST(discount AS DECIMAL(20, 8)) END AS discount_long_decimal, " +
             "   CASE WHEN orderkey % 41 = 0 THEN null ELSE CAST(tax AS DECIMAL(3, 2)) END AS tax_short_decimal, " +
-            "   CASE WHEN orderkey % 43 = 0 THEN null ELSE (CAST(discount AS DECIMAL(20, 8)), CAST(tax AS DECIMAL(20, 8))) END AS long_decimals, " +
-            "   CASE WHEN orderkey % 11 = 0 THEN null ELSE (orderkey, partkey, suppkey) END AS keys, \n" +
-            "   CASE WHEN orderkey % 41 = 0 THEN null ELSE (extendedprice, discount, tax) END AS doubles, \n" +
+            "   CASE WHEN orderkey % 43 = 0 THEN null ELSE ARRAY[CAST(discount AS DECIMAL(20, 8)), CAST(tax AS DECIMAL(20, 8))] END AS long_decimals, " +
+            "   CASE WHEN orderkey % 11 = 0 THEN null ELSE ARRAY[orderkey, partkey, suppkey] END AS keys, \n" +
+            "   CASE WHEN orderkey % 41 = 0 THEN null ELSE ARRAY[extendedprice, discount, tax] END AS doubles, \n" +
             "   CASE WHEN orderkey % 13 = 0 THEN null ELSE ARRAY[ARRAY[orderkey, partkey], ARRAY[suppkey], CASE WHEN orderkey % 17 = 0 THEN null ELSE ARRAY[orderkey, partkey] END] END AS nested_keys, \n" +
-            "   CASE WHEN orderkey % 17 = 0 THEN null ELSE (shipmode = 'AIR', returnflag = 'R') END as flags, \n" +
-            "   CASE WHEN orderkey % 19 = 0 THEN null ELSE (CAST(discount AS REAL), CAST(tax AS REAL)) END as reals, \n" +
+            "   CASE WHEN orderkey % 17 = 0 THEN null ELSE ARRAY[shipmode = 'AIR', returnflag = 'R'] END as flags, \n" +
+            "   CASE WHEN orderkey % 19 = 0 THEN null ELSE ARRAY[CAST(discount AS REAL), CAST(tax AS REAL)] END as reals, \n" +
             "   CASE WHEN orderkey % 23 = 0 THEN null ELSE (orderkey, linenumber, (CAST(day(shipdate) as TINYINT), CAST(month(shipdate) AS TINYINT), CAST(year(shipdate) AS INTEGER))) END AS info, \n" +
-            "   CASE WHEN orderkey % 31 = 0 THEN null ELSE (" +
+            "   CASE WHEN orderkey % 31 = 0 THEN null ELSE ARRAY[" +
             "       (CAST(day(shipdate) AS TINYINT), CAST(month(shipdate) AS TINYINT), CAST(year(shipdate) AS INTEGER)), " +
             "       (CAST(day(commitdate) AS TINYINT), CAST(month(commitdate) AS TINYINT), CAST(year(commitdate) AS INTEGER)), " +
-            "       (CAST(day(receiptdate) AS TINYINT), CAST(month(receiptdate) AS TINYINT), CAST(year(receiptdate) AS INTEGER))) END AS dates, \n" +
-            "   CASE WHEN orderkey % 37 = 0 THEN null ELSE (CAST(shipdate AS TIMESTAMP), CAST(commitdate AS TIMESTAMP)) END AS timestamps, \n" +
+            "       (CAST(day(receiptdate) AS TINYINT), CAST(month(receiptdate) AS TINYINT), CAST(year(receiptdate) AS INTEGER))] END AS dates, \n" +
+            "   CASE WHEN orderkey % 37 = 0 THEN null ELSE ARRAY[CAST(shipdate AS TIMESTAMP), CAST(commitdate AS TIMESTAMP)] END AS timestamps, \n" +
             "   CASE WHEN orderkey % 43 = 0 THEN null ELSE comment END AS comment, \n" +
             "   CASE WHEN orderkey % 43 = 0 THEN null ELSE upper(comment) END AS uppercase_comment, \n" +
             "   CAST('' as VARBINARY) AS empty_comment, \n" +
             "   CASE WHEN orderkey % 47 = 0 THEN null ELSE CAST(comment AS CHAR(5)) END AS fixed_comment, \n" +
-            "   CASE WHEN orderkey % 49 = 0 THEN null ELSE (CAST(comment AS CHAR(4)), CAST(comment AS CHAR(3)), CAST(SUBSTR(comment,length(comment) - 4) AS CHAR(4))) END AS char_array, \n" +
-            "   CASE WHEN orderkey % 49 = 0 THEN null ELSE (comment, comment) END AS varchar_array \n" +
+            "   CASE WHEN orderkey % 49 = 0 THEN null ELSE ARRAY[CAST(comment AS CHAR(4)), CAST(comment AS CHAR(3)), CAST(SUBSTR(comment,length(comment) - 4) AS CHAR(4))] END AS char_array, \n" +
+            "   CASE WHEN orderkey % 49 = 0 THEN null ELSE ARRAY[comment, comment] END AS varchar_array \n" +
 
             "FROM lineitem)\n";
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestTestUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestTestUtil.java
@@ -66,7 +66,7 @@ public class IcebergRestTestUtil
         backingCatalog.setConf(hdfsEnvironment.getConfiguration(new HdfsContext(SESSION), new Path(location)));
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put(URI, "jdbc:h2:mem:test_" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt())
+                .put(URI, "jdbc:h2:mem:test_" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt() + ";NON_KEYWORDS=KEY,VALUE") // key and value are reserved keywords in H2 2.x
                 .put(WAREHOUSE_LOCATION, location)
                 .put("jdbc.username", "user")
                 .put("jdbc.password", "password")

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbManagerSpecProvider.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbManagerSpecProvider.java
@@ -37,7 +37,7 @@ public class TestDbManagerSpecProvider
 
     private static H2DaoProvider setup(String prefix)
     {
-        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt());
+        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt() + ";NON_KEYWORDS=KEY,VALUE"); // key and value are reserved keywords in H2 2.x
         return new H2DaoProvider(config);
     }
 

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbSourceExactMatchSelector.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbSourceExactMatchSelector.java
@@ -40,7 +40,7 @@ public class TestDbSourceExactMatchSelector
     @BeforeClass
     public void setup()
     {
-        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_db-exact-match-selector" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt());
+        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_db-exact-match-selector" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt() + ";NON_KEYWORDS=KEY,VALUE"); // key and value are reserved keywords in H2 2.x
         dao = new H2DaoProvider(config).get();
         dao.createExactMatchSelectorsTable();
     }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
@@ -61,7 +61,7 @@ public class TestResourceGroupsDao
 
     static H2ResourceGroupsDao setup(String prefix)
     {
-        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt());
+        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt() + ";NON_KEYWORDS=KEY,VALUE"); // key and value are reserved keywords in H2 2.x
         return new H2DaoProvider(config).get();
     }
 

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfigurationManager.java
@@ -55,7 +55,7 @@ public class TestReloadingResourceGroupConfigurationManager
 
     static H2DaoProvider setup(String prefix)
     {
-        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt());
+        DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt() + ";NON_KEYWORDS=KEY,VALUE"); // key and value are reserved keywords in H2 2.x
         return new H2DaoProvider(config);
     }
 

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -211,7 +211,6 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -211,6 +211,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -1276,14 +1276,14 @@ public abstract class AbstractTestAggregations
                         "WHERE orderkey IN (1, 2, 3, 4, 5) " +
                         "GROUP BY GROUPING SETS ((), (orderpriority), (orderpriority, custkey))",
                 "VALUES " +
-                        "(NULL, NULL , ('F', 'O', 'O'))," +
-                        "('5-LOW', NULL , ('F', 'O'))," +
-                        "('1-URGENT', NULL , ('O'))," +
+                        "(NULL, NULL , ARRAY['F', 'O', 'O'])," +
+                        "('5-LOW', NULL , ARRAY['F', 'O'])," +
+                        "('1-URGENT', NULL , ARRAY['O'])," +
                         "('5-LOW', 370 , NULL)," +
-                        "('5-LOW', 1234, ('F'))," +
-                        "('5-LOW', 1369, ('O'))," +
+                        "('5-LOW', 1234, ARRAY['F'])," +
+                        "('5-LOW', 1369, ARRAY['O'])," +
                         "('5-LOW', 445 , NULL)," +
-                        "('1-URGENT', 781 , ('O'))");
+                        "('1-URGENT', 781 , ARRAY['O'])");
     }
 
     /**

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7061,7 +7061,7 @@ public abstract class AbstractTestQueries
 
         // decimal
         sql = "select array_cum_sum(k) from (values (array[cast(5.1 as decimal(38, 1)), 6, 0]), (ARRAY[]), (CAST(NULL AS array(decimal)))) t(k)";
-        assertQuery(sql, "values array[cast(5.1 as DECIMAL(3,1)), cast(11.1 as DECIMAL(3,1)), cast(11.1 as DECIMAL(3,1))], array[], null");
+        assertQuery(sql, "values array[cast(5.1 as decimal(3,1)), cast(11.1 as decimal(3,1)), cast(11.1 as decimal(3,1))], array[], null");
 
         sql = "select array_cum_sum(k) from (values (array[cast(5.1 as decimal(38, 1)), 6, null, 3]), (array[cast(null as decimal(38, 1)), 6, null, 3])) t(k)";
         assertQuery(sql, "values array[cast(5.1 as decimal(3,1)), cast(11.1 as decimal(3,1)), cast(null as decimal(3,1)), cast(null as decimal(3,1))], " +

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7061,10 +7061,10 @@ public abstract class AbstractTestQueries
 
         // decimal
         sql = "select array_cum_sum(k) from (values (array[cast(5.1 as decimal(38, 1)), 6, 0]), (ARRAY[]), (CAST(NULL AS array(decimal)))) t(k)";
-        assertQuery(sql, "values array[cast(5.1 as decimal), cast(11.1 as decimal), cast(11.1 as decimal)], array[], null");
+        assertQuery(sql, "values array[cast(5.1 as DECIMAL(3,1)), cast(11.1 as DECIMAL(3,1)), cast(11.1 as DECIMAL(3,1))], array[], null");
 
         sql = "select array_cum_sum(k) from (values (array[cast(5.1 as decimal(38, 1)), 6, null, 3]), (array[cast(null as decimal(38, 1)), 6, null, 3])) t(k)";
-        assertQuery(sql, "values array[cast(5.1 as decimal), cast(11.1 as decimal), cast(null as decimal), cast(null as decimal)], " +
+        assertQuery(sql, "values array[cast(5.1 as decimal(3,1)), cast(11.1 as decimal(3,1)), cast(null as decimal(3,1)), cast(null as decimal(3,1))], " +
                 "array[cast(null as decimal), cast(null as decimal), cast(null as decimal), cast(null as decimal)]");
 
         // varchar

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
@@ -1021,7 +1021,7 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 1 PRECEDING AND 10 PRECEDING) " +
                         "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null, " +
                         "null, " +
@@ -1034,7 +1034,7 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 10 FOLLOWING AND 1 FOLLOWING) " +
                         "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null, " +
                         "null, " +
@@ -1054,20 +1054,20 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
                         "FROM (VALUES 1.0, 1.1) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null");
 
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a NULLS LAST RANGE BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
                         "FROM (VALUES 1.0, 1.1, null) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "ARRAY[null]");
 
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
                         "FROM (VALUES 1.0, 1.1) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null");
 
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a NULLS FIRST RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
@@ -1122,14 +1122,14 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
                         "FROM (VALUES 1, 1, 1) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null");
 
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
                         "FROM (VALUES 1, 1, 1) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null");
 
@@ -1428,7 +1428,7 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 2 FOLLOWING AND 1 FOLLOWING) " +
                         "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null, " +
                         "null, " +
@@ -1542,7 +1542,7 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN 90 PRECEDING AND 100 PRECEDING) " +
                         "FROM (VALUES 1, null, null, 2, 1) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null, " +
                         "null, " +
@@ -1551,7 +1551,7 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN 100 FOLLOWING AND 90 FOLLOWING) " +
                         "FROM (VALUES 1, null, null, 2, 1) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null, " +
                         "null, " +
@@ -1607,14 +1607,14 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
                         "FROM (VALUES CAST(null AS integer), null, null) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null");
 
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
                         "FROM (VALUES CAST(null AS integer), null, null) T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null");
     }
@@ -1625,14 +1625,14 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
                         "FROM (VALUES 'a', 'a', 'a') T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null");
 
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
                         "FROM (VALUES 'a', 'a', 'a') T(a)",
                 "VALUES " +
-                        "CAST(null AS array), " +
+                        "null, " +
                         "null, " +
                         "null");
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
@@ -1338,11 +1338,11 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT x, array_agg(date) OVER(ORDER BY x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING), avg(number) OVER(ORDER BY x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
                         "FROM (VALUES " +
                         "(2, DATE '2222-01-01', 4.4), " +
-                        "(1, DATE '1111-01-01', 2.2), " +
+                        "(1, DATE '1999-01-01', 2.2), " +
                         "(3, DATE '3333-01-01', 6.6)) T(x, date, number)",
                 "VALUES " +
-                        "(1, ARRAY[DATE '1111-01-01', DATE '2222-01-01'], 3.3), " +
-                        "(2, ARRAY[DATE '1111-01-01', DATE '2222-01-01', DATE '3333-01-01'], 4.4), " +
+                        "(1, ARRAY[DATE '1999-01-01', DATE '2222-01-01'], 3.3), " +
+                        "(2, ARRAY[DATE '1999-01-01', DATE '2222-01-01', DATE '3333-01-01'], 4.4), " +
                         "(3, ARRAY[DATE '2222-01-01', DATE '3333-01-01'], 5.5)");
 
         assertQuery("SELECT x, array_agg(a) OVER(ORDER BY x RANGE BETWEEN 2 PRECEDING AND CURRENT ROW), array_agg(a) OVER(ORDER BY x RANGE BETWEEN CURRENT ROW AND 2 FOLLOWING) " +
@@ -1733,11 +1733,11 @@ public abstract class AbstractTestWindowQueries
         assertQuery("SELECT x, array_agg(date) OVER(ORDER BY x GROUPS BETWEEN 1 PRECEDING AND 1 PRECEDING), avg(number) OVER(ORDER BY x GROUPS BETWEEN 1 FOLLOWING AND 1 FOLLOWING) " +
                         "FROM (VALUES " +
                         "(2, DATE '2222-01-01', 4.4), " +
-                        "(1, DATE '1111-01-01', 2.2), " +
+                        "(1, DATE '1999-01-01', 2.2), " +
                         "(3, DATE '3333-01-01', 6.6)) T(x, date, number)",
                 "VALUES " +
                         "(1, null, 4.4), " +
-                        "(2, ARRAY[DATE '1111-01-01'], 6.6), " +
+                        "(2, ARRAY[DATE '1999-01-01'], 6.6), " +
                         "(3, ARRAY[DATE '2222-01-01'], null)");
 
         // three functions with different frame types

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2ConnectionModule.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2ConnectionModule.java
@@ -90,6 +90,6 @@ public class H2ConnectionModule
 
     public static String getJdbcUrl(String databaseName)
     {
-        return format("jdbc:h2:mem:test%s;MODE=MySQL;DATABASE_TO_LOWER=TRUE", databaseName);
+        return format("jdbc:h2:mem:test%s;MODE=MySQL;DATABASE_TO_LOWER=TRUE;NON_KEYWORDS=KEY,VALUE", databaseName); // key and value are reserved keywords in H2 2.x
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -116,8 +116,8 @@ public class H2QueryRunner
                 "  orderstatus CHAR(1) NOT NULL,\n" +
                 "  totalprice DOUBLE NOT NULL,\n" +
                 "  orderdate DATE NOT NULL,\n" +
-                "  orderpriority CHAR(15) NOT NULL,\n" +
-                "  clerk CHAR(15) NOT NULL,\n" +
+                "  orderpriority VARCHAR(15) NOT NULL,\n" +
+                "  clerk VARCHAR(15) NOT NULL,\n" +
                 "  shippriority INTEGER NOT NULL,\n" +
                 "  comment VARCHAR(79) NOT NULL\n" +
                 ")");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -107,7 +107,7 @@ public class H2QueryRunner
 
     public H2QueryRunner()
     {
-        handle = Jdbi.open("jdbc:h2:mem:test" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt());
+        handle = Jdbi.open("jdbc:h2:mem:test" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextLong() + ";NON_KEYWORDS=KEY,VALUE"); // key and value are reserved keywords in H2 2.x
         TpchMetadata tpchMetadata = new TpchMetadata("");
 
         handle.execute("CREATE TABLE orders (\n" +

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -107,7 +107,7 @@ public class H2QueryRunner
 
     public H2QueryRunner()
     {
-        handle = Jdbi.open("jdbc:h2:mem:test" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextLong() + ";NON_KEYWORDS=KEY,VALUE"); // key and value are reserved keywords in H2 2.x
+        handle = Jdbi.open("jdbc:h2:mem:test" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt() + ";NON_KEYWORDS=KEY,VALUE"); // key and value are reserved keywords in H2 2.x
         TpchMetadata tpchMetadata = new TpchMetadata("");
 
         handle.execute("CREATE TABLE orders (\n" +

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
@@ -116,7 +116,7 @@ public class H2TestUtil
 
     public static String getDbConfigUrl()
     {
-        return "jdbc:h2:mem:test_" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt();
+        return "jdbc:h2:mem:test_" + System.nanoTime() + "_" + ThreadLocalRandom.current().nextInt() + ";NON_KEYWORDS=KEY,VALUE"; // key and value are reserved keywords in H2 2.x
     }
 
     public static H2ResourceGroupsDao getDao(String url)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -109,12 +109,12 @@ public class TestLocalQueries
     @Test
     public void testDecimal()
     {
-        assertQuery("SELECT DECIMAL '1.0'", "SELECT CAST('1.0' AS DECIMAL)");
-        assertQuery("SELECT DECIMAL '1.'", "SELECT CAST('1.0' AS DECIMAL)");
-        assertQuery("SELECT DECIMAL '0.1'", "SELECT CAST('0.1' AS DECIMAL)");
-        assertQuery("SELECT 1.0", "SELECT CAST('1.0' AS DECIMAL)");
-        assertQuery("SELECT 1.", "SELECT CAST('1.0' AS DECIMAL)");
-        assertQuery("SELECT 0.1", "SELECT CAST('0.1' AS DECIMAL)");
+        assertQuery("SELECT DECIMAL '1.0'", "SELECT CAST('1.0' AS DECIMAL(2,1))");
+        assertQuery("SELECT DECIMAL '1.'", "SELECT CAST('1.0' AS DECIMAL(2,1))");
+        assertQuery("SELECT DECIMAL '0.1'", "SELECT CAST('0.1' AS DECIMAL(2,1))");
+        assertQuery("SELECT 1.0", "SELECT CAST('1.0' AS DECIMAL(2,1))");
+        assertQuery("SELECT 1.", "SELECT CAST('1.0' AS DECIMAL(2,1))");
+        assertQuery("SELECT 0.1", "SELECT CAST('0.1' AS DECIMAL(2,1))");
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes CVE-2022-23221 , CVE-2021-23463 and CVE-2021-42392  on com.h2database:h2.

## Motivation and Context
Resolve a new CVE.

## Impact
Should have no known impact to other code.

## Test Plan
Regular PR GitHub actions

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

