### PR TITLE
Show security mode in SHOW CREATE VIEW

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
@@ -339,10 +339,12 @@ public class TestIcebergSmokeRestNestedNamespace
         assertUpdate(session, "CREATE VIEW view_orders AS SELECT * from orders");
         assertQuery(session, "SELECT * FROM view_orders", "SELECT * from orders");
         assertThat(computeActual("SHOW CREATE VIEW view_orders").getOnlyValue())
-                .isEqualTo(format("CREATE VIEW iceberg.\"%s\".view_orders AS\n" +
-                        "SELECT *\n" +
-                        "FROM\n" +
-                        "  orders", schemaName));
+                .isEqualTo(format("CREATE VIEW iceberg.\"%s\".view_orders SECURITY %s AS\n" +
+                                "SELECT *\n" +
+                                "FROM\n" +
+                                "  orders",
+                        schemaName,
+                        "DEFINER"));
         assertUpdate(session, "DROP VIEW view_orders");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -472,7 +472,8 @@ final class ShowQueriesRewrite
                 }
 
                 Query query = parseView(viewDefinition.get().getOriginalSql(), objectName, node);
-                String sql = formatSql(new CreateView(createQualifiedName(objectName), query, false, Optional.empty()), Optional.of(parameters)).trim();
+                CreateView.Security security = (viewDefinition.get().isRunAsInvoker()) ? CreateView.Security.INVOKER : CreateView.Security.DEFINER;
+                String sql = formatSql(new CreateView(createQualifiedName(objectName), query, false, Optional.of(security)), Optional.of(parameters)).trim();
                 return singleValueQuery("Create View", sql);
             }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -583,8 +583,7 @@ public final class SqlFormatter
 
             node.getSecurity().ifPresent(security ->
                     builder.append(" SECURITY ")
-                            .append(security.toString())
-                            .append(" "));
+                            .append(security.toString()));
 
             builder.append(" AS\n");
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -1202,7 +1202,7 @@ public class TestPrestoSparkQueryRunner
     public void testCreateDropView()
     {
         // create table with default format orc
-        String createViewSql = "CREATE VIEW hive.hive_test.hive_view AS\n" +
+        String createViewSql = "CREATE VIEW hive.hive_test.hive_view SECURITY DEFINER AS\n" +
                 "SELECT *\n" +
                 "FROM\n" +
                 "  orders";

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -968,10 +968,11 @@ public abstract class AbstractTestDistributedQueries
 
         // test SHOW CREATE VIEW
         String expectedSql = formatSqlText(format(
-                "CREATE VIEW %s.%s.%s AS %s",
+                "CREATE VIEW %s.%s.%s SECURITY %s AS %s",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
                 "meta_test_view",
+                "DEFINER",
                 query)).trim();
 
         actual = computeActual("SHOW CREATE VIEW meta_test_view");


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
[T211135818](https://www.internalfb.com/intern/tasks/?t=211135818)

Currently, show create view does not include the security mode that was used at the time the view was defined.
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Manual testing on maven artifact version `0.291-20241230.214957-185` on verifier cluster `ftw3_verifier_t10_2`

```
> show create view prism.di.presto_query_statistics_view;

                                                                                     Create View                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE VIEW prism.di.presto_query_statistics_view SECURITY DEFINER AS                                                                                                             
 SELECT                                                                                                                                                                            
   query_id    
```

```
> show create view prism.di.presto_query_statistics_view_invoker;

                                  Create View                                  
-------------------------------------------------------------------------------
 CREATE VIEW prism.di.presto_query_statistics_view_invoker SECURITY INVOKER AS 
 (                                                                             
    SELECT *                                                                   
    FROM                                                                       
      presto_query_statistics_view                                             
 )                                                                             
(1 row)

Query 20241230_221014_00007_enmct, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
[Latency: client-side: 471ms, server-side: 360ms] [0 rows, 0B] [0 rows/s, 0B/s]
```

```
> show create view prism.di.presto_query_statistics_view_definer;
                                  Create View                                  
-------------------------------------------------------------------------------
 CREATE VIEW prism.di.presto_query_statistics_view_definer SECURITY DEFINER AS 
 (                                                                             
    SELECT *                                                                   
    FROM                                                                       
      presto_query_statistics_view                                             
 )                                                                             
(1 row)

Query 20241230_221046_00008_enmct, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
[Latency: client-side: 0:01, server-side: 497ms] [0 rows, 0B] [0 rows/s, 0B/s]

```



## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

