### PR TITLE
Add lookup function API to StandardFunctionResolution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -371,4 +371,10 @@ public final class FunctionResolution
     {
         return windowValueFunctions.contains(functionAndTypeResolver.getFunctionMetadata(functionHandle).getName());
     }
+
+    @Override
+    public FunctionHandle lookupBuiltInFunction(String functionName, List<Type> inputTypes)
+    {
+        return functionAndTypeResolver.lookupFunction(functionName, fromTypes(inputTypes));
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/relational/TestFunctionResolution.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/relational/TestFunctionResolution.java
@@ -16,14 +16,17 @@ package com.facebook.presto.sql.relational;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.common.function.OperatorType.ADD;
 import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -65,5 +68,9 @@ public class TestFunctionResolution
         // subscript
         assertTrue(standardFunctionResolution.isSubscriptFunction(standardFunctionResolution.subscriptFunction(new ArrayType(DOUBLE), BIGINT)));
         assertFalse(standardFunctionResolution.isBetweenFunction(standardFunctionResolution.subscriptFunction(new ArrayType(DOUBLE), BIGINT)));
+
+        // BuiltInFunction
+        assertEquals(standardFunctionResolution.notFunction(), standardFunctionResolution.lookupBuiltInFunction("not", ImmutableList.of(BOOLEAN)));
+        assertEquals(standardFunctionResolution.countFunction(), standardFunctionResolution.lookupBuiltInFunction("count", ImmutableList.of()));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
@@ -85,4 +85,6 @@ public interface StandardFunctionResolution
     boolean isApproximateSetFunction(FunctionHandle functionHandle);
 
     FunctionHandle approximateSetFunction(Type valueType);
+
+    FunctionHandle lookupBuiltInFunction(String functionName, List<Type> inputTypes);
 }


### PR DESCRIPTION
## Description
FunctionAndTypeResolver is in presto-main, and for code which has no access to presto-main, it relies on the interface StandardFunctionResolution in SPI to get function handle. 
In this PR, I add a API lookUpFunction so that it can work with internal functions which does not exist in OSS

## Motivation and Context
I need to create function call in connector optimizer, which has no access to presto-main. This change will enable resolve internal functions not exist in OSS

## Impact
As above

## Test Plan
Easy change. Existing tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

