### PR TITLE
Add SPI for delegating row expression optimizer

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
@@ -109,7 +109,7 @@ public class JdbcConnector
                 functionManager,
                 functionResolution,
                 rowExpressionService.getDeterminismEvaluator(),
-                rowExpressionService.getExpressionOptimizer());
+                rowExpressionService);
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
@@ -29,7 +29,7 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
-import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 
 import java.util.Optional;
@@ -44,7 +44,7 @@ import static java.util.Objects.requireNonNull;
 public class JdbcComputePushdown
         implements ConnectorPlanOptimizer
 {
-    private final ExpressionOptimizer expressionOptimizer;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
     private final JdbcFilterToSqlTranslator jdbcFilterToSqlTranslator;
     private final LogicalRowExpressions logicalRowExpressions;
 
@@ -52,7 +52,7 @@ public class JdbcComputePushdown
             FunctionMetadataManager functionMetadataManager,
             StandardFunctionResolution functionResolution,
             DeterminismEvaluator determinismEvaluator,
-            ExpressionOptimizer expressionOptimizer,
+            ExpressionOptimizerProvider expressionOptimizerProvider,
             String identifierQuote,
             Set<Class<?>> functionTranslators)
     {
@@ -62,7 +62,7 @@ public class JdbcComputePushdown
         requireNonNull(determinismEvaluator, "determinismEvaluator is null");
         requireNonNull(functionResolution, "functionResolution is null");
 
-        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         this.jdbcFilterToSqlTranslator = new JdbcFilterToSqlTranslator(
                 functionMetadataManager,
                 buildFunctionTranslator(functionTranslators),
@@ -106,7 +106,7 @@ public class JdbcComputePushdown
             TableHandle oldTableHandle = oldTableScanNode.getTable();
             JdbcTableHandle oldConnectorTable = (JdbcTableHandle) oldTableHandle.getConnectorHandle();
 
-            RowExpression predicate = expressionOptimizer.optimize(node.getPredicate(), OPTIMIZED, session);
+            RowExpression predicate = expressionOptimizerProvider.getExpressionOptimizer(session).optimize(node.getPredicate(), OPTIMIZED, session);
             predicate = logicalRowExpressions.convertToConjunctiveNormalForm(predicate);
             TranslatedExpression<JdbcExpression> jdbcExpression = translateWith(
                     predicate,

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcPlanOptimizerProvider.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcPlanOptimizerProvider.java
@@ -20,7 +20,7 @@ import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
-import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 
@@ -34,7 +34,7 @@ public class JdbcPlanOptimizerProvider
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
     private final DeterminismEvaluator determinismEvaluator;
-    private final ExpressionOptimizer expressionOptimizer;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
     private final String identifierQuote;
 
     @Inject
@@ -43,12 +43,12 @@ public class JdbcPlanOptimizerProvider
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
             DeterminismEvaluator determinismEvaluator,
-            ExpressionOptimizer expressionOptimizer)
+            ExpressionOptimizerProvider expressionOptimizerProvider)
     {
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
-        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         this.identifierQuote = jdbcClient.getIdentifierQuote();
     }
 
@@ -65,7 +65,7 @@ public class JdbcPlanOptimizerProvider
                 functionManager,
                 functionResolution,
                 determinismEvaluator,
-                expressionOptimizer,
+                expressionOptimizerProvider,
                 identifierQuote,
                 getFunctionTranslators()));
     }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/optimization/TestJdbcComputePushdown.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/optimization/TestJdbcComputePushdown.java
@@ -105,7 +105,7 @@ public class TestJdbcComputePushdown
                 functionAndTypeManager,
                 functionResolution,
                 determinismEvaluator,
-                new RowExpressionOptimizer(METADATA),
+                (ConnectorSession session) -> new RowExpressionOptimizer(METADATA),
                 "'",
                 getFunctionTranslators());
     }

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseConnector.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/ClickHouseConnector.java
@@ -113,8 +113,7 @@ public class ClickHouseConnector
                 clickHouseClient,
                 functionManager,
                 functionResolution,
-                rowExpressionService.getDeterminismEvaluator(),
-                rowExpressionService.getExpressionOptimizer(),
+                rowExpressionService,
                 clickhouseQueryGenerator);
     }
 

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/optimization/ClickHouseComputePushdown.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/optimization/ClickHouseComputePushdown.java
@@ -35,8 +35,8 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.PlanVisitor;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
-import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.google.common.collect.ImmutableList;
 
@@ -57,7 +57,7 @@ import static java.util.Objects.requireNonNull;
 public class ClickHouseComputePushdown
         implements ConnectorPlanOptimizer
 {
-    private final ExpressionOptimizer expressionOptimizer;
+    private final RowExpressionService rowExpressionService;
     private final ClickHouseFilterToSqlTranslator clickHouseFilterToSqlTranslator;
     private final LogicalRowExpressions logicalRowExpressions;
     private final ClickHouseQueryGenerator clickhouseQueryGenerator;
@@ -67,7 +67,7 @@ public class ClickHouseComputePushdown
             FunctionMetadataManager functionMetadataManager,
             StandardFunctionResolution functionResolution,
             DeterminismEvaluator determinismEvaluator,
-            ExpressionOptimizer expressionOptimizer,
+            RowExpressionService rowExpressionService,
             String identifierQuote,
             Set<Class<?>> functionTranslators,
             ClickHouseQueryGenerator clickhouseQueryGenerator)
@@ -78,7 +78,7 @@ public class ClickHouseComputePushdown
         requireNonNull(determinismEvaluator, "determinismEvaluator is null");
         requireNonNull(functionResolution, "functionResolution is null");
 
