### PR TITLE
Require state change consumers to provide both the callback and an executor to run the callback

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/StateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StateMachine.java
@@ -16,16 +16,16 @@ package com.facebook.presto.execution;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -46,15 +46,13 @@ public class StateMachine<T>
     private static final Logger log = Logger.get(StateMachine.class);
 
     private final String name;
-    private final Executor executor;
     private final Object lock = new Object();
     private final Set<T> terminalStates;
 
     @GuardedBy("lock")
     private volatile T state;
 
-    @GuardedBy("lock")
-    private final List<StateChangeListener<T>> stateChangeListeners = new ArrayList<>();
+    private final ConcurrentHashMap<StateChangeListener<T>, Executor> stateChangeListeners = new ConcurrentHashMap<>();
 
     private final AtomicReference<FutureStateChange<T>> futureStateChange = new AtomicReference<>(new FutureStateChange<>());
 
@@ -62,26 +60,23 @@ public class StateMachine<T>
      * Creates a state machine with the specified initial state and no terminal states.
      *
      * @param name name of this state machine to use in debug statements
-     * @param executor executor for firing state change events; must not be a same thread executor
      * @param initialState the initial state
      */
-    public StateMachine(String name, Executor executor, T initialState)
+    public StateMachine(String name, T initialState)
     {
-        this(name, executor, initialState, ImmutableSet.of());
+        this(name, initialState, ImmutableSet.of());
     }
 
     /**
      * Creates a state machine with the specified initial state and terminal states.
      *
      * @param name name of this state machine to use in debug statements
-     * @param executor executor for firing state change events; must not be a same thread executor
      * @param initialState the initial state
      * @param terminalStates the terminal states
      */
-    public StateMachine(String name, Executor executor, T initialState, Iterable<T> terminalStates)
+    public StateMachine(String name, T initialState, Iterable<T> terminalStates)
     {
         this.name = requireNonNull(name, "name is null");
-        this.executor = requireNonNull(executor, "executor is null");
         this.state = requireNonNull(initialState, "initialState is null");
         this.terminalStates = ImmutableSet.copyOf(requireNonNull(terminalStates, "terminalStates is null"));
     }
@@ -106,7 +101,7 @@ public class StateMachine<T>
 
         T oldState;
         FutureStateChange<T> futureStateChange;
