### PR TITLE
[native] Change C-style casts to C++-style

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -428,15 +428,15 @@ void PeriodicTaskManager::updateOperatingSystemStats() {
   getrusage(RUSAGE_SELF, &usage);
 
   const int64_t userCpuTimeUs{
-      (int64_t)usage.ru_utime.tv_sec * 1'000'000 +
-      (int64_t)usage.ru_utime.tv_usec};
+      static_cast<int64_t>(usage.ru_utime.tv_sec) * 1'000'000 +
+      static_cast<int64_t>(usage.ru_utime.tv_usec)};
   RECORD_METRIC_VALUE(
       kCounterOsUserCpuTimeMicros, userCpuTimeUs - lastUserCpuTimeUs_);
   lastUserCpuTimeUs_ = userCpuTimeUs;
 
   const int64_t systemCpuTimeUs{
-      (int64_t)usage.ru_stime.tv_sec * 1'000'000 +
-      (int64_t)usage.ru_stime.tv_usec};
+      static_cast<int64_t>(usage.ru_stime.tv_sec) * 1'000'000 +
+      static_cast<int64_t>(usage.ru_stime.tv_usec)};
   RECORD_METRIC_VALUE(
       kCounterOsSystemCpuTimeMicros, systemCpuTimeUs - lastSystemCpuTimeUs_);
   lastSystemCpuTimeUs_ = systemCpuTimeUs;

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -58,7 +58,8 @@ std::string bodyAsString(
   std::ostringstream oss;
   auto iobufs = response.consumeBody();
   for (auto& body : iobufs) {
-    oss << std::string((const char*)body->data(), body->length());
+    oss << std::string(
+        reinterpret_cast<const char*>(body->data()), body->length());
     if (pool != nullptr) {
       pool->free(body->writableData(), body->capacity());
     }

--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -69,7 +69,8 @@ std::string extractMessageBody(
   // TODO Avoid copy
   std::ostringstream oss;
   for (auto& buf : body) {
-    oss << std::string((const char*)buf->data(), buf->length());
+    oss << std::string(
+        reinterpret_cast<const char*>(buf->data()), buf->length());
   }
   return oss.str();
 }

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -276,8 +276,8 @@ void HttpServer::start(
   options.handlerFactories = handlerFactories.build();
 
   // Increase the default flow control to 1MB/10MB
-  options.initialReceiveWindow = uint32_t(1 << 20);
-  options.receiveStreamWindowSize = uint32_t(1 << 20);
+  options.initialReceiveWindow = static_cast<uint32_t>(1 << 20);
+  options.receiveStreamWindowSize = static_cast<uint32_t>(1 << 20);
   options.receiveSessionWindowSize = 10 * (1 << 20);
   options.h2cEnabled = true;
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
@@ -205,7 +205,9 @@ class BroadcastTest : public exec::test::OperatorTestBase {
     std::vector<ByteRange> ranges;
     for (const auto& range : *ioBuf) {
       ranges.emplace_back(ByteRange{
-          const_cast<uint8_t*>(range.data()), (int32_t)range.size(), 0});
+          const_cast<uint8_t*>(range.data()),
+          static_cast<int32_t>(range.size()),
+          0});
     }
     auto byteStream = std::make_unique<BufferInputStream>(std::move(ranges));
 

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.cpp
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.cpp
@@ -133,8 +133,8 @@ void PrometheusStatsReporter::registerHistogramMetricExportType(
                               .Register(*impl_->registry);
     ::prometheus::Summary::Quantiles quantiles;
     for (auto pct : pcts) {
-      quantiles.push_back(
-          ::prometheus::detail::CKMSQuantiles::Quantile(pct / (double)100, 0));
+      quantiles.push_back(::prometheus::detail::CKMSQuantiles::Quantile(
+          pct / static_cast<double>(100), 0));
     }
     auto& summaryMetric = summaryFamily.Add({impl_->labels}, quantiles);
     registeredMetricsMap_.emplace(

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
@@ -55,7 +55,7 @@ TEST_F(QueryContextCacheTest, basic) {
   for (int i = 0; i < 16; ++i) {
     auto queryId = fmt::format("query-{}", i);
     auto queryCtx = core::QueryCtx::create(
-        (folly::Executor*)nullptr, core::QueryConfig({}));
+        static_cast<folly::Executor*>(nullptr), core::QueryConfig({}));
     queryCtxs[queryId] = queryCtx;
     queryContextCache.insert(queryId, queryCtx);
   }

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -156,7 +156,9 @@ class Cursor {
     std::vector<ByteRange> byteRanges;
     for (auto& range : *buffer) {
       byteRanges.emplace_back(ByteRange{
-          const_cast<uint8_t*>(range.data()), (int32_t)range.size(), 0});
+          const_cast<uint8_t*>(range.data()),
+          static_cast<int32_t>(range.size()),
+          0});
     }
 
     const auto input =

--- a/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift-cpp.mustache
+++ b/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift-cpp.mustache
@@ -82,7 +82,7 @@ void toThrift(const protocol::{{class_name}}& proto, thrift::{{&class_name}}& th
 {{/struct}}
 {{#enum}}
 void toThrift(const protocol::{{class_name}}& proto, thrift::{{class_name}}& thrift) {
-  thrift = (thrift::{{class_name}})((int)proto);
+  thrift = (thrift::{{class_name}})(static_cast<int>(proto));
 }
 {{/enum}}
 {{/cinc}}

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -79,7 +79,7 @@ RowTypePtr toRowType(
 
 template <typename T>
 std::string toJsonString(const T& value) {
-  return ((json)value).dump();
+  return (static_cast<json>(value)).dump();
 }
 
 std::shared_ptr<connector::ColumnHandle> toColumnHandle(
@@ -1744,7 +1744,8 @@ core::ExecutionStrategy toStrategy(protocol::StageExecutionStrategy strategy) {
           "RECOVERABLE_GROUPED_EXECUTION "
           "Stage Execution Strategy is not supported");
   }
-  VELOX_UNSUPPORTED("Unknown Stage Execution Strategy type {}", (int)strategy);
+  VELOX_UNSUPPORTED(
+      "Unknown Stage Execution Strategy type {}", static_cast<int>(strategy));
 }
 
 // Presto doesn't have PartitionedOutputNode and assigns its source node's plan

--- a/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/Base64Util.cpp
@@ -22,7 +22,7 @@ namespace {
 std::unique_ptr<ByteInputStream> toByteStream(const std::string& input) {
   ByteRange byteRange{
       reinterpret_cast<uint8_t*>(const_cast<char*>(input.data())),
-      (int32_t)input.length(),
+      static_cast<int32_t>(input.length()),
       0};
   return std::make_unique<BufferInputStream>(std::vector<ByteRange>{byteRange});
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/VariableReferenceExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/VariableReferenceExpressionTest.cpp
@@ -38,6 +38,8 @@ TEST_F(VariableReferenceExpressionTest, basic) {
   testJsonRoundtrip(j, p);
 
   ASSERT_EQ(json_map_key(p), "segment<integer>") << "... json_map_key";
-  ASSERT_EQ((json)VariableReferenceExpression("segment<integer>"), (json)p)
+  ASSERT_EQ(
+      static_cast<json>(VariableReferenceExpression("segment<integer>")),
+      static_cast<json>(p))
       << "... string constructor";
 }


### PR DESCRIPTION
## Description
As per the security guideline in
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast

Covers the findings in the list from this issue and 
closes [#2493](https://github.ibm.com/lakehouse/presto/issues/2493)

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

