### PR TITLE
Updated lucene-core, lucene-analyzers-common, and lucene-queryparser version to 8.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <dep.joda.version>2.12.7</dep.joda.version>
         <dep.tempto.version>1.53</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
+        <dep.lucene.version>8.10.0</dep.lucene.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.13</dep.logback.version>
         <dep.parquet.version>1.13.1</dep.parquet.version>
@@ -2038,13 +2039,13 @@
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-analyzers-common</artifactId>
-                <version>7.2.1</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.lucene</groupId>
-                        <artifactId>lucene-core</artifactId>
-                    </exclusion>
-                </exclusions>
+                <version>${dep.lucene.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>${dep.lucene.version}</version>
             </dependency>
 
             <dependency>
@@ -2344,6 +2345,8 @@
                             <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                             <!-- Duplicate class is being brought in by several netty dependencies-->
                             <ignoredClassPattern>META-INF.versions.11.module-info</ignoredClassPattern>
+                            <!-- Ignore duplicate classes related to lucene-core and ranger-apache -->
+                            <ignoredClassPattern>META-INF.versions.9.org.apache.lucene.*</ignoredClassPattern>
                         </ignoredClassPatterns>
                     </configuration>
                 </plugin>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>presto-pinot-driver</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-core</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
                 </exclusion>


### PR DESCRIPTION
## Description

3 medium CVE resolved. 

**Upgradation performed :**

1. lucene-core(https://www.mend.io/vulnerability-database/WS-2021-0646) : 8.2.0 to 8.10.0
lucene-core (8.10.0) gets introduced through lucene-analyzers-common(8.10.0)
2. lucene-analyzer-common(https://www.mend.io/vulnerability-database/WS-2021-0646) : 7.7.3 to 8.10.0
3. lucene-queryparser(https://vuln.whitesourcesoftware.com/vulnerability/WS-2021-0646) : 8.2.0 to 8.10.0

## Motivation and Context

Apache Lucene through 7.x and 8.x before 8.10 is vulnerable to a denial of service. By sending a specific regular expression query, a remote attacker could exploit this vulnerability to consume all available CPU resources.

## Impact
3 medium cve got resolved.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes

* Upgrade lucene-core to 8.10.0 in response to 'WS-2021-0646 <https://www.mend.io/vulnerability-database/WS-2021-0646>' :pr:`24168`
* Upgrade lucene-queryparser to 8.10.0 in response to 'WS-2021-0646 <https://vuln.whitesourcesoftware.com/vulnerability/WS-2021-0646>' :pr:`24168`
* Upgrade lucene-analyzer-common to 8.10.0 in response to 'WS-2021-0646 <https://www.mend.io/vulnerability-database/WS-2021-0646>' :pr:`24168`

```

