### PR TITLE
[native] Add two new parameters for trace control

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -307,7 +307,7 @@ Minimum number of rows to use prefix-sort.
 The default value has been derived using micro-benchmarking.
 
 ``native_op_trace_directory_create_config``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``varchar``
 * **Default value:** ``""``
@@ -315,3 +315,65 @@ The default value has been derived using micro-benchmarking.
 Native Execution only. Config used to create operator trace directory. This config is provided
 to underlying file system and the config is free form. The form should be defined by the
 underlying file system.
+
+``native_query_trace_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Enable query tracing. After enabled, trace data will be generated with query execution, and
+can be used by TraceReplayer. It needs to be used together with native_query_trace_node_ids,
+native_query_trace_max_bytes, native_query_trace_fragment_id, and native_query_trace_shard_id
+to match the task to be traced.
+
+
+``native_query_trace_dir``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Default value:** ``""``
+
+The location to store the trace files.
+
+``native_query_trace_node_ids``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Default value:** ``""``
+
+A comma-separated list of plan node ids whose input data will be traced.
+Empty string if only want to trace the query metadata.
+
+``native_query_trace_max_bytes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+The max trace bytes limit. Tracing is disabled if zero.
+
+``native_query_trace_fragment_id``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Default value:** ``.*``
+
+The fragment id to be traced. If not specified, all fragments will be matched.
+
+``native_query_trace_shard_id``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Default value:** ``.*``
+
+The shard id to be traced. If not specified, all shards will be matched.
+
+``native_query_trace_task_reg_exp``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``varchar``
+* **Default value:** ``""``
+
+The regular expression to match a task for tracing. It will be deprecated if there is
+no issue with native_query_trace_fragment_id and native_query_trace_shard_id.

--- a/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -61,6 +61,8 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_QUERY_TRACE_NODE_IDS = "native_query_trace_node_ids";
     public static final String NATIVE_QUERY_TRACE_MAX_BYTES = "native_query_trace_max_bytes";
     public static final String NATIVE_QUERY_TRACE_REG_EXP = "native_query_trace_task_reg_exp";
+    public static final String NATIVE_QUERY_TRACE_FRAGMENT_ID = "native_query_trace_fragment_id";
+    public static final String NATIVE_QUERY_TRACE_SHARD_ID = "native_query_trace_shard_id";
     public static final String NATIVE_MAX_LOCAL_EXCHANGE_PARTITION_COUNT = "native_max_local_exchange_partition_count";
     public static final String NATIVE_SPILL_PREFIXSORT_ENABLED = "native_spill_prefixsort_enabled";
     public static final String NATIVE_PREFIXSORT_NORMALIZED_KEY_MAX_BYTES = "native_prefixsort_normalized_key_max_bytes";
@@ -229,6 +231,14 @@ public class NativeWorkerSessionPropertyProvider
                         !nativeExecution),
                 stringProperty(NATIVE_OP_TRACE_DIR_CREATE_CONFIG,
                         "Config used to create operator trace directory. This config is provided to underlying file system and the config is free form. The form should be defined by the underlying file system.",
+                        "",
+                        !nativeExecution),
+                stringProperty(NATIVE_QUERY_TRACE_FRAGMENT_ID,
+                            "The fragment id of the traced task.",
+                        "",
+                        !nativeExecution),
+                stringProperty(NATIVE_QUERY_TRACE_SHARD_ID,
+                        "The shard id of the traced task.",
                         "",
                         !nativeExecution),
                 longProperty(NATIVE_MAX_OUTPUT_BUFFER_SIZE,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -213,6 +213,16 @@ class SessionProperties {
   static constexpr const char* kOpTraceDirectoryCreateConfig =
       "native_op_trace_directory_create_config";
 
+  /// The fragment id of the traced task. Used to construct
+  /// the regular expression for matching
+  static constexpr const char* kQueryTraceFragmentId =
+      "native_query_trace_fragment_id";
+
+  /// The shard id of the traced task. Used to construct
+  /// the regular expression for matching
+  static constexpr const char* kQueryTraceShardId =
+      "native_query_trace_shard_id";
+
   /// The maximum size in bytes for the task's buffered output. The buffer is
   /// shared among all drivers.
   static constexpr const char* kMaxOutputBufferSize =


### PR DESCRIPTION
## Description
This is to improve the trace control experience. We added two new properties:
- native_query_trace_fragment_id
- native_query_trace_shard_id
Once specified, we automatically create a regex for Velox to match the taskID pattern, so developers don't need to compose the complicated regex themselves, and it is controlled at Prestissimo level.
If native_query_trace_task_reg_exp is also provided, it will be overridden.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
* Added native_query_trace_fragment_id and native_query_trace_shard_id for easier trace control:pr:`24209`
