### PR TITLE
Add enhanced cte scheduling mode

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
@@ -139,7 +139,8 @@ public class JdbcComputePushdown
                     oldTableScanNode.getAssignments(),
                     oldTableScanNode.getTableConstraints(),
                     oldTableScanNode.getCurrentConstraint(),
-                    oldTableScanNode.getEnforcedConstraint());
+                    oldTableScanNode.getEnforcedConstraint(),
+                    oldTableScanNode.getCteMaterializationInfo());
 
             return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), newTableScanNode, node.getPredicate());
         }

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/optimization/ClickHouseComputePushdown.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/optimization/ClickHouseComputePushdown.java
@@ -200,7 +200,8 @@ public class ClickHouseComputePushdown
                             ImmutableList.copyOf(assignments.keySet()),
                             assignments.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, (e) -> (ColumnHandle) (e.getValue()))),
                             tableScanNode.getCurrentConstraint(),
-                            tableScanNode.getEnforcedConstraint()));
+                            tableScanNode.getEnforcedConstraint(),
+                            tableScanNode.getCteMaterializationInfo()));
         }
 
         @Override
@@ -288,7 +289,8 @@ public class ClickHouseComputePushdown
                     oldTableScanNode.getOutputVariables(),
                     oldTableScanNode.getAssignments(),
                     oldTableScanNode.getCurrentConstraint(),
-                    oldTableScanNode.getEnforcedConstraint());
+                    oldTableScanNode.getEnforcedConstraint(),
+                    oldTableScanNode.getCteMaterializationInfo());
 
             return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), newTableScanNode, node.getPredicate());
         }

--- a/presto-docs/src/main/sphinx/admin/cte-materialization.rst
+++ b/presto-docs/src/main/sphinx/admin/cte-materialization.rst
@@ -118,7 +118,6 @@ This setting specifies the Hash function type for CTE materialization.
 
 Use the ``hive.bucket_function_type_for_cte_materialization`` session property to set on a per-query basis.
 
-
 ``query.max-written-intermediate-bytes``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -128,6 +127,17 @@ Use the ``hive.bucket_function_type_for_cte_materialization`` session property t
 This setting defines a cap on the amount of data that can be written during CTE Materialization. If a query exceeds this limit, it will fail.
 
 Use the ``query_max_written_intermediate_bytes`` session property to set on a per-query basis.
+
+``enhanced-cte-scheduling-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``boolean``
+    * **Default value:** ``true``
+
+Flag to enable or disable the enhanced-cte-blocking during CTE Materialization. Enhanced CTE blocking restricts only the table scan stages of the CTE TableScan, rather than blocking entire plan sections, including the main query, until the query completes.
+This approach can improve latency in scenarios where parts of the query can execute concurrently with CTE materialization writes.
+
+Use the ``enhanced_cte_scheduling_enabled`` session property to set on a per-query basis.
 
 
 How to Participate in Development

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidPlanOptimizer.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidPlanOptimizer.java
@@ -173,7 +173,8 @@ public class DruidPlanOptimizer
                             assignments.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, (e) -> (ColumnHandle) (e.getValue()))),
                             tableScanNode.getTableConstraints(),
                             tableScanNode.getCurrentConstraint(),
-                            tableScanNode.getEnforcedConstraint()));
+                            tableScanNode.getEnforcedConstraint(),
+                            tableScanNode.getCteMaterializationInfo()));
         }
 
         @Override

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryBase.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryBase.java
@@ -147,7 +147,7 @@ public class TestDruidQueryBase
                 variables,
                 assignments.build(),
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
     }
 
     protected FilterNode filter(PlanBuilder planBuilder, PlanNode source, RowExpression predicate)

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
@@ -307,7 +307,8 @@ public abstract class BaseSubfieldExtractionRewriter
                 tableScan.getAssignments(),
                 tableScan.getTableConstraints(),
                 pushdownFilterResult.getLayout().getPredicate(),
-                TupleDomain.all());
+                TupleDomain.all(),
+                tableScan.getCteMaterializationInfo());
     }
 
     private static ExtractionResult intersectExtractionResult(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
@@ -71,7 +71,8 @@ public class HiveAddRequestedColumnsToLayout
                     tableScan.getAssignments(),
                     tableScan.getTableConstraints(),
                     tableScan.getCurrentConstraint(),
-                    tableScan.getEnforcedConstraint());
+                    tableScan.getEnforcedConstraint(),
+                    tableScan.getCteMaterializationInfo());
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePartialAggregationPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePartialAggregationPushdown.java
@@ -297,7 +297,8 @@ public class HivePartialAggregationPushdown
                     ImmutableMap.copyOf(assignments),
                     oldTableScanNode.getTableConstraints(),
                     oldTableScanNode.getCurrentConstraint(),
-                    oldTableScanNode.getEnforcedConstraint()));
+                    oldTableScanNode.getEnforcedConstraint(),
+                    oldTableScanNode.getCteMaterializationInfo()));
         }
 
         @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java
@@ -1172,6 +1172,15 @@ public class TestCteExecution
     }
 
     @Test
