### PR TITLE
Assign event loop to tasks and run a task's methods in the same loop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${dep.netty.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-testing-docker</artifactId>
                 <version>${project.version}</version>
@@ -2653,7 +2659,9 @@
                         <executions>
                             <execution>
                                 <id>unlink-out-of-tree-build-directory</id>
-                                <goals><goal>exec</goal></goals>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
                                 <phase>pre-clean</phase>
                                 <configuration>
                                     <executable>rm</executable>
@@ -2665,7 +2673,9 @@
                             </execution>
                             <execution>
                                 <id>remove-out-of-tree-build-directory</id>
-                                <goals><goal>exec</goal></goals>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
                                 <phase>pre-clean</phase>
                                 <configuration>
                                     <executable>rm</executable>
@@ -2677,7 +2687,9 @@
                             </execution>
                             <execution>
                                 <id>create-out-of-tree-build-directory</id>
-                                <goals><goal>exec</goal></goals>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
                                 <phase>validate</phase>
                                 <configuration>
                                     <executable>mkdir</executable>
@@ -2689,7 +2701,9 @@
                             </execution>
                             <execution>
                                 <id>link-out-of-tree-build-directory</id>
-                                <goals><goal>exec</goal></goals>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
                                 <phase>validate</phase>
                                 <configuration>
                                     <executable>ln</executable>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -503,6 +503,11 @@
             <artifactId>ratis-common</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.server.remotetask;
 
-import com.facebook.airlift.concurrent.SetThreadName;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.http.client.ResponseHandler;
@@ -38,13 +37,9 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
+import io.netty.channel.EventLoop;
 
-import javax.annotation.concurrent.GuardedBy;
-
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
@@ -60,6 +55,7 @@ import static com.facebook.presto.server.thrift.ThriftCodecWrapper.unwrapThriftC
 import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_MISMATCH;
 import static com.facebook.presto.util.Failures.REMOTE_TASK_MISMATCH_ERROR;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.units.Duration.nanosSince;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -75,20 +71,16 @@ class ContinuousTaskStatusFetcher
     private final Codec<TaskStatus> taskStatusCodec;
 
     private final Duration refreshMaxWait;
-    private final Executor executor;
+    private final EventLoop taskEventLoop;
     private final HttpClient httpClient;
     private final RequestErrorTracker errorTracker;
     private final RemoteTaskStats stats;
     private final boolean binaryTransportEnabled;
     private final boolean thriftTransportEnabled;
     private final Protocol thriftProtocol;
-
-    private final AtomicLong currentRequestStartNanos = new AtomicLong();
-
-    @GuardedBy("this")
+    private long currentRequestStartNanos;
     private boolean running;
 
