### PR TITLE
Fix bug in constructing SessionPropertyManager for Presto-On-Spark

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionPropertyManagerProvider.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionPropertyManagerProvider.java
@@ -15,6 +15,8 @@ package com.facebook.presto.spark;
 
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.spiller.NodeSpillConfig;
+import com.facebook.presto.sql.analyzer.JavaFeaturesConfig;
 import com.google.common.collect.Streams;
 
 import javax.inject.Inject;
@@ -29,20 +31,27 @@ public class PrestoSparkSessionPropertyManagerProvider
 {
     private final SystemSessionProperties systemSessionProperties;
     private final PrestoSparkSessionProperties prestoSparkSessionProperties;
+    private final JavaFeaturesConfig javaFeaturesConfig;
+    private final NodeSpillConfig nodeSpillConfig;
 
     @Inject
-    public PrestoSparkSessionPropertyManagerProvider(SystemSessionProperties systemSessionProperties, PrestoSparkSessionProperties prestoSparkSessionProperties)
+    public PrestoSparkSessionPropertyManagerProvider(SystemSessionProperties systemSessionProperties, PrestoSparkSessionProperties prestoSparkSessionProperties, JavaFeaturesConfig javaFeaturesConfig, NodeSpillConfig nodeSpillConfig)
     {
         this.systemSessionProperties = requireNonNull(systemSessionProperties, "systemSessionProperties is null");
         this.prestoSparkSessionProperties = requireNonNull(prestoSparkSessionProperties, "prestoSparkSessionProperties is null");
+        this.javaFeaturesConfig = requireNonNull(javaFeaturesConfig, "javaFeaturesConfig is null");
+        this.nodeSpillConfig = requireNonNull(nodeSpillConfig, "nodeSpillConfig is null");
     }
 
     @Override
     public SessionPropertyManager get()
     {
-        return createTestingSessionPropertyManager(Streams.concat(
+        return createTestingSessionPropertyManager(
+                Streams.concat(
                         systemSessionProperties.getSessionProperties().stream(),
-                        prestoSparkSessionProperties.getSessionProperties().stream())
-                .collect(toImmutableList()));
+                        prestoSparkSessionProperties.getSessionProperties().stream()
+                ).collect(toImmutableList()),
+                javaFeaturesConfig,
+                nodeSpillConfig);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
@@ -38,6 +38,8 @@ import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.PlanFragmentId;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spiller.NodeSpillConfig;
+import com.facebook.presto.sql.analyzer.JavaFeaturesConfig;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -86,7 +88,7 @@ public class TestPickJoinSides
         tester = new RuleTester(
                 ImmutableList.of(),
                 ImmutableMap.of(),
-                new PrestoSparkSessionPropertyManagerProvider(new SystemSessionProperties(), new PrestoSparkSessionProperties()).get(),
+                new PrestoSparkSessionPropertyManagerProvider(new SystemSessionProperties(), new PrestoSparkSessionProperties(), new JavaFeaturesConfig(), new NodeSpillConfig()).get(),
                 Optional.of(NODES_COUNT),
                 new TpchConnectorFactory(1));
     }


### PR DESCRIPTION
## Description
While creating SessionPropertyManager for PoS, we end up using default 
values for JavaFeatureConfigs and NodeSpillConfigs which is incorrect and 
end up disabling features enabled via config properties.  Fixing the logic to 
use the injected JavaFeatureConfigs and NodeSpillConfigs.

## Motivation and Context
In https://github.com/prestodb/presto/commit/cee51f5c9d00de3a0164372363871140aac1249d#diff-6b3f683355576be08cb35ba82abba71ef57c9b3e135f0814a2362d8f59c9dd0d, worker session properties
were refactored and PrestoSparkSessionPropertyManagerProvider was modified the use the new code, which
introduced this bug.

## Test Plan
Tested some prod workload that was failing due to features getting disabled. After the fix, config
properties are picked up properly and queries are succeeding. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.


```
== NO RELEASE NOTE ==
```

