### PR TITLE
Adopt the Include-What-You-Use for presto_cpp/main/common/

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
@@ -10,16 +10,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(presto_exception Exception.cpp)
-add_library(presto_common Counters.cpp Utils.cpp ConfigReader.cpp Configs.cpp)
+add_library(presto_exception Exception.cpp Exception.h)
+
+add_library(presto_common_Counters Counters.cpp Counters.h)
+add_library(presto_common_Utils Utils.cpp Utils.h)
+add_library(presto_common_ConfigReader ConfigReader.cpp ConfigReader.h)
+add_library(presto_common_Configs Configs.cpp Configs.h)
+
+target_link_libraries(presto_common_ConfigReader  velox_common_config velox_exception)
+
+target_link_libraries(presto_common_Configs  velox_common_config velox_core velox_exception)
+
+target_link_libraries(presto_common_Counters  velox_common_config)
+
+target_link_libraries(presto_common_Utils  velox_common_config)
 
 target_link_libraries(presto_exception velox_exception)
-set_property(TARGET presto_exception PROPERTY JOB_POOL_LINK
-                                              presto_link_job_pool)
-
-target_link_libraries(presto_common velox_common_config velox_core
-                      velox_exception)
-set_property(TARGET presto_common PROPERTY JOB_POOL_LINK presto_link_job_pool)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
+++ b/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
@@ -13,10 +13,14 @@
  */
 
 #include "presto_cpp/main/common/ConfigReader.h"
