### PR TITLE
Fix ORC single rowgroup read to use StripeMetadataSource instead of M…

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -254,7 +254,7 @@ public class StripeReader
         ImmutableMap.Builder<StreamId, List<RowGroupIndex>> columnIndexes = ImmutableMap.builder();
         for (Entry<StreamId, Stream> entry : includedStreams.entrySet()) {
             if (entry.getKey().getStreamKind() == ROW_INDEX) {
-                List<RowGroupIndex> rowGroupIndexes = metadataReader.readRowIndexes(hiveWriterVersion, streamsData.get(entry.getKey()), null);
+                List<RowGroupIndex> rowGroupIndexes = stripeMetadataSource.getRowIndexes(metadataReader, hiveWriterVersion, stripeId, entry.getKey(), streamsData.get(entry.getKey()), null, runtimeStats);
                 checkState(rowGroupIndexes.size() == 1 || invalidCheckPoint, "expect a single row group or an invalid check point");
                 for (RowGroupIndex rowGroupIndex : rowGroupIndexes) {
                     ColumnStatistics columnStatistics = rowGroupIndex.getColumnStatistics();


### PR DESCRIPTION
## Description
This is a fix to use StripeMetadataSource instead of MetadataReader, even when there is only one row group in a stripe.

## Motivation and Context
Currently, when there are more than 1 rowgroups in a stripe, StripeMetadataSource is being used and when there is only 1 rowgroup, MetadataReader is used. This bypasses caching reader if enabled, losing the benefits of caching. Fixed to use StripeMetadataSource in both cases.

## Impact
No impact

## Test Plan
Current tests in AbstractTestOrcReader.java covers this scenario.

## Release Notes

```
== NO RELEASE NOTE ==
```

