### PR TITLE
[native] Introduce module presto-native-tests

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -165,6 +165,77 @@ jobs:
             -Duser.timezone=America/Bahia_Banderas \
             -T1C
 
+  prestocpp-linux-presto-native-tests:
+    needs: prestocpp-linux-build-for-test
+    runs-on: ubuntu-22.04
+    container:
+      image: prestodb/presto-native-dependency:0.292-20250204112033-cf8ba84
+    env:
+      MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
+      MAVEN_FAST_INSTALL: "-B -V --quiet -T 1C -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
+      MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fix git permissions
+        # Usually actions/checkout does this but as we run in a container
+        # it doesn't work
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: presto-native-build
+          path: presto-native-execution/_build/release
+
+      # Permissions are lost when uploading. Details here: https://github.com/actions/upload-artifact/issues/38
+      - name: Restore execute permissions and library path
+        run: |
+          chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server
+          chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
+          # Ensure transitive dependency libboost-iostreams is found.
+          ldconfig /usr/local/lib
+
+      - name: Install OpenJDK8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
+
+      - name: Maven install
+        env:
+          # Use different Maven options to install.
+          MAVEN_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
+        run: |
+          for i in $(seq 1 3); do ./mvnw clean install $MAVEN_FAST_INSTALL -pl 'presto-native-tests' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
+
+      - name: Run presto-native tests
+        run: |
+          export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server"
+          export TESTFILES=`find ./presto-native-tests/src/test -type f -name 'Test*.java'`
+          # Convert file paths to comma separated class names
+          export TESTCLASSES=
+          for test_file in $TESTFILES
+          do
+            tmp=${test_file##*/}
+            test_class=${tmp%%\.*}
+            export TESTCLASSES="${TESTCLASSES},$test_class"
+          done
+          export TESTCLASSES=${TESTCLASSES#,}
+          echo "TESTCLASSES = $TESTCLASSES"
+
+          mvn test \
+            ${MAVEN_TEST} \
+            -pl 'presto-native-tests' \
+            -Dtest="${TESTCLASSES}" \
+            -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
+            -DDATA_DIR=${RUNNER_TEMP} \
+            -Duser.timezone=America/Bahia_Banderas \
+            -T1C
+
   prestocpp-linux-presto-sidecar-tests:
     needs: prestocpp-linux-build-for-test
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           ./mvnw test -T 1 ${MAVEN_TEST} -pl '
             !presto-tests, 
+            !presto-native-tests,
             !presto-accumulo,
             !presto-cassandra,
             !presto-hive,

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
         <module>presto-test-coverage</module>
         <module>presto-hudi</module>
         <module>presto-native-execution</module>
+        <module>presto-native-tests</module>
         <module>presto-router</module>
         <module>presto-open-telemetry</module>
         <module>redis-hbo-provider</module>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -44,7 +44,9 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
@@ -128,7 +130,7 @@ public class PrestoNativeQueryRunnerUtils
         defaultQueryRunner.close();
 
         return createNativeQueryRunner(dataDirectory.get().toString(), prestoServerPath.get(), workerCount, cacheMaxSize, true, Optional.empty(),
-                storageFormat, addStorageFormatToPath, false, isCoordinatorSidecarEnabled, false, enableRuntimeMetricsCollection, enableSsdCache);
+                storageFormat, addStorageFormatToPath, false, isCoordinatorSidecarEnabled, false, enableRuntimeMetricsCollection, enableSsdCache, Collections.emptyMap());
     }
 
     public static QueryRunner createJavaQueryRunner()
@@ -335,7 +337,8 @@ public class PrestoNativeQueryRunnerUtils
             boolean isCoordinatorSidecarEnabled,
             boolean singleNodeExecutionEnabled,
             boolean enableRuntimeMetricsCollection,
-            boolean enableSsdCache)
+            boolean enableSsdCache,
+            Map<String, String> extraProperties)
             throws Exception
     {
         // The property "hive.allow-drop-table" needs to be set to true because security is always "legacy" in NativeQueryRunner.
@@ -359,6 +362,7 @@ public class PrestoNativeQueryRunnerUtils
                         .put("experimental.internal-communication.thrift-transport-enabled", String.valueOf(useThrift))
                         .putAll(getNativeWorkerSystemProperties())
                         .putAll(isCoordinatorSidecarEnabled ? getNativeSidecarProperties() : ImmutableMap.of())
+                        .putAll(extraProperties)
                         .build(),
                 coordinatorProperties.build(),
                 "legacy",
@@ -420,6 +424,28 @@ public class PrestoNativeQueryRunnerUtils
         return createNativeQueryRunner(false, DEFAULT_STORAGE_FORMAT, Optional.ofNullable(remoteFunctionServerUds), false, false, false, false, false);
     }
 