-        ImmutableList<StateChangeListener<T>> stateChangeListeners;
+        ImmutableMap<StateChangeListener<T>, Executor> stateChangeListeners;
         synchronized (lock) {
             if (state.equals(newState)) {
                 return state;
@@ -118,7 +113,7 @@ public class StateMachine<T>
             state = newState;
 
             futureStateChange = this.futureStateChange.getAndSet(new FutureStateChange<>());
-            stateChangeListeners = ImmutableList.copyOf(this.stateChangeListeners);
+            stateChangeListeners = ImmutableMap.copyOf(this.stateChangeListeners);
 
             // if we are now in a terminal state, free the listeners since this will be the last notification
             if (isTerminalState(state)) {
@@ -175,7 +170,7 @@ public class StateMachine<T>
         requireNonNull(newState, "newState is null");
 
         FutureStateChange<T> futureStateChange;
-        ImmutableList<StateChangeListener<T>> stateChangeListeners;
+        ImmutableMap<StateChangeListener<T>, Executor> stateChangeListeners;
         synchronized (lock) {
             if (!state.equals(expectedState)) {
                 return false;
@@ -191,7 +186,7 @@ public class StateMachine<T>
             state = newState;
 
             futureStateChange = this.futureStateChange.getAndSet(new FutureStateChange<>());
-            stateChangeListeners = ImmutableList.copyOf(this.stateChangeListeners);
+            stateChangeListeners = ImmutableMap.copyOf(this.stateChangeListeners);
 
             // if we are now in a terminal state, free the listeners since this will be the last notification
             if (isTerminalState(state)) {
@@ -203,24 +198,22 @@ public class StateMachine<T>
         return true;
     }
 
-    private void fireStateChanged(T newState, FutureStateChange<T> futureStateChange, List<StateChangeListener<T>> stateChangeListeners)
+    private void fireStateChanged(T newState, FutureStateChange<T> futureStateChange, Map<StateChangeListener<T>, Executor> stateChangeListeners)
     {
         checkState(!Thread.holdsLock(lock), "Can not fire state change event while holding the lock");
         requireNonNull(newState, "newState is null");
 
-        // always fire listener callbacks from a different thread
-        safeExecute(() -> {
-            checkState(!Thread.holdsLock(lock), "Can not notify while holding the lock");
-            try {
-                futureStateChange.complete(newState);
-            }
-            catch (Throwable e) {
-                log.error(e, "Error setting future state for %s", name);
-            }
-            for (StateChangeListener<T> stateChangeListener : stateChangeListeners) {
-                fireStateChangedListener(newState, stateChangeListener);
-            }
-        });
+        try {
+            futureStateChange.complete(newState);
+        }
+        catch (Throwable e) {
+            log.error(e, "Error setting future state for %s", name);
+        }
+
+        // use the provided executor to run the listener callbacks
+        for (Map.Entry<StateChangeListener<T>, Executor> entry : stateChangeListeners.entrySet()) {
+            safeExecute(() -> fireStateChangedListener(newState, entry.getKey()), entry.getValue());
+        }
     }
 
     private void fireStateChangedListener(T newState, StateChangeListener<T> stateChangeListener)
@@ -253,12 +246,11 @@ public class StateMachine<T>
 
     /**
      * Adds a listener to be notified when the state instance changes according to {@code .equals()}.
-     * Listener is always notified asynchronously using a dedicated notification thread pool so, care should
-     * be taken to avoid leaking {@code this} when adding a listener in a constructor. Additionally, it is
+     * Listener is always notified using the provided executor. Additionally, it is
      * possible notifications are observed out of order due to the asynchronous execution. The listener is
-     * immediately notified immediately of the current state.
+     * immediately notified of the current state.
      */
-    public void addStateChangeListener(StateChangeListener<T> stateChangeListener)
+    public void addStateChangeListener(StateChangeListener<T> stateChangeListener, Executor executor)
     {
         requireNonNull(stateChangeListener, "stateChangeListener is null");
 
@@ -268,13 +260,13 @@ public class StateMachine<T>
             currentState = state;
             inTerminalState = isTerminalState(currentState);
             if (!inTerminalState) {
-                stateChangeListeners.add(stateChangeListener);
+                stateChangeListeners.put(stateChangeListener, executor);
             }
         }
 
         // fire state change listener with the current state
-        // always fire listener callbacks from a different thread
-        safeExecute(() -> stateChangeListener.stateChanged(currentState));
+        // always execute listener callbacks within the given executor
+        safeExecute(() -> stateChangeListener.stateChanged(currentState), executor);
     }
 
     @VisibleForTesting
@@ -289,10 +281,10 @@ public class StateMachine<T>
     }
 
     @VisibleForTesting
-    List<StateChangeListener<T>> getStateChangeListeners()
+    ImmutableMap<StateChangeListener<T>, Executor> getStateChangeListeners()
     {
         synchronized (lock) {
-            return ImmutableList.copyOf(stateChangeListeners);
+            return ImmutableMap.copyOf(stateChangeListeners);
         }
     }
 
@@ -307,7 +299,7 @@ public class StateMachine<T>
         return get().toString();
     }
 
-    private void safeExecute(Runnable command)
+    private void safeExecute(Runnable command, Executor executor)
     {
         try {
             executor.execute(command);

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
@@ -85,6 +85,8 @@ public class ArbitraryOutputBuffer
 
     private final LifespanSerializedPageTracker pageTracker;
 
+    private final Executor executor;
+
     public ArbitraryOutputBuffer(
             String taskInstanceId,
             StateMachine<BufferState> state,
@@ -102,12 +104,13 @@ public class ArbitraryOutputBuffer
                 requireNonNull(notificationExecutor, "notificationExecutor is null"));
         this.pageTracker = new LifespanSerializedPageTracker(memoryManager);
         this.masterBuffer = new MasterBuffer(pageTracker);
+        this.executor = requireNonNull(notificationExecutor, "notificationExecutor is null");
     }
 
     @Override
     public void addStateChangeListener(StateChangeListener<BufferState> stateChangeListener)
     {
-        state.addStateChangeListener(stateChangeListener);
+        state.addStateChangeListener(stateChangeListener, executor);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
@@ -73,6 +73,7 @@ public class BroadcastOutputBuffer
     private final AtomicLong totalPagesAdded = new AtomicLong();
     private final AtomicLong totalRowsAdded = new AtomicLong();
     private final AtomicLong totalBufferedPages = new AtomicLong();
+    private final Executor executor;
 
     public BroadcastOutputBuffer(
             String taskInstanceId,
@@ -90,12 +91,13 @@ public class BroadcastOutputBuffer
         this.pageTracker = new LifespanSerializedPageTracker(memoryManager, Optional.of((lifespan, releasedPageCount, releasedSizeInBytes) -> {
             checkState(totalBufferedPages.addAndGet(-releasedPageCount) >= 0);
         }));
+        this.executor = requireNonNull(notificationExecutor, "notificationExecutor is null");
     }
 
     @Override
     public void addStateChangeListener(StateChangeListener<BufferState> stateChangeListener)
     {
-        state.addStateChangeListener(stateChangeListener);
+        state.addStateChangeListener(stateChangeListener, executor);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/DiscardingOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/DiscardingOutputBuffer.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
@@ -41,10 +42,13 @@ public class DiscardingOutputBuffer
     private final AtomicLong totalPagesAdded = new AtomicLong();
     private final AtomicLong totalRowsAdded = new AtomicLong();
 
-    public DiscardingOutputBuffer(OutputBuffers outputBuffers, StateMachine<BufferState> state)
+    private final Executor executor;
+
+    public DiscardingOutputBuffer(OutputBuffers outputBuffers, StateMachine<BufferState> state, Executor executor)
     {
         this.outputBuffers = requireNonNull(outputBuffers, "outputBuffers is null");
         this.state = requireNonNull(state, "state is null");
+        this.executor = requireNonNull(executor, "executor is null");
     }
 
     @Override
@@ -85,7 +89,7 @@ public class DiscardingOutputBuffer
     @Override
     public void addStateChangeListener(StateMachine.StateChangeListener<BufferState> stateChangeListener)
     {
-        state.addStateChangeListener(stateChangeListener);
+        state.addStateChangeListener(stateChangeListener, executor);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
@@ -80,7 +80,7 @@ public class LazyOutputBuffer
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.taskInstanceId = requireNonNull(taskInstanceId, "taskInstanceId is null");
         this.executor = requireNonNull(executor, "executor is null");
-        state = new StateMachine<>(taskId + "-buffer", executor, OPEN, TERMINAL_BUFFER_STATES);
+        state = new StateMachine<>(taskId + "-buffer", OPEN, TERMINAL_BUFFER_STATES);
         this.maxBufferSize = requireNonNull(maxBufferSize, "maxBufferSize is null");
         checkArgument(maxBufferSize.toBytes() > 0, "maxBufferSize must be at least 1");
         this.systemMemoryContextSupplier = requireNonNull(systemMemoryContextSupplier, "systemMemoryContextSupplier is null");
@@ -90,7 +90,7 @@ public class LazyOutputBuffer
     @Override
     public void addStateChangeListener(StateChangeListener<BufferState> stateChangeListener)
     {
-        state.addStateChangeListener(stateChangeListener);
+        state.addStateChangeListener(stateChangeListener, executor);
     }
 
     @Override
@@ -170,7 +170,7 @@ public class LazyOutputBuffer
                             outputBuffer = new ArbitraryOutputBuffer(taskInstanceId, state, maxBufferSize, systemMemoryContextSupplier, executor);
                             break;
                         case DISCARDING:
-                            outputBuffer = new DiscardingOutputBuffer(newOutputBuffers, state);
+                            outputBuffer = new DiscardingOutputBuffer(newOutputBuffers, state, executor);
                             break;
                         case SPOOLING:
                             outputBuffer = spoolingOutputBufferFactory.createSpoolingOutputBuffer(taskId, taskInstanceId, newOutputBuffers, state);

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
@@ -55,6 +55,8 @@ public class PartitionedOutputBuffer
     private final AtomicLong totalPagesAdded = new AtomicLong();
     private final AtomicLong totalRowsAdded = new AtomicLong();
 
+    private final Executor executor;
+
     public PartitionedOutputBuffer(
             String taskInstanceId,
             StateMachine<BufferState> state,
@@ -82,6 +84,7 @@ public class PartitionedOutputBuffer
             partitions.add(partition);
         }
         this.partitions = partitions.build();
+        this.executor = requireNonNull(notificationExecutor, "notificationExecutor is null");
 
         state.compareAndSet(OPEN, NO_MORE_BUFFERS);
         state.compareAndSet(NO_MORE_PAGES, FLUSHING);
@@ -91,7 +94,7 @@ public class PartitionedOutputBuffer
     @Override
     public void addStateChangeListener(StateChangeListener<BufferState> stateChangeListener)
     {
-        state.addStateChangeListener(stateChangeListener);
+        state.addStateChangeListener(stateChangeListener, executor);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBuffer.java
@@ -191,7 +191,7 @@ public class SpoolingOutputBuffer
     @Override
     public void addStateChangeListener(StateMachine.StateChangeListener<BufferState> stateChangeListener)
     {
-        state.addStateChangeListener(stateChangeListener);
+        state.addStateChangeListener(stateChangeListener, executor);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -42,11 +42,13 @@ import io.airlift.units.Duration;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CURRENT_STATE;
@@ -63,6 +65,7 @@ import static com.facebook.presto.util.Failures.REMOTE_TASK_MISMATCH_ERROR;
 import static io.airlift.units.Duration.nanosSince;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
 
 class ContinuousTaskStatusFetcher
         implements SimpleHttpResponseCallback<TaskStatus>
@@ -91,6 +94,8 @@ class ContinuousTaskStatusFetcher
     @GuardedBy("this")
     private ListenableFuture<BaseResponse<TaskStatus>> future;
 
+    private final ExecutorService executorService = newSingleThreadExecutor(daemonThreadsNamed("continuous-task-status-fetcher"));
+
     public ContinuousTaskStatusFetcher(
             Consumer<Throwable> onFail,
             TaskId taskId,
@@ -110,7 +115,7 @@ class ContinuousTaskStatusFetcher
 
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.onFail = requireNonNull(onFail, "onFail is null");
-        this.taskStatus = new StateMachine<>("task-" + taskId, executor, initialTaskStatus);
+        this.taskStatus = new StateMachine<>("task-" + taskId, initialTaskStatus);
 
         this.refreshMaxWait = requireNonNull(refreshMaxWait, "refreshMaxWait is null");
         this.taskStatusCodec = requireNonNull(taskStatusCodec, "taskStatusCodec is null");
@@ -303,7 +308,7 @@ class ContinuousTaskStatusFetcher
      */
     public void addStateChangeListener(StateMachine.StateChangeListener<TaskStatus> stateChangeListener)
     {
-        taskStatus.addStateChangeListener(stateChangeListener);
+        taskStatus.addStateChangeListener(stateChangeListener, executorService);
     }
 
     private void updateStats(long currentRequestStartNanos)

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
@@ -51,12 +51,14 @@ import javax.annotation.concurrent.GuardedBy;
 import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
 import static com.facebook.airlift.http.client.Request.Builder.preparePost;
@@ -73,6 +75,7 @@ import static com.facebook.presto.server.thrift.ThriftCodecWrapper.unwrapThriftC
 import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
 import static io.airlift.units.Duration.nanosSince;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class TaskInfoFetcher
@@ -123,6 +126,8 @@ public class TaskInfoFetcher
     private final ConnectorTypeSerdeManager connectorTypeSerdeManager;
     private final Protocol thriftProtocol;
 
+    private final ExecutorService executorService = newSingleThreadExecutor(daemonThreadsNamed("task-info-fetcher"));
+
     public TaskInfoFetcher(
             Consumer<Throwable> onFail,
             TaskInfo initialTask,
@@ -151,8 +156,8 @@ public class TaskInfoFetcher
 
         this.taskId = initialTask.getTaskId();
         this.onFail = requireNonNull(onFail, "onFail is null");
-        this.taskInfo = new StateMachine<>("task " + taskId, executor, initialTask);
-        this.finalTaskInfo = new StateMachine<>("task-" + taskId, executor, Optional.empty());
+        this.taskInfo = new StateMachine<>("task " + taskId, initialTask);
+        this.finalTaskInfo = new StateMachine<>("task-" + taskId, Optional.empty());
         this.taskInfoCodec = requireNonNull(taskInfoCodec, "taskInfoCodec is null");
 
         this.metadataUpdatesCodec = requireNonNull(metadataUpdatesCodec, "metadataUpdatesCodec is null");
@@ -219,7 +224,7 @@ public class TaskInfoFetcher
                 stateChangeListener.stateChanged(finalTaskInfo.get());
             }
         };
-        finalTaskInfo.addStateChangeListener(fireOnceStateChangeListener);
+        finalTaskInfo.addStateChangeListener(fireOnceStateChangeListener, executorService);
         fireOnceStateChangeListener.stateChanged(finalTaskInfo.get());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -646,7 +646,7 @@ public class TestSqlTaskExecution
     {
         return new PartitionedOutputBuffer(
                 "queryId.0.0",
-                new StateMachine<>("bufferState", taskNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", OPEN, TERMINAL_BUFFER_STATES),
                 createInitialEmptyOutputBuffers(PARTITIONED)
                         .withBuffer(OUTPUT_BUFFER_ID, 0)
                         .withNoMoreBufferIds(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStateMachine.java
@@ -37,7 +37,7 @@ public class TestStateMachine
         BREAKFAST, LUNCH, DINNER
     }
 
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+    private static final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("test-%s"));
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
@@ -50,13 +50,13 @@ public class TestStateMachine
             throws Exception
     {
         try {
-            new StateMachine<>("test", executor, null);
+            new StateMachine<>("test", null);
             fail("expected a NullPointerException");
         }
         catch (NullPointerException ignored) {
         }
 
-        StateMachine<State> stateMachine = new StateMachine<>("test", executor, State.BREAKFAST);
+        StateMachine<State> stateMachine = new StateMachine<>("test", State.BREAKFAST);
 
         assertNoStateChange(stateMachine, () -> {
             try {
@@ -108,7 +108,7 @@ public class TestStateMachine
     public void testSet()
             throws Exception
     {
-        StateMachine<State> stateMachine = new StateMachine<>("test", executor, State.BREAKFAST, ImmutableSet.of(State.DINNER));
+        StateMachine<State> stateMachine = new StateMachine<>("test", State.BREAKFAST, ImmutableSet.of(State.DINNER));
         assertEquals(stateMachine.get(), State.BREAKFAST);
 
         assertNoStateChange(stateMachine, () -> assertEquals(stateMachine.set(State.BREAKFAST), State.BREAKFAST));
@@ -136,7 +136,7 @@ public class TestStateMachine
     public void testCompareAndSet()
             throws Exception
     {
-        StateMachine<State> stateMachine = new StateMachine<>("test", executor, State.BREAKFAST, ImmutableSet.of(State.DINNER));
+        StateMachine<State> stateMachine = new StateMachine<>("test", State.BREAKFAST, ImmutableSet.of(State.DINNER));
         assertEquals(stateMachine.get(), State.BREAKFAST);
 
         // no match with new state
@@ -172,7 +172,7 @@ public class TestStateMachine
     public void testSetIf()
             throws Exception
     {
-        StateMachine<State> stateMachine = new StateMachine<>("test", executor, State.BREAKFAST, ImmutableSet.of(State.DINNER));
+        StateMachine<State> stateMachine = new StateMachine<>("test", State.BREAKFAST, ImmutableSet.of(State.DINNER));
         assertEquals(stateMachine.get(), State.BREAKFAST);
 
         // false predicate with new state
@@ -288,7 +288,7 @@ public class TestStateMachine
             else {
                 stateChanged.set(newState);
             }
-        });
+        }, executor);
 
         assertTrue(tryGetFutureValue(initialStateNotified, 10, SECONDS).isPresent(), "Initial state notification not fired");
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -456,9 +456,9 @@ public class TestArbitraryOutputBuffer
             addPage(buffer, createPage(33));
             assertThat(secondReads).allMatch(future -> !future.isDone(), "No secondary reads should complete until after all first reads");
             List<OutputBufferId> completedIds = firstReads.entrySet().stream()
-                                                        .filter(entry -> entry.getValue().isDone())
-                                                        .map(Map.Entry::getKey)
-                                                        .collect(toList());
+                    .filter(entry -> entry.getValue().isDone())
+                    .map(Map.Entry::getKey)
+                    .collect(toList());
             assertEquals(completedIds.size(), 1, "One completed buffer read per page addition");
             OutputBufferId completed = completedIds.get(0);
 
@@ -1075,7 +1075,7 @@ public class TestArbitraryOutputBuffer
     {
         ArbitraryOutputBuffer buffer = new ArbitraryOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", OPEN, TERMINAL_BUFFER_STATES),
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 stateNotificationExecutor);

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -1083,7 +1083,7 @@ public class TestBroadcastOutputBuffer
     {
         BroadcastOutputBuffer buffer = new BroadcastOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", OPEN, TERMINAL_BUFFER_STATES),
                 dataSize,
                 () -> memoryContext.newLocalMemoryContext("test"),
                 notificationExecutor);
@@ -1145,7 +1145,7 @@ public class TestBroadcastOutputBuffer
     {
         BroadcastOutputBuffer buffer = new BroadcastOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", OPEN, TERMINAL_BUFFER_STATES),
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 stateNotificationExecutor);

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
@@ -841,7 +841,7 @@ public class TestPartitionedOutputBuffer
     {
         PartitionedOutputBuffer buffer = new PartitionedOutputBuffer(
                 TASK_INSTANCE_ID,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", OPEN, TERMINAL_BUFFER_STATES),
                 buffers,
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestSpoolingOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestSpoolingOutputBuffer.java
@@ -556,7 +556,7 @@ public class TestSpoolingOutputBuffer
                 taskId,
                 TASK_INSTANCE_ID,
                 OUTPUT_BUFFERS,
-                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES));
+                new StateMachine<>("bufferState", OPEN, TERMINAL_BUFFER_STATES));
     }
 
     private static BufferResult bufferResult(long token, Page firstPage, Page... otherPages)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPartitionedOutputOperator.java
@@ -197,7 +197,7 @@ public class TestPartitionedOutputOperator
         }
         PartitionedOutputBuffer buffer = new PartitionedOutputBuffer(
                 "task-instance-id",
-                new StateMachine<>("bufferState", SCHEDULER, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", OPEN, TERMINAL_BUFFER_STATES),
                 buffers.withNoMoreBufferIds(),
                 new DataSize(Long.MAX_VALUE, BYTE),
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
@@ -359,7 +359,7 @@ public class BenchmarkPartitionedOutputOperator
         {
             return new TestingPartitionedOutputBuffer(
                     "task-instance-id",
-                    new StateMachine<>("bufferState", SCHEDULER, OPEN, TERMINAL_BUFFER_STATES),
+                    new StateMachine<>("bufferState", OPEN, TERMINAL_BUFFER_STATES),
                     buffers,
                     dataSize,
                     () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
@@ -931,7 +931,7 @@ public class TestOptimizedPartitionedOutputOperator
     {
         return new TestingPartitionedOutputBuffer(
                 "task-instance-id",
-                new StateMachine<>("bufferState", SCHEDULER, OPEN, TERMINAL_BUFFER_STATES),
+                new StateMachine<>("bufferState", OPEN, TERMINAL_BUFFER_STATES),
                 buffers,
                 dataSize,
                 () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),


### PR DESCRIPTION
## Description
1. This PR updates the StateMachine implementation so that 
    1. the state machine does not have a builtin executor
    2. state change consumers should provide both a callback method and an executor to be used to run the callback

## Motivation and Context
1. the current code will let foreign code to provide a callback to the state machine while the state machine is in charge of running the callback with its own executor. This is an anti pattern. It should be the responsibility of the state change listener to provide an executor to run the callback.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. running verifiers

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

