### PR TITLE
Security Vulnerability fix for snappy-0.2(CVE-2024-36124)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.iq80.snappy</groupId>
+                <artifactId>snappy</artifactId>
+                <version>0.5</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
                 <version>4.1.107.Final</version>


### PR DESCRIPTION
## Description
This PR is fixing the security vulnerability for the library "snappy-0.2" (CVE-2024-36124) https://mvnrepository.com/artifact/org.iq80.snappy/snappy/0.2. The library has been upgraded to the version 0.5 (https://mvnrepository.com/artifact/org.iq80.snappy/snappy/0.5). This fixes CVE-2024-36124.

## Motivation and Context
The snappy library currently used has a security vulnerability for the version 0.2. This PR focuses on upgrading the version to 0.5 to fix the current vulnerability.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes

* Upgrade the snappy version to 0.5 in response to `CVE-2024-36124 <https://github.com/advisories/GHSA-8wh2-6qhj-h7j9>`_. :pr:`24159`

```

