### PR TITLE
Add semijoin join delete tablewriter and table finish node to connector optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -23,17 +23,22 @@ import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.CteProducerNode;
 import com.facebook.presto.spi.plan.CteReferenceNode;
+import com.facebook.presto.spi.plan.DeleteNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.ExceptNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IntersectNode;
+import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.plan.SortNode;
+import com.facebook.presto.spi.plan.TableFinishNode;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.plan.ValuesNode;
@@ -78,7 +83,12 @@ public class ApplyConnectorOptimization
             MarkDistinctNode.class,
             UnionNode.class,
             IntersectNode.class,
-            ExceptNode.class);
+            ExceptNode.class,
+            SemiJoinNode.class,
+            JoinNode.class,
+            TableWriterNode.class,
+            TableFinishNode.class,
+            DeleteNode.class);
 
     // for a leaf node that does not belong to any connector (e.g., ValuesNode)
     private static final ConnectorId EMPTY_CONNECTOR_ID = new ConnectorId("$internal$" + ApplyConnectorOptimization.class + "_CONNECTOR");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java
@@ -29,7 +29,7 @@ import static com.facebook.presto.common.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
-public class DeleteNode
+public final class DeleteNode
         extends PlanNode
 {
     private final PlanNode source;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/JoinNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/JoinNode.java
@@ -46,7 +46,7 @@ import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
-public class JoinNode
+public final class JoinNode
         extends AbstractJoinNode
 {
     private final JoinType type;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/SemiJoinNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/SemiJoinNode.java
@@ -30,7 +30,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
-public class SemiJoinNode
+public final class SemiJoinNode
         extends AbstractJoinNode
 {
     private final PlanNode source;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableFinishNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableFinishNode.java
@@ -29,7 +29,7 @@ import static com.facebook.presto.common.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
-public class TableFinishNode
+public final class TableFinishNode
         extends PlanNode
 {
     private final PlanNode source;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableWriterNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableWriterNode.java
@@ -39,7 +39,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
-public class TableWriterNode
+public final class TableWriterNode
         extends PlanNode
 {
     private final PlanNode source;


### PR DESCRIPTION
## Description
As title, so that we can access these nodes in connector optimizer

## Motivation and Context
To access these nodes in connector optimizer

## Impact
as above

## Test Plan
existing tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add SemiJoin Join TableWriter Delete TableFinish node to connector optimizer :pr:`24154`
```

