### PR TITLE
Added new configuration to pass catalog name to metastore when creati…

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonClientConfig.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonClientConfig.java
@@ -46,6 +46,7 @@ public class HiveCommonClientConfig
     private boolean readNullMaskedParquetEncryptedValueEnabled;
     private boolean useParquetColumnNames;
     private boolean zstdJniDecompressionEnabled;
+    private String catalogName;
 
     public NodeSelectionStrategy getNodeSelectionStrategy()
     {
@@ -282,6 +283,19 @@ public class HiveCommonClientConfig
     public HiveCommonClientConfig setZstdJniDecompressionEnabled(boolean zstdJniDecompressionEnabled)
     {
         this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
+        return this;
+    }
+
+    public String getCatalogName()
+    {
+        return catalogName;
+    }
+
+    @Config("hive.metastore.catalog.name")
+    @ConfigDescription("Specified property to store the metastore catalog name.")
+    public HiveCommonClientConfig setCatalogName(String catalogName)
+    {
+        this.catalogName = catalogName;
         return this;
     }
 }

--- a/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
+++ b/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
@@ -28,6 +28,7 @@ import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.HiveCoercionPolicy;
 import com.facebook.presto.hive.HiveColumnConverterProvider;
 import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveCommonClientConfig;
 import com.facebook.presto.hive.HiveEncryptionInformationProvider;
 import com.facebook.presto.hive.HiveFileRenamer;
 import com.facebook.presto.hive.HiveHdfsConfiguration;
@@ -177,7 +178,9 @@ public class S3SelectTestHelper
                 new HiveFileRenamer(),
                 columnConverterProvider,
                 new QuickStatsProvider(hdfsEnvironment, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
-                new HiveTableWritabilityChecker(config));
+                new HiveTableWritabilityChecker(config),
+                new HiveCommonClientConfig());
+
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionManager,

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Database.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Database.java
@@ -39,6 +39,7 @@ public class Database
     private final PrincipalType ownerType;
     private final Optional<String> comment;
     private final Map<String, String> parameters;
+    private final Optional<String> catalogName;
 
     @JsonCreator
     public Database(
@@ -47,7 +48,8 @@ public class Database
             @JsonProperty("ownerName") String ownerName,
             @JsonProperty("ownerType") PrincipalType ownerType,
             @JsonProperty("comment") Optional<String> comment,
-            @JsonProperty("parameters") Map<String, String> parameters)
+            @JsonProperty("parameters") Map<String, String> parameters,
+            @JsonProperty("catalogName") Optional<String> catalogName)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.location = requireNonNull(location, "location is null");
@@ -55,6 +57,7 @@ public class Database
         this.ownerType = requireNonNull(ownerType, "ownerType is null");
         this.comment = requireNonNull(comment, "comment is null");
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
     }
 
     @JsonProperty
@@ -103,6 +106,12 @@ public class Database
         return new Builder(database);
     }
 
+    @JsonProperty
+    public Optional<String> getCatalogName()
+    {
+        return catalogName;
+    }
+
     public static class Builder
     {
         private String databaseName;
@@ -111,6 +120,7 @@ public class Database
         private PrincipalType ownerType;
         private Optional<String> comment = Optional.empty();
         private Map<String, String> parameters = new LinkedHashMap<>();
+        private Optional<String> catalogName = Optional.empty();
 
         public Builder() {}
 
@@ -122,6 +132,7 @@ public class Database
             this.ownerType = database.ownerType;
             this.comment = database.comment;
             this.parameters = database.parameters;
+            this.catalogName = database.catalogName;
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -166,6 +177,13 @@ public class Database
             return this;
         }
 
+        public Builder setCatalogName(Optional<String> catalogName)
+        {
+            requireNonNull(catalogName, "catalogName is null");
+            this.catalogName = catalogName;
+            return this;
+        }
+
         public Database build()
         {
             return new Database(
@@ -174,7 +192,8 @@ public class Database
                     ownerName,
                     ownerType,
                     comment,
-                    parameters);
+                    parameters,
+                    catalogName);
         }
     }
 
@@ -188,6 +207,7 @@ public class Database
                 .add("ownerType", ownerType)
                 .add("comment", comment)
                 .add("parameters", parameters)
+                .add("catalogName", catalogName)
                 .toString();
     }
 
