### PR TITLE
Remove Bootstrap logs from IcebergQueryRunner

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -290,6 +290,7 @@ public final class IcebergQueryRunner
         logging.setLevel("parquet.hadoop", WARN);
         logging.setLevel("org.apache.iceberg", WARN);
         logging.setLevel("com.facebook.airlift.bootstrap", WARN);
+        logging.setLevel("Bootstrap", WARN);
         logging.setLevel("org.apache.hadoop.io.compress", WARN);
     }
 


### PR DESCRIPTION
## Description

Set log level for airlift's `Bootstrap` log to `WARN`

## Motivation and Context

Should significantly reduce log spam and diagnosing errors easier through the Github Actions UI. ~75% of log messages seem to be from the Bootstrap printing configuration values.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