+    public static QueryRunner createNativeQueryRunner(Map<String, String> extraProperties, String storageFormat)
+            throws Exception
+    {
+        int cacheMaxSize = 0;
+        NativeQueryRunnerParameters nativeQueryRunnerParameters = getNativeQueryRunnerParameters();
+        return createNativeQueryRunner(
+                nativeQueryRunnerParameters.dataDirectory.toString(),
+                nativeQueryRunnerParameters.serverBinary.toString(),
+                nativeQueryRunnerParameters.workerCount,
+                cacheMaxSize,
+                true,
+                Optional.empty(),
+                storageFormat,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                extraProperties);
+    }
+
     public static QueryRunner createNativeQueryRunner(boolean useThrift)
             throws Exception
     {
@@ -464,7 +490,8 @@ public class PrestoNativeQueryRunnerUtils
                 isCoordinatorSidecarEnabled,
                 singleNodeExecutionEnabled,
                 enableRuntimeMetricsCollection,
-                enableSSDCache);
+                enableSSDCache,
+                Collections.emptyMap());
     }
 
     // Start the remote function server. Return the UDS path used to communicate with it.

--- a/presto-native-tests/README.md
+++ b/presto-native-tests/README.md
@@ -1,0 +1,31 @@
+# Presto Native Tests
+
+This module contains end-to-end tests that run queries from test classes in 
+the `presto-tests` module with Presto C++ workers. Please build the module
+`presto-native-execution` first. 
+
+The following command can be used to run all tests in this module:
+```
+mvn test 
+    -pl 'presto-native-tests' 
+    -Dtest="com.facebook.presto.nativetests.Test*" 
+    -Duser.timezone=America/Bahia_Banderas 
+    -DPRESTO_SERVER=${PRESTO_HOME}/presto-native-execution/cmake-build-debug/presto_cpp/main/presto_server 
+    -DWORKER_COUNT=${WORKER_COUNT} -T1C
+```
+Please update JVM argument `PRESTO_SERVER` to point to the Presto C++ worker
+binary `presto_server`. 
+
+## Adding new tests
+
+Presto C++ currently does not have the same behavior as Presto for certain 
+queries. This could be because of missing types, missing function signatures,
+among other reasons. Tests with these unsupported queries are therefore 
+expected to fail and the test asserts the error message is as expected. 
+
+Issues should also be created for the failing queries, so they are documented
+and fixed. Please add the tag `presto-native-tests` for these issues. 
+Once all the failures in a testcase are fixed, the overriden test in this 
+module should be removed and the testcase in the corresponding base class in
+`presto-tests` would be the single source of truth for Presto SQL coverage 
+tests.  

