### PR TITLE
Added use orc column names session

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonClientConfig.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonClientConfig.java
@@ -45,6 +45,7 @@ public class HiveCommonClientConfig
     private boolean rangeFiltersOnSubscriptsEnabled;
     private boolean readNullMaskedParquetEncryptedValueEnabled;
     private boolean useParquetColumnNames;
+    private boolean useOrcColumnNames;
     private boolean zstdJniDecompressionEnabled;
 
     public NodeSelectionStrategy getNodeSelectionStrategy()
@@ -270,6 +271,19 @@ public class HiveCommonClientConfig
     public HiveCommonClientConfig setUseParquetColumnNames(boolean useParquetColumnNames)
     {
         this.useParquetColumnNames = useParquetColumnNames;
+        return this;
+    }
+
+    public boolean isUseOrcColumnNames()
+    {
+        return useOrcColumnNames;
+    }
+
+    @Config("hive.orc.use-column-names")
+    @ConfigDescription("Access ORC columns using names from the file first, and fallback to Hive schema column names if not found to ensure backward compatibility with old data")
+    public HiveCommonClientConfig setUseOrcColumnNames(boolean useOrcColumnNames)
+    {
+        this.useOrcColumnNames = useOrcColumnNames;
         return this;
     }
 

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonSessionProperties.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonSessionProperties.java
@@ -60,6 +60,7 @@ public class HiveCommonSessionProperties
     private static final String PARQUET_BATCH_READER_VERIFICATION_ENABLED = "parquet_batch_reader_verification_enabled";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_USE_COLUMN_NAMES = "parquet_use_column_names";
