### PR TITLE
[native] cache.no_retention should also be false when hive.node_selection_strategy=HARD_AFFINITY

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -105,11 +105,13 @@ void updateVeloxConnectorConfigs(
     // is
     //       not set                             retain cache
     //       SOFT_AFFINITY                       retain cache
+    //       HARD_AFFINITY                       retain cache
     //       NO_PREFERENCE                       do not retain cache
     // If queryDataCacheEnabledDefault is false, when `node_selection_strategy`
     // is
     //       not set                             do not retain cache
     //       SOFT_AFFINITY                       retain cache
+    //       HARD_AFFINITY                       retain cache
     //       NO_PREFERENCE                       do not retain cache
     connectorConfig.emplace(
         connector::hive::HiveConfig::kCacheNoRetentionSession,
@@ -117,7 +119,9 @@ void updateVeloxConnectorConfigs(
     auto it = connectorConfig.find("node_selection_strategy");
     if (it != connectorConfig.end()) {
       connectorConfig[connector::hive::HiveConfig::kCacheNoRetentionSession] =
-          it->second == "SOFT_AFFINITY" ? "false" : "true";
+          (it->second != "SOFT_AFFINITY" && it->second != "HARD_AFFINITY")
+          ? "true"
+          : "false";
     }
   }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Previous PR below allows setting hive.node_selection_strategy=SOFT_AFFINITY to set cache.no_retention=FALSE.
https://github.com/prestodb/presto/pull/24076

This PR adds setting hive.node_selection_strategy=HARD_AFFINITY will set cache.no_retention=FALSE as well.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