--- a/presto-native-tests/pom.xml
+++ b/presto-native-tests/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.292-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-native-tests</artifactId>
+    <name>presto-native-tests</name>
+    <description>Presto Native Tests</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-native-execution</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpcds</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Disable git-commit-id-plugin plugin to allow for running tests without
+            a git checkout -->
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                        <ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
+                        <ignoredResourcePattern>iceberg-build.properties</ignoredResourcePattern>
+                        <ignoredResourcePattern>org.apache.avro.data/Json.avsc</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                    <ignoredClassPatterns>
+                        <ignoredClassPattern>com.esotericsoftware.kryo.*</ignoredClassPattern>
+                        <ignoredClassPattern>com.esotericsoftware.minlog.Log</ignoredClassPattern>
+                        <ignoredClassPattern>com.esotericsoftware.reflectasm.*</ignoredClassPattern>
+                        <ignoredClassPattern>module-info</ignoredClassPattern>
+                        <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                        <ignoredClassPattern>org.apache.avro.*</ignoredClassPattern>
+                        <ignoredClassPattern>com.github.benmanes.caffeine.*</ignoredClassPattern>
+                        <ignoredClassPattern>org.roaringbitmap.*</ignoredClassPattern>
+                    </ignoredClassPatterns>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Xms4g -Xmx4g</argLine>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <excludedGroups>remote-function,textfile_reader</excludedGroups>
+                    <systemPropertyVariables>
+                        <PRESTO_SERVER>/root/project/build/debug/presto_cpp/main/presto_server</PRESTO_SERVER>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestDistributedEngineOnlyQueries.java
+++ b/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestDistributedEngineOnlyQueries.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestEngineOnlyQueries;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class TestDistributedEngineOnlyQueries
+        extends AbstractTestEngineOnlyQueries
+{
+    private static final String timeTypeUnsupportedError = ".*Failed to parse type \\[time.*";
+
+    private static final String storageFormat = "PARQUET";
+
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(ImmutableMap.of(), storageFormat);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        try {
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(storageFormat);
+            NativeQueryRunnerUtils.createAllTables(javaQueryRunner, false);
+            javaQueryRunner.close();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /// TIME datatype is not supported in Prestissimo. See issue: https://github.com/prestodb/presto/issues/18844.
+    @Override
+    @Test
+    public void testTimeLiterals()
+    {
+        assertQueryFails("SELECT TIME '3:04:05'", timeTypeUnsupportedError);
+        assertQueryFails("SELECT TIME '3:04:05.123'", timeTypeUnsupportedError);
+        assertQueryFails("SELECT TIME '3:04:05'", timeTypeUnsupportedError);
+        assertQueryFails("SELECT TIME '0:04:05'", timeTypeUnsupportedError);
+        // TODO #7122 assertQueryFails(chicago, "SELECT TIME '3:04:05'", timeTypeUnsupportedError);
+        // TODO #7122 assertQueryFails(kathmandu, "SELECT TIME '3:04:05'", timeTypeUnsupportedError);
+
+        assertQueryFails("SELECT TIME '01:02:03.400 Z'", timeTypeUnsupportedError);
+        assertQueryFails("SELECT TIME '01:02:03.400 UTC'", timeTypeUnsupportedError);
+        assertQueryFails("SELECT TIME '3:04:05 +06:00'", timeTypeUnsupportedError);
+        assertQueryFails("SELECT TIME '3:04:05 +0507'", timeTypeUnsupportedError);
+        assertQueryFails("SELECT TIME '3:04:05 +03'", timeTypeUnsupportedError);
+    }
+
+    /// TIME datatype is not supported in Prestissimo. See issue: https://github.com/prestodb/presto/issues/18844.
+    @Override
+    @Test
+    public void testLocallyUnrepresentableTimeLiterals()
+    {
+        LocalTime localTimeThatDidNotOccurOn19700101 = LocalTime.of(0, 10);
+        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localTimeThatDidNotOccurOn19700101.atDate(LocalDate.ofEpochDay(0))).isEmpty(), "This test assumes certain JVM time zone");
+        checkState(!Objects.equals(java.sql.Time.valueOf(localTimeThatDidNotOccurOn19700101).toLocalTime(), localTimeThatDidNotOccurOn19700101), "This test assumes certain JVM time zone");
+        @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT TIME '''HH:mm:ss''").format(localTimeThatDidNotOccurOn19700101);
+        assertQueryFails(sql, timeTypeUnsupportedError);
+    }
+}

--- a/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestOrderByQueries.java
+++ b/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestOrderByQueries.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestOrderByQueries;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+public class TestOrderByQueries
+        extends AbstractTestOrderByQueries
+{
+    private static final String storageFormat = "PARQUET";
+
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(ImmutableMap.of(), storageFormat);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        try {
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(storageFormat);
+            NativeQueryRunnerUtils.createAllTables(javaQueryRunner, false);
+            javaQueryRunner.close();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /// Queries in this testcase use the apply function, which is used to test lambda expressions, and is currently
+    /// unsupported in Presto C++. See issue: https://github.com/prestodb/presto/issues/20741.
+    @Override
+    @Test(enabled = false)
+    public void testOrderByWithOutputColumnReferenceInLambdas() {}
+}

--- a/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestRepartitionQueries.java
+++ b/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestRepartitionQueries.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestRepartitionQueries;
+import com.google.common.collect.ImmutableMap;
+
+public class TestRepartitionQueries
+        extends AbstractTestRepartitionQueries
+{
+    private static final String storageFormat = "PARQUET";
+
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(ImmutableMap.of(), storageFormat);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        try {
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(storageFormat);
+            NativeQueryRunnerUtils.createAllTables(javaQueryRunner, false);
+            javaQueryRunner.close();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestRepartitionQueriesWithSmallPages.java
+++ b/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestRepartitionQueriesWithSmallPages.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestRepartitionQueries;
+import com.google.common.collect.ImmutableMap;
+
+public class TestRepartitionQueriesWithSmallPages
+        extends AbstractTestRepartitionQueries
+{
+    private static final String storageFormat = "PARQUET";
+
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(
+                // Use small SerializedPages to force flushing
+                ImmutableMap.of("driver.max-page-partitioning-buffer-size", "200B"), storageFormat);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        try {
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(storageFormat);
+            NativeQueryRunnerUtils.createAllTables(javaQueryRunner, false);
+            javaQueryRunner.close();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestWindowQueries.java
+++ b/presto-native-tests/src/test/java/com.facebook.presto.nativetests/TestWindowQueries.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestWindowQueries;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+public class TestWindowQueries
+        extends AbstractTestWindowQueries
+{
+    private static final String frameTypeDiffersError = ".*Window frame of type RANGE does not match types of the ORDER BY and frame column.*";
+
+    private String storageFormat = "PARQUET";
+
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(ImmutableMap.of(), storageFormat);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        try {
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner("PARQUET");
+            NativeQueryRunnerUtils.createAllTables(javaQueryRunner, false);
+            javaQueryRunner.close();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testAllPartitionSameValuesGroup() {}
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testConstantOffset() {}
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testEmptyFrameGroup() {}
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testInvalidOffsetGroup() {}
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testMixedTypeFrameBounds() {}
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testMultipleWindowFunctionsGroup() {}
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testNonConstantOffsetGroup() {}
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testNoValueFrameBoundsGroup() {}
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testOnlyNullsGroup() {}
+
+    /// Queries in this test fail because GROUPS mode in Window frame is not supported in Prestissimo. See issue:
+    /// https://github.com/prestodb/presto/issues/24413.
+    @Override
+    @Test(enabled = false)
+    public void testWindowPartitioningGroup() {}
+
+    /// This test is flaky so disabled for now, see issue: https://github.com/prestodb/presto/issues/21888.
+    @Override
+    @Test
+    public void testInvalidOffset() {}
+
+    /// Queries in this test fail because the Window's ORDER BY column type differs from the frame bound type. See
+    /// issue: https://github.com/prestodb/presto/issues/23269.
+    @Override
+    @Test(enabled = false)
+    public void testEmptyFrameMixedBounds() {}
+
+    /// Queries in this test fail because the Window's ORDER BY column type differs from the frame bound type. See
+    /// issue: https://github.com/prestodb/presto/issues/23269.
+    @Override
+    @Test(enabled = false)
+    public void testMixedTypeFrameBoundsAscendingNullsFirst() {}
+
+    /// Queries in this test fail because the Window's ORDER BY column type differs from the frame bound type. See
+    /// issue: https://github.com/prestodb/presto/issues/23269.
+    @Override
+    @Test(enabled = false)
+    public void testMixedTypeFrameBoundsAscendingNullsLast() {}
+
+    /// Queries in this test fail because the Window's ORDER BY column type differs from the frame bound type. See
+    /// issue: https://github.com/prestodb/presto/issues/23269.
+    @Override
+    @Test(enabled = false)
+    public void testMixedTypeFrameBoundsDescendingNullsFirst() {}
+
+    /// Queries in this test fail because the Window's ORDER BY column type differs from the frame bound type. See
+    /// issue: https://github.com/prestodb/presto/issues/23269.
+    @Override
+    @Test(enabled = false)
+    public void testMixedTypeFrameBoundsDescendingNullsLast() {}
+
+    /// Queries in this test fail because the Window's ORDER BY column type differs from the frame bound type. See
+    /// issue: https://github.com/prestodb/presto/issues/23269.
+    @Override
+    @Test(enabled = false)
+    public void testNonConstantOffset() {}
+
+    /// Queries in this test fail because the Window's ORDER BY column type differs from the frame bound type. See
+    /// issue: https://github.com/prestodb/presto/issues/23269.
+    @Override
+    @Test(enabled = false)
+    public void testWindowPartitioning() {}
+
+    /// The last query in this test fails because the Window's ORDER BY column type differs from the frame bound type.
+    /// See issue: https://github.com/prestodb/presto/issues/23269.
+    @Override
+    @Test
+    public void testMultipleWindowFunctions()
+    {
+        assertQuery("SELECT x, array_agg(date) OVER(ORDER BY x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING), avg(number) OVER(ORDER BY x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
+                        "FROM (VALUES " +
+                        "(2, DATE '2222-01-01', 4.4), " +
+                        "(1, DATE '1111-01-01', 2.2), " +
+                        "(3, DATE '3333-01-01', 6.6)) T(x, date, number)",
+                "VALUES " +
+                        "(1, ARRAY[DATE '1111-01-01', DATE '2222-01-01'], 3.3), " +
+                        "(2, ARRAY[DATE '1111-01-01', DATE '2222-01-01', DATE '3333-01-01'], 4.4), " +
+                        "(3, ARRAY[DATE '2222-01-01', DATE '3333-01-01'], 5.5)");
+
+        assertQueryFails("SELECT x, array_agg(a) OVER(ORDER BY x RANGE BETWEEN 2 PRECEDING AND CURRENT ROW), array_agg(a) OVER(ORDER BY x RANGE BETWEEN CURRENT ROW AND 2 FOLLOWING) " +
+                        "FROM (VALUES " +
+                        "(1.0, 1), " +
+                        "(2.0, 2), " +
+                        "(3.0, 3), " +
+                        "(4.0, 4), " +
+                        "(5.0, 5), " +
+                        "(6.0, 6)) T(x, a)", frameTypeDiffersError);
+    }
+
+    /// The first query in this test fails because the Window's ORDER BY column type differs from the frame bound type.
+    /// See issue: https://github.com/prestodb/presto/issues/23269.
+    /// The last query in this test fails because `plus` arithmetic function is currently unsupported for INTERVAL YEAR
+    /// MONTH type in Velox. See PR: https://github.com/facebookincubator/velox/pull/11612.
+    @Override
+    @Test
+    public void testTypes()
+    {
+        assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN DOUBLE '0.5' PRECEDING AND TINYINT '1' FOLLOWING) " +
+                        "FROM (VALUES 1, null, 2) T(a)",
+                frameTypeDiffersError);
+
+        assertQuery("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 0.5 PRECEDING AND 1.000 FOLLOWING) " +
+                        "FROM (VALUES REAL '1', null, 2) T(a)",
+                "VALUES " +
+                        "ARRAY[CAST('1' AS REAL), CAST('2' AS REAL)], " +
+                        "ARRAY[CAST('2' AS REAL)], " +
+                        "ARRAY[null]");
+
+        assertQuery("SELECT x, array_agg(x) OVER(ORDER BY x DESC RANGE BETWEEN interval '1' month PRECEDING AND interval '1' month FOLLOWING) " +
+                        "FROM (VALUES DATE '2001-01-31', DATE '2001-08-25', DATE '2001-09-25', DATE '2001-09-26') T(x)",
+                "VALUES " +
+                        "(DATE '2001-09-26', ARRAY[DATE '2001-09-26', DATE '2001-09-25']), " +
+                        "(DATE '2001-09-25', ARRAY[DATE '2001-09-26', DATE '2001-09-25', DATE '2001-08-25']), " +
+                        "(DATE '2001-08-25', ARRAY[DATE '2001-09-25', DATE '2001-08-25']), " +
+                        "(DATE '2001-01-31', ARRAY[DATE '2001-01-31'])");
+
+        // January 31 + 1 month sets the frame bound to the last day of February. March 1 is out of range.
+        assertQuery("SELECT x, array_agg(x) OVER(ORDER BY x RANGE BETWEEN CURRENT ROW AND interval '1' month FOLLOWING) " +
+                        "FROM (VALUES DATE '2001-01-31', DATE '2001-02-28', DATE '2001-03-01') T(x)",
+                "VALUES " +
+                        "(DATE '2001-01-31', ARRAY[DATE '2001-01-31', DATE '2001-02-28']), " +
+                        "(DATE '2001-02-28', ARRAY[DATE '2001-02-28', DATE '2001-03-01']), " +
+                        "(DATE '2001-03-01', ARRAY[DATE '2001-03-01'])");
+
+        // H2 and Presto has some type conversion problem for Interval type, hence use the same query runner for this query
+        assertQueryFails("SELECT x, array_agg(x) OVER(ORDER BY x RANGE BETWEEN interval '1' year PRECEDING AND interval '1' month FOLLOWING) " +
+                        "FROM (VALUES " +
+                        "INTERVAL '1' month, " +
+                        "INTERVAL '2' month, " +
+                        "INTERVAL '5' year) T(x)",
+                ".*Scalar function presto.default.plus not registered with arguments.*", true);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestEngineOnlyQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestEngineOnlyQueries.java
@@ -35,7 +35,7 @@ public abstract class AbstractTestEngineOnlyQueries
         extends AbstractTestQueryFramework
 {
     @Test
-    public void testTimeLiterals()
+    public void testDateLiterals()
     {
         Session chicago = Session.builder(getSession()).setTimeZoneKey(TimeZoneKey.getTimeZoneKey("America/Chicago")).build();
         Session kathmandu = Session.builder(getSession()).setTimeZoneKey(TimeZoneKey.getTimeZoneKey("Asia/Kathmandu")).build();
@@ -44,7 +44,11 @@ public abstract class AbstractTestEngineOnlyQueries
         assertQuery("SELECT DATE '2013-03-22'");
         assertQuery(chicago, "SELECT DATE '2013-03-22'");
         assertQuery(kathmandu, "SELECT DATE '2013-03-22'");
+    }
 
+    @Test
+    public void testTimeLiterals()
+    {
         assertEquals(computeScalar("SELECT TIME '3:04:05'"), LocalTime.of(3, 4, 5, 0));
         assertEquals(computeScalar("SELECT TIME '3:04:05.123'"), LocalTime.of(3, 4, 5, 123_000_000));
         assertQuery("SELECT TIME '3:04:05'");
@@ -57,7 +61,11 @@ public abstract class AbstractTestEngineOnlyQueries
         assertEquals(computeScalar("SELECT TIME '3:04:05 +06:00'"), OffsetTime.of(3, 4, 5, 0, ZoneOffset.ofHoursMinutes(6, 0)));
         assertEquals(computeScalar("SELECT TIME '3:04:05 +0507'"), OffsetTime.of(3, 4, 5, 0, ZoneOffset.ofHoursMinutes(5, 7)));
         assertEquals(computeScalar("SELECT TIME '3:04:05 +03'"), OffsetTime.of(3, 4, 5, 0, ZoneOffset.ofHoursMinutes(3, 0)));
+    }
 
+    @Test
+    public void testTimestampLiterals()
+    {
         assertEquals(computeScalar("SELECT TIMESTAMP '1960-01-22 3:04:05'"), LocalDateTime.of(1960, 1, 22, 3, 4, 5));
         assertEquals(computeScalar("SELECT TIMESTAMP '1960-01-22 3:04:05.123'"), LocalDateTime.of(1960, 1, 22, 3, 4, 5, 123_000_000));
         assertQuery("SELECT TIMESTAMP '1960-01-22 3:04:05'");
@@ -69,27 +77,35 @@ public abstract class AbstractTestEngineOnlyQueries
     }
 
     @Test
+    public void testLocallyUnrepresentableDateLiterals()
+    {
+        LocalDate localDateThatDidNotHaveMidnight = LocalDate.of(1970, 1, 1);
+        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localDateThatDidNotHaveMidnight.atStartOfDay()).isEmpty(), "This test assumes certain JVM time zone");
+        // This tests that both Presto runner and H2 can return DATE value for a day which midnight never happened in JVM's zone (e.g. is not exactly representable using java.sql.Date)
+        @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT DATE '''uuuu-MM-dd''").format(localDateThatDidNotHaveMidnight);
+        assertEquals(computeScalar(sql), localDateThatDidNotHaveMidnight); // this tests Presto and the QueryRunner
+        assertQuery(sql); // this tests H2QueryRunner
+    }
+
+    @Test
     public void testLocallyUnrepresentableTimeLiterals()
