### PR TITLE
[native] Advance Velox and cmake fix

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(
   PrestoToVeloxQueryPlan.cpp PrestoToVeloxExpr.cpp VeloxPlanValidator.cpp
   PrestoToVeloxSplit.cpp PrestoToVeloxConnector.cpp)
 add_dependencies(presto_types presto_operators presto_type_converter velox_type
-                 velox_type_fbhive velox_dwio_dwrf_proto)
+                 velox_type_fbhive)
 
 target_link_libraries(presto_types presto_type_converter velox_type_fbhive
                       velox_hive_partition_function velox_tpch_gen)


### PR DESCRIPTION
A follow-up cmake fix for https://github.com/facebookincubator/velox/pull/11751 that removes the `velox_dwio_dwrf_proto` object.