### PR TITLE
Resolving google-oauth and jetty-io vulnerability

### DIFF
--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -176,6 +176,10 @@
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-protobuf-lite</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.oauth-client</groupId>
+                    <artifactId>google-oauth-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -269,6 +269,12 @@
             <groupId>com.facebook.airlift</groupId>
             <artifactId>http-server</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -200,6 +200,12 @@
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>http-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -65,6 +65,12 @@
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>event</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
Identified  security vulnerability issues of severity high from jetty-io-9.4.14.v20181114.jar 1.31.2.jar and resolved the same. 
Excluded the transitive dependency of jetty-io occuring from parent packages that does not break the build or impact the functionality but removes the said exploitable.  

Identified security vulnerability issue of severity high from google-oauth-client-1.31.2.jar and resolved the same. 
Excluded the transitive dependency of google-oauth-client occuring from parent package google-cloud-bigquerystorage that does not break the build or impact the functionality but resolves the said exploitable. 


## Motivation and Context
```
Group id: org.eclipse.jetty
Artifact : jetty-io
Issue for version : jetty-io-9.4.14.v20181114.jar
```
```
Group id: com.google.oauth-client
Artifact : google-oauth-client
Issue for version : google-oauth-client-1.31.2.
```

## Direct vulnerabilities: 
[CVE-2021-28165](https://nvd.nist.gov/vuln/detail/cve-2021-28165)
[CVE-2021-22573](https://github.com/advisories/GHSA-hw42-3568-wj87)

## Impact
Eclipse Jetty is vulnerable to a denial of service, caused by improper input validation. By sending a specially-crafted TLS frame, a remote attacker could exploit this vulnerability to cause CPU resources to reach to 100% usage.

Google APIs google-oauth-java-client could allow a remote attacker to bypass security restrictions, caused by no PKCE support implemented. By executing a specially-crafted application, an attacker could exploit this vulnerability to obtain the authorization code, and gain authorization to the protected resource.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==


Security Changes
Resolving Aquasec scan CVE detected