-        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
+        this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
         this.clickHouseFilterToSqlTranslator = new ClickHouseFilterToSqlTranslator(
                 functionMetadataManager,
                 buildFunctionTranslator(functionTranslators),
@@ -257,7 +257,7 @@ public class ClickHouseComputePushdown
             TableHandle oldTableHandle = oldTableScanNode.getTable();
             ClickHouseTableHandle oldConnectorTable = (ClickHouseTableHandle) oldTableHandle.getConnectorHandle();
 
-            RowExpression predicate = expressionOptimizer.optimize(node.getPredicate(), OPTIMIZED, session);
+            RowExpression predicate = rowExpressionService.getExpressionOptimizer(session).optimize(node.getPredicate(), OPTIMIZED, session);
             predicate = logicalRowExpressions.convertToConjunctiveNormalForm(predicate);
             TranslatedExpression<ClickHouseExpression> clickHouseExpression = translateWith(
                     predicate,

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/optimization/ClickHousePlanOptimizerProvider.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/optimization/ClickHousePlanOptimizerProvider.java
@@ -20,7 +20,7 @@ import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
-import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpressionService;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 
@@ -33,8 +33,8 @@ public class ClickHousePlanOptimizerProvider
 {
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
+    private final RowExpressionService rowExpressionService;
     private final DeterminismEvaluator determinismEvaluator;
-    private final ExpressionOptimizer expressionOptimizer;
     private final String identifierQuote;
     private final ClickHouseQueryGenerator clickhouseQueryGenerator;
 
@@ -43,16 +43,15 @@ public class ClickHousePlanOptimizerProvider
             ClickHouseClient clickHouseClient,
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
-            DeterminismEvaluator determinismEvaluator,
-            ExpressionOptimizer expressionOptimizer,
+            RowExpressionService rowExpressionService,
             ClickHouseQueryGenerator clickhouseQueryGenerator)
     {
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
-        this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
-        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
+        this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
         this.identifierQuote = clickHouseClient.getIdentifierQuote();
         this.clickhouseQueryGenerator = clickhouseQueryGenerator;
+        this.determinismEvaluator = rowExpressionService.getDeterminismEvaluator();
     }
 
     @Override
@@ -68,7 +67,7 @@ public class ClickHousePlanOptimizerProvider
                 functionManager,
                 functionResolution,
                 determinismEvaluator,
-                expressionOptimizer,
+                rowExpressionService,
                 identifierQuote,
                 getFunctionTranslators(),
                 clickhouseQueryGenerator));

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/MetadataUtils.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/MetadataUtils.java
@@ -85,7 +85,7 @@ public final class MetadataUtils
             StandardFunctionResolution functionResolution,
             RowExpressionService rowExpressionService)
     {
-        SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session);
+        SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(session), session);
 
         return rowExpressionService.getDomainTranslator().toPredicate(
                 layoutHandle.getDomainPredicate()

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
@@ -217,7 +217,7 @@ public abstract class BaseSubfieldExtractionRewriter
         ExtractionResult<Subfield> decomposedFilter = rowExpressionService.getDomainTranslator()
                 .fromPredicate(session, filter, new SubfieldExtractor(
                         functionResolution,
-                        rowExpressionService.getExpressionOptimizer(),
+                        rowExpressionService.getExpressionOptimizer(session),
                         session).toColumnExtractor());
 
         if (currentLayoutHandle.isPresent()) {
@@ -231,7 +231,7 @@ public abstract class BaseSubfieldExtractionRewriter
             return new ConnectorPushdownFilterResult(EMPTY_TABLE_LAYOUT, FALSE_CONSTANT);
         }
 
-        RowExpression optimizedRemainingExpression = rowExpressionService.getExpressionOptimizer()
+        RowExpression optimizedRemainingExpression = rowExpressionService.getExpressionOptimizer(session)
                 .optimize(decomposedFilter.getRemainingExpression(), OPTIMIZED, session);
         if (optimizedRemainingExpression instanceof ConstantExpression) {
             ConstantExpression constantExpression = (ConstantExpression) optimizedRemainingExpression;
@@ -439,7 +439,7 @@ public abstract class BaseSubfieldExtractionRewriter
             // spurious query failures for partitions that would otherwise be filtered out.
             RowExpression optimized;
             try {
-                optimized = evaluator.getExpressionOptimizer().optimize(expression, OPTIMIZED, session, variableResolver);
+                optimized = evaluator.getExpressionOptimizer(session).optimize(expression, OPTIMIZED, session, variableResolver);
             }
             catch (PrestoException e) {
                 propagateIfUnhandled(e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/FilteringPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/FilteringPageSource.java
@@ -118,7 +118,7 @@ public class FilteringPageSource
                         columnHandle -> new VariableReferenceExpression(Optional.empty(), columnHandle.getName(), columnHandle.getHiveType().getType(typeManager)),
                         columnHandle -> new InputReferenceExpression(Optional.empty(), columnHandle.getHiveColumnIndex(), columnHandle.getHiveType().getType(typeManager))));
 
-        RowExpression optimizedRemainingPredicate = rowExpressionService.getExpressionOptimizer().optimize(remainingPredicate, OPTIMIZED, session);
+        RowExpression optimizedRemainingPredicate = rowExpressionService.getExpressionOptimizer(session).optimize(remainingPredicate, OPTIMIZED, session);
         if (TRUE_CONSTANT.equals(optimizedRemainingPredicate)) {
             this.filterFunction = null;
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -888,7 +888,7 @@ public class HiveMetadata
                 .transform(subfield -> isEntireColumn(subfield) ? subfield.getRootName() : null)
                 .transform(allColumns::get)));
 
-        SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session);
+        SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(session), session);
 
         RowExpression domainPredicate = rowExpressionService.getDomainTranslator().toPredicate(
                 hiveLayoutHandle.getDomainPredicate()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -129,7 +129,7 @@ public class HivePageSourceProvider
         this.optimizedRowExpressionCache = CacheBuilder.newBuilder()
                 .recordStats()
                 .maximumSize(10_000)
-                .build(CacheLoader.from(cacheKey -> rowExpressionService.getExpressionOptimizer().optimize(cacheKey.rowExpression, OPTIMIZED, cacheKey.session)));
+                .build(CacheLoader.from(cacheKey -> rowExpressionService.getExpressionOptimizer(cacheKey.session).optimize(cacheKey.rowExpression, OPTIMIZED, cacheKey.session)));
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -425,7 +425,7 @@ public class OrcSelectivePageSourceFactory
                 .forEach(column -> outputSubfields.put(column.getHiveColumnIndex(), new HashSet<>(column.getRequiredSubfields())));
 
         Map<Integer, Set<Subfield>> predicateSubfields = new HashMap<>();
-        SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session);
+        SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(session), session);
         remainingPredicate.accept(
                 new RequiredSubfieldsExtractor(subfieldExtractor),
                 subfield -> predicateSubfields.computeIfAbsent(columnIndices.get(subfield.getRootName()), v -> new HashSet<>()).add(subfield));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -524,7 +524,7 @@ public abstract class AbstractTestHiveClient
                             }).collect(toList()))
                     .build();
 
-    private static final SubfieldExtractor SUBFIELD_EXTRACTOR = new SubfieldExtractor(FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE.getExpressionOptimizer(), SESSION);
+    private static final SubfieldExtractor SUBFIELD_EXTRACTOR = new SubfieldExtractor(FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE.getExpressionOptimizer(SESSION), SESSION);
 
     private static final TypeProvider TYPE_PROVIDER_AFTER = TypeProvider.copyOf(MISMATCH_SCHEMA_TABLE_AFTER.stream()
             .collect(toImmutableMap(ColumnMetadata::getName, ColumnMetadata::getType)));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -126,7 +126,7 @@ public final class HiveTestUtils
         }
 
         @Override
-        public ExpressionOptimizer getExpressionOptimizer()
+        public ExpressionOptimizer getExpressionOptimizer(ConnectorSession session)
         {
             return new RowExpressionOptimizer(METADATA);
         }
@@ -151,7 +151,7 @@ public final class HiveTestUtils
     };
 
     public static final FilterStatsCalculatorService FILTER_STATS_CALCULATOR_SERVICE = new ConnectorFilterStatsCalculatorService(
-            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA), new StatsNormalizer()));
+            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, ROW_EXPRESSION_SERVICE), new StatsNormalizer()));
 
     public static final HiveClientConfig HIVE_CLIENT_CONFIG = new HiveClientConfig();
     public static final MetastoreClientConfig METASTORE_CLIENT_CONFIG = new MetastoreClientConfig();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergMetadataOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergMetadataOptimizer.java
@@ -356,7 +356,7 @@ public class IcebergMetadataOptimizer
                         throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "unsupported function: " + scalarFunctionName);
                     }
 
-                    RowExpression reducedValue = rowExpressionService.getExpressionOptimizer().optimize(
+                    RowExpression reducedValue = rowExpressionService.getExpressionOptimizer(connectorSession).optimize(
                             new CallExpression(
                                     Optional.empty(),
                                     scalarFunctionName,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
@@ -154,7 +154,7 @@ public class IcebergPlanOptimizer
 
             //TODO we should optimize the filter expression
             DomainTranslator.ExtractionResult<Subfield> decomposedFilter = rowExpressionService.getDomainTranslator()
-                    .fromPredicate(session, filterPredicate, new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session).toColumnExtractor());
+                    .fromPredicate(session, filterPredicate, new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(session), session).toColumnExtractor());
 
             // Only pushdown the range filters which apply to entire columns, because iceberg does not accept the filters on the subfields in nested structures
             TupleDomain<IcebergColumnHandle> entireColumnDomain = decomposedFilter.getTupleDomain()
@@ -167,7 +167,7 @@ public class IcebergPlanOptimizer
             Table icebergTable = getIcebergTable(metadata, session, tableHandle.getSchemaTableName());
 
             // Get predicate expression on subfield
-            SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session);
+            SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(session), session);
             Map<String, Type> columnTypes = nameToColumnHandlesMapping.entrySet().stream()
                     .collect(toImmutableMap(entry -> entry.getKey(), entry -> entry.getValue().getType()));
             TupleDomain<RowExpression> subfieldTupleDomain = decomposedFilter.getTupleDomain()

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -327,6 +327,7 @@ public final class SystemSessionProperties
     public static final String INLINE_PROJECTIONS_ON_VALUES = "inline_projections_on_values";
     public static final String INCLUDE_VALUES_NODE_IN_CONNECTOR_OPTIMIZER = "include_values_node_in_connector_optimizer";
     public static final String SINGLE_NODE_EXECUTION_ENABLED = "single_node_execution_enabled";
+    public static final String EXPRESSION_OPTIMIZER_NAME = "expression_optimizer_name";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -1852,7 +1853,12 @@ public final class SystemSessionProperties
                 booleanProperty(NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED,
                         "Enable automatic scaling of writer threads",
                         featuresConfig.isNativeExecutionScaleWritersThreadsEnabled(),
-                        !featuresConfig.isNativeExecutionEnabled()));
+                        !featuresConfig.isNativeExecutionEnabled()),
+                stringProperty(
+                        EXPRESSION_OPTIMIZER_NAME,
+                        "Configure which expression optimizer to use",
+                        featuresConfig.getExpressionOptimizerName(),
+                        false));
     }
 
     public static boolean isSpoolingOutputBufferEnabled(Session session)
