### PR TITLE
Fix strrpos function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -267,13 +267,15 @@ public final class StringFunctions
             return 1;
         }
 
+        String stringUtf8 = string.toStringUtf8();
+        String substringUtf8 = substring.toStringUtf8();
         int foundInstances = 0;
         // set the initial index just after the end of the string
         // this is to allow for the initial index decrement
-        int index = string.length();
+        int index = stringUtf8.length();
         do {
             // step backwards through string
-            index = string.toStringUtf8().lastIndexOf(substring.toStringUtf8(), index - 1);
+            index = stringUtf8.lastIndexOf(substringUtf8, index - 1);
             if (index < 0) {
                 return 0;
             }
@@ -281,7 +283,9 @@ public final class StringFunctions
         }
         while (foundInstances < instance);
 
-        return countCodePoints(string, 0, index) + 1;
+        // stringPositionFromStart function returns countCodePoints(string, 0, index) + 1 because it directly works on Slice and use indexOf function of Slice,
+        // Here we convert Slice to Utf8 string call lastIndexOf function of String to get index, hence directly return index+1
+        return index + 1;
     }
 
     @Description("suffix starting at given index")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -317,9 +317,10 @@ public class TestStringFunctions
         assertFunction("STRRPOS('x', '')", BIGINT, 1L);
         assertFunction("STRRPOS('', '')", BIGINT, 1L);
 
-        assertFunction("STRRPOS('\u4FE1\u5FF5,\u7231,\u5E0C\u671B', '\u7231')", BIGINT, 2L);
-        assertFunction("STRRPOS('\u4FE1\u5FF5,\u7231,\u5E0C\u671B', '\u5E0C\u671B')", BIGINT, 3L);
+        assertFunction("STRRPOS('\u4FE1\u5FF5,\u7231,\u5E0C\u671B', '\u7231')", BIGINT, 4L);
+        assertFunction("STRRPOS('\u4FE1\u5FF5,\u7231,\u5E0C\u671B', '\u5E0C\u671B')", BIGINT, 6L);
         assertFunction("STRRPOS('\u4FE1\u5FF5,\u7231,\u5E0C\u671B', 'nice')", BIGINT, 0L);
+        assertFunction("STRRPOS('Screenshot 2024-12-01 at 12.00.51\u202fPM.png', '.')", BIGINT, 37L);
 
         assertFunction("STRRPOS(NULL, '')", BIGINT, null);
         assertFunction("STRRPOS('', NULL)", BIGINT, null);


### PR DESCRIPTION
## Description
The current strrpos function returns wrong result for multibyte characters

## Motivation and Context
bug fix

## Impact
bug fix

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix bug in strrpos function for multibyte characters
```


