### PR TITLE
[WIP]: Invalidate ORC metadata cache based on file modification time

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -86,12 +86,10 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
-import io.airlift.slice.Slice;
 import org.weakref.jmx.MBeanExporter;
 
 import javax.inject.Singleton;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
@@ -101,6 +99,8 @@ import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static com.facebook.airlift.json.smile.SmileCodecBinder.smileCodecBinder;
 import static com.facebook.drift.codec.guice.ThriftCodecBinder.thriftCodecBinder;
+import static com.facebook.presto.orc.StripeMetadataSource.CacheableRowGroupIndices;
+import static com.facebook.presto.orc.StripeMetadataSource.CacheableSlice;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.lang.Math.toIntExact;
@@ -320,15 +320,15 @@ public class HiveClientModule
     {
         StripeMetadataSource stripeMetadataSource = new StorageStripeMetadataSource();
         if (orcCacheConfig.isStripeMetadataCacheEnabled()) {
-            Cache<StripeId, Slice> footerCache = CacheBuilder.newBuilder()
+            Cache<StripeId, CacheableSlice> footerCache = CacheBuilder.newBuilder()
                     .maximumWeight(orcCacheConfig.getStripeFooterCacheSize().toBytes())
-                    .weigher((id, footer) -> toIntExact(((Slice) footer).getRetainedSize()))
+                    .weigher((id, footer) -> toIntExact(((CacheableSlice) footer).getSlice().getRetainedSize()))
                     .expireAfterAccess(orcCacheConfig.getStripeFooterCacheTtlSinceLastAccess().toMillis(), MILLISECONDS)
                     .recordStats()
                     .build();
-            Cache<StripeStreamId, Slice> streamCache = CacheBuilder.newBuilder()
+            Cache<StripeStreamId, CacheableSlice> streamCache = CacheBuilder.newBuilder()
                     .maximumWeight(orcCacheConfig.getStripeStreamCacheSize().toBytes())
-                    .weigher((id, stream) -> toIntExact(((Slice) stream).getRetainedSize()))
+                    .weigher((id, stream) -> toIntExact(((CacheableSlice) stream).getSlice().getRetainedSize()))
                     .expireAfterAccess(orcCacheConfig.getStripeStreamCacheTtlSinceLastAccess().toMillis(), MILLISECONDS)
                     .recordStats()
                     .build();
@@ -337,11 +337,11 @@ public class HiveClientModule
             exporter.export(generatedNameOf(CacheStatsMBean.class, connectorId + "_StripeFooter"), footerCacheStatsMBean);
             exporter.export(generatedNameOf(CacheStatsMBean.class, connectorId + "_StripeStream"), streamCacheStatsMBean);
 
-            Optional<Cache<StripeStreamId, List<RowGroupIndex>>> rowGroupIndexCache = Optional.empty();
+            Optional<Cache<StripeStreamId, CacheableRowGroupIndices>> rowGroupIndexCache = Optional.empty();
             if (orcCacheConfig.isRowGroupIndexCacheEnabled()) {
                 rowGroupIndexCache = Optional.of(CacheBuilder.newBuilder()
                         .maximumWeight(orcCacheConfig.getRowGroupIndexCacheSize().toBytes())
-                        .weigher((id, rowGroupIndices) -> toIntExact(((List<RowGroupIndex>) rowGroupIndices).stream().mapToLong(RowGroupIndex::getRetainedSizeInBytes).sum()))
+                        .weigher((id, rowGroupIndices) -> toIntExact(((CacheableRowGroupIndices) rowGroupIndices).getRowGroupIndices().stream().mapToLong(RowGroupIndex::getRetainedSizeInBytes).sum()))
                         .expireAfterAccess(orcCacheConfig.getStripeStreamCacheTtlSinceLastAccess().toMillis(), MILLISECONDS)
                         .recordStats()
                         .build());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactoryUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactoryUtils.java
@@ -104,7 +104,8 @@ public class OrcPageSourceFactoryUtils
                 hiveFileContext.isCacheable(),
                 dwrfEncryptionProvider,
                 dwrfKeyProvider,
-                hiveFileContext.getStats());
+                hiveFileContext.getStats(),
+                hiveFileContext.getModificationTime());
         return reader;
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -155,6 +155,7 @@ import static com.facebook.presto.iceberg.delete.PositionDeleteFilter.readPositi
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
+import static com.facebook.presto.orc.OrcReader.MODIFICATION_TIME_NOT_SET;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getDescriptors;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetTypeByName;
@@ -504,7 +505,8 @@ public class IcebergPageSourceProvider
                     isCacheable,
                     dwrfEncryptionProvider,
                     dwrfKeyProvider,
-                    runtimeStats);
+                    runtimeStats,
+                    MODIFICATION_TIME_NOT_SET);
 
             List<HiveColumnHandle> physicalColumnHandles = new ArrayList<>(regularColumns.size());
             ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -155,7 +155,8 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
             StripeMetadataSource stripeMetadataSource,
             boolean cacheable,
             RuntimeStats runtimeStats,
-            Optional<OrcFileIntrospector> fileIntrospector)
+            Optional<OrcFileIntrospector> fileIntrospector,
+            long fileModificationTime)
     {
         requireNonNull(includedColumns, "includedColumns is null");
         requireNonNull(predicate, "predicate is null");
@@ -262,7 +263,8 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
                 cacheable,
                 this.dwrfEncryptionGroupMap,
                 runtimeStats,
-                fileIntrospector);
+                fileIntrospector,
+                fileModificationTime);
 
         this.streamReaders = requireNonNull(streamReaders, "streamReaders is null");
         for (int columnId = 0; columnId < root.getFieldCount(); columnId++) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/CachingStripeMetadataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/CachingStripeMetadataSource.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 
 import static com.facebook.presto.common.RuntimeUnit.BYTE;
 import static com.facebook.presto.common.RuntimeUnit.NONE;
