### PR TITLE
[Presto-Main] Add long overflow checks for IntervalDayTime

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeOperators.java
@@ -141,7 +141,8 @@ public final class IntervalDayTimeOperators
 
         try {
             return multiplyByDouble(left, 1.0 / right);
-        } catch (PrestoException e) {
+        }
+        catch (PrestoException e) {
             throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, format("interval_day_to_second division overflow: %s ms / %s", left, right));
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeOperators.java
@@ -16,6 +16,7 @@ package com.facebook.presto.type;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.AbstractLongType;
 import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.BlockIndex;
 import com.facebook.presto.spi.function.BlockPosition;
 import com.facebook.presto.spi.function.IsNull;
@@ -42,8 +43,11 @@ import static com.facebook.presto.common.function.OperatorType.MULTIPLY;
 import static com.facebook.presto.common.function.OperatorType.NEGATION;
 import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.format;
 
 public final class IntervalDayTimeOperators
 {
@@ -55,56 +59,103 @@ public final class IntervalDayTimeOperators
     @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
     public static long add(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long left, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long right)
     {
-        return left + right;
+        try {
+            return Math.addExact(left, right);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, format("interval_day_to_second addition overflow: %s ms + %s ms", left, right), e);
+        }
     }
 
     @ScalarOperator(SUBTRACT)
     @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
     public static long subtract(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long left, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long right)
     {
-        return left - right;
+        try {
+            return Math.subtractExact(left, right);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, format("interval_day_to_second subtraction overflow: %s ms - %s ms", left, right), e);
+        }
     }
 
     @ScalarOperator(MULTIPLY)
     @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
     public static long multiplyByBigint(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long left, @SqlType(StandardTypes.BIGINT) long right)
     {
-        return left * right;
+        try {
+            return Math.multiplyExact(left, right);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, format("interval_day_to_second multiply overflow: %s ms * %s", left, right), e);
+        }
     }
 
     @ScalarOperator(MULTIPLY)
     @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
     public static long multiplyByDouble(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long left, @SqlType(StandardTypes.DOUBLE) double right)
     {
-        return (long) (left * right);
+        try {
+            return Math.addExact(
+                    (long) (left * (right - (long) right)),
+                    Math.multiplyExact(left, (long) right));
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, format("interval_day_to_second multiply overflow: %s ms * %s", left, right), e);
+        }
     }
 
     @ScalarOperator(MULTIPLY)
     @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
     public static long bigintMultiply(@SqlType(StandardTypes.BIGINT) long left, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long right)
     {
-        return left * right;
+        try {
+            return Math.multiplyExact(left, right);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, format("interval_day_to_second multiply overflow: %s * %s ms", left, right), e);
+        }
     }
 
     @ScalarOperator(MULTIPLY)
     @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
     public static long doubleMultiply(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long right)
     {
-        return (long) (left * right);
+        try {
+            return Math.addExact(
+                Math.multiplyExact((long) left, right),
+                (long) ((left - (long) left) * right));
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, format("interval_day_to_second multiply overflow: %s * %s ms", left, right), e);
+        }
     }
 
     @ScalarOperator(DIVIDE)
     @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
     public static long divideByDouble(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long left, @SqlType(StandardTypes.DOUBLE) double right)
     {
-        return (long) (left / right);
+        if (right == 0) {
+            throw new PrestoException(DIVISION_BY_ZERO, format("interval_day_to_second division by zero: %s ms / %s", left, right));
+        }
+
+        try {
+            return multiplyByDouble(left, 1.0 / right);
+        } catch (PrestoException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, format("interval_day_to_second division overflow: %s ms / %s", left, right));
+        }
     }
 
     @ScalarOperator(NEGATION)
     @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
     public static long negate(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long value)
     {
-        return -value;
+        try {
+            return Math.negateExact(value);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, "interval_day_to_second negation overflow: " + value, e);
+        }
     }
 
     @ScalarOperator(EQUAL)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIntervalDayTime.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIntervalDayTime.java
@@ -21,6 +21,7 @@ import static com.facebook.presto.common.function.OperatorType.INDETERMINATE;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static org.testng.Assert.assertEquals;
 
