### PR TITLE
[jdk upgrade] Force maven central to take precedence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,15 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+              <enabled>false</enabled>
+            </snapshots>
+          </repository>
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>


### PR DESCRIPTION
Repository tag copied from the maven 3 super POM at https://maven.apache.org/ref/3.9.9/maven-model-builder/super-pom.html

Fixes issue with maven dependency checks that seem to pass locally but fail in CI. This change forces the `go-offline-maven-plugin` to try to resolve dependencies through central before going to jitpack. This should only be temporary while we allow jitpack dependencies. It can be removed once we move everything off of jitpack
