### PR TITLE
Use alluxio-core instead of shaded deps to get rid of CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dep.docker-java.version>3.3.0</dep.docker-java.version>
         <dep.jayway.version>2.9.0</dep.jayway.version>
         <dep.ratis.version>2.2.0</dep.ratis.version>
-        <dep.errorprone.version>2.18.0</dep.errorprone.version>
+        <dep.errorprone.version>2.28.0</dep.errorprone.version>
         <dep.guava.version>32.1.0-jre</dep.guava.version>
         <dep.jackson.version>2.15.4</dep.jackson.version>
         <dep.j2objc.version>2.8</dep.j2objc.version>
@@ -86,6 +86,9 @@
         <dep.netty.version>4.1.115.Final</dep.netty.version>
         <dep.snakeyaml.version>2.0</dep.snakeyaml.version>
         <dep.jetty.version>9.4.56.v20240826</dep.jetty.version>
+        <dep.gson.version>2.11.0</dep.gson.version>
+        <dep.commons.lang3.version>3.14.0</dep.commons.lang3.version>
+        <dep.guice.version>5.1.0</dep.guice.version>
 
         <!--
           America/Bahia_Banderas has:
@@ -564,6 +567,26 @@
 
             <dependency>
                 <groupId>io.grpc</groupId>
