### PR TITLE
Refactor ExpressionOptimizer

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
@@ -95,7 +95,7 @@ public class TestDomainTranslator
         }
 
         @Override
-        public Object optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+        public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
@@ -80,7 +80,7 @@ public class TestSubfieldExtractor
         }
 
         @Override
-        public Object optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+        public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergMetadataOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergMetadataOptimizer.java
@@ -356,7 +356,7 @@ public class IcebergMetadataOptimizer
                         throw new PrestoException(StandardErrorCode.NOT_SUPPORTED, "unsupported function: " + scalarFunctionName);
                     }
 
-                    Object reducedValue = rowExpressionService.getExpressionOptimizer().optimize(
+                    RowExpression reducedValue = rowExpressionService.getExpressionOptimizer().optimize(
                             new CallExpression(
                                     Optional.empty(),
                                     scalarFunctionName,
@@ -366,7 +366,8 @@ public class IcebergMetadataOptimizer
                             Level.EVALUATED,
                             connectorSession,
                             variableReferenceExpression -> null);
-                    reducedArguments.add(new ConstantExpression(reducedValue, returnType));
+                    checkArgument(reducedValue instanceof ConstantExpression, "unexpected expression type: %s", reducedValue.getClass().getSimpleName());
+                    reducedArguments.add(reducedValue);
                 }
                 arguments = reducedArguments;
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
@@ -46,9 +46,9 @@ public final class RowExpressionOptimizer
     }
 
     @Override
-    public Object optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+    public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
     {
         RowExpressionInterpreter interpreter = new RowExpressionInterpreter(expression, metadata.getFunctionAndTypeManager(), session, level);
-        return interpreter.optimize(variableResolver::apply);
+        return toRowExpression(expression.getSourceLocation(), interpreter.optimize(variableResolver::apply), expression.getType());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
@@ -20,11 +20,17 @@ import java.util.function.Function;
 public interface ExpressionOptimizer
 {
     /**
-     * Optimize a RowExpression to
+     * Optimize a RowExpression to its simplest equivalent form.
      */
-    RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session);
+    default RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
+    {
+        return optimize(rowExpression, level, session, variable -> variable);
+    }
 
-    Object optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver);
+    /**
+     * Optimize a RowExpression to its simplest equivalent form, replacing VariableReferenceExpressions with their associated values.
+     */
+    RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver);
 
     enum Level
     {


### PR DESCRIPTION
## Description
Refactor `ExpressionOptimizer` to consistently return `RowExpression`.  Before, `ExpressionOptimizer` would return `RowExpression` only for the method which did not take in a variable resolver function.  I cannot discern a good reason for this.  By refactoring this interface and making them both return `RowExpression`, and documenting that the two methods are equivalent when an identity function is used for the variable resolver, it becomes possible to share code that uses both methods.

## Motivation and Context
This is to help address PR review feedback here: https://github.com/prestodb/presto/pull/24144#discussion_r1890678899

## Impact
Code refactoring.  Implementations of `ExpressionOptimizer` in the SPI will need to update their plugins to accommodate the changed API.

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

SPI Changes
* Improve ExpressionOptimizer#optimize method with a variable resolver to return ``RowExpression``. :pr:`24287`
```

