### PR TITLE
[Native] Make PrestoServer create and pass connectorCpuExecutor to Connector

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -235,6 +235,9 @@ class PrestoServer {
   // Executor for background writing into SSD cache.
   std::unique_ptr<folly::CPUThreadPoolExecutor> cacheExecutor_;
 
+  // Executor for async execution for connectors.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> connectorCpuExecutor_;
+
   // Executor for async IO for connectors.
   std::unique_ptr<folly::IOThreadPoolExecutor> connectorIoExecutor_;
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -155,6 +155,7 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kHttpsClientCertAndKeyPath),
           NUM_PROP(kExchangeHttpClientNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kExchangeHttpClientNumCpuThreadsHwMultiplier, 1.0),
+          NUM_PROP(kConnectorNumCpuThreadsHwMultiplier, 0.0),
           NUM_PROP(kConnectorNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kDriverNumCpuThreadsHwMultiplier, 4.0),
           BOOL_PROP(kDriverThreadsBatchSchedulingEnabled, false),
@@ -373,6 +374,10 @@ double SystemConfig::exchangeHttpClientNumIoThreadsHwMultiplier() const {
 double SystemConfig::exchangeHttpClientNumCpuThreadsHwMultiplier() const {
   return optionalProperty<double>(kExchangeHttpClientNumCpuThreadsHwMultiplier)
       .value();
+}
+
+double SystemConfig::connectorNumCpuThreadsHwMultiplier() const {
+  return optionalProperty<double>(kConnectorNumCpuThreadsHwMultiplier).value();
 }
 
 double SystemConfig::connectorNumIoThreadsHwMultiplier() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -214,6 +214,14 @@ class SystemConfig : public ConfigBase {
       "https-client-cert-key-path"};
 
   /// Floating point number used in calculating how many threads we would use
+  /// for CPU executor for connectors mainly for async operators:
+  /// hw_concurrency x multiplier.
+  /// If 0.0 then connector CPU executor would not be created.
+  /// 0.0 is default.
+  static constexpr std::string_view kConnectorNumCpuThreadsHwMultiplier{
+      "connector.num-cpu-threads-hw-multiplier"};
+
+  /// Floating point number used in calculating how many threads we would use
   /// for IO executor for connectors mainly to do preload/prefetch:
   /// hw_concurrency x multiplier.
   /// If 0.0 then connector preload/prefetch is disabled.
@@ -723,6 +731,8 @@ class SystemConfig : public ConfigBase {
   double exchangeHttpClientNumIoThreadsHwMultiplier() const;
 
   double exchangeHttpClientNumCpuThreadsHwMultiplier() const;
+
+  double connectorNumCpuThreadsHwMultiplier() const;
 
   double connectorNumIoThreadsHwMultiplier() const;
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Create a CPUThreadPoolExecutor data member, connectorCpuExecutor_, for PrestoServer.
Pass it to every created Connector. Add a new config `connector.num-cpu-threads-hw-multiplier`
to control how many threads would be used for the executor.
`connector.num-cpu-threads-hw-multiplier` will set connectorCpuExecutor_ to nullptr.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Make a process-wise managed CPUThreadPoolExecutor instance available to all connectors.
Connector could schedule CPU-bound async operators to it so that they will not occupy
the driver thread pool.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
When the new config `connector.num-cpu-threads-hw-multiplier` is set to positive,
a process-wise CPUThreadPoolExecutor will be created.

## Test Plan
<!---Please fill in how you tested your change-->

## Release Notes

```
== NO RELEASE NOTE ==
```

