### PR TITLE
[native] Fix shuffle compression kind string in toVeloxConfigs()

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -228,12 +228,14 @@ QueryContextManager::toVeloxConfigs(
       if (it.second == "true") {
         // NOTE: Presto java only support lz4 compression so configure the same
         // compression kind on velox.
-        configs[core::QueryConfig::kShuffleCompressionKind] = std::to_string(
-            static_cast<uint32_t>(velox::common::CompressionKind_LZ4));
+        configs[core::QueryConfig::kShuffleCompressionKind] =
+            velox::common::compressionKindToString(
+                velox::common::CompressionKind_LZ4);
       } else {
         VELOX_USER_CHECK_EQ(it.second, "false");
-        configs[core::QueryConfig::kShuffleCompressionKind] = std::to_string(
-            static_cast<uint32_t>(velox::common::CompressionKind_NONE));
+        configs[core::QueryConfig::kShuffleCompressionKind] =
+            velox::common::compressionKindToString(
+                velox::common::CompressionKind_NONE);
       }
     } else {
       configs[sessionProperties_.toVeloxConfig(it.first)] = it.second;


### PR DESCRIPTION
The current code sets integer to shuffle compression kind, while code expects a compression kind string.

```
== NO RELEASE NOTE ==
```