+    {
+        LocalTime localTimeThatDidNotOccurOn19700101 = LocalTime.of(0, 10);
+        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localTimeThatDidNotOccurOn19700101.atDate(LocalDate.ofEpochDay(0))).isEmpty(), "This test assumes certain JVM time zone");
+        checkState(!Objects.equals(java.sql.Time.valueOf(localTimeThatDidNotOccurOn19700101).toLocalTime(), localTimeThatDidNotOccurOn19700101), "This test assumes certain JVM time zone");
+        @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT TIME '''HH:mm:ss''").format(localTimeThatDidNotOccurOn19700101);
+        assertEquals(computeScalar(sql), localTimeThatDidNotOccurOn19700101); // this tests Presto and the QueryRunner
+        assertQuery(sql); // this tests H2QueryRunner
+    }
+
+    @Test
+    public void testLocallyUnrepresentableTimestampLiterals()
     {
         LocalDateTime localTimeThatDidNotExist = LocalDateTime.of(2017, 4, 2, 2, 10);
         checkState(ZoneId.systemDefault().getRules().getValidOffsets(localTimeThatDidNotExist).isEmpty(), "This test assumes certain JVM time zone");
         // This tests that both Presto runner and H2 can return TIMESTAMP value that never happened in JVM's zone (e.g. is not representable using java.sql.Timestamp)
         @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT TIMESTAMP '''uuuu-MM-dd HH:mm:ss''").format(localTimeThatDidNotExist);
         assertEquals(computeScalar(sql), localTimeThatDidNotExist); // this tests Presto and the QueryRunner
