### PR TITLE
[native] Add DeleteNode to presto_protocol serialization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IndexSourceNode;
+import com.facebook.presto.spi.plan.InputDistribution;
 import com.facebook.presto.spi.plan.JoinDistributionType;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.LimitNode;
@@ -545,7 +546,7 @@ public class AddExchanges
             if (!node.getInputDistribution().isPresent()) {
                 return visitPlan(node, preferredProperties);
             }
-            DeleteNode.InputDistribution inputDistribution = node.getInputDistribution().get();
+            InputDistribution inputDistribution = node.getInputDistribution().get();
             List<LocalProperty<VariableReferenceExpression>> desiredProperties = new ArrayList<>();
             if (!inputDistribution.getPartitionBy().isEmpty()) {
                 desiredProperties.add(new GroupingProperty<>(inputDistribution.getPartitionBy()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.DeleteNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.InputDistribution;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
@@ -469,7 +470,7 @@ public class AddLocalExchanges
             if (!node.getInputDistribution().isPresent()) {
                 return visitPlan(node, parentPreferences);
             }
-            DeleteNode.InputDistribution inputDistribution = node.getInputDistribution().get();
+            InputDistribution inputDistribution = node.getInputDistribution().get();
             StreamPreferredProperties childRequirements = parentPreferences
                     .constrainTo(node.getSource().getOutputVariables())
                     .withDefaultParallelism(session)

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -636,6 +636,10 @@ void to_json(json& j, const std::shared_ptr<PlanNode>& p) {
     j = *std::static_pointer_cast<GroupIdNode>(p);
     return;
   }
+  if (type == ".DeleteNode") {
+    j = *std::static_pointer_cast<DeleteNode>(p);
+    return;
+  }
   if (type == ".DistinctLimitNode") {
     j = *std::static_pointer_cast<DistinctLimitNode>(p);
     return;
@@ -752,6 +756,12 @@ void from_json(const json& j, std::shared_ptr<PlanNode>& p) {
   }
   if (type == "com.facebook.presto.sql.planner.plan.GroupIdNode") {
     std::shared_ptr<GroupIdNode> k = std::make_shared<GroupIdNode>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<PlanNode>(k);
+    return;
+  }
+  if (type == ".DeleteNode") {
+    std::shared_ptr<DeleteNode> k = std::make_shared<DeleteNode>();
     j.get_to(*k);
     p = std::static_pointer_cast<PlanNode>(k);
     return;
@@ -1218,6 +1228,62 @@ void from_json(const json& j, Assignments& p) {
       "Assignments",
       "Map<VariableReferenceExpression, std::shared_ptr<RowExpression>>",
       "assignments");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+BaseInputDistribution::BaseInputDistribution() noexcept {
+  _type = ".BaseInputDistribution";
+}
+
+void to_json(json& j, const BaseInputDistribution& p) {
+  j = json::object();
+  j["@type"] = ".BaseInputDistribution";
+  to_json_key(
+      j,
+      "partitionBy",
+      p.partitionBy,
+      "BaseInputDistribution",
+      "List<VariableReferenceExpression>",
+      "partitionBy");
+  to_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "BaseInputDistribution",
+      "OrderingScheme",
+      "orderingScheme");
+  to_json_key(
+      j,
+      "inputVariables",
+      p.inputVariables,
+      "BaseInputDistribution",
+      "List<VariableReferenceExpression>",
+      "inputVariables");
+}
+
+void from_json(const json& j, BaseInputDistribution& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "partitionBy",
+      p.partitionBy,
+      "BaseInputDistribution",
+      "List<VariableReferenceExpression>",
+      "partitionBy");
+  from_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "BaseInputDistribution",
+      "OrderingScheme",
+      "orderingScheme");
+  from_json_key(
+      j,
+      "inputVariables",
+      p.inputVariables,
+      "BaseInputDistribution",
+      "List<VariableReferenceExpression>",
+      "inputVariables");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
@@ -3213,6 +3279,101 @@ void from_json(const json& j, DeleteHandle& p) {
       "DeleteHandle",
       "SchemaTableName",
       "schemaTableName");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<InputDistribution>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+
+  if (type == ".BaseInputDistribution") {
+    j = *std::static_pointer_cast<BaseInputDistribution>(p);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type InputDistribution ");
+}
+
+void from_json(const json& j, std::shared_ptr<InputDistribution>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) + " InputDistribution  InputDistribution");
+  }
+
+  if (type == ".BaseInputDistribution") {
+    std::shared_ptr<BaseInputDistribution> k =
+        std::make_shared<BaseInputDistribution>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<InputDistribution>(k);
+    return;
+  }
+
+  throw TypeError(type + " no abstract type InputDistribution ");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+DeleteNode::DeleteNode() noexcept {
+  _type = ".DeleteNode";
+}
+
+void to_json(json& j, const DeleteNode& p) {
+  j = json::object();
+  j["@type"] = ".DeleteNode";
+  to_json_key(j, "id", p.id, "DeleteNode", "PlanNodeId", "id");
+  to_json_key(j, "source", p.source, "DeleteNode", "PlanNode", "source");
+  to_json_key(
+      j,
+      "rowId",
+      p.rowId,
+      "DeleteNode",
+      "VariableReferenceExpression",
+      "rowId");
+  to_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "DeleteNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  to_json_key(
+      j,
+      "inputDistribution",
+      p.inputDistribution,
+      "DeleteNode",
+      "InputDistribution",
+      "inputDistribution");
+}
+
+void from_json(const json& j, DeleteNode& p) {
+  p._type = j["@type"];
+  from_json_key(j, "id", p.id, "DeleteNode", "PlanNodeId", "id");
+  from_json_key(j, "source", p.source, "DeleteNode", "PlanNode", "source");
+  from_json_key(
+      j,
+      "rowId",
+      p.rowId,
+      "DeleteNode",
+      "VariableReferenceExpression",
+      "rowId");
+  from_json_key(
+      j,
+      "outputVariables",
+      p.outputVariables,
+      "DeleteNode",
+      "List<VariableReferenceExpression>",
+      "outputVariables");
+  from_json_key(
+      j,
+      "inputDistribution",
+      p.inputDistribution,
+      "DeleteNode",
+      "InputDistribution",
+      "inputDistribution");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -67,21 +67,21 @@ extern const char* const PRESTO_ABORT_TASK_URL_PARAM;
 class Exception : public std::runtime_error {
  public:
   explicit Exception(const std::string& message)
-      : std::runtime_error(message){};
+      : std::runtime_error(message) {};
 };
 
 class TypeError : public Exception {
  public:
-  explicit TypeError(const std::string& message) : Exception(message){};
+  explicit TypeError(const std::string& message) : Exception(message) {};
 };
 
 class OutOfRange : public Exception {
  public:
-  explicit OutOfRange(const std::string& message) : Exception(message){};
+  explicit OutOfRange(const std::string& message) : Exception(message) {};
 };
 class ParseError : public Exception {
  public:
-  explicit ParseError(const std::string& message) : Exception(message){};
+  explicit ParseError(const std::string& message) : Exception(message) {};
 };
 
 using String = std::string;
@@ -313,6 +313,11 @@ void to_json(json& j, const std::shared_ptr<ConnectorOutputTableHandle>& p);
 void from_json(const json& j, std::shared_ptr<ConnectorOutputTableHandle>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+struct InputDistribution : public JsonEncodedSubclass {};
+void to_json(json& j, const std::shared_ptr<InputDistribution>& p);
+void from_json(const json& j, std::shared_ptr<InputDistribution>& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 struct ValueSet : public JsonEncodedSubclass {};
 void to_json(json& j, const std::shared_ptr<ValueSet>& p);
 void from_json(const json& j, std::shared_ptr<ValueSet>& p);
@@ -522,6 +527,17 @@ struct Assignments {
 };
 void to_json(json& j, const Assignments& p);
 void from_json(const json& j, Assignments& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct BaseInputDistribution : public InputDistribution {
+  List<VariableReferenceExpression> partitionBy = {};
+  std::shared_ptr<OrderingScheme> orderingScheme = {};
+  List<VariableReferenceExpression> inputVariables = {};
+
+  BaseInputDistribution() noexcept;
+};
+void to_json(json& j, const BaseInputDistribution& p);
+void from_json(const json& j, BaseInputDistribution& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 enum class BufferType {
@@ -1019,6 +1035,18 @@ struct DeleteHandle : public ExecutionWriterTarget {
 };
 void to_json(json& j, const DeleteHandle& p);
 void from_json(const json& j, DeleteHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct DeleteNode : public PlanNode {
+  std::shared_ptr<PlanNode> source = {};
+  VariableReferenceExpression rowId = {};
+  List<VariableReferenceExpression> outputVariables = {};
+  std::shared_ptr<InputDistribution> inputDistribution = {};
+
+  DeleteNode() noexcept;
+};
+void to_json(json& j, const DeleteNode& p);
+void from_json(const json& j, DeleteNode& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct DistinctLimitNode : public PlanNode {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -124,11 +124,17 @@ AbstractClasses:
       - { name: InsertHandle,            key: InsertHandle }
       - { name: DeleteHandle,            key: DeleteHandle }
 
+  InputDistribution:
+    super: JsonEncodedSubclass
+    subclasses:
+      - { name: BaseInputDistribution,   key: .BaseInputDistribution }
+
   PlanNode:
     super: JsonEncodedSubclass
     subclasses:
       - { name: AggregationNode,          key: .AggregationNode }
       - { name: GroupIdNode,              key: com.facebook.presto.sql.planner.plan.GroupIdNode }
+      - { name: DeleteNode,               key: .DeleteNode }
       - { name: DistinctLimitNode,        key: .DistinctLimitNode }
       - { name: EnforceSingleRowNode,     key: com.facebook.presto.sql.planner.plan.EnforceSingleRowNode }
       - { name: ExchangeNode,             key: com.facebook.presto.sql.planner.plan.ExchangeNode }
@@ -319,3 +325,5 @@ JavaClasses:
   - presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/PlanConversionFailureInfo.java
   - presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/PlanConversionResponse.java
   - presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/JsonBasedUdfFunctionMetadata.java
+  - presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java
+  - presto-spi/src/main/java/com/facebook/presto/spi/plan/BaseInputDistribution.java

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -123,11 +123,17 @@ AbstractClasses:
         - { name: InsertHandle,            key: InsertHandle }
         - { name: DeleteHandle,            key: DeleteHandle }
 
+    InputDistribution:
+      super: JsonEncodedSubclass
+      subclasses:
+        - { name: BaseInputDistribution,   key: BaseInputDistribution }
+
     PlanNode:
       super: JsonEncodedSubclass
       subclasses:
         - { name: AggregationNode,          key: .AggregationNode }
         - { name: GroupIdNode,              key: com.facebook.presto.sql.planner.plan.GroupIdNode }
+        - { name: DeleteNode,               key: .DeleteNode }
         - { name: DistinctLimitNode,        key: .DistinctLimitNode }
         - { name: EnforceSingleRowNode,     key: com.facebook.presto.sql.planner.plan.EnforceSingleRowNode }
         - { name: ExchangeNode,             key: com.facebook.presto.sql.planner.plan.ExchangeNode }
@@ -366,3 +372,5 @@ JavaClasses:
   - presto-main/src/main/java/com/facebook/presto/connector/system/SystemTransactionHandle.java
   - presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionMetadata.java
   - presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/JsonBasedUdfFunctionMetadata.java
+  - presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java
+  - presto-spi/src/main/java/com/facebook/presto/spi/plan/BaseInputDistribution.java

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   CallExpressionTest.cpp
   ConstantExpressionTest.cpp
   DataSizeTest.cpp
+  DeleteTest.cpp
   DomainTest.cpp
   DurationTest.cpp
   LifespanTest.cpp

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/DeleteTest.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/DeleteTest.cpp
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "presto_cpp/main/common/tests/test_json.h"
+
+using namespace facebook::presto::protocol;
+
+using namespace ::testing;
+
+class DeleteTest : public ::testing::Test {};
+
+TEST_F(DeleteTest, jsonRoundtrip) {
+  std::string str = R"(
+      {
+        "@type" : ".DeleteNode",
+        "id" : "0",
+        "source" : {
+          "@type" : ".ValuesNode",
+          "id" : "1",
+          "outputVariables" : [ {
+            "@type" : "variable",
+            "name" : "$row_group_id",
+            "type" : "varchar"
+          }, {
+            "@type" : "variable",
+            "name" : "$row_number",
+            "type" : "bigint"
+          } ],
+          "rows" : [ [ {
+              "@type" : "constant",
+              "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGFiY2Rl",
+              "type" : "varchar"
+            }, {
+              "@type" : "constant",
+              "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAAEAAAAAAAAA",
+              "type" : "bigint"
+          } ] ]
+        },
+        "rowId" : {
+          "@type" : "variable",
+          "name" : "$rowid",
+          "type" : "varbinary"
+        },
+        "outputVariables" : [ {
+            "@type" : "variable",
+            "name" : "$row_group_id",
+            "type" : "varchar"
+          }, {
+            "@type" : "variable",
+            "name" : "$row_number",
+            "type" : "bigint"
+          } ],
+        "inputDistribution" : {
+          "@type" : ".BaseInputDistribution",
+          "partitionBy" : [ {
+            "@type" : "variable",
+            "name" : "part_key",
+            "type" : "varchar"
+          } ],
+          "inputVariables" : [ {
+              "@type" : "variable",
+              "name" : "filter_key",
+              "type" : "bigint"
+          }, {
+              "@type" : "variable",
+              "name" : "$row_group_id",
+              "type" : "varchar"
+          }, {
+              "@type" : "variable",
+              "name" : "$row_number",
+              "type" : "bigint"
+          } ]
+        }
+      }
+  )";
+
+  json j = json::parse(str);
+  DeleteNode d = j;
+
+  // Check some values ...
+  ASSERT_NE(d.inputDistribution, nullptr);
+  ASSERT_EQ(d.inputDistribution->_type, ".BaseInputDistribution");
+
+  auto inputDistribution =
+      std::static_pointer_cast<BaseInputDistribution>(d.inputDistribution);
+  ASSERT_EQ(inputDistribution->partitionBy[0].name, "part_key");
+  ASSERT_EQ(inputDistribution->inputVariables.size(), 3);
+  ASSERT_EQ(inputDistribution->inputVariables[0].name, "filter_key");
+  ASSERT_EQ(inputDistribution->inputVariables[1].name, "$row_group_id");
+  ASSERT_EQ(inputDistribution->inputVariables[2].name, "$row_number");
+
+  ASSERT_EQ(d.outputVariables.size(), 2);
+  ASSERT_EQ(d.outputVariables[0].name, "$row_group_id");
+  ASSERT_EQ(d.outputVariables[1].name, "$row_number");
+
+  ASSERT_EQ(d.rowId.name, "$rowid");
+
+  testJsonRoundtrip(j, d);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/BaseInputDistribution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/BaseInputDistribution.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class BaseInputDistribution
+        implements InputDistribution
+{
+    private final List<VariableReferenceExpression> partitionedBy;
+    private final Optional<OrderingScheme> orderingScheme;
+    private final List<VariableReferenceExpression> inputVariables;
+
+    @JsonCreator
+    public BaseInputDistribution(
+            @JsonProperty("partitionBy") List<VariableReferenceExpression> partitionedBy,
+            @JsonProperty("orderingScheme") Optional<OrderingScheme> orderingScheme,
+            @JsonProperty("inputVariables") List<VariableReferenceExpression> inputVariables)
+    {
+        this.partitionedBy = requireNonNull(partitionedBy, "partitionedBy is null");
+        this.orderingScheme = requireNonNull(orderingScheme, "orderingScheme is null");
+        this.inputVariables = requireNonNull(inputVariables, "inputVariables is null");
+    }
+
+    @JsonProperty
+    @Override
+    public List<VariableReferenceExpression> getPartitionBy()
+    {
+        return partitionedBy;
+    }
+
+    @JsonProperty
+    @Override
+    public Optional<OrderingScheme> getOrderingScheme()
+    {
+        return orderingScheme;
+    }
+
+    @JsonProperty
+    @Override
+    public List<VariableReferenceExpression> getInputVariables()
+    {
+        return inputVariables;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java
@@ -115,22 +115,4 @@ public final class DeleteNode
     {
         return new DeleteNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, rowId, outputVariables, inputDistribution);
     }
-
-    public interface InputDistribution
-    {
-        default List<VariableReferenceExpression> getPartitionBy()
-        {
-            return Collections.emptyList();
-        }
-
-        default Optional<OrderingScheme> getOrderingScheme()
-        {
-            return Optional.empty();
-        }
-
-        default List<VariableReferenceExpression> getInputVariables()
-        {
-            return Collections.emptyList();
-        }
-    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/InputDistribution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/InputDistribution.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS, property = "@type")
+public interface InputDistribution
+{
+    default List<VariableReferenceExpression> getPartitionBy()
+    {
+        return Collections.emptyList();
+    }
+
+    default Optional<OrderingScheme> getOrderingScheme()
+    {
+        return Optional.empty();
+    }
+
+    default List<VariableReferenceExpression> getInputVariables()
+    {
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
## Description
This adds basic support for DeleteNode to presto_protocol serialization.  This is required for DELETE statement plans to be passed through to Prestissimo workers.

## Motivation and Context
This is the first step in adding DELETE query plan support to Prestissimo/Velox, by supporting basic serialization of the Java ``com.facebook.presto.spi.plan.DeleteNode`` class and members.  While this includes basic (de)serialization, the generated ``protocol::DeleteNode`` class is not yet hooked up to any connectors.  Conversion to Velox Hive Connector types will follow in a subsequent PR.

## Impact
DeleteNode has been added to presto_protocol so it is now available for use by Prestissimo connector implementations.

## Test Plan
A basic test, DeleteTest.cpp, is included, which validates round-trip serialization of a sample DeleteNode representation.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

