### PR TITLE
Add support for pluggable Custom Presto Authenticators

### DIFF
--- a/presto-docs/src/main/sphinx/develop/presto-authenticator.rst
+++ b/presto-docs/src/main/sphinx/develop/presto-authenticator.rst
@@ -1,0 +1,52 @@
+===========================
+Custom Presto Authenticator
+===========================
+
+Presto supports authentication via a custom presto authenticator
+that validates the request and creates a principal.
+
+Implementation
+--------------
+
+``PrestoAuthenticatorFactory`` is responsible for creating a
+``PrestoAuthenticator`` instance. It also defines the name of this
+authenticator which is used by the administrator in a Presto configuration.
+
+``PrestoAuthenticator`` contains a single method, ``createAuthenticatedPrincipal()``,
+that validates the request and returns a ``Principal``, which is then
+authorized by the :doc:`system-access-control`.
+
+The implementation of ``PrestoAuthenticatorFactory`` must be wrapped
+as a plugin and installed on the Presto cluster.
+
+Configuration
+-------------
+
+After a plugin that implements ``PrestoAuthenticatorFactory`` has been
+installed on the coordinator, it is configured using an
+``etc/presto-authenticator.properties`` file. All of the
+properties other than ``presto-authenticator.name`` are specific to the
+``PrestoAuthenticatorFactory`` implementation.
+
+The ``presto-authenticator.name`` property is used by Presto to find a
+registered ``PrestoAuthenticatorFactory`` based on the name returned by
+``PrestoAuthenticatorFactory.getName()``. The remaining properties are
+passed as a map to ``PrestoAuthenticatorFactory.create()``.
+
+Example configuration file:
+
+.. code-block:: none
+
+    presto-authenticator.name=custom-authenticator
+    custom-property1=custom-value1
+    custom-property2=custom-value2
+
+Additionally, the coordinator must be configured to use custom authentication
+and have HTTPS enabled.
+
+Below property needs to be added to the coordinator's ``config.properties`` file:
+
+.. code-block:: none
+
+    http-server.authentication.type=CUSTOM
+

--- a/presto-lark-sheets/pom.xml
+++ b/presto-lark-sheets/pom.xml
@@ -75,6 +75,13 @@
         </dependency>
 
         <!-- Presto SPI -->
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -27,6 +27,7 @@ import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
+import com.facebook.presto.server.security.PrestoAuthenticatorManager;
 import com.facebook.presto.spi.CoordinatorPlugin;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.analyzer.AnalyzerProvider;
@@ -40,6 +41,7 @@ import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
+import com.facebook.presto.spi.security.PrestoAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.session.WorkerSessionPropertyProviderFactory;
@@ -116,6 +118,7 @@ public class PluginManager
     private final ResourceGroupManager<?> resourceGroupManager;
     private final AccessControlManager accessControlManager;
     private final PasswordAuthenticatorManager passwordAuthenticatorManager;
+    private final PrestoAuthenticatorManager prestoAuthenticatorManager;
     private final EventListenerManager eventListenerManager;
     private final BlockEncodingManager blockEncodingManager;
     private final TempStorageManager tempStorageManager;
@@ -147,6 +150,7 @@ public class PluginManager
             QueryPreparerProviderManager queryPreparerProviderManager,
             AccessControlManager accessControlManager,
             PasswordAuthenticatorManager passwordAuthenticatorManager,
+            PrestoAuthenticatorManager prestoAuthenticatorManager,
             EventListenerManager eventListenerManager,
             BlockEncodingManager blockEncodingManager,
             TempStorageManager tempStorageManager,
@@ -176,6 +180,7 @@ public class PluginManager
         this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
         this.accessControlManager = requireNonNull(accessControlManager, "accessControlManager is null");
         this.passwordAuthenticatorManager = requireNonNull(passwordAuthenticatorManager, "passwordAuthenticatorManager is null");
+        this.prestoAuthenticatorManager = requireNonNull(prestoAuthenticatorManager, "prestoAuthenticatorManager is null");
         this.eventListenerManager = requireNonNull(eventListenerManager, "eventListenerManager is null");
         this.blockEncodingManager = requireNonNull(blockEncodingManager, "blockEncodingManager is null");
         this.tempStorageManager = requireNonNull(tempStorageManager, "tempStorageManager is null");