@@ -109,6 +110,7 @@ public class TestIntervalDayTime
         assertFunction("INTERVAL '3' SECOND + INTERVAL '3' SECOND", INTERVAL_DAY_TIME, new SqlIntervalDayTime(6 * 1000));
         assertFunction("INTERVAL '6' DAY + INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime(12 * 24 * 60 * 60 * 1000));
         assertFunction("INTERVAL '3' SECOND + INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime((6 * 24 * 60 * 60 * 1000) + (3 * 1000)));
+        assertFunction("INTERVAL '3' DAY + INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime((6 * 24 * 60 * 60 * 1000) + (3 * 1000)));
     }
 
     @Test
@@ -116,7 +118,6 @@ public class TestIntervalDayTime
     {
         assertFunction("INTERVAL '6' SECOND - INTERVAL '3' SECOND", INTERVAL_DAY_TIME, new SqlIntervalDayTime(3 * 1000));
         assertFunction("INTERVAL '9' DAY - INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime(3 * 24 * 60 * 60 * 1000));
-        assertFunction("INTERVAL '3' SECOND - INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime((3 * 1000) - (6 * 24 * 60 * 60 * 1000)));
     }
 
     @Test
@@ -131,6 +132,9 @@ public class TestIntervalDayTime
         assertFunction("2 * INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime(12 * 24 * 60 * 60 * 1000));
         assertFunction("INTERVAL '1' DAY * 2.5", INTERVAL_DAY_TIME, new SqlIntervalDayTime((long) (2.5 * 24 * 60 * 60 * 1000)));
         assertFunction("2.5 * INTERVAL '1' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime((long) (2.5 * 24 * 60 * 60 * 1000)));
+        assertNumericOverflow(
+                format("%s * INTERVAL '%s' DAY", Integer.MAX_VALUE, 64),
+                format("interval_day_to_second multiply overflow: %s * %s ms", Integer.MAX_VALUE, (64 * 24 * 60 * 60 * 1000L)));
     }
 
     @Test
@@ -141,6 +145,9 @@ public class TestIntervalDayTime
 
         assertFunction("INTERVAL '3' DAY / 2", INTERVAL_DAY_TIME, new SqlIntervalDayTime((long) (1.5 * 24 * 60 * 60 * 1000)));
         assertFunction("INTERVAL '4' DAY / 2.5", INTERVAL_DAY_TIME, new SqlIntervalDayTime((long) (1.6 * 24 * 60 * 60 * 1000)));
+        assertNumericOverflow(
+                format("INTERVAL '%s' DAY / %s", 64, 1 / (double) Integer.MAX_VALUE),
+                format("interval_day_to_second division overflow: %s ms / %s", (64 * 24 * 60 * 60 * 1000L), 1 / (double) Integer.MAX_VALUE));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIntervalDayTime.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIntervalDayTime.java
@@ -110,7 +110,6 @@ public class TestIntervalDayTime
         assertFunction("INTERVAL '3' SECOND + INTERVAL '3' SECOND", INTERVAL_DAY_TIME, new SqlIntervalDayTime(6 * 1000));
         assertFunction("INTERVAL '6' DAY + INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime(12 * 24 * 60 * 60 * 1000));
         assertFunction("INTERVAL '3' SECOND + INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime((6 * 24 * 60 * 60 * 1000) + (3 * 1000)));
-        assertFunction("INTERVAL '3' DAY + INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime((6 * 24 * 60 * 60 * 1000) + (3 * 1000)));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIntervalDayTime.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIntervalDayTime.java
@@ -117,6 +117,7 @@ public class TestIntervalDayTime
     {
         assertFunction("INTERVAL '6' SECOND - INTERVAL '3' SECOND", INTERVAL_DAY_TIME, new SqlIntervalDayTime(3 * 1000));
         assertFunction("INTERVAL '9' DAY - INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime(3 * 24 * 60 * 60 * 1000));
+        assertFunction("INTERVAL '3' SECOND - INTERVAL '6' DAY", INTERVAL_DAY_TIME, new SqlIntervalDayTime((3 * 1000) - (6 * 24 * 60 * 60 * 1000)));
     }
 
     @Test


### PR DESCRIPTION
## Description
Part of https://github.com/prestodb/presto/issues/24087. 

## Motivation and Context
Throwing an error instead of returning overflowed long values

## Impact
Where previously some expressions could have resulted in an overflow and incorrect results, now they will fail with a NUMERIC_VALUE_OUT_OF_RANGE error.

## Test Plan
 - Unit Tests
 - Local Testing:
```
Before:
presto> select interval '64' day * 2147483647;
           _col0
---------------------------
 -76065028926 14:25:51.616
(1 row)

After:
presto> select interval '64' day * 2147483647;
Query 20250113_175455_00000_rusmt failed: interval_day_to_second multiply overflow: 5529600000 ms * 2147483647
```


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve error handling of ``INTERVAL DAY``, ``INTERVAL HOUR``, and ``INTERVAL SECOND`` operators when experiencing overflows. :pr:`24353`

