### PR TITLE
Upgrade jetty dependencies to address CVE-2024-8184

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <dep.commons.compress.version>1.26.2</dep.commons.compress.version>
         <dep.protobuf-java.version>3.25.5</dep.protobuf-java.version>
         <dep.snakeyaml.version>2.0</dep.snakeyaml.version>
+        <dep.jetty.version>9.4.56.v20240826</dep.jetty.version>
 
         <!--
           America/Bahia_Banderas has:
@@ -207,6 +208,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${dep.jetty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>


### PR DESCRIPTION
## Description
Upgrade the jetty dependencies to CVE-2024-8184
If implemented this will:
Upgrade the jetty dependencies to 9.4.56.v20240826

## Motivation and Context
This upgrade was created to deal with [CVE-2024-8184](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-8184)

## Impact
None


## Checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Upgrade jetty dependencies to version 9.4.56.v20240826 in response to `CVE-2024-8184 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-8184>`_. :pr:`24184`
```