### PR TITLE
Add JDBC Properties section

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -337,3 +337,52 @@ The corresponding configuration property is :ref:`admin/properties:\`\`optimizer
 Enable retry for failed queries who can potentially be helped by HBO. 
 
 The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.retry-query-with-history-based-optimization\`\``. 
+
+JDBC Properties
+---------------
+
+
+``useJdbcMetadataCache``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Cache the result of the JDBC queries that fetch metadata about tables and columns.
+
+``allowDropTable``
+^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Allow connector to drop tables.
+
+``metadataCacheTtl``
+^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``Duration``
+* **Default value:** ``0``
+
+Setting a duration controls how long to cache data.
+
+``metadataCacheRefreshInterval``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``Duration``
+* **Default value:** ``0``
+
+``metadataCacheMaximumSize``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``long``
+* **Default value:** ``1``
+
+``metadataCacheThreadPoolSize``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``int``
+* **Default value:** ``1``
+
+The value represents the max background fetch threads for refreshing metadata.
+


### PR DESCRIPTION
Add JDBC Properties section with JdbcMetadataConfig properties

## Description
Add a new header JDBC Properties to [Presto Session Properties](https://github.com/prestodb/presto/issues/presto-docs/src/main/sphinx/admin/properties-session.rst)

## Motivation and Context
JdbcMetadataConfig session properties are undocumented. Addresses issue [#23918](https://github.com/prestodb/presto/issues/23918)

## Impact
Helping readers of Presto documentation by improving the documentation to include currently undocumented features.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

