### PR TITLE
Fix flaky test in memory connector caused by scaled writer

### DIFF
--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryWorkerCrash.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryWorkerCrash.java
@@ -17,8 +17,11 @@ import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 import static com.facebook.airlift.testing.Assertions.assertLessThan;
 import static io.airlift.units.Duration.nanosSince;
@@ -33,7 +36,8 @@ public class TestMemoryWorkerCrash
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return MemoryQueryRunner.createQueryRunner();
+        Map<String, String> coordinatorProperties = ImmutableMap.of("scale-writers", "false", "redistribute-writes", "true");
+        return MemoryQueryRunner.createQueryRunner(coordinatorProperties, ImmutableMap.of());
     }
 
     @Test


### PR DESCRIPTION
## Description

The default writer mode has been changed to scaled-writers in PR #24107. After the change, currently memory connector will always write the table data into one worker node when executing the following statement in test `TestMemoryWorkerCrash.tableAccessAfterWorkerCrash()`:

```
CREATE TABLE test_nation as SELECT * FROM nation;
```

This will lead in flaky, since the node we will close later may not necessarily be the one that contains the table data.

This PR keep write mode the same as before for test cases in `TestMemoryWorkerCrash`, and fix the flaky described in 
#24142.

## Motivation and Context

Fix #24142 

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