+    private static final String ORC_USE_COLUMN_NAMES = "orc_use_column_names";
     public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -174,6 +175,11 @@ public class HiveCommonSessionProperties
                         hiveCommonClientConfig.isUseParquetColumnNames(),
                         false),
                 booleanProperty(
+                        ORC_USE_COLUMN_NAMES,
+                        "Experimental: ORC: Access ORC columns using names from the file",
+                        hiveCommonClientConfig.isUseOrcColumnNames(),
+                        false),
+                booleanProperty(
                         READ_MASKED_VALUE_ENABLED,
                         "Return null when access is denied for an encrypted parquet column",
                         hiveCommonClientConfig.getReadNullMaskedParquetEncryptedValue(),
@@ -275,6 +281,11 @@ public class HiveCommonSessionProperties
     public static boolean isUseParquetColumnNames(ConnectorSession session)
     {
         return session.getProperty(PARQUET_USE_COLUMN_NAMES, Boolean.class);
+    }
+    
+    public static boolean isUseOrcColumnNames(ConnectorSession session)
+    {
+        return session.getProperty(ORC_USE_COLUMN_NAMES, Boolean.class);
     }
 
     public static boolean isRangeFiltersOnSubscriptsEnabled(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -749,8 +749,6 @@ public class HiveClientConfig
         return this;
     }
 
-
-
     public double getOrcDefaultBloomFilterFpp()
     {
         return orcDefaultBloomFilterFpp;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -109,7 +109,6 @@ public class HiveClientConfig
 
     private DataSize textMaxLineLength = new DataSize(100, MEGABYTE);
     private boolean assumeCanonicalPartitionKeys;
-    private boolean useOrcColumnNames;
     private double orcDefaultBloomFilterFpp = 0.05;
     private boolean rcfileOptimizedWriterEnabled = true;
     private boolean rcfileWriterValidate;
@@ -750,18 +749,7 @@ public class HiveClientConfig
         return this;
     }
 
-    public boolean isUseOrcColumnNames()
-    {
-        return useOrcColumnNames;
-    }
 
-    @Config("hive.orc.use-column-names")
-    @ConfigDescription("Access ORC columns using names from the file first, and fallback to Hive schema column names if not found to ensure backward compatibility with old data")
-    public HiveClientConfig setUseOrcColumnNames(boolean useOrcColumnNames)
-    {
-        this.useOrcColumnNames = useOrcColumnNames;
-        return this;
-    }
 
     public double getOrcDefaultBloomFilterFpp()
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -134,7 +134,6 @@ public final class HiveSessionProperties
     public static final String AFFINITY_SCHEDULING_FILE_SECTION_SIZE = "affinity_scheduling_file_section_size";
     public static final String SKIP_EMPTY_FILES = "skip_empty_files";
     public static final String LEGACY_TIMESTAMP_BUCKETING = "legacy_timestamp_bucketing";
-    private static final String ORC_USE_COLUMN_NAMES = "orc_use_column_names";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -397,11 +396,6 @@ public final class HiveSessionProperties
                         ADAPTIVE_FILTER_REORDERING_ENABLED,
                         "Experimental: enable adaptive filter reordering",
                         hiveClientConfig.isAdaptiveFilterReorderingEnabled(),
-                        false),
-                booleanProperty(
-                        ORC_USE_COLUMN_NAMES,
-                        "Experimental: ORC: Access ORC columns using names from the file",
-                        hiveClientConfig.isUseOrcColumnNames(),
                         false),
                 integerProperty(
                         VIRTUAL_BUCKET_COUNT,
@@ -1145,9 +1139,5 @@ public final class HiveSessionProperties
     public static boolean isLegacyTimestampBucketing(ConnectorSession session)
     {
         return session.getProperty(LEGACY_TIMESTAMP_BUCKETING, Boolean.class);
-    }
-    public static boolean isUseOrcColumnNames(ConnectorSession session)
-    {
-        return session.getProperty(ORC_USE_COLUMN_NAMES, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -399,7 +399,6 @@ public final class HiveSessionProperties
                         hiveClientConfig.isAdaptiveFilterReorderingEnabled(),
                         false),
                 booleanProperty(
-                       // HiveClientConfig = new HiveCommonSessionProperties()
                         ORC_USE_COLUMN_NAMES,
                         "Experimental: ORC: Access ORC columns using names from the file",
                         hiveClientConfig.isUseOrcColumnNames(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -134,6 +134,7 @@ public final class HiveSessionProperties
     public static final String AFFINITY_SCHEDULING_FILE_SECTION_SIZE = "affinity_scheduling_file_section_size";
     public static final String SKIP_EMPTY_FILES = "skip_empty_files";
     public static final String LEGACY_TIMESTAMP_BUCKETING = "legacy_timestamp_bucketing";
+    private static final String ORC_USE_COLUMN_NAMES = "orc_use_column_names";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -396,6 +397,12 @@ public final class HiveSessionProperties
                         ADAPTIVE_FILTER_REORDERING_ENABLED,
                         "Experimental: enable adaptive filter reordering",
                         hiveClientConfig.isAdaptiveFilterReorderingEnabled(),
+                        false),
+                booleanProperty(
+                       // HiveClientConfig = new HiveCommonSessionProperties()
+                        ORC_USE_COLUMN_NAMES,
+                        "Experimental: ORC: Access ORC columns using names from the file",
+                        hiveClientConfig.isUseOrcColumnNames(),
                         false),
                 integerProperty(
                         VIRTUAL_BUCKET_COUNT,
@@ -1139,5 +1146,9 @@ public final class HiveSessionProperties
     public static boolean isLegacyTimestampBucketing(ConnectorSession session)
     {
         return session.getProperty(LEGACY_TIMESTAMP_BUCKETING, Boolean.class);
+    }
+    public static boolean isUseOrcColumnNames(ConnectorSession session)
+    {
+        return session.getProperty(ORC_USE_COLUMN_NAMES, Boolean.class);
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This pull request adds a new session property orc_use_column_names to toggle the usage of ORC column names when accessing ORC files. This session property is analogous to the existing session property for Parquet (parquet_use_column_names). It allows users to enable or disable column name access for ORC files, offering more flexibility in how ORC files are processed within Presto.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Currently, there is no session property to control the use of column names when reading ORC files. This change aligns the behavior of ORC with that of Parquet, which already has a session property (parquet_use_column_names) to manage similar functionality. By adding this session property, users can now control whether column names are accessed from ORC files, improving consistency across file formats and enabling finer control over ORC file processing.

issue: https://github.com/prestodb/presto/issues/24134
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

- New Session Property: A new session property (orc_use_column_names) is added, allowing users to enable or disable the use of ORC column names.
- Behavior Change: This change introduces no breaking changes but adds flexibility to control how ORC files are processed.
- No Performance Impact: There is no expected performance impact from this change, as it simply introduces a configuration toggle.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

