### PR TITLE
[native] Add dummy class to fix Nexus release issues

### DIFF
--- a/presto-native-execution/src/main/java/com/facebook/presto/Dummy.java
+++ b/presto-native-execution/src/main/java/com/facebook/presto/Dummy.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+/**
+ * This class exists to force the creation of a jar for the presto-server module. This is needed to deploy the presto-server module to nexus.
+ */
+public class Dummy
+{
+}


### PR DESCRIPTION
## Description
Open source nexus deployment requires the creation of a JAR with Javadoc.  Because we depend on the code in the `presto-native-execution` module now in other modules for tests, we need to release these artifacts to Nexus along with the rest of the modules we release.

Because there is only testing code in this module, it fails during Nexus deployment.  Adding a dummy class with Javadoc to allow this artifact to be released.

## Motivation and Context
Allow this module to be released.

## Impact
N/A

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