@@ -48,11 +47,11 @@ public class CachingStripeMetadataSource
         implements StripeMetadataSource
 {
     private final StripeMetadataSource delegate;
-    private final Cache<StripeId, Slice> footerSliceCache;
-    private final Cache<StripeStreamId, Slice> stripeStreamCache;
-    private final Optional<Cache<StripeStreamId, List<RowGroupIndex>>> rowGroupIndexCache;
+    private final Cache<StripeId, CacheableSlice> footerSliceCache;
+    private final Cache<StripeStreamId, CacheableSlice> stripeStreamCache;
+    private final Optional<Cache<StripeStreamId, CacheableRowGroupIndices>> rowGroupIndexCache;
 
-    public CachingStripeMetadataSource(StripeMetadataSource delegate, Cache<StripeId, Slice> footerSliceCache, Cache<StripeStreamId, Slice> stripeStreamCache, Optional<Cache<StripeStreamId, List<RowGroupIndex>>> rowGroupIndexCache)
+    public CachingStripeMetadataSource(StripeMetadataSource delegate, Cache<StripeId, CacheableSlice> footerSliceCache, Cache<StripeStreamId, CacheableSlice> stripeStreamCache, Optional<Cache<StripeStreamId, CacheableRowGroupIndices>> rowGroupIndexCache)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.footerSliceCache = requireNonNull(footerSliceCache, "footerSliceCache is null");
@@ -61,39 +60,56 @@ public class CachingStripeMetadataSource
     }
 
     @Override
-    public Slice getStripeFooterSlice(OrcDataSource orcDataSource, StripeId stripeId, long footerOffset, int footerLength, boolean cacheable)
+    public Slice getStripeFooterSlice(OrcDataSource orcDataSource, StripeId stripeId, long footerOffset, int footerLength, boolean cacheable, long fileModificationTime)
             throws IOException
     {
-        try {
-            if (!cacheable) {
-                return delegate.getStripeFooterSlice(orcDataSource, stripeId, footerOffset, footerLength, cacheable);
-            }
-            return footerSliceCache.get(stripeId, () -> delegate.getStripeFooterSlice(orcDataSource, stripeId, footerOffset, footerLength, cacheable));
+        if (!cacheable) {
+            return delegate.getStripeFooterSlice(orcDataSource, stripeId, footerOffset, footerLength, cacheable, fileModificationTime);
         }
-        catch (ExecutionException | UncheckedExecutionException e) {
+        try {
+            CacheableSlice cacheableSlice = footerSliceCache.getIfPresent(stripeId);
+            if (cacheableSlice != null) {
+                if (cacheableSlice.getFileModificationTime() == fileModificationTime) {
+                    return cacheableSlice.getSlice();
+                }
+                footerSliceCache.invalidate(stripeId);
+                // This get call is to increment the miss count for invalidated entries so the stats are recorded correctly.
+                footerSliceCache.getIfPresent(stripeId);
+            }
+            cacheableSlice = new CacheableSlice(delegate.getStripeFooterSlice(orcDataSource, stripeId, footerOffset, footerLength, cacheable, fileModificationTime), fileModificationTime);
+            footerSliceCache.put(stripeId, cacheableSlice);
+            return cacheableSlice.getSlice();
+        }
+        catch (UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), IOException.class);
             throw new IOException("Unexpected error in stripe footer reading after footerSliceCache miss", e.getCause());
         }
     }
 
     @Override
