### PR TITLE
[MongoDB] add TLS CA File steps to docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -170,10 +170,10 @@ This property is optional; the default is ``0``.
 
 .. _tls-ca-definition-label:
 
-TLS CA File
-------------------------
+Configuring the MongoDB Connector to Use a TLS CA File
+------------------------------------------------------
 
-For instance, a TLS CA file may be required to connect securely to a MongoDB cluster hosted on DigitalOcean. Note that cluster hostnames do not resolve using standard ``dig`` requests to the hostname in the connection string. MongoDB clusters are hosted on multiple nodes, each with its own hostname.
+A TLS CA file may be required to connect securely to a MongoDB cluster hosted on DigitalOcean. A TLS CA file may be required to connect securely to a MongoDB cluster hosted on DigitalOcean. MongoDB clusters are hosted on multiple nodes, each with its own hostname. Cluster hostnames do not resolve using standard ``dig`` requests to the hostname in the connection string.
 
 Retrieve the Node Hostnames
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -190,12 +190,12 @@ For example, a properly formatted ``dig`` request would look like this:
 
     dig srv _mongodb._tcp.mongodb-prod-cluster-ba6e9b05.mongo.ondigitalocean.com
 
-The ``dig`` command will return the actual hosts (in the **Answer Section**) that you can use to connect to MongoDB through Presto. The regular hostname won’t work and will result in a "host not found" error.
+The ``dig`` command returns the actual hosts (in the **Answer Section**) that you can use to connect to MongoDB through Presto. The regular hostname won’t work and will result in a ``host not found`` error.
 
-Setting Up TLS CA File
-^^^^^^^^^^^^^^^^^^^^^^
+Set Up a TLS CA File
+^^^^^^^^^^^^^^^^^^^^
 
-The following steps assume you are using CentOS. Adapt them as needed for your environment.
+The following steps were developed using CentOS. Adapt them as needed for your environment.
 
 1. Create the certificate file:
 
@@ -205,7 +205,7 @@ The following steps assume you are using CentOS. Adapt them as needed for your e
 
 2. Paste the contents of the TLS CA file into the newly created file.
 
-3. Update the trust store by running:
+3. Update the trust store by running the following command:
 
    .. code-block:: bash
 
@@ -219,8 +219,8 @@ The following steps assume you are using CentOS. Adapt them as needed for your e
 
    The output should include ``CONNECTED`` and ``Verification: OK``, indicating the SSL connection is properly configured.
 
-Configuring the Catalog
-^^^^^^^^^^^^^^^^^^^^^^^
+Configure the Catalog
+^^^^^^^^^^^^^^^^^^^^^
 
 To configure a MongoDB catalog for this cluster, follow these steps:
 
@@ -230,7 +230,7 @@ To configure a MongoDB catalog for this cluster, follow these steps:
 
        touch etc/catalog/mongodb.properties
 
-2. Edit the file and include the host found using ``dig``. For example:
+2. Edit the file and include the host found using ``dig`` in `Retrieve the Node Hostnames <#retrieve-the-node-hostnames>`_. For example:
 
    .. code-block:: none
 
@@ -240,8 +240,8 @@ To configure a MongoDB catalog for this cluster, follow these steps:
        mongodb.ssl.enabled=true
        mongodb.required-replica-set=<mongodb-replica-set>
 
-Running Queries
-^^^^^^^^^^^^^^^
+Run Queries
+^^^^^^^^^^^
 
 After starting the Presto server, you should be able to connect to the catalog and execute queries. For instance:
 

--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -173,7 +173,7 @@ This property is optional; the default is ``0``.
 Configuring the MongoDB Connector to Use a TLS CA File
 ------------------------------------------------------
 
-A TLS CA file may be required to connect securely to a MongoDB cluster hosted on DigitalOcean. A TLS CA file may be required to connect securely to a MongoDB cluster hosted on DigitalOcean. MongoDB clusters are hosted on multiple nodes, each with its own hostname. Cluster hostnames do not resolve using standard ``dig`` requests to the hostname in the connection string.
+A TLS CA file may be required to connect securely to a MongoDB cluster hosted on DigitalOcean. MongoDB clusters are hosted on multiple nodes, each with its own hostname. Cluster hostnames do not resolve using standard ``dig`` requests to the hostname in the connection string.
 
 Retrieve the Node Hostnames
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -124,77 +124,9 @@ This property is optional; the default is ``false``.
 
 This flag enables SSL connections to MongoDB servers.
 
-This property is optional and defaults to ``false``. If you set it to ``true`` and host Presto yourself, it’s likely that you also use a TLS CA file. For instance, a TLS CA file may be required to connect securely to a MongoDB cluster hosted on DigitalOcean. Note that cluster hostnames do not resolve using standard ``dig`` requests to the hostname in the connection string. MongoDB clusters are hosted on multiple nodes, each with its own hostname.
+This property is optional and defaults to ``false``. If you set it to ``true`` and host Presto yourself, it’s likely that you also use a TLS CA file.
 