-    @GuardedBy("this")
     private ListenableFuture<BaseResponse<TaskStatus>> future;
 
     public ContinuousTaskStatusFetcher(
@@ -97,10 +89,9 @@ class ContinuousTaskStatusFetcher
             TaskStatus initialTaskStatus,
             Duration refreshMaxWait,
             Codec<TaskStatus> taskStatusCodec,
-            Executor executor,
+            EventLoop taskEventLoop,
             HttpClient httpClient,
             Duration maxErrorDuration,
-            ScheduledExecutorService errorScheduledExecutor,
             RemoteTaskStats stats,
             boolean binaryTransportEnabled,
             boolean thriftTransportEnabled,
@@ -110,23 +101,25 @@ class ContinuousTaskStatusFetcher
 
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.onFail = requireNonNull(onFail, "onFail is null");
-        this.taskStatus = new StateMachine<>("task-" + taskId, executor, initialTaskStatus);
+        this.taskStatus = new StateMachine<>("task-" + taskId, taskEventLoop, initialTaskStatus);
 
         this.refreshMaxWait = requireNonNull(refreshMaxWait, "refreshMaxWait is null");
         this.taskStatusCodec = requireNonNull(taskStatusCodec, "taskStatusCodec is null");
 
-        this.executor = requireNonNull(executor, "executor is null");
+        this.taskEventLoop = requireNonNull(taskEventLoop, "taskEventLoop is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
 
-        this.errorTracker = taskRequestErrorTracker(taskId, initialTaskStatus.getSelf(), maxErrorDuration, errorScheduledExecutor, "getting task status");
+        this.errorTracker = taskRequestErrorTracker(taskId, initialTaskStatus.getSelf(), maxErrorDuration, taskEventLoop, "getting task status");
         this.stats = requireNonNull(stats, "stats is null");
         this.binaryTransportEnabled = binaryTransportEnabled;
         this.thriftTransportEnabled = thriftTransportEnabled;
         this.thriftProtocol = requireNonNull(thriftProtocol, "thriftProtocol is null");
     }
 
-    public synchronized void start()
+    public void start()
     {
+        verify(taskEventLoop.inEventLoop());
+
         if (running) {
             // already running
             return;
@@ -135,8 +128,10 @@ class ContinuousTaskStatusFetcher
         scheduleNextRequest();
     }
 
-    public synchronized void stop()
+    public void stop()
     {
+        verify(taskEventLoop.inEventLoop());
+
         running = false;
         if (future != null) {
             // do not terminate if the request is already running to avoid closing pooled connections
@@ -145,8 +140,10 @@ class ContinuousTaskStatusFetcher
         }
     }
 
-    private synchronized void scheduleNextRequest()
+    private void scheduleNextRequest()
     {
+        verify(taskEventLoop.inEventLoop());
+
         // stopped or done?
         TaskStatus taskStatus = getTaskStatus();
         if (!running || taskStatus.getState().isDone()) {
@@ -163,7 +160,7 @@ class ContinuousTaskStatusFetcher
         // if throttled due to error, asynchronously wait for timeout and try again
         ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
         if (!errorRateLimit.isDone()) {
-            errorRateLimit.addListener(this::scheduleNextRequest, executor);
+            errorRateLimit.addListener(this::scheduleNextRequest, taskEventLoop);
             return;
         }
 
@@ -189,7 +186,7 @@ class ContinuousTaskStatusFetcher
 
         errorTracker.startRequest();
         future = httpClient.executeAsync(request, responseHandler);
-        currentRequestStartNanos.set(System.nanoTime());
+        currentRequestStartNanos = System.nanoTime();
         FutureCallback callback;
         if (thriftTransportEnabled) {
             callback = new ThriftHttpResponseHandler(this, request.getUri(), stats.getHttpResponseStats(), REMOTE_TASK_ERROR);
@@ -201,7 +198,7 @@ class ContinuousTaskStatusFetcher
         Futures.addCallback(
                 future,
                 callback,
-                executor);
+                taskEventLoop);
     }
 
     TaskStatus getTaskStatus()
@@ -212,59 +209,62 @@ class ContinuousTaskStatusFetcher
     @Override
     public void success(TaskStatus value)
     {
-        try (SetThreadName ignored = new SetThreadName("ContinuousTaskStatusFetcher-%s", taskId)) {
-            updateStats(currentRequestStartNanos.get());
-            try {
-                updateTaskStatus(value);
-                errorTracker.requestSucceeded();
-            }
-            finally {
-                scheduleNextRequest();
-            }
+        verify(taskEventLoop.inEventLoop());
+
+        updateStats(currentRequestStartNanos);
+        try {
+            updateTaskStatus(value);
+            errorTracker.requestSucceeded();
+        }
+        finally {
+            scheduleNextRequest();
         }
     }
 
     @Override
     public void failed(Throwable cause)
     {
-        try (SetThreadName ignored = new SetThreadName("ContinuousTaskStatusFetcher-%s", taskId)) {
-            updateStats(currentRequestStartNanos.get());
-            try {
-                // if task not already done, record error
-                TaskStatus taskStatus = getTaskStatus();
-                if (!taskStatus.getState().isDone()) {
-                    errorTracker.requestFailed(cause);
-                }
+        verify(taskEventLoop.inEventLoop());
+
+        updateStats(currentRequestStartNanos);
+        try {
+            // if task not already done, record error
+            TaskStatus taskStatus = getTaskStatus();
+            if (!taskStatus.getState().isDone()) {
+                errorTracker.requestFailed(cause);
             }
-            catch (Error e) {
-                onFail.accept(e);
-                throw e;
-            }
-            catch (RuntimeException e) {
-                onFail.accept(e);
-            }
-            finally {
-                scheduleNextRequest();
-            }
+        }
+        catch (Error e) {
+            onFail.accept(e);
+            throw e;
+        }
+        catch (RuntimeException e) {
+            onFail.accept(e);
+        }
+        finally {
+            scheduleNextRequest();
         }
     }
 
     @Override
     public void fatal(Throwable cause)
     {
-        try (SetThreadName ignored = new SetThreadName("ContinuousTaskStatusFetcher-%s", taskId)) {
-            updateStats(currentRequestStartNanos.get());
-            onFail.accept(cause);
-        }
+        verify(taskEventLoop.inEventLoop());
+
+        updateStats(currentRequestStartNanos);
+        onFail.accept(cause);
     }
 
     void updateTaskStatus(TaskStatus newValue)
     {
+        verify(taskEventLoop.inEventLoop());
+
         // change to new value if old value is not changed and new value has a newer version
         AtomicBoolean taskMismatch = new AtomicBoolean();
         taskStatus.setIf(newValue, oldValue -> {
             // did the task instance id change
-            boolean isEmpty = oldValue.getTaskInstanceIdLeastSignificantBits() == 0 && oldValue.getTaskInstanceIdMostSignificantBits() == 0;
+            boolean isEmpty = (oldValue.getTaskInstanceIdLeastSignificantBits() == 0 && oldValue.getTaskInstanceIdMostSignificantBits() == 0)
+                    || (newValue.getTaskInstanceIdLeastSignificantBits() == 0 && newValue.getTaskInstanceIdMostSignificantBits() == 0);
             if (!isEmpty &&
                     !(oldValue.getTaskInstanceIdLeastSignificantBits() == newValue.getTaskInstanceIdLeastSignificantBits() &&
                             oldValue.getTaskInstanceIdMostSignificantBits() == newValue.getTaskInstanceIdMostSignificantBits())) {
@@ -291,11 +291,6 @@ class ContinuousTaskStatusFetcher
         }
     }
 
-    public synchronized boolean isRunning()
-    {
-        return running;
-    }
-
     /**
      * Listener is always notified asynchronously using a dedicated notification thread pool so, care should
      * be taken to avoid leaking {@code this} when adding a listener in a constructor. Additionally, it is
@@ -308,6 +303,8 @@ class ContinuousTaskStatusFetcher
 
     private void updateStats(long currentRequestStartNanos)
     {
+        verify(taskEventLoop.inEventLoop());
+
         stats.statusRoundTripMillis(nanosSince(currentRequestStartNanos).toMillis());
     }
 }


### PR DESCRIPTION
## Description
1. this pr proposed to use a event loop to run task's methods so that multiple tasks can be assigned to the same event loop and a task's methods will only be executed on the same thread


## Motivation and Context
1. we saw a big number of tasks were created for certain queries which causes contention on the underlying synchronous queue
2. this pr proposed to use a event loop to run task's method so that multiple tasks can be assigned to the same event loop and a task's method will be executed on the same thread
3. some methods within http remote task does not need the "synchronized" keywords if we are certain they will be executed in the same thread.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. strobelight seems fine https://fburl.com/scuba/strobelight_java_asyncprofiler/on_demand/3qo6j1h9
<img width="1386" alt="Screenshot 2024-12-22 at 16 34 47" src="https://github.com/user-attachments/assets/15ef9137-ebc7-4eb9-9d97-b805431ec61b" />
2. ran verifier successfully (screenshot is coming)

## Contributor checklist

- [ x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ x] Adequate tests were added if applicable.
- [ x] CI passed.


```
== RELEASE NOTES ==

General Changes
* Improve efficiency of coordinator when running a large number of tasks. :pr:`24288`
```
