### PR TITLE
[For debugging purpose] add runtime stats for task create/update on the worker side

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -63,6 +63,11 @@ public class RuntimeMetricName
     // Blocked time for the operators due to waiting for inputs.
     public static final String TASK_BLOCKED_TIME_NANOS = "taskBlockedTimeNanos";
     public static final String TASK_UPDATE_DELIVERED_WALL_TIME_NANOS = "taskUpdateDeliveredWallTimeNanos";
+    public static final String TASK_UPDATE_RECEIVED_WALL_TIME_NANOS = "taskUpdateReceivedWallTimeNanos";
+    public static final String TASK_UPDATE_RECEIVED_CPU_TIME_NANOS = "taskUpdateReceivedCpuTimeNanos";
+    public static final String TASK_EXECUTION_CREATION_WALL_TIME_NANOS = "taskExecutionCreationWallTimeNanos";
+    public static final String TASK_EXECUTION_CREATION_CPU_TIME_NANOS = "taskExecutionCreationCpuTimeNanos";
+
     public static final String TASK_UPDATE_SERIALIZED_CPU_TIME_NANOS = "taskUpdateSerializedCpuNanos";
     public static final String TASK_PLAN_SERIALIZED_CPU_TIME_NANOS = "taskPlanSerializedCpuNanos";
     // Time taken for a read call to storage

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResourceUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResourceUtils.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.server;
 
+import com.facebook.presto.common.RuntimeMetricName;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.RuntimeUnit;
 import com.facebook.presto.connector.ConnectorTypeSerdeManager;
 import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.metadata.HandleResolver;
@@ -32,6 +35,7 @@ import java.util.List;
 
 import static com.facebook.presto.operator.OperatorInfoUnion.convertToOperatorInfo;
 import static com.facebook.presto.operator.OperatorInfoUnion.convertToOperatorInfoUnion;
+import static java.lang.Math.max;
 import static java.util.stream.Collectors.toList;
 
 public class TaskResourceUtils
@@ -522,5 +526,17 @@ public class TaskResourceUtils
         return metadataUpdateHandles.stream()
                 .map(e -> connectorTypeSerde.deserialize(handleResolver.getMetadataUpdateHandleClass(e.getId()), e.getBytes()))
                 .collect(toList());
+    }
+
+    public static void recordTaskUpdateReceivedTimeNanos(RuntimeStats runtimeStats, long cpuTimeNanos, long wallTimeNanos)
+    {
+        runtimeStats.addMetricValue(RuntimeMetricName.TASK_UPDATE_RECEIVED_CPU_TIME_NANOS, RuntimeUnit.NANO, max(0, cpuTimeNanos));
+        runtimeStats.addMetricValue(RuntimeMetricName.TASK_UPDATE_RECEIVED_WALL_TIME_NANOS, RuntimeUnit.NANO, max(0, wallTimeNanos));
+    }
+
+    public static void recordTaskExecutionCreationTimeNanos(RuntimeStats runtimeStats, long cpuTimeNanos, long wallTimeNanos)
+    {
+        runtimeStats.addMetricValue(RuntimeMetricName.TASK_EXECUTION_CREATION_CPU_TIME_NANOS, RuntimeUnit.NANO, max(0, cpuTimeNanos));
+        runtimeStats.addMetricValue(RuntimeMetricName.TASK_EXECUTION_CREATION_WALL_TIME_NANOS, RuntimeUnit.NANO, max(0, wallTimeNanos));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -1159,6 +1159,7 @@ public final class HttpRemoteTask
                         taskUpdateTimeline.removeElements(0, deliveredUpdates);
                     }
                     updateStats(currentRequestStartNanos);
+                    mergeTaskRuntimeStats(value);
                     processTaskUpdate(value, sources);
                     updateErrorTracker.requestSucceeded();
                     if (oldestTaskUpdateTime != 0) {
@@ -1169,6 +1170,11 @@ public final class HttpRemoteTask
                     sendUpdate();
                 }
             }
+        }
+
+        private void mergeTaskRuntimeStats(TaskInfo taskInfo)
+        {
+            session.getRuntimeStats().mergeWith(taskInfo.getStats().getRuntimeStats());
         }
 
         @Override


### PR DESCRIPTION
## Description
1. add runtime stats on the worker side to record the time for create/update task on the worker side

## Motivation and Context
1. we are investigating if there is any contention on jetty server at the worker side

## Impact
1. No significant efficiency impact expected

## Test Plan
1. TBD

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

