### PR TITLE
Resolving CVEs related to hibernate-validator-5.1.3.Final.jar

### DIFF
--- a/presto-benchto-benchmarks/pom.xml
+++ b/presto-benchto-benchmarks/pom.xml
@@ -47,6 +47,10 @@
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-beans</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## Description

This upgrade eliminates the vulnerability present in the version 5.1.3.Final  which fixes CVE-2023-1932 and CVE-2020-10693.

## Motivation and Context

1. [CVE-2023-1932](https://www.mend.io/vulnerability-database/CVE-2023-1932)
A vulnerability was found in hibernate-validator version 6.1.2.Final, where the method 'isValid' in the class org.hibernate.validator.internal.constraintvalidators.hv.SafeHtmlValidator can by bypassed by omitting the tag end (less than sign). Browsers typically still render the invalid html which leads to attacks like HTML injection and Cross-Site-Scripting.

2.[CVE-2020-10693](https://vuln.whitesourcesoftware.com/vulnerability/CVE-2020-10693)
A flaw was found in Hibernate Validator version 6.1.2.Final. A bug in the message interpolation processor enables invalid EL expressions to be evaluated as if they were valid. This flaw allows attackers to bypass input sanitation (escaping, stripping) controls that developers may have put in place when handling user-controlled data in error messages.

## Impact

2 medium CVE resolved.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```

Security Changes


* Update hibernate-validator to 6.2.0.Final in response to 'CVE-2023-1932 <https://www.mend.io/vulnerability-database/CVE-2023-1932>' :pr:`24177`
* Update hibernate-validator to 6.2.0.Final in response to 'CVE-2020-10693 <https://vuln.whitesourcesoftware.com/vulnerability/CVE-2020-10693>' :pr:`24177`


```

