### PR TITLE
Add session properties for prefixsort

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -276,3 +276,32 @@ bytes / number of destinations for each destination before producing a Serialize
 
 Maximum number of partitions created by a local exchange.
 Affects concurrency for pipelines containing LocalPartitionNode.
+
+
+``native_spill_enable_prefix_sort``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Enable the prefix sort or fallback to timsort in spill.
+The prefix sort is faster than timsort but requires the memory to build prefix data,
+which may cause out of memory.
+
+``native_prefixsort_normalized_key_max_bytes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``128``
+
+Maximum number of bytes to use for the normalized key in prefix-sort.
+Use 0 to disable prefix-sort.
+
+``native_prefixsort_min_rows``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``130``
+
+Minimum number of rows to use prefix-sort.
+The default value has been derived using micro-benchmarking.

--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -278,15 +278,15 @@ Maximum number of partitions created by a local exchange.
 Affects concurrency for pipelines containing LocalPartitionNode.
 
 
-``native_spill_enable_prefix_sort``
+``native_spill_prefixsort_enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``
 
-Enable the prefix sort or fallback to timsort in spill.
-The prefix sort is faster than timsort but requires the memory to build prefix data,
-which may cause out of memory.
+Enable the prefix sort or fallback to std::sort in spill. The prefix sort is
+faster than std::sort but requires the memory to build normalized prefix
+keys, which might have potential risk of running out of server memory.
 
 ``native_prefixsort_normalized_key_max_bytes``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -295,7 +295,7 @@ which may cause out of memory.
 * **Default value:** ``128``
 
 Maximum number of bytes to use for the normalized key in prefix-sort.
-Use 0 to disable prefix-sort.
+Use ``0`` to disable prefix-sort.
 
 ``native_prefixsort_min_rows``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -279,7 +279,7 @@ Affects concurrency for pipelines containing LocalPartitionNode.
 
 
 ``native_spill_prefixsort_enabled``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``
@@ -289,7 +289,7 @@ faster than std::sort but requires the memory to build normalized prefix
 keys, which might have potential risk of running out of server memory.
 
 ``native_prefixsort_normalized_key_max_bytes``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``integer``
 * **Default value:** ``128``
@@ -298,7 +298,7 @@ Maximum number of bytes to use for the normalized key in prefix-sort.
 Use ``0`` to disable prefix-sort.
 
 ``native_prefixsort_min_rows``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``integer``
 * **Default value:** ``130``

--- a/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -62,6 +62,9 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_QUERY_TRACE_MAX_BYTES = "native_query_trace_max_bytes";
     public static final String NATIVE_QUERY_TRACE_REG_EXP = "native_query_trace_task_reg_exp";
     public static final String NATIVE_MAX_LOCAL_EXCHANGE_PARTITION_COUNT = "native_max_local_exchange_partition_count";
+    public static final String NATIVE_SPILL_ENABLE_PREFIX_SORT = "native_spill_enable_prefix_sort";
+    public static final String NATIVE_PREFIXSORT_NORMALIZED_KEY_MAX_BYTES = "native_prefixsort_normalized_key_max_bytes";
+    public static final String NATIVE_PREFIXSORT_MIN_ROWS = "native_prefixsort_min_rows";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -239,6 +242,25 @@ public class NativeWorkerSessionPropertyProvider
                         "Maximum number of partitions created by a local exchange. " +
                                 "Affects concurrency for pipelines containing LocalPartitionNode",
                         null,
+                        !nativeExecution),
+                booleanProperty(
+                        NATIVE_SPILL_ENABLE_PREFIX_SORT,
+                        "Enable the prefix sort or fallback to timsort in spill. "+
+                                "The prefix sort is faster than timsort but requires the memory to build prefix data," +
+                                "which may cause out of memory.",
+                        false,
+                        !nativeExecution),
+                integerProperty(
+                        NATIVE_PREFIXSORT_NORMALIZED_KEY_MAX_BYTES,
+                        "Maximum number of bytes to use for the normalized key in prefix-sort. " +
+                                "Use 0 to disable prefix-sort.",
+                        128,
+                        !nativeExecution),
+                integerProperty(
+                        NATIVE_PREFIXSORT_MIN_ROWS,
+                        "Minimum number of rows to use prefix-sort. " +
+                                "The default value (130) has been derived using micro-benchmarking.",
+                        130,
                         !nativeExecution));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -62,7 +62,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_QUERY_TRACE_MAX_BYTES = "native_query_trace_max_bytes";
     public static final String NATIVE_QUERY_TRACE_REG_EXP = "native_query_trace_task_reg_exp";
     public static final String NATIVE_MAX_LOCAL_EXCHANGE_PARTITION_COUNT = "native_max_local_exchange_partition_count";
