### PR TITLE
Add session properties for scaled table scan configs to workers

### DIFF
--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -443,6 +443,23 @@ SessionProperties::SessionProperties() {
       false,
       QueryConfig::kScaleWriterMinProcessedBytesRebalanceThreshold,
       std::to_string(c.scaleWriterMinProcessedBytesRebalanceThreshold()));
+
+  addSessionProperty(
+      kTableScanScaledProcessingEnabled,
+      "If set to true, enables scaled processing for table scans.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kTableScanScaledProcessingEnabled,
+      std::to_string(c.tableScanScaledProcessingEnabled()));
+
+  addSessionProperty(
+      kTableScanScaleUpMemoryUsageRatio,
+      "Controls the ratio of available memory that can be used for scaling up table scans. "
+      "The value is in the range of (0, 1].",
+      DOUBLE(),
+      false,
+      QueryConfig::kTableScanScaleUpMemoryUsageRatio,
+      std::to_string(c.tableScanScaleUpMemoryUsageRatio()));
 }
 
 const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -287,6 +287,15 @@ class SessionProperties {
   static constexpr const char* kShuffleCompressionEnabled =
       "exchange_compression";
 
+  /// If set to true, enables scaled processing for table scans.
+  static constexpr const char* kTableScanScaledProcessingEnabled =
+      "native_table_scan_scaled_processing_enabled";
+
+  /// Controls the ratio of available memory that can be used for scaling up
+  /// table scans. The value is in the range of (0, 1].
+  static constexpr const char* kTableScanScaleUpMemoryUsageRatio =
+      "native_table_scan_scale_up_memory_usage_ratio";
+
   SessionProperties();
 
   const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -31,7 +31,9 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       SessionProperties::kScaleWriterMaxPartitionsPerWriter,
       SessionProperties::
           kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
-      SessionProperties::kScaleWriterMinProcessedBytesRebalanceThreshold};
+      SessionProperties::kScaleWriterMinProcessedBytesRebalanceThreshold,
+      SessionProperties::kTableScanScaledProcessingEnabled,
+      SessionProperties::kTableScanScaleUpMemoryUsageRatio};
   const std::vector<std::string> veloxConfigNames = {
       core::QueryConfig::kAdjustTimestampToTimezone,
       core::QueryConfig::kDriverCpuTimeSliceLimitMs,
@@ -40,7 +42,9 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       core::QueryConfig::kScaleWriterMaxPartitionsPerWriter,
       core::QueryConfig::
           kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
-      core::QueryConfig::kScaleWriterMinProcessedBytesRebalanceThreshold};
+      core::QueryConfig::kScaleWriterMinProcessedBytesRebalanceThreshold,
+      core::QueryConfig::kTableScanScaledProcessingEnabled,
+      core::QueryConfig::kTableScanScaleUpMemoryUsageRatio};
   auto sessionProperties = SessionProperties().getSessionProperties();
   const auto len = names.size();
   for (auto i = 0; i < len; i++) {


### PR DESCRIPTION
## Description
Follow up of https://github.com/prestodb/presto/pull/24284
Add session properties for scale writer query configs
```
table_scan_scaled_processing_enabled
table_scan_scale_up_memory_usage_ratio
```
## Motivation and Context


## Impact
Low impact 

## Test Plan
- [x] Added Unit Test
- [x] CI Tests passed
Unrelated error
```
Error:  Failures: 
Error:    TestResourceManagerClusterStatusSender.testQueryHeartbeat:130 Expected at least one subsequent query heartbeat, previous: 10, current: 10 expected [true] but found [false]
[INFO] 
Error:  Tests run: 8540, Failures: 1, Errors: 0, Skipped: 1
```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== RELEASE NOTES ==

Session changes
- Add session property: 'native_table_scan_scaled_processing_enabled' :pr:`24275 `
- Add session property: 'native_table_scan_scale_up_memory_usage_ratior' :pr:`24275 `
```

