### PR TITLE
Use StringBuilder for some toString methods instead of string concatenation 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionId.java
@@ -90,6 +90,14 @@ public class StageExecutionId
     @JsonValue
     public String toString()
     {
-        return stageId + "." + id;
+        StringBuilder builder = new StringBuilder();
+        appendString(builder);
+        return builder.toString();
+    }
+
+    public void appendString(StringBuilder builder)
+    {
+        stageId.appendString(builder);
+        builder.append(".").append(id);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageId.java
@@ -79,7 +79,15 @@ public class StageId
     @JsonValue
     public String toString()
     {
-        return queryId + "." + id;
+        StringBuilder builder = new StringBuilder();
+        appendString(builder);
+        return builder.toString();
+    }
+
+    public void appendString(StringBuilder builder)
+    {
+        queryId.appendString(builder);
+        builder.append(".").append(id);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskId.java
@@ -83,7 +83,15 @@ public class TaskId
     @JsonValue
     public String toString()
     {
-        return stageExecutionId + "." + id + "." + attemptNumber;
+        StringBuilder builder = new StringBuilder();
+        appendString(builder);
+        return builder.toString();
+    }
+
+    public void appendString(StringBuilder builder)
+    {
+        stageExecutionId.appendString(builder);
+        builder.append(".").append(id).append(".").append(attemptNumber);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestId.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestId.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.spi.QueryId;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestId
+{
+    @Test
+    public void testAppendString()
+    {
+        QueryId queryId = new QueryId("foo");
+        StageId stageId = new StageId(queryId, 1);
+        StageExecutionId stageExecutionId = new StageExecutionId(stageId, 2);
+        TaskId taskId = new TaskId(stageExecutionId, 3, 1);
+
+        assertEquals(queryId.toString(), "foo");
+        assertEquals(stageId.toString(), String.format("%s.%s", queryId.getId(), stageId.getId()));
+        assertEquals(stageExecutionId.toString(), String.format("%s.%s.%s", queryId.getId(), stageId.getId(), stageExecutionId.getId()));
+        assertEquals(taskId.toString(), String.format("%s.%s.%s.%s.%s", queryId.getId(), stageId.getId(), stageExecutionId.getId(), taskId.getId(), taskId.getAttemptNumber()));
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/QueryId.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/QueryId.java
@@ -58,6 +58,11 @@ public final class QueryId
         return id;
     }
 
+    public void appendString(StringBuilder builder)
+    {
+        builder.append(id);
+    }
+
     @Override
     public int hashCode()
     {


### PR DESCRIPTION
## Description
1. Passing a string builder along while creating ids (those with embedded ids) so that only one string builder will be created along the way

## Motivation and Context
1. While creating ids, say taskId, a string builder will be created to do so but this taskId will need a stageExecutionId which will trigger the creation of another string builder and stageExecutionId needs stagesId and the same will happen again.
2. We see some crazy cpu usage for toString method due to string concatenation, T212253302
![image](https://github.com/user-attachments/assets/993744cf-a10b-4469-8019-1afee5d67a2c)


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. Doing verifier tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Optimizations
* Improve toString method for a few Id classes using StringBuilder :pr:`24341`
```