-    public static final String NATIVE_SPILL_ENABLE_PREFIX_SORT = "native_spill_enable_prefix_sort";
+    public static final String NATIVE_SPILL_PREFIXSORT_ENABLED = "native_spill_prefixsort_enabled";
     public static final String NATIVE_PREFIXSORT_NORMALIZED_KEY_MAX_BYTES = "native_prefixsort_normalized_key_max_bytes";
     public static final String NATIVE_PREFIXSORT_MIN_ROWS = "native_prefixsort_min_rows";
     private final List<PropertyMetadata<?>> sessionProperties;
@@ -244,10 +244,10 @@ public class NativeWorkerSessionPropertyProvider
                         null,
                         !nativeExecution),
                 booleanProperty(
-                        NATIVE_SPILL_ENABLE_PREFIX_SORT,
-                        "Enable the prefix sort or fallback to timsort in spill. "+
-                                "The prefix sort is faster than timsort but requires the memory to build prefix data," +
-                                "which may cause out of memory.",
+                        NATIVE_SPILL_PREFIXSORT_ENABLED,
+                        "Enable the prefix sort or fallback to std::sort in spill. " +
+                                "The prefix sort is faster than std::sort but requires the memory to build normalized " +
+                                "prefix keys, which might have potential risk of running out of server memory.",
                         false,
                         !nativeExecution),
                 integerProperty(

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -363,6 +363,34 @@ SessionProperties::SessionProperties() {
       false,
       QueryConfig::kMaxLocalExchangePartitionCount,
       std::to_string(c.maxLocalExchangePartitionCount()));
+
+  addSessionProperty(
+      kSpillEnablePrefixSort,
+      "Enable the prefix sort or fallback to timsort in spill. The prefix sort is "
+      "faster than timsort but requires the memory to build prefix data, which "
+      "may cause out of memory.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kSpillEnablePrefixSort,
+      std::to_string(c.spillEnablePrefixSort()));
+
+  addSessionProperty(
+    kPrefixSortNormalizedKeyMaxBytes,
+    "Maximum number of bytes to use for the normalized key in prefix-sort. "
+    "Use 0 to disable prefix-sort.",
+    INTEGER(),
+    false,
+    QueryConfig::kPrefixSortNormalizedKeyMaxBytes,
+    std::to_string(c.prefixSortNormalizedKeyMaxBytes()));
+
+  addSessionProperty(
+  kPrefixSortMinRows,
+  "Minimum number of rows to use prefix-sort. The default value (130) has been "
+  "derived using micro-benchmarking.",
+  INTEGER(),
+  false,
+  QueryConfig::kPrefixSortMinRows,
+  std::to_string(c.prefixSortMinRows()));
 }
 
 const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -365,32 +365,32 @@ SessionProperties::SessionProperties() {
       std::to_string(c.maxLocalExchangePartitionCount()));
 
   addSessionProperty(
-      kSpillEnablePrefixSort,
-      "Enable the prefix sort or fallback to timsort in spill. The prefix sort is "
-      "faster than timsort but requires the memory to build prefix data, which "
-      "may cause out of memory.",
+      kSpillPrefixSortEnabled,
+      "Enable the prefix sort or fallback to std::sort in spill. The prefix sort is "
+      "faster than std::sort but requires the memory to build normalized prefix "
+      "keys, which might have potential risk of running out of server memory.",
       BOOLEAN(),
       false,
-      QueryConfig::kSpillEnablePrefixSort,
-      std::to_string(c.spillEnablePrefixSort()));
+      QueryConfig::kSpillPrefixSortEnabled,
+      std::to_string(c.spillPrefixSortEnabled()));
 
   addSessionProperty(
-    kPrefixSortNormalizedKeyMaxBytes,
-    "Maximum number of bytes to use for the normalized key in prefix-sort. "
-    "Use 0 to disable prefix-sort.",
-    INTEGER(),
-    false,
-    QueryConfig::kPrefixSortNormalizedKeyMaxBytes,
-    std::to_string(c.prefixSortNormalizedKeyMaxBytes()));
+      kPrefixSortNormalizedKeyMaxBytes,
+      "Maximum number of bytes to use for the normalized key in prefix-sort. "
+      "Use 0 to disable prefix-sort.",
+      INTEGER(),
+      false,
+      QueryConfig::kPrefixSortNormalizedKeyMaxBytes,
+      std::to_string(c.prefixSortNormalizedKeyMaxBytes()));
 
   addSessionProperty(
-  kPrefixSortMinRows,
-  "Minimum number of rows to use prefix-sort. The default value (130) has been "
-  "derived using micro-benchmarking.",
-  INTEGER(),
-  false,
-  QueryConfig::kPrefixSortMinRows,
-  std::to_string(c.prefixSortMinRows()));
+      kPrefixSortMinRows,
+      "Minimum number of rows to use prefix-sort. The default value (130) has been "
+      "derived using micro-benchmarking.",
+      INTEGER(),
+      false,
+      QueryConfig::kPrefixSortMinRows,
+      std::to_string(c.prefixSortMinRows()));
 }
 
 const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -225,9 +225,10 @@ class SessionProperties {
   static constexpr const char* kMaxLocalExchangePartitionCount =
       "native_max_local_exchange_partition_count";
 
-  /// Enable the prefix sort or fallback to std::sort in spill. The prefix sort is
-  /// faster than std::sort but requires the memory to build normalized prefix
-  /// keys, which might have potential risk of running out of server memory.
+  /// Enable the prefix sort or fallback to std::sort in spill. The prefix sort
+  /// is faster than std::sort but requires the memory to build normalized
+  /// prefix keys, which might have potential risk of running out of server
+  /// memory.
   static constexpr const char* kSpillPrefixSortEnabled =
       "spill_prefixsort_enabled";
 

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -225,6 +225,21 @@ class SessionProperties {
   static constexpr const char* kMaxLocalExchangePartitionCount =
       "native_max_local_exchange_partition_count";
 
+  /// Enable the prefix sort or fallback to timsort in spill. The prefix sort is
+  /// faster than timsort but requires the memory to build prefix data, which
+  /// may cause out of memory.
+  static constexpr const char* kSpillEnablePrefixSort =
+       "native_spill_enable_prefix_sort";
+
+  /// Maximum number of bytes to use for the normalized key in prefix-sort. Use
+  /// 0 to disable prefix-sort.
+  static constexpr const char* kPrefixSortNormalizedKeyMaxBytes =
+      "native_prefixsort_normalized_key_max_bytes";
+
+  /// Minimum number of rows to use prefix-sort. The default value (130) has been
+  /// derived using micro-benchmarking.
+  static constexpr const char* kPrefixSortMinRows = "native_prefixsort_min_rows";
+
   SessionProperties();
 
   const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -225,20 +225,21 @@ class SessionProperties {
   static constexpr const char* kMaxLocalExchangePartitionCount =
       "native_max_local_exchange_partition_count";
 
-  /// Enable the prefix sort or fallback to timsort in spill. The prefix sort is
-  /// faster than timsort but requires the memory to build prefix data, which
-  /// may cause out of memory.
-  static constexpr const char* kSpillEnablePrefixSort =
-       "native_spill_enable_prefix_sort";
+  /// Enable the prefix sort or fallback to std::sort in spill. The prefix sort is
+  /// faster than std::sort but requires the memory to build normalized prefix
+  /// keys, which might have potential risk of running out of server memory.
+  static constexpr const char* kSpillPrefixSortEnabled =
+      "spill_prefixsort_enabled";
 
   /// Maximum number of bytes to use for the normalized key in prefix-sort. Use
   /// 0 to disable prefix-sort.
   static constexpr const char* kPrefixSortNormalizedKeyMaxBytes =
       "native_prefixsort_normalized_key_max_bytes";
 
-  /// Minimum number of rows to use prefix-sort. The default value (130) has been
-  /// derived using micro-benchmarking.
-  static constexpr const char* kPrefixSortMinRows = "native_prefixsort_min_rows";
+  /// Minimum number of rows to use prefix-sort. The default value (130) has
+  /// been derived using micro-benchmarking.
+  static constexpr const char* kPrefixSortMinRows =
+      "native_prefixsort_min_rows";
 
   SessionProperties();
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
There are a few session properties supported in Velox but not passed from Presto. This PR adds the corresponding native properties:
spill_prefixsort_enabled
prefixsort_normalized_key_max_bytes
prefixsort_min_rows


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add session properties ``native_spill_prefixsort_enabled``, ``native_prefixsort_normalized_key_max_bytes ``, and ``native_prefixsort_min_rows ``. :pr:`24043`

