### PR TITLE
[native] Advance Velox and Fix Gcs naming

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -49,11 +49,7 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h"
-#ifdef VELOX_ENABLE_FORWARD_COMPATIBILITY
 #include "velox/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.h"
-#else
-#include "velox/connectors/hive/storage_adapters/gcs/RegisterGCSFileSystem.h"
-#endif
 #include "velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "velox/connectors/tpch/TpchConnector.h"
@@ -1296,11 +1292,7 @@ void PrestoServer::registerFileSystems() {
   velox::filesystems::registerLocalFileSystem();
   velox::filesystems::registerS3FileSystem();
   velox::filesystems::registerHdfsFileSystem();
-#ifdef VELOX_ENABLE_FORWARD_COMPATIBILITY
   velox::filesystems::registerGcsFileSystem();
-#else
-  velox::filesystems::registerGCSFileSystem();
-#endif
   velox::filesystems::abfs::registerAbfsFileSystem();
 }
 


### PR DESCRIPTION
A follow-up fix in Presto of https://github.com/facebookincubator/velox/pull/11328
```
== NO RELEASE NOTE ==
```