@@ -207,12 +227,13 @@ public class Database
                 Objects.equals(ownerName, database.ownerName) &&
                 ownerType == database.ownerType &&
                 Objects.equals(comment, database.comment) &&
-                Objects.equals(parameters, database.parameters);
+                Objects.equals(parameters, database.parameters) &&
+                Objects.equals(catalogName, database.catalogName);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(databaseName, location, ownerName, ownerType, comment, parameters);
+        return Objects.hash(databaseName, location, ownerName, ownerType, comment, parameters, catalogName);
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -150,6 +150,7 @@ public final class ThriftMetastoreUtil
         result.setOwnerType(toMetastoreApiPrincipalType(database.getOwnerType()));
         database.getComment().ifPresent(result::setDescription);
         result.setParameters(database.getParameters());
+        database.getCatalogName().ifPresent(result::setCatalogName);
         return result;
     }
 

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
@@ -67,7 +67,8 @@ public class TestRecordingHiveMetastore
             "owner",
             USER,
             Optional.of("comment"),
-            ImmutableMap.of("param", "value"));
+            ImmutableMap.of("param", "value"),
+            Optional.of("catalogName"));
     private static final Column TABLE_COLUMN = new Column(
             "column",
             HiveType.HIVE_INT,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -428,6 +428,7 @@ public class HiveMetadata
     private final HivePartitionStats hivePartitionStats;
     private final HiveFileRenamer hiveFileRenamer;
     private final TableWritabilityChecker tableWritabilityChecker;
+    private final String catalogName;
 
     public HiveMetadata(
             SemiTransactionalHiveMetastore metastore,
@@ -454,7 +455,8 @@ public class HiveMetadata
             HiveEncryptionInformationProvider encryptionInformationProvider,
             HivePartitionStats hivePartitionStats,
             HiveFileRenamer hiveFileRenamer,
-            TableWritabilityChecker tableWritabilityChecker)
+            TableWritabilityChecker tableWritabilityChecker,
+            String catalogName)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
 
@@ -482,6 +484,7 @@ public class HiveMetadata
         this.hivePartitionStats = requireNonNull(hivePartitionStats, "hivePartitionStats is null");
         this.hiveFileRenamer = requireNonNull(hiveFileRenamer, "hiveFileRenamer is null");
         this.tableWritabilityChecker = requireNonNull(tableWritabilityChecker, "tableWritabilityChecker is null");
+        this.catalogName = catalogName;
     }
 
     public SemiTransactionalHiveMetastore getMetastore()
@@ -946,6 +949,7 @@ public class HiveMetadata
                 .setLocation(location)
                 .setOwnerType(USER)
                 .setOwnerName(session.getUser())
+                .setCatalogName(Optional.ofNullable(catalogName))
                 .build();
 
         metastore.createDatabase(getMetastoreContext(session), database);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -72,6 +72,7 @@ public class HiveMetadataFactory
     private final ColumnConverterProvider columnConverterProvider;
     private final QuickStatsProvider quickStatsProvider;
     private final TableWritabilityChecker tableWritabilityChecker;
+    private final String catalogName;
 
     @Inject
     @SuppressWarnings("deprecation")
@@ -100,7 +101,8 @@ public class HiveMetadataFactory
             HiveFileRenamer hiveFileRenamer,
             ColumnConverterProvider columnConverterProvider,
             QuickStatsProvider quickStatsProvider,
-            TableWritabilityChecker tableWritabilityChecker)
+            TableWritabilityChecker tableWritabilityChecker,
+            HiveCommonClientConfig hiveCommonClientConfig)
     {
         this(
                 metastore,
@@ -135,7 +137,8 @@ public class HiveMetadataFactory
                 hiveFileRenamer,
                 columnConverterProvider,
                 quickStatsProvider,
-                tableWritabilityChecker);
+                tableWritabilityChecker,
+                hiveCommonClientConfig.getCatalogName());
     }
 
     public HiveMetadataFactory(
@@ -171,7 +174,8 @@ public class HiveMetadataFactory
             HiveFileRenamer hiveFileRenamer,
             ColumnConverterProvider columnConverterProvider,
             QuickStatsProvider quickStatsProvider,
-            TableWritabilityChecker tableWritabilityChecker)
+            TableWritabilityChecker tableWritabilityChecker,
+            String catalogName)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -206,6 +210,7 @@ public class HiveMetadataFactory
         this.columnConverterProvider = requireNonNull(columnConverterProvider, "columnConverterProvider is null");
         this.quickStatsProvider = requireNonNull(quickStatsProvider, "quickStatsProvider is null");
         this.tableWritabilityChecker = requireNonNull(tableWritabilityChecker, "tableWritabilityChecker is null");
