### PR TITLE
Add partition attributes to sort node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -752,7 +752,8 @@ public class CanonicalPlanGenerator
                 planNodeidAllocator.getNextId(),
                 source.get(),
                 getCanonicalOrderingScheme(node.getOrderingScheme(), context.getExpressions()),
-                node.isPartial());
+                node.isPartial(),
+                node.getPartitionBy());
         context.addPlan(node, new CanonicalPlan(canonicalPlan, strategy));
         return Optional.of(canonicalPlan);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -1260,7 +1260,7 @@ class QueryPlanner
         OrderingScheme orderingScheme = toOrderingScheme(
                 orderByExpressions.stream().map(subPlan::translate).collect(toImmutableList()),
                 orderBy.get().getSortItems().stream().map(PlannerUtils::toSortOrder).collect(toImmutableList()));
-        planNode = new SortNode(getSourceLocation(orderBy.get()), idAllocator.getNextId(), subPlan.getRoot(), orderingScheme, false);
+        planNode = new SortNode(getSourceLocation(orderBy.get()), idAllocator.getNextId(), subPlan.getRoot(), orderingScheme, false, ImmutableList.of());
 
         return subPlan.withNewRoot(planNode);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantSortColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantSortColumns.java
@@ -50,6 +50,6 @@ public class RemoveRedundantSortColumns
             return Result.empty();
         }
 
-        return Result.ofPlanNode(new SortNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), node.getSource(), newOrderingScheme, node.isPartial()));
+        return Result.ofPlanNode(new SortNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), node.getSource(), newOrderingScheme, node.isPartial(), node.getPartitionBy()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifySortWithConstantInput.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifySortWithConstantInput.java
@@ -68,7 +68,7 @@ public class SimplifySortWithConstantInput
                 return Result.ofPlanNode(projectNode);
             }
             OrderingScheme orderExcludeConstantVariable = new OrderingScheme(newOrderBy);
-            return Result.ofPlanNode(new SortNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), projectNode, orderExcludeConstantVariable, node.isPartial()));
+            return Result.ofPlanNode(new SortNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), projectNode, orderExcludeConstantVariable, node.isPartial(), node.getPartitionBy()));
         }
         return Result.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
@@ -207,7 +207,7 @@ public class LimitPushDown
             }
             else if (rewrittenSource != node.getSource()) {
                 planChanged = true;
-                return new SortNode(node.getSourceLocation(), node.getId(), rewrittenSource, node.getOrderingScheme(), node.isPartial());
+                return new SortNode(node.getSourceLocation(), node.getId(), rewrittenSource, node.getOrderingScheme(), node.isPartial(), node.getPartitionBy());
             }
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -714,7 +714,7 @@ public class PruneUnreferencedOutputs
 
             PlanNode source = context.rewrite(node.getSource(), expectedInputs);
 