@@ -3152,5 +3158,10 @@ public final class SystemSessionProperties
     public static boolean isNativeExecutionScaleWritersThreadsEnabled(Session session)
     {
         return session.getSystemProperty(NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED, Boolean.class);
+    }
+
+    public static String getExpressionOptimizerName(Session session)
+    {
+        return session.getSystemProperty(EXPRESSION_OPTIMIZER_NAME, String.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -62,12 +62,12 @@ import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.RecordPageSourceProvider;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.planPrinter.RowExpressionFormatter;
 import com.facebook.presto.sql.relational.ConnectorRowExpressionService;
 import com.facebook.presto.sql.relational.FunctionResolution;
-import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -116,6 +116,7 @@ public class ConnectorManager
     private final PageIndexerFactory pageIndexerFactory;
     private final NodeInfo nodeInfo;
     private final TransactionManager transactionManager;
+    private final ExpressionOptimizerManager expressionOptimizerManager;
     private final DomainTranslator domainTranslator;
     private final PredicateCompiler predicateCompiler;
     private final DeterminismEvaluator determinismEvaluator;
@@ -151,6 +152,7 @@ public class ConnectorManager
             PageSorter pageSorter,
             PageIndexerFactory pageIndexerFactory,
             TransactionManager transactionManager,
+            ExpressionOptimizerManager expressionOptimizerManager,
             DomainTranslator domainTranslator,
             PredicateCompiler predicateCompiler,
             DeterminismEvaluator determinismEvaluator,
@@ -176,6 +178,7 @@ public class ConnectorManager
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.nodeInfo = requireNonNull(nodeInfo, "nodeInfo is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
         this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
         this.predicateCompiler = requireNonNull(predicateCompiler, "predicateCompiler is null");
         this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
@@ -382,7 +385,7 @@ public class ConnectorManager
                 pageIndexerFactory,
                 new ConnectorRowExpressionService(
                         domainTranslator,
-                        new RowExpressionOptimizer(metadataManager),
+                        expressionOptimizerManager,
                         predicateCompiler,
                         determinismEvaluator,
                         new RowExpressionFormatter(metadataManager.getFunctionAndTypeManager())),

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -47,6 +47,7 @@ import com.facebook.presto.spi.security.PrestoAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.session.WorkerSessionPropertyProviderFactory;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.spi.storage.TempStorageFactory;
 import com.facebook.presto.spi.tracing.TracerProvider;
@@ -54,6 +55,7 @@ import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
 import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
 import com.facebook.presto.sql.analyzer.AnalyzerProviderManager;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.tracing.TracerProviderManager;
@@ -141,6 +143,7 @@ public class PluginManager
     private final NodeStatusNotificationManager nodeStatusNotificationManager;
     private final ClientRequestFilterManager clientRequestFilterManager;
     private final PlanCheckerProviderManager planCheckerProviderManager;
+    private final ExpressionOptimizerManager expressionOptimizerManager;
 
     @Inject
     public PluginManager(
@@ -165,7 +168,8 @@ public class PluginManager
             TracerProviderManager tracerProviderManager,
             NodeStatusNotificationManager nodeStatusNotificationManager,
             ClientRequestFilterManager clientRequestFilterManager,
-            PlanCheckerProviderManager planCheckerProviderManager)
+            PlanCheckerProviderManager planCheckerProviderManager,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
@@ -200,6 +204,7 @@ public class PluginManager
         this.nodeStatusNotificationManager = requireNonNull(nodeStatusNotificationManager, "nodeStatusNotificationManager is null");
         this.clientRequestFilterManager = requireNonNull(clientRequestFilterManager, "clientRequestFilterManager is null");
         this.planCheckerProviderManager = requireNonNull(planCheckerProviderManager, "planCheckerProviderManager is null");
+        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionManager is null");
     }
 
     public void loadPlugins()
@@ -391,6 +396,11 @@ public class PluginManager
         for (PlanCheckerProviderFactory planCheckerProviderFactory : plugin.getPlanCheckerProviderFactories()) {
             log.info("Registering plan checker provider factory %s", planCheckerProviderFactory.getName());
             planCheckerProviderManager.addPlanCheckerProviderFactory(planCheckerProviderFactory);
+        }
+
+        for (ExpressionOptimizerFactory expressionOptimizerFactory : plugin.getExpressionOptimizerFactories()) {
+            log.info("Registering expression optimizer factory %s", expressionOptimizerFactory.getName());
+            expressionOptimizerManager.addExpressionOptimizerFactory(expressionOptimizerFactory);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -54,6 +54,7 @@ import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.server.security.PrestoAuthenticatorManager;
 import com.facebook.presto.server.security.ServerSecurityModule;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.storage.TempStorageManager;
@@ -196,6 +197,8 @@ public class PrestoServer
             planCheckerProviderManager.loadPlanCheckerProviders(pluginNodeManager);
 
             injector.getInstance(ClientRequestFilterManager.class).loadClientRequestFilters();
+            injector.getInstance(ExpressionOptimizerManager.class).loadExpressionOptimizerFactories();
+
             startAssociatedProcesses(injector);
 
             injector.getInstance(Announcer.class).start();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -194,6 +194,7 @@ import com.facebook.presto.sql.analyzer.MetadataExtractor;
 import com.facebook.presto.sql.analyzer.MetadataExtractorMBean;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -358,6 +359,9 @@ public class ServerMainModule
         binder.bind(SessionPropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(SystemSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(SessionPropertyDefaults.class).in(Scopes.SINGLETON);
+
+        // expression manager
+        binder.bind(ExpressionOptimizerManager.class).in(Scopes.SINGLETON);
 
         // schema properties
         binder.bind(SchemaPropertyManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -74,6 +74,7 @@ import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
@@ -171,6 +172,7 @@ public class TestingPrestoServer
     private final TaskManager taskManager;
     private final GracefulShutdownHandler gracefulShutdownHandler;
     private final ShutdownAction shutdownAction;
+    private final ExpressionOptimizerManager expressionManager;
     private final RequestBlocker requestBlocker;
     private final boolean resourceManager;
     private final boolean catalogServer;
@@ -373,6 +375,7 @@ public class TestingPrestoServer
         procedureTester = injector.getInstance(ProcedureTester.class);
         splitManager = injector.getInstance(SplitManager.class);
         pageSourceManager = injector.getInstance(PageSourceManager.class);
+        expressionManager = injector.getInstance(ExpressionOptimizerManager.class);
         if (coordinator) {
             dispatchManager = injector.getInstance(DispatchManager.class);
             queryManager = injector.getInstance(QueryManager.class);
@@ -390,6 +393,7 @@ public class TestingPrestoServer
             eventListenerManager = ((TestingEventListenerManager) injector.getInstance(EventListenerManager.class));
             clusterStateProvider = null;
             planCheckerProviderManager = injector.getInstance(PlanCheckerProviderManager.class);
+            expressionManager.loadExpressionOptimizerFactories();
         }
         else if (resourceManager) {
             dispatchManager = null;
@@ -708,6 +712,11 @@ public class TestingPrestoServer
     public ShutdownAction getShutdownAction()
     {
         return shutdownAction;
+    }
+
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        return expressionManager;
     }
 
     public boolean isCoordinator()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -40,6 +40,7 @@ import java.util.List;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy.LEGACY;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy.NONE;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrategy.ORDER_BY_CREATE_TIME;
+import static com.facebook.presto.sql.expressions.ExpressionOptimizerManager.DEFAULT_EXPRESSION_OPTIMIZER_NAME;
 import static com.facebook.presto.sql.tree.CreateView.Security.DEFINER;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
@@ -293,6 +294,7 @@ public class FeaturesConfig
     private boolean prestoSparkExecutionEnvironment;
     private boolean singleNodeExecutionEnabled;
     private boolean nativeExecutionScaleWritersThreadsEnabled;
+    private String expressionOptimizerName = DEFAULT_EXPRESSION_OPTIMIZER_NAME;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -2913,6 +2915,19 @@ public class FeaturesConfig
     public FeaturesConfig setNativeExecutionScaleWritersThreadsEnabled(boolean nativeExecutionScaleWritersThreadsEnabled)
     {
         this.nativeExecutionScaleWritersThreadsEnabled = nativeExecutionScaleWritersThreadsEnabled;
+        return this;
+    }
+
+    public String getExpressionOptimizerName()
+    {
+        return expressionOptimizerName;
+    }
+
+    @Config("expression-optimizer-name")
+    @ConfigDescription("Set the expression optimizer name for parsing and analyzing.")
+    public FeaturesConfig setExpressionOptimizerName(String expressionOptimizerName)
+    {
+        this.expressionOptimizerName = expressionOptimizerName;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.expressions;
+
+import com.facebook.presto.FullConnectorSession;
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.nodeManager.PluginNodeManager;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerContext;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.presto.SystemSessionProperties.getExpressionOptimizerName;
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.io.Files.getNameWithoutExtension;
+import static java.util.Objects.requireNonNull;
+
+public class ExpressionOptimizerManager
+{
+    public static final String DEFAULT_EXPRESSION_OPTIMIZER_NAME = "default";
+    private static final File EXPRESSION_MANAGER_CONFIGURATION_DIRECTORY = new File("etc/expression-manager/");
+    private static final String EXPRESSION_MANAGER_FACTORY_NAME = "expression-manager-factory.name";
+
+    private final NodeManager nodeManager;
+    private final FunctionAndTypeManager functionAndTypeManager;
+    private final FunctionResolution functionResolution;
+    private final File configurationDirectory;
+
+    private final Map<String, ExpressionOptimizerFactory> expressionOptimizerFactories = new ConcurrentHashMap<>();
+    private final Map<String, ExpressionOptimizer> expressionOptimizers = new ConcurrentHashMap<>();
+
+    @Inject
+    public ExpressionOptimizerManager(PluginNodeManager nodeManager, FunctionAndTypeManager functionAndTypeManager)
+    {
+        this(nodeManager, functionAndTypeManager, EXPRESSION_MANAGER_CONFIGURATION_DIRECTORY);
+    }
+
+    public ExpressionOptimizerManager(PluginNodeManager nodeManager, FunctionAndTypeManager functionAndTypeManager, File configurationDirectory)
+    {
+        requireNonNull(nodeManager, "nodeManager is null");
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+        this.configurationDirectory = requireNonNull(configurationDirectory, "configurationDirectory is null");
+        expressionOptimizers.put(DEFAULT_EXPRESSION_OPTIMIZER_NAME, new RowExpressionOptimizer(functionAndTypeManager));
+    }
+
+    public void loadExpressionOptimizerFactories()
+    {
+        try {
+            for (File file : listFiles(configurationDirectory)) {
+                if (file.isFile() && file.getName().endsWith(".properties")) {
+                    loadExpressionOptimizerFactory(file);
+                }
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to load expression manager configuration", e);
+        }
+    }
+
+    private void loadExpressionOptimizerFactory(File configurationFile)
+            throws IOException
+    {
+        String name = getNameWithoutExtension(configurationFile.getName());
+        checkArgument(!isNullOrEmpty(name), "File name is empty, full path: %s", configurationFile.getAbsolutePath());
+        checkArgument(!name.equals(DEFAULT_EXPRESSION_OPTIMIZER_NAME), "Cannot name an expression optimizer instance %s", DEFAULT_EXPRESSION_OPTIMIZER_NAME);
+
+        Map<String, String> properties = new HashMap<>(loadProperties(configurationFile));
+        String factoryName = properties.remove(EXPRESSION_MANAGER_FACTORY_NAME);
+        checkArgument(!isNullOrEmpty(factoryName), "%s does not contain %s", configurationFile, EXPRESSION_MANAGER_FACTORY_NAME);
+        checkArgument(expressionOptimizerFactories.containsKey(factoryName),
+                "ExpressionOptimizerFactory %s is not registered, registered factories: ", factoryName, expressionOptimizerFactories.keySet());
+
+        ExpressionOptimizer optimizer = expressionOptimizerFactories.get(factoryName).createOptimizer(
+                properties,
+                new ExpressionOptimizerContext(nodeManager, functionAndTypeManager, functionResolution));
+        expressionOptimizers.put(name, optimizer);
+    }
+
+    public void addExpressionOptimizerFactory(ExpressionOptimizerFactory expressionOptimizerFactory)
+    {
+        String name = expressionOptimizerFactory.getName();
+        checkArgument(
+                expressionOptimizerFactories.putIfAbsent(name, expressionOptimizerFactory) == null,
+                "ExpressionOptimizerFactory %s is already registered", name);
+    }
+
+    public ExpressionOptimizer getExpressionOptimizer(ConnectorSession connectorSession)
+    {
+        // TODO: Remove this check once we have a more appropriate abstraction for session properties retrieved from plugins
+        checkArgument(connectorSession instanceof FullConnectorSession, "connectorSession is not an instance of FullConnectorSession");
+        Session session = ((FullConnectorSession) connectorSession).getSession();
+        String expressionOptimizerName = getExpressionOptimizerName(session);
+        checkArgument(expressionOptimizers.containsKey(expressionOptimizerName), "ExpressionOptimizer '%s' is not registered", expressionOptimizerName);
+        return expressionOptimizers.get(expressionOptimizerName);
+    }
+
+    private static List<File> listFiles(File directory)
+    {
+        if (directory.isDirectory()) {
+            File[] files = directory.listFiles();
+            if (files != null) {
+                return ImmutableList.copyOf(files);
+            }
+        }
+        return ImmutableList.of();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
@@ -20,6 +20,7 @@ import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.sql.planner.ExpressionOptimizerContext;
 import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
 import com.facebook.presto.sql.relational.FunctionResolution;
@@ -44,6 +45,7 @@ import static com.google.common.io.Files.getNameWithoutExtension;
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionOptimizerManager
+        implements ExpressionOptimizerProvider
 {
     public static final String DEFAULT_EXPRESSION_OPTIMIZER_NAME = "default";
     private static final File EXPRESSION_MANAGER_CONFIGURATION_DIRECTORY = new File("etc/expression-manager/");
@@ -114,6 +116,7 @@ public class ExpressionOptimizerManager
                 "ExpressionOptimizerFactory %s is already registered", name);
     }
 
+    @Override
     public ExpressionOptimizer getExpressionOptimizer(ConnectorSession connectorSession)
     {
         // TODO: Remove this check once we have a more appropriate abstraction for session properties retrieved from plugins

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -350,7 +350,7 @@ public class PlanOptimizers
                 estimatedExchangesCostCalculator,
                 new RewriteConstantArrayContainsToInExpression(metadata.getFunctionAndTypeManager()).rules());
 
-        PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser, featuresConfig.isNativeExecutionEnabled()));
+        PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser, expressionOptimizerManager, featuresConfig.isNativeExecutionEnabled()));
         PlanOptimizer prefilterForLimitingAggregation = new StatsRecordingPlanOptimizer(optimizerStats, new PrefilterForLimitingAggregation(metadata, statsCalculator));
 
         builder.add(
@@ -731,7 +731,7 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(new RemoveRedundantIdentityProjections(), new PruneRedundantProjectionAssignments())),
-                new PushdownSubfields(metadata));
+                new PushdownSubfields(metadata, expressionOptimizerManager));
 
         builder.add(predicatePushDown); // Run predicate push down one more time in case we can leverage new information from layouts' effective predicate
         builder.add(simplifyRowExpressionOptimizer); // Should be always run after PredicatePushDown

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
@@ -13,20 +13,20 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
-import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.google.common.annotations.VisibleForTesting;
 
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.SERIALIZABLE;
@@ -39,44 +39,44 @@ import static java.util.Objects.requireNonNull;
 public class SimplifyRowExpressions
         extends RowExpressionRewriteRuleSet
 {
-    public SimplifyRowExpressions(Metadata metadata)
+    public SimplifyRowExpressions(Metadata metadata, ExpressionOptimizerManager expressionOptimizerManager)
     {
-        super(new Rewriter(metadata));
+        super(new Rewriter(metadata, expressionOptimizerManager));
     }
 
     private static class Rewriter
             implements PlanRowExpressionRewriter
     {
-        private final RowExpressionOptimizer optimizer;
+        private final ExpressionOptimizerManager expressionOptimizerManager;
         private final LogicalExpressionRewriter logicalExpressionRewriter;
 
-        public Rewriter(Metadata metadata)
+        public Rewriter(Metadata metadata, ExpressionOptimizerManager expressionOptimizerManager)
         {
             requireNonNull(metadata, "metadata is null");
-            this.optimizer = new RowExpressionOptimizer(metadata);
+            requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
+            this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
             this.logicalExpressionRewriter = new LogicalExpressionRewriter(metadata.getFunctionAndTypeManager());
         }
 
         @Override
         public RowExpression rewrite(RowExpression expression, Rule.Context context)
         {
-            return rewrite(expression, context.getSession().toConnectorSession());
+            return rewrite(expression, context.getSession());
         }
 
-        private RowExpression rewrite(RowExpression expression, ConnectorSession session)
+        private RowExpression rewrite(RowExpression expression, Session session)
         {
             // Rewrite RowExpression first to reduce depth of RowExpression tree by balancing AND/OR predicates.
             // It doesn't matter whether we rewrite/optimize first because this will be called by IterativeOptimizer.
             RowExpression rewritten = RowExpressionTreeRewriter.rewriteWith(logicalExpressionRewriter, expression, true);
-            RowExpression optimizedRowExpression = optimizer.optimize(rewritten, SERIALIZABLE, session);
-            return optimizedRowExpression;
+            return expressionOptimizerManager.getExpressionOptimizer(session.toConnectorSession()).optimize(rewritten, SERIALIZABLE, session.toConnectorSession());
         }
     }
 
     @VisibleForTesting
-    public static RowExpression rewrite(RowExpression expression, Metadata metadata, ConnectorSession session)
+    public static RowExpression rewrite(RowExpression expression, Metadata metadata, Session session, ExpressionOptimizerManager expressionOptimizerManager)
     {
-        return new Rewriter(metadata).rewrite(expression, session);
+        return new Rewriter(metadata, expressionOptimizerManager).rewrite(expression, session);
     }
 
     private static class LogicalExpressionRewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.PlannerUtils;
 import com.facebook.presto.sql.planner.RowExpressionVariableInliner;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
@@ -87,10 +88,12 @@ public class CteProjectionAndPredicatePushDown
         implements PlanOptimizer
 {
     private final Metadata metadata;
+    private final ExpressionOptimizerManager expressionOptimizerManager;
 
-    public CteProjectionAndPredicatePushDown(Metadata metadata)
+    public CteProjectionAndPredicatePushDown(Metadata metadata, ExpressionOptimizerManager expressionOptimizerManager)
     {
-        this.metadata = metadata;
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
     }
 
     @Override
@@ -383,7 +386,7 @@ public class CteProjectionAndPredicatePushDown
                             resultPredicate, predicates.get(i));
                 }
             }
-            resultPredicate = SimplifyRowExpressions.rewrite(resultPredicate, metadata, session.toConnectorSession());
+            resultPredicate = SimplifyRowExpressions.rewrite(resultPredicate, metadata, session, expressionOptimizerManager);
             return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), node, resultPredicate);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -45,6 +45,7 @@ import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -65,7 +66,6 @@ import com.facebook.presto.sql.relational.Expressions;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