+        this.catalogName = catalogName;
 
         if (!allowCorruptWritesForTesting && !timeZone.equals(DateTimeZone.getDefault())) {
             log.warn("Hive writes are disabled. " +
@@ -252,6 +257,7 @@ public class HiveMetadataFactory
                 encryptionInformationProvider,
                 hivePartitionStats,
                 hiveFileRenamer,
-                tableWritabilityChecker);
+                tableWritabilityChecker,
+                catalogName);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -359,6 +359,7 @@ public abstract class AbstractTestHiveClient
     protected static final String INVALID_COLUMN = "totally_invalid_column_name";
 
     protected static final String TEST_SERVER_VERSION = "test_version";
+    private static final String TEST_CATALOG_NAME = "hive";
 
     protected static final Executor EXECUTOR = Executors.newFixedThreadPool(5);
     protected static final PageSinkContext TEST_HIVE_PAGE_SINK_CONTEXT = PageSinkContext.builder().setCommitRequired(false).setConnectorMetadataUpdater(new HiveMetadataUpdater(EXECUTOR)).build();
@@ -1044,7 +1045,7 @@ public abstract class AbstractTestHiveClient
                 new HiveFileRenamer(),
                 DEFAULT_COLUMN_CONVERTER_PROVIDER,
                 new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
-                new HiveTableWritabilityChecker(false));
+                new HiveTableWritabilityChecker(false), TEST_CATALOG_NAME);
 
         transactionManager = new HiveTransactionManager();
         encryptionInformationProvider = new HiveEncryptionInformationProvider(ImmutableList.of());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -225,7 +225,8 @@ public abstract class AbstractTestHiveFileSystem
                 new HiveFileRenamer(),
                 columnConverterProvider,
                 new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
-                new HiveTableWritabilityChecker(config));
+                new HiveTableWritabilityChecker(config),
+                new HiveCommonClientConfig());
 
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
@@ -81,6 +81,7 @@ public class TestHiveCommitHandleOutput
 {
     private static final String TEST_SCHEMA = "test_schema";
     private static final String TEST_TABLE = "test_table";
+    private static final String TEST_CATALOG_NAME = "hive";
 
     private static final Map<String, Object> testTableProperties;
     private static ConnectorTableMetadata testTableMetadata;
@@ -260,7 +261,7 @@ public class TestHiveCommitHandleOutput
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
                 new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
-                new HiveTableWritabilityChecker(false));
+                new HiveTableWritabilityChecker(false), TEST_CATALOG_NAME);
         return hiveMetadataFactory.get();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -92,6 +92,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
 {
     private static final String TEST_SERVER_VERSION = "test_version";
     private static final String TEST_DB_NAME = "test_db";
+    private static final String TEST_CATALOG_NAME = "hive";
     private static final JsonCodec<PartitionUpdate> PARTITION_CODEC = jsonCodec(PartitionUpdate.class);
     private static final ConnectorSession SESSION = new TestingConnectorSession(
             new HiveSessionProperties(new HiveClientConfig(), new OrcFileWriterConfig(), new ParquetFileWriterConfig(), new CacheConfig()).getSessionProperties(),
@@ -141,7 +142,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
                 new QuickStatsProvider(HDFS_ENVIRONMENT, HiveTestUtils.DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
-                new HiveTableWritabilityChecker(false));
+                new HiveTableWritabilityChecker(false), TEST_CATALOG_NAME);
 
         metastore.createDatabase(METASTORE_CONTEXT, Database.builder()
                 .setDatabaseName(TEST_DB_NAME)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -147,6 +147,7 @@ public class TestHiveSplitManager
     private static final Table TEST_TABLE = createTestTable(VIEW_STORAGE_FORMAT, ImmutableMap.of());
 
     private ListeningExecutorService executor;
+    private static final String TEST_CATALOG_NAME = "hive";
 
     @BeforeClass
     public void setUp()
@@ -532,7 +533,7 @@ public class TestHiveSplitManager
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
                 new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
-                new HiveTableWritabilityChecker(false));
+                new HiveTableWritabilityChecker(false), TEST_CATALOG_NAME);
 
         HiveSplitManager splitManager = new HiveSplitManager(
                 new TestingHiveTransactionManager(metadataFactory),
@@ -679,7 +680,7 @@ public class TestHiveSplitManager
                 new HiveFileRenamer(),
                 HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
                 new QuickStatsProvider(HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of()),
-                new HiveTableWritabilityChecker(false));
+                new HiveTableWritabilityChecker(false), TEST_CATALOG_NAME);
 
         HiveSplitManager splitManager = new HiveSplitManager(
                 new TestingHiveTransactionManager(metadataFactory),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingExtendedHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingExtendedHiveMetastore.java
@@ -52,7 +52,7 @@ public class TestingExtendedHiveMetastore
     @Override
     public Optional<Database> getDatabase(MetastoreContext metastoreContext, String databaseName)
     {
-        return Optional.of(new Database(databaseName, Optional.of("/"), "test_owner", PrincipalType.USER, Optional.empty(), ImmutableMap.of()));
+        return Optional.of(new Database(databaseName, Optional.of("/"), "test_owner", PrincipalType.USER, Optional.empty(), ImmutableMap.of(), Optional.of("testcatalog")));
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -151,6 +151,7 @@ public class IcebergHiveMetadata
     private final DateTimeZone timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(TimeZone.getDefault().getID())));
 
     private final FilterStatsCalculatorService filterStatsCalculatorService;
