### PR TITLE
[jdk-upgrade] Fix maven checks upto presto-benchmark-runner

### DIFF
--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -85,6 +85,7 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -185,4 +186,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>com.facebook.airlift:log-manager</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/JsonEventClient.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/JsonEventClient.java
@@ -42,7 +42,7 @@ public class JsonEventClient
             throws FileNotFoundException
     {
         requireNonNull(config.getJsonEventLogFile(), "jsonEventLogFile is null");
-        this.out = config.getJsonEventLogFile().isPresent() ? new PrintStream(config.getJsonEventLogFile().get()) : System.out;
+        this.out = config.getJsonEventLogFile().isPresent() ? new PrintStream(config.getJsonEventLogFile().orElseThrow()) : System.out;
     }
 
     @Override

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/AbstractPhaseExecutor.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/AbstractPhaseExecutor.java
@@ -93,10 +93,10 @@ public abstract class AbstractPhaseExecutor<T extends PhaseSpecification>
         Optional<String> stackTrace = Optional.empty();
 
         if (!succeeded && queryException.isPresent()) {
-            queryStats = queryException.get().getQueryStats();
-            errorCode = queryException.get().getPrestoErrorCode().map(ErrorCodeSupplier::toErrorCode).map(ErrorCode::getName);
-            errorMessage = Optional.of(queryException.get().getMessage());
-            stackTrace = Optional.of(getStackTraceAsString(queryException.get().getCause()));
+            queryStats = queryException.orElseThrow().getQueryStats();
+            errorCode = queryException.orElseThrow().getPrestoErrorCode().map(ErrorCodeSupplier::toErrorCode).map(ErrorCode::getName);
+            errorMessage = Optional.of(queryException.orElseThrow().getMessage());
+            stackTrace = Optional.of(getStackTraceAsString(queryException.orElseThrow().getCause()));
         }
 
         return new BenchmarkQueryEvent(

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/JdbcPrestoAction.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/JdbcPrestoAction.java
@@ -100,7 +100,7 @@ public class JdbcPrestoAction
                 if (converter.isPresent()) {
                     try (ResultSet resultSet = jdbcStatement.executeQuery(query)) {
                         while (resultSet.next()) {
-                            rows.add(converter.get().apply(resultSet));
+                            rows.add(converter.orElseThrow().apply(resultSet));
                         }
                     }
                 }
@@ -119,7 +119,7 @@ public class JdbcPrestoAction
                 }
 
                 checkState(progressMonitor.getLastQueryStats().isPresent(), "lastQueryStats is missing");
-                return new QueryResult<>(rows.build(), progressMonitor.getLastQueryStats().get());
+                return new QueryResult<>(rows.build(), progressMonitor.getLastQueryStats().orElseThrow());
             }
         }
         catch (SQLException e) {

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoExceptionClassifier.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoExceptionClassifier.java
@@ -64,7 +64,7 @@ public class PrestoExceptionClassifier
     {
         Optional<Throwable> clusterConnectionExceptionCause = getClusterConnectionExceptionCause(cause);
         if (clusterConnectionExceptionCause.isPresent()) {
-            return QueryException.forClusterConnection(clusterConnectionExceptionCause.get());
+            return QueryException.forClusterConnection(clusterConnectionExceptionCause.orElseThrow());
         }
 
         Optional<ErrorCodeSupplier> errorCode = Optional.ofNullable(errorByCode.get(cause.getErrorCode()));

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestConcurrentExecutor.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestConcurrentExecutor.java
@@ -42,7 +42,7 @@ import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
 import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static java.lang.String.format;
 import static org.testng.Assert.assertTrue;
 
@@ -94,7 +94,7 @@ public class TestConcurrentExecutor
         assertEquals(queryEvents.get("Q1").size(), 2);
         assertEvent(queryEvents.get("Q1").get(0), "Q1", BenchmarkQueryEvent.Status.SUCCEEDED);
         assertEvent(queryEvents.get("Q1").get(1), "Q1", BenchmarkQueryEvent.Status.SUCCEEDED);
-        assertEvent(getOnlyElement(queryEvents.get("Q2")), "Q2", BenchmarkQueryEvent.Status.SUCCEEDED);
+        assertEvent(queryEvents.get("Q2").stream().collect(onlyElement()), "Q2", BenchmarkQueryEvent.Status.SUCCEEDED);
     }
 
     @Test
@@ -108,8 +108,8 @@ public class TestConcurrentExecutor
 
         // check query events
         ListMultimap<String, BenchmarkQueryEvent> queryEvents = getEventClient().getQueryEventsByName();
-        assertEvent(getOnlyElement(queryEvents.get("Q1")), "Q1", BenchmarkQueryEvent.Status.SUCCEEDED);
-        assertEvent(getOnlyElement(queryEvents.get("QBad")), "QBad", BenchmarkQueryEvent.Status.FAILED);
+        assertEvent(queryEvents.get("Q1").stream().collect(onlyElement()), "Q1", BenchmarkQueryEvent.Status.SUCCEEDED);
+        assertEvent(queryEvents.get("QBad").stream().collect(onlyElement()), "QBad", BenchmarkQueryEvent.Status.FAILED);
     }
 
     @Test
