### PR TITLE
[native] Cancel pending async callback before resetting client and evb

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.cpp
@@ -41,6 +41,14 @@ void PeriodicServiceInventoryManager::start() {
 
 void PeriodicServiceInventoryManager::stop() {
   stopped_ = true;
+  // Simply cancel libevent timeout callback before calling reset on the client
+  // first. This is to ensure that the client is not destroyed while there is a
+  // pending request.
+  eventBaseThread_.getEventBase()->runInEventBaseThreadAndWait([this]() {
+    LOG(INFO) << fmt::format(
+        "Cancelled :{} async events in PeriodicServiceInventoryManager",
+        eventBaseThread_.getEventBase()->timer().cancelAll());
+  });
   client_.reset();
   eventBaseThread_.stop();
 }


### PR DESCRIPTION
## Description
There is a rare race at shutdown time when annoucer_->stop() is called which will reset fields like client_ and the evb_. However, this is race-y because the libevent timer on the evb can go-off, and we set stop_ = true even though sendRequest() has progressed beyond that point. Essentially, it suffers from time-of-check to time-of-use race.

To fix, we can cancel all pending events on the evb. 

Note, you may wonder why the comment in `sendRequest` doesn't work.
```
stop() calls EventBase's destructor which executed all pending callbacks;
make sure not to do anything if that's the case"
```

This is because client_ depends on evb_, so client must be destructed before evb_ due to dependency issue, otherwise there will be SIGSEGV in client_'s d-tor. This destruction order is actually not desirable because we want the evb_ to finish all of the clean up before client is destructed, but we cannot because of the order issue.

This is why we must explicitly call cancel on the evb_'s timer itself.  

## Motivation and Context

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Deploy to test cluster and restarted 4 times without any issues.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

