### PR TITLE
[native] Small doc change for query-data-cache-enabled-default config to include HARD_AFFINITY

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -193,7 +193,7 @@ Whether async data cache is enabled.
 If ``true``, SSD cache is enabled by default and is disabled only if
 ``node_selection_strategy`` is present and set to ``NO_PREFERENCE``.
 Otherwise, SSD cache is disabled by default and is enabled if
-``node_selection_strategy`` is present and set to ``SOFT_AFFINITY``.
+``node_selection_strategy`` is present and set to ``SOFT_AFFINITY`` or ``HARD_AFFINITY``.
 
 ``async-cache-ssd-gb``
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Small doc change for query-data-cache-enabled-default config to include HARD_AFFINITY as an option to also enable SSD cache to reflect accurately the implementation of the PRs below that recently have been merged for this config.

[query-data-cache-enabled-default PR](https://github.com/prestodb/presto/pull/24076)
[node_schedule_strategy=HARD_AFFINITY should also set cache.no_retention=false PR](https://github.com/prestodb/presto/pull/24147)

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