-    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable)
+    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable, long fileModificationTime)
             throws IOException
     {
         if (!cacheable) {
-            return delegate.getInputs(orcDataSource, stripeId, diskRanges, cacheable);
+            return delegate.getInputs(orcDataSource, stripeId, diskRanges, cacheable, fileModificationTime);
         }
 
         // Fetch existing stream slice from cache
         ImmutableMap.Builder<StreamId, OrcDataSourceInput> inputsBuilder = ImmutableMap.builder();
         ImmutableMap.Builder<StreamId, DiskRange> uncachedDiskRangesBuilder = ImmutableMap.builder();
         for (Entry<StreamId, DiskRange> entry : diskRanges.entrySet()) {
+            StripeStreamId stripeStreamId = new StripeStreamId(stripeId, entry.getKey());
             if (isCachedStream(entry.getKey().getStreamKind())) {
-                Slice streamSlice = stripeStreamCache.getIfPresent(new StripeStreamId(stripeId, entry.getKey()));
-                if (streamSlice != null) {
-                    inputsBuilder.put(entry.getKey(), new OrcDataSourceInput(new BasicSliceInput(streamSlice), streamSlice.length()));
+                CacheableSlice streamSlice = stripeStreamCache.getIfPresent(stripeStreamId);
+                if (streamSlice != null && streamSlice.getFileModificationTime() == fileModificationTime) {
+                    inputsBuilder.put(entry.getKey(), new OrcDataSourceInput(new BasicSliceInput(streamSlice.getSlice()), streamSlice.getSlice().length()));
                 }
                 else {
+                    if (streamSlice != null) {
+                        stripeStreamCache.invalidate(stripeStreamId);
+                        // This get call is to increment the miss count for invalidated entries so the stats are recorded correctly.
+                        stripeStreamCache.getIfPresent(stripeStreamId);
+                    }
                     uncachedDiskRangesBuilder.put(entry);
                 }
             }
@@ -103,12 +119,12 @@ public class CachingStripeMetadataSource
         }
 
         // read ranges and update cache
-        Map<StreamId, OrcDataSourceInput> uncachedInputs = delegate.getInputs(orcDataSource, stripeId, uncachedDiskRangesBuilder.build(), cacheable);
+        Map<StreamId, OrcDataSourceInput> uncachedInputs = delegate.getInputs(orcDataSource, stripeId, uncachedDiskRangesBuilder.build(), cacheable, fileModificationTime);
         for (Entry<StreamId, OrcDataSourceInput> entry : uncachedInputs.entrySet()) {
             if (isCachedStream(entry.getKey().getStreamKind())) {
                 // We need to rewind the input after eagerly reading the slice.
                 Slice streamSlice = Slices.wrappedBuffer(entry.getValue().getInput().readSlice(toIntExact(entry.getValue().getInput().length())).getBytes());
-                stripeStreamCache.put(new StripeStreamId(stripeId, entry.getKey()), streamSlice);
+                stripeStreamCache.put(new StripeStreamId(stripeId, entry.getKey()), new CacheableSlice(streamSlice, fileModificationTime));
                 inputsBuilder.put(entry.getKey(), new OrcDataSourceInput(new BasicSliceInput(streamSlice), toIntExact(streamSlice.getRetainedSize())));
             }
             else {
@@ -126,24 +142,31 @@ public class CachingStripeMetadataSource
             StreamId streamId,
             OrcInputStream inputStream,
             List<HiveBloomFilter> bloomFilters,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            long fileModificationTime)
             throws IOException
     {
+        StripeStreamId stripeStreamId = new StripeStreamId(stripId, streamId);
         if (rowGroupIndexCache.isPresent()) {
-            List<RowGroupIndex> rowGroupIndices = rowGroupIndexCache.get().getIfPresent(new StripeStreamId(stripId, streamId));
-            if (rowGroupIndices != null) {
+            CacheableRowGroupIndices cacheableRowGroupIndices = rowGroupIndexCache.get().getIfPresent(stripeStreamId);
+            if (cacheableRowGroupIndices != null && cacheableRowGroupIndices.getFileModificationTime() == fileModificationTime) {
                 runtimeStats.addMetricValue("OrcRowGroupIndexCacheHit", NONE, 1);
-                runtimeStats.addMetricValue("OrcRowGroupIndexInMemoryBytesRead", BYTE, rowGroupIndices.stream().mapToLong(RowGroupIndex::getRetainedSizeInBytes).sum());
-                return rowGroupIndices;
+                runtimeStats.addMetricValue("OrcRowGroupIndexInMemoryBytesRead", BYTE, cacheableRowGroupIndices.getRowGroupIndices().stream().mapToLong(RowGroupIndex::getRetainedSizeInBytes).sum());
+                return cacheableRowGroupIndices.getRowGroupIndices();
             }
             else {
+                if (cacheableRowGroupIndices != null) {
+                    rowGroupIndexCache.get().invalidate(stripeStreamId);
+                    // This get call is to increment the miss count for invalidated entries so the stats are recorded correctly.
+                    rowGroupIndexCache.get().getIfPresent(stripeStreamId);
+                }
                 runtimeStats.addMetricValue("OrcRowGroupIndexCacheHit", NONE, 0);
                 runtimeStats.addMetricValue("OrcRowGroupIndexStorageBytesRead", BYTE, inputStream.getRetainedSizeInBytes());
             }
         }
-        List<RowGroupIndex> rowGroupIndices = delegate.getRowIndexes(metadataReader, hiveWriterVersion, stripId, streamId, inputStream, bloomFilters, runtimeStats);
+        List<RowGroupIndex> rowGroupIndices = delegate.getRowIndexes(metadataReader, hiveWriterVersion, stripId, streamId, inputStream, bloomFilters, runtimeStats, fileModificationTime);
         if (rowGroupIndexCache.isPresent()) {
-            rowGroupIndexCache.get().put(new StripeStreamId(stripId, streamId), rowGroupIndices);
+            rowGroupIndexCache.get().put(stripeStreamId, new CacheableRowGroupIndices(rowGroupIndices, fileModificationTime));
         }
         return rowGroupIndices;
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/DwrfAwareStripeMetadataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DwrfAwareStripeMetadataSource.java
@@ -52,23 +52,23 @@ public class DwrfAwareStripeMetadataSource
     }
 
     @Override
-    public Slice getStripeFooterSlice(OrcDataSource orcDataSource, StripeId stripeId, long footerOffset, int footerLength, boolean cacheable)
+    public Slice getStripeFooterSlice(OrcDataSource orcDataSource, StripeId stripeId, long footerOffset, int footerLength, boolean cacheable, long fileModificationTime)
             throws IOException
     {
         Optional<Slice> stripeFooterSlice = stripeCache.getStripeFooterSlice(stripeId, footerLength);
         if (stripeFooterSlice.isPresent()) {
             return stripeFooterSlice.get();
         }
-        return delegate.getStripeFooterSlice(orcDataSource, stripeId, footerOffset, footerLength, cacheable);
+        return delegate.getStripeFooterSlice(orcDataSource, stripeId, footerOffset, footerLength, cacheable, fileModificationTime);
     }
 
     @Override
-    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable)
+    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable, long fileModificationTime)
             throws IOException
     {
         Optional<Slice> stripeCacheIndexStreamsSlice = stripeCache.getIndexStreamsSlice(stripeId);
         if (!stripeCacheIndexStreamsSlice.isPresent()) {
-            return delegate.getInputs(orcDataSource, stripeId, diskRanges, cacheable);
+            return delegate.getInputs(orcDataSource, stripeId, diskRanges, cacheable, fileModificationTime);
         }
 
         Slice cacheSlice = stripeCacheIndexStreamsSlice.get();
@@ -91,7 +91,7 @@ public class DwrfAwareStripeMetadataSource
 
         ImmutableMap<StreamId, DiskRange> dataStreams = dataStreamsBuilder.build();
         if (!dataStreams.isEmpty()) {
-            Map<StreamId, OrcDataSourceInput> dataStreamInputs = delegate.getInputs(orcDataSource, stripeId, dataStreams, cacheable);
+            Map<StreamId, OrcDataSourceInput> dataStreamInputs = delegate.getInputs(orcDataSource, stripeId, dataStreams, cacheable, fileModificationTime);
             inputsBuilder.putAll(dataStreamInputs);
         }
 
@@ -106,9 +106,10 @@ public class DwrfAwareStripeMetadataSource
             StreamId streamId,
             OrcInputStream inputStream,
             List<HiveBloomFilter> bloomFilters,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            long fileModificationTime)
             throws IOException
     {
-        return delegate.getRowIndexes(metadataReader, hiveWriterVersion, stripeId, streamId, inputStream, bloomFilters, runtimeStats);
+        return delegate.getRowIndexes(metadataReader, hiveWriterVersion, stripeId, streamId, inputStream, bloomFilters, runtimeStats, fileModificationTime);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -68,7 +68,8 @@ public class OrcBatchRecordReader
             int initialBatchSize,
             StripeMetadataSource stripeMetadataSource,
             boolean cacheable,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            long fileModificationTime)
             throws OrcCorruptionException
 
     {
@@ -107,7 +108,8 @@ public class OrcBatchRecordReader
                 stripeMetadataSource,
                 cacheable,
                 runtimeStats,
-                Optional.empty());
+                Optional.empty(),
+                 fileModificationTime);
     }
 
     public int nextBatch()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -66,6 +66,7 @@ public class OrcReader
     public static final int MAX_BATCH_SIZE = 1024;
     public static final int INITIAL_BATCH_SIZE = 1;
     public static final int BATCH_SIZE_GROWTH_FACTOR = 2;
