### PR TITLE
Upgrade netty dependencies to address CVE-2024-47535

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <dep.avro.version>1.11.4</dep.avro.version>
         <dep.commons.compress.version>1.26.2</dep.commons.compress.version>
         <dep.protobuf-java.version>3.25.5</dep.protobuf-java.version>
+        <dep.netty.version>4.1.115.Final</dep.netty.version>
         <dep.snakeyaml.version>2.0</dep.snakeyaml.version>
 
         <!--
@@ -209,10 +210,12 @@
         <dependencies>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>4.1.107.Final</version>
+                <artifactId>netty-bom</artifactId>
+                <version>${dep.netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-testing-docker</artifactId>
@@ -2301,6 +2304,8 @@
                         <ignoredClassPatterns combine.children="append">
                             <!-- Duplicate class is being brought in by commons-io & log4j-api -->
                             <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                            <!-- Duplicate class is being brought in by several netty dependencies-->
+                            <ignoredClassPattern>META-INF.versions.11.module-info</ignoredClassPattern>
                         </ignoredClassPatterns>
                     </configuration>
                 </plugin>

--- a/redis-hbo-provider/pom.xml
+++ b/redis-hbo-provider/pom.xml
@@ -11,7 +11,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <lettuce.version>6.2.4.RELEASE</lettuce.version>
-        <netty.version>4.1.115.Final</netty.version>
     </properties>
 
     <artifactId>redis-hbo-provider</artifactId>
@@ -22,19 +21,16 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>${netty.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>${netty.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
Upgrade the netty dependencies to CVE-2024-47535
If implemented this will:
Upgrade the netty dependencies to 4.1.115.Final
## Motivation and Context
This upgrade was created to deal with CVEs found in lower versions
## Impact
None

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Upgrade netty dependencies to version 4.1.115.Final in response to `CVE-2024-47535 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47535>`_. :pr:`24137`
```
