### PR TITLE
Support BigInt in the `QueryResult` component

### DIFF
--- a/presto-ui/src/components/QueryResults.jsx
+++ b/presto-ui/src/components/QueryResults.jsx
@@ -35,10 +35,11 @@ export function QueryResults({ results }) {
 
     const getColumns = () => {
         return results.columns.map((row, index) => {
-            return {
+            let column = {
                 name: row.name,
-                selector: row => row[index],
             };
+            column.selector = row.type === 'bigint' ? row => row[index].toString() : row => row[index];
+            return column;
         });
     };
 

--- a/presto-ui/src/package.json
+++ b/presto-ui/src/package.json
@@ -22,7 +22,7 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
-    "@prestodb/presto-js-client": "^1.0.0",
+    "@prestodb/presto-js-client": "^1.0.1",
     "antlr4": "^4.13.1-patch-1",
     "clsx": "^2.1.0",
     "copy-webpack-plugin": "^12.0.2",

--- a/presto-ui/src/yarn.lock
+++ b/presto-ui/src/yarn.lock
@@ -1098,10 +1098,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@prestodb/presto-js-client@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@prestodb/presto-js-client/-/presto-js-client-1.0.0.tgz#fa458866581a6ec4e0b9be7f8ab5bae3097f8c8a"
-  integrity sha512-B8d0Wl8XMrtqotRTTM45GVk6bV7GER1Pbt4vUb2Ex5dUP1/WkqKMuD0LMWoO9zaiSS70DtBpvwu372BS1GjNgQ==
+"@prestodb/presto-js-client@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@prestodb/presto-js-client/-/presto-js-client-1.0.1.tgz#978c9c22c17677f3157df80383efb23412d4aa70"
+  integrity sha512-6NHcpSi9EQZKgfYgOUYgyTuC4PAjs+23o9ANym5wZ/Omu8m586OplRVmels0MrzPC5LdHA94FWkscuunaEvcDg==
 
 "@sindresorhus/merge-streams@^2.1.0":
   version "2.3.0"


### PR DESCRIPTION
## Description
Check the data type of a column and pass different selector functions. BigInt data type needs to explicitly use the `toString()` function to print out the value.

## Motivation and Context
fix issue: [#23821](https://github.com/prestodb/presto/issues/23821)

## Impact
Presto UI can display BigInt data in supported browsers.

## Test Plan
Verify the BigInt data type in the supported browser: Chrome
and also verify it doesn't break unsupported browser: Firefox (at this moment, firefox hasn't supported it yet)

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for ``BigInt`` data type in the SQL Client on Presto UI on supported browsers. See
`compatibility <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#browser_compatibility>`_ for the supported browsers. :pr:`24336`

```