-import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
@@ -132,13 +132,15 @@ public class PredicatePushDown
     private final SqlParser sqlParser;
     private final RowExpressionDomainTranslator rowExpressionDomainTranslator;
     private final boolean nativeExecution;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
-    public PredicatePushDown(Metadata metadata, SqlParser sqlParser, boolean nativeExecution)
+    public PredicatePushDown(Metadata metadata, SqlParser sqlParser, ExpressionOptimizerProvider expressionOptimizerProvider, boolean nativeExecution)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         rowExpressionDomainTranslator = new RowExpressionDomainTranslator(metadata);
         this.effectivePredicateExtractor = new EffectivePredicateExtractor(rowExpressionDomainTranslator, metadata.getFunctionAndTypeManager());
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         this.nativeExecution = nativeExecution;
     }
 
@@ -150,7 +152,7 @@ public class PredicatePushDown
         requireNonNull(types, "types is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        Rewriter rewriter = new Rewriter(variableAllocator, idAllocator, metadata, effectivePredicateExtractor, rowExpressionDomainTranslator, sqlParser, session, nativeExecution);
+        Rewriter rewriter = new Rewriter(variableAllocator, idAllocator, metadata, effectivePredicateExtractor, rowExpressionDomainTranslator, expressionOptimizerProvider, sqlParser, session, nativeExecution);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, TRUE_CONSTANT);
         return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