+    private final String catalogName;
 
     public IcebergHiveMetadata(
             ExtendedHiveMetastore metastore,
@@ -160,12 +161,14 @@ public class IcebergHiveMetadata
             RowExpressionService rowExpressionService,
             JsonCodec<CommitTaskData> commitTaskCodec,
             NodeVersion nodeVersion,
-            FilterStatsCalculatorService filterStatsCalculatorService)
+            FilterStatsCalculatorService filterStatsCalculatorService,
+            String catalogName)
     {
         super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, nodeVersion);
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
+        this.catalogName = catalogName;
     }
 
     public ExtendedHiveMetastore getMetastore()
@@ -234,6 +237,7 @@ public class IcebergHiveMetadata
                 .setLocation(location)
                 .setOwnerType(USER)
                 .setOwnerName(session.getUser())
+                .setCatalogName(Optional.ofNullable(catalogName))
                 .build();
 
         MetastoreContext metastoreContext = getMetastoreContext(session);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveCommonClientConfig;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
@@ -38,6 +39,7 @@ public class IcebergHiveMetadataFactory
     final RowExpressionService rowExpressionService;
     final NodeVersion nodeVersion;
     final FilterStatsCalculatorService filterStatsCalculatorService;
+    final String catalogName;
 
     @Inject
     public IcebergHiveMetadataFactory(
@@ -48,7 +50,8 @@ public class IcebergHiveMetadataFactory
             RowExpressionService rowExpressionService,
             JsonCodec<CommitTaskData> commitTaskCodec,
             NodeVersion nodeVersion,
-            FilterStatsCalculatorService filterStatsCalculatorService)
+            FilterStatsCalculatorService filterStatsCalculatorService,
+            HiveCommonClientConfig commonConfig)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -58,10 +61,12 @@ public class IcebergHiveMetadataFactory
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
+        requireNonNull(commonConfig, "config is null");
+        this.catalogName = commonConfig.getCatalogName();
     }
 
     public ConnectorMetadata create()
     {
-        return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, functionResolution, rowExpressionService, commitTaskCodec, nodeVersion, filterStatsCalculatorService);
+        return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, functionResolution, rowExpressionService, commitTaskCodec, nodeVersion, filterStatsCalculatorService, catalogName);
     }
 }


### PR DESCRIPTION
Changes to pass catalog name in the create schema request to metastore.

## Description
This PR includes the changes in presto code to pass catalog name in the create schema request to metastore service.

## Motivation and Context
https://github.com/prestodb/presto/issues/22895

## Impact
NA

## Test Plan
CI passed

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== RELEASE NOTES ==
General Changes
* item 1 ... :pr:`22896`
```