+    public void testCTEMaterializationWithEnhancedScheduling()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        String sql = "WITH  temp as (SELECT orderkey FROM ORDERS) " +
+                "SELECT * FROM temp t1 JOIN (SELECT custkey FROM customer) c ON t1.orderkey=c.custkey";
+        verifyResults(queryRunner, sql, ImmutableList.of(generateMaterializedCTEInformation("temp", 1, false, true)));
+    }
+
+    @Test
     public void testWrittenIntemediateByteLimit()
             throws Exception
     {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
@@ -341,7 +341,8 @@ public class IcebergEqualityDeleteAsJoin
                     outputs,
                     deleteColumnAssignments,
                     TupleDomain.all(),
-                    TupleDomain.all());
+                    TupleDomain.all(),
+                    Optional.empty());
         }
 
         /**
@@ -382,7 +383,8 @@ public class IcebergEqualityDeleteAsJoin
                     assignmentsBuilder.build(),
                     node.getTableConstraints(),
                     node.getCurrentConstraint(),
-                    node.getEnforcedConstraint());
+                    node.getEnforcedConstraint(),
+                    node.getCteMaterializationInfo());
         }
 
         /**

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
@@ -238,7 +238,8 @@ public class IcebergPlanOptimizer
                             .intersect(tableScan.getCurrentConstraint()),
                     predicateNotChangedBySimplification ?
                             identityPartitionColumnPredicate.intersect(tableScan.getEnforcedConstraint()) :
-                            tableScan.getEnforcedConstraint());
+                            tableScan.getEnforcedConstraint(),
+                    tableScan.getCteMaterializationInfo());
 
             if (TRUE_CONSTANT.equals(remainingFilterExpression) && predicateNotChangedBySimplification) {
                 return newTableScan;

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -234,6 +234,7 @@ public final class SystemSessionProperties
     public static final String QUERY_RETRY_MAX_EXECUTION_TIME = "query_retry_max_execution_time";
     public static final String PARTIAL_RESULTS_ENABLED = "partial_results_enabled";
     public static final String PARTIAL_RESULTS_COMPLETION_RATIO_THRESHOLD = "partial_results_completion_ratio_threshold";
+    public static final String ENHANCED_CTE_SCHEDULING_ENABLED = "enhanced-cte-scheduling-enabled";
     public static final String PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER = "partial_results_max_execution_time_multiplier";
     public static final String OFFSET_CLAUSE_ENABLED = "offset_clause_enabled";
     public static final String VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED = "verbose_exceeded_memory_limit_errors_enabled";
@@ -1282,6 +1283,11 @@ public final class SystemSessionProperties
                         "Minimum query completion ratio threshold for partial results",
                         featuresConfig.getPartialResultsCompletionRatioThreshold(),
                         false),
+                booleanProperty(
+                        ENHANCED_CTE_SCHEDULING_ENABLED,
+                        "Applicable for CTE Materialization. If enabled, only tablescans of the pending tablewriters are blocked and other stages can continue.",
+                        featuresConfig.getEnhancedCTESchedulingEnabled(),
+                        true),
                 booleanProperty(
                         OFFSET_CLAUSE_ENABLED,
                         "Enable support for OFFSET clause",
@@ -2688,6 +2694,11 @@ public final class SystemSessionProperties
     public static double getPartialResultsCompletionRatioThreshold(Session session)
     {
         return session.getSystemProperty(PARTIAL_RESULTS_COMPLETION_RATIO_THRESHOLD, Double.class);
+    }
+
+    public static boolean isEnhancedCTESchedulingEnabled(Session session)
+    {
+        return isCteMaterializationApplicable(session) & session.getSystemProperty(ENHANCED_CTE_SCHEDULING_ENABLED, Boolean.class);
     }
 
     public static double getPartialResultsMaxExecutionTimeMultiplier(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/CTEMaterializationTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/CTEMaterializationTracker.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/*
+ * Tracks the completion status of table-finish nodes that write temporary tables for CTE materialization.
+ * CTEMaterializationTracker manages a map of materialized CTEs and their associated materialization futures.
+ * When a stage includes a CTE table finish, it marks the corresponding CTE as materialized and completes
+ * the associated future.
+ * This signals the scheduler that some dependency has been resolved, prompting it to resume/continue scheduling.
+ */
+public class CTEMaterializationTracker
+{
+    private final Map<String, SettableFuture<Void>> materializationFutures = new ConcurrentHashMap<>();
+
+    public ListenableFuture<Void> getFutureForCTE(String cteName)
+    {
+        return Futures.nonCancellationPropagating(
+                materializationFutures.compute(cteName, (key, existingFuture) -> {
+                    if (existingFuture == null) {
+                        // Create a new SettableFuture and store it internally
+                        return SettableFuture.create();
+                    }
+                    Preconditions.checkArgument(!existingFuture.isCancelled(),
+                            String.format("Error: Existing future was found cancelled in CTEMaterializationTracker for cte", cteName));
+                    return existingFuture;
+                }));
+    }
+
+    public void markCTEAsMaterialized(String cteName)
+    {
+        materializationFutures.compute(cteName, (key, existingFuture) -> {
+            if (existingFuture == null) {
+                SettableFuture<Void> completedFuture = SettableFuture.create();
+                completedFuture.set(null);
+                return completedFuture;
+            }
+            Preconditions.checkArgument(!existingFuture.isCancelled(),
+                    String.format("Error: Existing future was found cancelled in CTEMaterializationTracker for cte", cteName));
+            existingFuture.set(null); // Notify all listeners
+            return existingFuture;
+        });
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScheduleResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScheduleResult.java
@@ -57,6 +57,11 @@ public class ScheduleResult
          * grouped execution where there are multiple lifespans per task).
          */
         MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE,
+
+        /**
+         * Waiting for the completion of CTE materialization by the table writer.
+         */
+        WAITING_FOR_CTE_MATERIALIZATION,
         /**/;
 
         public BlockedReason combineWith(BlockedReason other)
@@ -64,6 +69,7 @@ public class ScheduleResult
             switch (this) {
                 case WRITER_SCALING:
                     throw new IllegalArgumentException("cannot be combined");
+                case WAITING_FOR_CTE_MATERIALIZATION:
                 case NO_ACTIVE_DRIVER_GROUP:
                     return other;
                 case SPLIT_QUEUES_FULL:

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SplitSchedulerStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SplitSchedulerStats.java
@@ -32,6 +32,8 @@ public class SplitSchedulerStats
     private final CounterStat splitQueuesFull = new CounterStat();
     private final CounterStat mixedSplitQueuesFullAndWaitingForSource = new CounterStat();
     private final CounterStat noActiveDriverGroup = new CounterStat();
+
+    private final CounterStat waitingForCTEMaterialization = new CounterStat();
     private final DistributionStat splitsPerIteration = new DistributionStat();
 
     @Managed
@@ -60,6 +62,13 @@ public class SplitSchedulerStats
     public CounterStat getWaitingForSource()
     {
         return waitingForSource;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getWaitingForCTEMaterialization()
+    {
+        return waitingForCTEMaterialization;
     }
 
     @Managed

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -138,6 +138,7 @@ public class FeaturesConfig
     private boolean ignoreStatsCalculatorFailures = true;
     private boolean printStatsForNonJoinQuery;
     private boolean defaultFilterFactorEnabled;
+    private boolean enhancedCteSchedulingEnabled = true;
     // Give a default 10% selectivity coefficient factor to avoid hitting unknown stats in join stats estimates
     // which could result in syntactic join order. Set it to 0 to disable this feature
     private double defaultJoinSelectivityCoefficient;
@@ -1288,6 +1289,18 @@ public class FeaturesConfig
     public boolean isDefaultFilterFactorEnabled()
     {
         return defaultFilterFactorEnabled;
+    }
+
+    @Config("enhanced-cte-scheduling-enabled")
+    public FeaturesConfig setEnhancedCTESchedulingEnabled(boolean enhancedCTEBlockingEnabled)
+    {
+        this.enhancedCteSchedulingEnabled = enhancedCTEBlockingEnabled;
+        return this;
+    }
+
+    public boolean getEnhancedCTESchedulingEnabled()
+    {
+        return enhancedCteSchedulingEnabled;
     }
 
     @Config("optimizer.default-join-selectivity-coefficient")

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -386,7 +386,8 @@ public abstract class BasePlanFragmenter
                 temporaryTableHandle,
                 exchange.getOutputVariables(),
                 variableToColumnMap,
-                Optional.of(partitioningMetadata));
+                Optional.of(partitioningMetadata),
+                Optional.empty());
 
         checkArgument(
                 !exchange.getPartitioningScheme().isReplicateNullsAndAny(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -252,7 +252,8 @@ public class CanonicalPlanGenerator
                 node.getTarget().map(target -> CanonicalWriterTarget.from(target)),
                 node.getRowCountVariable(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                node.getCteMaterializationInfo());
         context.addPlan(node, new CanonicalPlan(result, strategy));
         return Optional.of(result);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -240,7 +240,7 @@ public class LogicalPlanner
                 .putAll(tableScanOutputs.stream().collect(toImmutableMap(identity(), identity())))
                 .putAll(tableStatisticAggregation.getAdditionalVariables())
                 .build();
-        TableScanNode scanNode = new TableScanNode(getSourceLocation(analyzeStatement), idAllocator.getNextId(), targetTable, tableScanOutputs, variableToColumnHandle.build(), TupleDomain.all(), TupleDomain.all());
+        TableScanNode scanNode = new TableScanNode(getSourceLocation(analyzeStatement), idAllocator.getNextId(), targetTable, tableScanOutputs, variableToColumnHandle.build(), TupleDomain.all(), TupleDomain.all(), Optional.empty());
         PlanNode project = PlannerUtils.addProjections(scanNode, idAllocator, assignments);
         PlanNode planNode = new StatisticsWriterNode(
                 getSourceLocation(analyzeStatement),
@@ -442,7 +442,8 @@ public class LogicalPlanner
                     // final aggregation is run within the TableFinishOperator to summarize collected statistics
                     // by the partial aggregation from all of the writer nodes
                     Optional.of(aggregations.getFinalAggregation()),
-                    Optional.of(result.getDescriptor()));
+                    Optional.of(result.getDescriptor()),
+                    Optional.empty());
 
             return new RelationPlan(commitNode, analysis.getRootScope(), commitNode.getOutputVariables());
         }
@@ -468,6 +469,7 @@ public class LogicalPlanner
                 Optional.of(target),
                 variableAllocator.newVariable("rows", BIGINT),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
         return new RelationPlan(commitNode, analysis.getRootScope(), commitNode.getOutputVariables());
     }