@@ -184,6 +186,7 @@ public class PredicatePushDown
         private final Metadata metadata;
         private final EffectivePredicateExtractor effectivePredicateExtractor;
         private final RowExpressionDomainTranslator rowExpressionDomainTranslator;
+        private final ExpressionOptimizerProvider expressionOptimizerProvider;
         private final Session session;
         private final boolean nativeExecution;
         private final ExpressionEquivalence expressionEquivalence;
@@ -199,6 +202,7 @@ public class PredicatePushDown
                 Metadata metadata,
                 EffectivePredicateExtractor effectivePredicateExtractor,
                 RowExpressionDomainTranslator rowExpressionDomainTranslator,
+                ExpressionOptimizerProvider expressionOptimizerProvider,
                 SqlParser sqlParser,
                 Session session,
                 boolean nativeExecution)
@@ -208,6 +212,7 @@ public class PredicatePushDown
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.effectivePredicateExtractor = requireNonNull(effectivePredicateExtractor, "effectivePredicateExtractor is null");
             this.rowExpressionDomainTranslator = rowExpressionDomainTranslator;
+            this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
             this.session = requireNonNull(session, "session is null");
             this.nativeExecution = nativeExecution;
             this.expressionEquivalence = new ExpressionEquivalence(metadata, sqlParser);
@@ -1159,7 +1164,8 @@ public class PredicatePushDown
             }
         }
 
-        private InnerJoinPushDownResult processInnerJoin(RowExpression inheritedPredicate,
+        private InnerJoinPushDownResult processInnerJoin(
+                RowExpression inheritedPredicate,
                 RowExpression leftEffectivePredicate,
                 RowExpression rightEffectivePredicate,
                 RowExpression joinPredicate,
@@ -1283,6 +1289,7 @@ public class PredicatePushDown
             joinConjuncts.addAll(allInference.generateEqualitiesPartitionedBy(in(leftVariables)::apply).getScopeStraddlingEqualities()); // scope straddling equalities get dropped in as part of the join predicate
 
             return new Rewriter.InnerJoinPushDownResult(
+                    expressionOptimizerProvider,
                     logicalRowExpressions.combineConjuncts(leftPushDownConjuncts.build()),
                     logicalRowExpressions.combineConjuncts(rightPushDownConjuncts.build()),
                     logicalRowExpressions.combineConjuncts(joinConjuncts.build()), TRUE_CONSTANT);
@@ -1294,13 +1301,20 @@ public class PredicatePushDown
             private final RowExpression rightPredicate;
             private final RowExpression joinPredicate;
             private final RowExpression postJoinPredicate;
+            private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
-            private InnerJoinPushDownResult(RowExpression leftPredicate, RowExpression rightPredicate, RowExpression joinPredicate, RowExpression postJoinPredicate)
+            private InnerJoinPushDownResult(
+                    ExpressionOptimizerProvider expressionOptimizerProvider,
+                    RowExpression leftPredicate,
+                    RowExpression rightPredicate,
+                    RowExpression joinPredicate,
+                    RowExpression postJoinPredicate)
             {
-                this.leftPredicate = leftPredicate;
-                this.rightPredicate = rightPredicate;
-                this.joinPredicate = joinPredicate;
-                this.postJoinPredicate = postJoinPredicate;
+                this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
+                this.leftPredicate = requireNonNull(leftPredicate, "leftPredicate is null");
+                this.rightPredicate = requireNonNull(rightPredicate, "rightPredicate is null");
+                this.joinPredicate = requireNonNull(joinPredicate, "joinPredicate is null");
+                this.postJoinPredicate = requireNonNull(postJoinPredicate, "postJoinPredicate is null");
             }
 
             private RowExpression getLeftPredicate()
@@ -1425,7 +1439,7 @@ public class PredicatePushDown
         // Temporary implementation for joins because the SimplifyExpressions optimizers can not run properly on join clauses
         private RowExpression simplifyExpression(RowExpression expression)
         {
-            return new RowExpressionOptimizer(metadata).optimize(expression, ExpressionOptimizer.Level.SERIALIZABLE, session.toConnectorSession());
+            return expressionOptimizerProvider.getExpressionOptimizer(session.toConnectorSession()).optimize(expression, ExpressionOptimizer.Level.SERIALIZABLE, session.toConnectorSession());
         }
 
         private boolean areExpressionsEquivalent(RowExpression leftExpression, RowExpression rightExpression)
@@ -1440,7 +1454,7 @@ public class PredicatePushDown
         {
             expression = RowExpressionNodeInliner.replaceExpression(expression, nullSymbols.stream()
                     .collect(Collectors.toMap(identity(), variable -> constantNull(variable.getSourceLocation(), variable.getType()))));
-            return new RowExpressionOptimizer(metadata).optimize(expression, ExpressionOptimizer.Level.OPTIMIZED, session.toConnectorSession());
+            return expressionOptimizerProvider.getExpressionOptimizer(session.toConnectorSession()).optimize(expression, ExpressionOptimizer.Level.OPTIMIZED, session.toConnectorSession());
         }
 
         private Predicate<RowExpression> joinEqualityExpression(final Collection<VariableReferenceExpression> leftVariables)

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/ConnectorRowExpressionService.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/ConnectorRowExpressionService.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.PredicateCompiler;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
@@ -28,20 +29,20 @@ public final class ConnectorRowExpressionService
         implements RowExpressionService
 {
     private final DomainTranslator domainTranslator;
-    private final ExpressionOptimizer expressionOptimizer;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
     private final PredicateCompiler predicateCompiler;
     private final DeterminismEvaluator determinismEvaluator;
     private final RowExpressionFormatter rowExpressionFormatter;
 
     public ConnectorRowExpressionService(
             DomainTranslator domainTranslator,
-            ExpressionOptimizer expressionOptimizer,
+            ExpressionOptimizerProvider expressionOptimizerProvider,
             PredicateCompiler predicateCompiler,
             DeterminismEvaluator determinismEvaluator,
             RowExpressionFormatter rowExpressionFormatter)
     {
         this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
-        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         this.predicateCompiler = requireNonNull(predicateCompiler, "predicateCompiler is null");
         this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
         this.rowExpressionFormatter = requireNonNull(rowExpressionFormatter, "rowExpressionFormatter is null");
@@ -54,9 +55,9 @@ public final class ConnectorRowExpressionService
     }
 
     @Override
-    public ExpressionOptimizer getExpressionOptimizer()
+    public ExpressionOptimizer getExpressionOptimizer(ConnectorSession session)
     {
-        return expressionOptimizer;
+        return expressionOptimizerProvider.getExpressionOptimizer(session);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.relational;
 
+import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
@@ -29,18 +30,23 @@ import static java.util.Objects.requireNonNull;
 public final class RowExpressionOptimizer
         implements ExpressionOptimizer
 {
-    private final Metadata metadata;
+    private final FunctionAndTypeManager functionAndTypeManager;
 
     public RowExpressionOptimizer(Metadata metadata)
     {
-        this.metadata = requireNonNull(metadata, "metadata is null");
+        this(requireNonNull(metadata, "metadata is null").getFunctionAndTypeManager());
+    }
+
+    public RowExpressionOptimizer(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionMetadataManager is null");
     }
 
     @Override
     public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
     {
         if (level.ordinal() <= OPTIMIZED.ordinal()) {
-            return toRowExpression(rowExpression.getSourceLocation(), new RowExpressionInterpreter(rowExpression, metadata.getFunctionAndTypeManager(), session, level).optimize(), rowExpression.getType());
+            return toRowExpression(rowExpression.getSourceLocation(), new RowExpressionInterpreter(rowExpression, functionAndTypeManager, session, level).optimize(), rowExpression.getType());
         }
         throw new IllegalArgumentException("Not supported optimization level: " + level);
     }
@@ -48,7 +54,7 @@ public final class RowExpressionOptimizer
     @Override
     public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
     {
-        RowExpressionInterpreter interpreter = new RowExpressionInterpreter(expression, metadata.getFunctionAndTypeManager(), session, level);
+        RowExpressionInterpreter interpreter = new RowExpressionInterpreter(expression, functionAndTypeManager, session, level);
         return toRowExpression(expression.getSourceLocation(), interpreter.optimize(variableResolver::apply), expression.getType());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -463,7 +463,7 @@ public class LocalQueryRunner
         expressionOptimizerManager = new ExpressionOptimizerManager(new PluginNodeManager(nodeManager, nodeInfo.getEnvironment()), getFunctionAndTypeManager());
 
         this.statsNormalizer = new StatsNormalizer();
-        this.scalarStatsCalculator = new ScalarStatsCalculator(metadata);
+        this.scalarStatsCalculator = new ScalarStatsCalculator(metadata, expressionOptimizerManager);
         this.filterStatsCalculator = new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer);
         this.historyBasedPlanStatisticsManager = new HistoryBasedPlanStatisticsManager(objectMapper, createTestingSessionPropertyManager(), metadata, new HistoryBasedOptimizationConfig(), featuresConfig, new NodeVersion("1"));
         this.fragmentStatsProvider = new FragmentStatsProvider();
@@ -498,6 +498,7 @@ public class LocalQueryRunner
                 pageSorter,
                 pageIndexerFactory,
                 transactionManager,
+                expressionOptimizerManager,
                 new RowExpressionDomainTranslator(metadata),
                 new RowExpressionPredicateCompiler(metadata),
                 new RowExpressionDeterminismEvaluator(metadata.getFunctionAndTypeManager()),

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.Plan;
@@ -62,6 +63,8 @@ public interface QueryRunner
     Optional<EventListener> getEventListener();
 
     TestingAccessControlManager getAccessControl();
+
+    ExpressionOptimizerManager getExpressionManager();
 
     MaterializedResult execute(@Language("SQL") String sql);
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.PredicateCompiler;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
@@ -66,7 +67,8 @@ public class TestingConnectorContext
     private final DomainTranslator domainTranslator = new RowExpressionDomainTranslator(metadata);
     private final PredicateCompiler predicateCompiler = new RowExpressionPredicateCompiler(metadata);
     private final DeterminismEvaluator determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
-    private final FilterStatsCalculatorService filterStatsCalculatorService = new ConnectorFilterStatsCalculatorService(new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer()));
+    private final ExpressionOptimizerProvider expressionOptimizerProvider = (ConnectorSession session) -> new RowExpressionOptimizer(metadata);
+    private final FilterStatsCalculatorService filterStatsCalculatorService = new ConnectorFilterStatsCalculatorService(new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, expressionOptimizerProvider), new StatsNormalizer()));
     private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager();
 
     @Override
@@ -117,7 +119,7 @@ public class TestingConnectorContext
             }
 
             @Override
-            public ExpressionOptimizer getExpressionOptimizer()
+            public ExpressionOptimizer getExpressionOptimizer(ConnectorSession session)
             {
                 return new RowExpressionOptimizer(metadata);
             }

--- a/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestComparisonStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestComparisonStatsCalculator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
@@ -82,7 +83,7 @@ public abstract class AbstractTestComparisonStatsCalculator
             throws Exception
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        filterStatsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer());
+        filterStatsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata)), new StatsNormalizer());
 
         uStats = VariableStatsEstimate.builder()
                 .setAverageRowSize(8.0)

