### PR TITLE
Make max slice size in ORC slice reader configurable

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc;
 
 import io.airlift.units.DataSize;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class OrcRecordReaderOptions
@@ -24,10 +25,16 @@ public class OrcRecordReaderOptions
     private final DataSize maxBlockSize;
     private final boolean mapNullKeysEnabled;
     private final boolean appendRowNumber;
+    private final long maxSliceSize;
 
     public OrcRecordReaderOptions(OrcReaderOptions options)
     {
-        this(options.getMaxMergeDistance(), options.getTinyStripeThreshold(), options.getMaxBlockSize(), options.mapNullKeysEnabled(), options.appendRowNumber());
+        this(options.getMaxMergeDistance(),
+                options.getTinyStripeThreshold(),
+                options.getMaxBlockSize(),
+                options.mapNullKeysEnabled(),
+                options.appendRowNumber(),
+                options.getMaxSliceSize());
     }
 
     public OrcRecordReaderOptions(
@@ -35,13 +42,17 @@ public class OrcRecordReaderOptions
             DataSize tinyStripeThreshold,
             DataSize maxBlockSize,
             boolean mapNullKeysEnabled,
-            boolean appendRowNumber)
+            boolean appendRowNumber,
+            DataSize maxSliceSize)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
         this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
         this.mapNullKeysEnabled = mapNullKeysEnabled;
         this.appendRowNumber = appendRowNumber;
+        checkArgument(maxSliceSize.toBytes() < Integer.MAX_VALUE, "maxSliceSize cannot be larger than Integer.MAX_VALUE");
+        checkArgument(maxSliceSize.toBytes() > 0, "maxSliceSize must be positive");
+        this.maxSliceSize = maxSliceSize.toBytes();
     }
 
     public DataSize getMaxMergeDistance()
@@ -67,5 +78,10 @@ public class OrcRecordReaderOptions
     public boolean appendRowNumber()
     {
         return appendRowNumber;
+    }
+
+    public long getMaxSliceSize()
+    {
+        return maxSliceSize;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
@@ -49,7 +49,7 @@ public final class BatchStreamReaders
             case STRING:
             case VARCHAR:
             case CHAR:
-                return new SliceBatchStreamReader(type, streamDescriptor, systemMemoryContext);
+                return new SliceBatchStreamReader(type, streamDescriptor, systemMemoryContext, options.getMaxSliceSize());
             case TIMESTAMP:
             case TIMESTAMP_MICROSECONDS:
                 boolean enableMicroPrecision = type == TIMESTAMP_MICROSECONDS;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongSelectiveStreamReader.java
@@ -51,9 +51,10 @@ public class LongSelectiveStreamReader
             Optional<TupleDomainFilter> filter,
             Optional<Type> outputType,
             OrcAggregatedMemoryContext systemMemoryContext,
-            boolean isLowMemory)
+            boolean isLowMemory,
+            long maxSliceSize)
     {
-        this.context = new SelectiveReaderContext(streamDescriptor, outputType, filter, systemMemoryContext, isLowMemory);
+        this.context = new SelectiveReaderContext(streamDescriptor, outputType, filter, systemMemoryContext, isLowMemory, maxSliceSize);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
@@ -40,13 +40,15 @@ public class SelectiveReaderContext
 
     private final OrcAggregatedMemoryContext systemMemoryContext;
     private final boolean isLowMemory;
+    private final long maxSliceSize;
 
     public SelectiveReaderContext(
             StreamDescriptor streamDescriptor,
             Optional<Type> outputType,
             Optional<TupleDomainFilter> filter,
             OrcAggregatedMemoryContext systemMemoryContext,
-            boolean isLowMemory)
+            boolean isLowMemory,
+            long maxSliceSize)
     {
         this.filter = requireNonNull(filter, "filter is null").orElse(null);
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
@@ -57,6 +59,9 @@ public class SelectiveReaderContext
         this.isLowMemory = isLowMemory;
         this.nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();
         this.nullsAllowed = this.filter == null || nonDeterministicFilter || this.filter.testNull();
+        checkArgument(maxSliceSize < Integer.MAX_VALUE, "maxSliceSize cannot be larger than Integer.MAX_VALUE");
+        checkArgument(maxSliceSize > 0, "maxSliceSize must be positive");
+        this.maxSliceSize = maxSliceSize;
     }
 
     public StreamDescriptor getStreamDescriptor()
