### PR TITLE
Changes to normalize the string to improve security

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveZeroRowFileCreator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveZeroRowFileCreator.java
@@ -34,6 +34,7 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Paths;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -107,10 +108,12 @@ public class HiveZeroRowFileCreator
     {
         String tmpDirectoryPath = System.getProperty("java.io.tmpdir");
         String tmpFileName = format("presto-hive-zero-row-file-creator-%s-%s", session.getQueryId(), randomUUID().toString());
-        java.nio.file.Path tmpFilePath = Paths.get(tmpDirectoryPath, tmpFileName);
+        String normalizedDirPath = Normalizer.normalize(tmpDirectoryPath, Normalizer.Form.NFKC);
+        String normalizedFileName = Normalizer.normalize(tmpFileName, Normalizer.Form.NFKC);
+        java.nio.file.Path tmpFilePath = Paths.get(normalizedDirPath, normalizedFileName);
 
         try {
-            Path target = new Path(format("file://%s/%s", tmpDirectoryPath, tmpFileName));
+            Path target = new Path(format("file://%s/%s", normalizedDirPath, normalizedFileName));
 
             //https://github.com/prestodb/presto/issues/14401 JSON Format reader does not fetch compression from source system
             JobConf conf = configureCompression(

--- a/presto-main/src/main/java/com/facebook/presto/storage/TempStorageManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/storage/TempStorageManager.java
@@ -32,7 +32,9 @@ import javax.inject.Inject;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.Normalizer;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -96,12 +98,14 @@ public class TempStorageManager
         ImmutableMap.Builder<String, Map<String, String>> storageProperties = ImmutableMap.builder();
         // Always load local temp storage
         addTempStorageFactory(new LocalTempStorage.Factory());
+        Path tempStoragePath = Paths.get(System.getProperty("java.io.tmpdir"), "presto", "temp_storage").toAbsolutePath();
+        String normalizedTempStoragePath = Normalizer.normalize(tempStoragePath.toString(), Normalizer.Form.NFKC);
         storageProperties.put(
                 LocalTempStorage.NAME,
                 // TODO: Local temp storage should be configurable
                 ImmutableMap.of(
                         TEMP_STORAGE_PATH,
-                        Paths.get(System.getProperty("java.io.tmpdir"), "presto", "temp_storage").toAbsolutePath().toString(),
+                        normalizedTempStoragePath,
                         TEMP_STORAGE_FACTORY_NAME,
                         "local"));
 


### PR DESCRIPTION
## Description
Normalized the unnormalized string to increase security
Made the changes in
presto-hive/src/main/java/com/facebook/presto/hive/HiveZeroRowFileCreator.java
presto-main/src/main/java/com/facebook/presto/storage/TempStorageManager.java

## Motivation and Context
When a system accepts external inputs usually uses a filtering or validation technique to check if the input is safe or a malicious input. When filtering techniques like blacklisting are used, certain characters whose use can be malicious can skip this filtering if they are encoded in other different format than the expected.Java API provides the Normalizer class along with its normalize method to transform a string into a proper format.

## Impact
no impact

## Test Plan
Verified existing Unit test case for above fix :
(1)presto-main/src/main/java/com/facebook/presto/testing/TestingTempStorageManager.java



## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