-#include <fmt/format.h>
-#include <fstream>
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/config/Config.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fmt/format.h>
+#include <fstream>
 
 namespace facebook::presto::util {
 
@@ -52,7 +56,7 @@ std::unordered_map<std::string, std::string> readConfig(
   std::unordered_map<std::string, std::string> properties;
   std::string line;
   while (getline(configFile, line)) {
-    line.erase(std::remove_if(line.begin(), line.end(), isspace), line.end());
+    line.erase(remove_if(line.begin(), line.end(), isspace), line.end());
     if (line.empty() || line[0] == '#') {
       continue;
     }

--- a/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
+++ b/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
@@ -13,14 +13,12 @@
  */
 
 #include "presto_cpp/main/common/ConfigReader.h"
-
-#include "velox/common/base/Exceptions.h"
-#include "velox/common/config/Config.h"
-
 #include <algorithm>
 #include <cctype>
 #include <fmt/format.h>
 #include <fstream>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/config/Config.h"
 
 namespace facebook::presto::util {
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -15,11 +15,6 @@
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Utils.h"
-#include "velox/core/QueryConfig.h"
-
-#include <boost/lexical_cast.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 #if __has_include("filesystem")
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -27,6 +22,10 @@ namespace fs = std::filesystem;
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 #endif
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "velox/core/QueryConfig.h"
 
 namespace facebook::presto {
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -13,15 +13,14 @@
  */
 #pragma once
 
-#include "velox/common/base/Exceptions.h"
-#include "velox/common/config/Config.h"
-#include <folly/Optional.h>
-#include <folly/SocketAddress.h>
-
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <folly/Optional.h>
+#include <folly/SocketAddress.h>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/config/Config.h"
 
 namespace facebook::presto {
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -13,11 +13,15 @@
  */
 #pragma once
 
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/config/Config.h"
+#include <folly/Optional.h>
 #include <folly/SocketAddress.h>
+
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include "velox/common/config/Config.h"
 
 namespace facebook::presto {
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -15,8 +15,6 @@
 #include "presto_cpp/main/common/Counters.h"
 #include "velox/common/base/StatsReporter.h"
 
-
-
 namespace facebook::presto {
 
 void registerPrestoMetrics() {

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -15,6 +15,8 @@
 #include "presto_cpp/main/common/Counters.h"
 #include "velox/common/base/StatsReporter.h"
 
+
+
 namespace facebook::presto {
 
 void registerPrestoMetrics() {

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <folly/Range.h>
+#include <string_view>
 
 // Here we have all the counters presto cpp worker would export.
 namespace facebook::presto {

--- a/presto-native-execution/presto_cpp/main/common/Exception.h
+++ b/presto-native-execution/presto_cpp/main/common/Exception.h
@@ -14,11 +14,9 @@
 #pragma once
 
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
-
-#include "velox/common/base/VeloxException.h"
-
 #include <exception>
 #include <unordered_map>
+#include "velox/common/base/VeloxException.h"
 
 namespace std {
 class exception;

--- a/presto-native-execution/presto_cpp/main/common/Exception.h
+++ b/presto-native-execution/presto_cpp/main/common/Exception.h
@@ -13,9 +13,12 @@
  */
 #pragma once
 
-#include <unordered_map>
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
+
 #include "velox/common/base/VeloxException.h"
+
+#include <exception>
+#include <unordered_map>
 
 namespace std {
 class exception;

--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -13,8 +13,8 @@
  */
 
 #include "presto_cpp/main/common/Utils.h"
-#include <fmt/format.h>
 #include <sys/resource.h>
+#include <fmt/format.h>
 #include "velox/common/process/ThreadDebugInfo.h"
 
 namespace facebook::presto::util {

--- a/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
@@ -12,11 +12,11 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/common/Configs.h"
+#include <gtest/gtest.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/core/QueryConfig.h"
-#include <gtest/gtest.h>
 
 namespace facebook::presto::test {
 

--- a/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/BaseVeloxQueryConfigTest.cpp
@@ -11,12 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <gtest/gtest.h>
 #include "presto_cpp/main/common/Configs.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/core/QueryConfig.h"
+#include <gtest/gtest.h>
 
 namespace facebook::presto::test {
 

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -9,20 +9,41 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(presto_common_test CommonTest.cpp ConfigTest.cpp
-                                  BaseVeloxQueryConfigTest.cpp)
 
-add_test(presto_common_test presto_common_test)
+add_executable(presto_common_BaseVeloxQueryConfigTest BaseVeloxQueryConfigTest.cpp)
+add_executable(presto_common_CommonTest CommonTest.cpp)
+add_executable(presto_common_ConfigTest ConfigTest.cpp)
+
+add_test(presto_common_BaseVeloxQueryConfigTest presto_common_BaseVeloxQueryConfigTest)
+add_test(presto_common_CommonTest presto_common_CommonTest)
+add_test(presto_common_ConfigTest presto_common_ConfigTest)
 
 target_link_libraries(
-  presto_common_test
-  presto_common
-  presto_exception
-  velox_exception
-  velox_file
-  ${RE2}
-  GTest::gtest
-  GTest::gtest_main)
+        presto_common_CommonTest
+        presto_common_Utils
+        presto_exception
+        ${RE2}
+        velox_exception
+        GTest::gtest
+        GTest::gtest_main)
 
-set_property(TARGET presto_common_test PROPERTY JOB_POOL_LINK
-                                                presto_link_job_pool)
+target_link_libraries(
+        presto_common_ConfigTest
+        presto_common_ConfigReader
+        presto_common_Configs
+        ${RE2}
+        velox_exception
+        velox_file
+        GTest::gtest
+        GTest::gtest_main)
+
+target_link_libraries(
+        presto_common_BaseVeloxQueryConfigTest
+        presto_common_ConfigReader
+        presto_common_Configs
+        ${RE2}
+        velox_core
+        velox_exception
+        velox_file
+        GTest::gtest
+        GTest::gtest_main)

--- a/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
@@ -11,10 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <gtest/gtest.h>
 #include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/common/base/Exceptions.h"
+#include <gtest/gtest.h>
 
 using namespace facebook::velox;
 using namespace facebook::presto;

--- a/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
@@ -13,8 +13,8 @@
  */
 #include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/common/Utils.h"
-#include "velox/common/base/Exceptions.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/Exceptions.h"
 
 using namespace facebook::velox;
 using namespace facebook::presto;

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -11,13 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <gtest/gtest.h>
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Configs.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
+#include <gtest/gtest.h>
 
 namespace facebook::presto::test {
 

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -13,11 +13,11 @@
  */
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Configs.h"
+#include <gtest/gtest.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
-#include <gtest/gtest.h>
 
 namespace facebook::presto::test {
 


### PR DESCRIPTION
## Description
Adopt the Include-What
Propose to 1) adopt Include-What-You-Use ([IWYU](https://google.github.io/styleguide/cppguide.html#Include_What_You_Use)) for header files, and 2) link what-you-use in CMakeList.

## Motivation and Context

- reduce compilation time, specially for incremental compiles
- reduce object file size by avoid linking unnecessary libraries
- reduce chances for linking errors due to not adding new files in CMake: #11388
- avoid an inappropriate way to write CMake like add_executable(velox_query_replayer TraceReplayerMain.cpp TraceReplayRunner.cpp): #11406

<img width="918" alt="Screenshot 2024-12-11 at 10 05 23 PM" src="https://github.com/user-attachments/assets/333a6110-1596-4f30-8c34-b6be774a7ee4" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
