### PR TITLE
Upgrade gson to resolve CVE

### DIFF
--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -15,6 +15,16 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.9</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.facebook.airlift</groupId>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <grpc.version>1.41.0</grpc.version>
+        <grpc.version>1.68.0</grpc.version>
     </properties>
 
     <dependencies>
@@ -383,7 +383,7 @@
         <dependency>
             <groupId>io.perfmark</groupId>
             <artifactId>perfmark-api</artifactId>
-            <version>0.23.0</version>
+            <version>0.27.0</version>
         </dependency>
 
         <dependency>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <grpc.version>1.41.0</grpc.version>
+        <grpc.version>1.68.0</grpc.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Description
Upgraded gson to version 2.8.9
Upgraded grpc to version 1.68.0

## Motivation and Context
This upgrade was created to deal with the following CVE:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647

## Impact
None

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Upgrade gson to version 2.8.9 in response to `CVE-2022-25647 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647>` :pr:`24017`
* Upgrade grpc dependencies to version 1.68.0 in response to `CVE-2022-25647 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647>` :pr:`24017`
```
