### PR TITLE
feat(native): Link to mono Velox library instead of component libraries

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -234,9 +234,7 @@ include_directories(${CMAKE_BINARY_DIR})
 # set this for backwards compatibility, will be overwritten in velox/
 set(VELOX_GTEST_INCUDE_DIR "velox/third_party/googletest/googletest/include")
 
-# Do not use the Mono library because it causes link errors.
-set(VELOX_MONO_LIBRARY OFF CACHE BOOL "Build Velox mono library")
-
+set(VELOX_MONO_LIBRARY ON CACHE BOOL "Build Velox mono library")
 add_subdirectory(velox)
 
 if(PRESTO_ENABLE_TESTING)

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -67,43 +67,7 @@ target_link_libraries(
   presto_velox_plan_conversion
   presto_hive_functions
   presto_theta_sketch_functions
-  velox_abfs
-  velox_aggregates
-  velox_caching
-  velox_common_base
-  velox_core
-  velox_dwio_common_exception
-  velox_dwio_dwrf_reader
-  velox_dwio_dwrf_writer
-  velox_dwio_orc_reader
-  velox_dwio_parquet_reader
-  velox_dwio_parquet_writer
-  velox_dwio_text_reader_register
-  velox_dwio_text_writer_register
-  velox_dynamic_library_loader
-  velox_encode
-  velox_exec
-  velox_rpc_plan_node_translator
-  velox_file
-  velox_functions_lib
-  velox_functions_prestosql
-  velox_gcs
-  velox_hdfs
-  velox_connector_registry
-  velox_hive_connector
-  velox_hive_iceberg_splitreader
-  velox_hive_partition_function
-  velox_key_encoder
-  velox_presto_serializer
-  velox_presto_type_parser
-  velox_s3fs
-  velox_serialization
-  velox_time
-  velox_type
-  velox_type_fbhive
-  velox_type_tz
-  velox_vector
-  velox_window
+  velox
   ${RE2}
   ${FOLLY_WITH_DEPENDENCIES}
   ${GLOG}
@@ -112,22 +76,15 @@ target_link_libraries(
 )
 
 if(PRESTO_ENABLE_CUDF)
+  # The symbols from velox_cudf_exec are not included in the Velox mono library
+  # and need to be linked separately.
   target_link_libraries(presto_server_lib velox_cudf_exec)
 endif()
 
-# Enabling Parquet causes build errors with missing symbols on MacOS. This is
-# likely due to a conflict between Arrow Thrift from velox_hive_connector and
-# FBThrift libraries. The build issue is fixed by linking velox_hive_connector
-# dependencies first followed by FBThrift.
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   add_library(presto_server_remote_function JsonSignatureParser.cpp RemoteFunctionRegisterer.cpp)
 
-  target_link_libraries(
-    presto_server_remote_function
-    velox_expression
-    velox_functions_remote
-    ${FOLLY_WITH_DEPENDENCIES}
-  )
+  target_link_libraries(presto_server_remote_function velox ${FOLLY_WITH_DEPENDENCIES})
   target_link_libraries(presto_server_lib presto_server_remote_function)
 endif()
 
@@ -145,12 +102,7 @@ else()
   target_link_options(presto_server BEFORE PUBLIC "-Wl,-export-dynamic")
 endif()
 
-# velox_tpch_connector is an OBJECT target in Velox and so needs to be linked to
-# the executable or use TARGET_OBJECT linkage for the presto_server_lib target.
-# However, we also would need to add its dependencies (tpch_gen etc). TODO
-# change the target in Velox to a library target then we can move this to the
-# presto_server_lib.
-target_link_libraries(presto_server presto_server_lib velox_tpch_connector velox_tpcds_connector)
+target_link_libraries(presto_server presto_server_lib)
 
 # Clang requires explicit linking with libatomic.
 if(

--- a/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/CMakeLists.txt
@@ -20,16 +20,10 @@ add_library(
   LegacyHiveConfigKeys.cpp
 )
 
-target_link_libraries(presto_exception velox_exception)
+target_link_libraries(presto_exception velox)
 set_property(TARGET presto_exception PROPERTY JOB_POOL_LINK presto_link_job_pool)
 
-target_link_libraries(
-  presto_common
-  velox_common_config
-  velox_core
-  velox_exception
-  velox_presto_serializer
-)
+target_link_libraries(presto_common velox)
 set_property(TARGET presto_common PROPERTY JOB_POOL_LINK presto_link_job_pool)
 
 if(PRESTO_ENABLE_TESTING)

--- a/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/common/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 # limitations under the License.
 add_library(presto_mutable_configs MutableConfigs.cpp)
 
-target_link_libraries(presto_mutable_configs presto_common velox_file)
+target_link_libraries(presto_mutable_configs presto_common velox)
 
 add_executable(presto_common_test CommonTest.cpp ConfigTest.cpp LegacyHiveConfigKeysTest.cpp)
 
@@ -21,14 +21,7 @@ target_link_libraries(
   presto_common_test
   presto_common
   presto_exception
-  velox_aggregates
-  velox_exception
-  velox_file
-  velox_functions_prestosql
-  velox_function_registry
-  velox_presto_serializer
-  velox_presto_types
-  velox_window
+  velox
   ${RE2}
   GTest::gtest
 )

--- a/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
@@ -29,11 +29,6 @@ if(PRESTO_ENABLE_CUDF)
   target_link_libraries(presto_connectors velox_cudf_hive_connector cudf::cudf)
 endif()
 
-target_link_libraries(
-  presto_connectors
-  presto_velox_expr_conversion
-  velox_type_fbhive
-  velox_tpcds_connector
-)
+target_link_libraries(presto_connectors presto_velox_expr_conversion velox)
 
 add_subdirectory(hive)

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/CMakeLists.txt
@@ -29,7 +29,7 @@ target_compile_definitions(presto_flight_connector PUBLIC PRESTO_ENABLE_ARROW_FL
 
 target_link_libraries(
   presto_flight_connector
-  velox_connector
+  velox
   ArrowFlight::arrow_flight_shared
   presto_flight_connector_utils
   presto_flight_connector_auth

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/auth/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/auth/CMakeLists.txt
@@ -11,4 +11,4 @@
 # limitations under the License.
 add_library(presto_flight_connector_auth Authenticator.cpp)
 
-target_link_libraries(presto_flight_connector_auth presto_flight_connector_utils velox_exception)
+target_link_libraries(presto_flight_connector_auth presto_flight_connector_utils velox)

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/utils/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/utils/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(
   presto_flight_connector_test_lib
   arrow
   presto_flight_connector
-  velox_exception
+  velox
   presto_flight_connector_utils
   velox_exec_test_lib
 )

--- a/presto-native-execution/presto_cpp/main/connectors/hive/functions/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/hive/functions/CMakeLists.txt
@@ -11,11 +11,7 @@
 # limitations under the License.
 
 add_library(presto_hive_functions HiveFunctionRegistration.cpp)
-target_link_libraries(
-  presto_hive_functions
-  presto_dynamic_function_registrar
-  velox_functions_string
-)
+target_link_libraries(presto_hive_functions presto_dynamic_function_registrar velox)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/functions/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/CMakeLists.txt
@@ -11,12 +11,7 @@
 # limitations under the License.
 
 add_library(presto_function_metadata OBJECT FunctionMetadata.cpp)
-target_link_libraries(
-  presto_function_metadata
-  presto_common
-  velox_function_registry
-  velox_async_rpc_function_registry
-)
+target_link_libraries(presto_function_metadata presto_common velox)
 
 add_subdirectory(dynamic_registry)
 add_subdirectory(theta_sketch)

--- a/presto-native-execution/presto_cpp/main/functions/remote/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/remote/CMakeLists.txt
@@ -11,15 +11,10 @@
 # limitations under the License.
 
 add_library(presto_to_velox_remote_functions PrestoRestFunctionRegistration.cpp)
-target_link_libraries(
-  presto_to_velox_remote_functions
-  presto_functions_remote
-  velox_type_fbhive
-  Boost::url
-)
+target_link_libraries(presto_to_velox_remote_functions presto_functions_remote velox Boost::url)
 
 add_library(presto_functions_remote RestRemoteFunction.cpp)
-target_link_libraries(presto_functions_remote presto_functions_rest_client velox_functions_remote)
+target_link_libraries(presto_functions_remote presto_functions_rest_client velox)
 
 add_subdirectory(client)
 

--- a/presto-native-execution/presto_cpp/main/functions/remote/tests/server/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/remote/tests/server/CMakeLists.txt
@@ -11,4 +11,4 @@
 # limitations under the License.
 
 add_library(presto_functions_rest_server RemoteFunctionRestService.cpp RestFunctionRegistry.cpp)
-target_link_libraries(presto_functions_rest_server velox_presto_serializer)
+target_link_libraries(presto_functions_rest_server velox)

--- a/presto-native-execution/presto_cpp/main/functions/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/tests/CMakeLists.txt
@@ -24,9 +24,7 @@ target_link_libraries(
   presto_common
   presto_protocol
   presto_type_test_utils
-  velox_aggregates
-  velox_functions_prestosql
-  velox_window
+  velox
   GTest::gtest
   GTest::gtest_main
 )

--- a/presto-native-execution/presto_cpp/main/functions/theta_sketch/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/theta_sketch/CMakeLists.txt
@@ -12,7 +12,7 @@
 
 add_library(presto_theta_sketch_functions ThetaSketchAggregate.cpp ThetaSketchFunctions.cpp)
 
-target_link_libraries(presto_theta_sketch_functions velox_common_base Folly::folly)
+target_link_libraries(presto_theta_sketch_functions velox Folly::folly)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/functions/theta_sketch/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/theta_sketch/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ add_test(
 target_link_libraries(
   presto_theta_sketch_functions_test
   presto_theta_sketch_functions
-  velox_exec
+  velox
   velox_exec_test_lib
   velox_functions_aggregates_test_lib
   GTest::gtest

--- a/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/http/CMakeLists.txt
@@ -22,8 +22,7 @@ target_link_libraries(
   presto_http
   http_filters
   presto_common
-  velox_memory
-  velox_exception
+  velox
   ${PROXYGEN_LIBRARIES}
   ${LIBSODIUM_LIBRARY}
   ${OPENSSL_SSL_LIBRARY}

--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -27,16 +27,7 @@ add_library(
   ShuffleWrite.cpp
 )
 
-target_link_libraries(
-  presto_operators
-  presto_common
-  presto_native-cpp2
-  velox_core
-  velox_exec
-  velox_presto_serializer
-  velox_vector
-  velox_row_fast
-)
+target_link_libraries(presto_operators presto_common presto_native-cpp2 velox)
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 # limitations under the License.
 add_library(presto_operators_plan_builder PlanBuilder.cpp)
 
-target_link_libraries(presto_operators_plan_builder velox_core)
+target_link_libraries(presto_operators_plan_builder velox)
 
 add_executable(
   presto_operators_test
@@ -33,14 +33,9 @@ target_link_libraries(
   presto_type_converter
   presto_types
   velox_vector_fuzzer
+  velox
   velox_exec_test_lib
-  velox_hive_partition_function
   velox_vector_test_lib
-  velox_type
-  velox_vector
-  velox_exec
-  velox_memory
-  velox_exec
   GTest::gmock
   GTest::gtest
   GTest::gtest_main
@@ -60,14 +55,9 @@ target_link_libraries(
   presto_protocol
   presto_type_converter
   presto_types
-  velox_vector_fuzzer
+  velox
   velox_exec_test_lib
-  velox_hive_partition_function
   velox_vector_test_lib
-  velox_type
-  velox_vector
-  velox_exec
-  velox_memory
   GTest::gmock
   GTest::gtest
 )
@@ -83,13 +73,7 @@ add_test(
   COMMAND presto_materialized_exchange_reclaim_test
 )
 
-target_link_libraries(
-  presto_materialized_exchange_reclaim_test
-  presto_operators
-  velox_exec
-  velox_memory
-  GTest::gtest
-)
+target_link_libraries(presto_materialized_exchange_reclaim_test presto_operators velox GTest::gtest)
 
 set_property(
   TARGET presto_materialized_exchange_reclaim_test

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -44,18 +44,11 @@ add_test(
 
 target_link_libraries(
   presto_server_test
-  velox_caching
-  velox_exec_test_lib
   presto_server_lib
-  velox_dwio_common_test_utils
   $<TARGET_OBJECTS:presto_type_converter>
   $<TARGET_OBJECTS:presto_types>
-  velox_hive_connector
-  velox_tpch_connector
-  velox_presto_serializer
-  velox_functions_prestosql
-  velox_aggregates
-  velox_hive_partition_function
+  velox
+  velox_exec_test_lib
   presto_mutable_configs
   ${RE2}
   GTest::gmock
@@ -89,7 +82,7 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   target_link_libraries(
     presto_server_remote_function_test
     presto_server_remote_function
-    velox_expression
+    velox
     GTest::gmock
     GTest::gtest
     GTest::gtest_main

--- a/presto-native-execution/presto_cpp/main/tool/trace/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tool/trace/CMakeLists.txt
@@ -12,13 +12,7 @@
 
 add_library(presto_tool_trace_replayers PartitionAndSerializeReplayer.cpp)
 
-target_link_libraries(
-  presto_tool_trace_replayers
-  presto_operators
-  velox_core
-  velox_exec
-  velox_query_trace_replayer_base
-)
+target_link_libraries(presto_tool_trace_replayers presto_operators velox)
 
 add_executable(presto_trace_replayer TraceReplayerMain.cpp)
 
@@ -27,9 +21,7 @@ target_link_libraries(
   presto_tool_trace_replayers
   presto_operators
   presto_type_converter
-  velox_core
-  velox_exec
-  velox_query_trace_replayer_base
+  velox
   ${FOLLY_WITH_DEPENDENCIES}
   ${GFLAGS_LIBRARIES}
 )

--- a/presto-native-execution/presto_cpp/main/tool/trace/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tool/trace/tests/CMakeLists.txt
@@ -17,12 +17,8 @@ target_link_libraries(
   presto_tool_trace_replayers
   presto_operators
   presto_plan_builder
-  velox_core
-  velox_exec
+  velox
   velox_exec_test_lib
-  velox_hive_connector
-  velox_hive_iceberg_splitreader
-  velox_query_trace_replayer_base
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}

--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -11,10 +11,10 @@
 # limitations under the License.
 
 add_library(presto_type_converter OBJECT TypeParser.cpp)
-target_link_libraries(presto_type_converter velox_presto_type_parser)
+target_link_libraries(presto_type_converter velox)
 
 add_library(presto_velox_expr_conversion OBJECT PrestoToVeloxExpr.cpp)
-target_link_libraries(presto_velox_expr_conversion velox_presto_types velox_vector velox_exception)
+target_link_libraries(presto_velox_expr_conversion velox)
 
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   target_link_libraries(presto_velox_expr_conversion presto_to_velox_remote_functions)
@@ -28,14 +28,13 @@ target_link_libraries(
   presto_operators
   presto_type_converter
   presto_session_properties
-  velox_type
-  velox_type_fbhive
+  velox
 )
 
 set_property(TARGET presto_types PROPERTY JOB_POOL_LINK presto_link_job_pool)
 
 add_library(presto_velox_plan_conversion OBJECT VeloxPlanConversion.cpp)
-target_link_libraries(presto_velox_plan_conversion velox_type)
+target_link_libraries(presto_velox_plan_conversion velox)
 
 add_library(presto_velox_to_presto_expr VeloxToPrestoExpr.cpp)
 

--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -23,18 +23,9 @@ target_link_libraries(
   presto_connectors
   presto_operators
   presto_protocol
-  velox_dwio_common
-  velox_dwio_orc_reader
-  velox_hive_connector
-  velox_hive_iceberg_splitreader
-  velox_tpch_connector
-  velox_tpcds_connector
-  velox_exec
-  velox_dwio_common_exception
   presto_type_converter
   presto_types
-  velox_type_fbhive
-  velox_hive_partition_function
+  velox
 )
 
 add_executable(
@@ -65,15 +56,7 @@ target_link_libraries(
   presto_mutable_configs
   presto_type_test_utils
   presto_session_properties
-  velox_core
-  velox_exec
-  velox_exec_test_lib
-  velox_functions_prestosql
-  velox_presto_type_parser
-  velox_hive_connector
-  velox_hive_iceberg_splitreader
-  velox_tpch_connector
-  velox_type
+  velox
   Boost::filesystem
 )
 
@@ -94,11 +77,7 @@ target_link_libraries(
   presto_operators
   presto_type_converter
   presto_types
-  velox_dwio_common
-  velox_hive_connector
-  velox_hive_iceberg_splitreader
-  velox_tpch_connector
-  velox_tpcds_connector
+  velox
   GTest::gtest
   GTest::gtest_main
 )
@@ -122,11 +101,7 @@ target_link_libraries(
   presto_protocol
   presto_type_converter
   presto_types
-  velox_dwio_common
-  velox_exec_test_lib
-  velox_hive_connector
-  velox_hive_iceberg_splitreader
-  velox_tpch_connector
+  velox
   GTest::gtest
   GTest::gtest_main
 )

--- a/presto-native-execution/presto_cpp/presto_protocol/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(
   core/ConnectorProtocol.cpp
 )
 
-target_link_libraries(presto_protocol velox_type velox_presto_serializer ${RE2})
+target_link_libraries(presto_protocol velox ${RE2})
 
 if(PRESTO_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/CMakeLists.txt
@@ -43,11 +43,7 @@ target_link_libraries(
   GTest::gtest
   GTest::gtest_main
   $<TARGET_OBJECTS:presto_protocol>
-  velox_type
-  velox_encode
-  velox_exception
-  velox_vector
-  velox_presto_serializer
+  velox
   Boost::filesystem
   ${RE2}
   ${FOLLY_LIBRARIES}


### PR DESCRIPTION
This change makes use of the Velox mono library for all components. This removes the need to add individual velox subcomponent libraries.

The sum of all the Velox library components for clang on macOS with debug symbols is about 3.4GB. The velox mono library only consumes about 2.9GB resulting in a saving of about 400MB when switching over.
Similar results are to be expected on Linux and the release build (the latter saving is less because overall there would be less added code).

Edit: As of Jun 2026, the shared Velox debug library is about 850MB and release is at 228MB for a basic build on macOS (Clang 21).
```
❯ ls -ltr ./_build/release/velox/lib/libvelox.dylib
-rwxr-xr-x  1 czentgr  staff  221185520 Jun 19 09:25 ./_build/release/velox/lib/libvelox.dylib
❯ ls -ltr ./_build/debug/velox/lib/libvelox.dylib
-rwxr-xr-x  1 czentgr  staff  851066528 Jun 19 09:39 ./_build/debug/velox/lib/libvelox.dylib
```

For the static library the size has only increased from the last check
```
❯ ls -ltr ./_build/release/velox/lib/libvelox.a
-rw-r--r--  1 czentgr  staff  342963336 Jun 28 10:48 ./_build/release/velox/lib/libvelox.a
❯ ls -ltr ./_build/debug/velox/lib/libvelox.a
-rw-r--r--  1 czentgr  staff  4148721376 Jun 28 10:39 ./_build/debug/velox/lib/libvelox.a
```
With the resulting executable size
```
❯ ls -ltr ./_build/release/presto_cpp/main/presto_server
-rwxr-xr-x  1 czentgr  staff  218261168 Jun 28 10:48 ./_build/release/presto_cpp/main/presto_server
❯ ls -ltr ./_build/debug/presto_cpp/main/presto_server
-rwxr-xr-x  1 czentgr  staff  860398544 Jun 28 10:39 ./_build/debug/presto_cpp/main/presto_server
```


## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