@@ -303,6 +308,11 @@ public class PluginManager
         for (PasswordAuthenticatorFactory authenticatorFactory : plugin.getPasswordAuthenticatorFactories()) {
             log.info("Registering password authenticator %s", authenticatorFactory.getName());
             passwordAuthenticatorManager.addPasswordAuthenticatorFactory(authenticatorFactory);
+        }
+
+        for (PrestoAuthenticatorFactory authenticatorFactory : plugin.getPrestoAuthenticatorFactories()) {
+            log.info("Registering presto authenticator %s", authenticatorFactory.getName());
+            prestoAuthenticatorManager.addPrestoAuthenticatorFactory(authenticatorFactory);
         }
 
         for (EventListenerFactory eventListenerFactory : plugin.getEventListenerFactories()) {

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -45,6 +45,7 @@ import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AccessControlModule;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
+import com.facebook.presto.server.security.PrestoAuthenticatorManager;
 import com.facebook.presto.server.security.ServerSecurityModule;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
@@ -171,6 +172,7 @@ public class PrestoServer
                 injector.getInstance(AccessControlManager.class).loadSystemAccessControl();
             }
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
+            injector.getInstance(PrestoAuthenticatorManager.class).loadPrestoAuthenticator();
             injector.getInstance(EventListenerManager.class).loadConfiguredEventListener();
             injector.getInstance(TempStorageManager.class).loadTempStorages();
             injector.getInstance(QueryPrerequisitesManager.class).loadQueryPrerequisites();

