### PR TITLE
[native] Wrap multistatement macros in a do-while loop

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -32,11 +32,11 @@
 #include <sys/resource.h>
 
 namespace {
-#define REPORT_IF_NOT_ZERO(name, counter)   \
-  do {                                      \
-    if ((counter) != 0) {                   \
+#define REPORT_IF_NOT_ZERO(name, counter)     \
+  do {                                        \
+    if ((counter) != 0) {                     \
       RECORD_METRIC_VALUE((name), (counter)); \
-    }                                       \
+    }                                         \
   } while (0)
 } // namespace
 

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -35,7 +35,7 @@ namespace {
 #define REPORT_IF_NOT_ZERO(name, counter)   \
   do {                                      \
     if ((counter) != 0) {                   \
-    RECORD_METRIC_VALUE((name), (counter)); \
+      RECORD_METRIC_VALUE((name), (counter)); \
     }                                       \
   } while (0)
 } // namespace

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -33,9 +33,11 @@
 
 namespace {
 #define REPORT_IF_NOT_ZERO(name, counter)   \
-  if ((counter) != 0) {                     \
+  do {                                      \
+    if ((counter) != 0) {                   \
     RECORD_METRIC_VALUE((name), (counter)); \
-  }
+    }                                       \
+  } while (0)
 } // namespace
 
 namespace facebook::presto {


### PR DESCRIPTION
## Description
Updated the REPORT_IF_NOT_ZERO macro to wrap multistatement operations in a do { ... } while (0) construct. This change ensures proper scoping and avoids potential bugs when the macro is used in conditional statements without braces.

## Motivation and Context
The previous implementation of the macro did not enforce scoping, which could lead to unintended behavior in specific contexts, such as when used in an if-else block without braces. By adhering to best practices recommended by CERT C's PRE10-C standard, this update improves code reliability and maintainability.
## Impact
This change prevents subtle bugs and undefined behavior caused by improper scoping of multistatement macros. It aligns the code with industry best practices and coding standards, enhancing overall robustness without affecting functionality or performance.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