-            return new SortNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), source, node.getOrderingScheme(), node.isPartial());
+            return new SortNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), source, node.getOrderingScheme(), node.isPartial(), node.getPartitionBy());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -563,7 +563,7 @@ public class UnaliasSymbolReferences
         {
             PlanNode source = context.rewrite(node.getSource());
 
-            return new SortNode(node.getSourceLocation(), node.getId(), source, canonicalizeAndDistinct(node.getOrderingScheme()), node.isPartial());
+            return new SortNode(node.getSourceLocation(), node.getId(), source, canonicalizeAndDistinct(node.getOrderingScheme()), node.isPartial(), node.getPartitionBy());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -1104,9 +1104,11 @@ public class PlanPrinter
         {
             Iterable<String> keys = Iterables.transform(node.getOrderingScheme().getOrderByVariables(), input -> input + " " + node.getOrderingScheme().getOrdering(input));
 
-            addNode(node,
-                    format("%sSort", node.isPartial() ? "Partial" : ""),
-                    format("[%s]", Joiner.on(", ").join(keys)));
+            String detail = format("[%s]", Joiner.on(", ").join(keys));
+            if (!node.getPartitionBy().isEmpty()) {
+                detail = format("%s[Partition by %s]", detail, Joiner.on(", ").join(node.getPartitionBy()));
+            }
+            addNode(node, format("%sSort", node.isPartial() ? "Partial" : ""), detail);
 
             return processChildren(node, context);
         }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -352,6 +352,8 @@ public class LocalQueryRunner
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
+    private List<PlanOptimizer> additionalOptimizer = ImmutableList.of();
+
     public LocalQueryRunner(Session defaultSession)
     {
         this(defaultSession, new FeaturesConfig(), new FunctionsConfig(), new NodeSpillConfig(), false, false);
@@ -1094,12 +1096,21 @@ public class LocalQueryRunner
         return createPlan(session, sql, getPlanOptimizers(forceSingleNode), stage, warningCollector);
     }
 
+    public void setAdditionalOptimizer(List<PlanOptimizer> additionalOptimizer)
+    {
+        this.additionalOptimizer = additionalOptimizer;
+    }
+
     public List<PlanOptimizer> getPlanOptimizers(boolean forceSingleNode)
     {
         FeaturesConfig featuresConfig = new FeaturesConfig()
                 .setDistributedIndexJoinsEnabled(false)
                 .setOptimizeHashGeneration(true);
-        return new PlanOptimizers(
+        ImmutableList.Builder<PlanOptimizer> planOptimizers = ImmutableList.builder();
+        if (!additionalOptimizer.isEmpty()) {
+            planOptimizers.addAll(additionalOptimizer);
+        }
+        planOptimizers.addAll(new PlanOptimizers(
                 metadata,
                 sqlParser,
                 forceSingleNode,
@@ -1113,7 +1124,8 @@ public class LocalQueryRunner
                 new CostComparator(featuresConfig),
                 taskCountEstimator,
                 partitioningProviderManager,
-                featuresConfig).getPlanningTimeOptimizers();
+                featuresConfig).getPlanningTimeOptimizers());
+        return planOptimizers.build();
     }
 
     public Plan createPlan(Session session, @Language("SQL") String sql, List<PlanOptimizer> optimizers, WarningCollector warningCollector)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -318,7 +318,8 @@ public class TestEffectivePredicateExtractor
                                 equals(BV, CV),
                                 lessThan(CV, bigintLiteral(10)))),
                 new OrderingScheme(ImmutableList.of(new Ordering(AV, SortOrder.ASC_NULLS_LAST))),
-                false);
+                false,
+                ImmutableList.of());
 
         RowExpression effectivePredicate = effectivePredicateExtractor.extract(node);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
@@ -91,7 +91,7 @@ public class BasePlanTest
         return objectMapper;
     }
 
