### PR TITLE
[WIP] Add native row expression optimizer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
                 <artifactId>netty-handler</artifactId>
                 <version>4.1.107.Final</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-testing-docker</artifactId>
@@ -726,6 +726,13 @@
 
             <dependency>
                 <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-tests</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-benchmark</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -917,6 +924,19 @@
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-open-telemetry</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-native-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-native-execution</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
             </dependency>
 
             <dependency>

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
@@ -109,7 +109,7 @@ public class JdbcConnector
                 functionManager,
                 functionResolution,
                 rowExpressionService.getDeterminismEvaluator(),
-                rowExpressionService.getExpressionOptimizer());
+                rowExpressionService);
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
@@ -29,7 +29,7 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
-import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 
 import java.util.Optional;
@@ -44,7 +44,7 @@ import static java.util.Objects.requireNonNull;
 public class JdbcComputePushdown
         implements ConnectorPlanOptimizer
 {
-    private final ExpressionOptimizer expressionOptimizer;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
     private final JdbcFilterToSqlTranslator jdbcFilterToSqlTranslator;
     private final LogicalRowExpressions logicalRowExpressions;
 
@@ -52,7 +52,7 @@ public class JdbcComputePushdown
             FunctionMetadataManager functionMetadataManager,
             StandardFunctionResolution functionResolution,
             DeterminismEvaluator determinismEvaluator,
-            ExpressionOptimizer expressionOptimizer,
+            ExpressionOptimizerProvider expressionOptimizerProvider,
             String identifierQuote,
             Set<Class<?>> functionTranslators)
     {
@@ -62,7 +62,7 @@ public class JdbcComputePushdown
         requireNonNull(determinismEvaluator, "determinismEvaluator is null");
         requireNonNull(functionResolution, "functionResolution is null");
 
-        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         this.jdbcFilterToSqlTranslator = new JdbcFilterToSqlTranslator(
                 functionMetadataManager,
                 buildFunctionTranslator(functionTranslators),
@@ -106,7 +106,7 @@ public class JdbcComputePushdown
             TableHandle oldTableHandle = oldTableScanNode.getTable();
             JdbcTableHandle oldConnectorTable = (JdbcTableHandle) oldTableHandle.getConnectorHandle();
 
-            RowExpression predicate = expressionOptimizer.optimize(node.getPredicate(), OPTIMIZED, session);
+            RowExpression predicate = expressionOptimizerProvider.getExpressionOptimizer().optimize(node.getPredicate(), OPTIMIZED, session);
             predicate = logicalRowExpressions.convertToConjunctiveNormalForm(predicate);
             TranslatedExpression<JdbcExpression> jdbcExpression = translateWith(
                     predicate,

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcPlanOptimizerProvider.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcPlanOptimizerProvider.java
@@ -20,7 +20,7 @@ import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
-import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 
@@ -34,7 +34,7 @@ public class JdbcPlanOptimizerProvider
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
     private final DeterminismEvaluator determinismEvaluator;
-    private final ExpressionOptimizer expressionOptimizer;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
     private final String identifierQuote;
 
     @Inject
@@ -43,12 +43,12 @@ public class JdbcPlanOptimizerProvider
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
             DeterminismEvaluator determinismEvaluator,
-            ExpressionOptimizer expressionOptimizer)
+            ExpressionOptimizerProvider expressionOptimizerProvider)
     {
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
-        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         this.identifierQuote = jdbcClient.getIdentifierQuote();
     }
 
@@ -65,7 +65,7 @@ public class JdbcPlanOptimizerProvider
                 functionManager,
                 functionResolution,
                 determinismEvaluator,
-                expressionOptimizer,
+                expressionOptimizerProvider,
                 identifierQuote,
                 getFunctionTranslators()));
     }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/optimization/TestJdbcComputePushdown.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/optimization/TestJdbcComputePushdown.java
@@ -105,7 +105,7 @@ public class TestJdbcComputePushdown
                 functionAndTypeManager,
                 functionResolution,
                 determinismEvaluator,
-                new RowExpressionOptimizer(METADATA),
+                () -> new RowExpressionOptimizer(METADATA),
                 "'",
                 getFunctionTranslators());
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -151,7 +151,7 @@ public final class HiveTestUtils
     };
 
     public static final FilterStatsCalculatorService FILTER_STATS_CALCULATOR_SERVICE = new ConnectorFilterStatsCalculatorService(
-            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA), new StatsNormalizer()));
+            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, ROW_EXPRESSION_SERVICE), new StatsNormalizer()));
 
     public static final HiveClientConfig HIVE_CLIENT_CONFIG = new HiveClientConfig();
     public static final MetastoreClientConfig METASTORE_CLIENT_CONFIG = new MetastoreClientConfig();

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -325,6 +325,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZER_USE_HISTOGRAMS = "optimizer_use_histograms";
     public static final String WARN_ON_COMMON_NAN_PATTERNS = "warn_on_common_nan_patterns";
     public static final String INLINE_PROJECTIONS_ON_VALUES = "inline_projections_on_values";
+    public static final String DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED = "delegating_row_expression_optimizer_enabled";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -1830,6 +1831,11 @@ public final class SystemSessionProperties
                         NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING,
                         "Minimum number of columnar encoding channels to consider row wise encoding for partitioned exchange. Native execution only",
                         queryManagerConfig.getMinColumnarEncodingChannelsToPreferRowWiseEncoding(),
+                        false),
+                booleanProperty(
+                        DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED,
+                        "Enable delegating row optimizer",
+                        featuresConfig.isDelegatingRowExpressionOptimizerEnabled(),
                         false));
     }
 
@@ -3110,5 +3116,10 @@ public final class SystemSessionProperties
     public static int getMinColumnarEncodingChannelsToPreferRowWiseEncoding(Session session)
     {
         return session.getSystemProperty(NATIVE_MIN_COLUMNAR_ENCODING_CHANNELS_TO_PREFER_ROW_WISE_ENCODING, Integer.class);
+    }
+
+    public static boolean isDelegatingRowExpressionOptimizerEnabled(Session session)
+    {
+        return session.getSystemProperty(DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -62,12 +62,12 @@ import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.RecordPageSourceProvider;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.planPrinter.RowExpressionFormatter;
 import com.facebook.presto.sql.relational.ConnectorRowExpressionService;
 import com.facebook.presto.sql.relational.FunctionResolution;
-import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -116,6 +116,7 @@ public class ConnectorManager
     private final PageIndexerFactory pageIndexerFactory;
     private final NodeInfo nodeInfo;
     private final TransactionManager transactionManager;
+    private final ExpressionOptimizerManager expressionOptimizerManager;
     private final DomainTranslator domainTranslator;
     private final PredicateCompiler predicateCompiler;
     private final DeterminismEvaluator determinismEvaluator;
@@ -151,6 +152,7 @@ public class ConnectorManager
             PageSorter pageSorter,
             PageIndexerFactory pageIndexerFactory,
             TransactionManager transactionManager,
+            ExpressionOptimizerManager expressionOptimizerManager,
             DomainTranslator domainTranslator,
             PredicateCompiler predicateCompiler,
             DeterminismEvaluator determinismEvaluator,
@@ -176,6 +178,7 @@ public class ConnectorManager
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.nodeInfo = requireNonNull(nodeInfo, "nodeInfo is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
         this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
         this.predicateCompiler = requireNonNull(predicateCompiler, "predicateCompiler is null");
         this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
@@ -382,7 +385,7 @@ public class ConnectorManager
                 pageIndexerFactory,
                 new ConnectorRowExpressionService(
                         domainTranslator,
-                        new RowExpressionOptimizer(metadataManager),
+                        expressionOptimizerManager,
                         predicateCompiler,
                         determinismEvaluator,
                         new RowExpressionFormatter(metadataManager.getFunctionAndTypeManager())),

--- a/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
@@ -31,11 +31,11 @@ import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
 import com.facebook.presto.sql.analyzer.Scope;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.NoOpVariableResolver;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.relational.FunctionResolution;
-import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
 import com.facebook.presto.sql.tree.AstVisitor;
@@ -78,11 +78,13 @@ import static java.util.Objects.requireNonNull;
 public class ScalarStatsCalculator
 {
     private final Metadata metadata;
+    private final ExpressionOptimizerManager expressionOptimizerManager;
 
     @Inject
-    public ScalarStatsCalculator(Metadata metadata)
+    public ScalarStatsCalculator(Metadata metadata, ExpressionOptimizerManager expressionOptimizerManager)
     {
         this.metadata = requireNonNull(metadata, "metadata can not be null");
+        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager can not be null");
     }
 
     @Deprecated
@@ -126,7 +128,7 @@ public class ScalarStatsCalculator
                 return computeArithmeticBinaryStatistics(call, context);
             }
 
-            RowExpression value = new RowExpressionOptimizer(metadata).optimize(call, OPTIMIZED, session);
+            RowExpression value = expressionOptimizerManager.getExpressionOptimizer().optimize(call, OPTIMIZED, session);
 
             if (isNull(value)) {
                 return nullStatsEstimate();

--- a/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.InputReferenceExpression;
 import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -78,13 +79,18 @@ import static java.util.Objects.requireNonNull;
 public class ScalarStatsCalculator
 {
     private final Metadata metadata;
-    private final ExpressionOptimizerManager expressionOptimizerManager;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
     @Inject
     public ScalarStatsCalculator(Metadata metadata, ExpressionOptimizerManager expressionOptimizerManager)
     {
+        this(metadata, (ExpressionOptimizerProvider) expressionOptimizerManager);
+    }
+
+    public ScalarStatsCalculator(Metadata metadata, ExpressionOptimizerProvider expressionOptimizerProvider)
+    {
         this.metadata = requireNonNull(metadata, "metadata can not be null");
-        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager can not be null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerManager can not be null");
     }
 
     @Deprecated
@@ -128,7 +134,7 @@ public class ScalarStatsCalculator
                 return computeArithmeticBinaryStatistics(call, context);
             }
 
-            RowExpression value = expressionOptimizerManager.getExpressionOptimizer().optimize(call, OPTIMIZED, session);
+            RowExpression value = expressionOptimizerProvider.getExpressionOptimizer().optimize(call, OPTIMIZED, session);
 
             if (isNull(value)) {
                 return nullStatsEstimate();

--- a/presto-main/src/main/java/com/facebook/presto/metadata/HandleJsonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/HandleJsonModule.java
@@ -23,6 +23,18 @@ import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 public class HandleJsonModule
         implements Module
 {
+    private final HandleResolver handleResolver;
+
+    public HandleJsonModule()
+    {
+        this(null);
+    }
+
+    public HandleJsonModule(HandleResolver handleResolver)
+    {
+        this.handleResolver = handleResolver;
+    }
+
     @Override
     public void configure(Binder binder)
     {
@@ -38,6 +50,11 @@ public class HandleJsonModule
         jsonBinder(binder).addModuleBinding().to(FunctionHandleJacksonModule.class);
         jsonBinder(binder).addModuleBinding().to(MetadataUpdateJacksonModule.class);
 
-        binder.bind(HandleResolver.class).in(Scopes.SINGLETON);
+        if (handleResolver == null) {
+            binder.bind(HandleResolver.class).in(Scopes.SINGLETON);
+        }
+        else {
+            binder.bind(HandleResolver.class).toInstance(handleResolver);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -43,6 +43,7 @@ import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.session.WorkerSessionPropertyProviderFactory;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
 import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.spi.storage.TempStorageFactory;
 import com.facebook.presto.spi.tracing.TracerProvider;
@@ -50,6 +51,7 @@ import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
 import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
 import com.facebook.presto.sql.analyzer.AnalyzerProviderManager;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.tracing.TracerProviderManager;
@@ -135,6 +137,7 @@ public class PluginManager
     private final QueryPreparerProviderManager queryPreparerProviderManager;
     private final NodeStatusNotificationManager nodeStatusNotificationManager;
     private final PlanCheckerProviderManager planCheckerProviderManager;
+    private final ExpressionOptimizerManager expressionOptimizerManager;
 
     @Inject
     public PluginManager(
@@ -157,7 +160,8 @@ public class PluginManager
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
             TracerProviderManager tracerProviderManager,
             NodeStatusNotificationManager nodeStatusNotificationManager,
-            PlanCheckerProviderManager planCheckerProviderManager)
+            PlanCheckerProviderManager planCheckerProviderManager,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
@@ -190,6 +194,7 @@ public class PluginManager
         this.queryPreparerProviderManager = requireNonNull(queryPreparerProviderManager, "queryPreparerProviderManager is null");
         this.nodeStatusNotificationManager = requireNonNull(nodeStatusNotificationManager, "nodeStatusNotificationManager is null");
         this.planCheckerProviderManager = requireNonNull(planCheckerProviderManager, "planCheckerProviderManager is null");
+        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionManager is null");
     }
 
     public void loadPlugins()
@@ -371,6 +376,11 @@ public class PluginManager
         for (WorkerSessionPropertyProviderFactory providerFactory : plugin.getWorkerSessionPropertyProviderFactories()) {
             log.info("Registering system session property provider factory %s", providerFactory.getName());
             metadata.getSessionPropertyManager().addSessionPropertyProviderFactory(providerFactory);
+        }
+
+        for (ExpressionOptimizerFactory expressionOptimizerFactory : plugin.getExpressionOptimizerFactories()) {
+            log.info("Registering expression optimizer factory %s", expressionOptimizerFactory.getName());
+            expressionOptimizerManager.addExpressionOptimizerFactory(expressionOptimizerFactory);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -47,6 +47,7 @@ import com.facebook.presto.security.AccessControlModule;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.server.security.ServerSecurityModule;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
 import com.facebook.presto.storage.TempStorageManager;
@@ -181,6 +182,7 @@ public class PrestoServer
             injector.getInstance(GracefulShutdownHandler.class).loadNodeStatusNotification();
             injector.getInstance(PlanCheckerProviderManager.class).loadPlanCheckerProviders();
             injector.getInstance(SessionPropertyManager.class).loadSessionPropertyProviders();
+            injector.getInstance(ExpressionOptimizerManager.class).loadExpressionOptimizerFactory();
             startAssociatedProcesses(injector);
 
             injector.getInstance(Announcer.class).start();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -148,6 +148,7 @@ import com.facebook.presto.spi.ConnectorTypeSerde;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
+import com.facebook.presto.spi.RowExpressionSerde;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.plan.SimplePlanFragment;
@@ -155,6 +156,7 @@ import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.PredicateCompiler;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.session.WorkerSessionPropertyProvider;
 import com.facebook.presto.spiller.FileSingleStreamSpillerFactory;
@@ -195,6 +197,7 @@ import com.facebook.presto.sql.analyzer.MetadataExtractorMBean;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
+import com.facebook.presto.sql.expressions.JsonCodecRowExpressionSerde;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -362,6 +365,7 @@ public class ServerMainModule
 
         // expression manager
         binder.bind(ExpressionOptimizerManager.class).in(Scopes.SINGLETON);
+        binder.bind(RowExpressionSerde.class).to(JsonCodecRowExpressionSerde.class).in(Scopes.SINGLETON);
 
         // schema properties
         binder.bind(SchemaPropertyManager.class).in(Scopes.SINGLETON);
@@ -555,6 +559,7 @@ public class ServerMainModule
         jsonCodecBinder(binder).bindJsonCodec(SqlInvokedFunction.class);
         jsonCodecBinder(binder).bindJsonCodec(TaskSource.class);
         jsonCodecBinder(binder).bindJsonCodec(TableWriteInfo.class);
+        jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
         smileCodecBinder(binder).bindSmileCodec(TaskStatus.class);
         smileCodecBinder(binder).bindSmileCodec(TaskInfo.class);
         thriftCodecBinder(binder).bindThriftCodec(TaskStatus.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -194,6 +194,7 @@ import com.facebook.presto.sql.analyzer.MetadataExtractor;
 import com.facebook.presto.sql.analyzer.MetadataExtractorMBean;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -358,6 +359,9 @@ public class ServerMainModule
         binder.bind(SessionPropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(SystemSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(SessionPropertyDefaults.class).in(Scopes.SINGLETON);
+
+        // expression manager
+        binder.bind(ExpressionOptimizerManager.class).in(Scopes.SINGLETON);
 
         // schema properties
         binder.bind(SchemaPropertyManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -71,6 +71,7 @@ import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
@@ -168,6 +169,7 @@ public class TestingPrestoServer
     private final TaskManager taskManager;
     private final GracefulShutdownHandler gracefulShutdownHandler;
     private final ShutdownAction shutdownAction;
+    private final ExpressionOptimizerManager expressionManager;
     private final RequestBlocker requestBlocker;
     private final boolean resourceManager;
     private final boolean catalogServer;
@@ -368,6 +370,7 @@ public class TestingPrestoServer
         procedureTester = injector.getInstance(ProcedureTester.class);
         splitManager = injector.getInstance(SplitManager.class);
         pageSourceManager = injector.getInstance(PageSourceManager.class);
+        expressionManager = injector.getInstance(ExpressionOptimizerManager.class);
         if (coordinator) {
             dispatchManager = injector.getInstance(DispatchManager.class);
             queryManager = injector.getInstance(QueryManager.class);
@@ -385,6 +388,7 @@ public class TestingPrestoServer
             eventListenerManager = ((TestingEventListenerManager) injector.getInstance(EventListenerManager.class));
             clusterStateProvider = null;
             planCheckerProviderManager = injector.getInstance(PlanCheckerProviderManager.class);
+            expressionManager.loadExpressionOptimizerFactory();
         }
         else if (resourceManager) {
             dispatchManager = null;
@@ -702,6 +706,11 @@ public class TestingPrestoServer
     public ShutdownAction getShutdownAction()
     {
         return shutdownAction;
+    }
+
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        return expressionManager;
     }
 
     public boolean isCoordinator()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -280,6 +280,8 @@ public class FeaturesConfig
     private boolean generateDomainFilters;
     private boolean printEstimatedStatsFromCache;
     private boolean removeCrossJoinWithSingleConstantRow = true;
+    private boolean delegatingRowOptimizerEnabled;
+    private int delegatingRowOptimizerMaxIterations = 10;
     private CreateView.Security defaultViewSecurityMode = DEFINER;
     private boolean useHistograms;
 
@@ -2858,6 +2860,33 @@ public class FeaturesConfig
     public FeaturesConfig setPrestoSparkExecutionEnvironment(boolean prestoSparkExecutionEnvironment)
     {
         this.prestoSparkExecutionEnvironment = prestoSparkExecutionEnvironment;
+        return this;
+    }
+
+    public boolean isDelegatingRowExpressionOptimizerEnabled()
+    {
+        return delegatingRowOptimizerEnabled;
+    }
+
+    @Config("optimizer.delegating-row-expression-optimizer-enabled")
+    @ConfigDescription("Enable delegating row optimizer")
+    public FeaturesConfig setDelegatingRowExpressionOptimizerEnabled(boolean delegatingRowOptimizerEnabled)
+    {
+        this.delegatingRowOptimizerEnabled = delegatingRowOptimizerEnabled;
+        return this;
+    }
+
+    @Min(1)
+    public int getDelegatingRowExpressionOptimizerMaxIterations()
+    {
+        return delegatingRowOptimizerMaxIterations;
+    }
+
+    @Config("optimizer.delegating-row-expression-optimizer-max-iterations")
+    @ConfigDescription("Maximum number of iterations for delegating row optimizer")
+    public FeaturesConfig setDelegatingRowExpressionOptimizerMaxIterations(int delegatingRowOptimizerMaxIterations)
+    {
+        this.delegatingRowOptimizerMaxIterations = delegatingRowOptimizerMaxIterations;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.expressions;
+
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.nodeManager.PluginNodeManager;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerContext;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+
+public class ExpressionOptimizerManager
+        implements ExpressionOptimizerProvider
+{
+    private static final File EXPRESSION_MANAGER_CONFIGURATION = new File("etc/expression-manager.properties");
+    public static final String EXPRESSION_MANAGER_FACTORY_NAME = "expression-manager-factory.name";
+
+    private final Map<String, ExpressionOptimizerFactory> expressionOptimizerFactories = new ConcurrentHashMap<>();
+    private final AtomicReference<ExpressionOptimizer> rowExpressionInterpreter = new AtomicReference<>();
+    private final NodeManager nodeManager;
+    private final FunctionAndTypeManager functionAndTypeManager;
+    private final FunctionResolution functionResolution;
+    private final ExpressionOptimizer defaultExpressionOptimizer;
+
+    @Inject
+    public ExpressionOptimizerManager(PluginNodeManager nodeManager, FunctionAndTypeManager functionAndTypeManager)
+    {
+        requireNonNull(nodeManager, "nodeManager is null");
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+        this.defaultExpressionOptimizer = new RowExpressionOptimizer(functionAndTypeManager);
+        rowExpressionInterpreter.set(defaultExpressionOptimizer);
+    }
+
+    public void loadExpressionOptimizerFactory()
+    {
+        try {
+            if (EXPRESSION_MANAGER_CONFIGURATION.exists()) {
+                Map<String, String> properties = new HashMap<>(loadProperties(EXPRESSION_MANAGER_CONFIGURATION));
+                loadExpressionOptimizerFactory(properties);
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to load expression manager configuration", e);
+        }
+    }
+
+    private void loadExpressionOptimizerFactory(Map<String, String> properties)
+    {
+        properties = new HashMap<>(properties);
+        String factoryName = properties.remove(EXPRESSION_MANAGER_FACTORY_NAME);
+        checkArgument(!isNullOrEmpty(factoryName), "%s does not contain %s", EXPRESSION_MANAGER_CONFIGURATION, EXPRESSION_MANAGER_FACTORY_NAME);
+        checkArgument(
+                rowExpressionInterpreter.compareAndSet(
+                        defaultExpressionOptimizer,
+                                expressionOptimizerFactories.get(factoryName).createOptimizer(properties, new ExpressionOptimizerContext(nodeManager, functionAndTypeManager, functionResolution))),
+                "ExpressionManager is already loaded");
+    }
+
+    public void addExpressionOptimizerFactory(ExpressionOptimizerFactory expressionOptimizerFactory)
+    {
+        String name = expressionOptimizerFactory.getName();
+        checkArgument(
+                this.expressionOptimizerFactories.putIfAbsent(name, expressionOptimizerFactory) == null,
+                "ExpressionOptimizerFactory %s is already registered", name);
+    }
+
+    @Override
+    public ExpressionOptimizer getExpressionOptimizer()
+    {
+        return rowExpressionInterpreter.get();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.expressions;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.RowExpressionSerde;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.sql.planner.ExpressionOptimizerContext;
@@ -48,15 +49,17 @@ public class ExpressionOptimizerManager
     private final AtomicReference<ExpressionOptimizer> rowExpressionInterpreter = new AtomicReference<>();
     private final NodeManager nodeManager;
     private final FunctionAndTypeManager functionAndTypeManager;
+    private final RowExpressionSerde rowExpressionSerde;
     private final FunctionResolution functionResolution;
     private final ExpressionOptimizer defaultExpressionOptimizer;
 
     @Inject
-    public ExpressionOptimizerManager(PluginNodeManager nodeManager, FunctionAndTypeManager functionAndTypeManager)
+    public ExpressionOptimizerManager(PluginNodeManager nodeManager, FunctionAndTypeManager functionAndTypeManager, RowExpressionSerde rowExpressionSerde)
     {
         requireNonNull(nodeManager, "nodeManager is null");
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        this.rowExpressionSerde = requireNonNull(rowExpressionSerde, "rowExpressionSerde is null");
         this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
         this.defaultExpressionOptimizer = new RowExpressionOptimizer(functionAndTypeManager);
         rowExpressionInterpreter.set(defaultExpressionOptimizer);
@@ -75,7 +78,7 @@ public class ExpressionOptimizerManager
         }
     }
 
-    private void loadExpressionOptimizerFactory(Map<String, String> properties)
+    public void loadExpressionOptimizerFactory(Map<String, String> properties)
     {
         properties = new HashMap<>(properties);
         String factoryName = properties.remove(EXPRESSION_MANAGER_FACTORY_NAME);
@@ -83,7 +86,7 @@ public class ExpressionOptimizerManager
         checkArgument(
                 rowExpressionInterpreter.compareAndSet(
                         defaultExpressionOptimizer,
-                                expressionOptimizerFactories.get(factoryName).createOptimizer(properties, new ExpressionOptimizerContext(nodeManager, functionAndTypeManager, functionResolution))),
+                                expressionOptimizerFactories.get(factoryName).createOptimizer(properties, new ExpressionOptimizerContext(nodeManager, rowExpressionSerde, functionAndTypeManager, functionResolution))),
                 "ExpressionManager is already loaded");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/expressions/JsonCodecRowExpressionSerde.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/expressions/JsonCodecRowExpressionSerde.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.expressions;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.spi.RowExpressionSerde;
+import com.facebook.presto.spi.relation.RowExpression;
+
+import javax.inject.Inject;
+
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Objects.requireNonNull;
+
+public class JsonCodecRowExpressionSerde
+        implements RowExpressionSerde
+{
+    private final JsonCodec<RowExpression> codec;
+
+    @Inject
+    public JsonCodecRowExpressionSerde(JsonCodec<RowExpression> codec)
+    {
+        this.codec = requireNonNull(codec, "codec is null");
+    }
+
+    @Override
+    public String serialize(RowExpression expression)
+    {
+        return new String(codec.toBytes(expression), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public RowExpression deserialize(String data)
+    {
+        return codec.fromBytes(data.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -22,6 +22,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.Rule;
@@ -219,7 +220,8 @@ public class PlanOptimizers
             CostComparator costComparator,
             TaskCountEstimator taskCountEstimator,
             PartitioningProviderManager partitioningProviderManager,
-            FeaturesConfig featuresConfig)
+            FeaturesConfig featuresConfig,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
         this(metadata,
                 sqlParser,
@@ -234,7 +236,8 @@ public class PlanOptimizers
                 costComparator,
                 taskCountEstimator,
                 partitioningProviderManager,
-                featuresConfig);
+                featuresConfig,
+                expressionOptimizerManager);
     }
 
     @PostConstruct
@@ -265,7 +268,8 @@ public class PlanOptimizers
             CostComparator costComparator,
             TaskCountEstimator taskCountEstimator,
             PartitioningProviderManager partitioningProviderManager,
-            FeaturesConfig featuresConfig)
+            FeaturesConfig featuresConfig,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
         this.exporter = exporter;
         ImmutableList.Builder<PlanOptimizer> builder = ImmutableList.builder();
@@ -320,7 +324,7 @@ public class PlanOptimizers
                 statsCalculator,
                 estimatedExchangesCostCalculator,
                 ImmutableSet.<Rule<?>>builder()
-                        .addAll(new SimplifyRowExpressions(metadata).rules())
+                        .addAll(new SimplifyRowExpressions(metadata, expressionOptimizerManager, featuresConfig).rules())
                         .add(new PruneRedundantProjectionAssignments())
                         .build());
 
@@ -486,7 +490,7 @@ public class PlanOptimizers
                         estimatedExchangesCostCalculator,
                         ImmutableSet.<Rule<?>>builder()
                                 .add(new InlineProjectionsOnValues(metadata.getFunctionAndTypeManager()))
-                                .addAll(new SimplifyRowExpressions(metadata).rules())
+                                .addAll(new SimplifyRowExpressions(metadata, expressionOptimizerManager, featuresConfig).rules())
                                 .build()),
                 new IterativeOptimizer(
                         metadata,
@@ -845,7 +849,7 @@ public class PlanOptimizers
                             statsCalculator,
                             estimatedExchangesCostCalculator,
                             ImmutableSet.of(new PushTableWriteThroughUnion()))); // Must run before AddExchanges
-            builder.add(new CteProjectionAndPredicatePushDown(metadata)); // must run before PhysicalCteOptimizer
+            builder.add(new CteProjectionAndPredicatePushDown(metadata, expressionOptimizerManager, featuresConfig)); // must run before PhysicalCteOptimizer
             builder.add(new PhysicalCteOptimizer(metadata)); // Must run before AddExchanges
             builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(metadata, partitioningProviderManager, featuresConfig.isNativeExecutionEnabled())));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -349,7 +349,7 @@ public class PlanOptimizers
                 estimatedExchangesCostCalculator,
                 new RewriteConstantArrayContainsToInExpression(metadata.getFunctionAndTypeManager()).rules());
 
-        PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser, featuresConfig.isNativeExecutionEnabled()));
+        PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser, expressionOptimizerManager, featuresConfig.isNativeExecutionEnabled()));
         PlanOptimizer prefilterForLimitingAggregation = new StatsRecordingPlanOptimizer(optimizerStats, new PrefilterForLimitingAggregation(metadata, statsCalculator));
 
         builder.add(
@@ -730,7 +730,7 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(new RemoveRedundantIdentityProjections(), new PruneRedundantProjectionAssignments())),
-                new PushdownSubfields(metadata));
+                new PushdownSubfields(metadata, expressionOptimizerManager));
 
         builder.add(predicatePushDown); // Run predicate push down one more time in case we can leverage new information from layouts' effective predicate
         builder.add(simplifyRowExpressionOptimizer); // Should be always run after PredicatePushDown

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
@@ -13,22 +13,27 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.relational.DelegatingRowExpressionOptimizer;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.google.common.annotations.VisibleForTesting;
 
+import static com.facebook.presto.SystemSessionProperties.isDelegatingRowExpressionOptimizerEnabled;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.SERIALIZABLE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
@@ -39,44 +44,52 @@ import static java.util.Objects.requireNonNull;
 public class SimplifyRowExpressions
         extends RowExpressionRewriteRuleSet
 {
-    public SimplifyRowExpressions(Metadata metadata)
+    public SimplifyRowExpressions(Metadata metadata, ExpressionOptimizerManager expressionOptimizerManager, FeaturesConfig featuresConfig)
     {
-        super(new Rewriter(metadata));
+        super(new Rewriter(metadata, expressionOptimizerManager, featuresConfig));
     }
 
     private static class Rewriter
             implements PlanRowExpressionRewriter
     {
-        private final RowExpressionOptimizer optimizer;
+        private final ExpressionOptimizer inMemoryExpressionOptimizer;
+        private final ExpressionOptimizer delegatingExpressionOptimizer;
         private final LogicalExpressionRewriter logicalExpressionRewriter;
 
-        public Rewriter(Metadata metadata)
+        public Rewriter(Metadata metadata, ExpressionOptimizerManager expressionOptimizerManager, FeaturesConfig featuresConfig)
         {
             requireNonNull(metadata, "metadata is null");
-            this.optimizer = new RowExpressionOptimizer(metadata);
+            requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
+            requireNonNull(featuresConfig, "featuresConfig is null");
+            this.inMemoryExpressionOptimizer = new RowExpressionOptimizer(metadata);
+            this.delegatingExpressionOptimizer = new DelegatingRowExpressionOptimizer(metadata, expressionOptimizerManager, featuresConfig.getDelegatingRowExpressionOptimizerMaxIterations());
             this.logicalExpressionRewriter = new LogicalExpressionRewriter(metadata.getFunctionAndTypeManager());
         }
 
         @Override
         public RowExpression rewrite(RowExpression expression, Rule.Context context)
         {
-            return rewrite(expression, context.getSession().toConnectorSession());
+            return rewrite(expression, context.getSession());
         }
 
-        private RowExpression rewrite(RowExpression expression, ConnectorSession session)
+        private RowExpression rewrite(RowExpression expression, Session session)
         {
             // Rewrite RowExpression first to reduce depth of RowExpression tree by balancing AND/OR predicates.
             // It doesn't matter whether we rewrite/optimize first because this will be called by IterativeOptimizer.
             RowExpression rewritten = RowExpressionTreeRewriter.rewriteWith(logicalExpressionRewriter, expression, true);
-            RowExpression optimizedRowExpression = optimizer.optimize(rewritten, SERIALIZABLE, session);
-            return optimizedRowExpression;
+            if (isDelegatingRowExpressionOptimizerEnabled(session)) {
+                return delegatingExpressionOptimizer.optimize(rewritten, SERIALIZABLE, session.toConnectorSession());
+            }
+            else {
+                return inMemoryExpressionOptimizer.optimize(rewritten, SERIALIZABLE, session.toConnectorSession());
+            }
         }
     }
 
     @VisibleForTesting
-    public static RowExpression rewrite(RowExpression expression, Metadata metadata, ConnectorSession session)
+    public static RowExpression rewrite(RowExpression expression, Metadata metadata, Session session, ExpressionOptimizerManager expressionOptimizerManager, FeaturesConfig featuresConfig)
     {
-        return new Rewriter(metadata).rewrite(expression, session);
+        return new Rewriter(metadata, expressionOptimizerManager, featuresConfig).rewrite(expression, session);
     }
 
     private static class LogicalExpressionRewriter

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CteProjectionAndPredicatePushDown.java
@@ -26,6 +26,8 @@ import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.PlannerUtils;
 import com.facebook.presto.sql.planner.RowExpressionVariableInliner;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
@@ -87,10 +89,14 @@ public class CteProjectionAndPredicatePushDown
         implements PlanOptimizer
 {
     private final Metadata metadata;
+    private final ExpressionOptimizerManager expressionOptimizerManager;
+    private final FeaturesConfig featuresConfig;
 
-    public CteProjectionAndPredicatePushDown(Metadata metadata)
+    public CteProjectionAndPredicatePushDown(Metadata metadata, ExpressionOptimizerManager expressionOptimizerManager, FeaturesConfig featuresConfig)
     {
-        this.metadata = metadata;
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
+        this.featuresConfig = requireNonNull(featuresConfig, "featuresConfig is null");
     }
 
     @Override
@@ -383,7 +389,7 @@ public class CteProjectionAndPredicatePushDown
                             resultPredicate, predicates.get(i));
                 }
             }
-            resultPredicate = SimplifyRowExpressions.rewrite(resultPredicate, metadata, session.toConnectorSession());
+            resultPredicate = SimplifyRowExpressions.rewrite(resultPredicate, metadata, session, expressionOptimizerManager, featuresConfig);
             return new FilterNode(node.getSourceLocation(), idAllocator.getNextId(), node, resultPredicate);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -45,6 +45,7 @@ import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -65,7 +66,6 @@ import com.facebook.presto.sql.relational.Expressions;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
-import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
@@ -132,13 +132,15 @@ public class PredicatePushDown
     private final SqlParser sqlParser;
     private final RowExpressionDomainTranslator rowExpressionDomainTranslator;
     private final boolean nativeExecution;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
-    public PredicatePushDown(Metadata metadata, SqlParser sqlParser, boolean nativeExecution)
+    public PredicatePushDown(Metadata metadata, SqlParser sqlParser, ExpressionOptimizerProvider expressionOptimizerProvider, boolean nativeExecution)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         rowExpressionDomainTranslator = new RowExpressionDomainTranslator(metadata);
         this.effectivePredicateExtractor = new EffectivePredicateExtractor(rowExpressionDomainTranslator, metadata.getFunctionAndTypeManager());
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         this.nativeExecution = nativeExecution;
     }
 
@@ -150,7 +152,7 @@ public class PredicatePushDown
         requireNonNull(types, "types is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        Rewriter rewriter = new Rewriter(variableAllocator, idAllocator, metadata, effectivePredicateExtractor, rowExpressionDomainTranslator, sqlParser, session, nativeExecution);
+        Rewriter rewriter = new Rewriter(variableAllocator, idAllocator, metadata, effectivePredicateExtractor, rowExpressionDomainTranslator, expressionOptimizerProvider, sqlParser, session, nativeExecution);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, TRUE_CONSTANT);
         return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
@@ -184,6 +186,7 @@ public class PredicatePushDown
         private final Metadata metadata;
         private final EffectivePredicateExtractor effectivePredicateExtractor;
         private final RowExpressionDomainTranslator rowExpressionDomainTranslator;
+        private final ExpressionOptimizerProvider expressionOptimizerProvider;
         private final Session session;
         private final boolean nativeExecution;
         private final ExpressionEquivalence expressionEquivalence;
@@ -199,6 +202,7 @@ public class PredicatePushDown
                 Metadata metadata,
                 EffectivePredicateExtractor effectivePredicateExtractor,
                 RowExpressionDomainTranslator rowExpressionDomainTranslator,
+                ExpressionOptimizerProvider expressionOptimizerProvider,
                 SqlParser sqlParser,
                 Session session,
                 boolean nativeExecution)
@@ -208,6 +212,7 @@ public class PredicatePushDown
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.effectivePredicateExtractor = requireNonNull(effectivePredicateExtractor, "effectivePredicateExtractor is null");
             this.rowExpressionDomainTranslator = rowExpressionDomainTranslator;
+            this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
             this.session = requireNonNull(session, "session is null");
             this.nativeExecution = nativeExecution;
             this.expressionEquivalence = new ExpressionEquivalence(metadata, sqlParser);
@@ -1159,7 +1164,8 @@ public class PredicatePushDown
             }
         }
 
