### PR TITLE
Remove 'enable flat map' property for DWRF writer

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -207,8 +207,8 @@ public final class HiveSessionProperties
                         false),
                 booleanProperty(
                         ORC_OPTIMIZED_WRITER_FLAT_MAP_WRITER_ENABLED,
-                        "ORC: Enable flat map writer",
-                        orcFileWriterConfig.isFlatMapWriterEnabled(),
+                        "ORC: DEPRECATED Enable flat map writer",
+                        true,
                         true),
                 integerProperty(
                         ORC_OPTIMIZED_WRITER_COMPRESSION_LEVEL,
@@ -724,11 +724,6 @@ public final class HiveSessionProperties
     public static boolean isStringDictionarySortingEnabled(ConnectorSession session)
     {
         return session.getProperty(ORC_OPTIMIZED_WRITER_STRING_DICTIONARY_SORTING_ENABLED, Boolean.class);
-    }
-
-    public static boolean isFlatMapWriterEnabled(ConnectorSession session)
-    {
-        return session.getProperty(ORC_OPTIMIZED_WRITER_FLAT_MAP_WRITER_ENABLED, Boolean.class);
     }
 
     public static OptionalInt getCompressionLevel(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.configuration.DefunctConfig;
 import com.facebook.presto.orc.DefaultOrcWriterFlushPolicy;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
@@ -28,6 +29,7 @@ import java.util.OptionalInt;
 import static com.facebook.presto.hive.OrcFileWriterConfig.StreamLayoutType.BY_COLUMN_SIZE;
 
 @SuppressWarnings("unused")
+@DefunctConfig("hive.orc.writer.flat-map-writer-enabled")
 public class OrcFileWriterConfig
 {
     public enum StreamLayoutType
@@ -37,7 +39,6 @@ public class OrcFileWriterConfig
     }
 
     public static final int DEFAULT_COMPRESSION_LEVEL = Integer.MIN_VALUE;
-    private static final boolean DEFAULT_FLAT_MAP_WRITER_ENABLED = false;
 
     private DataSize stripeMinSize = DefaultOrcWriterFlushPolicy.DEFAULT_STRIPE_MIN_SIZE;
     private DataSize stripeMaxSize = DefaultOrcWriterFlushPolicy.DEFAULT_STRIPE_MAX_SIZE;
@@ -54,7 +55,6 @@ public class OrcFileWriterConfig
     private boolean isIntegerDictionaryEncodingEnabled = OrcWriterOptions.DEFAULT_INTEGER_DICTIONARY_ENCODING_ENABLED;
     private boolean isStringDictionaryEncodingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_ENCODING_ENABLED;
     private boolean isStringDictionarySortingEnabled = OrcWriterOptions.DEFAULT_STRING_DICTIONARY_SORTING_ENABLED;
-    private boolean isFlatMapWriterEnabled = DEFAULT_FLAT_MAP_WRITER_ENABLED;
     private boolean addHostnameToFileMetadataEnabled = true;
 
     public OrcWriterOptions.Builder toOrcWriterOptionsBuilder()
@@ -180,18 +180,6 @@ public class OrcFileWriterConfig
     public OrcFileWriterConfig setStringDictionarySortingEnabled(boolean isStringDictionarySortingEnabled)
     {
         this.isStringDictionarySortingEnabled = isStringDictionarySortingEnabled;
-        return this;
-    }
-
-    public boolean isFlatMapWriterEnabled()
-    {
-        return isFlatMapWriterEnabled;
-    }
-
-    @Config("hive.orc.writer.flat-map-writer-enabled")
-    public OrcFileWriterConfig setFlatMapWriterEnabled(boolean isFlatMapWriterEnabled)
-    {
-        this.isFlatMapWriterEnabled = isFlatMapWriterEnabled;
         return this;
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TesOrcFileWriterFactory.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TesOrcFileWriterFactory.java
@@ -91,7 +91,6 @@ public class TesOrcFileWriterFactory
     private static OrcWriterOptions getOrcWriterOptions(Properties serDe)
     {
         OrcFileWriterConfig orcFileWriterConfig = new OrcFileWriterConfig();
-        orcFileWriterConfig.setFlatMapWriterEnabled(true);
         OrcFileWriterFactory orcFileWriterFactory = getDefaultOrcFileWriterFactory(HIVE_CLIENT_CONFIG, METASTORE_CLIENT_CONFIG);
         HiveSessionProperties sessionProperties = new HiveSessionProperties(
                 new HiveClientConfig(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -64,7 +64,6 @@ public class TestOrcFileWriterConfig
                 .setIntegerDictionaryEncodingEnabled(false)
                 .setStringDictionaryEncodingEnabled(true)
                 .setStringDictionarySortingEnabled(true)
-                .setFlatMapWriterEnabled(false)
                 .setAddHostnameToFileMetadataEnabled(true));
     }
 
@@ -87,7 +86,6 @@ public class TestOrcFileWriterConfig
                 .put("hive.orc.writer.integer-dictionary-encoding-enabled", "true")
                 .put("hive.orc.writer.string-dictionary-encoding-enabled", "false")
                 .put("hive.orc.writer.string-dictionary-sorting-enabled", "false")
-                .put("hive.orc.writer.flat-map-writer-enabled", "true")
                 .put("hive.orc.writer.add-hostname-to-file-metadata-enabled", "false")
                 .build();
 
@@ -107,7 +105,6 @@ public class TestOrcFileWriterConfig
                 .setIntegerDictionaryEncodingEnabled(true)
                 .setStringDictionaryEncodingEnabled(false)
                 .setStringDictionarySortingEnabled(false)
-                .setFlatMapWriterEnabled(true)
                 .setAddHostnameToFileMetadataEnabled(false);
 
         assertFullMapping(properties, expected);
@@ -149,8 +146,7 @@ public class TestOrcFileWriterConfig
                 .setDwrfStripeCacheEnabled(false)
                 .setDwrfStripeCacheMaxSize(dwrfStripeCacheMaxSize)
                 .setDwrfStripeCacheMode(dwrfStripeCacheMode)
-                .setCompressionLevel(5)
-                .setFlatMapWriterEnabled(flatMapWriterEnabled);
+                .setCompressionLevel(5);
 
         assertEquals(stripeMinSize, config.getStripeMinSize());
         assertEquals(stripeMaxSize, config.getStripeMaxSize());
@@ -164,7 +160,6 @@ public class TestOrcFileWriterConfig
         assertEquals(dwrfStripeCacheMaxSize, config.getDwrfStripeCacheMaxSize());
         assertEquals(dwrfStripeCacheMode, config.getDwrfStripeCacheMode());
         assertEquals(compressionLevel, config.getCompressionLevel());
-        assertEquals(flatMapWriterEnabled, config.isFlatMapWriterEnabled());
 
         assertNotSame(config.toOrcWriterOptionsBuilder(), config.toOrcWriterOptionsBuilder());
         OrcWriterOptions options = config.toOrcWriterOptionsBuilder().build();


### PR DESCRIPTION
Summary: Remove the "not so useful" property that used to control the flat map writer during the initial rollout.

Differential Revision: D66584420


