### PR TITLE
Use jitpack snapshot release for release-notes.sh

### DIFF
--- a/src/release/release-notes.sh
+++ b/src/release/release-notes.sh
@@ -5,6 +5,6 @@ if [[ "$#" -ne 2 ]]; then
     exit 1
 fi
 
-curl -L -o /tmp/presto_release "https://oss.sonatype.org/service/local/artifact/maven/redirect?g=com.facebook.presto&a=presto-release-tools&v=RELEASE&r=releases&c=executable&e=jar"
+curl -L -o /tmp/presto_release "https://jitpack.io/com/github/prestodb/presto-release-tools/presto-release-tools/master-SNAPSHOT/presto-release-tools-master-SNAPSHOT-executable.jar"
 chmod 755 /tmp/presto_release
 /tmp/presto_release release-notes --github-user $1 --github-access-token $2


### PR DESCRIPTION
## Description

Changes the URL to download the release notes tool executable jar.

## Motivation and Context

There were updates added a while back in https://github.com/prestodb/presto-release-tools/commit/0194b7ac6e6aee4d176163fe7b2ef9e660ea2e14 which never got used because we are a bit slow on publishing releases. Using the jitpack repository will allow us to use the latest code without having to publish a release.

## Impact

N/A

## Test Plan

Verified download worked

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