--- a/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestFilterStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestFilterStatsCalculator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Expression;
@@ -146,7 +147,7 @@ public abstract class AbstractTestFilterStatsCalculator
                 .build());
 
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer());
+        statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata)), new StatsNormalizer());
         translator = new TestingRowExpressionTranslator(MetadataManager.createTestMetadataManager());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.DoubleRange;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Expression;
@@ -56,7 +57,12 @@ public class TestConnectorFilterStatsCalculatorService
     {
         session = testSessionBuilder().build();
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        FilterStatsCalculator statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer());
+        FilterStatsCalculator statsCalculator = new FilterStatsCalculator(
+                metadata,
+                new ScalarStatsCalculator(
+                        metadata,
+                        new InMemoryExpressionOptimizerProvider(metadata)),
+                new StatsNormalizer());
         statsCalculatorService = new ConnectorFilterStatsCalculatorService(statsCalculator);
         xStats = ColumnStatistics.builder()
                 .setDistinctValuesCount(Estimate.of(40))

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
@@ -18,8 +18,10 @@ import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -90,8 +92,10 @@ public class TestJoinStatsRule
 
     private static final MetadataManager METADATA = createTestMetadataManager();
     private static final StatsNormalizer NORMALIZER = new StatsNormalizer();
+
+    private static final ExpressionOptimizerProvider EXPRESSION_OPTIMIZER_PROVIDER = new InMemoryExpressionOptimizerProvider(METADATA);
     private static final JoinStatsRule JOIN_STATS_RULE = new JoinStatsRule(
-            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA), NORMALIZER),
+            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, EXPRESSION_OPTIMIZER_PROVIDER), NORMALIZER),
             NORMALIZER,
             1.0);
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.LiteralEncoder;
@@ -68,9 +69,10 @@ public class TestScalarStatsCalculator
     @BeforeClass
     public void setUp()
     {
-        calculator = new ScalarStatsCalculator(MetadataManager.createTestMetadataManager());
+        MetadataManager metadata = createTestMetadataManager();
+        calculator = new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata));
         session = testSessionBuilder().build();