-        assertQuery(sql); // this tests H2QueryRunner
-
-        LocalDate localDateThatDidNotHaveMidnight = LocalDate.of(1970, 1, 1);
-        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localDateThatDidNotHaveMidnight.atStartOfDay()).isEmpty(), "This test assumes certain JVM time zone");
-        // This tests that both Presto runner and H2 can return DATE value for a day which midnight never happened in JVM's zone (e.g. is not exactly representable using java.sql.Date)
-        sql = DateTimeFormatter.ofPattern("'SELECT DATE '''uuuu-MM-dd''").format(localDateThatDidNotHaveMidnight);
-        assertEquals(computeScalar(sql), localDateThatDidNotHaveMidnight); // this tests Presto and the QueryRunner
-        assertQuery(sql); // this tests H2QueryRunner
-
-        LocalTime localTimeThatDidNotOccurOn19700101 = LocalTime.of(0, 10);
-        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localTimeThatDidNotOccurOn19700101.atDate(LocalDate.ofEpochDay(0))).isEmpty(), "This test assumes certain JVM time zone");
-        checkState(!Objects.equals(java.sql.Time.valueOf(localTimeThatDidNotOccurOn19700101).toLocalTime(), localTimeThatDidNotOccurOn19700101), "This test assumes certain JVM time zone");
-        sql = DateTimeFormatter.ofPattern("'SELECT TIME '''HH:mm:ss''").format(localTimeThatDidNotOccurOn19700101);
-        assertEquals(computeScalar(sql), localTimeThatDidNotOccurOn19700101); // this tests Presto and the QueryRunner
         assertQuery(sql); // this tests H2QueryRunner
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestOrderByQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestOrderByQueries.java
@@ -86,11 +86,6 @@ public abstract class AbstractTestOrderByQueries
         assertQueryOrdered("SELECT -a AS a, a AS b FROM (VALUES 1, 2) t(a) GROUP BY a ORDER BY t.a+2*a", "VALUES (-2, 2), (-1, 1)");
         assertQueryOrdered("SELECT -a AS a, a AS b FROM (VALUES 1, 2) t(a) GROUP BY t.a ORDER BY t.a+2*a", "VALUES (-2, 2), (-1, 1)");
 
