### PR TITLE
Upgrade gson and grpc to address CVE-2022-25647

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <air.test.parallel>methods</air.test.parallel>
         <air.test.thread-count>2</air.test.thread-count>
         <air.test.jvmsize>4g</air.test.jvmsize>
-        <grpc.version>1.64.0</grpc.version>
+        <grpc.version>1.68.0</grpc.version>
 
         <air.javadoc.lint>-missing</air.javadoc.lint>
     </properties>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <grpc.version>1.68.0</grpc.version>
     </properties>
 
     <dependencyManagement>
@@ -83,13 +84,13 @@
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-context</artifactId>
-                <version>1.64.0</version>
+                <version>${grpc.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-protobuf-lite</artifactId>
-                <version>1.64.0</version>
+                <version>${grpc.version}</version>
             </dependency>
 
             <!-- Pinned version is required. -->
@@ -97,7 +98,7 @@
             <dependency>
                 <groupId>io.perfmark</groupId>
                 <artifactId>perfmark-api</artifactId>
-                <version>0.26.0</version>
+                <version>0.27.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -15,6 +15,16 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.9</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.facebook.airlift</groupId>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <grpc.version>1.41.0</grpc.version>
+        <grpc.version>1.68.0</grpc.version>
     </properties>
 
     <dependencies>
@@ -383,7 +383,7 @@
         <dependency>
             <groupId>io.perfmark</groupId>
             <artifactId>perfmark-api</artifactId>
-            <version>0.23.0</version>
+            <version>0.27.0</version>
         </dependency>
 
         <dependency>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <grpc.version>1.41.0</grpc.version>
+        <grpc.version>1.68.0</grpc.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Description
 Upgraded gson to version 2.8.9 and grpc to version 1.68.0 to fix
security vulnerability CVE-2022-25647. Versions of com.google.code.gson:gson prior to 2.8.9 were susceptible to deserialization of untrusted data through the writeReplace() method in internal classes, potentially leading to a Denial of Service (DoS) attack.

This update ensures safer data handling and mitigates the risk of exploitation from this vulnerability.


Resolves: CVE-2022-25647
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Upgrade gson to version 2.8.9 in response to `CVE-2022-25647 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647>` :pr:`24051`
* Upgrade grpc dependencies to version 1.68.0 in response to `CVE-2022-25647 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647>` :pr:`24051`