@@ -123,9 +123,9 @@ public class TestConcurrentExecutor
 
         // check query events
         ListMultimap<String, BenchmarkQueryEvent> queryEvents = getEventClient().getQueryEventsByName();
-        assertEvent(getOnlyElement(queryEvents.get("Q1")), "Q1", BenchmarkQueryEvent.Status.SUCCEEDED);
-        assertEvent(getOnlyElement(queryEvents.get("Q2")), "Q2", BenchmarkQueryEvent.Status.SUCCEEDED);
-        assertEvent(getOnlyElement(queryEvents.get("QBad")), "QBad", BenchmarkQueryEvent.Status.FAILED);
+        assertEvent(queryEvents.get("Q1").stream().collect(onlyElement()), "Q1", BenchmarkQueryEvent.Status.SUCCEEDED);
+        assertEvent(queryEvents.get("Q2").stream().collect(onlyElement()), "Q2", BenchmarkQueryEvent.Status.SUCCEEDED);
+        assertEvent(queryEvents.get("QBad").stream().collect(onlyElement()), "QBad", BenchmarkQueryEvent.Status.FAILED);
     }
 
     private ConcurrentPhaseExecutor createExecutor()

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -33,6 +33,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hdfs-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -162,6 +172,27 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>com.facebook.presto:presto-hdfs-core</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>com.facebook.airlift:json</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>com.google.guava:guava</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>com.facebook.presto:presto-hive-metastore</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>com.facebook.presto:presto-hive-common</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>com.facebook.airlift:concurrent</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>com.facebook.airlift:stats</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>com.facebook.presto:presto-cache</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/presto-thrift-connector/pom.xml
+++ b/presto-thrift-connector/pom.xml
@@ -43,6 +43,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-transport-spi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -191,4 +196,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>com.facebook.drift:drift-codec</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>com.facebook.drift:drift-transport-spi</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
@@ -190,7 +190,7 @@ public class ThriftMetadata
             throw new TableNotFoundException(schemaTableName);
         }
         else {
-            return table.get();
+            return table.orElseThrow();
         }
     }
 

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPlugin.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPlugin.java
@@ -23,7 +23,7 @@ import java.util.ServiceLoader;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static java.util.Objects.requireNonNull;
 
 public class ThriftPlugin
@@ -60,6 +60,6 @@ public class ThriftPlugin
         ClassLoader classLoader = ThriftPlugin.class.getClassLoader();
         ServiceLoader<ThriftPluginInfo> loader = ServiceLoader.load(ThriftPluginInfo.class, classLoader);
         List<ThriftPluginInfo> list = ImmutableList.copyOf(loader);
-        return list.isEmpty() ? new ThriftPluginInfo() : getOnlyElement(list);
+        return list.isEmpty() ? new ThriftPluginInfo() : list.stream().collect(onlyElement());
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/location/ExtendedSimpleAddressSelector.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/location/ExtendedSimpleAddressSelector.java
@@ -49,7 +49,7 @@ public class ExtendedSimpleAddressSelector
             return delegate.selectAddress(context, attempted);
         }
 
-        List<String> list = Splitter.on(',').splitToList(context.get());
+        List<String> list = Splitter.on(',').splitToList(context.orElseThrow());
         String value = list.get(ThreadLocalRandom.current().nextInt(list.size()));
         HostAndPort address = HostAndPort.fromString(value);
         return Optional.of(new SimpleAddress(address));

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/util/TupleDomainConversion.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/util/TupleDomainConversion.java
@@ -30,7 +30,7 @@ public final class TupleDomainConversion
         if (!tupleDomain.getDomains().isPresent()) {
             return new PrestoThriftTupleDomain(null);
         }
-        return new PrestoThriftTupleDomain(tupleDomain.getDomains().get()
+        return new PrestoThriftTupleDomain(tupleDomain.getDomains().orElseThrow()
                 .entrySet().stream()
                 .collect(toImmutableMap(
                         entry -> ((ThriftColumnHandle) entry.getKey()).getColumnName(),

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftPlugin.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftPlugin.java
@@ -24,7 +24,8 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import static com.facebook.airlift.testing.Assertions.assertInstanceOf;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.util.stream.StreamSupport.stream;
 import static org.testng.Assert.assertNotNull;
 
 public class TestThriftPlugin
@@ -34,7 +35,7 @@ public class TestThriftPlugin
     {
         ThriftPlugin plugin = loadPlugin(ThriftPlugin.class);
 
-        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        ConnectorFactory factory = stream(plugin.getConnectorFactories().spliterator(), false).collect(onlyElement());
         assertInstanceOf(factory, ThriftConnectorFactory.class);
 
         Map<String, String> config = ImmutableMap.of("presto.thrift.client.addresses", "localhost:7779");

--- a/presto-thrift-testing-server/pom.xml
+++ b/presto-thrift-testing-server/pom.xml
@@ -127,4 +127,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>org.testng:testng</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This PR fixes maven checks for the following modules:

- presto-thrift-testing-server
- presto-thrift-connector
- presto-hive-hadoop2
- presto-benchmark-runner