@@ -486,6 +488,7 @@ public class LogicalPlanner
                 deleteNode,
                 Optional.of(deleteHandle),
                 variableAllocator.newVariable("rows", BIGINT),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 
@@ -527,6 +530,7 @@ public class LogicalPlanner
                 updateNode,
                 Optional.of(updateTarget),
                 variableAllocator.newVariable("rows", BIGINT),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenterUtils.java
@@ -257,6 +257,7 @@ public class PlanFragmenterUtils
                 .filter(node -> node instanceof TableWriterNode)
                 .map(node -> (TableWriterNode) node)
                 .filter(tableWriterNode -> !tableWriterNode.getIsTemporaryTableWriter().orElse(false))
+                .map(node -> (TableWriterNode) node)
                 .map(TableWriterNode::getId)
                 .collect(toImmutableSet());
     }
@@ -306,7 +307,8 @@ public class PlanFragmenterUtils
                     node.getOutputVariables(),
                     node.getAssignments(),
                     node.getCurrentConstraint(),
-                    node.getEnforcedConstraint());
+                    node.getEnforcedConstraint(),
+                    node.getCteMaterializationInfo());
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -357,7 +357,7 @@ public class PlannerUtils
                 newAssignments,
                 scanNode.getTableConstraints(),
                 scanNode.getCurrentConstraint(),
