### PR TITLE
Fix for security vulnerability in swagger-ui

### DIFF
--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -314,10 +314,6 @@
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
                     <artifactId>jackson-dataformat-yaml</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.webjars</groupId>
-                    <artifactId>swagger-ui</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -262,6 +262,10 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-transport-native-epoll</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.webjars</groupId>
+                    <artifactId>swagger-ui</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## Description
This PR addresses the security vulnerability https://github.com/advisories/GHSA-cr3q-pqgq-m8c2 in the swagger-ui WebJar , which is included as a transitive dependency in our project via presto-pinot-driver.

And Revert of https://github.com/prestodb/presto/pull/24153

## Motivation and Context
By excluding the vulnerable version of swagger-ui, we ensure that our application is not susceptible to the XSS vulnerability associated with https://github.com/advisories/GHSA-cr3q-pqgq-m8c2.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```

== RELEASE NOTES ==

Security Changes
* Fix security vulnerability in swagger-ui jar in response to 'CVE-2018-25031 <https://nvd.nist.gov/vuln/detail/CVE-2018-25031>' .  :pr:`24199`


