### PR TITLE
[native] Update README

### DIFF
--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -22,7 +22,7 @@ using [Velox](https://github.com/facebookincubator/velox).
 Dependency installation scripts based on the operating system are
 available inside `presto/presto-native-execution/scripts`.
 
-* MacOS: `setup-macos.sh`
+* macOS: `setup-macos.sh`
 * CentOS Stream 9: `setup-centos.sh`
 * Ubuntu: `setup-ubuntu.sh`
 
@@ -32,9 +32,9 @@ working directory.
 
 Use `INSTALL_PREFIX` to set the install directory of the packages. This defaults to
 `deps-install` in the current working directory on macOS and to the default install
-location (for example, `/usr/local`) on linux.
+location (for example, `/usr/local`) on Linux.
 Using the default install location `/usr/local` on macOS is discouraged because this
-location is used by certain Homebrew versions.
+location is owned by `root`.
 
 Manually add the `INSTALL_PREFIX` value in the IDE or bash environment, so subsequent
 Prestissimo builds can use the installed packages. Say
@@ -50,7 +50,7 @@ not listed below.
 | [Velox](https://github.com/facebookincubator/velox)  | Latest  |
 | [CMake](https://cmake.org/) | Minimum `3.10` |
 | [gperf](https://www.gnu.org/software/gperf) |`v3.1`|
-| [proxygen](https://github.com/facebook/proxygen) |`v2024.04.01.00`|
+| [proxygen](https://github.com/facebook/proxygen) |`v2024.07.01.00`|
 
 Prestissimo sources the Velox scripts and the configuration for the installation
 location and other configuration applies to Prestissimo. Please make sure to also
@@ -70,13 +70,13 @@ Compilers (and versions) not mentioned are known to not work or have not been tr
 | -- | -------- |
 | CentOS 9/RHEL 9 | `gcc12` |
 | Ubuntu 22.04 | `gcc11` |
-| MacOS | `clang15` |
+| macOS | `clang15` |
 
 #### Older alternatives
 | OS | compiler |
 | -- | -------- |
 | Ubuntu 20.04 | `gcc9` |
-| MacOS | `clang14` |
+| macOS | `clang14` |
 
 ### Build Prestissimo
 #### Parquet and S3 Support
@@ -112,10 +112,8 @@ follow these steps:
 
 * After installing the above dependencies, from the
 `presto/presto-native-execution` directory, run `make`
-* For development, use
-`make debug` to build a non-optimized debug version.
-* Use `make unittest` to build
-and run tests.
+* For development, use `make debug` to build a non-optimized debug version.
+* Use `make unittest` to build and run tests.
 
 ### Makefile Targets
 A reminder of the available Makefile targets can be obtained using `make help`
@@ -223,7 +221,7 @@ headers and clang-tidy warnings.  These targets are shortcuts for calling
 
 GitHub Actions run `make format-check`, `make header-check` and
 `make tidy-check` as part of our continuous integration.  Pull requests should
-pass linux-build, format-check, header-check and other jobs without errors
+pass Linux-build, format-check, header-check and other jobs without errors
 before being accepted.
 
 Formatting issues found on the changed lines in the current commit can be

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -221,7 +221,7 @@ headers and clang-tidy warnings.  These targets are shortcuts for calling
 
 GitHub Actions run `make format-check`, `make header-check` and
 `make tidy-check` as part of our continuous integration.  Pull requests should
-pass Linux-build, format-check, header-check and other jobs without errors
+pass linux-build, format-check, header-check and other jobs without errors
 before being accepted.
 
 Formatting issues found on the changed lines in the current commit can be


### PR DESCRIPTION
Change includes `proxygen` version update per [Velox](https://github.com/facebookincubator/velox/blob/99979c4e7a3999e74a9d8640f302050953c5f39b/scripts/setup-macos.sh#L45).

https://github.com/prestodb/presto/blob/6e87912f1e80ba202fad2f4ea7d0ab1072c9d515/presto-native-execution/scripts/setup-macos.sh#L27



```
== NO RELEASE NOTE ==
```