+                <artifactId>grpc-netty</artifactId>
+                <version>${grpc.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.grpc</groupId>
                 <artifactId>grpc-netty-shaded</artifactId>
                 <version>${grpc.version}</version>
                 <exclusions>
@@ -584,8 +607,30 @@
 
             <dependency>
                 <groupId>io.grpc</groupId>
+                <artifactId>grpc-services</artifactId>
+                <version>${grpc.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.grpc</groupId>
                 <artifactId>grpc-core</artifactId>
                 <version>${grpc.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1475,24 +1520,136 @@
 
             <dependency>
                 <groupId>org.alluxio</groupId>
-                <artifactId>alluxio-shaded-client</artifactId>
+                <artifactId>alluxio-core-client-hdfs</artifactId>
                 <version>${dep.alluxio.version}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>org.alluxio</groupId>
+                        <artifactId>alluxio-core-transport</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.alluxio</groupId>
+                <artifactId>alluxio-core-client-fs</artifactId>
+                <version>${dep.alluxio.version}</version>
+                <exclusions>
                     <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
+                        <groupId>com.github.stateless4j</groupId>
+                        <artifactId>stateless4j</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.rocksdb</groupId>
+                        <artifactId>rocksdbjni</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.alluxio</groupId>
+                <artifactId>alluxio-core-common</artifactId>
+                <version>${dep.alluxio.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.rabbitmq</groupId>
+                        <artifactId>amqp-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-cli</groupId>
+                        <artifactId>commons-cli</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.etcd</groupId>
+                        <artifactId>jetcd-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.prometheus</groupId>
+                        <artifactId>prometheus-metrics-exporter-servlet-jakarta</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.swagger</groupId>
+                        <artifactId>swagger-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.curator</groupId>
+                        <artifactId>curator-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.curator</groupId>
+                        <artifactId>curator-framework</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-servlet</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.reflections</groupId>
+                        <artifactId>reflections</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1651,6 +1808,10 @@
                         <artifactId>jackson-dataformat-smile</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>com.google.inject.extensions</groupId>
+                        <artifactId>guice-multibindings</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>it.unimi.dsi</groupId>
                         <artifactId>fastutil</artifactId>
                     </exclusion>
@@ -1700,13 +1861,13 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.5</version>
+                <version>4.5.14</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.9</version>
+                <version>4.4.16</version>
             </dependency>
 
             <dependency>
@@ -1990,6 +2151,10 @@
                         <groupId>com.google.code.findbugs</groupId>
                         <artifactId>annotations</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.google.inject.extensions</groupId>
+                        <artifactId>guice-multibindings</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -2218,6 +2383,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${dep.gson.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
                 <version>${dep.errorprone.version}</version>
@@ -2245,6 +2416,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${dep.commons.compress.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${dep.commons.lang3.version}</version>
             </dependency>
 
             <dependency>
@@ -2346,7 +2523,6 @@
                             <requireUpperBoundDeps>
                                 <excludes combine.children="append">
                                     <!-- TODO: fix this in Airlift resolver -->
-                                    <exclude>org.alluxio:alluxio-shaded-client</exclude>
                                     <exclude>org.codehaus.plexus:plexus-utils</exclude>
                                     <exclude>com.google.guava:guava</exclude>
                                     <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
@@ -2363,6 +2539,7 @@
                     <artifactId>duplicate-finder-maven-plugin</artifactId>
                     <configuration>
                         <ignoredClassPatterns combine.children="append">
+                            <ignoredClassPattern>com.github.benmanes.caffeine.*</ignoredClassPattern>
                             <!-- Duplicate class is being brought in by commons-io & log4j-api -->
                             <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                             <!-- Duplicate class is being brought in by several netty dependencies-->
@@ -2370,6 +2547,9 @@
                             <!-- Ignore duplicate classes related to lucene-core and ranger-apache -->
                             <ignoredClassPattern>META-INF.versions.9.org.apache.lucene.*</ignoredClassPattern>
                         </ignoredClassPatterns>
+                        <ignoredResourcePatterns combine.children="append">
+                            <ignoredResourcePattern>git.properties</ignoredResourcePattern>
+                        </ignoredResourcePatterns>
                     </configuration>
                 </plugin>
 

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -232,7 +232,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
         </dependency>
 
         <dependency>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -28,12 +28,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>2.10.1</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.threeten</groupId>
                 <artifactId>threetenbp</artifactId>
                 <version>1.5.1</version>
@@ -43,24 +37,6 @@
                 <groupId>io.opencensus</groupId>
                 <artifactId>opencensus-api</artifactId>
                 <version>0.31.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.14.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore</artifactId>
-                <version>4.4.16</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>4.5.14</version>
             </dependency>
 
             <dependency>

--- a/presto-cache/pom.xml
+++ b/presto-cache/pom.xml
@@ -79,7 +79,17 @@
 
         <dependency>
             <groupId>org.alluxio</groupId>
-            <artifactId>alluxio-shaded-client</artifactId>
+            <artifactId>alluxio-core-client-hdfs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-core-client-fs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-core-common</artifactId>
         </dependency>
 
         <!-- Presto SPI -->
@@ -139,4 +149,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <configuration>
+                        <ignoredUsedUndeclaredDependencies>
+                            <!-- Ignore because it's picked up as false-positive from alluxio's dependencies -->
+                            <dependency>io.dropwizard.metrics:metrics-core</dependency>
+                        </ignoredUsedUndeclaredDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
 </project>

--- a/presto-cache/src/main/java/com/facebook/presto/cache/CacheFactory.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CacheFactory.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.conf.Configuration;
 import java.io.IOException;
 import java.net.URI;
 
-import static alluxio.shaded.client.com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Preconditions.checkState;
 
 public class CacheFactory
 {

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
@@ -16,7 +16,6 @@ package com.facebook.presto.cache.alluxio;
 import alluxio.client.file.cache.CacheManager;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
-import alluxio.shaded.client.org.apache.commons.lang3.NotImplementedException;
 import alluxio.util.io.FileUtils;
 import com.facebook.presto.cache.CacheConfig;
 import com.facebook.presto.hive.CacheQuota;
@@ -665,7 +664,7 @@ public class TestAlluxioCachingFileSystem
         @Override
         public short getDefaultReplication()
         {
-            throw new NotImplementedException("getDefaultReplication not implemented");
+            throw new UnsupportedOperationException("getDefaultReplication not implemented");
         }
 
         @Override
@@ -677,7 +676,7 @@ public class TestAlluxioCachingFileSystem
         @Override
         public long getDefaultBlockSize()
         {
-            throw new NotImplementedException("getDefaultBlockSize not implemented");
+            throw new UnsupportedOperationException("getDefaultBlockSize not implemented");
         }
 
         @Override

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -127,7 +127,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
 
             <exclusions>
                 <!-- elasticsearch-rest-high-level-client 6.0.0 brings in httpcore 4.4.5 vs (4.4.4) -->
@@ -151,7 +150,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.5</version>
         </dependency>
 
         <dependency>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -14,17 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>2.11.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
+    
     <dependencies>
         <dependency>
             <groupId>com.facebook.airlift</groupId>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -81,12 +81,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.alluxio</groupId>
-            <artifactId>alluxio-shaded-client</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -499,10 +499,6 @@
                             <groupId>net.bytebuddy</groupId>
                             <artifactId>byte-buddy</artifactId>
                         </dependency>
-                        <dependency>
-                            <groupId>org.alluxio</groupId>
-                            <artifactId>alluxio-shaded-client</artifactId>
-                        </dependency>
                     </ignoredDependencies>
                 </configuration>
             </plugin>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -672,7 +672,6 @@
                             <ignoredClassPattern>module-info</ignoredClassPattern>
                             <ignoredClassPattern>org.apache.avro.*</ignoredClassPattern>
                             <ignoredClassPattern>org.apache.parquet.*</ignoredClassPattern>
-                            <ignoredClassPattern>com.github.benmanes.caffeine.*</ignoredClassPattern>
                             <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                         </ignoredClassPatterns>
                     </configuration>

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -112,6 +112,10 @@
                     <groupId>org.apache.parquet</groupId>
                     <artifactId>parquet-format-structures</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -247,7 +251,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -281,7 +284,6 @@
                         <ignoredClassPattern>module-info</ignoredClassPattern>
                         <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                         <ignoredClassPattern>org.apache.avro.*</ignoredClassPattern>
-                        <ignoredClassPattern>com.github.benmanes.caffeine.*</ignoredClassPattern>
                         <ignoredClassPattern>org.roaringbitmap.*</ignoredClassPattern>
                     </ignoredClassPatterns>
                 </configuration>

--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -232,7 +232,6 @@
                         <ignoredClassPattern>module-info</ignoredClassPattern>
                         <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
                         <ignoredClassPattern>org.apache.avro.*</ignoredClassPattern>
-                        <ignoredClassPattern>com.github.benmanes.caffeine.*</ignoredClassPattern>
                         <ignoredClassPattern>org.roaringbitmap.*</ignoredClassPattern>
                     </ignoredClassPatterns>
                 </configuration>

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -121,7 +121,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -18,16 +18,6 @@
         <scala.version>2.12.2</scala.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.14.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
## Description
Replace `alluxio-shaded-client` by `alluxio-core-client-hdfs`, `alluxio-core-client-fs` and `alluxio-core-common`.
This change fixes the following Critical and HIGH CVEs introduced by `alluxio-shaded-client v313`:

**CRITICAL**
- zookeeper: CVE-2023-44981

**HIGH**
- protobuf-java: CVE-2024-7254
- commons-io: CVE-2024-47554
- netty-codec-http2: GHSA-xpw8-rcwv-8f8p
- commons-compress: CVE-2024-25710 
- ion-java: CVE-2024-21634

The following dependencies need to be **upgraded** due to this change:
- errorprone 2.28.0
- commons-lang3 3.14.0
- gson 2.11.0
- httpclient 4.5.14
- httpcore   4.4.16
- guice 5.1.0, this change forces the exclusion of `guice-multibindings` from some libraries that depend on earlier versions of Guice, since `guice-multibindings` has been moved to `guice-core` v4.2.

## Motivation and Context
Using the `alluxio-core` libraries instead of the shaded version prevents a lot of CVEs of Critical and HIGH severity. 
In general, the shaded versions should be avoided for this reason.


## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Replace `alluxio-shaded-client` with `alluxio-core` libraries libraries in response to `CVE-2023-44981
 <https://github.com/advisories/GHSA-7286-pgfv-vxvh>`_. :pr:`24231`