-        // lambdas
-        assertQueryOrdered("SELECT x AS y FROM (values (1,2), (2,3)) t(x, y) GROUP BY x ORDER BY apply(x, x -> -x) + 2*x", "VALUES 1, 2");
-        assertQueryOrdered("SELECT -y AS x FROM (values (1,2), (2,3)) t(x, y) GROUP BY y ORDER BY apply(x, x -> -x)", "VALUES -2, -3");
-        assertQueryOrdered("SELECT -y AS x FROM (values (1,2), (2,3)) t(x, y) GROUP BY y ORDER BY sum(apply(-y, x -> x * 1.0))", "VALUES -3, -2");
-
         // distinct
         assertQueryOrdered("SELECT DISTINCT -a AS b FROM (VALUES 1, 2) t(a) ORDER BY b", "VALUES -2, -1");
         assertQueryOrdered("SELECT DISTINCT -a AS b FROM (VALUES 1, 2) t(a) ORDER BY 1", "VALUES -2, -1");
@@ -104,6 +99,14 @@ public abstract class AbstractTestOrderByQueries
         assertQueryOrdered("SELECT -a AS a FROM (VALUES 1, 2) t(a) ORDER BY first_value(a+t.a*2) OVER (ORDER BY a ROWS 0 PRECEDING)", "VALUES -1, -2");
 
         assertQueryFails("SELECT a, a* -1 AS a FROM (VALUES -1, 0, 2) t(a) ORDER BY a", ".*'a' is ambiguous");
