### PR TITLE
[iceberg] Disallow in-memory hive metastore caching

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -515,19 +515,7 @@ JMX queries to get the metrics and verify the cache usage::
 Metastore Cache
 ^^^^^^^^^^^^^^^
 
-Metastore Cache only caches the schema, table, and table statistics. The table object cached in the `tableCache`
-is only used for reading the table metadata location and table properties and, the rest of the table metadata
-is fetched from the filesystem/object storage metadata location.
-
-.. note::
-
-    Metastore Cache would be applicable only for Hive Catalog in the Presto Iceberg connector.
-
-.. code-block:: none
-
-    hive.metastore-cache-ttl=2d
-    hive.metastore-refresh-interval=3d
-    hive.metastore-cache-maximum-size=10000000
+Iceberg Connector does not support Metastore Caching.
 
 Extra Hidden Metadata Columns
 -----------------------------

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
@@ -29,6 +29,7 @@ import com.google.inject.Scopes;
 import java.util.Optional;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
@@ -52,6 +53,10 @@ public class IcebergHiveModule
         configBinder(binder).bindConfig(IcebergHiveTableOperationsConfig.class);
 
         configBinder(binder).bindConfig(MetastoreClientConfig.class);
+
+        long metastoreCacheTtl = buildConfigObject(MetastoreClientConfig.class).getMetastoreCacheTtl().toMillis();
+        checkArgument(metastoreCacheTtl == 0, "In-memory hive metastore caching must not be enabled for Iceberg");
+
         binder.bind(PartitionMutator.class).to(HivePartitionMutator.class).in(Scopes.SINGLETON);
 
         binder.bind(MetastoreCacheStats.class).to(HiveMetastoreCacheStats.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConnectorFactory.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConnectorFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.testing.TestingConnectorContext;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestIcebergConnectorFactory
+{
+    @Test
+    public void testCachingHiveMetastore()
+    {
+        Map<String, String> config = ImmutableMap.<String, String>builder()
+                .put("hive.metastore.uri", "thrift://localhost:9083")
+                .put("hive.metastore-cache-ttl", "10m")
+                .buildOrThrow();
+
+        assertThatThrownBy(() -> createConnector(config))
+                .hasMessageContaining("In-memory hive metastore caching must not be enabled for Iceberg");
+    }
+
+    private static void createConnector(Map<String, String> config)
+    {
+        ConnectorFactory factory = new IcebergConnectorFactory();
+        factory.create("iceberg-test", config, new TestingConnectorContext())
+                .shutdown();
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This PR introduces a check to disallow metastore caching for the Iceberg connector. As outlined in the linked issue, this serves as an immediate solution to address the problem. I will follow up with another PR to redesign the metastore cache, enabling caching for specific metadata that does not violate the ACID contract.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fixes #24325 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Presto users will encounter an exception if metastore caching is enabled for the Iceberg connector.

## Test Plan
<!---Please fill in how you tested your change-->
Verified by enabling cache

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Remove in-memory hive metastore cache in Iceberg connector. :pr:`24326`
```


