### PR TITLE
[native] Change SSD Cache Executor to use CPUThreadPool

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -791,7 +791,9 @@ std::unique_ptr<velox::cache::SsdCache> PrestoServer::setupSsdCache() {
   }
 
   constexpr int32_t kNumSsdShards = 16;
-  cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(kNumSsdShards);
+  cacheExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+     kNumSsdShards,
+     std::make_shared<folly::NamedThreadFactory>("SsdCache"));
   velox::cache::SsdCache::Config cacheConfig(
       systemConfig->asyncCacheSsdPath(),
       systemConfig->asyncCacheSsdGb() << 30,

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -792,8 +792,7 @@ std::unique_ptr<velox::cache::SsdCache> PrestoServer::setupSsdCache() {
 
   constexpr int32_t kNumSsdShards = 16;
   cacheExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
-     kNumSsdShards,
-     std::make_shared<folly::NamedThreadFactory>("SsdCache"));
+      kNumSsdShards, std::make_shared<folly::NamedThreadFactory>("SsdCache"));
   velox::cache::SsdCache::Config cacheConfig(
       systemConfig->asyncCacheSsdPath(),
       systemConfig->asyncCacheSsdGb() << 30,

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -233,7 +233,7 @@ class PrestoServer {
   std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer_;
 
   // Executor for background writing into SSD cache.
-  std::unique_ptr<folly::IOThreadPoolExecutor> cacheExecutor_;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> cacheExecutor_;
 
   // Executor for async IO for connectors.
   std::unique_ptr<folly::IOThreadPoolExecutor> connectorIoExecutor_;


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Use CPUThreadPoolExecutor for SSD cache

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
Prestissimo's SSD Executor is using IOThreadPoolExecutor even though we are not using evb or io_uring at all. We have no need for IOThreadPoolExecutor. Given that IOThreadPoolExecutor can suffer from head of line blocking because it picks threads in a round robin manner and each thread has its own queue.
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
N/A; Low impact

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