-        private InnerJoinPushDownResult processInnerJoin(RowExpression inheritedPredicate,
+        private InnerJoinPushDownResult processInnerJoin(
+                RowExpression inheritedPredicate,
                 RowExpression leftEffectivePredicate,
                 RowExpression rightEffectivePredicate,
                 RowExpression joinPredicate,
@@ -1283,6 +1289,7 @@ public class PredicatePushDown
             joinConjuncts.addAll(allInference.generateEqualitiesPartitionedBy(in(leftVariables)::apply).getScopeStraddlingEqualities()); // scope straddling equalities get dropped in as part of the join predicate
 
             return new Rewriter.InnerJoinPushDownResult(
+                    expressionOptimizerProvider,
                     logicalRowExpressions.combineConjuncts(leftPushDownConjuncts.build()),
                     logicalRowExpressions.combineConjuncts(rightPushDownConjuncts.build()),
                     logicalRowExpressions.combineConjuncts(joinConjuncts.build()), TRUE_CONSTANT);
@@ -1294,13 +1301,20 @@ public class PredicatePushDown
             private final RowExpression rightPredicate;
             private final RowExpression joinPredicate;
             private final RowExpression postJoinPredicate;
+            private final ExpressionOptimizerProvider expressionOptimizerProvider;
 
-            private InnerJoinPushDownResult(RowExpression leftPredicate, RowExpression rightPredicate, RowExpression joinPredicate, RowExpression postJoinPredicate)
+            private InnerJoinPushDownResult(
+                    ExpressionOptimizerProvider expressionOptimizerProvider,
+                    RowExpression leftPredicate,
+                    RowExpression rightPredicate,
+                    RowExpression joinPredicate,
+                    RowExpression postJoinPredicate)
             {
-                this.leftPredicate = leftPredicate;
-                this.rightPredicate = rightPredicate;
-                this.joinPredicate = joinPredicate;
-                this.postJoinPredicate = postJoinPredicate;
+                this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
+                this.leftPredicate = requireNonNull(leftPredicate, "leftPredicate is null");
+                this.rightPredicate = requireNonNull(rightPredicate, "rightPredicate is null");
+                this.joinPredicate = requireNonNull(joinPredicate, "joinPredicate is null");
+                this.postJoinPredicate = requireNonNull(postJoinPredicate, "postJoinPredicate is null");
             }
 
             private RowExpression getLeftPredicate()
@@ -1425,7 +1439,7 @@ public class PredicatePushDown
         // Temporary implementation for joins because the SimplifyExpressions optimizers can not run properly on join clauses
         private RowExpression simplifyExpression(RowExpression expression)
         {
-            return new RowExpressionOptimizer(metadata).optimize(expression, ExpressionOptimizer.Level.SERIALIZABLE, session.toConnectorSession());
+            return expressionOptimizerProvider.getExpressionOptimizer().optimize(expression, ExpressionOptimizer.Level.SERIALIZABLE, session.toConnectorSession());
         }
 
         private boolean areExpressionsEquivalent(RowExpression leftExpression, RowExpression rightExpression)
@@ -1440,7 +1454,7 @@ public class PredicatePushDown
         {
             expression = RowExpressionNodeInliner.replaceExpression(expression, nullSymbols.stream()
                     .collect(Collectors.toMap(identity(), variable -> constantNull(variable.getSourceLocation(), variable.getType()))));
-            return new RowExpressionOptimizer(metadata).optimize(expression, ExpressionOptimizer.Level.OPTIMIZED, session.toConnectorSession());
+            return expressionOptimizerProvider.getExpressionOptimizer().optimize(expression, ExpressionOptimizer.Level.OPTIMIZED, session.toConnectorSession());
         }
 
         private Predicate<RowExpression> joinEqualityExpression(final Collection<VariableReferenceExpression> leftVariables)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -55,6 +55,7 @@ import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
@@ -70,7 +71,6 @@ import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UnnestNode;
 import com.facebook.presto.sql.relational.FunctionResolution;
-import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -110,11 +110,13 @@ public class PushdownSubfields
     public static final QualifiedObjectName ELEMENT_AT = QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "element_at");
     public static final QualifiedObjectName CAST = QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "$operator$cast");
     private final Metadata metadata;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
     private boolean isEnabledForTesting;
 
-    public PushdownSubfields(Metadata metadata)
+    public PushdownSubfields(Metadata metadata, ExpressionOptimizerProvider expressionOptimizerProvider)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
     }
 
     @Override
@@ -140,7 +142,7 @@ public class PushdownSubfields
             return PlanOptimizerResult.optimizerResult(plan, false);
         }
 
-        Rewriter rewriter = new Rewriter(session, metadata);
+        Rewriter rewriter = new Rewriter(session, metadata, expressionOptimizerProvider);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new Rewriter.Context());
         return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
     }
@@ -156,12 +158,13 @@ public class PushdownSubfields
         private static final QualifiedObjectName ARBITRARY_AGGREGATE_FUNCTION = QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "arbitrary");
         private boolean planChanged;
 
-        public Rewriter(Session session, Metadata metadata)
+        public Rewriter(Session session, Metadata metadata, ExpressionOptimizerProvider expressionOptimizerProvider)
         {
             this.session = requireNonNull(session, "session is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
+            requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
             this.functionResolution = new FunctionResolution(metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver());
-            this.expressionOptimizer = new RowExpressionOptimizer(metadata);
+            this.expressionOptimizer = expressionOptimizerProvider.getExpressionOptimizer();
             this.subfieldExtractor = new SubfieldExtractor(
                     functionResolution,
                     expressionOptimizer,

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/ConnectorRowExpressionService.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/ConnectorRowExpressionService.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.PredicateCompiler;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
@@ -28,20 +29,20 @@ public final class ConnectorRowExpressionService
         implements RowExpressionService
 {
     private final DomainTranslator domainTranslator;
-    private final ExpressionOptimizer expressionOptimizer;
+    private final ExpressionOptimizerProvider expressionOptimizerProvider;
     private final PredicateCompiler predicateCompiler;
     private final DeterminismEvaluator determinismEvaluator;
     private final RowExpressionFormatter rowExpressionFormatter;
 
     public ConnectorRowExpressionService(
             DomainTranslator domainTranslator,
-            ExpressionOptimizer expressionOptimizer,
+            ExpressionOptimizerProvider expressionOptimizerProvider,
             PredicateCompiler predicateCompiler,
             DeterminismEvaluator determinismEvaluator,
             RowExpressionFormatter rowExpressionFormatter)
     {
         this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
-        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
+        this.expressionOptimizerProvider = requireNonNull(expressionOptimizerProvider, "expressionOptimizerProvider is null");
         this.predicateCompiler = requireNonNull(predicateCompiler, "predicateCompiler is null");
         this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
         this.rowExpressionFormatter = requireNonNull(rowExpressionFormatter, "rowExpressionFormatter is null");
@@ -56,7 +57,7 @@ public final class ConnectorRowExpressionService
     @Override
     public ExpressionOptimizer getExpressionOptimizer()
     {
-        return expressionOptimizer;
+        return expressionOptimizerProvider.getExpressionOptimizer();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/DelegatingRowExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/DelegatingRowExpressionOptimizer.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+
+import java.util.function.Function;
+
+import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class DelegatingRowExpressionOptimizer
+        implements ExpressionOptimizer
+{
+    private static final int DEFAULT_MAX_OPTIMIZATION_ATTEMPTS = 10;
+    private final ExpressionOptimizerProvider expressionOptimizerManager;
+    private final int maxOptimizationAttempts;
+
+    public DelegatingRowExpressionOptimizer(Metadata metadata, ExpressionOptimizerProvider expressionOptimizerManager)
+    {
+        this(metadata, expressionOptimizerManager, DEFAULT_MAX_OPTIMIZATION_ATTEMPTS);
+    }
+
+    public DelegatingRowExpressionOptimizer(Metadata metadata, ExpressionOptimizerProvider expressionOptimizerManager, int maxOptimizationAttempts)
+    {
+        requireNonNull(metadata, "metadata is null");
+        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
+        checkArgument(maxOptimizationAttempts > 0, "maxOptimizationAttempts must be greater than 0");
+        this.maxOptimizationAttempts = maxOptimizationAttempts;
+    }
+
+    @Override
+    public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
+    {
+        ExpressionOptimizer delegate = expressionOptimizerManager.getExpressionOptimizer();
+        RowExpression originalExpression;
+        for (int i = 0; i < maxOptimizationAttempts; i++) {
+            // Do not optimize ConstantExpression, and InputReferenceExpression because they cannot be optimized further
+            if (rowExpression instanceof ConstantExpression || rowExpression instanceof InputReferenceExpression) {
+                return rowExpression;
+            }
+            originalExpression = rowExpression;
+            rowExpression = delegate.optimize(rowExpression, level, session);
+            requireNonNull(rowExpression, "optimized expression is null");
+            if (originalExpression.equals(rowExpression)) {
+                break;
+            }
+        }
+        return rowExpression;
+    }
+
+    @Override
+    public Object optimize(RowExpression rowExpression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+    {
+        ExpressionOptimizer delegate = expressionOptimizerManager.getExpressionOptimizer();
+        Object currentExpression = rowExpression;
+        Object originalExpression;
+        for (int i = 0; i < maxOptimizationAttempts; i++) {
+            // Do not optimize ConstantExpression, and InputReferenceExpression because they cannot be optimized further
+            if (currentExpression instanceof ConstantExpression || currentExpression instanceof InputReferenceExpression) {
+                return currentExpression;
+            }
+            originalExpression = currentExpression;
+            currentExpression = delegate.optimize(toRowExpression(currentExpression, rowExpression.getType()), level, session, variableResolver);
+            if (currentExpression == null || currentExpression.equals(originalExpression)) {
+                break;
+            }
+        }
+        return currentExpression;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -105,6 +105,7 @@ import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.metadata.SchemaPropertyManager;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.TablePropertyManager;
+import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.operator.Driver;
 import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.DriverFactory;
@@ -167,6 +168,7 @@ import com.facebook.presto.sql.analyzer.FunctionsConfig;
 import com.facebook.presto.sql.analyzer.JavaFeaturesConfig;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -351,6 +353,7 @@ public class LocalQueryRunner
     private static ExecutorService metadataExtractorExecutor = newCachedThreadPool(threadsNamed("query-execution-%s"));
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private ExpressionOptimizerManager expressionOptimizerManager;
 
     public LocalQueryRunner(Session defaultSession)
     {
@@ -446,8 +449,12 @@ public class LocalQueryRunner
         this.planFragmenter = new PlanFragmenter(this.metadata, this.nodePartitioningManager, new QueryManagerConfig(), featuresConfig, planCheckerProviderManager);
         this.joinCompiler = new JoinCompiler(metadata);
         this.pageIndexerFactory = new GroupByHashPageIndexerFactory(joinCompiler);
+
+        NodeInfo nodeInfo = new NodeInfo("test");
+        expressionOptimizerManager = new ExpressionOptimizerManager(new PluginNodeManager(nodeManager, nodeInfo.getEnvironment()), getFunctionAndTypeManager());
+
         this.statsNormalizer = new StatsNormalizer();
-        this.scalarStatsCalculator = new ScalarStatsCalculator(metadata);
+        this.scalarStatsCalculator = new ScalarStatsCalculator(metadata, expressionOptimizerManager);
         this.filterStatsCalculator = new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer);
         this.historyBasedPlanStatisticsManager = new HistoryBasedPlanStatisticsManager(objectMapper, createTestingSessionPropertyManager(), metadata, new HistoryBasedOptimizationConfig(), featuresConfig, new NodeVersion("1"));
         this.fragmentStatsProvider = new FragmentStatsProvider();
@@ -462,7 +469,6 @@ public class LocalQueryRunner
         this.expressionCompiler = new ExpressionCompiler(metadata, pageFunctionCompiler);
         this.joinFilterFunctionCompiler = new JoinFilterFunctionCompiler(metadata);
 
-        NodeInfo nodeInfo = new NodeInfo("test");
         NodeVersion nodeVersion = new NodeVersion("testversion");
         this.connectorManager = new ConnectorManager(
                 metadata,
@@ -525,7 +531,8 @@ public class LocalQueryRunner
                 historyBasedPlanStatisticsManager,
                 new TracerProviderManager(new TracingConfig()),
                 new NodeStatusNotificationManager(),
-                planCheckerProviderManager);
+                planCheckerProviderManager,
+                expressionOptimizerManager);
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory);
         connectorManager.createConnection(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());
@@ -700,6 +707,12 @@ public class LocalQueryRunner
     public TestingAccessControlManager getAccessControl()
     {
         return accessControl;
+    }
+
+    @Override
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        return expressionOptimizerManager;
     }
 
     public ExecutorService getExecutor()
@@ -1113,7 +1126,8 @@ public class LocalQueryRunner
                 new CostComparator(featuresConfig),
                 taskCountEstimator,
                 partitioningProviderManager,
-                featuresConfig).getPlanningTimeOptimizers();
+                featuresConfig,
+                expressionOptimizerManager).getPlanningTimeOptimizers();
     }
 
     public Plan createPlan(Session session, @Language("SQL") String sql, List<PlanOptimizer> optimizers, WarningCollector warningCollector)

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -489,6 +489,7 @@ public class LocalQueryRunner
                 pageSorter,
                 pageIndexerFactory,
                 transactionManager,
+                expressionOptimizerManager,
                 new RowExpressionDomainTranslator(metadata),
                 new RowExpressionPredicateCompiler(metadata),
                 new RowExpressionDeterminismEvaluator(metadata.getFunctionAndTypeManager()),

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -143,6 +143,7 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.SimplePlanFragment;
 import com.facebook.presto.spi.plan.StageExecutionDescriptor;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spiller.FileSingleStreamSpillerFactory;
 import com.facebook.presto.spiller.GenericPartitioningSpillerFactory;
 import com.facebook.presto.spiller.GenericSpillerFactory;
@@ -169,6 +170,7 @@ import com.facebook.presto.sql.analyzer.JavaFeaturesConfig;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
+import com.facebook.presto.sql.expressions.JsonCodecRowExpressionSerde;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -451,7 +453,7 @@ public class LocalQueryRunner
         this.pageIndexerFactory = new GroupByHashPageIndexerFactory(joinCompiler);
 
         NodeInfo nodeInfo = new NodeInfo("test");
-        expressionOptimizerManager = new ExpressionOptimizerManager(new PluginNodeManager(nodeManager, nodeInfo.getEnvironment()), getFunctionAndTypeManager());
+        expressionOptimizerManager = new ExpressionOptimizerManager(new PluginNodeManager(nodeManager, nodeInfo.getEnvironment()), getFunctionAndTypeManager(), new JsonCodecRowExpressionSerde(jsonCodec(RowExpression.class)));
 
         this.statsNormalizer = new StatsNormalizer();
         this.scalarStatsCalculator = new ScalarStatsCalculator(metadata, expressionOptimizerManager);

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.Plan;
@@ -62,6 +63,8 @@ public interface QueryRunner
     Optional<EventListener> getEventListener();
 
     TestingAccessControlManager getAccessControl();
+
+    ExpressionOptimizerManager getExpressionManager();
 
     MaterializedResult execute(@Language("SQL") String sql);
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.PredicateCompiler;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
@@ -66,7 +67,8 @@ public class TestingConnectorContext
     private final DomainTranslator domainTranslator = new RowExpressionDomainTranslator(metadata);
     private final PredicateCompiler predicateCompiler = new RowExpressionPredicateCompiler(metadata);
     private final DeterminismEvaluator determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
-    private final FilterStatsCalculatorService filterStatsCalculatorService = new ConnectorFilterStatsCalculatorService(new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer()));
+    private final ExpressionOptimizerProvider expressionOptimizerProvider = () -> new RowExpressionOptimizer(metadata);
+    private final FilterStatsCalculatorService filterStatsCalculatorService = new ConnectorFilterStatsCalculatorService(new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, expressionOptimizerProvider), new StatsNormalizer()));
     private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager();
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestComparisonStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestComparisonStatsCalculator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
@@ -82,7 +83,7 @@ public abstract class AbstractTestComparisonStatsCalculator
             throws Exception
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        filterStatsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer());
+        filterStatsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata)), new StatsNormalizer());
 
         uStats = VariableStatsEstimate.builder()
                 .setAverageRowSize(8.0)

--- a/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestFilterStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/AbstractTestFilterStatsCalculator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Expression;
@@ -146,7 +147,7 @@ public abstract class AbstractTestFilterStatsCalculator
                 .build());
 
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer());
+        statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata)), new StatsNormalizer());
         translator = new TestingRowExpressionTranslator(MetadataManager.createTestMetadataManager());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.DoubleRange;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Expression;
@@ -56,7 +57,12 @@ public class TestConnectorFilterStatsCalculatorService
     {
         session = testSessionBuilder().build();
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
-        FilterStatsCalculator statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer());
+        FilterStatsCalculator statsCalculator = new FilterStatsCalculator(
+                metadata,
+                new ScalarStatsCalculator(
+                        metadata,
+                        new InMemoryExpressionOptimizerProvider(metadata)),
+                new StatsNormalizer());
         statsCalculatorService = new ConnectorFilterStatsCalculatorService(statsCalculator);
         xStats = ColumnStatistics.builder()
                 .setDistinctValuesCount(Estimate.of(40))

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
@@ -18,8 +18,10 @@ import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -90,8 +92,10 @@ public class TestJoinStatsRule
 
     private static final MetadataManager METADATA = createTestMetadataManager();
     private static final StatsNormalizer NORMALIZER = new StatsNormalizer();
+
+    private static final ExpressionOptimizerProvider EXPRESSION_OPTIMIZER_PROVIDER = new InMemoryExpressionOptimizerProvider(METADATA);
     private static final JoinStatsRule JOIN_STATS_RULE = new JoinStatsRule(
-            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA), NORMALIZER),
+            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA, EXPRESSION_OPTIMIZER_PROVIDER), NORMALIZER),
             NORMALIZER,
             1.0);
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.LiteralEncoder;
@@ -68,9 +69,10 @@ public class TestScalarStatsCalculator
     @BeforeClass
     public void setUp()
     {
-        calculator = new ScalarStatsCalculator(MetadataManager.createTestMetadataManager());
+        MetadataManager metadata = createTestMetadataManager();
+        calculator = new ScalarStatsCalculator(metadata, new InMemoryExpressionOptimizerProvider(metadata));
         session = testSessionBuilder().build();
-        translator = new TestingRowExpressionTranslator(MetadataManager.createTestMetadataManager());
+        translator = new TestingRowExpressionTranslator(metadata);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/InMemoryExpressionOptimizerProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/InMemoryExpressionOptimizerProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.ExpressionOptimizerProvider;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+
+import static java.util.Objects.requireNonNull;
+
+public class InMemoryExpressionOptimizerProvider
+        implements ExpressionOptimizerProvider
+{
+    private final Metadata metadata;
+
+    public InMemoryExpressionOptimizerProvider(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public ExpressionOptimizer getExpressionOptimizer()
+    {
+        return new RowExpressionOptimizer(metadata);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -247,7 +247,9 @@ public class TestFeaturesConfig
                 .setInlineProjectionsOnValues(false)
                 .setEagerPlanValidationEnabled(false)
                 .setEagerPlanValidationThreadPoolSize(20)
-                .setPrestoSparkExecutionEnvironment(false));
+                .setPrestoSparkExecutionEnvironment(false)
+                .setDelegatingRowExpressionOptimizerEnabled(false)
+                .setDelegatingRowExpressionOptimizerMaxIterations(10));
     }
 
     @Test
@@ -444,6 +446,8 @@ public class TestFeaturesConfig
                 .put("eager-plan-validation-enabled", "true")
                 .put("eager-plan-validation-thread-pool-size", "2")
                 .put("presto-spark-execution-environment", "true")
+                .put("optimizer.delegating-row-expression-optimizer-enabled", "true")
+                .put("optimizer.delegating-row-expression-optimizer-max-iterations", "5")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -637,7 +641,9 @@ public class TestFeaturesConfig
                 .setInlineProjectionsOnValues(true)
                 .setEagerPlanValidationEnabled(true)
                 .setEagerPlanValidationThreadPoolSize(2)
-                .setPrestoSparkExecutionEnvironment(true);
+                .setPrestoSparkExecutionEnvironment(true)
+                .setDelegatingRowExpressionOptimizerEnabled(true)
+                .setDelegatingRowExpressionOptimizerMaxIterations(5);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -14,10 +14,18 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.functionNamespace.FunctionNamespaceManagerPlugin;
 import com.facebook.presto.functionNamespace.json.JsonFileBasedFunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AggregationFunctionMetadata;
+import com.facebook.presto.spi.function.FunctionKind;
+import com.facebook.presto.spi.function.Parameter;
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -76,8 +84,12 @@ import static com.facebook.presto.SystemSessionProperties.getMaxLeafNodesInPlan;
 import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_LAST;
 import static com.facebook.presto.common.predicate.Domain.singleValue;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_LIMIT_CLAUSE;
+import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.DETERMINISTIC;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Language.CPP;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
@@ -88,8 +100,6 @@ import static com.facebook.presto.spi.plan.JoinType.LEFT;
 import static com.facebook.presto.spi.plan.JoinType.RIGHT;
 import static com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED;
 import static com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED_AND_VALIDATED;
-import static com.facebook.presto.sql.TestExpressionInterpreter.AVG_UDAF_CPP;
-import static com.facebook.presto.sql.TestExpressionInterpreter.SQUARE_UDF_CPP;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
@@ -144,6 +154,26 @@ import static org.testng.Assert.fail;
 public class TestLogicalPlanner
         extends BasePlanTest
 {
+    public static final SqlInvokedFunction SQUARE_UDF_CPP = new SqlInvokedFunction(
+            QualifiedObjectName.valueOf(new CatalogSchemaName("json", "test_schema"), "square"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.BIGINT))),
+            parseTypeSignature(StandardTypes.BIGINT),
+            "Integer square",
+            RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).setLanguage(CPP).build(),
+            "",
+            notVersioned());
+
+    public static final SqlInvokedFunction AVG_UDAF_CPP = new SqlInvokedFunction(
+            QualifiedObjectName.valueOf(new CatalogSchemaName("json", "test_schema"), "avg"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.DOUBLE))),
+            parseTypeSignature(StandardTypes.DOUBLE),
+            "Returns mean of doubles",
+            RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).setLanguage(CPP).build(),
+            "",
+            notVersioned(),
+            FunctionKind.AGGREGATE,
+            Optional.of(new AggregationFunctionMetadata(parseTypeSignature("ROW(double, int)"), false)));
+
     // TODO: Use com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder#tableScan with required node/stream
     // partitioning to properly test aggregation, window function and join.
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.WindowNode;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
@@ -476,7 +477,7 @@ public class TestPredicatePushdown
     public void testPredicatePushDownCanReduceInnerToCrossJoin()
     {
         RuleTester tester = new RuleTester();
-        tester.assertThat(new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), false))
+        tester.assertThat(new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), new InMemoryExpressionOptimizerProvider(tester.getMetadata()), false))
                 .on(p ->
                         p.join(INNER,
                                 p.filter(p.comparison(OperatorType.EQUAL, p.variable("a1"), constant(1L, INTEGER)),
@@ -509,7 +510,7 @@ public class TestPredicatePushdown
     public void testPredicatePushdownDoesNotAddProjectsBetweenJoinNodes()
     {
         RuleTester tester = new RuleTester();
-        PredicatePushDown predicatePushDownOptimizer = new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), false);
+        PredicatePushDown predicatePushDownOptimizer = new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), new InMemoryExpressionOptimizerProvider(tester.getMetadata()), false);
 
         tester.assertThat(predicatePushDownOptimizer)
                 .on("SELECT 1 " +
@@ -589,7 +590,7 @@ public class TestPredicatePushdown
     public void testDomainFiltersCanBeInferredForLargeDisjunctiveFilters()
     {
         RuleTester tester = new RuleTester(emptyList(), ImmutableMap.of(GENERATE_DOMAIN_FILTERS, "true"));
-        PredicatePushDown predicatePushDownOptimizer = new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), false);
+        PredicatePushDown predicatePushDownOptimizer = new PredicatePushDown(tester.getMetadata(), tester.getSqlParser(), new InMemoryExpressionOptimizerProvider(tester.getMetadata()), false);
 
         // For Inner Join
         tester.assertThat(predicatePushDownOptimizer)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
