### PR TITLE
Fix setting iceberg table location on creation for REST/NESSIE catalog

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergDistributedHadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergDistributedHadoop.java
@@ -16,7 +16,11 @@ package com.facebook.presto.iceberg.hadoop;
 import com.facebook.presto.iceberg.IcebergDistributedTestBase;
 import org.testng.annotations.Test;
 
+import java.net.URI;
+
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.google.common.io.Files.createTempDir;
+import static java.lang.String.format;
 
 @Test
 public class TestIcebergDistributedHadoop
@@ -25,5 +29,14 @@ public class TestIcebergDistributedHadoop
     public TestIcebergDistributedHadoop()
     {
         super(HADOOP);
+    }
+
+    @Override
+    public void testCreateTableWithCustomLocation()
+    {
+        String tableName = "test_hadoop_table_with_custom_location";
+        URI tableTargetURI = createTempDir().toURI();
+        assertQueryFails(format("create table %s (a int, b varchar)" + " with (location = '%s')", tableName, tableTargetURI.toString()),
+                "Cannot set a custom location for a path-based table.*");
     }
 }


### PR DESCRIPTION
## Description

Currently we ignore the specified table property `location` when creating tables on iceberg catalogs based on `IcebergNativeMetadata`, this will result in that the newly created table's location  always using default values, regardless of whether a custom location is explicitly specified or not. 

This behavior is somewhat unreasonable, as for catalogs that support specifying table locations on creation (like Rest and Nessie), the newly created table's location should be the specified path; while for catalogs that do not support specifying table locations on creation (like Hadoop), exceptions should be thrown directly.

This PR fix the above problem, pass the specified table `location` to Iceberg lib when creating tables on catalogs based on `IcebergNativeMetadata `.

## Motivation and Context

Support specifying table location on creation for Iceberg connector on as many catalog types as possible.

## Impact

Iceberg connector configured with REST and NESSIE catalogs now support specifying table location on creation.
Iceberg connector configured with HADOOP catalogs now fail directly when specifying table location on creation.

## Test Plan

- Newly added test cases for creating iceberg table with custom location

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support of specifying table location on creation for Iceberg connector when configured with ``REST`` and ``NESSIE``. :pr:`24218`
```
