### PR TITLE
[native] Deprecate regex property for tracing

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -369,15 +369,6 @@ The fragment id to be traced. If not specified, all fragments will be matched.
 
 The shard id to be traced. If not specified, all shards will be matched.
 
-``native_query_trace_task_reg_exp``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* **Type:** ``varchar``
-* **Default value:** ``""``
-
-The regular expression to match a task for tracing. It will be deprecated if there is
-no issue with native_query_trace_fragment_id and native_query_trace_shard_id.
-
 ``native_scaled_writer_rebalance_max_memory_usage_ratio``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -61,7 +61,6 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_QUERY_TRACE_DIR = "native_query_trace_dir";
     public static final String NATIVE_QUERY_TRACE_NODE_IDS = "native_query_trace_node_ids";
     public static final String NATIVE_QUERY_TRACE_MAX_BYTES = "native_query_trace_max_bytes";
-    public static final String NATIVE_QUERY_TRACE_REG_EXP = "native_query_trace_task_reg_exp";
     public static final String NATIVE_QUERY_TRACE_FRAGMENT_ID = "native_query_trace_fragment_id";
     public static final String NATIVE_QUERY_TRACE_SHARD_ID = "native_query_trace_shard_id";
     public static final String NATIVE_MAX_LOCAL_EXCHANGE_PARTITION_COUNT = "native_max_local_exchange_partition_count";
@@ -229,10 +228,6 @@ public class NativeWorkerSessionPropertyProvider
                 longProperty(NATIVE_QUERY_TRACE_MAX_BYTES,
                         "The max trace bytes limit. Tracing is disabled if zero.",
                         0L,
-                        !nativeExecution),
-                stringProperty(NATIVE_QUERY_TRACE_REG_EXP,
-                        "The regexp of traced task id. We only enable trace on a task if its id matches.",
-                        "",
                         !nativeExecution),
                 stringProperty(NATIVE_OP_TRACE_DIR_CREATE_CONFIG,
                         "Config used to create operator trace directory. This config is provided to underlying file system and the config is free form. The form should be defined by the underlying file system.",

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -297,14 +297,6 @@ SessionProperties::SessionProperties() {
       QueryConfig::kQueryTraceMaxBytes,
       std::to_string(c.queryTraceMaxBytes()));
 
-  addSessionProperty(
-      kQueryTraceTaskRegExp,
-      "The regexp of traced task id. We only enable trace on a task if its id"
-      " matches.",
-      VARCHAR(),
-      false,
-      QueryConfig::kQueryTraceTaskRegExp,
-      c.queryTraceTaskRegExp());
 
   addSessionProperty(
       kOpTraceDirectoryCreateConfig,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -227,11 +227,6 @@ class SessionProperties {
   static constexpr const char* kQueryTraceMaxBytes =
       "native_query_trace_max_bytes";
 
-  /// The regexp of traced task id. We only enable trace on a task if its id
-  /// matches.
-  static constexpr const char* kQueryTraceTaskRegExp =
-      "native_query_trace_task_reg_exp";
-
   /// Config used to create operator trace directory. This config is provided to
   /// underlying file system and the config is free form. The form should be
   /// defined by the underlying file system.


### PR DESCRIPTION
## Description
It's a follow up of #24209 . Regex property in Prestissimo can be deprecated with the two new properties.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
e2e testing with tracing and unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Deprecated  native_query_trace_task_reg_exp session property from Prestissimo:pr:`24270`