+    public static final long MODIFICATION_TIME_NOT_SET = 0L;
 
     private final OrcDataSource orcDataSource;
     private final ExceptionWrappingMetadataReader metadataReader;
@@ -86,10 +87,11 @@ public class OrcReader
     private final OrcReaderOptions orcReaderOptions;
 
     private final boolean cacheable;
+    private final long fileModificationTime;
 
     private final RuntimeStats runtimeStats;
 
-    // This is based on the Apache Hive ORC code
+    // For testing only
     public OrcReader(
             OrcDataSource orcDataSource,
             OrcEncoding orcEncoding,
@@ -108,6 +110,35 @@ public class OrcReader
                 orcEncoding,
                 orcFileTailSource,
                 StripeMetadataSourceFactory.of(stripeMetadataSource),
+                aggregatedMemoryContext,
+                orcReaderOptions,
+                cacheable,
+                dwrfEncryptionProvider,
+                dwrfKeyProvider,
+                runtimeStats,
+                MODIFICATION_TIME_NOT_SET);
+    }
+
+    // This is based on the Apache Hive ORC code
+    public OrcReader(
+            OrcDataSource orcDataSource,
+            OrcEncoding orcEncoding,
+            OrcFileTailSource orcFileTailSource,
+            StripeMetadataSource stripeMetadataSource,
+            OrcAggregatedMemoryContext aggregatedMemoryContext,
+            OrcReaderOptions orcReaderOptions,
+            boolean cacheable,
+            DwrfEncryptionProvider dwrfEncryptionProvider,
+            DwrfKeyProvider dwrfKeyProvider,
+            RuntimeStats runtimeStats,
+            long fileModificationTime)
+            throws IOException
+    {
+        this(
+                orcDataSource,
+                orcEncoding,
+                orcFileTailSource,
+                StripeMetadataSourceFactory.of(stripeMetadataSource),
                 Optional.empty(),
                 aggregatedMemoryContext,
                 orcReaderOptions,
@@ -115,7 +146,8 @@ public class OrcReader
                 dwrfEncryptionProvider,
                 dwrfKeyProvider,
                 runtimeStats,
-                Optional.empty());
+                Optional.empty(),
+                fileModificationTime);
     }
 
     public OrcReader(
@@ -128,7 +160,8 @@ public class OrcReader
             boolean cacheable,
             DwrfEncryptionProvider dwrfEncryptionProvider,
             DwrfKeyProvider dwrfKeyProvider,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            long fileModificationTime)
             throws IOException
     {
         this(
@@ -143,7 +176,8 @@ public class OrcReader
                 dwrfEncryptionProvider,
                 dwrfKeyProvider,
                 runtimeStats,
-                Optional.empty());
+                Optional.empty(),
+                fileModificationTime);
     }
 
     OrcReader(
@@ -158,7 +192,8 @@ public class OrcReader
             DwrfEncryptionProvider dwrfEncryptionProvider,
             DwrfKeyProvider dwrfKeyProvider,
             RuntimeStats runtimeStats,
-            Optional<OrcFileIntrospector> fileIntrospector)
+            Optional<OrcFileIntrospector> fileIntrospector,
+            long fileModificationTime)
             throws IOException
     {
         this.orcReaderOptions = requireNonNull(orcReaderOptions, "orcReaderOptions is null");
@@ -170,7 +205,7 @@ public class OrcReader
         this.writeValidation = requireNonNull(writeValidation, "writeValidation is null");
         this.fileIntrospector = requireNonNull(fileIntrospector, "fileIntrospector is null");
 
-        OrcFileTail orcFileTail = orcFileTailSource.getOrcFileTail(orcDataSource, metadataReader, writeValidation, cacheable);
+        OrcFileTail orcFileTail = orcFileTailSource.getOrcFileTail(orcDataSource, metadataReader, writeValidation, cacheable, fileModificationTime);
         fileIntrospector.ifPresent(introspector -> introspector.onFileTail(orcFileTail));
 
         this.bufferSize = orcFileTail.getBufferSize();
@@ -234,6 +269,7 @@ public class OrcReader
         }
 
         this.cacheable = requireNonNull(cacheable, "cacheable is null");
+        this.fileModificationTime = fileModificationTime;
 
         Optional<DwrfStripeCache> dwrfStripeCache = Optional.empty();
         if (orcFileTail.getDwrfStripeCacheData().isPresent() && footer.getDwrfStripeCacheOffsets().isPresent()) {
@@ -366,7 +402,8 @@ public class OrcReader
                 initialBatchSize,
                 stripeMetadataSource,
                 cacheable,
-                runtimeStats);
+                runtimeStats,
+                fileModificationTime);
     }
 
     public OrcSelectiveRecordReader createSelectiveRecordReader(
@@ -420,7 +457,8 @@ public class OrcReader
                 stripeMetadataSource,
                 cacheable,
                 runtimeStats,
-                fileIntrospector);
+                fileIntrospector,
+                fileModificationTime);
     }
 
     private static OrcDataSource wrapWithCacheIfTiny(OrcDataSource dataSource, DataSize maxCacheSize, OrcAggregatedMemoryContext systemMemoryContext)
