### PR TITLE
[Native] Fix table writer to use the actual storage format for insert

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
@@ -1267,7 +1267,7 @@ HivePrestoToVeloxConnector::toVeloxInsertTableHandle(
   return std::make_unique<connector::hive::HiveInsertTableHandle>(
       inputColumns,
       toLocationHandle(hiveInsertTableHandle->locationHandle),
-      toFileFormat(hiveInsertTableHandle->tableStorageFormat, "TableWrite"),
+      toFileFormat(hiveInsertTableHandle->actualStorageFormat, "TableWrite"),
       toHiveBucketProperty(
           inputColumns, hiveInsertTableHandle->bucketProperty, typeParser),
       std::optional(


### PR DESCRIPTION
## Description
https://github.com/prestodb/presto/pull/23923 fixed the CreateHandle. 
As a follwup, also fix the InsertHandle

```
== NO RELEASE NOTE ==
```