-To retrieve the node hostnames of a cluster using ``dig``, specify the ``srv`` record type in the request and prepend ``_mongodb._tcp.`` to the hostname in the connection string, as shown below:
-
-.. code-block:: bash
-
-    dig srv _mongodb._tcp.<cluster-hostname>
-
-For example, a properly formatted ``dig`` request would look like this:
-
-.. code-block:: bash
-
-    dig srv _mongodb._tcp.mongodb-prod-cluster-ba6e9b05.mongo.ondigitalocean.com
-
-The ``dig`` command will return the actual hosts (in the **Answer Section**) that you can use to connect to MongoDB through Presto. The regular hostname won’t work and will result in a "host not found" error.
-
-### Setting Up TLS CA File
-
-The following steps assume you are using CentOS. Adapt them as needed for your environment.
-
-1. Create the certificate file:
-
-   .. code-block:: bash
-
-       touch /etc/pki/ca-trust/source/anchors/mongo.prod-cluster.crt
-
-2. Paste the contents of the TLS CA file into the newly created file.
-
-3. Update the trust store by running:
-
-   .. code-block:: bash
-
-       update-ca-trust
-
-4. Verify the setup by running the following command:
-
-   .. code-block:: bash
-
-       openssl s_client -connect <host-found-with-dig-above>:27017 < /dev/null
-
-   The output should include ``CONNECTED`` and ``Verification: OK``, indicating the SSL connection is properly configured.
-
-### Configuring the Catalog
-
-To configure a MongoDB catalog for this cluster, follow these steps:
-
-1. Create the catalog configuration file:
-
-   .. code-block:: bash
-
-       touch etc/catalog/mongodb.properties
-
-2. Edit the file and include the host found using ``dig``. For example:
-
-   .. code-block:: none
-
-       connector.name=mongodb
-       mongodb.seeds=<host-found-with-dig-above>:27017
-       mongodb.credentials=<user>:<password>@<mongodb-auth-source>
-       mongodb.ssl.enabled=true
-       mongodb.required-replica-set=<mongodb-replica-set>
-
-### Running Queries
-
-After starting the Presto server, you should be able to connect to the catalog and execute queries. For instance:
-
-.. code-block:: sql
-
-    SELECT name
-    FROM users
-    WHERE _id = ObjectId('66fe8898c4ce1100c811cbe0');
+For setup instructions, see :ref:`tls-ca-definition-label`.
 
 ``mongodb.read-preference``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -235,6 +167,89 @@ If batchSize is negative, it will limit of number objects returned, that fit wit
 .. note:: Do not use a batch size of ``1``.
 
 This property is optional; the default is ``0``.
+
+.. _tls-ca-definition-label:
+
+TLS CA File
+------------------------
+
+For instance, a TLS CA file may be required to connect securely to a MongoDB cluster hosted on DigitalOcean. Note that cluster hostnames do not resolve using standard ``dig`` requests to the hostname in the connection string. MongoDB clusters are hosted on multiple nodes, each with its own hostname.
+
+Retrieve the Node Hostnames
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To retrieve the node hostnames of a cluster using ``dig``, specify the ``srv`` record type in the request and prepend ``_mongodb._tcp.`` to the hostname in the connection string, as shown below:
+
+.. code-block:: bash
+
+    dig srv _mongodb._tcp.<cluster-hostname>
+
+For example, a properly formatted ``dig`` request would look like this:
+
+.. code-block:: bash
+
+    dig srv _mongodb._tcp.mongodb-prod-cluster-ba6e9b05.mongo.ondigitalocean.com
+
+The ``dig`` command will return the actual hosts (in the **Answer Section**) that you can use to connect to MongoDB through Presto. The regular hostname won’t work and will result in a "host not found" error.
+
+Setting Up TLS CA File
+^^^^^^^^^^^^^^^^^^^^^^
+
+The following steps assume you are using CentOS. Adapt them as needed for your environment.
+
+1. Create the certificate file:
+
+   .. code-block:: bash
+
+       touch /etc/pki/ca-trust/source/anchors/mongo.prod-cluster.crt
+
+2. Paste the contents of the TLS CA file into the newly created file.
+
+3. Update the trust store by running:
+
+   .. code-block:: bash
+
+       update-ca-trust
+
+4. Verify the setup by running the following command:
+
+   .. code-block:: bash
+
+       openssl s_client -connect <host-found-with-dig-above>:27017 < /dev/null
+
+   The output should include ``CONNECTED`` and ``Verification: OK``, indicating the SSL connection is properly configured.
+
+Configuring the Catalog
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To configure a MongoDB catalog for this cluster, follow these steps:
+
+1. Create the catalog configuration file:
+
+   .. code-block:: bash
+
+       touch etc/catalog/mongodb.properties
+
+2. Edit the file and include the host found using ``dig``. For example:
+
+   .. code-block:: none
+
+       connector.name=mongodb
+       mongodb.seeds=<host-found-with-dig-above>:27017
+       mongodb.credentials=<user>:<password>@<mongodb-auth-source>
+       mongodb.ssl.enabled=true
+       mongodb.required-replica-set=<mongodb-replica-set>
+
+Running Queries
+^^^^^^^^^^^^^^^
+
+After starting the Presto server, you should be able to connect to the catalog and execute queries. For instance:
+
+.. code-block:: sql
+
+    SELECT name
+    FROM users
+    WHERE _id = ObjectId('66fe8898c4ce1100c811cbe0');
 
 .. _table-definition-label:
 


### PR DESCRIPTION
## Description
Noticed there's no documentation on how to really connect Presto to a MongoDB Cluster, as it usually requires access to a TLS Certificate.

## Motivation and Context
When I was setting up Presto, I had to add the TLS CA File we have from Digital Ocean to connect to the MongoDB Cluster. I noticed the docs are missing steps for such thing, despite being a very common requirement. This adds that missing information, step by step.

## Release Notes

```
== RELEASE NOTES ==

MongoDB Connector Changes
* Add steps to connect to MongoDB cluster with TLS CA File to :doc:`/connector/mongodb`. :pr:`24352`
```
