### PR TITLE
Added catalog and schema level access checks in USE statement

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/UseTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/UseTask.java
@@ -15,18 +15,24 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.AccessDeniedException;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.Use;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 
 import static com.facebook.presto.metadata.MetadataUtil.getConnectorIdOrThrow;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCatalogAccess;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.CATALOG_NOT_SPECIFIED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -54,9 +60,9 @@ public class UseTask
 
         checkCatalogAndSessionPresent(statement, session);
 
-        checkAndSetCatalog(statement, metadata, stateMachine, session);
+        checkAndSetCatalog(statement, metadata, stateMachine, session, accessControl);
 
-        checkAndSetSchema(statement, metadata, stateMachine, session);
+        checkAndSetSchema(statement, metadata, stateMachine, session, accessControl);
 
         return immediateFuture(null);
     }
@@ -68,16 +74,19 @@ public class UseTask
         }
     }
 
-    private void checkAndSetCatalog(Use statement, Metadata metadata, QueryStateMachine stateMachine, Session session)
+    private void checkAndSetCatalog(Use statement, Metadata metadata, QueryStateMachine stateMachine, Session session, AccessControl accessControl)
     {
-        if (statement.getCatalog().isPresent()) {
-            String catalog = statement.getCatalog().get().getValueLowerCase();
-            getConnectorIdOrThrow(session, metadata, catalog);
-            stateMachine.setSetCatalog(catalog);
+        String catalog = statement.getCatalog()
+                .map(Identifier::getValueLowerCase)
+                .orElseGet(() -> session.getCatalog().map(String::toLowerCase).get());
+        getConnectorIdOrThrow(session, metadata, catalog);
+        if (!hasCatalogAccess(session.getIdentity(), session.getAccessControlContext(), catalog, accessControl)) {
+            denyCatalogAccess(catalog);
         }
+        stateMachine.setSetCatalog(catalog);
     }
 
-    private void checkAndSetSchema(Use statement, Metadata metadata, QueryStateMachine stateMachine, Session session)
+    private void checkAndSetSchema(Use statement, Metadata metadata, QueryStateMachine stateMachine, Session session, AccessControl accessControl)
     {
         String catalog = statement.getCatalog()
                 .map(Identifier::getValueLowerCase)
@@ -86,6 +95,19 @@ public class UseTask
         if (!metadata.getMetadataResolver(session).schemaExists(new CatalogSchemaName(catalog, schema))) {
             throw new SemanticException(MISSING_SCHEMA, format("Schema does not exist: %s.%s", catalog, schema));
         }
+        if (!hasSchemaAccess(session.getTransactionId().get(), session.getIdentity(), session.getAccessControlContext(), catalog, schema, accessControl)) {
+            throw new AccessDeniedException("Cannot access schema: " + new CatalogSchemaName(catalog, schema));
+        }
         stateMachine.setSetSchema(schema);
+    }
+
+    private boolean hasCatalogAccess(Identity identity, AccessControlContext context, String catalog, AccessControl accessControl)
+    {
+        return !accessControl.filterCatalogs(identity, context, ImmutableSet.of(catalog)).isEmpty();
+    }
+
+    private boolean hasSchemaAccess(TransactionId transactionId, Identity identity, AccessControlContext context, String catalog, String schema, AccessControl accessControl)
+    {
+        return !accessControl.filterSchemas(transactionId, identity, context, catalog, ImmutableSet.of(schema)).isEmpty();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestUseTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestUseTask.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.connector.MockConnectorFactory;
+import com.facebook.presto.metadata.Catalog;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.spi.security.AccessDeniedException;
+import com.facebook.presto.spi.security.AllowAllAccessControl;
+import com.facebook.presto.spi.security.DenyAllAccessControl;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.sql.analyzer.SemanticException;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.Use;
+import com.facebook.presto.testing.TestingConnectorContext;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.connector.MockConnectorFactory.builder;
+import static com.facebook.presto.execution.TaskTestUtils.createQueryStateMachine;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.ConnectorId.createInformationSchemaConnectorId;
+import static com.facebook.presto.spi.ConnectorId.createSystemTablesConnectorId;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+
+@Test(singleThreaded = true)
+public class TestUseTask
+{
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+    private CatalogManager catalogManager;
+    private TransactionManager transactionManager;
+    private MetadataManager metadata;
+
+    @BeforeClass
+    public void setUp()
+    {
+        catalogManager = new CatalogManager();
+        transactionManager = createTestTransactionManager(catalogManager);
+        metadata = createTestMetadataManager(transactionManager);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testUse()
+    {
+        Use use = new Use(Optional.of(new Identifier("test_catalog")), new Identifier("test_schema"));
+        String sqlString = "USE test_catalog.test_schema";
+        AccessControl accessControl = new AllowAllAccessControl();
+        executeUse(use, sqlString, TEST_SESSION, accessControl);
+    }
+
+    @Test(
+            expectedExceptions = SemanticException.class,
+            expectedExceptionsMessageRegExp = "Catalog must be specified when session catalog is not set")
+    public void testUseNoCatalog()
+    {
+        Use use = new Use(Optional.empty(), new Identifier("test_schema"));
+        String sqlString = "USE test_schema";
+        Session session = testSessionBuilder()
+                .setCatalog(null)
+                .setSchema(null)
+                .build();
+        AccessControl accessControl = new AllowAllAccessControl();
+        executeUse(use, sqlString, session, accessControl);
+    }
+
+    @Test(
+            expectedExceptions = SemanticException.class,
+            expectedExceptionsMessageRegExp = "Catalog does not exist: invalid_catalog")
+    public void testUseInvalidCatalog()
+    {
+        Use use = new Use(Optional.of(new Identifier("invalid_catalog")), new Identifier("test_schema"));
+        String sqlString = "USE invalid_catalog.test_schema";
+        AccessControl accessControl = new AllowAllAccessControl();
+        executeUse(use, sqlString, TEST_SESSION, accessControl);
+    }
+
+    @Test(
+            expectedExceptions = SemanticException.class,
+            expectedExceptionsMessageRegExp = "Schema does not exist: test_catalog.invalid_schema")
+    public void testUseInvalidSchema()
+    {
+        Use use = new Use(Optional.of(new Identifier("test_catalog")), new Identifier("invalid_schema"));
+        String sqlString = "USE test_catalog.invalid_schema";
+        Session session = testSessionBuilder()
+                .setSchema("invalid_schema")
+                .build();
+        AccessControl accessControl = new AllowAllAccessControl();
+        executeUse(use, sqlString, session, accessControl);
+    }
+
+    @Test(
+            expectedExceptions = AccessDeniedException.class,
+            expectedExceptionsMessageRegExp = "Access Denied: Cannot access catalog test_catalog")
+    public void testUseAccessDenied()
+    {
+        Use use = new Use(Optional.of(new Identifier("test_catalog")), new Identifier("test_schema"));
+        String sqlString = "USE test_catalog.test_schema";
+        Session session = testSessionBuilder()
+                .setIdentity(new Identity("user", Optional.empty()))
+                .build();
+        AccessControl accessControl = new DenyAllAccessControl();
+        executeUse(use, sqlString, session, accessControl);
+    }
+
+    private void executeUse(Use use, String sqlString, Session session, AccessControl accessControl)
+    {
+        MockConnectorFactory mockConnectorFactory = builder()
+                .withListSchemaNames(connectorSession -> ImmutableList.of("test_schema"))
+                .build();
+        catalogManager = new CatalogManager();
+        transactionManager = createTestTransactionManager(catalogManager);
+        metadata = createTestMetadataManager(transactionManager);
+
+        Connector testConnector = mockConnectorFactory.create("test", ImmutableMap.of(), new TestingConnectorContext());
+        String catalogName = "test_catalog";
+        ConnectorId connectorId = new ConnectorId(catalogName);
+        catalogManager.registerCatalog(new Catalog(
+                catalogName,
+                connectorId,
+                testConnector,
+                createInformationSchemaConnectorId(connectorId),
+                testConnector,
+                createSystemTablesConnectorId(connectorId),
+                testConnector));
+
+        QueryStateMachine stateMachine = createQueryStateMachine(sqlString, session, false, transactionManager, executor, metadata);
+        UseTask useTask = new UseTask();
+        useTask.execute(use, transactionManager, metadata, accessControl, stateMachine, emptyList());
+    }
+}


### PR DESCRIPTION
Added catalog and schema level access checks when a user tries USE statement

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
A user with any role who has not been granted access to a specific catalog or schema is still able to execute the USE command. The expected behavior is that such users should receive an "Access Denied" error when attempting to access a catalog or schema for which they lack permission.
Refer : https://github.com/prestodb/presto/issues/23881

## Test Plan
<!---Please fill in how you tested your change-->
Added the related testcases to the code change

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add catalog and schema level access checks in :doc:`/sql/use`
 statement. :pr:`24182`
```