+    }
+
+    @Test
+    public void testOrderByWithOutputColumnReferenceInLambdas()
+    {
+        assertQueryOrdered("SELECT x AS y FROM (values (1,2), (2,3)) t(x, y) GROUP BY x ORDER BY apply(x, x -> -x) + 2*x", "VALUES 1, 2");
+        assertQueryOrdered("SELECT -y AS x FROM (values (1,2), (2,3)) t(x, y) GROUP BY y ORDER BY apply(x, x -> -x)", "VALUES -2, -3");
+        assertQueryOrdered("SELECT -y AS x FROM (values (1,2), (2,3)) t(x, y) GROUP BY y ORDER BY sum(apply(-y, x -> x * 1.0))", "VALUES -3, -2");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -316,6 +316,11 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertQueryFails(queryRunner, getSession(), sql, expectedMessageRegExp);
     }
 
+    protected void assertQueryFails(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp, boolean usePatternMatcher)
+    {
+        QueryAssertions.assertQueryFails(queryRunner, getSession(), sql, expectedMessageRegExp, usePatternMatcher);
+    }
+
     protected void assertQueryFails(Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
     {
         QueryAssertions.assertQueryFails(queryRunner, session, sql, expectedMessageRegExp);
@@ -334,6 +339,11 @@ public abstract class AbstractTestQueryFramework
     protected void assertQueryError(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
     {
         assertQueryError(queryRunner, getSession(), sql, expectedMessageRegExp);
+    }
+
+    protected void assertQueryFails(Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp, boolean usePatternMatcher)
+    {
+        QueryAssertions.assertQueryFails(queryRunner, session, sql, expectedMessageRegExp, usePatternMatcher);
     }
 
     protected void assertQueryReturnsEmptyResult(@Language("SQL") String sql)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
@@ -1016,7 +1016,7 @@ public abstract class AbstractTestWindowQueries
     }
 
     @Test
-    public void testEmptyFrame()
+    public void testEmptyFrameIntegralBounds()
     {
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 1 PRECEDING AND 10 PRECEDING) " +
                         "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) T(a)",
@@ -1044,6 +1044,23 @@ public abstract class AbstractTestWindowQueries
                         "ARRAY[null, null, null, null], " +
                         "ARRAY[null, null, null, null]");
 
+        assertQuery("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
+                        "FROM (VALUES 1, 2) T(a)",
+                "VALUES " +
+                        "null, " +
+                        "ARRAY[1]");
+
+        assertQuery("SELECT array_agg(a) OVER(ORDER BY a NULLS FIRST RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
+                        "FROM (VALUES null, 1, 2) T(a)",
+                "VALUES " +
+                        "ARRAY[null], " +
+                        "null, " +
+                        "ARRAY[1]");
+    }
+
+    @Test
+    public void testEmptyFrameMixedBounds()
+    {
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 0.5 FOLLOWING AND 1.5 FOLLOWING) " +
                         "FROM (VALUES 1, 2, 4) T(a)",
                 "VALUES " +
