### PR TITLE
[native] Update docs for VARCHAR type length value

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -28,7 +28,7 @@ Integer
 
 .. note::
 
-    Cast conversion functions allow leading and trailing spaces when casting 
+    Cast conversion functions allow leading and trailing spaces when casting
     a string to ``TINYINT``, ``SMALLINT``, ``INTEGER``, or ``BIGINT``.
 
 ``TINYINT``
@@ -102,9 +102,10 @@ Example literals: ``DECIMAL '10.3'``, ``DECIMAL '1234567890'``, ``1.1``
 
 .. note::
 
-    For compatibility reasons decimal literals without explicit type specifier (e.g. ``1.2``)
-    are treated as values of the ``DOUBLE`` type by default up to version 0.198. 
-    After 0.198 they are parsed as DECIMAL.
+    Decimal literals without explicit type specifier such as ``1.2``
+    are parsed as values of the ``DECIMAL`` type by default.
+    To change the behavior and parse such values as ``DOUBLE`` type set
+    the following property to ``true``:
 
     - System wide property: ``parse-decimal-literals-as-double``
     - Session wide property: ``parse_decimal_literals_as_double``
@@ -115,9 +116,13 @@ String
 ``VARCHAR``
 ^^^^^^^^^^^
 
-Variable length character data with an optional maximum length.
+Variable length character data with an optional maximum length indicating
+the maximum number of characters allowed.
 
 Example type definitions: ``varchar``, ``varchar(20)``.
+
+For ``varchar(20)`` the length value indicates that the string data may
+consist of up to 20 characters.
 
 SQL supports simple and Unicode string literals:
  - Literal string : ``'Hello winter !'``
@@ -144,10 +149,10 @@ equal, but comparison of such values implicitly converts the types to the same
 length and pads with spaces so that the following query returns `true`:
 
 ``SELECT cast('example' AS char(20)) = cast('example    ' AS char(25));``
-    
+
 As with `VARCHAR`, a single quote in a `CHAR`
 literal can be escaped with another single quote:
-    
+
 ``SELECT CHAR 'All right, Mr. DeMille, I''m ready for my close-up.'``
 
 


### PR DESCRIPTION
The documentation does not clearly indicate what the length value in the varchar type definition means. Clear up that it is the number of characters and not the number of bytes.

Do some cleanup for DECIMAL type documentation.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
The documentation is somewhat unclear as to the meaning of the numeric value used for varchar. It is clear when it is used in the CHAR type context. This leaves it up for interpretation: number of characters vs number of bytes.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

