### PR TITLE
[native] Refactor Duration::toString and DataSize::toString to use fmt::format

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/core/DataSize.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/DataSize.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/presto_protocol/core/DataSize.h"
+#include <fmt/format.h>
 #include <math.h>
 
 namespace facebook::presto::protocol {
@@ -29,16 +30,9 @@ DataSize::DataSize(const std::string& string) {
 }
 
 std::string DataSize::toString() const {
-  char buffer[32];
-  snprintf(
-      buffer,
-      sizeof(buffer),
-      "%f%s",
-      round(value_ * 100.0) / 100.0,
-      dataUnitToString(dataUnit_).c_str());
-  return std::string(buffer);
+  return fmt::format(
+      "{:f}{}", round(value_ * 100.0) / 100.0, dataUnitToString(dataUnit_));
 }
-
 double DataSize::toBytesPerDataUnit(DataUnit dataUnit) {
   switch (dataUnit) {
     case DataUnit::BYTE:

--- a/presto-native-execution/presto_cpp/presto_protocol/core/Duration.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/Duration.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/presto_protocol/core/Duration.h"
+#include <fmt/format.h>
 
 namespace facebook::presto::protocol {
 
@@ -27,14 +28,7 @@ Duration::Duration(const std::string& duration) {
 }
 
 std::string Duration::toString() const {
-  char buffer[32];
-  snprintf(
-      buffer,
-      sizeof(buffer),
-      "%.2f%s",
-      value_,
-      timeUnitToString(timeUnit_).c_str());
-  return std::string(buffer);
+  return fmt::format("{:.2f}{}", value_, timeUnitToString(timeUnit_));
 }
 
 double Duration::toMillisPerTimeUnit(TimeUnit timeUnit) {


### PR DESCRIPTION
## Description
Refactored the Duration::toString and DataSize::toString methods to replace the use of snprintf with fmt::format. This change modernizes the codebase, eliminates the need for manual buffer management, and ensures safer and more readable formatting operations.

## Motivation and Context
Refactored to align with modern C++ practices, improving safety, readability, and maintainability. fmt::format eliminates manual buffer management and the risks of buffer overflows inherent in snprintf.

## Impact
Simplifies the code, reduces error-prone logic, and aligns with modern C++ standards. The output remains consistent with the original implementation, with minimal performance impact and improved maintainability.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