-                scanNode.getEnforcedConstraint());
+                scanNode.getEnforcedConstraint(), scanNode.getCteMaterializationInfo());
     }
 
     public static PlanNode clonePlanNode(PlanNode planNode, Session session, Metadata metadata, PlanNodeIdAllocator planNodeIdAllocator, List<VariableReferenceExpression> fieldsToKeep, Map<VariableReferenceExpression, VariableReferenceExpression> varMap)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -275,7 +275,7 @@ class QueryPlanner
 
         // create table scan
         List<VariableReferenceExpression> outputVariables = outputVariablesBuilder.build();
-        PlanNode tableScan = new TableScanNode(getSourceLocation(node), idAllocator.getNextId(), handle, outputVariables, columns.build(), TupleDomain.all(), TupleDomain.all());
+        PlanNode tableScan = new TableScanNode(getSourceLocation(node), idAllocator.getNextId(), handle, outputVariables, columns.build(), TupleDomain.all(), TupleDomain.all(), Optional.empty());
         Scope scope = Scope.builder().withRelationType(RelationId.anonymous(), new RelationType(fields.build())).build();
         RelationPlan relationPlan = new RelationPlan(tableScan, scope, outputVariables);
 
@@ -344,7 +344,7 @@ class QueryPlanner
 
         // create table scan
         List<VariableReferenceExpression> outputVariables = outputVariablesBuilder.build();
-        PlanNode tableScan = new TableScanNode(getSourceLocation(node), idAllocator.getNextId(), handle, outputVariables, columns.build(), TupleDomain.all(), TupleDomain.all());
+        PlanNode tableScan = new TableScanNode(getSourceLocation(node), idAllocator.getNextId(), handle, outputVariables, columns.build(), TupleDomain.all(), TupleDomain.all(), Optional.empty());
         Scope scope = Scope.builder().withRelationType(RelationId.anonymous(), new RelationType(fields.build())).build();
         RelationPlan relationPlan = new RelationPlan(tableScan, scope, outputVariables);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -219,7 +219,8 @@ class RelationPlanner
         List<VariableReferenceExpression> outputVariables = outputVariablesBuilder.build();
         List<TableConstraint<ColumnHandle>> tableConstraints = metadata.getTableMetadata(session, handle).getMetadata().getTableConstraintsHolder().getTableConstraintsWithColumnHandles();
         context.incrementLeafNodes(session);
-        PlanNode root = new TableScanNode(getSourceLocation(node.getLocation()), idAllocator.getNextId(), handle, outputVariables, columns.build(), tableConstraints, TupleDomain.all(), TupleDomain.all());
+        PlanNode root = new TableScanNode(getSourceLocation(node.getLocation()), idAllocator.getNextId(), handle, outputVariables, columns.build(),
+                tableConstraints, TupleDomain.all(), TupleDomain.all(), Optional.empty());
 
         return new RelationPlan(root, scope, outputVariables);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -228,7 +228,8 @@ public class PickTableLayout
                     tableScanNode.getAssignments(),
                     tableScanNode.getTableConstraints(),
                     layout.getLayout().getPredicate(),
-                    TupleDomain.all()));
+                    TupleDomain.all(),
+                    tableScanNode.getCteMaterializationInfo()));
         }
     }
 
@@ -324,7 +325,8 @@ public class PickTableLayout
                 node.getAssignments(),
                 node.getTableConstraints(),
                 layout.getLayout().getPredicate(),
-                computeEnforced(newDomain, layout.getUnenforcedConstraint()));
+                computeEnforced(newDomain, layout.getUnenforcedConstraint()),
+                node.getCteMaterializationInfo());
 
         // The order of the arguments to combineConjuncts matters:
         // * Unenforced constraints go first because they can only be simple column references,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
@@ -46,6 +46,6 @@ public class PruneTableScanColumns
                         filterKeys(tableScanNode.getAssignments(), referencedOutputs::contains),
                         tableScanNode.getTableConstraints(),
                         tableScanNode.getCurrentConstraint(),
-                        tableScanNode.getEnforcedConstraint()));
+                        tableScanNode.getEnforcedConstraint(), tableScanNode.getCteMaterializationInfo()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
@@ -524,7 +524,8 @@ public class RowExpressionRewriteRuleSet
                         node.getTarget(),
                         node.getRowCountVariable(),
                         rewrittenStatisticsAggregation,
-                        node.getStatisticsAggregationDescriptor()));
+                        node.getStatisticsAggregationDescriptor(),
+                        node.getCteMaterializationInfo()));
             }
             return Result.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PhysicalCteOptimizer.java
