### PR TITLE
Complete iceberg support for time type

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -22,6 +22,7 @@ import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.predicate.ValueSet;
 import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.EncryptionInformation;
@@ -572,6 +573,15 @@ public class IcebergPageSourceProvider
                 isRowPositionList.add(column.isRowPositionColumn());
             }
 
+            // Skip the time type columns in predicate, converted on page source level
+            ImmutableMap.Builder<IcebergColumnHandle, Domain> predicateExcludeTimeType = ImmutableMap.builder();
+            effectivePredicate.getDomains().get().forEach((columnHandle, domain) -> {
+                if (!(columnHandle.getType() instanceof TimeType)) {
+                    predicateExcludeTimeType.put(columnHandle, domain);
+                }
+            });
+
+            effectivePredicate = TupleDomain.withColumnDomains(predicateExcludeTimeType.build());
             TupleDomain<HiveColumnHandle> hiveColumnHandleTupleDomain = effectivePredicate.transform(column -> {
                 IcebergOrcColumn icebergOrcColumn;
                 if (fileOrcColumnByIcebergId.isEmpty()) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -509,7 +509,7 @@ public final class IcebergUtil
         }
     }
 
-    private static boolean isValidPartitionType(FileFormat fileFormat, Type type)
+    private static boolean isValidPartitionType(Type type)
     {
         return type instanceof DecimalType ||
                 BOOLEAN.equals(type) ||
@@ -521,15 +521,15 @@ public final class IcebergUtil
                 DOUBLE.equals(type) ||
                 DATE.equals(type) ||
                 type instanceof TimestampType ||
-                (TIME.equals(type) && fileFormat == PARQUET) ||
+                TIME.equals(type) ||
                 VARBINARY.equals(type) ||
                 isVarcharType(type) ||
                 isCharType(type);
     }
 
-    private static void verifyPartitionTypeSupported(FileFormat fileFormat, String partitionName, Type type)
+    private static void verifyPartitionTypeSupported(String partitionName, Type type)
     {
-        if (!isValidPartitionType(fileFormat, type)) {
+        if (!isValidPartitionType(type)) {
             throw new PrestoException(NOT_SUPPORTED, format("Unsupported type [%s] for partition: %s", type, partitionName));
         }
     }
@@ -540,7 +540,7 @@ public final class IcebergUtil
             Type prestoType,
             String partitionName)
     {
-        verifyPartitionTypeSupported(fileFormat, partitionName, prestoType);
+        verifyPartitionTypeSupported(partitionName, prestoType);
 
         Object partitionValue = deserializePartitionValue(prestoType, partitionStringValue, partitionName);
         return partitionValue == null ? NullableValue.asNull(prestoType) : NullableValue.of(prestoType, partitionValue);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -310,6 +310,9 @@ public final class TypeConverter
         if (DOUBLE.equals(type)) {
             return HIVE_DOUBLE.getTypeInfo();
         }
+        if (TimeType.TIME.equals(type)) {
+            return HIVE_LONG.getTypeInfo();
+        }
         if (type instanceof VarcharType) {
             VarcharType varcharType = (VarcharType) type;
             if (varcharType.isUnbounded()) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryBatchStreamReader.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcLocalMemoryContext;
@@ -81,7 +82,7 @@ public class LongDictionaryBatchStreamReader
             throws OrcCorruptionException
     {
         requireNonNull(type, "type is null");
-        verifyStreamType(streamDescriptor, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType);
+        verifyStreamType(streamDescriptor, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType || t instanceof TimeType);
         this.type = type;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc.writer;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.FixedWidthType;
+import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.ColumnWriterOptions;
 import com.facebook.presto.orc.DwrfDataEncryptor;
@@ -43,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.LongFunction;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
@@ -69,6 +71,7 @@ public class LongColumnWriter
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
     private final CompressedMetadataWriter metadataWriter;
+    private final LongFunction<Long> convertUnits;
     private long columnStatisticsRetainedSizeInBytes;
     private PresentOutputStream presentStream;
 
@@ -111,6 +114,13 @@ public class LongColumnWriter
         this.metadataWriter = new CompressedMetadataWriter(metadataWriter, columnWriterOptions, dwrfEncryptor);
         this.statisticsBuilderSupplier = requireNonNull(statisticsBuilderSupplier, "statisticsBuilderSupplier is null");
         this.statisticsBuilder = statisticsBuilderSupplier.get();
+
+        if (this.type instanceof TimeType) {
+            this.convertUnits = longValue -> Math.multiplyExact(longValue, 1000L);
+        }
+        else {
+            this.convertUnits = longValue -> longValue;
+        }
     }
 
     @Override
@@ -158,7 +168,7 @@ public class LongColumnWriter
         int nonNullValueCount = 0;
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
-                long value = type.getLong(block, position);
+                long value = this.convertUnits.apply(type.getLong(block, position));
                 writeValue(value);
                 nonNullValueCount++;
             }


### PR DESCRIPTION
## Description
Bringing this functionality from IBM's repository.  Added support for partitioning over the time type in orc files through the iceberg connector

[Lakehouse PR for those with access](https://github.ibm.com/lakehouse/presto/pull/696)
```
== RELEASE NOTES ==

General Changes
* Add support for time type partitioning in the ORC file format for Iceberg. :pr:`24091`
* Add testing for partitioning using time type in Iceberg. :pr:`24091`
```

