### PR TITLE
[Iceberg]Fix flaky caused by rename view test

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
@@ -157,16 +157,18 @@ public class TestIcebergMetadataListing
     @Test
     public void testRenameView()
     {
-        assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_test_table (_string VARCHAR, _integer INTEGER)");
-        assertUpdate("CREATE VIEW iceberg.test_schema.test_view_to_be_renamed AS SELECT * FROM iceberg.test_schema.iceberg_test_table");
-        assertUpdate("ALTER VIEW IF EXISTS iceberg.test_schema.test_view_to_be_renamed RENAME TO iceberg.test_schema.test_view_renamed");
-        assertUpdate("CREATE VIEW iceberg.test_schema.test_view2_to_be_renamed AS SELECT * FROM iceberg.test_schema.iceberg_test_table");
-        assertUpdate("ALTER VIEW iceberg.test_schema.test_view2_to_be_renamed RENAME TO iceberg.test_schema.test_view2_renamed");
-        assertQuerySucceeds("SELECT * FROM iceberg.test_schema.test_view_renamed");
-        assertQuerySucceeds("SELECT * FROM iceberg.test_schema.test_view2_renamed");
-        assertUpdate("DROP VIEW iceberg.test_schema.test_view_renamed");
-        assertUpdate("DROP VIEW iceberg.test_schema.test_view2_renamed");
-        assertUpdate("DROP TABLE iceberg.test_schema.iceberg_test_table");
+        assertQuerySucceeds("CREATE SCHEMA iceberg.test_rename_view_schema");
+        assertQuerySucceeds("CREATE TABLE iceberg.test_rename_view_schema.iceberg_test_table (_string VARCHAR, _integer INTEGER)");
+        assertUpdate("CREATE VIEW iceberg.test_rename_view_schema.test_view_to_be_renamed AS SELECT * FROM iceberg.test_rename_view_schema.iceberg_test_table");
+        assertUpdate("ALTER VIEW IF EXISTS iceberg.test_rename_view_schema.test_view_to_be_renamed RENAME TO iceberg.test_rename_view_schema.test_view_renamed");
+        assertUpdate("CREATE VIEW iceberg.test_rename_view_schema.test_view2_to_be_renamed AS SELECT * FROM iceberg.test_rename_view_schema.iceberg_test_table");
+        assertUpdate("ALTER VIEW iceberg.test_rename_view_schema.test_view2_to_be_renamed RENAME TO iceberg.test_rename_view_schema.test_view2_renamed");
+        assertQuerySucceeds("SELECT * FROM iceberg.test_rename_view_schema.test_view_renamed");
+        assertQuerySucceeds("SELECT * FROM iceberg.test_rename_view_schema.test_view2_renamed");
+        assertUpdate("DROP VIEW iceberg.test_rename_view_schema.test_view_renamed");
+        assertUpdate("DROP VIEW iceberg.test_rename_view_schema.test_view2_renamed");
+        assertUpdate("DROP TABLE iceberg.test_rename_view_schema.iceberg_test_table");
+        assertQuerySucceeds("DROP SCHEMA IF EXISTS iceberg.test_rename_view_schema");
     }
     @Test
     public void testRenameViewIfNotExists()


### PR DESCRIPTION
## Description

Fix #24290 

The newly added test method `testRenameView()` in `TestIcebergMetadataListing` create tables and views in an existing schema who's metadata would be read and validated in another test method `testTableColumnListing()`. This will lead to flaky when they are running concurrently in multi-thread environment.

This PR use a dedicated schema in `testRenameView()`, in this way fix the flaky issue.

## Motivation and Context

Fix #24290 

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