@@ -138,7 +138,8 @@ public class PhysicalCteOptimizer
                                         temporaryTableHandle,
                                         actualSource.getOutputVariables(),
                                         variableToColumnMap,
-                                        Optional.empty()), node.getOutputVariables()));
+                                        Optional.empty(),
+                                        Optional.of(node.getCteId())), node.getOutputVariables()));
             }
             catch (PrestoException e) {
                 if (e.getErrorCode().equals(NOT_SUPPORTED.toErrorCode())) {
@@ -159,7 +160,8 @@ public class PhysicalCteOptimizer
                     temporaryTableHandle,
                     actualSource.getOutputVariables(),
                     variableToColumnMap,
-                    node.getRowCountVariable());
+                    node.getRowCountVariable(),
+                    Optional.of(node.getCteId()));
         }
 
         public boolean isPlanRewritten()
@@ -210,7 +212,8 @@ public class PhysicalCteOptimizer
                     newOutputVariables,
                     newColumnAssignmentsMap,
                     tempScan.getCurrentConstraint(),
-                    tempScan.getEnforcedConstraint());
+                    tempScan.getEnforcedConstraint(),
+                    tempScan.getCteMaterializationInfo());
 
             // The temporary table scan might have columns removed by the UnaliasSymbolReferences and other optimizers (its a plan tree after all),
             // use originalOutputVariables (which are also canonicalized and maintained) and add them back

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -483,7 +483,8 @@ public class PruneUnreferencedOutputs
                     newAssignments,
                     node.getTableConstraints(),
                     node.getCurrentConstraint(),
-                    node.getEnforcedConstraint());
+                    node.getEnforcedConstraint(),
+                    node.getCteMaterializationInfo());
         }
 
         @Override
@@ -796,7 +797,8 @@ public class PruneUnreferencedOutputs
                     node.getTarget(),
                     node.getRowCountVariable(),
                     node.getStatisticsAggregation(),
-                    node.getStatisticsAggregationDescriptor());
+                    node.getStatisticsAggregationDescriptor(),
+                    node.getCteMaterializationInfo());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -399,7 +399,7 @@ public class PushdownSubfields
                     newAssignments.build(),
                     node.getTableConstraints(),
                     node.getCurrentConstraint(),
-                    node.getEnforcedConstraint());
+                    node.getEnforcedConstraint(), node.getCteMaterializationInfo());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -283,7 +283,8 @@ public class SymbolMapper
                 node.getTarget(),
                 map(node.getRowCountVariable()),
                 node.getStatisticsAggregation().map(this::map),
-                node.getStatisticsAggregationDescriptor().map(descriptor -> descriptor.map(this::map)));
+                node.getStatisticsAggregationDescriptor().map(descriptor -> descriptor.map(this::map)),
+                node.getCteMaterializationInfo());
     }
 
     public TableWriterMergeNode map(TableWriterMergeNode node, PlanNode source)

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -921,7 +921,7 @@ public class TestCostCalculator
                 variables,
                 assignments.build(),
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
     }
 
     private PlanNode project(String id, PlanNode source, VariableReferenceExpression variable, RowExpression expression)

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -124,7 +124,7 @@ public class MockRemoteTaskFactory
                         ImmutableList.of(variable),
                         ImmutableMap.of(variable, new TestingColumnHandle("column")),
                         TupleDomain.all(),
-                        TupleDomain.all()),
+                        TupleDomain.all(), Optional.empty()),
                 ImmutableSet.of(variable),
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(sourceId),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -120,7 +120,7 @@ public final class TaskTestUtils
                         ImmutableList.of(VARIABLE),
                         ImmutableMap.of(VARIABLE, new TestingColumnHandle("column", 0, BIGINT)),
                         TupleDomain.all(),
-                        TupleDomain.all()),
+                        TupleDomain.all(), Optional.empty()),
                 ImmutableSet.of(VARIABLE),
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(TABLE_SCAN_NODE_ID),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -206,7 +206,7 @@ public class TestPhasedExecutionSchedule
                 ImmutableList.of(variable),
                 ImmutableMap.of(variable, new TestingColumnHandle("column")),
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
 
         RemoteSourceNode remote = new RemoteSourceNode(Optional.empty(), new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of(), false, Optional.empty(), REPLICATE);
         PlanNode join = new JoinNode(
@@ -266,7 +266,7 @@ public class TestPhasedExecutionSchedule
                 ImmutableList.of(variable),
                 ImmutableMap.of(variable, new TestingColumnHandle("column")),
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
 
         return createFragment(planNode);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -489,7 +489,8 @@ public class TestSourcePartitionedScheduler
                 ImmutableList.of(variable),
                 ImmutableMap.of(variable, new TestingColumnHandle("column")),
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(),
+                Optional.empty());
 
         RemoteSourceNode remote = new RemoteSourceNode(Optional.empty(), new PlanNodeId("remote_id"), new PlanFragmentId(0), ImmutableList.of(), false, Optional.empty(), GATHER);
         PlanFragment testFragment = new PlanFragment(

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -113,7 +113,7 @@ public class TestDriver
                             ImmutableList.of(),
                             ImmutableMap.of(),
                             TupleDomain.all(),
-                            TupleDomain.all()),
+                            TupleDomain.all(), Optional.empty()),
                     ImmutableMap.of(),
                     singleGroupingSet(ImmutableList.of()),
                     ImmutableList.of(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -250,7 +250,8 @@ public class TestFeaturesConfig
                 .setEagerPlanValidationThreadPoolSize(20)
                 .setPrestoSparkExecutionEnvironment(false)
                 .setSingleNodeExecutionEnabled(false)
-                .setNativeExecutionScaleWritersThreadsEnabled(false));
+                .setNativeExecutionScaleWritersThreadsEnabled(false)
+                .setEnhancedCTESchedulingEnabled(true));
     }
 
     @Test
