### PR TITLE
[native] Allow incoming Velox abfs namespace change

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1301,7 +1301,11 @@ void PrestoServer::registerFileSystems() {
   velox::filesystems::registerS3FileSystem();
   velox::filesystems::registerHdfsFileSystem();
   velox::filesystems::registerGcsFileSystem();
+#ifdef VELOX_ENABLE_FORWARD_COMPATIBILITY
+  velox::filesystems::registerAbfsFileSystem();
+#else
   velox::filesystems::abfs::registerAbfsFileSystem();
+#endif
 }
 
 void PrestoServer::unregisterFileSystems() {


### PR DESCRIPTION
abfs namespace is being removed in Velox for the AbfsFileSystem to be consistent with other File Systems.
Velox PR: https://github.com/facebookincubator/velox/pull/11419

```
== NO RELEASE NOTE ==
```