-    private static ObjectMapper createObjectMapper()
+    protected static ObjectMapper createObjectMapper()
     {
         TestingTypeManager typeManager = new TestingTypeManager();
         TestingBlockEncodingSerde blockEncodingSerde = new TestingBlockEncodingSerde();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -246,7 +246,8 @@ public class PlanBuilder
                 idAllocator.getNextId(),
                 source,
                 new OrderingScheme(orderBy.stream().map(variable -> new Ordering(variable, SortOrder.ASC_NULLS_FIRST)).collect(toImmutableList())),
-                false);
+                false,
+                ImmutableList.of());
     }
 
     public OffsetNode offset(long rowCount, PlanNode source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddPartitionToSortRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddPartitionToSortRule.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.SortNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.matching.Pattern.typeOf;
+import static com.google.common.base.Preconditions.checkState;
+
+public class TestAddPartitionToSortRule
+        implements Rule<SortNode>
+{
+    @Override
+    public Pattern<SortNode> getPattern()
+    {
+        return typeOf(SortNode.class);
+    }
+
+    @Override
+    public Result apply(SortNode node, Captures captures, Context context)
+    {
+        if (!node.getPartitionBy().isEmpty()) {
+            return Result.empty();
+        }
+        Optional<VariableReferenceExpression> partition = node.getSource().getOutputVariables().stream().filter(x -> x.getType().equals(BIGINT)).findFirst();
+        checkState(partition.isPresent());
+        return Result.ofPlanNode(new SortNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), node.getSource(), node.getOrderingScheme(), node.isPartial(), ImmutableList.of(partition.get())));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSortWithinPartitionPlans.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSortWithinPartitionPlans.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.RuleStatsRecorder;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.TASK_CONCURRENCY;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+
+public class TestSortWithinPartitionPlans
+        extends BasePlanTest
+{
+    @Test
+    public void testSortWithPartition()
+    {
+        LocalQueryRunner localQueryRunner = getQueryRunner();
+        localQueryRunner.setAdditionalOptimizer(ImmutableList.of(new IterativeOptimizer(
+                localQueryRunner.getMetadata(),
+                new RuleStatsRecorder(),
+                localQueryRunner.getStatsCalculator(),
+                localQueryRunner.getEstimatedExchangesCostCalculator(),
+                ImmutableSet.of(new TestAddPartitionToSortRule()))));
+        Session session = Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(TASK_CONCURRENCY, "2")
+                .build();
+
+        assertDistributedPlan("SELECT partkey, discount from lineitem order by discount",
+                session,
+                anyTree(
+                        exchange(REMOTE_STREAMING, GATHER, ImmutableList.of(),
+                                sort(
+                                        anyTree(
+                                                exchange(LOCAL, REPARTITION,
+                                                        exchange(REMOTE_STREAMING, REPARTITION,
+                                                                anyTree(
+                                                                        tableScan("lineitem")))))))));
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSortWithPartitionQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSortWithPartitionQueries.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.sql.planner.RuleStatsRecorder;
+import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
+import com.facebook.presto.sql.planner.optimizations.TestAddPartitionToSortRule;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.SystemSessionProperties.TASK_CONCURRENCY;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static com.google.common.base.Preconditions.checkState;
+
+public class TestSortWithPartitionQueries
+        extends AbstractTestQueryFramework
+{
+    @Test
+    public void testSortByPartition()
+    {
+        LocalQueryRunner localQueryRunner = (LocalQueryRunner) getQueryRunner();
+        localQueryRunner.setAdditionalOptimizer(ImmutableList.of(new IterativeOptimizer(
+                localQueryRunner.getMetadata(),
+                new RuleStatsRecorder(),
+                localQueryRunner.getStatsCalculator(),
+                localQueryRunner.getEstimatedExchangesCostCalculator(),
+                ImmutableSet.of(new TestAddPartitionToSortRule()))));
+        Session session = Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(TASK_CONCURRENCY, "8")
+                .build();
+
+        MaterializedResult result = computeActual(session, "SELECT partkey, extendedprice from lineitem order by extendedprice");
+        List<MaterializedRow> rowList = result.getMaterializedRows();
+        Map<Long, Double> maxPrice = new HashMap<>();
+        for (MaterializedRow row : rowList) {
+            long partkey = (long) row.getField(0);
+            double price = (double) row.getField(1);
+            if (maxPrice.containsKey(partkey)) {
+                checkState(price >= maxPrice.get(partkey));
+            }
+            maxPrice.put(partkey, price);
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session defaultSession = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+
+        LocalQueryRunner localQueryRunner = new LocalQueryRunner(defaultSession);
+
+        localQueryRunner.createCatalog(
+                defaultSession.getCatalog().get(),
+                new TpchConnectorFactory(1),
+                ImmutableMap.of());
+
+        return localQueryRunner;
+    }
+}


### PR DESCRIPTION
## Description
During query planning, the SortNode will be converted to a partial sort node, followed by gather exchange with `ensureSourceOrdering` to be true and only one single worker and thread do the final merge to make sure that we get the data sorted as specified.

However, for an internal feature we are developing, data to be sorted within each partition is enough, rather than globally. In order to achieve this, we need to plan the query so that we have the sort node working on partitioned data, and do not need the single threaded gathering exchange.

In this PR, I added a new field partitionedBy to the sort node, which specifies the scope for sort, with empty list to be global sort, which is the current behavior.

## Motivation and Context
Described above

## Impact
Enable sort within partitions

## Test Plan
Add unit tests
Since the partitioned by attributed will always be empty after parser, and only be set in optimizer, it has no change for current production.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add a partition by attribute to specify the scope of sort node. :pr:`24095`
```
