### PR TITLE
[native] Remove const from VeloxPlanValidator.

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/VeloxPlanConversion.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxPlanConversion.cpp
@@ -36,7 +36,7 @@ namespace facebook::presto {
 protocol::PlanConversionResponse prestoToVeloxPlanConversion(
     const std::string& planFragmentJson,
     memory::MemoryPool* pool,
-    const VeloxPlanValidator* planValidator) {
+    VeloxPlanValidator* planValidator) {
   protocol::PlanConversionResponse response;
 
   try {

--- a/presto-native-execution/presto_cpp/main/types/VeloxPlanConversion.h
+++ b/presto-native-execution/presto_cpp/main/types/VeloxPlanConversion.h
@@ -27,6 +27,6 @@ namespace facebook::presto {
 protocol::PlanConversionResponse prestoToVeloxPlanConversion(
     const std::string& planFragmentJson,
     velox::memory::MemoryPool* pool,
-    const VeloxPlanValidator* planValidator);
+    VeloxPlanValidator* planValidator);
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/types/VeloxPlanValidator.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxPlanValidator.cpp
@@ -33,7 +33,7 @@ bool planHasNestedJoinLoop(const velox::core::PlanNodePtr planNode) {
 }
 
 void VeloxPlanValidator::validatePlanFragment(
-    const velox::core::PlanFragment& fragment) const {
+    const velox::core::PlanFragment& fragment) {
   const auto failOnNestedLoopJoin =
       SystemConfig::instance()
           ->optionalProperty<bool>(

--- a/presto-native-execution/presto_cpp/main/types/VeloxPlanValidator.h
+++ b/presto-native-execution/presto_cpp/main/types/VeloxPlanValidator.h
@@ -17,8 +17,7 @@
 namespace facebook::presto {
 class VeloxPlanValidator {
  public:
-  virtual void validatePlanFragment(
-      const velox::core::PlanFragment& fragment) const;
+  virtual void validatePlanFragment(const velox::core::PlanFragment& fragment);
   virtual ~VeloxPlanValidator() = default;
 };
 } // namespace facebook::presto


### PR DESCRIPTION
## Description
Removing const from VeloxPlanValidator so that classes that extends Validator can update member variables.

## Motivation and Context
In meta internal system, VeloxPlanValidator is inherited to override validatePlanFragment. Inside validatePlanFragment, it maintains update to private variables. Hence adding const qualifier breaks the build. 

## Impact
None

## Test Plan
Build

```
== NO RELEASE NOTE ==
```