@@ -463,7 +501,8 @@ public class OrcReader
                     dwrfEncryptionProvider,
                     dwrfKeyProvider,
                     new RuntimeStats(),
-                    Optional.empty());
+                    Optional.empty(),
+                    MODIFICATION_TIME_NOT_SET);
             try (OrcBatchRecordReader orcRecordReader = orcReader.createBatchRecordReader(
                     readTypes.build(),
                     OrcPredicate.TRUE,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -188,7 +188,8 @@ public class OrcSelectiveRecordReader
             StripeMetadataSource stripeMetadataSource,
             boolean cacheable,
             RuntimeStats runtimeStats,
-            Optional<OrcFileIntrospector> fileIntrospector)
+            Optional<OrcFileIntrospector> fileIntrospector,
+            long fileModificationTime)
     {
         super(includedColumns,
                 requiredSubfields,
@@ -231,7 +232,8 @@ public class OrcSelectiveRecordReader
                 stripeMetadataSource,
                 cacheable,
                 runtimeStats,
-                fileIntrospector);
+                fileIntrospector,
+                fileModificationTime);
 
         // Hive column indices can't be used to index into arrays because they are negative
         // for partition and hidden columns. Hence, we create synthetic zero-based indices.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StorageStripeMetadataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StorageStripeMetadataSource.java
@@ -32,7 +32,7 @@ public class StorageStripeMetadataSource
         implements StripeMetadataSource
 {
     @Override
-    public Slice getStripeFooterSlice(OrcDataSource orcDataSource, StripeId stripeId, long footerOffset, int footerLength, boolean cacheable)
+    public Slice getStripeFooterSlice(OrcDataSource orcDataSource, StripeId stripeId, long footerOffset, int footerLength, boolean cacheable, long fileModificationTime)
             throws IOException
     {
         byte[] tailBuffer = new byte[footerLength];
@@ -41,7 +41,7 @@ public class StorageStripeMetadataSource
     }
 
     @Override
-    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable)
+    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable, long fileModificationTime)
             throws IOException
     {
         //
@@ -68,7 +68,8 @@ public class StorageStripeMetadataSource
             StreamId streamId,
             OrcInputStream inputStream,
             List<HiveBloomFilter> bloomFilters,
-            RuntimeStats runtimeStats)
+            RuntimeStats runtimeStats,
+            long fileModificationTime)
             throws IOException
     {
         return metadataReader.readRowIndexes(hiveWriterVersion, inputStream, bloomFilters);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -96,6 +96,7 @@ public class StripeReader
     private final Optional<OrcWriteValidation> writeValidation;
     private final StripeMetadataSource stripeMetadataSource;
     private final boolean cacheable;
+    private final long fileModificationTime;
     private final Multimap<Integer, Integer> dwrfEncryptionGroupColumns;
     private final RuntimeStats runtimeStats;
     private final Optional<OrcFileIntrospector> fileIntrospector;
@@ -114,7 +115,8 @@ public class StripeReader
             boolean cacheable,
             Map<Integer, Integer> dwrfEncryptionGroupMap,
             RuntimeStats runtimeStats,
-            Optional<OrcFileIntrospector> fileIntrospector)
+            Optional<OrcFileIntrospector> fileIntrospector,
+            long fileModificationTime)
     {
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
         this.decompressor = requireNonNull(decompressor, "decompressor is null");
@@ -130,6 +132,7 @@ public class StripeReader
         this.dwrfEncryptionGroupColumns = invertEncryptionGroupMap(requireNonNull(dwrfEncryptionGroupMap, "dwrfEncryptionGroupMap is null"));
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
         this.fileIntrospector = requireNonNull(fileIntrospector, "fileIntrospector is null");
+        this.fileModificationTime = fileModificationTime;
     }
 
     private Multimap<Integer, Integer> invertEncryptionGroupMap(Map<Integer, Integer> dwrfEncryptionGroupMap)
@@ -346,7 +349,7 @@ public class StripeReader
         //
 
         // read ranges
-        Map<StreamId, OrcDataSourceInput> streamsData = stripeMetadataSource.getInputs(orcDataSource, stripeId, diskRanges, cacheable);
+        Map<StreamId, OrcDataSourceInput> streamsData = stripeMetadataSource.getInputs(orcDataSource, stripeId, diskRanges, cacheable, fileModificationTime);
 
         // transform streams to OrcInputStream
         ImmutableMap.Builder<StreamId, OrcInputStream> streamsBuilder = ImmutableMap.builder();
@@ -484,7 +487,7 @@ public class StripeReader
         int footerLength = toIntExact(stripe.getFooterLength());
 
         // read the footer
