### PR TITLE
[jdk-upgrade] Fix missing license header checks in presto-ui module

### DIFF
--- a/presto-ui/pom.xml
+++ b/presto-ui/pom.xml
@@ -38,10 +38,14 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
-                    <excludes combine.children="append">
-                        <exclude>**/*.graffle</exclude>
-                        <exclude>src/**</exclude>
-                    </excludes>
+                    <licenseSets>
+                        <licenseSet>
+                            <excludes combine.children="append">
+                                <exclude>**/*.graffle</exclude>
+                                <exclude>src/**</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Fix missing license header checks in presto-ui module

```
[ERROR] Failed to execute goal com.mycila:license-maven-plugin:4.3:check (default) on project presto-ui: Some files do not have the expected license header. Run license:format to update them. -> [Help 1]
```

Migrate from deprecated excludes config to LicenseSet.excludes in license-maven-plugin