@@ -23,10 +23,12 @@ import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.Optimizer;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
+import com.facebook.presto.sql.expressions.JsonCodecRowExpressionSerde;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -50,6 +52,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.sql.planner.assertions.PlanAssert.assertPlan;
 import static com.facebook.presto.sql.planner.assertions.PlanAssert.assertPlanDoesNotMatch;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
@@ -178,7 +181,8 @@ public class OptimizerAssert
                                 metadata,
                                 new ExpressionOptimizerManager(
                                         new PluginNodeManager(new InMemoryNodeManager()),
-                                        queryRunner.getFunctionAndTypeManager()),
+                                        queryRunner.getFunctionAndTypeManager(),
+                                        new JsonCodecRowExpressionSerde(jsonCodec(RowExpression.class))),
                                 new FeaturesConfig()).rules()));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
@@ -16,13 +16,17 @@ package com.facebook.presto.sql.planner.assertions;
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.Optimizer;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -170,7 +174,12 @@ public class OptimizerAssert
                         new RuleStatsRecorder(),
                         queryRunner.getStatsCalculator(),
                         queryRunner.getCostCalculator(),
-                        new SimplifyRowExpressions(metadata).rules()));
+                        new SimplifyRowExpressions(
+                                metadata,
+                                new ExpressionOptimizerManager(
+                                        new PluginNodeManager(new InMemoryNodeManager()),
+                                        queryRunner.getFunctionAndTypeManager()),
+                                new FeaturesConfig()).rules()));
     }
 
     private <T> void inTransaction(Function<Session, T> transactionSessionConsumer)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveMapCastRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveMapCastRule.java
@@ -14,12 +14,15 @@
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.SystemSessionProperties.DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.REMOVE_MAP_CAST;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -33,12 +36,24 @@ import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.as
 public class TestRemoveMapCastRule
         extends BaseRuleTest
 {
-    @Test
-    public void testSubscriptCast()
+    @DataProvider(name = "delegating-row-expression-optimizer-enabled")
+    public Object[][] delegatingDataProvider()
+    {
+        return new Object[][] {
+                {true},
+                {false},
+        };
+    }
+    @Test(dataProvider = "delegating-row-expression-optimizer-enabled")
+    public void testSubscriptCast(boolean enableDelegatingRowExpressionOptimizer)
     {
         tester().assertThat(
-                        ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(new RemoveMapCastRule(getFunctionManager()).rules()).build())
+                        ImmutableSet.<Rule<?>>builder()
+                                .addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager(), new FeaturesConfig()).rules())
+                                .addAll(new RemoveMapCastRule(getFunctionManager()).rules())
+                                .build())
                 .setSystemProperty(REMOVE_MAP_CAST, "true")
+                .setSystemProperty(DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED, Boolean.toString(enableDelegatingRowExpressionOptimizer))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", DOUBLE);
                     VariableReferenceExpression feature = p.variable("feature", createMapType(getFunctionManager(), INTEGER, DOUBLE));
@@ -53,12 +68,16 @@ public class TestRemoveMapCastRule
                                 values("feature", "key")));
     }
 
-    @Test
-    public void testElementAtCast()
+    @Test(dataProvider = "delegating-row-expression-optimizer-enabled")
+    public void testElementAtCast(boolean enableDelegatingRowExpressionOptimizer)
     {
         tester().assertThat(
-                        ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(new RemoveMapCastRule(getFunctionManager()).rules()).build())
+                        ImmutableSet.<Rule<?>>builder()
+                                .addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager(), new FeaturesConfig()).rules())
+                                .addAll(new RemoveMapCastRule(getFunctionManager()).rules())
+                                .build())
                 .setSystemProperty(REMOVE_MAP_CAST, "true")
+                .setSystemProperty(DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED, Boolean.toString(enableDelegatingRowExpressionOptimizer))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", DOUBLE);
                     VariableReferenceExpression feature = p.variable("feature", createMapType(getFunctionManager(), INTEGER, DOUBLE));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteConstantArrayContainsToInExpression.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteConstantArrayContainsToInExpression.java
@@ -15,12 +15,15 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.SystemSessionProperties.DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -32,13 +35,25 @@ import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.as
 public class TestRewriteConstantArrayContainsToInExpression
         extends BaseRuleTest
 {
-    @Test
-    public void testNoNull()
+    @DataProvider(name = "delegating-row-expression-optimizer-enabled")
+    public Object[][] delegatingDataProvider()
+    {
+        return new Object[][] {
+                {true},
+                {false},
+        };
+    }
+
+    @Test(dataProvider = "delegating-row-expression-optimizer-enabled")
+    public void testNoNull(boolean enableDelegatingRowExpressionOptimizer)
     {
         tester().assertThat(
-                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
-                        new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
+                ImmutableSet.<Rule<?>>builder()
+                        .addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager(), new FeaturesConfig()).rules())
+                        .addAll(new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules())
+                        .build())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
+                .setSystemProperty(DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED, Boolean.toString(enableDelegatingRowExpressionOptimizer))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", BOOLEAN);
                     VariableReferenceExpression b = p.variable("b");
@@ -52,11 +67,12 @@ public class TestRewriteConstantArrayContainsToInExpression
                                 values("b")));
     }
 
-    @Test
-    public void testDoesNotFireForNestedArray()
+    @Test(dataProvider = "delegating-row-expression-optimizer-enabled")
+    public void testDoesNotFireForNestedArray(boolean enableDelegatingRowExpressionOptimizer)
     {
         tester().assertThat(new RewriteConstantArrayContainsToInExpression(getFunctionManager()).projectRowExpressionRewriteRule())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
+                .setSystemProperty(DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED, Boolean.toString(enableDelegatingRowExpressionOptimizer))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", BOOLEAN);
                     VariableReferenceExpression b = p.variable("b", new ArrayType(BIGINT));
@@ -67,8 +83,8 @@ public class TestRewriteConstantArrayContainsToInExpression
                 .doesNotFire();
     }
 
-    @Test
-    public void testDoesNotFireForNull()
+    @Test(dataProvider = "delegating-row-expression-optimizer-enabled")
+    public void testDoesNotFireForNull(boolean enableDelegatingRowExpressionOptimizer)
     {
         tester().assertThat(new RewriteConstantArrayContainsToInExpression(getFunctionManager()).projectRowExpressionRewriteRule())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
@@ -82,8 +98,8 @@ public class TestRewriteConstantArrayContainsToInExpression
                 .doesNotFire();
     }
 
-    @Test
-    public void testDoesNotFireForEmpty()
+    @Test(dataProvider = "delegating-row-expression-optimizer-enabled")
+    public void testDoesNotFireForEmpty(boolean enableDelegatingRowExpressionOptimizer)
     {
         tester().assertThat(new RewriteConstantArrayContainsToInExpression(getFunctionManager()).projectRowExpressionRewriteRule())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
@@ -97,12 +113,14 @@ public class TestRewriteConstantArrayContainsToInExpression
                 .doesNotFire();
     }
 
-    @Test
-    public void testNotFire()
+    @Test(dataProvider = "delegating-row-expression-optimizer-enabled")
+    public void testNotFire(boolean enableDelegatingRowExpressionOptimizer)
     {
         tester().assertThat(
-                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
-                        new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
+                ImmutableSet.<Rule<?>>builder()
+                        .addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager(), new FeaturesConfig()).rules())
+                        .addAll(new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules())
+                        .build())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", BOOLEAN);
@@ -118,12 +136,14 @@ public class TestRewriteConstantArrayContainsToInExpression
                                 values("b", "c")));
     }
 
-    @Test
-    public void testWithNull()
+    @Test(dataProvider = "delegating-row-expression-optimizer-enabled")
+    public void testWithNull(boolean enableDelegatingRowExpressionOptimizer)
     {
         tester().assertThat(
-                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
-                        new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
+                ImmutableSet.<Rule<?>>builder()
+                        .addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager(), new FeaturesConfig()).rules())
+                        .addAll(new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules())
+                        .build())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", BOOLEAN);
@@ -138,12 +158,14 @@ public class TestRewriteConstantArrayContainsToInExpression
                                 values("b")));
     }
 
-    @Test
-    public void testLambda()
+    @Test(dataProvider = "delegating-row-expression-optimizer-enabled")
+    public void testLambda(boolean enableDelegatingRowExpressionOptimizer)
     {
         tester().assertThat(
-                ImmutableSet.<Rule<?>>builder().addAll(new SimplifyRowExpressions(getMetadata()).rules()).addAll(
-                        new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules()).build())
+                ImmutableSet.<Rule<?>>builder()
+                        .addAll(new SimplifyRowExpressions(getMetadata(), getExpressionManager(), new FeaturesConfig()).rules())
+                        .addAll(new RewriteConstantArrayContainsToInExpression(getFunctionManager()).rules())
+                        .build())
                 .setSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, "true")
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", BOOLEAN);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
@@ -13,15 +13,20 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
+import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Expression;
@@ -36,6 +41,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.SystemSessionProperties.DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -43,6 +49,8 @@ import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
 import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
 import static com.facebook.presto.sql.relational.Expressions.specialForm;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -181,12 +189,24 @@ public class TestSimplifyRowExpressions
     {
         Expression actualExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expression));
 
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+        ExpressionOptimizerManager expressionOptimizerManager = new ExpressionOptimizerManager(new PluginNodeManager(nodeManager), METADATA.getFunctionAndTypeManager());
+        expressionOptimizerManager.loadExpressionOptimizerFactory();
+
         TestingRowExpressionTranslator translator = new TestingRowExpressionTranslator(METADATA);
         RowExpression actualRowExpression = translator.translate(actualExpression, TypeProvider.viewOf(TYPES));
-        RowExpression simplifiedRowExpression = SimplifyRowExpressions.rewrite(actualRowExpression, METADATA, TEST_SESSION.toConnectorSession());
+        RowExpression simplifiedRowExpression = SimplifyRowExpressions.rewrite(actualRowExpression, METADATA, TEST_SESSION, expressionOptimizerManager, new FeaturesConfig());
         Expression expectedByRowExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(rowExpressionExpected));
         RowExpression simplifiedByExpression = translator.translate(expectedByRowExpression, TypeProvider.viewOf(TYPES));
         assertEquals(normalize(simplifiedRowExpression), normalize(simplifiedByExpression));
+
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema(TINY_SCHEMA_NAME)
+                .setSystemProperty(DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED, "true")
+                .build();
+        RowExpression sidecarSimplifiedExpressions = SimplifyRowExpressions.rewrite(actualRowExpression, METADATA, session, expressionOptimizerManager, new FeaturesConfig());
+        assertEquals(normalize(sidecarSimplifiedExpressions), normalize(simplifiedByExpression));
     }
 
     private static RowExpression normalize(RowExpression expression)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
+import com.facebook.presto.sql.expressions.JsonCodecRowExpressionSerde;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Expression;
@@ -40,6 +41,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.SystemSessionProperties.DELEGATING_ROW_EXPRESSION_OPTIMIZER_ENABLED;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -190,7 +192,7 @@ public class TestSimplifyRowExpressions
         Expression actualExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expression));
 
         InMemoryNodeManager nodeManager = new InMemoryNodeManager();
-        ExpressionOptimizerManager expressionOptimizerManager = new ExpressionOptimizerManager(new PluginNodeManager(nodeManager), METADATA.getFunctionAndTypeManager());
+        ExpressionOptimizerManager expressionOptimizerManager = new ExpressionOptimizerManager(new PluginNodeManager(nodeManager), METADATA.getFunctionAndTypeManager(), new JsonCodecRowExpressionSerde(jsonCodec(RowExpression.class)));
         expressionOptimizerManager.loadExpressionOptimizerFactory();
 
         TestingRowExpressionTranslator translator = new TestingRowExpressionTranslator(METADATA);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/BaseRuleTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/BaseRuleTest.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule.test;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.AfterClass;
@@ -83,5 +84,10 @@ public abstract class BaseRuleTest
                         .where(isInstanceOfAny(nodeClass))
                         .matches(),
                 "Expected " + nodeClass.toString() + " in plan after optimization. ");
+    }
+
+    protected ExpressionOptimizerManager getExpressionManager()
+    {
+        return tester.getExpressionManager();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.plan.LogicalPropertiesProvider;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.assertions.OptimizerAssert;
@@ -61,6 +62,7 @@ public class RuleTester
     private final PageSourceManager pageSourceManager;
     private final AccessControl accessControl;
     private final SqlParser sqlParser;
+    private ExpressionOptimizerManager expressionOptimizerManager;
 
     public RuleTester()
     {
@@ -107,6 +109,8 @@ public class RuleTester
                 connectorFactory,
                 ImmutableMap.of());
         plugins.stream().forEach(queryRunner::installPlugin);
+        expressionOptimizerManager = queryRunner.getExpressionManager();
+        expressionOptimizerManager.loadExpressionOptimizerFactory();
 
         this.metadata = queryRunner.getMetadata();
         this.transactionManager = queryRunner.getTransactionManager();
@@ -196,5 +200,10 @@ public class RuleTester
             metadata.getCatalogHandle(transactionSession, session.getCatalog().get());
             return metadata.getTableMetadata(transactionSession, tableHandle).getMetadata().getTableConstraintsHolder().getTableConstraintsWithColumnHandles();
         });
+    }
+
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        return expressionOptimizerManager;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestCteProjectionAndPredicatePushdown.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.optimizations;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.Optimizer;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
@@ -144,7 +145,7 @@ public class TestCteProjectionAndPredicatePushdown
                                 new RemoveIdentityProjectionsBelowProjection(),
                                 new PruneRedundantProjectionAssignments())),
                 new PruneUnreferencedOutputs(),
-                new CteProjectionAndPredicatePushDown(metadata));
+                new CteProjectionAndPredicatePushDown(metadata, getQueryRunner().getExpressionManager(), new FeaturesConfig()));
         assertPlan(sql, getSession(), Optimizer.PlanStage.OPTIMIZED, pattern, optimizers);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.spi.plan.WindowNode;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
