### PR TITLE
[native] Advance Velox and remove abfs namespace

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1301,11 +1301,7 @@ void PrestoServer::registerFileSystems() {
   velox::filesystems::registerS3FileSystem();
   velox::filesystems::registerHdfsFileSystem();
   velox::filesystems::registerGcsFileSystem();
-#ifdef VELOX_ENABLE_FORWARD_COMPATIBILITY
   velox::filesystems::registerAbfsFileSystem();
-#else
-  velox::filesystems::abfs::registerAbfsFileSystem();
-#endif
 }
 
 void PrestoServer::unregisterFileSystems() {


### PR DESCRIPTION
A follow-up fix in Presto after https://github.com/facebookincubator/velox/pull/11419
```
== NO RELEASE NOTE ==
```