@@ -450,6 +451,7 @@ public class TestFeaturesConfig
                 .put("presto-spark-execution-environment", "true")
                 .put("single-node-execution-enabled", "true")
                 .put("native-execution-scale-writer-threads-enabled", "true")
+                .put("enhanced-cte-scheduling-enabled", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -646,7 +648,8 @@ public class TestFeaturesConfig
                 .setEagerPlanValidationThreadPoolSize(2)
                 .setPrestoSparkExecutionEnvironment(true)
                 .setSingleNodeExecutionEnabled(true)
-                .setNativeExecutionScaleWritersThreadsEnabled(true);
+                .setNativeExecutionScaleWritersThreadsEnabled(true)
+                .setEnhancedCTESchedulingEnabled(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
@@ -375,7 +375,7 @@ public class TestCanonicalPlanGenerator
                         .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
-                ImmutableSet.of("table", "assignments", "outputVariables", "currentConstraint", "enforcedConstraint", "tableConstraints"));
+                ImmutableSet.of("table", "assignments", "outputVariables", "currentConstraint", "enforcedConstraint", "tableConstraints", "cteMaterializationInfo"));
         assertEquals(
                 Arrays.stream(CanonicalTableScanNode.class.getDeclaredFields())
                         .filter(f -> !f.isSynthetic())

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -144,7 +144,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
     }
 
     @Test
@@ -373,7 +373,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
         RowExpression effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(effectivePredicate, TRUE_CONSTANT);
 
@@ -384,7 +384,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 TupleDomain.none(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
         effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(effectivePredicate, FALSE_CONSTANT);
 
@@ -395,7 +395,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 TupleDomain.withColumnDomains(ImmutableMap.of(scanAssignments.get(AV), Domain.singleValue(BIGINT, 1L))),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
         effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(1L), AV)));
 
@@ -408,7 +408,7 @@ public class TestEffectivePredicateExtractor
                 TupleDomain.withColumnDomains(ImmutableMap.of(
                         scanAssignments.get(AV), Domain.singleValue(BIGINT, 1L),
                         scanAssignments.get(BV), Domain.singleValue(BIGINT, 2L))),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
         effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(2L), BV), equals(bigintLiteral(1L), AV)));
 
@@ -419,7 +419,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
         effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(effectivePredicate, TRUE_CONSTANT);
     }
@@ -783,7 +783,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(scanAssignments.keySet()),
                 scanAssignments,
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
     }
 
     private static PlanNodeId newId()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
@@ -162,7 +162,7 @@ public class TestLocalExecutionPlanner
                 ImmutableList.of(variable),
                 ImmutableMap.of(variable, new TestingMetadata.TestingColumnHandle("column")),
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
         PlanNode node1 = new CustomNodeA(new PlanNodeId("node1"), scan);
         PlanNode node2 = new CustomNodeB(new PlanNodeId("node2"), node1);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -121,7 +121,7 @@ public class TestTypeValidator
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -545,7 +545,8 @@ public class PlanBuilder
                 assignments,
                 ImmutableList.of(),
                 currentConstraint,
-                enforcedConstraint);
+                enforcedConstraint,
+                Optional.empty());
     }
 
     public TableScanNode tableScan(
@@ -564,7 +565,7 @@ public class PlanBuilder
                 assignments,
                 tableConstraints,
                 currentConstraint,
-                enforcedConstraint);
+                enforcedConstraint, Optional.empty());
     }
 
     public TableFinishNode tableDelete(SchemaTableName schemaTableName, PlanNode deleteSource, VariableReferenceExpression deleteRowId)
@@ -592,7 +593,7 @@ public class PlanBuilder
                 Optional.of(deleteHandle),
                 deleteRowId,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(), Optional.empty());
     }
 
     public ExchangeNode gatheringExchange(ExchangeNode.Scope scope, PlanNode child)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
@@ -338,7 +338,7 @@ public class TestConnectorOptimization
                         tableScanNode.getAssignments(),
                         tableScanNode.getTableConstraints(),
                         TupleDomain.all(),
-                        TupleDomain.all());
+                        TupleDomain.all(), Optional.empty());
             }
             return node;
         }

--- a/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestGraphvizPrinter.java
@@ -67,7 +67,7 @@ public class TestGraphvizPrinter
             ImmutableList.of(),
             ImmutableMap.of(),
             TupleDomain.all(),
