### PR TITLE
Add input distribution to delete node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -294,7 +294,7 @@ class QueryPlanner
                 variableAllocator.newVariable("partialrows", BIGINT),
                 variableAllocator.newVariable("fragment", VARBINARY));
 
-        return new DeleteNode(getSourceLocation(node), idAllocator.getNextId(), builder.getRoot(), rowId, deleteNodeOutputVariables);
+        return new DeleteNode(getSourceLocation(node), idAllocator.getNextId(), builder.getRoot(), rowId, deleteNodeOutputVariables, Optional.empty());
     }
 
     public UpdateNode plan(Update node)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -801,8 +801,13 @@ public class PruneUnreferencedOutputs
         @Override
         public PlanNode visitDelete(DeleteNode node, RewriteContext<Set<VariableReferenceExpression>> context)
         {
-            PlanNode source = context.rewrite(node.getSource(), ImmutableSet.of(node.getRowId()));
-            return new DeleteNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), source, node.getRowId(), node.getOutputVariables());
+            ImmutableSet.Builder<VariableReferenceExpression> builder = ImmutableSet.builder();
+            builder.add(node.getRowId());
+            if (node.getInputDistribution().isPresent()) {
+                builder.addAll(node.getInputDistribution().get().getInputVariables());
+            }
+            PlanNode source = context.rewrite(node.getSource(), builder.build());
+            return new DeleteNode(node.getSourceLocation(), node.getId(), node.getStatsEquivalentPlanNode(), source, node.getRowId(), node.getOutputVariables(), node.getInputDistribution());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinInDelete.java
@@ -88,7 +88,8 @@ public class ReplicateSemiJoinInDelete
                     node.getId(),
                     rewrittenSource,
                     node.getRowId(),
-                    node.getOutputVariables());
+                    node.getOutputVariables(),
+                    node.getInputDistribution());
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -448,7 +448,7 @@ public class UnaliasSymbolReferences
         @Override
         public PlanNode visitDelete(DeleteNode node, RewriteContext<Void> context)
         {
-            return new DeleteNode(node.getSourceLocation(), node.getId(), context.rewrite(node.getSource()), canonicalize(node.getRowId()), node.getOutputVariables());
+            return new DeleteNode(node.getSourceLocation(), node.getId(), context.rewrite(node.getSource()), canonicalize(node.getRowId()), node.getOutputVariables(), node.getInputDistribution());
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -585,7 +585,8 @@ public class PlanBuilder
                                 idAllocator.getNextId(),
                                 deleteSource,
                                 deleteRowId,
-                                ImmutableList.of(deleteRowId)))
+                                ImmutableList.of(deleteRowId),
+                                Optional.empty()))
                         .addInputsSet(deleteRowId)
                         .singleDistributionPartitioningScheme(deleteRowId)),
                 Optional.of(deleteHandle),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java
@@ -35,6 +35,7 @@ public final class DeleteNode
     private final PlanNode source;
     private final VariableReferenceExpression rowId;
     private final List<VariableReferenceExpression> outputVariables;
+    private final Optional<InputDistribution> inputDistribution;
 
     @JsonCreator
     public DeleteNode(
@@ -42,9 +43,10 @@ public final class DeleteNode
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
             @JsonProperty("rowId") VariableReferenceExpression rowId,
-            @JsonProperty("outputVariables") List<VariableReferenceExpression> outputVariables)
+            @JsonProperty("outputVariables") List<VariableReferenceExpression> outputVariables,
+            @JsonProperty("inputDistribution") Optional<InputDistribution> inputDistribution)
     {
-        this(sourceLocation, id, Optional.empty(), source, rowId, outputVariables);
+        this(sourceLocation, id, Optional.empty(), source, rowId, outputVariables, inputDistribution);
     }
 
     public DeleteNode(
@@ -53,13 +55,15 @@ public final class DeleteNode
             Optional<PlanNode> statsEquivalentPlanNode,
             PlanNode source,
             VariableReferenceExpression rowId,
-            List<VariableReferenceExpression> outputVariables)
+            List<VariableReferenceExpression> outputVariables,
+            Optional<InputDistribution> inputDistribution)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
 
         this.source = requireNonNull(source, "source is null");
         this.rowId = requireNonNull(rowId, "rowId is null");
         this.outputVariables = Collections.unmodifiableList(new ArrayList<>(requireNonNull(outputVariables, "outputVariables is null")));
+        this.inputDistribution = requireNonNull(inputDistribution, "dataPartition is null");
     }
 
     @JsonProperty
@@ -81,6 +85,12 @@ public final class DeleteNode
         return outputVariables;
     }
 
+    @JsonProperty
+    public Optional<InputDistribution> getInputDistribution()
+    {
+        return inputDistribution;
+    }
+
     @Override
     public List<PlanNode> getSources()
     {
@@ -97,12 +107,30 @@ public final class DeleteNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         checkArgument(newChildren.size() == 1);
-        return new DeleteNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), rowId, outputVariables);
+        return new DeleteNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), newChildren.get(0), rowId, outputVariables, inputDistribution);
     }
 
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new DeleteNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, rowId, outputVariables);
+        return new DeleteNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, rowId, outputVariables, inputDistribution);
+    }
+
+    public interface InputDistribution
+    {
+        default List<VariableReferenceExpression> getPartitionBy()
+        {
+            return Collections.emptyList();
+        }
+
+        default Optional<OrderingScheme> getOrderingScheme()
+        {
+            return Optional.empty();
+        }
+
+        default List<VariableReferenceExpression> getInputVariables()
+        {
+            return Collections.emptyList();
+        }
     }
 }


### PR DESCRIPTION
## Description
Add an optional field to DeleteNode so that DeleteNode can specify the input data distributions for a DeleteNode.

This PR also include changes which moved the DeleteNode to SPI

## Motivation and Context
To enable specify input data properties for DeleteNode. Default is empty which means no requirement.

## Impact
Allow to specify input data properties for DeleteNode.

## Test Plan
Existing tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add an optional input distribution constraint to DeleteNode :pr:`24104`
```