@@ -105,5 +110,10 @@ public class SelectiveReaderContext
     public boolean isNullsAllowed()
     {
         return nullsAllowed;
+    }
+
+    public long getMaxSliceSize()
+    {
+        return maxSliceSize;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
@@ -83,7 +83,7 @@ public final class SelectiveStreamReaders
             case DATE: {
                 checkArgument(requiredSubfields.isEmpty(), "Primitive type stream reader doesn't support subfields");
                 verifyStreamType(streamDescriptor, outputType, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType);
-                return new LongSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), outputType, systemMemoryContext, isLowMemory);
+                return new LongSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), outputType, systemMemoryContext, isLowMemory, options.getMaxSliceSize());
             }
             case FLOAT: {
                 checkArgument(requiredSubfields.isEmpty(), "Float type stream reader doesn't support subfields");
@@ -100,7 +100,7 @@ public final class SelectiveStreamReaders
             case CHAR:
                 checkArgument(requiredSubfields.isEmpty(), "Primitive stream reader doesn't support subfields");
                 verifyStreamType(streamDescriptor, outputType, t -> t instanceof VarcharType || t instanceof CharType || t instanceof VarbinaryType);
-                return new SliceSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), outputType, systemMemoryContext, isLowMemory);
+                return new SliceSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), outputType, systemMemoryContext, isLowMemory, options.getMaxSliceSize());
             case TIMESTAMP:
             case TIMESTAMP_MICROSECONDS: {
                 boolean enableMicroPrecision = outputType.isPresent() && outputType.get() == TIMESTAMP_MICROSECONDS;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
@@ -55,13 +55,13 @@ public class SliceBatchStreamReader
     private final SliceDictionaryBatchStreamReader dictionaryReader;
     private BatchStreamReader currentReader;
 
-    public SliceBatchStreamReader(Type type, StreamDescriptor streamDescriptor, OrcAggregatedMemoryContext systemMemoryContext)
+    public SliceBatchStreamReader(Type type, StreamDescriptor streamDescriptor, OrcAggregatedMemoryContext systemMemoryContext, long maxSliceSize)
             throws OrcCorruptionException
     {
         requireNonNull(type, "type is null");
         verifyStreamType(streamDescriptor, type, t -> t instanceof VarcharType || t instanceof CharType || t instanceof VarbinaryType);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        this.directReader = new SliceDirectBatchStreamReader(streamDescriptor, getMaxCodePointCount(type), isCharType(type));
+        this.directReader = new SliceDirectBatchStreamReader(streamDescriptor, getMaxCodePointCount(type), isCharType(type), maxSliceSize);
         this.dictionaryReader = new SliceDictionaryBatchStreamReader(streamDescriptor, getMaxCodePointCount(type), isCharType(type), systemMemoryContext.newOrcLocalMemoryContext(SliceBatchStreamReader.class.getSimpleName()));
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceSelectiveStreamReader.java
@@ -50,9 +50,15 @@ public class SliceSelectiveStreamReader
     private SliceDictionarySelectiveReader dictionaryReader;
     private SelectiveStreamReader currentReader;
 
-    public SliceSelectiveStreamReader(StreamDescriptor streamDescriptor, Optional<TupleDomainFilter> filter, Optional<Type> outputType, OrcAggregatedMemoryContext systemMemoryContext, boolean isLowMemory)
+    public SliceSelectiveStreamReader(
+            StreamDescriptor streamDescriptor,
+            Optional<TupleDomainFilter> filter,
+            Optional<Type> outputType,
+            OrcAggregatedMemoryContext systemMemoryContext,
+            boolean isLowMemory,
+            long maxSliceSize)
     {
-        this.context = new SelectiveReaderContext(streamDescriptor, outputType, filter, systemMemoryContext, isLowMemory);
+        this.context = new SelectiveReaderContext(streamDescriptor, outputType, filter, systemMemoryContext, isLowMemory, maxSliceSize);
     }
 
     public static int computeTruncatedLength(Slice slice, int offset, int length, int maxCodePointCount, boolean isCharType)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/reader/TestMaxSliceReadSize.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/reader/TestMaxSliceReadSize.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.common.GenericInternalException;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.facebook.presto.orc.DwrfKeyProvider;
+import com.facebook.presto.orc.FileOrcDataSource;
+import com.facebook.presto.orc.OrcDataSource;
+import com.facebook.presto.orc.OrcEncoding;
+import com.facebook.presto.orc.OrcPredicate;
+import com.facebook.presto.orc.OrcReader;
+import com.facebook.presto.orc.OrcReaderOptions;
+import com.facebook.presto.orc.OrcSelectiveRecordReader;
+import com.facebook.presto.orc.OrcTester;
+import com.facebook.presto.orc.StorageStripeMetadataSource;
+import com.facebook.presto.orc.TempFile;
+import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
+import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
+import static com.facebook.presto.orc.OrcTester.Format.DWRF;
+import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class TestMaxSliceReadSize
+{
+    @Test
+    public void test()
+            throws Exception
+    {
+        SqlVarbinary value = new SqlVarbinary(new byte[10 * 1024]);
+
+        try (TempFile tempFile = new TempFile()) {
+            OrcTester.writeOrcColumnsPresto(
+                    tempFile.getFile(),
+                    DWRF,
+                    CompressionKind.NONE,
+                    Optional.empty(),
+                    ImmutableList.of(VARBINARY),
+                    ImmutableList.of(ImmutableList.of(value)),
+                    NOOP_WRITER_STATS);
+
+            OrcSelectiveRecordReader readerNoLimits = createReader(tempFile, new DataSize(1, MEGABYTE));
+            Page page = readerNoLimits.getNextPage().getLoadedPage();
+            assertEquals(page.getPositionCount(), 1);
+
+            OrcSelectiveRecordReader readerBelowThreshold = createReader(tempFile, new DataSize(1, KILOBYTE));
+            GenericInternalException exception = expectThrows(GenericInternalException.class, () -> readerBelowThreshold.getNextPage().getLoadedPage());
+            assertTrue(exception.getMessage().startsWith("Values in column \"test\" are too large to process for Presto. Requested to read [10240] bytes, when max allowed is [1024] bytes "));
+        }
+    }
+
+    private static OrcSelectiveRecordReader createReader(TempFile tempFile, DataSize maxSliceSize)
+            throws IOException
+    {
+        OrcDataSource orcDataSource = new FileOrcDataSource(
+                tempFile.getFile(),
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                true);
+
+        OrcReaderOptions options = OrcReaderOptions.builder()
+                .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+                .withMaxBlockSize(new DataSize(1, MEGABYTE))
+                .withMaxSliceSize(maxSliceSize)
+                .build();
+
+        OrcReader orcReader = new OrcReader(
+                orcDataSource,
+                OrcEncoding.DWRF,
+                new StorageOrcFileTailSource(),
+                new StorageStripeMetadataSource(),
+                NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
+                options,
+                false,
+                NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats());
+
+        return orcReader.createSelectiveRecordReader(
+                ImmutableMap.of(0, VARBINARY),
+                ImmutableList.of(0),
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                OrcPredicate.TRUE,
+                0,
+                orcDataSource.getSize(),
+                HIVE_STORAGE_TIME_ZONE,
+                NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
+                Optional.empty(),
+                1);
+    }
+}


### PR DESCRIPTION
## Description
ORC slice reader has a hardcoded max slice size of 1GB, it throws when it one attempts to read a slice(s) larger than 1GB. Make it configurable to be able to increase the threshold in Spark for some failing jobs.

Plumbed the new value trough OrcReaderOptions -> OrcRecordReaderOptions -> OrcReader -> SelectiveReaderContext -> SliceDirectSelectiveStreamReader.

## Motivation and Context
Hardcoded value of 1GB is too low for some files and needs to be increased to accommodate such cases.

## Impact
No impact.

## Test Plan
Existing and new unit tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