--- a/presto-main/src/main/java/com/facebook/presto/server/security/PrestoAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/PrestoAuthenticator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.security;
+
+import com.facebook.airlift.http.server.AuthenticationException;
+import com.facebook.airlift.http.server.Authenticator;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+
+import java.security.Principal;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoAuthenticator
+        implements Authenticator
+{
+    private PrestoAuthenticatorManager authenticatorManager;
+
+    @Inject
+    public PrestoAuthenticator(PrestoAuthenticatorManager authenticatorManager)
+    {
+        this.authenticatorManager = requireNonNull(authenticatorManager, "authenticatorManager is null");
+        authenticatorManager.setRequired();
+    }
+
+    @Override
+    public Principal authenticate(HttpServletRequest request)
+            throws AuthenticationException
+    {
+        try {
+            return authenticatorManager.getAuthenticator().createAuthenticatedPrincipal(request);
+        }
+        catch (RuntimeException e) {
+            throw new RuntimeException("Authentication error", e);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/security/PrestoAuthenticatorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/PrestoAuthenticatorManager.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.security;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.security.PrestoAuthenticator;
+import com.facebook.presto.spi.security.PrestoAuthenticatorFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoAuthenticatorManager
+{
+    private static final Logger log = Logger.get(PrestoAuthenticatorManager.class);
+
+    private static final File CONFIG_FILE = new File("etc/presto-authenticator.properties");
+    private static final String NAME_PROPERTY = "presto-authenticator.name";
+
+    private final AtomicBoolean required = new AtomicBoolean();
+    private final Map<String, PrestoAuthenticatorFactory> factories = new ConcurrentHashMap<>();
+    private final AtomicReference<PrestoAuthenticator> authenticator = new AtomicReference<>();
+
+    @VisibleForTesting
+    public void setAuthenticator(PrestoAuthenticator authenticator)
+    {
+        this.authenticator.set(requireNonNull(authenticator, "authenticator is null"));
+    }
+
+    public void setRequired()
+    {
+        required.set(true);
+    }
+
+    public void addPrestoAuthenticatorFactory(PrestoAuthenticatorFactory factory)
+    {
+        checkArgument(factories.putIfAbsent(factory.getName(), factory) == null,
+                "Presto authenticator '%s' is already registered", factory.getName());
+    }
+
+    public void loadPrestoAuthenticator()
+            throws Exception
+    {
+        if (!required.get()) {
+            return;
+        }
+
+        File configFileLocation = CONFIG_FILE.getAbsoluteFile();
+        Map<String, String> properties = new HashMap<>(loadProperties(configFileLocation));
+
+        String name = properties.remove(NAME_PROPERTY);
+        checkArgument(!isNullOrEmpty(name),
+                "Presto authenticator configuration %s does not contain %s", configFileLocation, NAME_PROPERTY);
+
+        log.info("-- Loading Presto authenticator --");
+
+        PrestoAuthenticatorFactory factory = factories.get(name);
+        checkState(factory != null, "Presto authenticator %s is not registered", name);
+
+        PrestoAuthenticator authenticator = factory.create(ImmutableMap.copyOf(properties));
+        this.authenticator.set(requireNonNull(authenticator, "authenticator is null"));
+
+        log.info("-- Loaded Presto authenticator %s --", name);
+    }
+
+    public PrestoAuthenticator getAuthenticator()
+    {
+        checkState(authenticator.get() != null, "authenticator was not loaded");
+        return authenticator.get();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig
         CERTIFICATE,
         KERBEROS,
         PASSWORD,
-        JWT
+        JWT,
+        CUSTOM
     }
 
     @NotNull
@@ -56,7 +57,7 @@ public class SecurityConfig
     }
 
     @Config("http-server.authentication.type")
-    @ConfigDescription("Authentication types (supported types: CERTIFICATE, KERBEROS, PASSWORD, JWT)")
+    @ConfigDescription("Authentication types (supported types: CERTIFICATE, KERBEROS, PASSWORD, JWT, CUSTOM)")
     public SecurityConfig setAuthenticationTypes(String types)
     {
         if (types == null) {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.presto.server.security.SecurityConfig.AuthenticationType.CERTIFICATE;
+import static com.facebook.presto.server.security.SecurityConfig.AuthenticationType.CUSTOM;
 import static com.facebook.presto.server.security.SecurityConfig.AuthenticationType.JWT;
 import static com.facebook.presto.server.security.SecurityConfig.AuthenticationType.KERBEROS;
 import static com.facebook.presto.server.security.SecurityConfig.AuthenticationType.PASSWORD;
@@ -39,6 +40,7 @@ public class ServerSecurityModule
     protected void setup(Binder binder)
     {
         binder.bind(PasswordAuthenticatorManager.class).in(Scopes.SINGLETON);
+        binder.bind(PrestoAuthenticatorManager.class).in(Scopes.SINGLETON);
 
         List<AuthenticationType> authTypes = buildConfigObject(SecurityConfig.class).getAuthenticationTypes();
         Multibinder<Authenticator> authBinder = newSetBinder(binder, Authenticator.class);
@@ -57,6 +59,9 @@ public class ServerSecurityModule
             else if (authType == JWT) {
                 configBinder(binder).bindConfig(JsonWebTokenConfig.class);
                 authBinder.addBinding().to(JsonWebTokenAuthenticator.class).in(Scopes.SINGLETON);
+            }
+            else if (authType == CUSTOM) {
+                authBinder.addBinding().to(PrestoAuthenticator.class).in(Scopes.SINGLETON);
             }
             else {
                 throw new AssertionError("Unhandled auth type: " + authType);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -123,6 +123,7 @@ import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.PluginManagerConfig;
 import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
+import com.facebook.presto.server.security.PrestoAuthenticatorManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
@@ -515,6 +516,7 @@ public class LocalQueryRunner
                 new QueryPreparerProviderManager(queryPreparerProvider),
                 accessControl,
                 new PasswordAuthenticatorManager(),
+                new PrestoAuthenticatorManager(),
                 new EventListenerManager(),
                 blockEncodingManager,
                 new TestingTempStorageManager(),

--- a/presto-password-authenticators/pom.xml
+++ b/presto-password-authenticators/pom.xml
@@ -63,6 +63,12 @@
             <version>0.9.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -27,6 +27,7 @@ import com.facebook.presto.security.AccessControlModule;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
+import com.facebook.presto.server.security.PrestoAuthenticatorManager;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkBootstrapTimer;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
 import com.facebook.presto.spi.security.AccessControl;
@@ -182,6 +183,7 @@ public class PrestoSparkInjectorFactory
             injector.getInstance(StaticCatalogStore.class).loadCatalogs(catalogProperties);
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
+            injector.getInstance(PrestoAuthenticatorManager.class).loadPrestoAuthenticator();
             eventListenerProperties.ifPresent(properties -> injector.getInstance(EventListenerManager.class).loadConfiguredEventListener(properties));
             bootstrapTimer.endSharedModulesLoading();
 

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>jol-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
+import com.facebook.presto.spi.security.PrestoAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
@@ -72,6 +73,11 @@ public interface Plugin
     }
 
     default Iterable<PasswordAuthenticatorFactory> getPasswordAuthenticatorFactories()
+    {
+        return emptyList();
+    }
+
+    default Iterable<PrestoAuthenticatorFactory> getPrestoAuthenticatorFactories()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/PrestoAuthenticator.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/PrestoAuthenticator.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.security.Principal;
+
+public interface PrestoAuthenticator
+{
+    /**
+     * Authenticate the provided token.
+     *
+     * @return the authenticated Principal
+     * @throws AccessDeniedException if not allowed
+     */
+    Principal createAuthenticatedPrincipal(HttpServletRequest request);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/PrestoAuthenticatorFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/PrestoAuthenticatorFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.security;
+
+import java.util.Map;
+
+public interface PrestoAuthenticatorFactory
+{
+    String getName();
+
+    PrestoAuthenticator create(Map<String, String> config);
+}


### PR DESCRIPTION
## Description

A pluggable authenticator in Presto allows the authentication process to be customized based on specific use cases, such as integrating with different identity providers or token validation strategies. 

## Motivation and Context

Fixes #24052 


## Test Plan

Added Unit Tests

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Add support for pluggable Custom Presto Authenticators :pr:`#24053`

```