-        translator = new TestingRowExpressionTranslator(MetadataManager.createTestMetadataManager());
+        translator = new TestingRowExpressionTranslator(metadata);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/InMemoryExpressionOptimizerProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/InMemoryExpressionOptimizerProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+
+import static java.util.Objects.requireNonNull;
+
+public class InMemoryExpressionOptimizerProvider
+        implements ExpressionOptimizerProvider
+{
+    private final Metadata metadata;
+
+    public InMemoryExpressionOptimizerProvider(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public ExpressionOptimizer getExpressionOptimizer(ConnectorSession session)
+    {
+        return new RowExpressionOptimizer(metadata);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -1677,7 +1677,7 @@ public class TestExpressionInterpreter
 
     private static Object optimize(RowExpression expression, Level level)
     {
-        return new RowExpressionInterpreter(expression, METADATA.getFunctionAndTypeManager(), TEST_SESSION.toConnectorSession(), level).optimize(variable -> {
+        return new RowExpressionInterpreter(expression, METADATA, TEST_SESSION.toConnectorSession(), level).optimize(variable -> {
             Symbol symbol = new Symbol(variable.getName());
             Object value = symbolConstant(symbol);
             if (value == null) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -251,7 +251,8 @@ public class TestFeaturesConfig
                 .setPrestoSparkExecutionEnvironment(false)
                 .setSingleNodeExecutionEnabled(false)
                 .setNativeExecutionScaleWritersThreadsEnabled(false)
-                .setEnhancedCTESchedulingEnabled(true));
+                .setEnhancedCTESchedulingEnabled(true)
+                .setExpressionOptimizerName("default"));
     }
 
     @Test
@@ -452,6 +453,7 @@ public class TestFeaturesConfig
                 .put("single-node-execution-enabled", "true")
                 .put("native-execution-scale-writer-threads-enabled", "true")
                 .put("enhanced-cte-scheduling-enabled", "false")
+                .put("expression-optimizer-name", "custom")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -649,7 +651,8 @@ public class TestFeaturesConfig
                 .setPrestoSparkExecutionEnvironment(true)
                 .setSingleNodeExecutionEnabled(true)
                 .setNativeExecutionScaleWritersThreadsEnabled(true)
-                .setEnhancedCTESchedulingEnabled(false);
+                .setEnhancedCTESchedulingEnabled(false)
+                .setExpressionOptimizerName("custom");
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/expressions/TestExpressionOptimizerManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/expressions/TestExpressionOptimizerManager.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.expressions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.nodeManager.PluginNodeManager;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerContext;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.lang.String.format;
+import static java.nio.file.Files.createTempDirectory;
+import static java.nio.file.Files.newOutputStream;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+@Test(singleThreaded = true)
+public class TestExpressionOptimizerManager
+{
+    private static final MetadataManager METADATA = MetadataManager.createTestMetadataManager();
+    private static final TestingRowExpressionTranslator TRANSLATOR = new TestingRowExpressionTranslator(METADATA);
+    private File directory;
+    private ExpressionOptimizerManager manager;
+
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        directory = createTempDirectory("test-optimizers").toFile();
+        directory.deleteOnExit();
+
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+        PluginNodeManager pluginNodeManager = new PluginNodeManager(nodeManager);
+        manager = new ExpressionOptimizerManager(
+                pluginNodeManager,
+                METADATA.getFunctionAndTypeManager(),
+                directory);
+    }
+
+    @AfterMethod
+    public void tearDown()
+            throws Exception
+    {
+        deleteRecursively(directory.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testBasicIntegration()
+            throws Exception
+    {
+        createPropertiesFile("foo.properties", ImmutableMap.of("expression-manager-factory.name", "foo"));
+        createPropertiesFile("bar.properties", ImmutableMap.of("expression-manager-factory.name", "bar"));
+
+        manager.addExpressionOptimizerFactory(getExpressionOptimizerFactory("foo"));
+        manager.addExpressionOptimizerFactory(getExpressionOptimizerFactory("bar"));
+        manager.loadExpressionOptimizerFactories();
+
+        assertOptimizedExpression("1+1", "2", ImmutableMap.of());
+        assertOptimizedExpression("1+1", "2", ImmutableMap.of("expression_optimizer_name", "default"));
+
+        // Override the default optimizer based on session property
+        assertOptimizedExpression("1+1", "'foo'", ImmutableMap.of("expression_optimizer_name", "foo"));
+        assertOptimizedExpression("1+1", "'bar'", ImmutableMap.of("expression_optimizer_name", "bar"));
+    }
+
+    @Test
+    public void testNoNewOptimizerNameCalledDefault()
+            throws Exception
+    {
+        createPropertiesFile("default.properties", ImmutableMap.of("expression-manager-factory.name", "default"));
+
+        manager.addExpressionOptimizerFactory(getExpressionOptimizerFactory("default"));
+        assertThrows(IllegalArgumentException.class, () -> manager.loadExpressionOptimizerFactories());
+    }
+
+    @Test
+    public void testNoFactoryName()
+            throws Exception
+    {
+        createPropertiesFile("foo.properties", ImmutableMap.of());
+
+        manager.addExpressionOptimizerFactory(getExpressionOptimizerFactory("foo"));
+        assertThrows(IllegalArgumentException.class, () -> manager.loadExpressionOptimizerFactories());
+    }
+
+    @Test
+    public void testNoFactoryRegistered()
+            throws Exception
+    {
+        createPropertiesFile("foo.properties", ImmutableMap.of("expression-manager-factory.name", "foo"));
+        assertThrows(IllegalArgumentException.class, () -> manager.loadExpressionOptimizerFactories());
+    }
+
+    private void assertOptimizedExpression(String originalExpression, String optimizedExpression, Map<String, String> systemProperties)
+    {
+        Session.SessionBuilder sessionBuilder = testSessionBuilder();
+        systemProperties.forEach(sessionBuilder::setSystemProperty);
+        Session session = sessionBuilder.build();
+        assertEquals(manager.getExpressionOptimizer(session.toConnectorSession()).optimize(expression(originalExpression), OPTIMIZED, session.toConnectorSession()),
+                expression(optimizedExpression));
+    }
+
+    private static RowExpression expression(String expression)
+    {
+        return TRANSLATOR.translate(expression, ImmutableMap.of());
+    }
+
+    private void createPropertiesFile(String fileName, Map<String, String> propertiesMap)
+            throws IOException
+    {
+        File newProperties = new File(directory, fileName);
+        newProperties.deleteOnExit();
+        Properties properties = new Properties();
+        properties.putAll(propertiesMap);
+        properties.store(newOutputStream(newProperties.toPath()), null);
+    }
+
+    public ExpressionOptimizerFactory getExpressionOptimizerFactory(String name)
+    {
+        return new ExpressionOptimizerFactory() {
+            @Override
+            public ExpressionOptimizer createOptimizer(Map<String, String> config, ExpressionOptimizerContext context)
+            {
+                return (expression, level, session, variableResolver) -> constant(
+                        Slices.utf8Slice(name),
+                        METADATA.getType(TypeSignature.parseTypeSignature(format("varchar(%s)", name.length()))));
+            }
+
+            @Override
+            public String getName()
+            {
+                return name;
+            }
+        };
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.WindowNode;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
@@ -476,7 +477,7 @@ public class TestPredicatePushdown
     public void testPredicatePushDownCanReduceInnerToCrossJoin()
     {
         RuleTester tester = new RuleTester();
-        tester.assertThat(new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), false))
+        tester.assertThat(new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), new InMemoryExpressionOptimizerProvider(tester.getMetadata()), false))
                 .on(p ->
                         p.join(INNER,
                                 p.filter(p.comparison(OperatorType.EQUAL, p.variable("a1"), constant(1L, INTEGER)),
@@ -509,7 +510,7 @@ public class TestPredicatePushdown
     public void testPredicatePushdownDoesNotAddProjectsBetweenJoinNodes()
     {
         RuleTester tester = new RuleTester();
-        PredicatePushDown predicatePushDownOptimizer = new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), false);
+        PredicatePushDown predicatePushDownOptimizer = new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), new InMemoryExpressionOptimizerProvider(tester.getMetadata()), false);
 
         tester.assertThat(predicatePushDownOptimizer)
                 .on("SELECT 1 " +
@@ -589,7 +590,7 @@ public class TestPredicatePushdown
     public void testDomainFiltersCanBeInferredForLargeDisjunctiveFilters()
     {
         RuleTester tester = new RuleTester(emptyList(), ImmutableMap.of(GENERATE_DOMAIN_FILTERS, "true"));
-        PredicatePushDown predicatePushDownOptimizer = new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), false);
+        PredicatePushDown predicatePushDownOptimizer = new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), new InMemoryExpressionOptimizerProvider(tester.getMetadata()), false);
 
         // For Inner Join
         tester.assertThat(predicatePushDownOptimizer)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
@@ -16,13 +16,16 @@ package com.facebook.presto.sql.planner.assertions;
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.Optimizer;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -170,7 +173,11 @@ public class OptimizerAssert
                         new RuleStatsRecorder(),
                         queryRunner.getStatsCalculator(),
                         queryRunner.getCostCalculator(),
-                        new SimplifyRowExpressions(metadata).rules()));
+                        new SimplifyRowExpressions(
+                                metadata,
+                                new ExpressionOptimizerManager(
+                                        new PluginNodeManager(new InMemoryNodeManager()),
+                                        queryRunner.getFunctionAndTypeManager())).rules()));
     }
 
     private <T> void inTransaction(Function<Session, T> transactionSessionConsumer)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveMapCastRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveMapCastRule.java
