### PR TITLE
[native] Add config for cpp cache default behavior

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -184,6 +184,17 @@ disabled if ``connector.num-io-threads-hw-multiplier`` is set to zero.
 
 Whether async data cache is enabled.
 
+``query-data-cache-enabled-default``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type** ``bool``
+* **Default value:** ``true``
+
+If ``true``, SSD cache is enabled by default and is disabled only if
+``node_selection_strategy`` is present and set to ``NO_PREFERENCE``.
+Otherwise, SSD cache is disabled by default and is enabled if
+``node_selection_strategy`` is present and set to ``SOFT_AFFINITY``.
+
 ``async-cache-ssd-gb``
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -178,6 +178,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kNativeSidecar, false),
           BOOL_PROP(kAsyncDataCacheEnabled, true),
           NUM_PROP(kAsyncCacheSsdGb, 0),
+          BOOL_PROP(kQueryDataCacheEnabledDefault, true),
           NUM_PROP(kAsyncCacheSsdCheckpointGb, 0),
           STR_PROP(kAsyncCacheSsdPath, "/mnt/flash/async_cache."),
           NUM_PROP(kAsyncCacheMaxSsdWriteRatio, 0.7),
@@ -462,6 +463,10 @@ uint64_t SystemConfig::asyncCacheSsdGb() const {
 
 bool SystemConfig::asyncDataCacheEnabled() const {
   return optionalProperty<bool>(kAsyncDataCacheEnabled).value();
+}
+
+bool SystemConfig::queryDataCacheEnabledDefault() const {
+  return optionalProperty<bool>(kQueryDataCacheEnabledDefault).value();
 }
 
 uint64_t SystemConfig::asyncCacheSsdCheckpointGb() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -313,6 +313,12 @@ class SystemConfig : public ConfigBase {
 
   static constexpr std::string_view kAsyncDataCacheEnabled{
       "async-data-cache-enabled"};
+  /// If true, SSD cache is enabled by default and is disabled only if
+  /// `node_selection_strategy` is present and set to `NO_PREFERENCE`.
+  /// Otherwise, SSD cache is disabled by default and is enabled if
+  /// `node_selection_strategy` is present and set to `SOFT_AFFINITY`.
+  static constexpr std::string_view kQueryDataCacheEnabledDefault{
+      "query-data-cache-enabled-default"};
   static constexpr std::string_view kAsyncCacheSsdGb{"async-cache-ssd-gb"};
   static constexpr std::string_view kAsyncCacheSsdCheckpointGb{
       "async-cache-ssd-checkpoint-gb"};
@@ -751,6 +757,8 @@ class SystemConfig : public ConfigBase {
   uint32_t mallocMemMaxHeapDumpFiles() const;
 
   bool asyncDataCacheEnabled() const;
+
+  bool queryDataCacheEnabledDefault() const;
 
   uint64_t asyncCacheSsdGb() const;
 


### PR DESCRIPTION
## Description
In Presto Java, cache is disabled by default and only enabled when the config `node_preference` is set to `SOFT_AFFINITY`, while in CPP, cache is enabled by default and only disabled when the config node_preference is set to "NO_PREFERENCE".

This change adds a new config to support the alignment of the default cache behavior.


```
== RELEASE NOTES ==

General Changes
* Add ``query-data-cache-enabled-default`` configuration property to align C++ cache behavior with Java. Set it to ``true``(default) for current C++ behavior or to ``false`` to match Java's cache logic. :pr:`24076`
```