@@ -322,7 +323,7 @@ public class TestReorderWindows
     {
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),
-                new PredicatePushDown(getMetadata(), getQueryRunner().getSqlParser(), false),
+                new PredicatePushDown(getMetadata(), getQueryRunner().getSqlParser(), new InMemoryExpressionOptimizerProvider(getMetadata()), false),
                 new IterativeOptimizer(
                         getMetadata(),
                         new RuleStatsRecorder(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDelegatingRowExpressionOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDelegatingRowExpressionOptimizer.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.SERIALIZABLE;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestDelegatingRowExpressionOptimizer
+{
+    private DelegatingRowExpressionOptimizer optimizer;
+    private static final MetadataManager METADATA = MetadataManager.createTestMetadataManager();
+
+    private static final TestingRowExpressionTranslator TRANSLATOR = new TestingRowExpressionTranslator(METADATA);
+
+    @BeforeClass
+    public void setUp()
+    {
+        optimizer = new DelegatingRowExpressionOptimizer(METADATA, InnerOptimizer::new, 3);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        optimizer = null;
+    }
+
+    @Test
+    public void testBasicExpressions()
+    {
+        assertEquals(optimize(expression("BIGINT'1' + 1")), expression("BIGINT'2'"));
+        assertEquals(optimize(expression("IF(TRUE, 1, 2)")), expression("1"));
+    }
+
+    @Test
+    public void testVariableReference()
+    {
+        VariableReferenceExpression variable = new VariableReferenceExpression(Optional.empty(), "x", BIGINT);
+        assertEquals(optimize(variable), variable);
+        ImmutableMap<String, Type> typeMap = ImmutableMap.of("x", BIGINT);
+        assertEquals(optimize(expression("x + 1", typeMap)), expression("x + 1", typeMap));
+        assertEquals(optimize(expression("x + 1", typeMap), ImmutableMap.of(variable, 1L)), expression("BIGINT'2'"));
+    }
+
+    @Test
+    public void testComplexExpressions()
+    {
+        assertEquals(optimize(expression("IF(TRUE, 1, 2) + 3")), expression("4"));
+        assertEquals(optimize(expression("IF(TRUE, 1, 2) + 3 + 4")), expression("8"));
+        assertEquals(optimize(expression("IF(TRUE, 1, 2) + 3 + 4 + 5")), expression("8 + 5"));
+
+        VariableReferenceExpression variable = new VariableReferenceExpression(Optional.empty(), "x", INTEGER);
+        ImmutableMap<String, Type> typeMap = ImmutableMap.of("x", INTEGER);
+        assertEquals(optimize(expression("IF(TRUE, 1, 2) + x", typeMap), ImmutableMap.of(variable, 3L)), expression("4"));
+        assertEquals(optimize(expression("IF(TRUE, 1, 2) + x + 4", typeMap), ImmutableMap.of(variable, 3L)), expression("8"));
+        assertEquals(optimize(expression("IF(TRUE, 1, 2) + x + 4 + 5", typeMap), ImmutableMap.of(variable, 3L)), expression("8 + 5"));
+    }
+
+    @Test
+    public void testDifferentOptimizationLevels()
+    {
+        assertEquals(optimize(expression("rand(10) + 1 > 0"), EVALUATED), expression("true"));
+        assertEquals(optimize(expression("rand(10) + 1 > 0"), OPTIMIZED), expression("rand(10) + 1 > 0"));
+        assertEquals(optimize(expression("rand(10) + 1 > 0"), SERIALIZABLE), expression("rand(10) + 1 > 0"));
+    }
+
+    private Object optimize(RowExpression expression, Map<VariableReferenceExpression, Object> variableMap)
+    {
+        return optimize(expression, variableMap, OPTIMIZED);
+    }
+
+    private Object optimize(RowExpression expression, Map<VariableReferenceExpression, Object> variableMap, Level level)
+    {
+        return optimizer.optimize(expression, level, SESSION, variableMap::get);
+    }
+
+    private RowExpression optimize(RowExpression expression)
+    {
+        return optimize(expression, OPTIMIZED);
+    }
+
+    private RowExpression optimize(RowExpression expression, Level level)
+    {
+        return optimizer.optimize(expression, level, SESSION);
+    }
+
+    private static RowExpression expression(String expressionSql)
+    {
+        return expression(expressionSql, ImmutableMap.of());
+    }
+
+    private static RowExpression expression(String expressionSql, Map<String, Type> typeMap)
+    {
+        return TRANSLATOR.translate(expressionSql, typeMap);
+    }
+
+    private static class InnerOptimizer
+            implements ExpressionOptimizer
+    {
+        @Override
+        public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
+        {
+            OneLevelDeepExpressionRewriter rewriter = new OneLevelDeepExpressionRewriter(level, variable -> variable);
+            return rowExpression.accept(rewriter, null);
+        }
+
+        @Override
+        public Object optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+        {
+            OneLevelDeepExpressionRewriter rewriter = new OneLevelDeepExpressionRewriter(level, variableResolver);
+            return expression.accept(rewriter, null);
+        }
+    }
+
+    // This visitor will only rewrite the first expression it comes across.  It is intended to be used to test
+    // the DelegatingRowExpressionOptimizer, which will call the inner optimizer multiple times.
+    private static class OneLevelDeepExpressionRewriter
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final RowExpressionOptimizer innerOptimizer = new RowExpressionOptimizer(METADATA);
+        private final Level level;
+        private final Function<VariableReferenceExpression, Object> variableResolver;
+
+        private boolean rewritten;
+
+        public OneLevelDeepExpressionRewriter(Level level, Function<VariableReferenceExpression, Object> variableResolver)
+        {
+            this.level = level;
+            this.variableResolver = requireNonNull(variableResolver, "variableResolver is null");
+        }
+
+        @Override
+        public RowExpression visitExpression(RowExpression node, Void context)
+        {
+            return node;
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
+        {
+            if (variableResolver == null) {
+                return reference;
+            }
+            Object value = variableResolver.apply(reference);
+            if (value == null) {
+                return reference;
+            }
+            return toRowExpression(value, reference.getType());
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            List<RowExpression> arguments = call.getArguments().stream()
+                    .map(argument -> argument.accept(this, context))
+                    .collect(toImmutableList());
+            if (!rewritten) {
+                RowExpression rewritten = toRowExpression(innerOptimizer.optimize(call, level, SESSION, variableResolver), call.getType());
+                if (!rewritten.equals(call)) {
+                    this.rewritten = true;
+                    return rewritten;
+                }
+            }
+            return call(call.getDisplayName(), call.getFunctionHandle(), call.getType(), arguments);
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            List<RowExpression> arguments = specialForm.getArguments().stream()
+                    .map(argument -> argument.accept(this, context))
+                    .collect(toImmutableList());
+            if (!rewritten) {
+                RowExpression rewritten = toRowExpression(innerOptimizer.optimize(specialForm, OPTIMIZED, SESSION, variableResolver), specialForm.getType());
+                if (!rewritten.equals(specialForm)) {
+                    this.rewritten = true;
+                    return rewritten;
+                }
+            }
+            return new SpecialFormExpression(specialForm.getForm(), specialForm.getType(), arguments);
+        }
+    }
+}

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(operators)
 add_subdirectory(types)
 add_subdirectory(http)
 add_subdirectory(common)
+add_subdirectory(expression)
 add_subdirectory(thrift)
 
 add_library(
@@ -50,6 +51,7 @@ target_link_libraries(
   presto_function_metadata
   presto_http
   presto_operators
+  presto_expr_eval
   velox_aggregates
   velox_caching
   velox_common_base

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1475,6 +1475,16 @@ void PrestoServer::registerSidecarEndpoints() {
          proxygen::ResponseHandler* downstream) {
         http::sendOkResponse(downstream, getFunctionsMetadata());
       });
+
+  rowExpressionEvaluator_ =
+      std::make_unique<expression::RowExpressionEvaluator>();
+  httpServer_->registerPost(
+      "/v1/expressions",
+      [&](proxygen::HTTPMessage* message,
+          const std::vector<std::unique_ptr<folly::IOBuf>>& body,
+          proxygen::ResponseHandler* downstream) {
+        return rowExpressionEvaluator_->evaluate(message, body, downstream);
+      });
 }
 
 protocol::NodeStatus PrestoServer::fetchNodeStatus() {

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -25,6 +25,7 @@
 #include "presto_cpp/main/PeriodicHeartbeatManager.h"
 #include "presto_cpp/main/PrestoExchangeSource.h"
 #include "presto_cpp/main/PrestoServerOperations.h"
+#include "presto_cpp/main/expression/RowExpressionEvaluator.h"
 #include "presto_cpp/main/types/VeloxPlanValidator.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/MemoryAllocator.h"
@@ -287,6 +288,7 @@ class PrestoServer {
   std::string address_;
   std::string nodeLocation_;
   folly::SSLContextPtr sslContext_;
+  std::unique_ptr<expression::RowExpressionEvaluator> rowExpressionEvaluator_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/expression/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/expression/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_library(presto_expr_eval RowExpressionEvaluator.cpp)
+
+target_link_libraries(
+  presto_expr_eval
+  presto_type_converter
+  presto_types
+  presto_protocol
+  presto_http
+  velox_coverage_util
+  velox_parse_expression
+  velox_parse_parser
+  velox_presto_serializer
+  velox_serialization
+  velox_type_parser
+  ${FOLLY_WITH_DEPENDENCIES})
+
+if(PRESTO_ENABLE_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/presto-native-execution/presto_cpp/main/expression/RowExpressionEvaluator.cpp
+++ b/presto-native-execution/presto_cpp/main/expression/RowExpressionEvaluator.cpp
@@ -1,0 +1,637 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/expression/RowExpressionEvaluator.h"
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include "presto_cpp/main/common/Utils.h"
+#include "velox/common/encode/Base64.h"
+#include "velox/exec/ExchangeQueue.h"
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprCompiler.h"
+#include "velox/expression/FieldReference.h"
+
+using namespace facebook::presto;
+using namespace facebook::velox;
+
+namespace facebook::presto::expression {
+
+namespace {
+
+protocol::TypeSignature getTypeSignature(const TypePtr& type) {
+  std::string typeSignature;
+  if (type->parameters().empty()) {
+    typeSignature = type->toString();
+    boost::algorithm::to_lower(typeSignature);
+  } else if (type->isDecimal()) {
+    typeSignature = type->toString();
+  } else {
+    std::vector<TypePtr> childTypes;
+    if (type->isRow()) {
+      typeSignature = "row(";
+      childTypes = asRowType(type)->children();
+    } else if (type->isArray()) {
+      typeSignature = "array(";
+      childTypes = type->asArray().children();
+    } else if (type->isMap()) {
+      typeSignature = "map(";
+      const auto mapType = type->asMap();
+      childTypes = {mapType.keyType(), mapType.valueType()};
+    } else {
+      VELOX_USER_FAIL("Invalid type {}", type->toString());
+    }
+
+    if (!childTypes.empty()) {
+      auto numChildren = childTypes.size();
+      for (auto i = 0; i < numChildren - 1; i++) {
+        typeSignature += fmt::format("{},", getTypeSignature(childTypes[i]));
+      }
+      typeSignature += getTypeSignature(childTypes[numChildren - 1]);
+    }
+    typeSignature += ")";
+  }
+
+  return typeSignature;
+}
+
+json toVariableReferenceExpression(
+    const std::shared_ptr<const exec::FieldReference>& fieldReference) {
+  protocol::VariableReferenceExpression vexpr;
+  vexpr.name = fieldReference->name();
+  vexpr._type = "variable";
+  vexpr.type = getTypeSignature(fieldReference->type());
+  json res;
+  protocol::to_json(res, vexpr);
+
+  return res;
+}
+
+bool isPrestoSpecialForm(const std::string& name) {
+  static const std::unordered_set<std::string> kPrestoSpecialForms = {
+      "and",
+      "coalesce",
+      "if",
+      "in",
+      "is_null",
+      "or",
+      "switch",
+      "when",
+      "null_if"};
+  return kPrestoSpecialForms.count(name) != 0;
+}
+
+json::array_t getInputExpressions(
+    const std::vector<std::unique_ptr<folly::IOBuf>>& body) {
+  std::ostringstream oss;
+  for (auto& buf : body) {
+    oss << std::string((const char*)buf->data(), buf->length());
+  }
+  return json::parse(oss.str());
+}
+} // namespace
+
+// ValueBlock in ConstantExpression requires only the column from the serialized
+// PrestoPage without the page header.
+std::string RowExpressionConverter::getValueBlock(const VectorPtr& vector) {
+  std::ostringstream output;
+  serde_->serializeSingleColumn(vector, nullptr, pool_.get(), &output);
+  const auto serialized = output.str();
+  const auto serializedSize = serialized.size();
+  return velox::encoding::Base64::encode(serialized.c_str(), serializedSize);
+}
+
+std::shared_ptr<protocol::ConstantExpression>
+RowExpressionConverter::getConstantRowExpression(
+    const std::shared_ptr<const exec::ConstantExpr>& constantExpr) {
+  protocol::ConstantExpression cexpr;
+  cexpr.type = getTypeSignature(constantExpr->type());
+  cexpr.valueBlock.data = getValueBlock(constantExpr->value());
+  return std::make_shared<protocol::ConstantExpression>(cexpr);
+}
+
+// TODO: Remove this once native plugin supports evaluation of current_user.
+std::shared_ptr<protocol::ConstantExpression>
+RowExpressionConverter::getCurrentUser(const std::string& currentUser) {
+  protocol::ConstantExpression cexpr;
+  cexpr.type = getTypeSignature(VARCHAR());
+  cexpr.valueBlock.data = getValueBlock(
+      BaseVector::createConstant(VARCHAR(), currentUser, 1, pool_.get()));
+  return std::make_shared<protocol::ConstantExpression>(cexpr);
+}
+
+json RowExpressionConverter::getRowConstructorSpecialForm(
+    const exec::ExprPtr& expr,
+    const json& input) {
+  json res;
+  res["@type"] = "special";
+  res["form"] = "ROW_CONSTRUCTOR";
+  res["returnType"] = getTypeSignature(expr->type());
+
+  res["arguments"] = json::array();
+  auto exprInputs = expr->inputs();
+  if (!exprInputs.empty()) {
+    for (const auto& exprInput : exprInputs) {
+      res["arguments"].push_back(veloxExprToRowExpression(exprInput, input));
+    }
+  } else if (
+      auto constantExpr =
+          std::dynamic_pointer_cast<const exec::ConstantExpr>(expr)) {
+    auto value = constantExpr->value();
+    auto* constVector = value->as<ConstantVector<ComplexType>>();
+    auto* rowVector = constVector->valueVector()->as<RowVector>();
+    auto type = asRowType(constantExpr->type());
+    auto children = rowVector->children();
+    auto size = children.size();
+
+    json j;
+    protocol::ConstantExpression cexpr;
+    for (auto i = 0; i < size; i++) {
+      cexpr.type = getTypeSignature(type->childAt(i));
+      cexpr.valueBlock.data = getValueBlock(rowVector->childAt(i));
+      protocol::to_json(j, cexpr);
+      res["arguments"].push_back(j);
+    }
+  }
+
+  return res;
+}
+
+// When the second value in the returned pair is true, the arguments for switch
+// special form are returned. Otherwise, the switch expression has been
+// simplified and the first value corresponding to the switch case that always
+// evaluates to true is returned.
+std::pair<json::array_t, bool> RowExpressionConverter::getSwitchSpecialFormArgs(
+    const exec::ExprPtr& expr,
+    const json& input) {
+  json::array_t inputArgs = input["arguments"];
+  auto numArgs = inputArgs.size();
+  json::array_t result = json::array();
+  const std::vector<exec::ExprPtr> exprInputs = expr->inputs();
+  const auto numInputs = exprInputs.size();
+
+  auto getWhenSpecialForm = [&](const json::array_t& whenArgs,
+                                const vector_size_t idx) -> json {
+    json when;
+    when["@type"] = "special";
+    when["form"] = "WHEN";
+    when["arguments"] = whenArgs;
+    when["returnType"] = getTypeSignature(exprInputs[idx + 1]->type());
+    return when;
+  };
+
+  // The searched form of the conditional expression needs to be handled
+  // differently from the simple form. The searched form can be detected by the
+  // presence of a boolean value in the first argument. This default boolean
+  // argument is not present in the Velox switch expression, so it is added to
+  // the arguments of output switch expression unchanged.
+  if (inputArgs[0].at("@type") == "constant" &&
+      inputArgs[0].at("type") == "boolean") {
+    result.emplace_back(inputArgs[0]);
+    for (auto i = 0; i < numInputs - 1; i += 2) {
+      const vector_size_t argsIdx = i / 2 + 1;
+      json::array_t inputWhenArgs = inputArgs[argsIdx].at("arguments");
+      json::array_t whenArgs;
+      whenArgs.emplace_back(
+          veloxExprToRowExpression(exprInputs[i], inputWhenArgs[0]));
+      whenArgs.emplace_back(
+          veloxExprToRowExpression(exprInputs[i + 1], inputWhenArgs[1]));
+
+      result.emplace_back(getWhenSpecialForm(whenArgs, i));
+    }
+  } else {
+    // The case 'expression' in simple form of conditional cannot be inferred
+    // from Velox since it could evaluate all when clauses to true or false, so
+    // we get it from the input json.
+    result.emplace_back(inputArgs[0]);
+    for (auto i = 0; i < numInputs - 1; i += 2) {
+      json::array_t whenArgs;
+      const vector_size_t argsIdx = i / 2 + 1;
+      const auto& caseValue = exprInputs[i + 1];
+      json::array_t inputWhenArgs = inputArgs[argsIdx].at("arguments");
+
+      if (exprInputs[i]->isConstant()) {
+        auto constantExpr =
+            std::dynamic_pointer_cast<const exec::ConstantExpr>(exprInputs[i]);
+        if (auto constVector =
+                constantExpr->value()->as<ConstantVector<bool>>()) {
+          if (constVector->valueAt(0)) {
+            if (result.size() == 1) {
+              // This is the first case statement that evaluates to true, so
+              // return the expression corresponding to this case.
+              return {
+                  json::array(
+                      {veloxExprToRowExpression(caseValue, inputWhenArgs[1])}),
+                  false};
+            } else {
+              // If the case has been constant folded to false in the Velox
+              // switch expression, we do not have access to the expression
+              // inputs in Velox anymore. So we return the corresponding
+              // argument from the input switch expression.
+              result.emplace_back(inputArgs[argsIdx]);
+            }
+          } else {
+            // Skip cases that evaluate to false from the output switch
+            // expression's arguments.
+            continue;
+          }
+        } else {
+          whenArgs.emplace_back(getConstantRowExpression(constantExpr));
+        }
+      } else {
+        VELOX_USER_CHECK(!exprInputs[i]->inputs().empty());
+        const auto& matchExpr = exprInputs[i]->inputs().back();
+        whenArgs.emplace_back(
+            veloxExprToRowExpression(matchExpr, inputWhenArgs[0]));
+      }
+
+      whenArgs.emplace_back(
+          veloxExprToRowExpression(caseValue, inputWhenArgs[1]));
+      result.emplace_back(getWhenSpecialForm(whenArgs, i));
+    }
+  }
+
+  // Else clause.
+  if (numInputs % 2 != 0) {
+    result.push_back(veloxExprToRowExpression(
+        exprInputs[numInputs - 1], inputArgs[numArgs - 1]));
+  }
+  return {result, true};
+}
+
+json RowExpressionConverter::getSpecialForm(
+    const exec::ExprPtr& expr,
+    const json& input) {
+  json res;
+  res["@type"] = "special";
+  std::string form;
+  if (input.contains("form")) {
+    form = input["form"];
+  } else {
+    // If input json is a call expression instead of a special form, for cases
+    // like 'is_null', the key 'form' will not be present in the input json.
+    form = expr->name();
+  }
+  // Presto requires the field form to be in upper case.
+  std::transform(form.begin(), form.end(), form.begin(), ::toupper);
+  res["form"] = form;
+  auto exprInputs = expr->inputs();
+  res["arguments"] = json::array();
+
+  // Arguments for switch expression include special form expression 'when'
+  // so it is constructed separately. If the switch expression evaluation found
+  // a case that always evaluates to true, the second value in pair switchResult
+  // will be false and the first value in pair will contain the value
+  // corresponding to the simplified case.
+  if (form == "SWITCH") {
+    auto switchResult = getSwitchSpecialFormArgs(expr, input);
+    if (switchResult.second) {
+      res["arguments"] = switchResult.first;
+    } else {
+      return switchResult.first.front();
+    }
+  } else {
+    json::array_t inputArguments = input["arguments"];
+    const auto numInputs = exprInputs.size();
+    VELOX_USER_CHECK_LE(numInputs, inputArguments.size());
+    for (auto i = 0; i < numInputs; i++) {
+      res["arguments"].push_back(
+          veloxExprToRowExpression(exprInputs[i], inputArguments[i]));
+    }
+  }
+  res["returnType"] = getTypeSignature(expr->type());
+
+  return res;
+}
+
+json RowExpressionConverter::toConstantRowExpression(
+    const velox::exec::ExprPtr& expr) {
+  json res;
+  auto constantExpr = std::dynamic_pointer_cast<const exec::ConstantExpr>(expr);
+  VELOX_USER_CHECK_NOT_NULL(constantExpr);
+  auto constantRowExpr = getConstantRowExpression(constantExpr);
+  protocol::to_json(res, constantRowExpr);
+  return res;
+}
+
+json RowExpressionConverter::toCallRowExpression(
+    const exec::ExprPtr& expr,
+    const json& input) {
+  json res;
+  res["@type"] = "call";
+  protocol::Signature signature;
+  std::string exprName = expr->name();
+  if (veloxToPrestoOperatorMap_.find(expr->name()) !=
+      veloxToPrestoOperatorMap_.end()) {
+    exprName = veloxToPrestoOperatorMap_.at(expr->name());
+  }
+  signature.name = exprName;
+  res["displayName"] = exprName;
+  signature.kind = protocol::FunctionKind::SCALAR;
+  signature.typeVariableConstraints = {};
+  signature.longVariableConstraints = {};
+  signature.returnType = getTypeSignature(expr->type());
+
+  std::vector<protocol::TypeSignature> argumentTypes;
+  auto exprInputs = expr->inputs();
+  auto numArgs = exprInputs.size();
+  argumentTypes.reserve(numArgs);
+  for (auto i = 0; i < numArgs; i++) {
+    argumentTypes.emplace_back(getTypeSignature(exprInputs[i]->type()));
+  }
+  signature.argumentTypes = argumentTypes;
+  signature.variableArity = false;
+
+  protocol::BuiltInFunctionHandle builtInFunctionHandle;
+  builtInFunctionHandle._type = "$static";
+  builtInFunctionHandle.signature = signature;
+  res["functionHandle"] = builtInFunctionHandle;
+  res["returnType"] = getTypeSignature(expr->type());
+  res["arguments"] = json::array();
+  for (const auto& exprInput : exprInputs) {
+    res["arguments"].push_back(veloxExprToRowExpression(exprInput, input));
+  }
+
+  return res;
+}
+
+json RowExpressionConverter::veloxExprToRowExpression(
+    const exec::ExprPtr& expr,
+    const json& input) {
+  if (expr->type()->isRow()) {
+    // Velox constant expressions of ROW type map to special form expression
+    // row_constructor in Presto.
+    return getRowConstructorSpecialForm(expr, input);
+  } else if (expr->isConstant()) {
+    if (expr->inputs().empty()) {
+      return toConstantRowExpression(expr);
+    } else {
+      // Inputs to constant expressions are constant, eg: divide(1, 2).
+      return input;
+    }
+  } else if (
+      auto field =
+          std::dynamic_pointer_cast<const exec::FieldReference>(expr)) {
+    return toVariableReferenceExpression(field);
+  } else if (expr->isSpecialForm() || expr->vectorFunction()) {
+    // Check if special form expression or call expression.
+    auto exprName = expr->name();
+    boost::algorithm::to_lower(exprName);
+    if (isPrestoSpecialForm(exprName)) {
+      return getSpecialForm(expr, input);
+    } else {
+      return toCallRowExpression(expr, input);
+    }
+  }
+
+  VELOX_NYI(
+      "Conversion of Velox Expr {} to Presto RowExpression is not supported",
+      expr->toString());
+}
+
+RowExpressionPtr RowExpressionEvaluator::optimizeAndSpecialForm(
+    const SpecialFormExpressionPtr& specialFormExpr) {
+  auto left = specialFormExpr->arguments[0];
+  auto right = specialFormExpr->arguments[1];
+  auto leftExpr = compileExpression(left);
+  bool isLeftNull;
+
+  if (auto constantExpr =
+          std::dynamic_pointer_cast<const exec::ConstantExpr>(leftExpr)) {
+    isLeftNull = constantExpr->value()->isNullAt(0);
+    if (!isLeftNull) {
+      if (auto constVector =
+              constantExpr->value()->as<ConstantVector<bool>>()) {
+        if (!constVector->valueAt(0)) {
+          return rowExpressionConverter_.getConstantRowExpression(constantExpr);
+        } else {
+          return right;
+        }
+      }
+    }
+  }
+
+  auto rightExpr = compileExpression(right);
+  if (auto constantExpr =
+          std::dynamic_pointer_cast<const exec::ConstantExpr>(rightExpr)) {
+    if (isLeftNull && constantExpr->value()->isNullAt(0)) {
+      return rowExpressionConverter_.getConstantRowExpression(constantExpr);
+    }
+    if (auto constVector = constantExpr->value()->as<ConstantVector<bool>>()) {
+      if (constVector->valueAt(0)) {
+        return left;
+      }
+      return right;
+    }
+  }
+
+  return specialFormExpr;
+}
+
+RowExpressionPtr RowExpressionEvaluator::optimizeIfSpecialForm(
+    const SpecialFormExpressionPtr& specialFormExpr) {
+  auto condition = specialFormExpr->arguments[0];
+  auto expr = compileExpression(condition);
+
+  if (auto constantExpr =
+          std::dynamic_pointer_cast<const exec::ConstantExpr>(expr)) {
+    if (auto constVector = constantExpr->value()->as<ConstantVector<bool>>()) {
+      if (constVector->valueAt(0)) {
+        return specialFormExpr->arguments[1];
+      }
+      return specialFormExpr->arguments[2];
+    }
+  }
+
+  return specialFormExpr;
+}
+
+RowExpressionPtr RowExpressionEvaluator::optimizeIsNullSpecialForm(
+    const SpecialFormExpressionPtr& specialFormExpr) {
+  auto expr = compileExpression(specialFormExpr);
+  if (auto constantExpr =
+          std::dynamic_pointer_cast<const exec::ConstantExpr>(expr)) {
+    if (constantExpr->value()->isNullAt(0)) {
+      return rowExpressionConverter_.getConstantRowExpression(constantExpr);
+    }
+  }
+
+  return specialFormExpr;
+}
+
+RowExpressionPtr RowExpressionEvaluator::optimizeOrSpecialForm(
+    const SpecialFormExpressionPtr& specialFormExpr) {
+  auto left = specialFormExpr->arguments[0];
+  auto right = specialFormExpr->arguments[1];
+  auto leftExpr = compileExpression(left);
+  bool isLeftNull;
+
+  if (auto constantExpr =
+          std::dynamic_pointer_cast<const exec::ConstantExpr>(leftExpr)) {
+    isLeftNull = constantExpr->value()->isNullAt(0);
+    if (!isLeftNull) {
+      if (auto constVector =
+              constantExpr->value()->as<ConstantVector<bool>>()) {
+        if (constVector->valueAt(0)) {
+          return rowExpressionConverter_.getConstantRowExpression(constantExpr);
+        }
+        return right;
+      }
+    }
+  }
+
+  auto rightExpr = compileExpression(right);
+  if (auto constantExpr =
+          std::dynamic_pointer_cast<const exec::ConstantExpr>(rightExpr)) {
+    if (isLeftNull && constantExpr->value()->isNullAt(0)) {
+      return rowExpressionConverter_.getConstantRowExpression(constantExpr);
+    }
+    if (auto constVector = constantExpr->value()->as<ConstantVector<bool>>()) {
+      if (!constVector->valueAt(0)) {
+        return left;
+      }
+      return right;
+    }
+  }
+
+  return specialFormExpr;
+}
+
+RowExpressionPtr RowExpressionEvaluator::optimizeCoalesceSpecialForm(
+    const SpecialFormExpressionPtr& specialFormExpr) {
+  auto argsNoNulls = specialFormExpr->arguments;
+  argsNoNulls.erase(
+      std::remove_if(
+          argsNoNulls.begin(),
+          argsNoNulls.end(),
+          [&](const auto& arg) {
+            auto compiledExpr = compileExpression(arg);
+            if (auto constantExpr =
+                    std::dynamic_pointer_cast<const exec::ConstantExpr>(
+                        compiledExpr)) {
+              return constantExpr->value()->isNullAt(0);
+            }
+            return false;
+          }),
+      argsNoNulls.end());
+
+  if (argsNoNulls.empty()) {
+    return specialFormExpr->arguments[0];
+  }
+  specialFormExpr->arguments = argsNoNulls;
+  return specialFormExpr;
+}
+
+RowExpressionPtr RowExpressionEvaluator::optimizeSpecialForm(
+    const std::shared_ptr<protocol::SpecialFormExpression>& specialFormExpr) {
+  switch (specialFormExpr->form) {
+    case protocol::Form::IF:
+      return optimizeIfSpecialForm(specialFormExpr);
+    case protocol::Form::NULL_IF:
+      VELOX_USER_FAIL("NULL_IF specialForm not supported");
+      break;
+    case protocol::Form::IS_NULL:
+      return optimizeIsNullSpecialForm(specialFormExpr);
+    case protocol::Form::AND:
+      return optimizeAndSpecialForm(specialFormExpr);
+    case protocol::Form::OR:
+      return optimizeOrSpecialForm(specialFormExpr);
+    case protocol::Form::COALESCE:
+      return optimizeCoalesceSpecialForm(specialFormExpr);
+    case protocol::Form::IN:
+    case protocol::Form::DEREFERENCE:
+    case protocol::Form::SWITCH:
+    case protocol::Form::WHEN:
+    case protocol::Form::ROW_CONSTRUCTOR:
+    case protocol::Form::BIND:
+    default:
+      break;
+  }
+
+  return specialFormExpr;
+}
+
+exec::ExprPtr RowExpressionEvaluator::compileExpression(
+    const std::shared_ptr<protocol::RowExpression>& inputRowExpr) {
+  auto typedExpr = veloxExprConverter_.toVeloxExpr(inputRowExpr);
+  exec::ExprSet exprSet{{typedExpr}, execCtx_.get()};
+  auto compiledExprs =
+      exec::compileExpressions({typedExpr}, execCtx_.get(), &exprSet, true);
+  return compiledExprs[0];
+}
+
+json::array_t RowExpressionEvaluator::evaluateExpressions(
+    const json::array_t& input,
+    const std::string& currentUser) {
+  const auto numExpr = input.size();
+  json::array_t output = json::array();
+  for (auto i = 0; i < numExpr; i++) {
+    // TODO: current_user to be evaluated in the native plugin and will not be
+    //  sent to the sidecar.
+    if (input[i].contains("displayName") &&
+        input[i].at("displayName") == "$current_user") {
+      output.emplace_back(rowExpressionConverter_.getCurrentUser(currentUser));
+      continue;
+    }
+
+    std::shared_ptr<protocol::RowExpression> inputRowExpr = input[i];
+    if (const auto special =
+            std::dynamic_pointer_cast<protocol::SpecialFormExpression>(
+                inputRowExpr)) {
+      inputRowExpr = optimizeSpecialForm(special);
+    }
+    const auto compiledExpr = compileExpression(inputRowExpr);
+    json resultJson = rowExpressionConverter_.veloxExprToRowExpression(
+        compiledExpr, input[i]);
+    output.push_back(resultJson);
+  }
+
+  return output;
+}
+
+void RowExpressionEvaluator::evaluate(
+    proxygen::HTTPMessage* message,
+    const std::vector<std::unique_ptr<folly::IOBuf>>& body,
+    proxygen::ResponseHandler* downstream) {
+  try {
+    auto timezone =
+        message->getHeaders().getSingleOrEmpty("X-Presto-Time-Zone");
+    auto currentUser = message->getHeaders().getSingleOrEmpty("X-Presto-User");
+    std::unordered_map<std::string, std::string> config(
+        {{core::QueryConfig::kSessionTimezone, timezone},
+         {core::QueryConfig::kAdjustTimestampToTimezone, "true"}});
+    auto queryCtx =
+        core::QueryCtx::create(nullptr, core::QueryConfig{std::move(config)});
+    execCtx_ =
+        std::make_unique<velox::core::ExecCtx>(pool_.get(), queryCtx.get());
+
+    json::array_t inputList = getInputExpressions(body);
+    json output = evaluateExpressions(inputList, currentUser);
+    proxygen::ResponseBuilder(downstream)
+        .status(http::kHttpOk, "OK")
+        .header(
+            proxygen::HTTP_HEADER_CONTENT_TYPE, http::kMimeTypeApplicationJson)
+        .body(output.dump())
+        .sendWithEOM();
+  } catch (const velox::VeloxUserError& e) {
+    VLOG(1) << "VeloxUserError during expression evaluation: " << e.what();
+    http::sendErrorResponse(downstream, e.what());
+  } catch (const velox::VeloxException& e) {
+    VLOG(1) << "VeloxException during expression evaluation: " << e.what();
+    http::sendErrorResponse(downstream, e.what());
+  } catch (const std::exception& e) {
+    VLOG(1) << "std::exception during expression evaluation: " << e.what();
+    http::sendErrorResponse(downstream, e.what());
+  }
+}
+
+} // namespace facebook::presto::expression

--- a/presto-native-execution/presto_cpp/main/expression/RowExpressionEvaluator.h
+++ b/presto-native-execution/presto_cpp/main/expression/RowExpressionEvaluator.h
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "presto_cpp/external/json/nlohmann/json.hpp"
+#include "presto_cpp/main/http/HttpServer.h"
+#include "presto_cpp/main/types/PrestoToVeloxExpr.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/expression/ConstantExpr.h"
+#include "velox/expression/Expr.h"
+#include "velox/serializers/PrestoSerializer.h"
+
+namespace facebook::presto::expression {
+
+using RowExpressionPtr = std::shared_ptr<protocol::RowExpression>;
+using SpecialFormExpressionPtr =
+    std::shared_ptr<protocol::SpecialFormExpression>;
+
+// Helper class to convert Velox Expr of different types to the respective kind
+// of Presto RowExpression.
+class RowExpressionConverter {
+ public:
+  explicit RowExpressionConverter(
+      const std::shared_ptr<velox::memory::MemoryPool>& pool)
+      : pool_(pool), veloxToPrestoOperatorMap_(veloxToPrestoOperatorMap()) {}
+
+  std::shared_ptr<protocol::ConstantExpression> getConstantRowExpression(
+      const std::shared_ptr<const velox::exec::ConstantExpr>& constantExpr);
+
+  std::shared_ptr<protocol::ConstantExpression> getCurrentUser(
+      const std::string& currentUser);
+
+  json veloxExprToRowExpression(
+      const velox::exec::ExprPtr& expr,
+      const json& inputRowExpr);
+
+ protected:
+  std::string getValueBlock(const velox::VectorPtr& vector);
+
+  json getRowConstructorSpecialForm(
+      const velox::exec::ExprPtr& expr,
+      const json& inputRowExpr);
+
+  std::pair<json::array_t, bool> getSwitchSpecialFormArgs(
+      const velox::exec::ExprPtr& expr,
+      const json& input);
+
+  json getSpecialForm(
+      const velox::exec::ExprPtr& expr,
+      const json& inputRowExpr);
+
+  json toConstantRowExpression(const velox::exec::ExprPtr& expr);
+
+  json toCallRowExpression(const velox::exec::ExprPtr& expr, const json& input);
+
+  const std::shared_ptr<velox::memory::MemoryPool> pool_;
+  const std::unordered_map<std::string, std::string> veloxToPrestoOperatorMap_;
+  const std::unique_ptr<velox::serializer::presto::PrestoVectorSerde> serde_ =
+      std::make_unique<velox::serializer::presto::PrestoVectorSerde>();
+};
+
+class RowExpressionEvaluator {
+ public:
+  explicit RowExpressionEvaluator()
+      : pool_(velox::memory::MemoryManager::getInstance()->addLeafPool(
+            "RowExpressionEvaluator")),
+        veloxExprConverter_(pool_.get(), &typeParser_),
+        rowExpressionConverter_(RowExpressionConverter(pool_)) {}
+
+  /// Evaluate expressions sent along endpoint '/v1/expressions'.
+  void evaluate(
+      proxygen::HTTPMessage* message,
+      const std::vector<std::unique_ptr<folly::IOBuf>>& body,
+      proxygen::ResponseHandler* downstream);
+
+ protected:
+  RowExpressionPtr optimizeAndSpecialForm(
+      const SpecialFormExpressionPtr& specialFormExpr);
+
+  RowExpressionPtr optimizeIfSpecialForm(
+      const SpecialFormExpressionPtr& specialFormExpr);
+
+  RowExpressionPtr optimizeIsNullSpecialForm(
+      const SpecialFormExpressionPtr& specialFormExpr);
+
+  RowExpressionPtr optimizeOrSpecialForm(
+      const SpecialFormExpressionPtr& specialFormExpr);
+
+  RowExpressionPtr optimizeCoalesceSpecialForm(
+      const SpecialFormExpressionPtr& specialFormExpr);
+
+  /// Optimizes special form expressions. Optimization rules borrowed from
+  /// Presto function visitSpecialForm() in RowExpressionInterpreter.java.
+  RowExpressionPtr optimizeSpecialForm(
+      const SpecialFormExpressionPtr& specialFormExpr);
+
+  /// Converts protocol::RowExpression into a velox expression with constant
+  /// folding enabled during velox expression compilation.
+  velox::exec::ExprPtr compileExpression(const RowExpressionPtr& inputRowExpr);
+
+  /// Optimizes and constant folds each expression from input json array and
+  /// returns an array of expressions that are optimized and constant folded.
+  /// Uses RowExpressionConverter to convert Velox expression(s) to their
+  /// corresponding Presto RowExpression(s).
+  json::array_t evaluateExpressions(
+      const json::array_t& input,
+      const std::string& currentUser);
+
+  const std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<velox::core::ExecCtx> execCtx_;
+  TypeParser typeParser_;
+  VeloxExprConverter veloxExprConverter_;
+  RowExpressionConverter rowExpressionConverter_;
+};
+} // namespace facebook::presto::expression

--- a/presto-native-execution/presto_cpp/main/expression/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/expression/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_executable(presto_expr_eval_test RowExpressionEvaluatorTest.cpp)
+
+add_test(presto_expr_eval_test presto_expr_eval_test)
+
+target_link_libraries(
+  presto_expr_eval_test
+  presto_expr_eval
+  presto_http
+  velox_exec_test_lib
+  velox_presto_serializer
+  GTest::gtest
+  GTest::gtest_main
+  ${PROXYGEN_LIBRARIES})

--- a/presto-native-execution/presto_cpp/main/expression/tests/RowExpressionEvaluatorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/expression/tests/RowExpressionEvaluatorTest.cpp
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/expression/RowExpressionEvaluator.h"
+#include <folly/SocketAddress.h>
+#include <folly/Uri.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <gtest/gtest.h>
+#include "presto_cpp/main/common/tests/test_json.h"
+#include "presto_cpp/main/http/tests/HttpTestBase.h"
+#include "velox/exec/OutputBufferManager.h"
+#include "velox/expression/RegisterSpecialForm.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/VectorStream.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::presto;
+using namespace facebook::velox;
+
+namespace {
+std::string getDataPath(const std::string& fileName) {
+  std::string currentPath = fs::current_path().c_str();
+
+  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
+    return currentPath +
+        "/github/presto-trunk/presto-native-execution/presto_cpp/main/expression/tests/data/" +
+        fileName;
+  }
+
+  if (boost::algorithm::ends_with(currentPath, "fbsource")) {
+    return currentPath + "/third-party/presto_cpp/main/expression/tests/data/" +
+        fileName;
+  }
+
+  // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
+  // directory. Hard-coded json files are not copied there and test fails with
+  // file not found. Fixing the path so that we can trigger these tests from
+  // CLion.
+  boost::algorithm::replace_all(currentPath, "cmake-build-release/", "");
+  boost::algorithm::replace_all(currentPath, "cmake-build-debug/", "");
+
+  return currentPath + "/data/" + fileName;
+}
+} // namespace
+
+// RowExpressionEvaluatorTest only tests basic expression evaluation via the
+// 'v1/expressions' endpoint. End to end tests for different expression types
+// can be found in TestDelegatingExpressionOptimizer.java, in the module
+// presto-native-sidecar-plugin.
+class RowExpressionEvaluatorTest
+    : public ::testing::Test,
+      public facebook::velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    parse::registerTypeResolver();
+    functions::prestosql::registerAllScalarFunctions("presto.default.");
+    exec::registerFunctionCallToSpecialForms();
+
+    auto httpServer = std::make_unique<http::HttpServer>(
+        httpSrvIOExecutor_,
+        std::make_unique<http::HttpConfig>(
+            folly::SocketAddress("127.0.0.1", 0)));
+    driverExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(4);
+    rowExpressionEvaluator_ =
+        std::make_unique<expression::RowExpressionEvaluator>();
+    httpServer->registerPost(
+        "/v1/expressions",
+        [&](proxygen::HTTPMessage* message,
+            const std::vector<std::unique_ptr<folly::IOBuf>>& body,
+            proxygen::ResponseHandler* downstream) {
+          return rowExpressionEvaluator_->evaluate(message, body, downstream);
+        });
+    httpServerWrapper_ =
+        std::make_unique<HttpServerWrapper>(std::move(httpServer));
+    auto address = httpServerWrapper_->start().get();
+    client_ = clientFactory_.newClient(
+        address,
+        std::chrono::milliseconds(100'000),
+        std::chrono::milliseconds(0),
+        false,
+        pool_);
+  }
+
+  void TearDown() override {
+    if (httpServerWrapper_) {
+      httpServerWrapper_->stop();
+    }
+  }
+
+  static std::string getHttpBody(
+      const std::unique_ptr<http::HttpResponse>& response) {
+    std::ostringstream oss;
+    auto iobufs = response->consumeBody();
+    for (auto& body : iobufs) {
+      oss << std::string((const char*)body->data(), body->length());
+    }
+    return oss.str();
+  }
+
+  void validateHttpResponse(
+      const std::string& inputStr,
+      const std::string& expectedStr) {
+    http::RequestBuilder()
+        .method(proxygen::HTTPMethod::POST)
+        .url("/v1/expressions")
+        .send(client_.get(), inputStr)
+        .via(driverExecutor_.get())
+        .thenValue([expectedStr](std::unique_ptr<http::HttpResponse> response) {
+          VELOX_USER_CHECK_EQ(
+              response->headers()->getStatusCode(), http::kHttpOk);
+          if (response->hasError()) {
+            VELOX_USER_FAIL(
+                "Expression evaluation failed: {}", response->error());
+          }
+
+          auto resStr = getHttpBody(response);
+          auto resJson = json::parse(resStr);
+          ASSERT_TRUE(resJson.is_array());
+          auto expectedJson = json::parse(expectedStr);
+          ASSERT_TRUE(expectedJson.is_array());
+          EXPECT_EQ(expectedJson.size(), resJson.size());
+          auto size = resJson.size();
+          for (auto i = 0; i < size; i++) {
+            EXPECT_EQ(resJson[i], expectedJson[i]);
+          }
+        })
+        .thenError(
+            folly::tag_t<std::exception>{}, [&](const std::exception& e) {
+              VLOG(1) << "Expression evaluation failed: " << e.what();
+            });
+  }
+
+  void testFile(const std::string& prefix) {
+    std::string input = slurp(getDataPath(fmt::format("{}Input.json", prefix)));
+    auto inputExpressions = json::parse(input);
+    std::string output =
+        slurp(getDataPath(fmt::format("{}Expected.json", prefix)));
+    auto expectedExpressions = json::parse(output);
+
+    validateHttpResponse(inputExpressions.dump(), expectedExpressions.dump());
+  }
+
+  std::unique_ptr<expression::RowExpressionEvaluator> rowExpressionEvaluator_;
+  std::unique_ptr<HttpServerWrapper> httpServerWrapper_;
+  HttpClientFactory clientFactory_;
+  std::shared_ptr<http::HttpClient> client_;
+  std::shared_ptr<folly::IOThreadPoolExecutor> httpSrvIOExecutor_{
+      std::make_shared<folly::IOThreadPoolExecutor>(8)};
+  std::unique_ptr<folly::CPUThreadPoolExecutor> driverExecutor_;
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool("RowExpressionEvaluatorTest")};
+};
+
+TEST_F(RowExpressionEvaluatorTest, simple) {
+  // File SimpleExpressions{Input|Expected}.json contain the input and expected
+  // JSON representing the RowExpressions resulting from the following queries:
+  // select 1 + 2;
+  // select abs(-11) + ceil(cast(3.4 as double)) + floor(cast(5.6 as double));
+  // select 2 between 1 and 3;
+  // Simple expression evaluation with constant folding is verified here.
+  testFile("SimpleExpressions");
+}
+
+TEST_F(RowExpressionEvaluatorTest, specialFormRewrites) {
+  // File SpecialExpressions{Input|Expected}.json contain the input and expected
+  // JSON representing the RowExpressions resulting from the following queries:
+  // select if(1 < 2, 2, 3);
+  // select (1 < 2) and (2 < 3);
+  // select (1 < 2) or (2 < 3);
+  // Special form expression rewrites are verified here.
+  testFile("SpecialForm");
+}

--- a/presto-native-execution/presto_cpp/main/expression/tests/data/SimpleExpressionsExpected.json
+++ b/presto-native-execution/presto_cpp/main/expression/tests/data/SimpleExpressionsExpected.json
@@ -1,0 +1,17 @@
+[
+  {
+    "@type": "constant",
+    "type": "integer",
+    "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAwAAAA=="
+  },
+  {
+    "@type": "constant",
+    "type": "double",
+    "valueBlock": "CgAAAExPTkdfQVJSQVkBAAAAAAAAAAAAADRA"
+  },
+  {
+    "@type": "constant",
+    "type": "boolean",
+    "valueBlock": "CgAAAEJZVEVfQVJSQVkBAAAAAAE="
+  }
+]

--- a/presto-native-execution/presto_cpp/main/expression/tests/data/SimpleExpressionsInput.json
+++ b/presto-native-execution/presto_cpp/main/expression/tests/data/SimpleExpressionsInput.json
@@ -1,0 +1,278 @@
+[
+  {
+    "@type": "call",
+    "arguments": [
+      {
+        "@type": "constant",
+        "type": "integer",
+        "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAQAAAA=="
+      },
+      {
+        "@type": "constant",
+        "type": "integer",
+        "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAgAAAA=="
+      }
+    ],
+    "displayName": "ADD",
+    "functionHandle": {
+      "@type": "$static",
+      "signature": {
+        "argumentTypes": [
+          "integer",
+          "integer"
+        ],
+        "kind": "SCALAR",
+        "longVariableConstraints": [],
+        "name": "presto.default.$operator$add",
+        "returnType": "integer",
+        "typeVariableConstraints": [],
+        "variableArity": false
+      }
+    },
+    "returnType": "integer"
+  },
+  {
+    "@type": "call",
+    "arguments": [
+      {
+        "@type": "call",
+        "arguments": [
+          {
+            "@type": "call",
+            "arguments": [
+              {
+                "@type": "call",
+                "arguments": [
+                  {
+                    "@type": "call",
+                    "arguments": [
+                      {
+                        "@type": "constant",
+                        "type": "integer",
+                        "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAACwAAAA=="
+                      }
+                    ],
+                    "displayName": "NEGATION",
+                    "functionHandle": {
+                      "@type": "$static",
+                      "signature": {
+                        "argumentTypes": [
+                          "integer"
+                        ],
+                        "kind": "SCALAR",
+                        "longVariableConstraints": [],
+                        "name": "presto.default.$operator$negation",
+                        "returnType": "integer",
+                        "typeVariableConstraints": [],
+                        "variableArity": false
+                      }
+                    },
+                    "returnType": "integer"
+                  }
+                ],
+                "displayName": "abs",
+                "functionHandle": {
+                  "@type": "$static",
+                  "signature": {
+                    "argumentTypes": [
+                      "integer"
+                    ],
+                    "kind": "SCALAR",
+                    "longVariableConstraints": [],
+                    "name": "presto.default.abs",
+                    "returnType": "integer",
+                    "typeVariableConstraints": [],
+                    "variableArity": false
+                  }
+                },
+                "returnType": "integer"
+              }
+            ],
+            "displayName": "CAST",
+            "functionHandle": {
+              "@type": "$static",
+              "signature": {
+                "argumentTypes": [
+                  "integer"
+                ],
+                "kind": "SCALAR",
+                "longVariableConstraints": [],
+                "name": "presto.default.$operator$cast",
+                "returnType": "double",
+                "typeVariableConstraints": [],
+                "variableArity": false
+              }
+            },
+            "returnType": "double"
+          },
+          {
+            "@type": "call",
+            "arguments": [
+              {
+                "@type": "call",
+                "arguments": [
+                  {
+                    "@type": "constant",
+                    "type": "decimal(2,1)",
+                    "valueBlock": "CgAAAExPTkdfQVJSQVkBAAAAACIAAAAAAAAA"
+                  }
+                ],
+                "displayName": "CAST",
+                "functionHandle": {
+                  "@type": "$static",
+                  "signature": {
+                    "argumentTypes": [
+                      "decimal(2,1)"
+                    ],
+                    "kind": "SCALAR",
+                    "longVariableConstraints": [],
+                    "name": "presto.default.$operator$cast",
+                    "returnType": "double",
+                    "typeVariableConstraints": [],
+                    "variableArity": false
+                  }
+                },
+                "returnType": "double"
+              }
+            ],
+            "displayName": "ceil",
+            "functionHandle": {
+              "@type": "$static",
+              "signature": {
+                "argumentTypes": [
+                  "double"
+                ],
+                "kind": "SCALAR",
+                "longVariableConstraints": [],
+                "name": "presto.default.ceil",
+                "returnType": "double",
+                "typeVariableConstraints": [],
+                "variableArity": false
+              }
+            },
+            "returnType": "double"
+          }
+        ],
+        "displayName": "ADD",
+        "functionHandle": {
+          "@type": "$static",
+          "signature": {
+            "argumentTypes": [
+              "double",
+              "double"
+            ],
+            "kind": "SCALAR",
+            "longVariableConstraints": [],
+            "name": "presto.default.$operator$add",
+            "returnType": "double",
+            "typeVariableConstraints": [],
+            "variableArity": false
+          }
+        },
+        "returnType": "double"
+      },
+      {
+        "@type": "call",
+        "arguments": [
+          {
+            "@type": "call",
+            "arguments": [
+              {
+                "@type": "constant",
+                "type": "decimal(2,1)",
+                "valueBlock": "CgAAAExPTkdfQVJSQVkBAAAAADgAAAAAAAAA"
+              }
+            ],
+            "displayName": "CAST",
+            "functionHandle": {
+              "@type": "$static",
+              "signature": {
+                "argumentTypes": [
+                  "decimal(2,1)"
+                ],
+                "kind": "SCALAR",
+                "longVariableConstraints": [],
+                "name": "presto.default.$operator$cast",
+                "returnType": "double",
+                "typeVariableConstraints": [],
+                "variableArity": false
+              }
+            },
+            "returnType": "double"
+          }
+        ],
+        "displayName": "floor",
+        "functionHandle": {
+          "@type": "$static",
+          "signature": {
+            "argumentTypes": [
+              "double"
+            ],
+            "kind": "SCALAR",
+            "longVariableConstraints": [],
+            "name": "presto.default.floor",
+            "returnType": "double",
+            "typeVariableConstraints": [],
+            "variableArity": false
+          }
+        },
+        "returnType": "double"
+      }
+    ],
+    "displayName": "ADD",
+    "functionHandle": {
+      "@type": "$static",
+      "signature": {
+        "argumentTypes": [
+          "double",
+          "double"
+        ],
+        "kind": "SCALAR",
+        "longVariableConstraints": [],
+        "name": "presto.default.$operator$add",
+        "returnType": "double",
+        "typeVariableConstraints": [],
+        "variableArity": false
+      }
+    },
+    "returnType": "double"
+  },
+  {
+    "@type": "call",
+    "arguments": [
+      {
+        "@type": "constant",
+        "type": "integer",
+        "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAgAAAA=="
+      },
+      {
+        "@type": "constant",
+        "type": "integer",
+        "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAQAAAA=="
+      },
+      {
+        "@type": "constant",
+        "type": "integer",
+        "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAwAAAA=="
+      }
+    ],
+    "displayName": "BETWEEN",
+    "functionHandle": {
+      "@type": "$static",
+      "signature": {
+        "argumentTypes": [
+          "integer",
+          "integer",
+          "integer"
+        ],
+        "kind": "SCALAR",
+        "longVariableConstraints": [],
+        "name": "presto.default.$operator$between",
+        "returnType": "boolean",
+        "typeVariableConstraints": [],
+        "variableArity": false
+      }
+    },
+    "returnType": "boolean"
+  }
+]

--- a/presto-native-execution/presto_cpp/main/expression/tests/data/SpecialFormExpected.json
+++ b/presto-native-execution/presto_cpp/main/expression/tests/data/SpecialFormExpected.json
@@ -1,0 +1,17 @@
+[
+  {
+    "@type": "constant",
+    "type": "integer",
+    "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAgAAAA=="
+  },
+  {
+    "@type": "constant",
+    "type": "boolean",
+    "valueBlock": "CgAAAEJZVEVfQVJSQVkBAAAAAAE="
+  },
+  {
+    "@type": "constant",
+    "type": "boolean",
+    "valueBlock": "CgAAAEJZVEVfQVJSQVkBAAAAAAE="
+  }
+]

--- a/presto-native-execution/presto_cpp/main/expression/tests/data/SpecialFormInput.json
+++ b/presto-native-execution/presto_cpp/main/expression/tests/data/SpecialFormInput.json
@@ -1,0 +1,193 @@
+[
+  {
+    "@type": "special",
+    "arguments": [
+      {
+        "@type": "call",
+        "arguments": [
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAQAAAA=="
+          },
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAgAAAA=="
+          }
+        ],
+        "displayName": "LESS_THAN",
+        "functionHandle": {
+          "@type": "$static",
+          "signature": {
+            "argumentTypes": [
+              "integer",
+              "integer"
+            ],
+            "kind": "SCALAR",
+            "longVariableConstraints": [],
+            "name": "presto.default.$operator$less_than",
+            "returnType": "boolean",
+            "typeVariableConstraints": [],
+            "variableArity": false
+          }
+        },
+        "returnType": "boolean"
+      },
+      {
+        "@type": "constant",
+        "type": "integer",
+        "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAgAAAA=="
+      },
+      {
+        "@type": "constant",
+        "type": "integer",
+        "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAwAAAA=="
+      }
+    ],
+    "form": "IF",
+    "returnType": "integer"
+  },
+  {
+    "@type": "special",
+    "arguments": [
+      {
+        "@type": "call",
+        "arguments": [
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAQAAAA=="
+          },
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAgAAAA=="
+          }
+        ],
+        "displayName": "LESS_THAN",
+        "functionHandle": {
+          "@type": "$static",
+          "signature": {
+            "argumentTypes": [
+              "integer",
+              "integer"
+            ],
+            "kind": "SCALAR",
+            "longVariableConstraints": [],
+            "name": "presto.default.$operator$less_than",
+            "returnType": "boolean",
+            "typeVariableConstraints": [],
+            "variableArity": false
+          }
+        },
+        "returnType": "boolean"
+      },
+      {
+        "@type": "call",
+        "arguments": [
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAgAAAA=="
+          },
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAwAAAA=="
+          }
+        ],
+        "displayName": "LESS_THAN",
+        "functionHandle": {
+          "@type": "$static",
+          "signature": {
+            "argumentTypes": [
+              "integer",
+              "integer"
+            ],
+            "kind": "SCALAR",
+            "longVariableConstraints": [],
+            "name": "presto.default.$operator$less_than",
+            "returnType": "boolean",
+            "typeVariableConstraints": [],
+            "variableArity": false
+          }
+        },
+        "returnType": "boolean"
+      }
+    ],
+    "form": "AND",
+    "returnType": "boolean"
+  },
+  {
+    "@type": "special",
+    "arguments": [
+      {
+        "@type": "call",
+        "arguments": [
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAQAAAA=="
+          },
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAgAAAA=="
+          }
+        ],
+        "displayName": "LESS_THAN",
+        "functionHandle": {
+          "@type": "$static",
+          "signature": {
+            "argumentTypes": [
+              "integer",
+              "integer"
+            ],
+            "kind": "SCALAR",
+            "longVariableConstraints": [],
+            "name": "presto.default.$operator$less_than",
+            "returnType": "boolean",
+            "typeVariableConstraints": [],
+            "variableArity": false
+          }
+        },
+        "returnType": "boolean"
+      },
+      {
+        "@type": "call",
+        "arguments": [
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAgAAAA=="
+          },
+          {
+            "@type": "constant",
+            "type": "integer",
+            "valueBlock": "CQAAAElOVF9BUlJBWQEAAAAAAwAAAA=="
+          }
+        ],
+        "displayName": "LESS_THAN",
+        "functionHandle": {
+          "@type": "$static",
+          "signature": {
+            "argumentTypes": [
+              "integer",
+              "integer"
+            ],
+            "kind": "SCALAR",
+            "longVariableConstraints": [],
+            "name": "presto.default.$operator$less_than",
+            "returnType": "boolean",
+            "typeVariableConstraints": [],
+            "variableArity": false
+          }
+        },
+        "returnType": "boolean"
+      }
+    ],
+    "form": "OR",
+    "returnType": "boolean"
+  }
+]

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -33,32 +33,10 @@ std::string toJsonString(const T& value) {
 }
 
 std::string mapScalarFunction(const std::string& name) {
-  static const std::unordered_map<std::string, std::string> kFunctionNames = {
-      // Operator overrides: com.facebook.presto.common.function.OperatorType
-      {"presto.default.$operator$add", "presto.default.plus"},
-      {"presto.default.$operator$between", "presto.default.between"},
-      {"presto.default.$operator$divide", "presto.default.divide"},
-      {"presto.default.$operator$equal", "presto.default.eq"},
-      {"presto.default.$operator$greater_than", "presto.default.gt"},
-      {"presto.default.$operator$greater_than_or_equal", "presto.default.gte"},
-      {"presto.default.$operator$is_distinct_from",
-       "presto.default.distinct_from"},
-      {"presto.default.$operator$less_than", "presto.default.lt"},
-      {"presto.default.$operator$less_than_or_equal", "presto.default.lte"},
-      {"presto.default.$operator$modulus", "presto.default.mod"},
-      {"presto.default.$operator$multiply", "presto.default.multiply"},
-      {"presto.default.$operator$negation", "presto.default.negate"},
-      {"presto.default.$operator$not_equal", "presto.default.neq"},
-      {"presto.default.$operator$subtract", "presto.default.minus"},
-      {"presto.default.$operator$subscript", "presto.default.subscript"},
-      // Special form function overrides.
-      {"presto.default.in", "in"},
-  };
-
   std::string lowerCaseName = boost::to_lower_copy(name);
 
-  auto it = kFunctionNames.find(lowerCaseName);
-  if (it != kFunctionNames.end()) {
+  auto it = kPrestoOperatorMap.find(lowerCaseName);
+  if (it != kPrestoOperatorMap.end()) {
     return it->second;
   }
 
@@ -101,6 +79,15 @@ std::string getFunctionName(const protocol::SqlFunctionId& functionId) {
 }
 
 } // namespace
+
+const std::unordered_map<std::string, std::string> veloxToPrestoOperatorMap() {
+  std::unordered_map<std::string, std::string> veloxToPrestoOperatorMap;
+  for (const auto& entry : kPrestoOperatorMap) {
+    veloxToPrestoOperatorMap[entry.second] = entry.first;
+  }
+  veloxToPrestoOperatorMap.insert({"cast", "presto.default.$operator$cast"});
+  return veloxToPrestoOperatorMap;
+}
 
 velox::variant VeloxExprConverter::getConstantValue(
     const velox::TypePtr& type,

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.h
@@ -20,6 +20,30 @@
 
 namespace facebook::presto {
 
+static const std::unordered_map<std::string, std::string> kPrestoOperatorMap = {
+    // Operator overrides: com.facebook.presto.common.function.OperatorType
+    {"presto.default.$operator$add", "presto.default.plus"},
+    {"presto.default.$operator$between", "presto.default.between"},
+    {"presto.default.$operator$divide", "presto.default.divide"},
+    {"presto.default.$operator$equal", "presto.default.eq"},
+    {"presto.default.$operator$greater_than", "presto.default.gt"},
+    {"presto.default.$operator$greater_than_or_equal", "presto.default.gte"},
+    {"presto.default.$operator$is_distinct_from",
+     "presto.default.distinct_from"},
+    {"presto.default.$operator$less_than", "presto.default.lt"},
+    {"presto.default.$operator$less_than_or_equal", "presto.default.lte"},
+    {"presto.default.$operator$modulus", "presto.default.mod"},
+    {"presto.default.$operator$multiply", "presto.default.multiply"},
+    {"presto.default.$operator$negation", "presto.default.negate"},
+    {"presto.default.$operator$not_equal", "presto.default.neq"},
+    {"presto.default.$operator$subtract", "presto.default.minus"},
+    {"presto.default.$operator$subscript", "presto.default.subscript"},
+    // Special form function overrides.
+    {"presto.default.in", "in"},
+};
+
+const std::unordered_map<std::string, std::string> veloxToPrestoOperatorMap();
+
 class VeloxExprConverter {
  public:
   VeloxExprConverter(velox::memory::MemoryPool* pool, TypeParser* typeParser)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
@@ -226,6 +227,12 @@ public class ContainerQueryRunner
 
     @Override
     public TestingAccessControlManager getAccessControl()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExpressionOptimizerManager getExpressionManager()
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -483,6 +484,11 @@ public class PrestoNativeQueryRunnerUtils
 
     public static Optional<BiFunction<Integer, URI, Process>> getExternalWorkerLauncher(String catalogName, String prestoServerPath, int cacheMaxSize, Optional<String> remoteFunctionServerUds, Boolean failOnNestedLoopJoin, boolean isCoordinatorSidecarEnabled)
     {
+        return getExternalWorkerLauncher(catalogName, prestoServerPath, OptionalInt.empty(), cacheMaxSize, remoteFunctionServerUds, failOnNestedLoopJoin, isCoordinatorSidecarEnabled);
+    }
+
+    public static Optional<BiFunction<Integer, URI, Process>> getExternalWorkerLauncher(String catalogName, String prestoServerPath, OptionalInt port, int cacheMaxSize, Optional<String> remoteFunctionServerUds, Boolean failOnNestedLoopJoin, boolean isCoordinatorSidecarEnabled)
+    {
         return
                 Optional.of((workerIndex, discoveryUri) -> {
                     try {
@@ -490,13 +496,13 @@ public class PrestoNativeQueryRunnerUtils
                         Files.createDirectories(dir);
                         Path tempDirectoryPath = Files.createTempDirectory(dir, "worker");
                         log.info("Temp directory for Worker #%d: %s", workerIndex, tempDirectoryPath.toString());
-                        int port = 1234 + workerIndex;
 
                         // Write config file
                         String configProperties = format("discovery.uri=%s%n" +
                                 "presto.version=testversion%n" +
                                 "system-memory-gb=4%n" +
-                                "http-server.http.port=%d", discoveryUri, port);
+                                "native-sidecar=true%n" +
+                                "http-server.http.port=%d", discoveryUri, port.orElse(1234 + workerIndex));
 
                         if (isCoordinatorSidecarEnabled) {
                             configProperties = format("%s%n" +
@@ -559,6 +565,45 @@ public class PrestoNativeQueryRunnerUtils
                 });
     }
 
+    public static Process getNativeSidecarProcess(URI discoveryUri, int port)
+            throws IOException
+    {
+        NativeQueryRunnerParameters nativeQueryRunnerParameters = getNativeQueryRunnerParameters();
+        return getNativeSidecarProcess(nativeQueryRunnerParameters.serverBinary.toString(), discoveryUri, port);
+    }
+
+    public static Process getNativeSidecarProcess(String prestoServerPath, URI discoveryUri, int port)
+            throws IOException
+    {
+        Path tempDirectoryPath = Files.createTempDirectory(PrestoNativeQueryRunnerUtils.class.getSimpleName());
+        log.info("Temp directory for Sidecar: %s", tempDirectoryPath.toString());
+
+        // Write config file
+        String configProperties = format("discovery.uri=%s%n" +
+                "presto.version=testversion%n" +
+                "system-memory-gb=4%n" +
+                "native-sidecar=true%n" +
+                "http-server.http.port=%d", discoveryUri, port);
+
+        Files.write(tempDirectoryPath.resolve("config.properties"), configProperties.getBytes());
+        Files.write(tempDirectoryPath.resolve("node.properties"),
+                format("node.id=%s%n" +
+                        "node.internal-address=127.0.0.1%n" +
+                        "node.environment=testing%n" +
+                        "node.location=test-location", UUID.randomUUID()).getBytes());
+
+        // TODO: sidecars require that a catalog directory exist
+        Path catalogDirectoryPath = tempDirectoryPath.resolve("catalog");
+        Files.createDirectory(catalogDirectoryPath);
+
+        return new ProcessBuilder(prestoServerPath)
+                .directory(tempDirectoryPath.toFile())
+                .redirectErrorStream(true)
+                .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("sidecar.out").toFile()))
+                .redirectError(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("sidecar.out").toFile()))
+                .start();
+    }
+
     public static class NativeQueryRunnerParameters
     {
         public final Path serverBinary;
@@ -604,5 +649,13 @@ public class PrestoNativeQueryRunnerUtils
                 ImmutableMap.of(),
                 Optional.empty(),
                 Optional.empty());
+    }
+
+    public static int findRandomPortForWorker()
+            throws IOException
+    {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -596,7 +596,7 @@ public class PrestoNativeQueryRunnerUtils
         Path catalogDirectoryPath = tempDirectoryPath.resolve("catalog");
         Files.createDirectory(catalogDirectoryPath);
 
-        return new ProcessBuilder(prestoServerPath)
+        return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1")
                 .directory(tempDirectoryPath.toFile())
                 .redirectErrorStream(true)
                 .redirectOutput(ProcessBuilder.Redirect.to(tempDirectoryPath.resolve("sidecar.out").toFile()))

--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -43,6 +43,21 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/ForSidecarInfo.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/ForSidecarInfo.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@BindingAnnotation
+public @interface ForSidecarInfo
+{
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionOptimizer.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Collections.newSetFromMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
+
+public class NativeExpressionOptimizer
+        implements ExpressionOptimizer
+{
+    private static final Function<VariableReferenceExpression, Object> NO_RESOLUTION = i -> i;
+    private final FunctionMetadataManager functionMetadataManager;
+    private final StandardFunctionResolution resolution;
+    private final NativeSidecarExpressionInterpreter rowExpressionInterpreterService;
+
+    public NativeExpressionOptimizer(
+            NativeSidecarExpressionInterpreter rowExpressionInterpreterService,
+            FunctionMetadataManager functionMetadataManager,
+            StandardFunctionResolution resolution)
+    {
+        this.rowExpressionInterpreterService = requireNonNull(rowExpressionInterpreterService, "rowExpressionInterpreterService is null");
+        this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
+        this.resolution = requireNonNull(resolution, "resolution is null");
+    }
+
+    @Override
+    public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session)
+    {
+        return toRowExpression(
+                expression.getSourceLocation(),
+                optimize(expression, level, session, NO_RESOLUTION),
+                expression.getType());
+    }
+
+    @Override
+    public Object optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+    {
+        // Collect expressions to optimize
+        CollectingVisitor collectingVisitor = new CollectingVisitor(functionMetadataManager, level, resolution);
+        expression.accept(collectingVisitor, variableResolver);
+        List<RowExpression> expressionsToOptimize = collectingVisitor.getExpressionsToOptimize();
+        Map<RowExpression, RowExpression> expressions = expressionsToOptimize.stream()
+                .collect(toMap(
+                        Function.identity(),
+                        rowExpression -> toRowExpression(
+                                rowExpression.getSourceLocation(),
+                                rowExpression.accept(new ReplacingVisitor(variableResolver), null),
+                                rowExpression.getType()),
+                        (a, b) -> a));
+        if (expressions.isEmpty()) {
+            return expression;
+        }
+
+        // Constants can be trivially replaced without invoking the interpreter.  Move them into a separate map.
+        Map<RowExpression, RowExpression> constants = new HashMap<>();
+        Iterator<Map.Entry<RowExpression, RowExpression>> entries = expressions.entrySet().iterator();
+        while (entries.hasNext()) {
+            Map.Entry<RowExpression, RowExpression> entry = entries.next();
+            if (entry.getValue() instanceof ConstantExpression) {
+                constants.put(entry.getKey(), entry.getValue());
+                entries.remove();
+            }
+        }
+
+        // Optimize the expressions using the sidecar interpreter
+        Map<RowExpression, Object> replacements = new HashMap<>();
+        if (!expressions.isEmpty()) {
+            replacements.putAll(rowExpressionInterpreterService.optimizeBatch(session, expressions, level));
+        }
+
+        // Add back in the constants
+        replacements.putAll(constants);
+
+        // Replace all the expressions in the original expression with the optimized expressions
+        return expression.accept(new ReplacingVisitor(replacements), null);
+    }
+
+    private static class CollectingVisitor
+            implements RowExpressionVisitor<Void, Object>
+    {
+        private final FunctionMetadataManager functionMetadataManager;
+        private final Level optimizationLevel;
+        private final StandardFunctionResolution resolution;
+        private final Set<RowExpression> expressionsToOptimize = newSetFromMap(new IdentityHashMap<>());
+
+        public CollectingVisitor(FunctionMetadataManager functionMetadataManager, Level optimizationLevel, StandardFunctionResolution resolution)
+        {
+            this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
+            this.optimizationLevel = requireNonNull(optimizationLevel, "optimizationLevel is null");
+            this.resolution = requireNonNull(resolution, "resolution is null");
+        }
+
+        @Override
+        public Void visitExpression(RowExpression node, Object context)
+        {
+            return null;
+        }
+
+        @Override
+        public Void visitConstant(ConstantExpression node, Object context)
+        {
+            addRowExpressionToOptimize(node);
+            return null;
+        }
+
+        @Override
+        public Void visitVariableReference(VariableReferenceExpression node, Object context)
+        {
+            Object value = ((Function<VariableReferenceExpression, Object>) context).apply(node);
+            if (value == null || value instanceof RowExpression) {
+                return null;
+            }
+            addRowExpressionToOptimize(node);
+            return null;
+        }
+
+        @Override
+        public Void visitCall(CallExpression node, Object context)
+        {
+            // If the optimization level is not EVALUATED, then we cannot optimize non-deterministic functions
+            boolean isDeterministic = functionMetadataManager.getFunctionMetadata(node.getFunctionHandle()).isDeterministic();
+            boolean canBeEvaluated = (optimizationLevel.ordinal() < EVALUATED.ordinal() && isDeterministic) ||
+                    optimizationLevel.ordinal() == EVALUATED.ordinal();
+
+            // All arguments must be optimizable in order to evaluate the function
+            boolean allConstantFoldable = node.getArguments().stream()
+                    .peek(argument -> argument.accept(this, context))
+                    .reduce(true, (a, b) -> canBeOptimized(b) && a, (a, b) -> a && b);
+            if (canBeEvaluated && allConstantFoldable) {
+                addRowExpressionToOptimize(node);
+                return null;
+            }
+
+            // If it's a cast and the type is already the same, then it's constant foldable
+            if (resolution.isCastFunction(node.getFunctionHandle())
+                    && node.getArguments().size() == 1
+                    && node.getType().equals(node.getArguments().get(0).getType())) {
+                addRowExpressionToOptimize(node);
+                return null;
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitSpecialForm(SpecialFormExpression node, Object context)
+        {
+            // Most special form expressions short circuit, meaning that they potentially don't evaluate all arguments.  For example, the AND expression
+            // will stop evaluating arguments as soon as it finds a false argument.  Because a sub-expression could be simplified into a constant, and this
+            // constant could cause the expression to short circuit, if there is at least one argument which is optimizable, then the entire expression should
+            // be sent to the sidecar to be optimized.
+            boolean anyArgumentsOptimizable = node.getArguments().stream()
+                    .peek(argument -> argument.accept(this, context))
+                    .anyMatch(this::canBeOptimized);
+
+            // If all arguments are constant foldable, then the whole expression is constant foldable
+            if (anyArgumentsOptimizable) {
+                addRowExpressionToOptimize(node);
+                return null;
+            }
+
+            // If the special form is COALESCE, then we can optimize it if there are any duplicate arguments
+            if (node.getForm() == COALESCE) {
+                ImmutableSet.Builder<RowExpression> builder = ImmutableSet.builder();
+                // Check if there's any duplicate arguments, these can be de-duplicated
+                for (RowExpression argument : node.getArguments()) {
+                    // The duplicate argument must either be a leaf (variable reference) or constant foldable
+                    if (canBeOptimized(argument)) {
+                        builder.add(argument);
+                    }
+                }
+                // If there were any duplicates, or if there's no arguments (cancel out), or if there's only one argument (just return it),
+                // then it's also constant foldable
+                boolean canBeOptimized = builder.build().size() <= node.getArguments().size() || node.getArguments().size() <= 1;
+                if (canBeOptimized) {
+                    addRowExpressionToOptimize(node);
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitLambda(LambdaDefinitionExpression node, Object context)
+        {
+            node.getBody().accept(this, (Function<VariableReferenceExpression, Object>) variable -> variable);
+            if (canBeOptimized(node.getBody())) {
+                addRowExpressionToOptimize(node.getBody());
+            }
+            return null;
+        }
+
+        public boolean canBeOptimized(RowExpression rowExpression)
+        {
+            return expressionsToOptimize.contains(rowExpression);
+        }
+
+        private void removeChildren(RowExpression resolvedRowExpression)
+        {
+            for (RowExpression rowExpression : resolvedRowExpression.getChildren()) {
+                expressionsToOptimize.remove(rowExpression);
+            }
+        }
+
+        private void addRowExpressionToOptimize(RowExpression original)
+        {
+            requireNonNull(original, "original is null");
+            removeChildren(original);
+            expressionsToOptimize.add(original);
+        }
+
+        public List<RowExpression> getExpressionsToOptimize()
+        {
+            return ImmutableList.copyOf(expressionsToOptimize);
+        }
+    }
+
+    private static class ReplacingVisitor
+            implements RowExpressionVisitor<Object, Void>
+    {
+        private final Function<RowExpression, Object> resolver;
+
+        public ReplacingVisitor(Map<RowExpression, Object> replacements)
+        {
+            requireNonNull(replacements, "replacements is null");
+            this.resolver = i -> replacements.getOrDefault(i, i);
+        }
+
+        public ReplacingVisitor(Function<VariableReferenceExpression, Object> variableResolver)
+        {
+            requireNonNull(variableResolver, "variableResolver is null");
+            this.resolver = i -> i instanceof VariableReferenceExpression ? variableResolver.apply((VariableReferenceExpression) i) : i;
+        }
+
+        private boolean canBeReplaced(RowExpression rowExpression)
+        {
+            return resolver.apply(rowExpression) != rowExpression;
+        }
+
+        @Override
+        public Object visitExpression(RowExpression originalExpression, Void context)
+        {
+            return resolver.apply(originalExpression);
+        }
+
+        @Override
+        public Object visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            if (canBeReplaced(lambda.getBody())) {
+                return new LambdaDefinitionExpression(
+                        lambda.getSourceLocation(),
+                        lambda.getArgumentTypes(),
+                        lambda.getArguments(),
+                        toRowExpression(lambda.getSourceLocation(), resolver.apply(lambda.getBody()), lambda.getBody().getType()));
+            }
+            return lambda;
+        }
+
+        @Override
+        public Object visitCall(CallExpression call, Void context)
+        {
+            if (canBeReplaced(call)) {
+                return resolver.apply(call);
+            }
+            List<RowExpression> updatedArguments = call.getArguments().stream()
+                    .map(argument -> toRowExpression(argument.getSourceLocation(), argument.accept(this, context), argument.getType()))
+                    .collect(toImmutableList());
+            return new CallExpression(call.getSourceLocation(), call.getDisplayName(), call.getFunctionHandle(), call.getType(), updatedArguments);
+        }
+
+        @Override
+        public Object visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            if (canBeReplaced(specialForm)) {
+                return resolver.apply(specialForm);
+            }
+            List<RowExpression> updatedArguments = specialForm.getArguments().stream()
+                    .map(argument -> toRowExpression(argument.getSourceLocation(), argument.accept(this, context), argument.getType()))
+                    .collect(toImmutableList());
+            return new SpecialFormExpression(specialForm.getSourceLocation(), specialForm.getForm(), specialForm.getType(), updatedArguments);
+        }
+    }
+
+    private static RowExpression toRowExpression(Optional<SourceLocation> sourceLocation, Object object, Type type)
+    {
+        requireNonNull(type, "type is null");
+
+        if (object instanceof RowExpression) {
+            return (RowExpression) object;
+        }
+
+        return new ConstantExpression(sourceLocation, object, type);
+    }
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionOptimizerFactory.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionOptimizerFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerContext;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class NativeExpressionOptimizerFactory
+        implements ExpressionOptimizerFactory
+{
+    private final ClassLoader classLoader;
+
+    public NativeExpressionOptimizerFactory(ClassLoader classLoader)
+    {
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public ExpressionOptimizer createOptimizer(Map<String, String> config, ExpressionOptimizerContext context)
+    {
+        requireNonNull(context, "context is null");
+
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app = new Bootstrap(
+                    new JsonModule(),
+                    new NativeExpressionsCommunicationModule(),
+                    new NativeExpressionsModule(context.getNodeManager(), context.getRowExpressionSerde(), context.getFunctionMetadataManager(), context.getFunctionResolution()));
+
+            Injector injector = app
+                    .noStrictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .quiet()
+                    .initialize();
+            return injector.getInstance(NativeExpressionOptimizerProvider.class).createOptimizer();
+        }
+    }
+
+    @Override
+    public String getName()
+    {
+        return "native";
+    }
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionOptimizerProvider.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionOptimizerProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class NativeExpressionOptimizerProvider
+{
+    private final NativeSidecarExpressionInterpreter expressionInterpreterService;
+    private final FunctionMetadataManager functionMetadataManager;
+    private final StandardFunctionResolution resolution;
+
+    @Inject
+    public NativeExpressionOptimizerProvider(NativeSidecarExpressionInterpreter expressionInterpreterService, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution resolution)
+    {
+        this.expressionInterpreterService = requireNonNull(expressionInterpreterService, "expressionInterpreterService is null");
+        this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
+        this.resolution = requireNonNull(resolution, "resolution is null");
+    }
+
+    public ExpressionOptimizer createOptimizer()
+    {
+        return new NativeExpressionOptimizer(expressionInterpreterService, functionMetadataManager, resolution);
+    }
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionsCommunicationModule.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionsCommunicationModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
+
+public class NativeExpressionsCommunicationModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        httpClientBinder(binder).bindHttpClient("sidecar", ForSidecarInfo.class);
+    }
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionsModule.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeExpressionsModule.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.RowExpressionSerde;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static java.util.Objects.requireNonNull;
+
+public class NativeExpressionsModule
+        implements Module
+{
+    private final NodeManager nodeManager;
+    private final RowExpressionSerde rowExpressionSerde;
+    private final FunctionMetadataManager functionMetadataManager;
+    private final StandardFunctionResolution functionResolution;
+
+    public NativeExpressionsModule(NodeManager nodeManager, RowExpressionSerde rowExpressionSerde, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution functionResolution)
+    {
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.rowExpressionSerde = requireNonNull(rowExpressionSerde, "rowExpressionSerde is null");
+        this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
+        this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        // Core dependencies
+        binder.bind(NodeManager.class).toInstance(nodeManager);
+        binder.bind(RowExpressionSerde.class).toInstance(rowExpressionSerde);
+        binder.bind(FunctionMetadataManager.class).toInstance(functionMetadataManager);
+        binder.bind(StandardFunctionResolution.class).toInstance(functionResolution);
+
+        // JSON dependencies and setup
+        binder.install(new JsonModule());
+        jsonBinder(binder).addDeserializerBinding(RowExpression.class).to(RowExpressionDeserializer.class).in(Scopes.SINGLETON);
+        jsonBinder(binder).addSerializerBinding(RowExpression.class).to(RowExpressionSerializer.class).in(Scopes.SINGLETON);
+        jsonCodecBinder(binder).bindListJsonCodec(RowExpression.class);
+
+        binder.bind(NativeSidecarExpressionInterpreter.class).in(Scopes.SINGLETON);
+
+        // The main service provider
+        binder.bind(NativeExpressionOptimizerProvider.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeSidecarExpressionInterpreter.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/NativeSidecarExpressionInterpreter.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpUriBuilder;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.net.HttpHeaders.ACCEPT;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class NativeSidecarExpressionInterpreter
+{
+    private static final String PRESTO_TIME_ZONE_HEADER = "X-Presto-Time-Zone";
+    private static final String PRESTO_USER_HEADER = "X-Presto-User";
+    private static final String PRESTO_EXPRESSION_OPTIMIZER_LEVEL_HEADER = "X-Presto-Expression-Optimizer-Level";
+    private static final String SIDECAR_ENDPOINT = "/v1/expressions";
+    private final NodeManager nodeManager;
+    private final HttpClient httpClient;
+    private final JsonCodec<List<RowExpression>> rowExpressionSerde;
+
+    @Inject
+    public NativeSidecarExpressionInterpreter(NodeManager nodeManager, @ForSidecarInfo HttpClient httpClient, JsonCodec<List<RowExpression>> rowExpressionSerde)
+    {
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.rowExpressionSerde = requireNonNull(rowExpressionSerde, "rowExpressionSerde is null");
+    }
+
+    public Map<RowExpression, Object> optimizeBatch(ConnectorSession session, Map<RowExpression, RowExpression> expressions, ExpressionOptimizer.Level level)
+    {
+        ImmutableList.Builder<RowExpression> originalExpressionsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<RowExpression> resolvedExpressionsBuilder = ImmutableList.builder();
+        for (Map.Entry<RowExpression, RowExpression> entry : expressions.entrySet()) {
+            originalExpressionsBuilder.add(entry.getKey());
+            resolvedExpressionsBuilder.add(entry.getValue());
+        }
+        List<RowExpression> originalExpressions = originalExpressionsBuilder.build();
+        List<RowExpression> resolvedExpressions = resolvedExpressionsBuilder.build();
+
+        List<RowExpression> optimizedExpressions = httpClient.execute(
+                getSidecarRequest(session, level, resolvedExpressions),
+                createJsonResponseHandler(rowExpressionSerde));
+        checkArgument(
+                optimizedExpressions.size() == resolvedExpressions.size(),
+                "Expected %s optimized expressions, but got %s",
+                resolvedExpressions.size(),
+                optimizedExpressions.size());
+
+        ImmutableMap.Builder<RowExpression, Object> result = ImmutableMap.builder();
+        for (int i = 0; i < optimizedExpressions.size(); i++) {
+            result.put(originalExpressions.get(i), optimizedExpressions.get(i));
+        }
+        return result.build();
+    }
+
+    private Request getSidecarRequest(ConnectorSession session, Level level, List<RowExpression> resolvedExpressions)
+    {
+        return preparePost()
+                .setUri(getLocation())
+                .setBodyGenerator(jsonBodyGenerator(rowExpressionSerde, resolvedExpressions))
+                .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                .setHeader(ACCEPT, JSON_UTF_8.toString())
+                .setHeader(PRESTO_TIME_ZONE_HEADER, session.getSqlFunctionProperties().getTimeZoneKey().getId())
+                .setHeader(PRESTO_USER_HEADER, session.getUser())
+                .setHeader(PRESTO_EXPRESSION_OPTIMIZER_LEVEL_HEADER, level.name())
+                .build();
+    }
+
+    private URI getLocation()
+    {
+        Node sidecarNode = nodeManager.getSidecarNode();
+        return HttpUriBuilder.uriBuilder()
+                .scheme("http")
+                .host(sidecarNode.getHost())
+                .port(sidecarNode.getHostAndPort().getPort())
+                .appendPath(SIDECAR_ENDPOINT)
+                .build();
+    }
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/RowExpressionDeserializer.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/RowExpressionDeserializer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.facebook.presto.spi.RowExpressionSerde;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.google.inject.Inject;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public final class RowExpressionDeserializer
+        extends JsonDeserializer<RowExpression>
+{
+    private final RowExpressionSerde rowExpressionSerde;
+
+    @Inject
+    public RowExpressionDeserializer(RowExpressionSerde rowExpressionSerde)
+    {
+        this.rowExpressionSerde = requireNonNull(rowExpressionSerde, "rowExpressionSerde is null");
+    }
+
+    @Override
+    public RowExpression deserialize(JsonParser jsonParser, DeserializationContext context)
+            throws IOException
+    {
+        return rowExpressionSerde.deserialize(jsonParser.readValueAsTree().toString());
+    }
+
+    @Override
+    public RowExpression deserializeWithType(JsonParser jsonParser, DeserializationContext context, TypeDeserializer typeDeserializer)
+            throws IOException
+    {
+        return deserialize(jsonParser, context);
+    }
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/RowExpressionSerializer.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/session/sql/expressions/RowExpressionSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.facebook.presto.spi.RowExpressionSerde;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.google.inject.Inject;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public final class RowExpressionSerializer
+        extends JsonSerializer<RowExpression>
+{
+    private final RowExpressionSerde rowExpressionSerde;
+
+    @Inject
+    public RowExpressionSerializer(RowExpressionSerde rowExpressionSerde)
+    {
+        this.rowExpressionSerde = requireNonNull(rowExpressionSerde, "rowExpressionSerde is null");
+    }
+
+    @Override
+    public void serialize(RowExpression rowExpression, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException
+    {
+        jsonGenerator.writeRawValue(rowExpressionSerde.serialize(rowExpression));
+    }
+
+    @Override
+    public void serializeWithType(RowExpression rowExpression, JsonGenerator jsonGenerator, SerializerProvider serializerProvider, TypeSerializer typeSerializer)
+            throws IOException
+    {
+        serialize(rowExpression, jsonGenerator, serializerProvider);
+    }
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/NativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/NativeSidecarPlugin.java
@@ -13,9 +13,11 @@
  */
 package com.facebook.presto.sidecar;
 
+import com.facebook.presto.session.sql.expressions.NativeExpressionOptimizerFactory;
 import com.facebook.presto.sidecar.sessionpropertyproviders.NativeSystemSessionPropertyProviderFactory;
 import com.facebook.presto.spi.CoordinatorPlugin;
 import com.facebook.presto.spi.session.WorkerSessionPropertyProviderFactory;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
 import com.google.common.collect.ImmutableList;
 
 public class NativeSidecarPlugin
@@ -25,5 +27,23 @@ public class NativeSidecarPlugin
     public Iterable<WorkerSessionPropertyProviderFactory> getWorkerSessionPropertyProviderFactories()
     {
         return ImmutableList.of(new NativeSystemSessionPropertyProviderFactory());
+    }
+    @Override
+    public Iterable<ExpressionOptimizerFactory> getExpressionOptimizerFactories()
+    {
+        return ImmutableList.of(new NativeExpressionOptimizerFactory(getClassLoader()));
+    }
+
+    private static ClassLoader getClassLoader()
+    {
+        return firstNonNull(Thread.currentThread().getContextClassLoader(), NativeSidecarPlugin.class.getClassLoader());
+    }
+
+    private static ClassLoader firstNonNull(ClassLoader contextClassLoader, ClassLoader classLoader)
+    {
+        if (contextClassLoader != null) {
+            return contextClassLoader;
+        }
+        return classLoader;
     }
 }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/session/sql/expressions/TestNativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/session/sql/expressions/TestNativeExpressionOptimizer.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.relational.DelegatingRowExpressionOptimizer;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.tests.expressions.TestExpressions;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.findRandomPortForWorker;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.getNativeSidecarProcess;
+import static com.facebook.presto.session.sql.expressions.TestNativeExpressions.getExpressionOptimizer;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.type.LikeFunctions.castVarcharToLikePattern;
+import static com.facebook.presto.type.LikePatternType.LIKE_PATTERN;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.testng.Assert.assertEquals;
+
+public class TestNativeExpressionOptimizer
+        extends TestExpressions
+{
+    private ExpressionOptimizer expressionOptimizer;
+    private Process sidecar;
+    private FunctionResolution functionResolution;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        int port = findRandomPortForWorker();
+        URI sidecarUri = URI.create("http://127.0.0.1:" + port);
+        sidecar = getNativeSidecarProcess(sidecarUri, port);
+
+        this.functionResolution = new FunctionResolution(getMetadata().getFunctionAndTypeManager().getFunctionAndTypeResolver());
+        ExpressionOptimizer optimizer = getExpressionOptimizer(getMetadata(), new HandleResolver());
+        expressionOptimizer = new DelegatingRowExpressionOptimizer(getMetadata(), () -> optimizer);
+    }
+
+    @AfterClass
+    public void tearDown()
+    {
+        sidecar.destroyForcibly();
+    }
+
+    // TODO: Pending on native function namespace manager.
+    @Test(enabled = false)
+    public void assertLikeOptimizations()
+    {
+        assertOptimizedMatches("unbound_string LIKE bound_pattern", "unbound_string LIKE CAST('%el%' AS varchar)");
+    }
+
+    // TODO: this test is invalid as it manually constructs an expression which can't be serialized
+    @Test(enabled = false)
+    @Override
+    public void testLikeInvalidUtf8()
+    {
+    }
+
+    // TODO: Pending on native function namespace manager.
+    @Test(enabled = false)
+    @Override
+    public void testLike()
+    {
+    }
+
+    // TODO: Pending on native function namespace manager.
+    @Test(enabled = false)
+    @Override
+    public void testLikeOptimization()
+    {
+    }
+
+    // TODO: Pending on native function namespace manager.
+    @Test(enabled = false)
+    @Override
+    public void testInvalidLike()
+    {
+    }
+
+    @Test(enabled = false)
+    @Override
+    public void testLambda()
+    {
+        assertDoNotOptimize("transform(unbound_array, x -> x + x)", OPTIMIZED);
+        assertOptimizedEquals("transform(ARRAY[1, 5], x -> x + x)", "transform(ARRAY[1, 5], x -> x + x)");
+        assertOptimizedEquals("transform(sequence(1, 5), x -> x + x)", "transform(sequence(1, 5), x -> x + x)");
+        assertRowExpressionEquals(
+                OPTIMIZED,
+                "transform(sequence(1, unbound_long), x -> cast(json_parse('[1, 2]') AS ARRAY<INTEGER>)[1] + x)",
+                "transform(sequence(1, unbound_long), x -> 1 + x)");
+        assertRowExpressionEquals(
+                OPTIMIZED,
+                "transform(sequence(1, unbound_long), x -> cast(json_parse('[1, 2]') AS ARRAY<INTEGER>)[1] + 1)",
+                "transform(sequence(1, unbound_long), x -> 2)");
+        // TODO: lambdas are currently unsupported by this test
+//        assertEquals(evaluate("reduce(ARRAY[1, 5], 0, (x, y) -> x + y, x -> x)", true), 6L);
+    }
+
+    // TODO: current timestamp returns the session timestamp, which is not supported by this test
+    @Test(enabled = false)
+    @Override
+    public void testCurrentTimestamp()
+    {
+    }
+
+    // TODO: this function is not supported by this test because its contents are not serializable
+    @Test(enabled = false)
+    @Override
+    public void testMassiveArray()
+    {
+    }
+
+    // TODO: apply function is not supported in Presto native.
+    @Test(enabled = false)
+    @Override
+    public void testBind()
+    {
+    }
+
+    @Test
+    @Override
+    public void testLiterals()
+    {
+        optimize("date '2013-04-03' + unbound_interval");
+        // TODO: TIME type is unsupported in Presto native.
+//        optimize("time '03:04:05.321' + unbound_interval");
+//        optimize("time '03:04:05.321 UTC' + unbound_interval");
+        optimize("timestamp '2013-04-03 03:04:05.321' + unbound_interval");
+        optimize("timestamp '2013-04-03 03:04:05.321 UTC' + unbound_interval");
+
+        optimize("interval '3' day * unbound_long");
+        // TODO: Pending on velox PR: https://github.com/facebookincubator/velox/pull/11612.
+//        optimize("interval '3' year * unbound_integer");
+    }
+
+    // TODO: NULL_IF special form is unsupported in Presto native.
+    @Test(enabled = false)
+    @Override
+    public void testNullIf()
+    {
+    }
+
+    @Test
+    @Override
+    public void testCastBigintToBoundedVarchar()
+    {
+        assertEvaluatedEquals("CAST(12300000000 AS varchar(11))", "'12300000000'");
+        assertEvaluatedEquals("CAST(12300000000 AS varchar(50))", "'12300000000'");
+
+        // TODO: Velox permits this cast, but Presto does not
+//        try {
+//            evaluate("CAST(12300000000 AS varchar(3))", true);
+//            fail("Expected to throw an INVALID_CAST_ARGUMENT exception");
+//        }
+//        catch (PrestoException e) {
+//            try {
+//                assertEquals(e.getErrorCode(), INVALID_CAST_ARGUMENT.toErrorCode());
+//                assertEquals(e.getMessage(), "Value 12300000000 cannot be represented as varchar(3)");
+//            }
+//            catch (Throwable failure) {
+//                failure.addSuppressed(e);
+//                throw failure;
+//            }
+//        }
+//
+//        try {
+//            evaluate("CAST(-12300000000 AS varchar(3))", true);
+//        }
+//        catch (PrestoException e) {
+//            try {
+//                assertEquals(e.getErrorCode(), INVALID_CAST_ARGUMENT.toErrorCode());
+//                assertEquals(e.getMessage(), "Value -12300000000 cannot be represented as varchar(3)");
+//            }
+//            catch (Throwable failure) {
+//                failure.addSuppressed(e);
+//                throw failure;
+//            }
+//        }
+    }
+
+    // TODO: Non-legacy map subscript is not supported in Presto native.
+    @Test(enabled = false)
+    @Override
+    public void testMapSubscriptMissingKey()
+    {
+    }
+
+    // TODO: This test is not applicable in the sidecar so disabled for now.
+    //  To be enabled after changes in sidecar query runner to support Json
+    //  based UDF registration.
+    @Test(enabled = false)
+    @Override
+    public void testCppAggregateFunctionCall()
+    {
+    }
+
+    // TODO: This test is not applicable in the sidecar so disabled for now.
+    //  To be enabled after changes in sidecar query runner to support Json
+    //  based UDF registration.
+    @Test(enabled = false)
+    @Override
+    public void testCppFunctionCall()
+    {
+    }
+
+    @Override
+    protected void assertLike(byte[] value, String pattern, boolean expected)
+    {
+        CallExpression predicate = call(
+                "LIKE",
+                functionResolution.likeVarcharFunction(),
+                BOOLEAN,
+                ImmutableList.of(
+                        new ConstantExpression(wrappedBuffer(value), VARCHAR),
+                        new ConstantExpression(castVarcharToLikePattern(utf8Slice(pattern)), LIKE_PATTERN)));
+        assertEquals(optimizeRowExpression(predicate, EVALUATED), expected);
+    }
+    @Override
+    protected Object evaluate(String expression, boolean deterministic)
+    {
+        assertRoundTrip(expression);
+        RowExpression rowExpression = sqlToRowExpression(expression);
+        return optimizeRowExpression(rowExpression, EVALUATED);
+    }
+
+    @Override
+    protected Object optimize(String expression)
+    {
+        assertRoundTrip(expression);
+        RowExpression parsedExpression = sqlToRowExpression(expression);
+        return optimizeRowExpression(parsedExpression, OPTIMIZED);
+    }
+
+    @Override
+    protected Object optimizeRowExpression(RowExpression expression, Level level)
+    {
+        Object optimized = expressionOptimizer.optimize(
+                expression,
+                level,
+                TEST_SESSION.toConnectorSession(),
+                variable -> {
+                    Symbol symbol = new Symbol(variable.getName());
+                    Object value = symbolConstant(symbol);
+                    if (value == null) {
+                        return new VariableReferenceExpression(Optional.empty(), symbol.getName(), SYMBOL_TYPES.get(symbol.toSymbolReference()));
+                    }
+                    return value;
+                });
+        return unwrap(optimized);
+    }
+
+    public Object unwrap(Object result)
+    {
+        if (result instanceof ConstantExpression) {
+            return ((ConstantExpression) result).getValue();
+        }
+        else {
+            return result;
+        }
+    }
+
+    @Override
+    protected void assertOptimizedEquals(String actual, String expected)
+    {
+        Object optimizedActual = optimize(actual);
+        Object optimizedExpected = optimize(expected);
+        assertRowExpressionEvaluationEquals(optimizedActual, optimizedExpected);
+    }
+
+    @Override
+    protected void assertOptimizedMatches(String actual, String expected)
+    {
+        Object actualOptimized = optimize(actual);
+        Object expectedOptimized = optimize(expected);
+        assertRowExpressionEvaluationEquals(
+                actualOptimized,
+                expectedOptimized);
+    }
+
+    @Override
+    protected void assertDoNotOptimize(String expression, Level optimizationLevel)
+    {
+        assertRoundTrip(expression);
+        RowExpression rowExpression = sqlToRowExpression(expression);
+        Object rowExpressionResult = optimizeRowExpression(rowExpression, optimizationLevel);
+        assertRowExpressionEvaluationEquals(rowExpressionResult, rowExpression);
+    }
+}

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/session/sql/expressions/TestNativeExpressions.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/session/sql/expressions/TestNativeExpressions.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.session.sql.expressions;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.testing.TestingHttpClient;
+import com.facebook.airlift.jaxrs.JsonMapper;
+import com.facebook.airlift.jaxrs.testing.JaxrsTestingHttpProcessor;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.block.BlockJsonSerde;
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncoding;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.HandleJsonModule;
+import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.nodeManager.PluginNodeManager;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.RowExpressionSerde;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.expressions.JsonCodecRowExpressionSerde;
+import com.facebook.presto.sql.planner.RowExpressionInterpreter;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.type.TypeDeserializer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriBuilder;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.SERIALIZABLE;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestNativeExpressions
+{
+    public static final URI SIDECAR_URI = URI.create("http://127.0.0.1:1122");
+    private static final Metadata METADATA = MetadataManager.createTestMetadataManager();
+    private static final TestingRowExpressionTranslator TRANSLATOR = new TestingRowExpressionTranslator(METADATA);
+    @Test
+    public void testLoadPlugin()
+    {
+        ExpressionOptimizer interpreterService = getExpressionOptimizer(METADATA, null);
+
+        // Test the native row expression interpreter service with some simple expressions
+        RowExpression simpleAddition = compileExpression("1+1");
+        RowExpression unnecessaryCoalesce = compileExpression("coalesce(1, 2)");
+
+        // Assert simple optimizations are performed
+        assertEquals(interpreterService.optimize(simpleAddition, OPTIMIZED, TEST_SESSION.toConnectorSession()), toRowExpression(2L, simpleAddition.getType()));
+        assertEquals(interpreterService.optimize(unnecessaryCoalesce, OPTIMIZED, TEST_SESSION.toConnectorSession()), toRowExpression(1L, unnecessaryCoalesce.getType()));
+    }
+
+    private static RowExpression compileExpression(String expression)
+    {
+        return TRANSLATOR.translate(expression, ImmutableMap.of());
+    }
+
+    protected static ExpressionOptimizer getExpressionOptimizer(Metadata metadata, HandleResolver handleResolver)
+    {
+        // Set up dependencies in main for this module
+        InMemoryNodeManager nodeManager = getNodeManagerWithSidecar(SIDECAR_URI);
+        Injector prestoMainInjector = getPrestoMainInjector(metadata, handleResolver);
+        JsonMapper jsonMapper = prestoMainInjector.getInstance(JsonMapper.class);
+        RowExpressionSerde rowExpressionSerde = prestoMainInjector.getInstance(RowExpressionSerde.class);
+        FunctionAndTypeManager functionMetadataManager = prestoMainInjector.getInstance(FunctionAndTypeManager.class);
+
+        // Set up the mock HTTP endpoint that delegates to the Java based row expression interpreter
+        TestingExpressionOptimizerResource resource = new TestingExpressionOptimizerResource(
+                metadata.getFunctionAndTypeManager(),
+                testSessionBuilder().build().toConnectorSession(),
+                SERIALIZABLE);
+        JaxrsTestingHttpProcessor jaxrsTestingHttpProcessor = new JaxrsTestingHttpProcessor(
+                UriBuilder.fromUri(SIDECAR_URI).path("/").build(),
+                resource,
+                jsonMapper);
+        TestingHttpClient testingHttpClient = new TestingHttpClient(jaxrsTestingHttpProcessor);
+
+        // Create the native row expression interpreter service
+        return createExpressionOptimizer(nodeManager, rowExpressionSerde, testingHttpClient, functionMetadataManager);
+    }
+
+    private static InMemoryNodeManager getNodeManagerWithSidecar(URI sidecarUri)
+    {
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+        nodeManager.addNode(new ConnectorId("test"), new InternalNode("test", sidecarUri, NodeVersion.UNKNOWN, false, false, false, true));
+        return nodeManager;
+    }
+
+    private static ExpressionOptimizer createExpressionOptimizer(InternalNodeManager internalNodeManager, RowExpressionSerde rowExpressionSerde, HttpClient httpClient, FunctionAndTypeManager functionMetadataManager)
+    {
+        requireNonNull(internalNodeManager, "inMemoryNodeManager is null");
+        NodeManager nodeManager = new PluginNodeManager(internalNodeManager);
+        FunctionResolution functionResolution = new FunctionResolution(functionMetadataManager.getFunctionAndTypeResolver());
+
+        Bootstrap app = new Bootstrap(
+                // Specially use a testing HTTP client instead of a real one
+                binder -> binder.bind(HttpClient.class).annotatedWith(ForSidecarInfo.class).toInstance(httpClient),
+                // Otherwise use the exact same module as the native row expression interpreter service
+                new NativeExpressionsModule(nodeManager, rowExpressionSerde, functionMetadataManager, functionResolution));
+
+        Injector injector = app
+                .noStrictConfig()
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(ImmutableMap.of())
+                .quiet()
+                .initialize();
+        return injector.getInstance(NativeExpressionOptimizerProvider.class).createOptimizer();
+    }
+
+    private static Injector getPrestoMainInjector(Metadata metadata, HandleResolver handleResolver)
+    {
+        Module module = binder -> {
+            // Installs the JSON codec
+            binder.install(new JsonModule());
+            // Required to deserialize function handles
+            binder.install(new HandleJsonModule(handleResolver));
+            // Required for this test in the JaxrsTestingHttpProcessor because the underlying object mapper
+            // must be the same as all other object mappers
+            binder.bind(JsonMapper.class);
+
+            // These dependencies are needed to serialize and deserialize types (found in expressions)
+            FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
+            binder.bind(FunctionAndTypeManager.class).toInstance(functionAndTypeManager);
+            binder.bind(TypeManager.class).toInstance(functionAndTypeManager);
+            jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+            newSetBinder(binder, Type.class);
+
+            // These dependencies are needed to serialize and deserialize blocks (found in constant values of expressions)
+            binder.bind(BlockEncodingSerde.class).to(BlockEncodingManager.class).in(Scopes.SINGLETON);
+            newSetBinder(binder, BlockEncoding.class);
+            jsonBinder(binder).addSerializerBinding(Block.class).to(BlockJsonSerde.Serializer.class);
+            jsonBinder(binder).addDeserializerBinding(Block.class).to(BlockJsonSerde.Deserializer.class);
+
+            // Create the serde which is used by the plugin to serialize and deserialize expressions
+            jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
+            binder.bind(RowExpressionSerde.class).to(JsonCodecRowExpressionSerde.class).in(Scopes.SINGLETON);
+        };
+        Bootstrap app = new Bootstrap(ImmutableList.of(module));
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+        return injector;
+    }
+
+    @Path("/v1/expressions")
+    public static class TestingExpressionOptimizerResource
+    {
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final ConnectorSession connectorSession;
+        private final ExpressionOptimizer.Level level;
+
+        public TestingExpressionOptimizerResource(FunctionAndTypeManager functionAndTypeManager, ConnectorSession connectorSession, ExpressionOptimizer.Level level)
+        {
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.connectorSession = requireNonNull(connectorSession, "connectorSession is null");
+            this.level = requireNonNull(level, "level is null");
+        }
+
+        @POST
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public List<RowExpression> post(List<RowExpression> rowExpressions)
+        {
+            Map<RowExpression, RowExpression> input = rowExpressions.stream().collect(toImmutableMap(i -> i, i -> i));
+            Map<RowExpression, Object> optimizedExpressions = new HashMap<>();
+            input.forEach((key, value) -> optimizedExpressions.put(
+                    key,
+                    new RowExpressionInterpreter(key, functionAndTypeManager, connectorSession, level).optimize()));
+            ImmutableList.Builder<RowExpression> builder = ImmutableList.builder();
+            for (RowExpression inputExpression : rowExpressions) {
+                builder.add(toRowExpression(optimizedExpressions.get(inputExpression), inputExpression.getType()));
+            }
+            return builder.build();
+        }
+    }
+}

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/NativeSidecarPluginQueryRunnerUtils.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/NativeSidecarPluginQueryRunnerUtils.java
@@ -12,8 +12,10 @@
  * limitations under the License.
  */
 package com.facebook.presto.sidecar;
+import com.facebook.presto.session.sql.expressions.NativeExpressionOptimizerFactory;
 import com.facebook.presto.sidecar.sessionpropertyproviders.NativeSystemSessionPropertyProviderFactory;
 import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableMap;
 
 public class NativeSidecarPluginQueryRunnerUtils
 {
@@ -23,5 +25,7 @@ public class NativeSidecarPluginQueryRunnerUtils
     {
         queryRunner.installCoordinatorPlugin(new NativeSidecarPlugin());
         queryRunner.loadSessionPropertyProvider(NativeSystemSessionPropertyProviderFactory.NAME);
+        queryRunner.getExpressionManager().addExpressionOptimizerFactory(new NativeExpressionOptimizerFactory(ClassLoader.getSystemClassLoader()));
+        queryRunner.getExpressionManager().loadExpressionOptimizerFactory(ImmutableMap.<String, String>builder().put("expression-manager-factory.name", "native").build());
     }
 }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar;
+
+import com.facebook.presto.spi.CoordinatorPlugin;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerContext;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class TestNativeSidecarPlugin
+{
+    @Test
+    public void testLoadPlugin()
+    {
+        CoordinatorPlugin plugin = new NativeSidecarPlugin();
+        Iterable<ExpressionOptimizerFactory> serviceFactories = plugin.getExpressionOptimizerFactories();
+        ExpressionOptimizerFactory factory = getOnlyElement(serviceFactories);
+        factory.createOptimizer(
+                ImmutableMap.of(),
+                new ExpressionOptimizerContext(
+                        new UnimplementedNodeManager(),
+                        new UnimplementedRowExpressionSerde(),
+                        new UnimplementedFunctionMetadataManager(),
+                        new UnimplementedFunctionResolution()));
+    }
+}

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/UnimplementedFunctionMetadataManager.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/UnimplementedFunctionMetadataManager.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar;
+
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+
+class UnimplementedFunctionMetadataManager
+        implements FunctionMetadataManager
+{
+    @Override
+    public FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/UnimplementedFunctionResolution.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/UnimplementedFunctionResolution.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar;
+
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+
+import java.util.List;
+
+class UnimplementedFunctionResolution
+        implements StandardFunctionResolution
+{
+    @Override
+    public FunctionHandle notFunction()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isNotFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle negateFunction(Type type)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isNegateFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle likeVarcharFunction()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle likeCharFunction(Type valueType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isLikeFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle likePatternFunction()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isLikePatternFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle arrayConstructor(List<? extends Type> argumentTypes)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle arithmeticFunction(OperatorType operator, Type leftType, Type rightType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isArithmeticFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle comparisonFunction(OperatorType operator, Type leftType, Type rightType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isComparisonFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEqualsFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle betweenFunction(Type valueType, Type lowerBoundType, Type upperBoundType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isBetweenFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle subscriptFunction(Type baseType, Type indexType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSubscriptFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCastFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCountFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle countFunction()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle countFunction(Type valueType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isMaxFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle maxFunction(Type valueType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle greatestFunction(List<Type> valueTypes)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isMinFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle minFunction(Type valueType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle leastFunction(List<Type> valueTypes)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isApproximateCountDistinctFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle approximateCountDistinctFunction(Type valueType)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isApproximateSetFunction(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionHandle approximateSetFunction(Type valueType)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/UnimplementedNodeManager.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/UnimplementedNodeManager.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar;
+
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.NodePoolType;
+
+import java.net.URI;
+import java.util.Set;
+
+class UnimplementedNodeManager
+        implements NodeManager
+{
+    @Override
+    public Set<Node> getAllNodes()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Node> getWorkerNodes()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node getCurrentNode()
+    {
+        return new Node()
+        {
+            @Override
+            public String getHost()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public HostAddress getHostAndPort()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public URI getHttpUri()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String getNodeIdentifier()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String getVersion()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isCoordinator()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isResourceManager()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isCatalogServer()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isCoordinatorSidecar()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public NodePoolType getPoolType()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public Node getSidecarNode()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getEnvironment()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/UnimplementedRowExpressionSerde.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/UnimplementedRowExpressionSerde.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar;
+
+import com.facebook.presto.spi.RowExpressionSerde;
+import com.facebook.presto.spi.relation.RowExpression;
+
+class UnimplementedRowExpressionSerde
+        implements RowExpressionSerde
+{
+    @Override
+    public String serialize(RowExpression expression)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RowExpression deserialize(String value)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-openapi/src/main/resources/expressions.yaml
+++ b/presto-openapi/src/main/resources/expressions.yaml
@@ -1,0 +1,173 @@
+openapi: 3.0.0
+info:
+  title: Presto Expression API
+  description: API for evaluating and simplifying row expressions in Presto
+  version: "1"
+servers:
+  - url: http://localhost:8080
+    description: Presto endpoint when running locally
+paths:
+  /v1/expressions:
+    post:
+      summary: Simplify the list of row expressions
+      description: This endpoint takes in a list of row expressions and attempts to simplify them to their simplest logical equivalent expression.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RowExpressions'
+        required: true
+      responses:
+        '200':
+          description: Results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RowExpressions'
+components:
+  schemas:
+    RowExpressions:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/RowExpression"
+    RowExpression:
+      oneOf:
+        - $ref: "#/components/schemas/ConstantExpression"
+        - $ref: "#/components/schemas/VariableReferenceExpression"
+        - $ref: "#/components/schemas/InputReferenceExpression"
+        - $ref: "#/components/schemas/LambdaDefinitionExpression"
+        - $ref: "#/components/schemas/SpecialFormExpression"
+        - $ref: "#/components/schemas/CallExpression"
+    RowExpressionParent:
+      type: object
+      properties:
+        sourceLocation:
+           $ref: "#/components/schemas/SourceLocation"
+    SourceLocation:
+      description: The source location of the row expression in the original query, referencing the line and the column of the query.
+      type: object
+      properties:
+        line:
+          type: integer
+        column:
+          type: integer
+    ConstantExpression:
+      description: A constant expression is a row expression that represents a constant value.  The value attribute is the constant value.
+      allOf:
+        - $ref: "#/components/schemas/RowExpressionParent"
+        - type: object
+          properties:
+            "@type":
+              type: string
+              enum : ["constant"]
+            typeSignature:
+              type: string
+            valueBlock:
+              type: string
+    VariableReferenceExpression:
+      description: A variable reference expression is a row expression that represents a reference to a variable.  The name attribute indicates the name of the variable.
+      allOf:
+        - $ref: "#/components/schemas/RowExpressionParent"
+        - type: object
+          properties:
+            "@type":
+              type: string
+              enum : ["variable"]
+            typeSignature:
+              type: string
+            name:
+              type: string
+    InputReferenceExpression:
+      description: >
+        An input reference expression is a row expression that represents a reference to a column in the input schema.  The field attribute indicates the index of the column in the
+        input schema.
+      allOf:
+        - $ref: "#/components/schemas/RowExpressionParent"
+        - type: object
+          properties:
+            "@type":
+              type: string
+              enum : ["input"]
+            typeSignature:
+              type: string
+            field:
+                type: integer
+    LambdaDefinitionExpression:
+      description: >
+        A lambda definition expression is a row expression that represents a lambda function.  The lambda function is defined by a list of argument types, a list of argument names, 
+        and a body expression.
+      allOf:
+        - $ref: "#/components/schemas/RowExpressionParent"
+        - type: object
+          properties:
+            "@type":
+              type: string
+              enum : ["lambda"]
+            argumentTypeSignatures:
+              type: array
+              items:
+                type: string
+            arguments:
+              type: array
+              items:
+                type: string
+            body:
+              $ref: "#/components/schemas/RowExpression"
+    SpecialFormExpression:
+      description: >
+        A special form expression is a row expression that represents a special language construct.  The form attribute indicates the specific form of the special form,
+        which is a well known list, and with each having special semantics.  The arguments attribute is a list of row expressions that are the arguments to the special form, with
+        each form taking in a specific number of arguments.
+      allOf:
+        - $ref: "#/components/schemas/RowExpressionParent"
+        - type: object
+          properties:
+            "@type":
+              type: string
+              enum : ["special"]
+            form:
+                type: string
+                enum: ["IF","NULL_IF","SWITCH","WHEN","IS_NULL","COALESCE","IN","AND","OR","DEREFERENCE","ROW_CONSTRUCTOR","BIND"]
+            returnTypeSignature:
+              type: string
+            arguments:
+              type: array
+              items:
+                  $ref: "#/components/schemas/RowExpression"
+    CallExpression:
+      description: >
+          A call expression is a row expression that represents a call to a function.  The functionHandle attribute is an opaque handle to the function that is being called.
+          The arguments attribute is a list of row expressions that are the arguments to the function.
+      allOf:
+        - $ref: "#/components/schemas/RowExpressionParent"
+        - type: object
+          properties:
+            "@type":
+              type: string
+              enum : ["call"]
+            displayName:
+              type: string
+            functionHandle:
+              $ref: "#/components/schemas/FunctionHandle"
+            returnTypeSignature:
+              type: string
+            arguments:
+              type: array
+              items:
+                $ref: "#/components/schemas/RowExpression"
+    FunctionHandle:
+      description: An opaque handle to a function that may be invoked.  This is interpreted by the registered function namespace manager.
+      anyOf:
+        - $ref: "#/components/schemas/OpaqueFunctionHandle"
+        - $ref: "#/components/schemas/SqlFunctionHandle"
+    OpaqueFunctionHandle:
+      type: object
+      properties: {} # any opaque object may be passed and interpreted by a function namespace manager
+    SqlFunctionHandle:
+      type: object
+      properties:
+        functionId:
+          type: string
+        version:
+          type: string

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -135,6 +135,7 @@ import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
 import com.facebook.presto.spi.ConnectorTypeSerde;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
+import com.facebook.presto.spi.RowExpressionSerde;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.plan.SimplePlanFragment;
@@ -142,6 +143,7 @@ import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.PredicateCompiler;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spiller.GenericPartitioningSpillerFactory;
 import com.facebook.presto.spiller.GenericSpillerFactory;
@@ -175,6 +177,7 @@ import com.facebook.presto.sql.analyzer.MetadataExtractorMBean;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
+import com.facebook.presto.sql.expressions.JsonCodecRowExpressionSerde;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -304,6 +307,7 @@ public class PrestoSparkModule
         jsonCodecBinder(binder).bindJsonCodec(BroadcastFileInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(SimplePlanFragment.class);
         binder.bind(SimplePlanFragmentSerde.class).to(JsonCodecSimplePlanFragmentSerde.class).in(Scopes.SINGLETON);
+        jsonCodecBinder(binder).bindJsonCodec(RowExpression.class);
 
         // smile codecs
         smileCodecBinder(binder).bindSmileCodec(TaskSource.class);
@@ -350,6 +354,7 @@ public class PrestoSparkModule
 
         // expression manager
         binder.bind(ExpressionOptimizerManager.class).in(Scopes.SINGLETON);
+        binder.bind(RowExpressionSerde.class).to(JsonCodecRowExpressionSerde.class).in(Scopes.SINGLETON);
 
         // tracer provider managers
         binder.bind(TracerProviderManager.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -80,6 +80,7 @@ import com.facebook.presto.metadata.StaticCatalogStoreConfig;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStoreConfig;
 import com.facebook.presto.metadata.TablePropertyManager;
+import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.operator.FileFragmentResultCacheConfig;
 import com.facebook.presto.operator.FileFragmentResultCacheManager;
 import com.facebook.presto.operator.FragmentCacheStats;
@@ -173,6 +174,7 @@ import com.facebook.presto.sql.analyzer.MetadataExtractor;
 import com.facebook.presto.sql.analyzer.MetadataExtractorMBean;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -346,6 +348,9 @@ public class PrestoSparkModule
         binder.bind(AnalyzePropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(QuerySessionSupplier.class).in(Scopes.SINGLETON);
 
+        // expression manager
+        binder.bind(ExpressionOptimizerManager.class).in(Scopes.SINGLETON);
+
         // tracer provider managers
         binder.bind(TracerProviderManager.class).in(Scopes.SINGLETON);
 
@@ -508,6 +513,7 @@ public class PrestoSparkModule
 
         // TODO: Decouple and remove: required by ConnectorManager
         binder.bind(InternalNodeManager.class).toInstance(new PrestoSparkInternalNodeManager());
+        binder.bind(PluginNodeManager.class);
 
         // TODO: Decouple and remove: required by PluginManager
         binder.bind(InternalResourceGroupManager.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -64,6 +64,7 @@ import com.facebook.presto.spi.function.FunctionImplementationType;
 import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
@@ -502,6 +503,12 @@ public class PrestoSparkQueryRunner
     public TestingAccessControlManager getAccessControl()
     {
         return testingAccessControlManager;
+    }
+
+    @Override
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        throw new UnsupportedOperationException();
     }
 
     public HistoryBasedPlanStatisticsManager getHistoryBasedPlanStatisticsManager()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/CoordinatorPlugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/CoordinatorPlugin.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi;
 
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.session.WorkerSessionPropertyProviderFactory;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
 
 import static java.util.Collections.emptyList;
 
@@ -33,6 +34,11 @@ public interface CoordinatorPlugin
     }
 
     default Iterable<WorkerSessionPropertyProviderFactory> getWorkerSessionPropertyProviderFactories()
+    {
+        return emptyList();
+    }
+
+    default Iterable<ExpressionOptimizerFactory> getExpressionOptimizerFactories()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/RowExpressionSerde.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/RowExpressionSerde.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.facebook.presto.spi.relation.RowExpression;
+
+public interface RowExpressionSerde
+{
+    String serialize(RowExpression expression);
+
+    RowExpression deserialize(String value);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizerProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizerProvider.java
@@ -13,24 +13,7 @@
  */
 package com.facebook.presto.spi.relation;
 
-import com.facebook.presto.spi.ConnectorSession;
-
-/**
- * A set of services/utilities that are helpful for connectors to operate on row expressions
- */
-public interface RowExpressionService
-        extends ExpressionOptimizerProvider
+public interface ExpressionOptimizerProvider
 {
-    DomainTranslator getDomainTranslator();
-
     ExpressionOptimizer getExpressionOptimizer();
-
-    PredicateCompiler getPredicateCompiler();
-
-    DeterminismEvaluator getDeterminismEvaluator();
-
-    /**
-     * @return user-friendly representation of the expression similar to original SQL
-     */
-    String formatRowExpression(ConnectorSession session, RowExpression expression);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerContext.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.sql.planner;
 
 import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.RowExpressionSerde;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 
@@ -22,12 +23,14 @@ import static java.util.Objects.requireNonNull;
 public class ExpressionOptimizerContext
 {
     private final NodeManager nodeManager;
+    private final RowExpressionSerde rowExpressionSerde;
     private final FunctionMetadataManager functionMetadataManager;
     private final StandardFunctionResolution functionResolution;
 
-    public ExpressionOptimizerContext(NodeManager nodeManager, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution functionResolution)
+    public ExpressionOptimizerContext(NodeManager nodeManager, RowExpressionSerde rowExpressionSerde, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution functionResolution)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.rowExpressionSerde = requireNonNull(rowExpressionSerde, "rowExpressionSerde is null");
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
     }
@@ -35,6 +38,11 @@ public class ExpressionOptimizerContext
     public NodeManager getNodeManager()
     {
         return nodeManager;
+    }
+
+    public RowExpressionSerde getRowExpressionSerde()
+    {
+        return rowExpressionSerde;
     }
 
     public FunctionMetadataManager getFunctionMetadataManager()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerContext.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.sql.planner;
+
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+
+import static java.util.Objects.requireNonNull;
+
+public class ExpressionOptimizerContext
+{
+    private final NodeManager nodeManager;
+    private final FunctionMetadataManager functionMetadataManager;
+    private final StandardFunctionResolution functionResolution;
+
+    public ExpressionOptimizerContext(NodeManager nodeManager, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution functionResolution)
+    {
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
+        this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+    }
+
+    public NodeManager getNodeManager()
+    {
+        return nodeManager;
+    }
+
+    public FunctionMetadataManager getFunctionMetadataManager()
+    {
+        return functionMetadataManager;
+    }
+
+    public StandardFunctionResolution getFunctionResolution()
+    {
+        return functionResolution;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.sql.planner;
+
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+
+import java.util.Map;
+
+public interface ExpressionOptimizerFactory
+{
+    ExpressionOptimizer createOptimizer(Map<String, String> config, ExpressionOptimizerContext context);
+
+    String getName();
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -26,10 +26,12 @@ import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.security.AccessDeniedException;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
+import com.facebook.presto.sql.expressions.JsonCodecRowExpressionSerde;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.Plan;
@@ -61,6 +63,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Consumer;
 
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
 import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
@@ -576,7 +579,8 @@ public abstract class AbstractTestQueryFramework
                 featuresConfig,
                 new ExpressionOptimizerManager(
                         new PluginNodeManager(new InMemoryNodeManager()),
-                        queryRunner.getMetadata().getFunctionAndTypeManager()))
+                        queryRunner.getMetadata().getFunctionAndTypeManager(),
+                        new JsonCodecRowExpressionSerde(jsonCodec(RowExpression.class))))
                 .getPlanningTimeOptimizers();
         return new QueryExplainer(
                 optimizers,

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
@@ -624,6 +625,13 @@ public class DistributedQueryRunner
     {
         checkState(coordinators.size() == 1, "Expected a single coordinator");
         return coordinators.get(0).getPlanCheckerProviderManager();
+    }
+
+    @Override
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        checkState(coordinators.size() == 1, "Expected a single coordinator");
+        return coordinators.get(0).getExpressionManager();
     }
 
     public TestingPrestoServer getCoordinator()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
@@ -186,6 +187,12 @@ public final class StandaloneQueryRunner
     public TestingAccessControlManager getAccessControl()
     {
         return server.getAccessControl();
+    }
+
+    @Override
+    public ExpressionOptimizerManager getExpressionManager()
+    {
+        return server.getExpressionManager();
     }
 
     public TestingPrestoServer getServer()

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -512,7 +512,7 @@ public class TestMemoryManager
         queryRunner2.close();
     }
 
-    @Test(timeOut = 60_000, groups = {"clusterPoolsMultiCoordinator"})
+    @Test(timeOut = 600_000, groups = {"clusterPoolsMultiCoordinator"})
     public void testClusterPoolsMultiCoordinator()
             throws Exception
     {
@@ -544,6 +544,7 @@ public class TestMemoryManager
             generalPool = memoryManager.getClusterInfo(GENERAL_POOL);
             reservedPool = memoryManager.getClusterInfo(RESERVED_POOL);
             MILLISECONDS.sleep(10);
+            System.out.println("waiting");
         }
 
         // Make sure the queries are blocked

--- a/presto-tests/src/test/java/com/facebook/presto/tests/expressions/TestDelegatingExpressionOptimizer.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/expressions/TestDelegatingExpressionOptimizer.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.expressions;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.relational.DelegatingRowExpressionOptimizer;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.type.LikeFunctions.castVarcharToLikePattern;
+import static com.facebook.presto.type.LikePatternType.LIKE_PATTERN;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.testng.Assert.assertEquals;
+
+public class TestDelegatingExpressionOptimizer
+        extends TestExpressions
+{
+    private FunctionResolution resolution;
+    private ExpressionOptimizer expressionOptimizer;
+
+    @BeforeClass
+    public void setup()
+    {
+        expressionOptimizer = new DelegatingRowExpressionOptimizer(getMetadata(), new InMemoryExpressionOptimizerProvider(getMetadata()));
+        resolution = new FunctionResolution(getMetadata().getFunctionAndTypeManager().getFunctionAndTypeResolver());
+    }
+
+    @Test
+    public void assertLikeOptimizations()
+    {
+        assertOptimizedMatches("unbound_string LIKE bound_pattern", "unbound_string LIKE CAST('%el%' AS varchar)");
+    }
+
+    @Override
+    protected void assertLike(byte[] value, String pattern, boolean expected)
+    {
+        CallExpression predicate = call(
+                "LIKE",
+                resolution.likeVarcharFunction(),
+                BOOLEAN,
+                ImmutableList.of(
+                        new ConstantExpression(wrappedBuffer(value), VARCHAR),
+                        new ConstantExpression(castVarcharToLikePattern(utf8Slice(pattern)), LIKE_PATTERN)));
+        assertEquals(optimizeRowExpression(predicate, EVALUATED), expected);
+    }
+    @Override
+    protected Object evaluate(String expression, boolean deterministic)
+    {
+        assertRoundTrip(expression);
+        RowExpression rowExpression = sqlToRowExpression(expression);
+        return optimizeRowExpression(rowExpression, EVALUATED);
+    }
+
+    @Override
+    protected Object optimize(@Language("SQL") String expression)
+    {
+        assertRoundTrip(expression);
+        RowExpression parsedExpression = sqlToRowExpression(expression);
+        return optimizeRowExpression(parsedExpression, OPTIMIZED);
+    }
+
+    @Override
+    protected Object optimizeRowExpression(RowExpression expression, Level level)
+    {
+        Object optimized = expressionOptimizer.optimize(
+                expression,
+                level,
+                TEST_SESSION.toConnectorSession(),
+                variable -> {
+                    Symbol symbol = new Symbol(variable.getName());
+                    Object value = symbolConstant(symbol);
+                    if (value == null) {
+                        return new VariableReferenceExpression(Optional.empty(), symbol.getName(), SYMBOL_TYPES.get(symbol.toSymbolReference()));
+                    }
+                    return value;
+                });
+        return unwrap(optimized);
+    }
+
+    public Object unwrap(Object result)
+    {
+        if (result instanceof ConstantExpression) {
+            return ((ConstantExpression) result).getValue();
+        }
+        else {
+            return result;
+        }
+    }
+
+    @Override
+    protected void assertOptimizedEquals(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        Object optimizedActual = optimize(actual);
+        Object optimizedExpected = optimize(expected);
+        assertRowExpressionEvaluationEquals(optimizedActual, optimizedExpected);
+    }
+
+    @Override
+    protected void assertOptimizedMatches(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        Object actualOptimized = optimize(actual);
+        Object expectedOptimized = optimize(expected);
+        assertRowExpressionEvaluationEquals(
+                actualOptimized,
+                expectedOptimized);
+    }
+
+    @Override
+    protected void assertDoNotOptimize(@Language("SQL") String expression, Level optimizationLevel)
+    {
+        assertRoundTrip(expression);
+        RowExpression rowExpression = sqlToRowExpression(expression);
+        Object rowExpressionResult = optimizeRowExpression(rowExpression, optimizationLevel);
+        assertRowExpressionEvaluationEquals(rowExpressionResult, rowExpression);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/expressions/TestExpressionInterpreter.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/expressions/TestExpressionInterpreter.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.expressions;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.scalar.FunctionAssertions;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.planner.ExpressionInterpreter;
+import com.facebook.presto.sql.planner.RowExpressionInterpreter;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.LikePredicate;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static com.facebook.presto.sql.planner.ExpressionInterpreter.expressionInterpreter;
+import static com.facebook.presto.sql.planner.ExpressionInterpreter.expressionOptimizer;
+import static com.facebook.presto.sql.planner.RowExpressionInterpreter.rowExpressionInterpreter;
+import static java.util.Collections.emptyMap;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestExpressionInterpreter
+        extends TestExpressions
+{
+    private final TestingRowExpressionTranslator translator = new TestingRowExpressionTranslator(getMetadata());
+
+    @Test
+    public void assertLikeOptimizations()
+    {
+        assertOptimizedEquals("unbound_string LIKE bound_pattern", "unbound_string LIKE bound_pattern");
+    }
+
+    @Override
+    protected void assertLike(byte[] value, String pattern, boolean expected)
+    {
+        Expression predicate = new LikePredicate(
+                rawStringLiteral(Slices.wrappedBuffer(value)),
+                new StringLiteral(pattern),
+                Optional.empty());
+        assertEquals(evaluate(predicate, true), expected);
+    }
+
+    private static StringLiteral rawStringLiteral(final Slice slice)
+    {
+        return new StringLiteral(slice.toStringUtf8())
+        {
+            @Override
+            public Slice getSlice()
+            {
+                return slice;
+            }
+        };
+    }
+
+    @Override
+    protected void assertOptimizedEquals(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        assertEquals(optimize(actual), optimize(expected));
+    }
+
+    @Override
+    protected void assertOptimizedMatches(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        // replaces FunctionCalls to FailureFunction by fail()
+        Object actualOptimized = optimize(actual);
+        if (actualOptimized instanceof Expression) {
+            actualOptimized = ExpressionTreeRewriter.rewriteWith(new FailedFunctionRewriter(), (Expression) actualOptimized);
+        }
+        assertEquals(
+                actualOptimized,
+                rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expected)));
+    }
+
+    @Override
+    protected Object optimize(@Language("SQL") String expression)
+    {
+        assertRoundTrip(expression);
+
+        Expression parsedExpression = expression(expression);
+        Object expressionResult = optimize(parsedExpression);
+
+        RowExpression rowExpression = toRowExpression(parsedExpression);
+        Object rowExpressionResult = optimizeRowExpression(rowExpression, OPTIMIZED);
+        assertExpressionAndRowExpressionEquals(expressionResult, rowExpressionResult);
+        return expressionResult;
+    }
+
+    @Override
+    protected Object optimizeRowExpression(RowExpression expression, ExpressionOptimizer.Level level)
+    {
+        RowExpressionInterpreter rowExpressionInterpreter = new RowExpressionInterpreter(expression, getMetadata(), TEST_SESSION.toConnectorSession(), level);
+        return rowExpressionInterpreter.optimize(variable -> {
+            Symbol symbol = new Symbol(variable.getName());
+            Object value = symbolConstant(symbol);
+            if (value == null) {
+                return new VariableReferenceExpression(Optional.empty(), symbol.getName(), SYMBOL_TYPES.get(symbol.toSymbolReference()));
+            }
+            return value;
+        });
+    }
+
+    private Expression expression(String expression)
+    {
+        return FunctionAssertions.createExpression(expression, getMetadata(), SYMBOL_TYPES);
+    }
+
+    private RowExpression toRowExpression(Expression expression)
+    {
+        return translator.translate(expression, SYMBOL_TYPES);
+    }
+
+    private Object optimize(Expression expression)
+    {
+        Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, getMetadata(), SQL_PARSER, SYMBOL_TYPES, expression, emptyMap(), WarningCollector.NOOP);
+        ExpressionInterpreter interpreter = expressionOptimizer(expression, getMetadata(), TEST_SESSION, expressionTypes);
+        return interpreter.optimize(variable -> {
+            Symbol symbol = new Symbol(variable.getName());
+            Object value = symbolConstant(symbol);
+            if (value == null) {
+                return symbol.toSymbolReference();
+            }
+            return value;
+        });
+    }
+
+    @Override
+    protected void assertDoNotOptimize(@Language("SQL") String expression, Level optimizationLevel)
+    {
+        assertRoundTrip(expression);
+        Expression translatedExpression = expression(expression);
+        RowExpression rowExpression = toRowExpression(translatedExpression);
+
+        Object expressionResult = optimize(translatedExpression);
+        if (expressionResult instanceof Expression) {
+            expressionResult = toRowExpression((Expression) expressionResult);
+        }
+        Object rowExpressionResult = optimizeRowExpression(rowExpression, optimizationLevel);
+        assertRowExpressionEvaluationEquals(expressionResult, rowExpressionResult);
+        assertRowExpressionEvaluationEquals(rowExpressionResult, rowExpression);
+    }
+
+    private void assertExpressionAndRowExpressionEquals(Object expressionResult, Object rowExpressionResult)
+    {
+        if (rowExpressionResult instanceof RowExpression) {
+            // Cannot be completely evaluated into a constant; compare expressions
+            assertTrue(expressionResult instanceof Expression);
+
+            // It is tricky to check the equivalence of an expression and a row expression.
+            // We rely on the optimized translator to fill the gap.
+            RowExpression translated = translator.translateAndOptimize((Expression) expressionResult, SYMBOL_TYPES);
+            assertRowExpressionEvaluationEquals(translated, rowExpressionResult);
+        }
+        else {
+            // We have constants; directly compare
+            assertRowExpressionEvaluationEquals(expressionResult, rowExpressionResult);
+        }
+    }
+    @Override
+    protected Object evaluate(String expression, boolean deterministic)
+    {
+        assertRoundTrip(expression);
+
+        Expression parsedExpression = FunctionAssertions.createExpression(expression, getMetadata(), SYMBOL_TYPES);
+
+        return evaluate(parsedExpression, deterministic);
+    }
+
+    private Object evaluate(Expression expression, boolean deterministic)
+    {
+        Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, getMetadata(), SQL_PARSER, SYMBOL_TYPES, expression, emptyMap(), WarningCollector.NOOP);
+        Object expressionResult = expressionInterpreter(expression, getMetadata(), TEST_SESSION, expressionTypes).evaluate();
+        Object rowExpressionResult = rowExpressionInterpreter(translator.translateAndOptimize(expression), getMetadata().getFunctionAndTypeManager(), TEST_SESSION.toConnectorSession()).evaluate();
+
+        if (deterministic) {
+            assertExpressionAndRowExpressionEquals(expressionResult, rowExpressionResult);
+        }
+        return expressionResult;
+    }
+
+    private static class FailedFunctionRewriter
+            extends ExpressionRewriter<Object>
+    {
+        @Override
+        public Expression rewriteFunctionCall(FunctionCall node, Object context, ExpressionTreeRewriter<Object> treeRewriter)
+        {
+            if (node.getName().equals(QualifiedName.of("fail"))) {
+                return new FunctionCall(QualifiedName.of("fail"), ImmutableList.of(node.getArguments().get(0), new StringLiteral("ignored failure message")));
+            }
+            return node;
+        }
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/expressions/TestExpressionOptimizers.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/expressions/TestExpressionOptimizers.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.expressions;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+import com.google.common.collect.ImmutableList;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.type.LikeFunctions.castVarcharToLikePattern;
+import static com.facebook.presto.type.LikePatternType.LIKE_PATTERN;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.testng.Assert.assertEquals;
+
+public class TestExpressionOptimizers
+        extends TestExpressions
+{
+    private final FunctionResolution resolution = new FunctionResolution(getMetadata().getFunctionAndTypeManager().getFunctionAndTypeResolver());
+    private ExpressionOptimizer expressionOptimizer;
+
+    @BeforeClass
+    public void setup()
+    {
+        expressionOptimizer = new RowExpressionOptimizer(getMetadata().getFunctionAndTypeManager());
+    }
+
+    @Test
+    public void assertLikeOptimizations()
+    {
+        assertOptimizedMatches("unbound_string LIKE bound_pattern", "unbound_string LIKE CAST('%el%' AS varchar)");
+    }
+
+    @Override
+    protected void assertLike(byte[] value, String pattern, boolean expected)
+    {
+        CallExpression predicate = call(
+                "LIKE",
+                resolution.likeVarcharFunction(),
+                BOOLEAN,
+                ImmutableList.of(
+                        new ConstantExpression(wrappedBuffer(value), VARCHAR),
+                        new ConstantExpression(castVarcharToLikePattern(utf8Slice(pattern)), LIKE_PATTERN)));
+        assertEquals(optimizeRowExpression(predicate, EVALUATED), expected);
+    }
+    @Override
+    protected Object evaluate(String expression, boolean deterministic)
+    {
+        assertRoundTrip(expression);
+        RowExpression rowExpression = sqlToRowExpression(expression);
+        return optimizeRowExpression(rowExpression, EVALUATED);
+    }
+
+    @Override
+    protected Object optimize(@Language("SQL") String expression)
+    {
+        assertRoundTrip(expression);
+        RowExpression parsedExpression = sqlToRowExpression(expression);
+        return optimizeRowExpression(parsedExpression, OPTIMIZED);
+    }
+
+    @Override
+    protected Object optimizeRowExpression(RowExpression expression, ExpressionOptimizer.Level level)
+    {
+        return expressionOptimizer.optimize(
+                expression,
+                level,
+                TEST_SESSION.toConnectorSession(),
+                variable -> {
+                    Symbol symbol = new Symbol(variable.getName());
+                    Object value = symbolConstant(symbol);
+                    if (value == null) {
+                        return new VariableReferenceExpression(Optional.empty(), symbol.getName(), SYMBOL_TYPES.get(symbol.toSymbolReference()));
+                    }
+                    return value;
+                });
+    }
+
+    @Override
+    protected void assertOptimizedEquals(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        Object optimizedActual = optimize(actual);
+        Object optimizedExpected = optimize(expected);
+        assertEquals(optimizedActual, optimizedExpected);
+    }
+
+    @Override
+    protected void assertOptimizedMatches(@Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        Object actualOptimized = optimize(actual);
+        Object expectedOptimized = optimize(expected);
+        assertRowExpressionEvaluationEquals(
+                actualOptimized,
+                expectedOptimized);
+    }
+
+    @Override
+    protected void assertDoNotOptimize(@Language("SQL") String expression, Level optimizationLevel)
+    {
+        assertRoundTrip(expression);
+        RowExpression rowExpression = sqlToRowExpression(expression);
+        Object rowExpressionResult = optimizeRowExpression(rowExpression, optimizationLevel);
+        assertRowExpressionEvaluationEquals(rowExpressionResult, rowExpression);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/expressions/TestExpressions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/expressions/TestExpressions.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.sql;
+package com.facebook.presto.tests.expressions;
 
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
@@ -24,14 +24,11 @@ import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.common.type.SqlTimestampWithTimeZone;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.functionNamespace.json.JsonFileBasedFunctionNamespaceManagerFactory;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.operator.scalar.FunctionAssertions;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.AggregationFunctionMetadata;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.function.Parameter;
@@ -39,26 +36,19 @@ import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.InputReferenceExpression;
 import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.ExpressionInterpreter;
-import com.facebook.presto.sql.planner.RowExpressionInterpreter;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.ExpressionRewriter;
-import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
-import com.facebook.presto.sql.tree.FunctionCall;
-import com.facebook.presto.sql.tree.LikePredicate;
-import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.sql.tree.StringLiteral;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -71,11 +61,9 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.math.BigInteger;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
@@ -91,37 +79,33 @@ import static com.facebook.presto.common.type.TimeType.TIME;
 import static com.facebook.presto.common.type.TimeZoneKey.getTimeZoneKey;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.operator.scalar.ApplyFunction.APPLY_FUNCTION;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
 import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.DETERMINISTIC;
 import static com.facebook.presto.spi.function.RoutineCharacteristics.Language.CPP;
-import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.SERIALIZABLE;
 import static com.facebook.presto.sql.ExpressionFormatter.formatExpression;
-import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
-import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
-import static com.facebook.presto.sql.planner.ExpressionInterpreter.expressionInterpreter;
-import static com.facebook.presto.sql.planner.ExpressionInterpreter.expressionOptimizer;
-import static com.facebook.presto.sql.planner.RowExpressionInterpreter.rowExpressionInterpreter;
 import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 import static com.facebook.presto.util.AnalyzerUtil.createParsingOptions;
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.String.format;
-import static java.util.Collections.emptyMap;
 import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-public class TestExpressionInterpreter
+public abstract class TestExpressions
 {
-    public static final SqlInvokedFunction SQUARE_UDF_CPP = new SqlInvokedFunction(
+    private static final SqlInvokedFunction SQUARE_UDF_CPP = new SqlInvokedFunction(
             QualifiedObjectName.valueOf(new CatalogSchemaName("json", "test_schema"), "square"),
             ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.BIGINT))),
             parseTypeSignature(StandardTypes.BIGINT),
@@ -130,7 +114,7 @@ public class TestExpressionInterpreter
             "",
             notVersioned());
 
-    public static final SqlInvokedFunction AVG_UDAF_CPP = new SqlInvokedFunction(
+    private static final SqlInvokedFunction AVG_UDAF_CPP = new SqlInvokedFunction(
             QualifiedObjectName.valueOf(new CatalogSchemaName("json", "test_schema"), "avg"),
             ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.DOUBLE))),
             parseTypeSignature(StandardTypes.DOUBLE),
@@ -142,11 +126,11 @@ public class TestExpressionInterpreter
             Optional.of(new AggregationFunctionMetadata(parseTypeSignature("ROW(double, int)"), false)));
 
     private static final int TEST_VARCHAR_TYPE_LENGTH = 17;
-    private static final TypeProvider SYMBOL_TYPES = TypeProvider.viewOf(ImmutableMap.<String, Type>builder()
+    protected static final TypeProvider SYMBOL_TYPES = TypeProvider.viewOf(ImmutableMap.<String, Type>builder()
             .put("bound_integer", INTEGER)
             .put("bound_long", BIGINT)
             .put("bound_string", createVarcharType(TEST_VARCHAR_TYPE_LENGTH))
-            .put("bound_varbinary", VarbinaryType.VARBINARY)
+            .put("bound_varbinary", VARBINARY)
             .put("bound_double", DOUBLE)
             .put("bound_boolean", BOOLEAN)
             .put("bound_date", DATE)
@@ -173,16 +157,20 @@ public class TestExpressionInterpreter
             .put("unbound_null_string", VARCHAR)
             .build());
 
-    private static final SqlParser SQL_PARSER = new SqlParser();
-    private static final Metadata METADATA = MetadataManager.createTestMetadataManager();
-    private static final TestingRowExpressionTranslator TRANSLATOR = new TestingRowExpressionTranslator(METADATA);
-    private static final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager();
+    protected static final SqlParser SQL_PARSER = new SqlParser();
+    private final Metadata metadata = createTestMetadataManager();
+    private final TestingRowExpressionTranslator translator = new TestingRowExpressionTranslator(metadata);
+    private static final BlockEncodingSerde BLOCK_ENCODING_SERDE = new BlockEncodingManager();
 
-    @BeforeClass
-    public void setup()
+    public TestExpressions()
     {
-        METADATA.getFunctionAndTypeManager().registerBuiltInFunctions(ImmutableList.of(APPLY_FUNCTION));
-        setupJsonFunctionNamespaceManager(METADATA.getFunctionAndTypeManager());
+        metadata.getFunctionAndTypeManager().registerBuiltInFunctions(ImmutableList.of(APPLY_FUNCTION));
+        setupJsonFunctionNamespaceManager(metadata.getFunctionAndTypeManager());
+    }
+
+    public Metadata getMetadata()
+    {
+        return metadata;
     }
 
     @Test
@@ -415,19 +403,19 @@ public class TestExpressionInterpreter
     @Test
     public void testCppFunctionCall()
     {
-        METADATA.getFunctionAndTypeManager().createFunction(SQUARE_UDF_CPP, false);
+        metadata.getFunctionAndTypeManager().createFunction(SQUARE_UDF_CPP, false);
         assertOptimizedEquals("json.test_schema.square(-5)", "json.test_schema.square(-5)");
     }
 
     @Test
     public void testCppAggregateFunctionCall()
     {
-        METADATA.getFunctionAndTypeManager().createFunction(AVG_UDAF_CPP, false);
+        metadata.getFunctionAndTypeManager().createFunction(AVG_UDAF_CPP, false);
         assertOptimizedEquals("json.test_schema.avg(1.0)", "json.test_schema.avg(1.0)");
     }
 
     // Run this method exactly once.
-    private void setupJsonFunctionNamespaceManager(FunctionAndTypeManager functionAndTypeManager)
+    protected void setupJsonFunctionNamespaceManager(FunctionAndTypeManager functionAndTypeManager)
     {
         functionAndTypeManager.addFunctionNamespaceFactory(new JsonFileBasedFunctionNamespaceManagerFactory());
         functionAndTypeManager.loadFunctionNamespaceManager(
@@ -1162,14 +1150,14 @@ public class TestExpressionInterpreter
                         "else 3 " +
                         "end");
 
-        assertOptimizedEquals("case true " +
+        assertOptimizedMatches("case true " +
                         "when unbound_long = 1 then 1 " +
                         "when 0 / 0 = 0 then 2 " +
                         "else 33 end",
                 "" +
                         "case true " +
-                        "when unbound_long = 1 then 1 " +
-                        "when 0 / 0 = 0 then 2 else 33 " +
+                        "when unbound_long = BIGINT '1' then 1 " +
+                        "when CAST(fail(8, 'ignored failure message') AS boolean) then 2 else 33 " +
                         "end");
 
         assertOptimizedEquals("case bound_long " +
@@ -1197,18 +1185,6 @@ public class TestExpressionInterpreter
                 "" +
                         "case bound_long " +
                         "when unbound_long then 4 " +
-                        "end");
-
-        assertOptimizedMatches("case 1 " +
-                        "when unbound_long then 1 " +
-                        "when 0 / 0 then 2 " +
-                        "else 1 " +
-                        "end",
-                "" +
-                        "case BIGINT '1' " +
-                        "when unbound_long then 1 " +
-                        "when cast(fail(8, 'ignored failure message') AS integer) then 2 " +
-                        "else 1 " +
                         "end");
 
         assertOptimizedMatches("case 1 " +
@@ -1394,16 +1370,15 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("unbound_string LIKE 'a#_b' ESCAPE '#'", "unbound_string = CAST('a_b' AS VARCHAR)");
         assertOptimizedEquals("unbound_string LIKE 'a#%b' ESCAPE '#'", "unbound_string = CAST('a%b' AS VARCHAR)");
         assertOptimizedEquals("unbound_string LIKE 'a#_##b' ESCAPE '#'", "unbound_string = CAST('a_#b' AS VARCHAR)");
-        assertOptimizedEquals("unbound_string LIKE 'a#__b' ESCAPE '#'", "unbound_string LIKE 'a#__b' ESCAPE '#'");
-        assertOptimizedEquals("unbound_string LIKE 'a##%b' ESCAPE '#'", "unbound_string LIKE 'a##%b' ESCAPE '#'");
+        assertOptimizedMatches("unbound_string LIKE 'a#__b' ESCAPE '#'", "unbound_string LIKE 'a#__b' ESCAPE '#'");
+        assertOptimizedMatches("unbound_string LIKE 'a##%b' ESCAPE '#'", "unbound_string LIKE 'a##%b' ESCAPE '#'");
 
         assertOptimizedEquals("bound_string LIKE bound_pattern", "true");
         assertOptimizedEquals("'abc' LIKE bound_pattern", "false");
 
-        assertOptimizedEquals("unbound_string LIKE bound_pattern", "unbound_string LIKE bound_pattern");
         assertDoNotOptimize("unbound_string LIKE 'abc%'", SERIALIZABLE);
 
-        assertOptimizedEquals("unbound_string LIKE unbound_pattern ESCAPE unbound_string", "unbound_string LIKE unbound_pattern ESCAPE unbound_string");
+        assertOptimizedMatches("unbound_string LIKE unbound_pattern ESCAPE unbound_string", "unbound_string LIKE unbound_pattern ESCAPE unbound_string");
     }
 
     @Test
@@ -1586,123 +1561,27 @@ public class TestExpressionInterpreter
         optimize("interval '3' day * unbound_long");
         optimize("interval '3' year * unbound_long");
 
-        assertEquals(optimize("X'1234'"), Slices.wrappedBuffer((byte) 0x12, (byte) 0x34));
+        assertEquals(optimize("X'1234'"), wrappedBuffer((byte) 0x12, (byte) 0x34));
     }
+    protected abstract Object evaluate(String expression, boolean deterministic);
 
-    private static void assertLike(byte[] value, String pattern, boolean expected)
+    protected abstract Object optimize(@Language("SQL") String expression);
+
+    protected abstract void assertOptimizedEquals(@Language("SQL") String expression, @Language("SQL") String expected);
+
+    protected abstract void assertLike(byte[] value, String pattern, boolean expected);
+
+    protected abstract void assertOptimizedMatches(@Language("SQL") String actual, @Language("SQL") String expected);
+
+    protected abstract void assertDoNotOptimize(@Language("SQL") String expression, ExpressionOptimizer.Level optimizationLevel);
+
+    protected RowExpression sqlToRowExpression(String expression)
     {
-        Expression predicate = new LikePredicate(
-                rawStringLiteral(Slices.wrappedBuffer(value)),
-                new StringLiteral(pattern),
-                Optional.empty());
-        assertEquals(evaluate(predicate, true), expected);
+        Expression parsedExpression = FunctionAssertions.createExpression(expression, metadata, SYMBOL_TYPES);
+        return translator.translate(parsedExpression, SYMBOL_TYPES);
     }
 
-    private static StringLiteral rawStringLiteral(final Slice slice)
-    {
-        return new StringLiteral(slice.toStringUtf8())
-        {
-            @Override
-            public Slice getSlice()
-            {
-                return slice;
-            }
-        };
-    }
-
-    private static void assertOptimizedEquals(@Language("SQL") String actual, @Language("SQL") String expected)
-    {
-        assertEquals(optimize(actual), optimize(expected));
-    }
-
-    private static void assertRowExpressionEquals(Level level, @Language("SQL") String actual, @Language("SQL") String expected)
-    {
-        Object actualResult = optimize(toRowExpression(expression(actual)), level);
-        Object expectedResult = optimize(toRowExpression(expression(expected)), level);
-        if (actualResult instanceof Block && expectedResult instanceof Block) {
-            assertEquals(blockToSlice((Block) actualResult), blockToSlice((Block) expectedResult));
-            return;
-        }
-        assertEquals(actualResult, expectedResult);
-    }
-
-    private static void assertOptimizedMatches(@Language("SQL") String actual, @Language("SQL") String expected)
-    {
-        // replaces FunctionCalls to FailureFunction by fail()
-        Object actualOptimized = optimize(actual);
-        if (actualOptimized instanceof Expression) {
-            actualOptimized = ExpressionTreeRewriter.rewriteWith(new FailedFunctionRewriter(), (Expression) actualOptimized);
-        }
-        assertEquals(
-                actualOptimized,
-                rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expected)));
-    }
-
-    private static Object optimize(@Language("SQL") String expression)
-    {
-        assertRoundTrip(expression);
-
-        Expression parsedExpression = expression(expression);
-        Object expressionResult = optimize(parsedExpression);
-
-        RowExpression rowExpression = toRowExpression(parsedExpression);
-        Object rowExpressionResult = optimize(rowExpression, OPTIMIZED);
-        assertExpressionAndRowExpressionEquals(expressionResult, rowExpressionResult);
-        return expressionResult;
-    }
-
-    private static Expression expression(String expression)
-    {
-        return FunctionAssertions.createExpression(expression, METADATA, SYMBOL_TYPES);
-    }
-
-    private static RowExpression toRowExpression(Expression expression)
-    {
-        return TRANSLATOR.translate(expression, SYMBOL_TYPES);
-    }
-
-    private static Object optimize(Expression expression)
-    {
-        Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, SYMBOL_TYPES, expression, emptyMap(), WarningCollector.NOOP);
-        ExpressionInterpreter interpreter = expressionOptimizer(expression, METADATA, TEST_SESSION, expressionTypes);
-        return interpreter.optimize(variable -> {
-            Symbol symbol = new Symbol(variable.getName());
-            Object value = symbolConstant(symbol);
-            if (value == null) {
-                return symbol.toSymbolReference();
-            }
-            return value;
-        });
-    }
-
-    private static Object optimize(RowExpression expression, Level level)
-    {
-        return new RowExpressionInterpreter(expression, METADATA.getFunctionAndTypeManager(), TEST_SESSION.toConnectorSession(), level).optimize(variable -> {
-            Symbol symbol = new Symbol(variable.getName());
-            Object value = symbolConstant(symbol);
-            if (value == null) {
-                return new VariableReferenceExpression(Optional.empty(), symbol.getName(), SYMBOL_TYPES.get(symbol.toSymbolReference()));
-            }
-            return value;
-        });
-    }
-
-    private static void assertDoNotOptimize(@Language("SQL") String expression, Level optimizationLevel)
-    {
-        assertRoundTrip(expression);
-        Expression translatedExpression = expression(expression);
-        RowExpression rowExpression = toRowExpression(translatedExpression);
-
-        Object expressionResult = optimize(translatedExpression);
-        if (expressionResult instanceof Expression) {
-            expressionResult = toRowExpression((Expression) expressionResult);
-        }
-        Object rowExpressionResult = optimize(rowExpression, optimizationLevel);
-        assertRowExpressionEvaluationEquals(expressionResult, rowExpressionResult);
-        assertRowExpressionEvaluationEquals(rowExpressionResult, rowExpression);
-    }
-
-    private static Object symbolConstant(Symbol symbol)
+    protected Object symbolConstant(Symbol symbol)
     {
         switch (symbol.getName().toLowerCase(ENGLISH)) {
             case "bound_integer":
@@ -1733,32 +1612,14 @@ public class TestExpressionInterpreter
         return null;
     }
 
-    private static void assertExpressionAndRowExpressionEquals(Object expressionResult, Object rowExpressionResult)
-    {
-        if (rowExpressionResult instanceof RowExpression) {
-            // Cannot be completely evaluated into a constant; compare expressions
-            assertTrue(expressionResult instanceof Expression);
-
-            // It is tricky to check the equivalence of an expression and a row expression.
-            // We rely on the optimized translator to fill the gap.
-            RowExpression translated = TRANSLATOR.translateAndOptimize((Expression) expressionResult, SYMBOL_TYPES);
-            assertRowExpressionEvaluationEquals(translated, rowExpressionResult);
-        }
-        else {
-            // We have constants; directly compare
-            assertRowExpressionEvaluationEquals(expressionResult, rowExpressionResult);
-        }
-    }
-
     /**
      * Assert the evaluation result of two row expressions equivalent
      * no matter they are constants or remaining row expressions.
      */
-    private static void assertRowExpressionEvaluationEquals(Object left, Object right)
+    protected void assertRowExpressionEvaluationEquals(Object left, Object right)
     {
         if (right instanceof RowExpression) {
             assertTrue(left instanceof RowExpression);
-            // assertEquals(((RowExpression) left).getType(), ((RowExpression) right).getType());
             if (left instanceof ConstantExpression) {
                 if (isRemovableCast(right)) {
                     assertRowExpressionEvaluationEquals(left, ((CallExpression) right).getArguments().get(0));
@@ -1769,6 +1630,13 @@ public class TestExpressionInterpreter
             }
             else if (left instanceof InputReferenceExpression || left instanceof VariableReferenceExpression) {
                 assertEquals(left, right);
+            }
+            else if (left instanceof CallExpression && ((CallExpression) left).getFunctionHandle().getName().contains("fail")) {
+                assertTrue(right instanceof CallExpression && ((CallExpression) right).getFunctionHandle().getName().contains("fail"));
+                assertEquals(((CallExpression) left).getArguments().size(), ((CallExpression) right).getArguments().size());
+                for (int i = 0; i < ((CallExpression) left).getArguments().size(); i++) {
+                    assertRowExpressionEvaluationEquals(((CallExpression) left).getArguments().get(i), ((CallExpression) right).getArguments().get(i));
+                }
             }
             else if (left instanceof CallExpression) {
                 assertTrue(right instanceof CallExpression);
@@ -1806,68 +1674,46 @@ public class TestExpressionInterpreter
         }
     }
 
-    private static boolean isRemovableCast(Object value)
+    private boolean isRemovableCast(Object value)
     {
         if (value instanceof CallExpression &&
-                new FunctionResolution(METADATA.getFunctionAndTypeManager().getFunctionAndTypeResolver()).isCastFunction(((CallExpression) value).getFunctionHandle())) {
+                new FunctionResolution(metadata.getFunctionAndTypeManager().getFunctionAndTypeResolver()).isCastFunction(((CallExpression) value).getFunctionHandle())) {
             Type targetType = ((CallExpression) value).getType();
             Type sourceType = ((CallExpression) value).getArguments().get(0).getType();
-            return METADATA.getFunctionAndTypeManager().canCoerce(sourceType, targetType);
+            return metadata.getFunctionAndTypeManager().canCoerce(sourceType, targetType);
         }
         return false;
     }
 
-    private static Slice blockToSlice(Block block)
+    protected Slice blockToSlice(Block block)
     {
         // This function is strictly for testing use only
         SliceOutput sliceOutput = new DynamicSliceOutput(1000);
-        BlockSerdeUtil.writeBlock(blockEncodingSerde, sliceOutput, block);
+        BlockSerdeUtil.writeBlock(BLOCK_ENCODING_SERDE, sliceOutput, block);
         return sliceOutput.slice();
     }
 
-    private static void assertEvaluatedEquals(@Language("SQL") String actual, @Language("SQL") String expected)
+    protected void assertEvaluatedEquals(@Language("SQL") String actual, @Language("SQL") String expected)
     {
         assertEquals(evaluate(actual, true), evaluate(expected, true));
     }
 
-    private static Object evaluate(String expression, boolean deterministic)
-    {
-        assertRoundTrip(expression);
-
-        Expression parsedExpression = FunctionAssertions.createExpression(expression, METADATA, SYMBOL_TYPES);
-
-        return evaluate(parsedExpression, deterministic);
-    }
-
-    private static void assertRoundTrip(String expression)
+    protected void assertRoundTrip(String expression)
     {
         ParsingOptions parsingOptions = createParsingOptions(TEST_SESSION);
         assertEquals(SQL_PARSER.createExpression(expression, parsingOptions),
                 SQL_PARSER.createExpression(formatExpression(SQL_PARSER.createExpression(expression, parsingOptions), Optional.empty()), parsingOptions));
     }
-
-    private static Object evaluate(Expression expression, boolean deterministic)
+    protected void assertRowExpressionEquals(ExpressionOptimizer.Level level, @Language("SQL") String actual, @Language("SQL") String expected)
     {
-        Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, SYMBOL_TYPES, expression, emptyMap(), WarningCollector.NOOP);
-        Object expressionResult = expressionInterpreter(expression, METADATA, TEST_SESSION, expressionTypes).evaluate();
-        Object rowExpressionResult = rowExpressionInterpreter(TRANSLATOR.translateAndOptimize(expression), METADATA.getFunctionAndTypeManager(), TEST_SESSION.toConnectorSession()).evaluate();
-
-        if (deterministic) {
-            assertExpressionAndRowExpressionEquals(expressionResult, rowExpressionResult);
+        Object actualResult = optimizeRowExpression(sqlToRowExpression(actual), level);
+        Object expectedResult = optimizeRowExpression(sqlToRowExpression(expected), level);
+        if (actualResult instanceof Block && expectedResult instanceof Block) {
+            assertEquals(blockToSlice((Block) actualResult), blockToSlice((Block) expectedResult));
+            return;
         }
-        return expressionResult;
+        assertEquals(actualResult, expectedResult);
     }
 
-    private static class FailedFunctionRewriter
-            extends ExpressionRewriter<Object>
-    {
-        @Override
-        public Expression rewriteFunctionCall(FunctionCall node, Object context, ExpressionTreeRewriter<Object> treeRewriter)
-        {
-            if (node.getName().equals(QualifiedName.of("fail"))) {
-                return new FunctionCall(QualifiedName.of("fail"), ImmutableList.of(node.getArguments().get(0), new StringLiteral("ignored failure message")));
-            }
-            return node;
-        }
-    }
+    protected abstract Object optimizeRowExpression(RowExpression expression, ExpressionOptimizer.Level level);
 }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.sanity.PlanCheckerProviderManager;
@@ -252,6 +253,12 @@ public final class ThriftQueryRunner
         public TestingAccessControlManager getAccessControl()
         {
             return source.getAccessControl();
+        }
+
+        @Override
+        public ExpressionOptimizerManager getExpressionManager()
+        {
+            return source.getExpressionManager();
         }
 
         @Override


### PR DESCRIPTION
## Description
Add a `ExpressionOptimizer` which delegates to the native sidecar process to evaluate expressions with Velox.

Depends on #24144

## Motivation and Context
[RFC-0006](https://github.com/prestodb/rfcs/blob/main/RFC-0006-expression-eval.md). See https://github.com/prestodb/presto/pull/24126 for larger changes that include the Presto sidecar as described in the RFC.

## Impact
No impact by default as the old in-memory evaluation is the default.

## Test Plan
Tests have been added.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