@@ -37,7 +37,7 @@ public class TestRemoveMapCastRule
     public void testSubscriptCast()
     {
         tester().assertThat(
-                        ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(new RemoveMapCastRule(getFunctionManager()).rules()).build())
+                        ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager()).rules()).addAll(new RemoveMapCastRule(getFunctionManager()).rules()).build())
                 .setSystemProperty(REMOVE_MAP_CAST, "true")
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", DOUBLE);
@@ -57,7 +57,7 @@ public class TestRemoveMapCastRule
     public void testElementAtCast()
     {
         tester().assertThat(
-                        ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(new RemoveMapCastRule(getFunctionManager()).rules()).build())
+                        ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager()).rules()).addAll(new RemoveMapCastRule(getFunctionManager()).rules()).build())
                 .setSystemProperty(REMOVE_MAP_CAST, "true")
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", DOUBLE);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteConstantArrayContainsToInExpression.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteConstantArrayContainsToInExpression.java
@@ -36,7 +36,7 @@ public class TestRewriteConstantArrayContainsToInExpression
     public void testNoNull()
     {
         tester().assertThat(
-                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
+                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager()).rules()).addAll(
                         new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
                 .on(p -> {
@@ -101,7 +101,7 @@ public class TestRewriteConstantArrayContainsToInExpression
     public void testNotFire()
     {
         tester().assertThat(
-                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
+                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager()).rules()).addAll(
                         new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
                 .on(p -> {
@@ -122,7 +122,7 @@ public class TestRewriteConstantArrayContainsToInExpression
     public void testWithNull()
     {
         tester().assertThat(
-                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
+                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager()).rules()).addAll(
                         new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
                 .on(p -> {
@@ -142,7 +142,7 @@ public class TestRewriteConstantArrayContainsToInExpression
     public void testLambda()
     {
         tester().assertThat(
-                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
+                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager()).rules()).addAll(
                         new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
                 .on(p -> {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/BaseRuleTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/BaseRuleTest.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule.test;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.AfterClass;
@@ -83,5 +84,10 @@ public abstract class BaseRuleTest
                         .where(isInstanceOfAny(nodeClass))
                         .matches(),
                 "Expected " + nodeClass.toString() + " in plan after optimization. ");
+    }
+
+    protected ExpressionOptimizerManager getExpressionManager()
+    {
+        return tester.getExpressionManager();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.plan.LogicalPropertiesProvider;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.assertions.OptimizerAssert;
@@ -61,6 +62,7 @@ public class RuleTester
     private final PageSourceManager pageSourceManager;
     private final AccessControl accessControl;
     private final SqlParser sqlParser;
+    private ExpressionOptimizerManager expressionOptimizerManager;
 
     public RuleTester()
     {
@@ -107,6 +109,7 @@ public class RuleTester
                 connectorFactory,
                 ImmutableMap.of());
         plugins.stream().forEach(queryRunner::installPlugin);
+        expressionOptimizerManager = queryRunner.getExpressionManager();
 
         this.metadata = queryRunner.getMetadata();
         this.transactionManager = queryRunner.getTransactionManager();
@@ -196,5 +199,10 @@ public class RuleTester
             metadata.getCatalogHandle(transactionSession, session.getCatalog().get());
             return metadata.getTableMetadata(transactionSession, tableHandle).getMetadata().getTableConstraintsHolder().getTableConstraintsWithColumnHandles();
         });
+    }
+
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        return expressionOptimizerManager;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
@@ -144,7 +144,7 @@ public class TestCteProjectionAndPredicatePushdown
                                 new RemoveIdentityProjectionsBelowProjection(),
                                 new PruneRedundantProjectionAssignments())),
                 new PruneUnreferencedOutputs(),
-                new CteProjectionAndPredicatePushDown(metadata));
+                new CteProjectionAndPredicatePushDown(metadata, getQueryRunner().getExpressionManager()));
         assertPlan(sql, getSession(), Optimizer.PlanStage.OPTIMIZED, pattern, optimizers);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.spi.plan.WindowNode;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
@@ -322,7 +323,7 @@ public class TestReorderWindows
     {
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),
-                new PredicatePushDown(getMetadata(), getQueryRunner().getSqlParser(), false),
+                new PredicatePushDown(getMetadata(), getQueryRunner().getSqlParser(), new InMemoryExpressionOptimizerProvider(getMetadata()), false),
                 new IterativeOptimizer(
                         getMetadata(),
                         new RuleStatsRecorder(),

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
@@ -229,6 +230,12 @@ public class ContainerQueryRunner
 
     @Override
     public TestingAccessControlManager getAccessControl()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExpressionOptimizerManager getExpressionManager()
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/rule/ParquetDereferencePushDown.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/rule/ParquetDereferencePushDown.java
@@ -328,7 +328,7 @@ public abstract class ParquetDereferencePushDown
             Map<RowExpression, Subfield> dereferenceToNestedColumnMap = extractDereferences(
                     baseColumnHandles,
                     session,
-                    rowExpressionService.getExpressionOptimizer(),
+                    rowExpressionService.getExpressionOptimizer(session),
                     new HashSet<>(project.getAssignments().getExpressions()));
             if (dereferenceToNestedColumnMap.isEmpty()) {
                 return visitPlan(project, context);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -81,6 +81,7 @@ import com.facebook.presto.metadata.StaticCatalogStoreConfig;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStoreConfig;
 import com.facebook.presto.metadata.TablePropertyManager;
+import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.operator.FileFragmentResultCacheConfig;
 import com.facebook.presto.operator.FileFragmentResultCacheManager;
 import com.facebook.presto.operator.FragmentCacheStats;
@@ -174,6 +175,7 @@ import com.facebook.presto.sql.analyzer.MetadataExtractor;
 import com.facebook.presto.sql.analyzer.MetadataExtractorMBean;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -347,6 +349,9 @@ public class PrestoSparkModule
         binder.bind(AnalyzePropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(QuerySessionSupplier.class).in(Scopes.SINGLETON);
 
+        // expression manager
+        binder.bind(ExpressionOptimizerManager.class).in(Scopes.SINGLETON);
+
         // tracer provider managers
         binder.bind(TracerProviderManager.class).in(Scopes.SINGLETON);
 
@@ -509,6 +514,7 @@ public class PrestoSparkModule
 
         // TODO: Decouple and remove: required by ConnectorManager
         binder.bind(InternalNodeManager.class).toInstance(new PrestoSparkInternalNodeManager());
+        binder.bind(PluginNodeManager.class);
 
         // TODO: Decouple and remove: required by PluginManager
         binder.bind(InternalResourceGroupManager.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -64,6 +64,7 @@ import com.facebook.presto.spi.function.FunctionImplementationType;
 import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
@@ -502,6 +503,12 @@ public class PrestoSparkQueryRunner
     public TestingAccessControlManager getAccessControl()
     {
         return testingAccessControlManager;
+    }
+
+    @Override
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        throw new UnsupportedOperationException();
     }
 
     public HistoryBasedPlanStatisticsManager getHistoryBasedPlanStatisticsManager()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/CoordinatorPlugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/CoordinatorPlugin.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
 import com.facebook.presto.spi.session.WorkerSessionPropertyProviderFactory;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
 
 import static java.util.Collections.emptyList;
 
@@ -37,6 +38,11 @@ public interface CoordinatorPlugin
     }
 
     default Iterable<PlanCheckerProviderFactory> getPlanCheckerProviderFactories()
+    {
+        return emptyList();
+    }
+
+    default Iterable<ExpressionOptimizerFactory> getExpressionOptimizerFactories()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizerProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizerProvider.java
@@ -15,22 +15,7 @@ package com.facebook.presto.spi.relation;
 
 import com.facebook.presto.spi.ConnectorSession;
 
-/**
- * A set of services/utilities that are helpful for connectors to operate on row expressions
- */
-public interface RowExpressionService
-        extends ExpressionOptimizerProvider
+public interface ExpressionOptimizerProvider
 {
-    DomainTranslator getDomainTranslator();
-
     ExpressionOptimizer getExpressionOptimizer(ConnectorSession session);
-
-    PredicateCompiler getPredicateCompiler();
-
-    DeterminismEvaluator getDeterminismEvaluator();
-
-    /**
-     * @return user-friendly representation of the expression similar to original SQL
-     */
-    String formatRowExpression(ConnectorSession session, RowExpression expression);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerContext.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.sql.planner;
+
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+
+import static java.util.Objects.requireNonNull;
+
+public class ExpressionOptimizerContext
+{
+    private final NodeManager nodeManager;
+    private final FunctionMetadataManager functionMetadataManager;
+    private final StandardFunctionResolution functionResolution;
+
+    public ExpressionOptimizerContext(NodeManager nodeManager, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution functionResolution)
+    {
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
+        this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+    }
+
+    public NodeManager getNodeManager()
+    {
+        return nodeManager;
+    }
+
+    public FunctionMetadataManager getFunctionMetadataManager()
+    {
+        return functionMetadataManager;
+    }
+
+    public StandardFunctionResolution getFunctionResolution()
+    {
+        return functionResolution;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.sql.planner;
+
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+
+import java.util.Map;
+
+public interface ExpressionOptimizerFactory
+{
+    ExpressionOptimizer createOptimizer(Map<String, String> config, ExpressionOptimizerContext context);
+
+    String getName();
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
@@ -624,6 +625,13 @@ public class DistributedQueryRunner
     {
         checkState(coordinators.size() == 1, "Expected a single coordinator");
         return coordinators.get(0).getPlanCheckerProviderManager();
+    }
+
+    @Override
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        checkState(coordinators.size() == 1, "Expected a single coordinator");
+        return coordinators.get(0).getExpressionManager();
     }
 
     public TestingPrestoServer getCoordinator()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
@@ -186,6 +187,12 @@ public final class StandaloneQueryRunner
     public TestingAccessControlManager getAccessControl()
     {
         return server.getAccessControl();
+    }
+
+    @Override
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        return server.getExpressionManager();
     }
 
     public TestingPrestoServer getServer()

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
@@ -252,6 +253,12 @@ public final class ThriftQueryRunner
         public TestingAccessControlManager getAccessControl()
         {
             return source.getAccessControl();
+        }
+
+        @Override
+        public ExpressionOptimizerManager getExpressionManager()
+        {
+            return source.getExpressionManager();
         }
 
         @Override


### PR DESCRIPTION
## Description
As part of [RFC-0006](https://github.com/prestodb/rfcs/blob/main/RFC-0006-expression-eval.md), we need to support out of process expression evaluation.  Add support for pluggable expression optimization and planner support to utilize the new SPI.

## Motivation and Context
[RFC-0006](https://github.com/prestodb/rfcs/blob/main/RFC-0006-expression-eval.md). See https://github.com/prestodb/presto/pull/24126 for larger changes that include the Presto sidecar as described in the RFC.

## Impact
No impact by default as the old in-memory evaluation is the default.

## Test Plan
Tests have been added.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

SPI Changes
* Add ``CoordinatorPlugin#getExpressionOptimizerFactories`` to customize expression evaluation in the Presto coordinator. :pr:`24144`
```
