### PR TITLE
Fix Password Authenticator Documentation

### DIFF
--- a/presto-docs/src/main/sphinx/develop/password-authenticator.rst
+++ b/presto-docs/src/main/sphinx/develop/password-authenticator.rst
@@ -25,7 +25,7 @@ Configuration
 After a plugin that implements ``PasswordAuthenticatorFactory`` has been
 installed on the coordinator, it is configured using an
 ``etc/password-authenticator.properties`` file. All of the
-properties other than ``access-control.name`` are specific to the
+properties other than ``password-authenticator.name`` are specific to the
 ``PasswordAuthenticatorFactory`` implementation.
 
 The ``password-authenticator.name`` property is used by Presto to find a
@@ -37,9 +37,15 @@ Example configuration file:
 
 .. code-block:: none
 
-    password-authenticator.name=custom-access-control
+    password-authenticator.name=custom-password-authenticator
     custom-property1=custom-value1
     custom-property2=custom-value2
 
 Additionally, the coordinator must be configured to use password authentication
 and have HTTPS enabled.
+
+Add the property shown below to the coordinator's ``config.properties`` file :
+
+.. code-block:: none
+
+   http-server.authentication.type=PASSWORD


### PR DESCRIPTION
## Description
Documentation modified for password-authenticator.rst

## Motivation and Context

Updated the property name from access-control.name to password-authenticator.name to align with the declaration in the code: private static final String NAME_PROPERTY = "password-authenticator.name";.

## Impact

This change ensures that the configuration aligns correctly with the expected property name in the code (password-authenticator.name). It prevents potential misconfigurations and runtime errors caused by mismatched property names, thereby improving reliability and clarity in the authentication setup process.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==

```

