### PR TITLE
Tighten checks for "bins" elements in width_bucket(x, bins)

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -168,8 +168,12 @@ Mathematical Functions
 .. function:: width_bucket(x, bins) -> bigint
 
     Returns the bin number of ``x`` according to the bins specified by the
-    array ``bins``. The ``bins`` parameter must be an array of doubles and is
-    assumed to be in sorted ascending order.
+    array ``bins``. The ``bins`` parameter must be an array of doubles, should not
+    contain ``null`` or non-finite elements, and is assumed to be in sorted ascending order.
+
+    Note: The function returns an error if it encounters a ``null`` or non-finite
+    element in ``bins``, but due to the binary search algorithm some such elements
+    might go unnoticed and the function will return a result.
 
 Probability Functions: cdf
 --------------------------

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -1572,17 +1572,23 @@ public final class MathFunctions
 
         int index;
         double bin;
+        double lowerBin;
+        double upperBin;
 
         while (lower < upper) {
-            if (DOUBLE.getDouble(bins, lower) > DOUBLE.getDouble(bins, upper - 1)) {
-                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Bin values are not sorted in ascending order");
+            index = (lower + upper) / 2;
+            if (bins.isNull(lower) || bins.isNull(index) || bins.isNull(upper - 1)) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Bin values cannot be NULL");
             }
 
-            index = (lower + upper) / 2;
             bin = DOUBLE.getDouble(bins, index);
-
-            if (!isFinite(bin)) {
-                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Bin value must be finite, got " + bin);
+            lowerBin = DOUBLE.getDouble(bins, lower);
+            upperBin = DOUBLE.getDouble(bins, upper - 1);
+            if (lowerBin > upperBin || lowerBin > bin || bin > upperBin) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Bin values are not sorted in ascending order");
+            }
+            if (!isFinite(bin) || !isFinite(lowerBin) || !isFinite(upperBin)) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Bin values must be finite");
             }
 
             if (operand < bin) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1315,15 +1315,26 @@ public class TestMathFunctions
         // failure modes
         assertInvalidFunction("width_bucket(3.14E0, array[])", "Bins cannot be an empty array");
         assertInvalidFunction("width_bucket(nan(), array[1.0E0, 2.0E0, 3.0E0])", "Operand cannot be NaN");
-        assertInvalidFunction("width_bucket(3.14E0, array[0.0E0, infinity()])", "Bin value must be finite, got Infinity");
+        assertInvalidFunction("width_bucket(3.14E0, array[0.0E0, infinity()])", "Bin values must be finite");
 
         // fail if we aren't sorted
+        assertInvalidFunction("width_bucket(3.14E0, array[0.0E0, infinity(), 10.0E0])", "Bin values are not sorted in ascending order");
         assertInvalidFunction("width_bucket(3.145E0, array[1.0E0, 0.0E0])", "Bin values are not sorted in ascending order");
         assertInvalidFunction("width_bucket(3.145E0, array[1.0E0, 0.0E0, -1.0E0])", "Bin values are not sorted in ascending order");
         assertInvalidFunction("width_bucket(3.145E0, array[1.0E0, 0.3E0, 0.0E0, -1.0E0])", "Bin values are not sorted in ascending order");
+        assertInvalidFunction("width_bucket(1.5E0, array[1.0E0, 2.3E0, 2.0E0])", "Bin values are not sorted in ascending order");
 
-        // this is a case that we can't catch because we are using binary search to bisect the bins array
-        assertFunction("width_bucket(1.5E0, array[1.0E0, 2.3E0, 2.0E0])", BIGINT, 1L);
+        // Cases with nulls. When we hit a null element we throw.
+        assertInvalidFunction("width_bucket(3.14E0, array[cast(null as double)])", "Bin values cannot be NULL");
+        assertInvalidFunction("width_bucket(3.14E0, array[0.0E0, null, 4.0E0])", "Bin values cannot be NULL");
+        assertInvalidFunction("width_bucket(3.14E0, array[0.0E0, 2.0E0, 4.0E0, null])", "Bin values cannot be NULL");
+
+        // Cases we cannot catch due to the binary search algorithm.
+        // Has null elements.
+        assertFunction("width_bucket(3.14E0, array[0.0E0, null, 2.0E0, 4.0E0])", BIGINT, 3L);
+        assertFunction("width_bucket(3.14E0, array[0.0E0, null, 1.0E0, 2.0E0, 4.0E0])", BIGINT, 4L);
+        // Not properly sorted and has infinity.
+        assertFunction("width_bucket(3.14E0, array[0.0E0, infinity(), 1.0E0, 2.0E0, 4.0E0])", BIGINT, 4L);
     }
 
     @Test


### PR DESCRIPTION
## Description
Make width_bucket(x, bins) throw error if it finds a `null` or non-finite element in `bins`.

## Motivation and Context
Solves https://github.com/prestodb/presto/issues/24055

## Impact
Changes behavior of [width_bucket(x, bins)](https://prestodb.io/docs/current/functions/math.html#width_bucket-x-bound1-bound2-n-bigint) which previously was treating all `null` elements in `bins` as zero. Now the function will throw an error.

## Test Plan
Updated unit test to handle few cases with nulls.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== RELEASE NOTES ==
General Changes
* Fix behavior of :func:`width_bucket(x, bins) -> bigint` which previously treated all ``null`` elements in bins as ``0``. Now the function will throw an error if it finds a ``null`` or non-finite element in ``bins``..  :pr:`24103`
```