### PR TITLE
[native] Advance Velox and corresponding unit test updates

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
@@ -83,9 +83,10 @@ class BroadcastTest : public exec::test::OperatorTestBase {
         std::dynamic_pointer_cast<const BroadcastWriteNode>(writerPlan)
             ->serdeRowType();
 
-    exec::test::CursorParameters params;
+    exec::CursorParameters params;
     params.planNode = writerPlan;
-    auto [taskCursor, results] = readCursor(params, [](auto /*task*/) {});
+    auto [taskCursor, results] =
+        exec::test::readCursor(params, [](auto /*task*/) {});
 
     std::vector<std::string> broadcastFilePaths;
     for (auto result : results) {
@@ -96,9 +97,7 @@ class BroadcastTest : public exec::test::OperatorTestBase {
     return {serdeRowType, broadcastFilePaths};
   }
 
-  std::pair<
-      std::unique_ptr<velox::exec::test::TaskCursor>,
-      std::vector<RowVectorPtr>>
+  std::pair<std::unique_ptr<velox::exec::TaskCursor>, std::vector<RowVectorPtr>>
   executeBroadcastRead(
       RowTypePtr dataType,
       const std::string& basePath,
@@ -107,7 +106,7 @@ class BroadcastTest : public exec::test::OperatorTestBase {
     auto readerPlan = exec::test::PlanBuilder()
                           .exchange(dataType, velox::VectorSerde::Kind::kPresto)
                           .planNode();
-    exec::test::CursorParameters broadcastReadParams;
+    exec::CursorParameters broadcastReadParams;
     broadcastReadParams.planNode = readerPlan;
 
     std::vector<std::string> fileInfos;
@@ -118,7 +117,7 @@ class BroadcastTest : public exec::test::OperatorTestBase {
 
     uint8_t splitIndex = 0;
     // Read back result using BroadcastExchangeSource.
-    return readCursor(broadcastReadParams, [&](auto* task) {
+    return exec::test::readCursor(broadcastReadParams, [&](auto* task) {
       if (splitIndex >= broadcastFilePaths.size()) {
         task->noMoreSplits("0");
         return;
@@ -361,11 +360,11 @@ TEST_F(BroadcastTest, malformedBroadcastInfoJson) {
   auto readerPlan = exec::test::PlanBuilder()
                         .exchange(dataType, velox::VectorSerde::Kind::kPresto)
                         .planNode();
-  exec::test::CursorParameters broadcastReadParams;
+  exec::CursorParameters broadcastReadParams;
   broadcastReadParams.planNode = readerPlan;
 
   VELOX_ASSERT_THROW(
-      readCursor(
+      exec::test::readCursor(
           broadcastReadParams,
           [&](auto* task) {
             auto fileInfos =


### PR DESCRIPTION
## Description
It's a follow up from https://github.com/facebookincubator/velox/pull/12014 which changed namespace naming in cursor.h.
The Presto tests are updated together with Velox version advance.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

