### PR TITLE
Update commons-dbcp2 version to fix common vulnerabilities and exposures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2252,6 +2252,13 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>${dep.snakeyaml.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-dbcp2</artifactId>
+                <version>2.12.0</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Description
Changes to upgrade commons-dbcp2 versions to remove vulnerabilities in presto-pinot-toolkit and presto-product-tests.

## Motivation and Context
The presto-pinot-toolkit and presto-product-tests have interdependencies with commons-dbcp2 versions 2.6.0 and 2.1, respectively, both of which contain vulnerabilities. These vulnerabilities can be removed by upgrading the commons-dbcp2 dependency to 2.12.0.

## Impact

## Test Plan

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Fix security vulnerability in presto-pinot-toolkit and presto-product-tests in response to `CVE-2020-0287 <https://nvd.nist.gov/vuln/detail/CVE-2020-0287>`_. :pr:`24249`
```