@@ -1076,19 +1093,6 @@ public abstract class AbstractTestWindowQueries
                         "ARRAY[cast(null as decimal(2,1))], " +
                         "null, " +
                         "null");
-
-        assertQuery("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                        "FROM (VALUES 1, 2) T(a)",
-                "VALUES " +
-                        "null, " +
-                        "ARRAY[1]");
-
-        assertQuery("SELECT array_agg(a) OVER(ORDER BY a NULLS FIRST RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                        "FROM (VALUES null, 1, 2) T(a)",
-                "VALUES " +
-                        "ARRAY[null], " +
-                        "null, " +
-                        "ARRAY[1]");
 
         assertQuery("SELECT array_agg(a) OVER(ORDER BY a NULLS FIRST RANGE BETWEEN 2 PRECEDING AND 1.5 PRECEDING) " +
                         "FROM (VALUES null, 1, 2) T(a)",

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
@@ -346,7 +347,18 @@ public final class QueryAssertions
             fail(format("Expected query to fail: %s", sql));
         }
         catch (RuntimeException ex) {
-            assertExceptionMessage(sql, ex, expectedMessageRegExp);
+            assertExceptionMessage(sql, ex, expectedMessageRegExp, false);
+        }
+    }
+
+    protected static void assertQueryFails(QueryRunner queryRunner, Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp, boolean usePatternMatcher)
+    {
+        try {
+            queryRunner.execute(session, sql);
+            fail(format("Expected query to fail: %s", sql));
+        }
+        catch (RuntimeException ex) {
+            assertExceptionMessage(sql, ex, expectedMessageRegExp, usePatternMatcher);
         }
     }
 
@@ -362,10 +374,18 @@ public final class QueryAssertions
         }
     }
 
-    private static void assertExceptionMessage(String sql, Exception exception, @Language("RegExp") String regex)
+    private static void assertExceptionMessage(String sql, Exception exception, @Language("RegExp") String regex, boolean usePatternMatcher)
     {
-        if (!nullToEmpty(exception.getMessage()).matches(regex)) {
-            fail(format("Expected exception message '%s' to match '%s' for query: %s", exception.getMessage(), regex, sql), exception);
+        if (usePatternMatcher) {
+            Pattern p = Pattern.compile(regex, Pattern.MULTILINE);
+            if (!(p.matcher(exception.getMessage()).find())) {
+                fail(format("Expected exception message '%s' to match '%s' for query: %s", exception.getMessage(), regex, sql), exception);
+            }
+        }
+        else {
+            if (!nullToEmpty(exception.getMessage()).matches(regex)) {
+                fail(format("Expected exception message '%s' to match '%s' for query: %s", exception.getMessage(), regex, sql), exception);
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Introduces module `presto-native-tests` to run end-to-end tests with Presto native workers. Adds Github action to run these tests. 

## Motivation and Context
Improves Presto native test coverage by extending product tests from `presto-tests` module to use the native worker. For full context please refer to #23671.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== RELEASE NOTES ==
General Changes
* Introduces module presto-native-tests to run end-to-end tests with Presto native workers. 
```