### PR TITLE
[native] Improve an error message.

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -168,11 +168,7 @@ HttpResponse::nextAllocationSize(uint64_t dataLength) const {
 }
 
 std::string HttpResponse::dumpBodyChain() const {
-  std::string responseBody;
-  if (!bodyChain_.empty()) {
-    responseBody = util::extractMessageBody(bodyChain_);
-  }
-  return responseBody;
+  return bodyChain_.empty() ? "Empty response" : util::extractMessageBody(bodyChain_);
 }
 
 class ResponseHandler : public proxygen::HTTPTransactionHandler {


### PR DESCRIPTION
## Description
Improve error message for better debugging

## Motivation and Context
Sometimes we get empty response in httpclient. The error message looks like `Heartbeat failed: HTTP 404 -`. Its better to explicitly print empty response to be clear. New message is `Heartbeat failed: HTTP 404 - Empty response`

```
== NO RELEASE NOTE ==
```