-            TupleDomain.all());
+            TupleDomain.all(), Optional.empty());
     private static final String TEST_TABLE_SCAN_NODE_INNER_OUTPUT = format(
             "label=\"{TableScan | [TableHandle \\{connectorId='%s', connectorHandle='%s', layout='Optional.empty'\\}]|Estimates: \\{rows: ? (0B), cpu: ?, memory: ?, network: ?\\}\n" +
                     "}\", style=\"rounded, filled\", shape=record, fillcolor=deepskyblue",

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/rule/ParquetDereferencePushDown.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/rule/ParquetDereferencePushDown.java
@@ -371,7 +371,8 @@ public abstract class ParquetDereferencePushDown
                     newAssignments,
                     tableScan.getTableConstraints(),
                     tableScan.getCurrentConstraint(),
-                    tableScan.getEnforcedConstraint());
+                    tableScan.getEnforcedConstraint(),
+                    tableScan.getCteMaterializationInfo());
 
             Assignments.Builder newProjectAssignmentBuilder = Assignments.builder();
             for (Map.Entry<VariableReferenceExpression, RowExpression> entry : project.getAssignments().entrySet()) {

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPlanOptimizer.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPlanOptimizer.java
@@ -184,7 +184,8 @@ public class PinotPlanOptimizer
                             ImmutableList.copyOf(assignments.keySet()),
                             assignments.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, (e) -> (ColumnHandle) (e.getValue()))),
                             tableScanNode.getCurrentConstraint(),
-                            tableScanNode.getEnforcedConstraint()));
+                            tableScanNode.getEnforcedConstraint(),
+                            tableScanNode.getCteMaterializationInfo()));
         }
 
         @Override

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestIterativePlanFragmenter.java
@@ -312,7 +312,7 @@ public class TestIterativePlanFragmenter
                 variables,
                 assignments.build(),
                 TupleDomain.all(),
-                TupleDomain.all());
+                TupleDomain.all(), Optional.empty());
     }
 
     private PlanNode project(String id, PlanNode source, VariableReferenceExpression variable, RowExpression expression)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteMaterializationInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteMaterializationInfo.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+/*
+ * Contains information about the identifier (cteId) of the CTE being materialized. This information is stored tablescans and tablefinish plan nodesg
+ */
+public class CteMaterializationInfo
+{
+    private final String cteId;
+
+    public CteMaterializationInfo(String cteId)
+    {
+        this.cteId = cteId;
+    }
+
+    public String getCteId()
+    {
+        return cteId;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableFinishNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableFinishNode.java
@@ -38,6 +38,8 @@ public final class TableFinishNode
     private final Optional<StatisticAggregations> statisticsAggregation;
     private final Optional<StatisticAggregationsDescriptor<VariableReferenceExpression>> statisticsAggregationDescriptor;
 
+    private final Optional<CteMaterializationInfo> temporaryTableInfo;
+
     @JsonCreator
     public TableFinishNode(
             Optional<SourceLocation> sourceLocation,
@@ -46,9 +48,10 @@ public final class TableFinishNode
             @JsonProperty("target") Optional<TableWriterNode.WriterTarget> target,
             @JsonProperty("rowCountVariable") VariableReferenceExpression rowCountVariable,
             @JsonProperty("statisticsAggregation") Optional<StatisticAggregations> statisticsAggregation,
-            @JsonProperty("statisticsAggregationDescriptor") Optional<StatisticAggregationsDescriptor<VariableReferenceExpression>> statisticsAggregationDescriptor)
+            @JsonProperty("statisticsAggregationDescriptor") Optional<StatisticAggregationsDescriptor<VariableReferenceExpression>> statisticsAggregationDescriptor,
+            @JsonProperty("cteMaterializationInfo") Optional<CteMaterializationInfo> temporaryTableInfo)
     {
-        this(sourceLocation, id, Optional.empty(), source, target, rowCountVariable, statisticsAggregation, statisticsAggregationDescriptor);
+        this(sourceLocation, id, Optional.empty(), source, target, rowCountVariable, statisticsAggregation, statisticsAggregationDescriptor, temporaryTableInfo);
     }
 
     public TableFinishNode(
@@ -59,11 +62,13 @@ public final class TableFinishNode
             Optional<TableWriterNode.WriterTarget> target,
             VariableReferenceExpression rowCountVariable,
             Optional<StatisticAggregations> statisticsAggregation,
-            Optional<StatisticAggregationsDescriptor<VariableReferenceExpression>> statisticsAggregationDescriptor)
+            Optional<StatisticAggregationsDescriptor<VariableReferenceExpression>> statisticsAggregationDescriptor,
+            Optional<CteMaterializationInfo> temporaryTableInfo)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
 
         checkArgument(target != null || source instanceof TableWriterNode);
+        this.temporaryTableInfo = temporaryTableInfo;
         this.source = requireNonNull(source, "source is null");
         this.target = requireNonNull(target, "target is null");
         this.rowCountVariable = requireNonNull(rowCountVariable, "rowCountVariable is null");
@@ -120,6 +125,11 @@ public final class TableFinishNode
         return visitor.visitTableFinish(this, context);
     }
 
+    public Optional<CteMaterializationInfo> getCteMaterializationInfo()
+    {
+        return temporaryTableInfo;
+    }
+
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
@@ -132,7 +142,8 @@ public final class TableFinishNode
                 target,
                 rowCountVariable,
                 statisticsAggregation,
-                statisticsAggregationDescriptor);
+                statisticsAggregationDescriptor,
+                temporaryTableInfo);
     }
 
     @Override
@@ -146,6 +157,7 @@ public final class TableFinishNode
                 target,
                 rowCountVariable,
                 statisticsAggregation,
-                statisticsAggregationDescriptor);
+                statisticsAggregationDescriptor,
+                temporaryTableInfo);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableScanNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableScanNode.java
@@ -50,6 +50,8 @@ public final class TableScanNode
     private final TupleDomain<ColumnHandle> enforcedConstraint;
     private final List<TableConstraint<ColumnHandle>> tableConstraints;
 