-        Slice footerSlice = stripeMetadataSource.getStripeFooterSlice(orcDataSource, stripeId, footerOffset, footerLength, cacheable);
+        Slice footerSlice = stripeMetadataSource.getStripeFooterSlice(orcDataSource, stripeId, footerOffset, footerLength, cacheable, fileModificationTime);
         try (InputStream inputStream = new OrcInputStream(
                 orcDataSource.getId(),
                 // Memory is not accounted as the buffer is expected to be tiny and will be immediately discarded
@@ -531,7 +534,7 @@ public class StripeReader
             if (stream.getStreamKind() == ROW_INDEX) {
                 OrcInputStream inputStream = streamsData.get(streamId);
                 List<HiveBloomFilter> bloomFilters = bloomFilterIndexes.get(streamId.getColumn());
-                List<RowGroupIndex> rowGroupIndexes = stripeMetadataSource.getRowIndexes(metadataReader, hiveWriterVersion, stripeId, streamId, inputStream, bloomFilters, runtimeStats);
+                List<RowGroupIndex> rowGroupIndexes = stripeMetadataSource.getRowIndexes(metadataReader, hiveWriterVersion, stripeId, streamId, inputStream, bloomFilters, runtimeStats, fileModificationTime);
                 columnIndexes.put(entry.getKey(), rowGroupIndexes);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/cache/OrcFileTailSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/cache/OrcFileTailSource.java
@@ -23,6 +23,6 @@ import java.util.Optional;
 
 public interface OrcFileTailSource
 {
-    OrcFileTail getOrcFileTail(OrcDataSource orcDataSource, MetadataReader metadataReader, Optional<OrcWriteValidation> writeValidation, boolean cacheable)
+    OrcFileTail getOrcFileTail(OrcDataSource orcDataSource, MetadataReader metadataReader, Optional<OrcWriteValidation> writeValidation, boolean cacheable, long fileModificationTime)
             throws IOException;
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
@@ -64,7 +64,7 @@ public class StorageOrcFileTailSource
     }
 
     @Override
-    public OrcFileTail getOrcFileTail(OrcDataSource orcDataSource, MetadataReader metadataReader, Optional<OrcWriteValidation> writeValidation, boolean cacheable)
+    public OrcFileTail getOrcFileTail(OrcDataSource orcDataSource, MetadataReader metadataReader, Optional<OrcWriteValidation> writeValidation, boolean cacheable, long fileModificationTime)
             throws IOException
     {
         long size = orcDataSource.getSize();
@@ -162,7 +162,7 @@ public class StorageOrcFileTailSource
             dwrfStripeCacheData = Optional.of(new DwrfStripeCacheData(dwrfStripeCacheSlice, dwrfStripeCacheSize, stripeCacheMode));
         }
 
-        return new OrcFileTail(hiveWriterVersion, bufferSize, compressionKind, footerSlice, footerSize, metadataSlice, metadataSize, dwrfStripeCacheData);
+        return new OrcFileTail(hiveWriterVersion, bufferSize, compressionKind, footerSlice, footerSize, metadataSlice, metadataSize, dwrfStripeCacheData, fileModificationTime);
     }
 
     /**

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcFileTail.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcFileTail.java
@@ -30,6 +30,7 @@ public class OrcFileTail
     private final Slice metadataSlice;
     private final int metadataSize;
     private final Optional<DwrfStripeCacheData> dwrfStripeCacheData;
+    private final long fileModificationTime;
 
     public OrcFileTail(
             HiveWriterVersion hiveWriterVersion,
@@ -39,7 +40,8 @@ public class OrcFileTail
             int footerSize,
             Slice metadataSlice,
             int metadataSize,
-            Optional<DwrfStripeCacheData> dwrfStripeCacheData)
+            Optional<DwrfStripeCacheData> dwrfStripeCacheData,
+            long fileModificationTime)
     {
         this.hiveWriterVersion = requireNonNull(hiveWriterVersion, "hiveWriterVersion is null");
         this.bufferSize = bufferSize;
@@ -49,6 +51,7 @@ public class OrcFileTail
         this.metadataSlice = requireNonNull(metadataSlice, "metadataSlice is null");
         this.metadataSize = metadataSize;
         this.dwrfStripeCacheData = requireNonNull(dwrfStripeCacheData, "dwrfStripeCacheData is null");
+        this.fileModificationTime = fileModificationTime;
     }
 
     public HiveWriterVersion getHiveWriterVersion()
@@ -103,5 +106,10 @@ public class OrcFileTail
     public int getTotalSize()
     {
         return getFooterSize() + getMetadataSize() + getDwrfStripeCacheSize();
+    }
+
+    public long getFileModificationTime()
+    {
+        return fileModificationTime;
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
@@ -36,7 +36,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
-import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
@@ -79,6 +78,8 @@ import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
 import static com.facebook.presto.orc.OrcTester.createCustomOrcRecordReader;
 import static com.facebook.presto.orc.OrcTester.createOrcRecordWriter;
 import static com.facebook.presto.orc.OrcTester.createSettableStructObjectInspector;
+import static com.facebook.presto.orc.StripeMetadataSource.CacheableRowGroupIndices;
+import static com.facebook.presto.orc.StripeMetadataSource.CacheableSlice;
 import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.google.common.collect.Iterables.concat;
@@ -202,32 +203,32 @@ public abstract class AbstractTestOrcReader
                 .build();
         OrcFileTailSource orcFileTailSource = new CachingOrcFileTailSource(new StorageOrcFileTailSource(), orcFileTailCache);
 
-        Cache<StripeId, Slice> stripeFootercache = CacheBuilder.newBuilder()
+        Cache<StripeId, CacheableSlice> stripeFootercache = CacheBuilder.newBuilder()
                 .maximumWeight(new DataSize(1, MEGABYTE).toBytes())
-                .weigher((id, footer) -> ((Slice) footer).length())
+                .weigher((id, footer) -> ((CacheableSlice) footer).getSlice().length())
                 .expireAfterAccess(new Duration(10, MINUTES).toMillis(), MILLISECONDS)
                 .recordStats()
                 .build();
-        Cache<StripeStreamId, Slice> stripeStreamCache = CacheBuilder.newBuilder()
+        Cache<StripeStreamId, CacheableSlice> stripeStreamCache = CacheBuilder.newBuilder()
                 .maximumWeight(new DataSize(1, MEGABYTE).toBytes())
-                .weigher((id, stream) -> ((Slice) stream).length())
+                .weigher((id, stream) -> ((CacheableSlice) stream).getSlice().length())
                 .expireAfterAccess(new Duration(10, MINUTES).toMillis(), MILLISECONDS)
                 .recordStats()
                 .build();
-        Optional<Cache<StripeStreamId, List<RowGroupIndex>>> rowGroupIndexCache = Optional.of(CacheBuilder.newBuilder()
+        Optional<Cache<StripeStreamId, CacheableRowGroupIndices>> rowGroupIndexCache = Optional.of(CacheBuilder.newBuilder()
                 .maximumWeight(new DataSize(1, MEGABYTE).toBytes())
-                .weigher((id, rowGroupIndices) -> toIntExact(((List<RowGroupIndex>) rowGroupIndices).stream().mapToLong(RowGroupIndex::getRetainedSizeInBytes).sum()))
+                .weigher((id, rowGroupIndices) -> toIntExact(((CacheableRowGroupIndices) rowGroupIndices).getRowGroupIndices().stream().mapToLong(RowGroupIndex::getRetainedSizeInBytes).sum()))
                 .expireAfterAccess(new Duration(10, MINUTES).toMillis(), MILLISECONDS)
                 .recordStats()
                 .build());
         StripeMetadataSource stripeMetadataSource = new CachingStripeMetadataSource(new StorageStripeMetadataSource(), stripeFootercache, stripeStreamCache, rowGroupIndexCache);
 
         try (TempFile tempFile = createTempFile(10001)) {
-            OrcBatchRecordReader storageReader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, ImmutableList.of(BIGINT), INITIAL_BATCH_SIZE, orcFileTailSource, stripeMetadataSource, true, ImmutableMap.of(), false);
+            OrcBatchRecordReader storageReader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, ImmutableList.of(BIGINT), INITIAL_BATCH_SIZE, orcFileTailSource, stripeMetadataSource, true, ImmutableMap.of(), false, tempFile.getFile().lastModified());
             assertEquals(orcFileTailCache.stats().missCount(), 1);
             assertEquals(orcFileTailCache.stats().hitCount(), 0);
 
-            OrcBatchRecordReader cacheReader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, ImmutableList.of(BIGINT), INITIAL_BATCH_SIZE, orcFileTailSource, stripeMetadataSource, true, ImmutableMap.of(), false);
+            OrcBatchRecordReader cacheReader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, ImmutableList.of(BIGINT), INITIAL_BATCH_SIZE, orcFileTailSource, stripeMetadataSource, true, ImmutableMap.of(), false, tempFile.getFile().lastModified());
             assertEquals(orcFileTailCache.stats().missCount(), 1);
             assertEquals(orcFileTailCache.stats().hitCount(), 1);
 
@@ -250,6 +251,20 @@ public abstract class AbstractTestOrcReader
             assertEquals(rowGroupIndexCache.get().stats().missCount(), 1);
             assertEquals(rowGroupIndexCache.get().stats().hitCount(), 1);
             assertEquals(storageReader.readBlock(0).getInt(0), cacheReader.readBlock(0).getInt(0));
+
+            // Test cache invalidation based on file modified time.
+            long fileModificationTime = System.currentTimeMillis();
+            // This read will invalidate the entry and increases the hit count and miss count
+            cacheReader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, ImmutableList.of(BIGINT), INITIAL_BATCH_SIZE, orcFileTailSource, stripeMetadataSource, true, ImmutableMap.of(), false, fileModificationTime);
+            assertEquals(orcFileTailCache.stats().missCount(), 2);
+            assertEquals(orcFileTailCache.stats().hitCount(), 2);
+            cacheReader.nextBatch();
+            assertEquals(stripeFootercache.stats().missCount(), 2);
+            assertEquals(stripeFootercache.stats().hitCount(), 2);
+            assertEquals(stripeStreamCache.stats().missCount(), 4);
+            assertEquals(stripeStreamCache.stats().hitCount(), 4);
+            assertEquals(rowGroupIndexCache.get().stats().missCount(), 2);
+            assertEquals(rowGroupIndexCache.get().stats().hitCount(), 2);
         }
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -155,6 +155,7 @@ import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
 import static com.facebook.presto.orc.NoOpOrcWriterStats.NOOP_WRITER_STATS;
 import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
 import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
+import static com.facebook.presto.orc.OrcReader.MODIFICATION_TIME_NOT_SET;
 import static com.facebook.presto.orc.OrcTester.Format.DWRF;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_11;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
@@ -1143,7 +1144,7 @@ public class OrcTester
             return;
         }
 
-        try (OrcBatchRecordReader recordReader = createCustomOrcRecordReader(tempFile, orcEncoding, orcPredicate, types, MAX_BATCH_SIZE, new StorageOrcFileTailSource(), new StorageStripeMetadataSource(), false, intermediateEncryptionKeys, false)) {
+        try (OrcBatchRecordReader recordReader = createCustomOrcRecordReader(tempFile, orcEncoding, orcPredicate, types, MAX_BATCH_SIZE, new StorageOrcFileTailSource(), new StorageStripeMetadataSource(), false, intermediateEncryptionKeys, false, tempFile.getFile().lastModified())) {
             assertEquals(recordReader.getReaderPosition(), 0);
             assertEquals(recordReader.getFilePosition(), 0);
 
@@ -1561,7 +1562,8 @@ public class OrcTester
                 new StorageStripeMetadataSource(),
                 cacheable,
                 ImmutableMap.of(),
-                mapNullKeysEnabled);
+                mapNullKeysEnabled,
+                MODIFICATION_TIME_NOT_SET);
     }
 
     static OrcBatchRecordReader createCustomOrcRecordReader(
@@ -1574,7 +1576,8 @@ public class OrcTester
             StripeMetadataSource stripeMetadataSource,
             boolean cacheable,
             Map<Integer, Slice> intermediateEncryptionKeys,
-            boolean mapNullKeysEnabled)
+            boolean mapNullKeysEnabled,
+            long fileModificationTime)
             throws IOException
     {
         OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
@@ -1593,7 +1596,8 @@ public class OrcTester
                 cacheable,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
                 DwrfKeyProvider.of(intermediateEncryptionKeys),
-                new RuntimeStats());
+                new RuntimeStats(),
+                fileModificationTime);
 
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnStatistics.java
@@ -959,7 +959,8 @@ public class TestColumnStatistics
                 NO_ENCRYPTION,
                 DwrfKeyProvider.EMPTY,
                 new RuntimeStats(),
-                Optional.of(introspector));
+                Optional.of(introspector),
+                file.getFile().lastModified());
 
         OrcSelectiveRecordReader recordReader = reader.createSelectiveRecordReader(
                 ImmutableMap.of(0, type),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcFileIntrospection.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcFileIntrospection.java
@@ -140,7 +140,8 @@ public class TestOrcFileIntrospection
                 DwrfEncryptionProvider.NO_ENCRYPTION,
                 DwrfKeyProvider.EMPTY,
                 new RuntimeStats(),
-                Optional.of(introspector));
+                Optional.of(introspector),
+                tempFile.getFile().lastModified());
 
         OrcSelectiveRecordReader recordReader = reader.createSelectiveRecordReader(
                 ImmutableMap.of(0, type),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderDwrfStripeCaching.java
@@ -254,7 +254,8 @@ public class TestOrcReaderDwrfStripeCaching
                 false,
                 NO_ENCRYPTION,
                 DwrfKeyProvider.EMPTY,
-                new RuntimeStats());
+                new RuntimeStats(),
+                orcFile.lastModified());
         return stripeMetadataSourceFactory.getDwrfStripeCache();
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcRecordReaderDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcRecordReaderDwrfStripeCaching.java
@@ -156,7 +156,8 @@ public class TestOrcRecordReaderDwrfStripeCaching
                     false,
                     NO_ENCRYPTION,
                     DwrfKeyProvider.EMPTY,
-                    new RuntimeStats());
+                    new RuntimeStats(),
+                    orcFile.lastModified());
 
             assertRecordValues(orcDataSource, orcReader);
 
@@ -181,7 +182,8 @@ public class TestOrcRecordReaderDwrfStripeCaching
                     false,
                     NO_ENCRYPTION,
                     DwrfKeyProvider.EMPTY,
-                    new RuntimeStats());
+                    new RuntimeStats(),
+                    orcFile.lastModified());
 
             assertRecordValues(orcDataSource, orcReader);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.OrcReader.MODIFICATION_TIME_NOT_SET;
 import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX_AND_FOOTER;
 import static com.facebook.presto.orc.proto.DwrfProto.CompressionKind.NONE;
 import static com.facebook.presto.orc.proto.DwrfProto.StripeCacheMode.BOTH;
@@ -91,7 +92,7 @@ public class TestStorageOrcFileTailSource
         int expectedFooterSizeInBytes = 567;
         StorageOrcFileTailSource src = new StorageOrcFileTailSource(expectedFooterSizeInBytes, false);
         TestingOrcDataSource orcDataSource = new TestingOrcDataSource(createFileOrcDataSource());
-        src.getOrcFileTail(orcDataSource, metadataReader, Optional.empty(), false);
+        src.getOrcFileTail(orcDataSource, metadataReader, Optional.empty(), false, MODIFICATION_TIME_NOT_SET);
 
         // make sure only the configured expectedFooterSizeInBytes bytes have been read
         assertEquals(orcDataSource.getReadCount(), 1);
@@ -121,7 +122,7 @@ public class TestStorageOrcFileTailSource
         // read the file tail with the disabled "read dwrf stripe cache" feature
         StorageOrcFileTailSource src = new StorageOrcFileTailSource(tailReadSizeInBytes, false);
         TestingOrcDataSource orcDataSource = new TestingOrcDataSource(createFileOrcDataSource());
-        OrcFileTail orcFileTail = src.getOrcFileTail(orcDataSource, metadataReader, Optional.empty(), false);
+        OrcFileTail orcFileTail = src.getOrcFileTail(orcDataSource, metadataReader, Optional.empty(), false, MODIFICATION_TIME_NOT_SET);
 
         assertEquals(orcFileTail.getMetadataSize(), 0);
         DwrfProto.Footer actualFooter = readFooter(orcFileTail);
@@ -160,7 +161,7 @@ public class TestStorageOrcFileTailSource
         // read the file tail with the enabled "read dwrf stripe cache" feature
         StorageOrcFileTailSource src = new StorageOrcFileTailSource(FOOTER_READ_SIZE_IN_BYTES, true);
         OrcDataSource orcDataSource = createFileOrcDataSource();
-        OrcFileTail orcFileTail = src.getOrcFileTail(orcDataSource, metadataReader, Optional.empty(), false);
+        OrcFileTail orcFileTail = src.getOrcFileTail(orcDataSource, metadataReader, Optional.empty(), false, MODIFICATION_TIME_NOT_SET);
 
         assertEquals(orcFileTail.getMetadataSize(), 0);
         DwrfProto.Footer actualFooter = readFooter(orcFileTail);
@@ -190,7 +191,7 @@ public class TestStorageOrcFileTailSource
         // read the file tail with the enabled "read dwrf stripe cache" feature
         StorageOrcFileTailSource src = new StorageOrcFileTailSource(FOOTER_READ_SIZE_IN_BYTES, true);
         OrcDataSource orcDataSource = createFileOrcDataSource();
-        OrcFileTail orcFileTail = src.getOrcFileTail(orcDataSource, metadataReader, Optional.empty(), false);
+        OrcFileTail orcFileTail = src.getOrcFileTail(orcDataSource, metadataReader, Optional.empty(), false, MODIFICATION_TIME_NOT_SET);
 
         assertEquals(orcFileTail.getMetadataSize(), 0);
         DwrfProto.Footer actualFooter = readFooter(orcFileTail);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
@@ -735,7 +735,8 @@ public class TestStreamLayout
                 DwrfEncryptionProvider.NO_ENCRYPTION,
                 DwrfKeyProvider.EMPTY,
                 new RuntimeStats(),
-                Optional.of(introspector));
+                Optional.of(introspector),
+                tempFile.getFile().lastModified());
 
         OrcSelectiveRecordReader recordReader = reader.createSelectiveRecordReader(
                 ImmutableMap.of(0, type),


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

