### PR TITLE
cryptographically secure random index

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -105,6 +106,7 @@ public class DistributedQueryRunner
     private static final String ENVIRONMENT = "testing";
     private static final String DEFAULT_USER = "user";
     private static final SqlParserOptions DEFAULT_SQL_PARSER_OPTIONS = new SqlParserOptions();
+    private static final SecureRandom secureRandom = new SecureRandom();
 
     private final TestingDiscoveryServer discoveryServer;
     private final List<TestingPrestoServer> coordinators;
@@ -503,7 +505,7 @@ public class DistributedQueryRunner
 
     private int getRandomCoordinatorIndex()
     {
-        return ThreadLocalRandom.current().nextInt(prestoClients.size());
+        return secureRandom.nextInt(prestoClients.size());
     }
 
     @Override


### PR DESCRIPTION
## Description
ThreadLocalRandom is not cryptographically secure, to generate random indexes. Replace ThreadLocalRandom with SecureRandom, which provides cryptographically secure random number generation.

## Motivation and Context
Insecure randomness errors occur when a function that can produce predictable values is used as a source of randomness in a security-sensitive context: security tokens (like anti-CSRF or password-reset tokens), values used in cryptographic operations (session key material, initialization vector in block or stream ciphers), or password seeds. ThreadLocalRandom is suitable for non-security purposes but should not be used in contexts where randomness must be secure or unpredictable. In security-sensitive applications , using insecure randomness can lead to vulnerabilities where attackers might predict or reverse-engineer the random values.

## Impact
No

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
Security Changes
Secure randomly generated index in response to `CWE-330 <https://cwe.mitre.org/data/definitions/330.html>`.  :pr:`24031`
```