+    private final Optional<CteMaterializationInfo> cteMaterializationInfo;
+
     /**
      * This constructor is for JSON deserialization only.  Do not use!
      */
@@ -69,6 +71,7 @@ public final class TableScanNode
         this.currentConstraint = null;
         this.enforcedConstraint = null;
         this.tableConstraints = emptyList();
+        this.cteMaterializationInfo = Optional.empty();
     }
 
     public TableScanNode(
@@ -78,9 +81,9 @@ public final class TableScanNode
             List<VariableReferenceExpression> outputVariables,
             Map<VariableReferenceExpression, ColumnHandle> assignments,
             TupleDomain<ColumnHandle> currentConstraint,
-            TupleDomain<ColumnHandle> enforcedConstraint)
+            TupleDomain<ColumnHandle> enforcedConstraint, Optional<CteMaterializationInfo> cteMaterializationInfo)
     {
-        this (sourceLocation, id, table, outputVariables, assignments, emptyList(), currentConstraint, enforcedConstraint);
+        this(sourceLocation, id, table, outputVariables, assignments, emptyList(), currentConstraint, enforcedConstraint, cteMaterializationInfo);
     }
 
     public TableScanNode(
@@ -91,9 +94,9 @@ public final class TableScanNode
             Map<VariableReferenceExpression, ColumnHandle> assignments,
             List<TableConstraint<ColumnHandle>> tableConstraints,
             TupleDomain<ColumnHandle> currentConstraint,
-            TupleDomain<ColumnHandle> enforcedConstraint)
+            TupleDomain<ColumnHandle> enforcedConstraint, Optional<CteMaterializationInfo> cteMaterializationInfo)
     {
-        this (sourceLocation, id, Optional.empty(), table, outputVariables, assignments, tableConstraints, currentConstraint, enforcedConstraint);
+        this(sourceLocation, id, Optional.empty(), table, outputVariables, assignments, tableConstraints, currentConstraint, enforcedConstraint, cteMaterializationInfo);
     }
 
     public TableScanNode(
@@ -105,12 +108,14 @@ public final class TableScanNode
             Map<VariableReferenceExpression, ColumnHandle> assignments,
             List<TableConstraint<ColumnHandle>> tableConstraints,
             TupleDomain<ColumnHandle> currentConstraint,
-            TupleDomain<ColumnHandle> enforcedConstraint)
+            TupleDomain<ColumnHandle> enforcedConstraint,
+            Optional<CteMaterializationInfo> cteMaterializationInfo)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
         this.table = requireNonNull(table, "table is null");
         this.outputVariables = unmodifiableList(requireNonNull(outputVariables, "outputVariables is null"));
         this.assignments = unmodifiableMap(new HashMap<>(requireNonNull(assignments, "assignments is null")));
+        this.cteMaterializationInfo = requireNonNull(cteMaterializationInfo, "cteMaterializationInfo is null");
         checkArgument(assignments.keySet().containsAll(outputVariables), "assignments does not cover all of outputs");
         this.currentConstraint = requireNonNull(currentConstraint, "currentConstraint is null");
         this.enforcedConstraint = requireNonNull(enforcedConstraint, "enforcedConstraint is null");
@@ -118,6 +123,11 @@ public final class TableScanNode
             checkArgument(table.getLayout().isPresent(), "tableLayout must be present when currentConstraint or enforcedConstraint is non-trivial");
         }
         this.tableConstraints = requireNonNull(tableConstraints, "tableConstraints is null");
+    }
+
+    public Optional<CteMaterializationInfo> getCteMaterializationInfo()
+    {
+        return cteMaterializationInfo;
     }
 
     /**
@@ -206,7 +216,7 @@ public final class TableScanNode
     @Override
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
-        return new TableScanNode(getSourceLocation(), getId(), statsEquivalentPlanNode, table, outputVariables, assignments, tableConstraints, currentConstraint, enforcedConstraint);
+        return new TableScanNode(getSourceLocation(), getId(), statsEquivalentPlanNode, table, outputVariables, assignments, tableConstraints, currentConstraint, enforcedConstraint, cteMaterializationInfo);
     }
 
     @Override


### PR DESCRIPTION
## Description

Fixes #22205 

Enhance the scheduler to selectively block only the TableScan stages that depend on incomplete CTE TableWriter stages, rather than blocking all dependent sections.

Previously, all sections relying on a CTE writer were blocked until the writer completed. 
With this change, only the specific TableScans referencing the CTE are delayed, allowing other stages to proceed. This optimization can significantly improve query latency.

For example for the materialized CTE T:

```
WITH T AS (SELECT * FROM tpch.orders) 
SELECT * 
FROM T 
JOIN (SELECT * FROM customer) b 
ON t.uuid = b.uuid;

```
In this query, the right side of the join can be executed and kept in memory concurrently while the CTE write operation completes.


2 commits
1. Add the CTE used info to tablescans and table finish 
2. Use this info in scheduling by adding a central manager per scheduler and then using this to unblock/wake up tasks and to maintain completed ctes.

Can cause more resource utilization in some cases where intermediate results get blocked due to written ctes  but that may also happen without any materialization


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Existing UTs + prod queries

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve scheduling for CTE materialization: Now, only the stages containing CTE table scans that reference CTE table write stages are blocked till the write is complete, instead of the entire query being blocked as was the case previously. This is controlled by the session property ``enhanced_cte_scheduling_enabled`` (on by default) :pr:`24108`

```
