### PR TITLE
Add support for SHOW CREATE SCHEMA

### DIFF
--- a/presto-docs/src/main/sphinx/sql.rst
+++ b/presto-docs/src/main/sphinx/sql.rst
@@ -47,6 +47,7 @@ This chapter describes the SQL syntax used in Presto.
     sql/show-catalogs
     sql/show-columns
     sql/show-create-function
+    sql/show-create-schema
     sql/show-create-table
     sql/show-create-view
     sql/show-functions

--- a/presto-docs/src/main/sphinx/sql/show-create-schema.rst
+++ b/presto-docs/src/main/sphinx/sql/show-create-schema.rst
@@ -1,0 +1,37 @@
+=================
+SHOW CREATE SCHEMA
+=================
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    SHOW CREATE SCHEMA schema_name
+
+Description
+-----------
+
+Show the SQL statement that creates the specified schema.
+
+Examples
+--------
+
+Show the SQL that can be run to create the ``sf1`` schema::
+
+    SHOW CREATE SCHEMA hive.sf1;
+
+.. code-block:: none
+
+                  Create Schema
+    -----------------------------------------
+     CREATE SCHEMA hive.sf1
+     WITH (
+        location = 'hdfs://localhost:9000/user/hive/warehouse/sf1.db'
+     )
+    (1 row)
+
+See Also
+--------
+
+:doc:`create-schema`

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/SchemaProperties.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/SchemaProperties.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;
@@ -38,5 +40,12 @@ public final class SchemaProperties
     public static Optional<String> getLocation(Map<String, Object> schemaProperties)
     {
         return Optional.ofNullable((String) schemaProperties.get(LOCATION_PROPERTY));
+    }
+
+    public static Map<String, Object> getDatabaseProperties(Database database)
+    {
+        ImmutableMap.Builder<String, Object> result = ImmutableMap.builder();
+        database.getLocation().ifPresent(location -> result.put(LOCATION_PROPERTY, location));
+        return result.build();
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2781,6 +2781,24 @@ public class TestHiveIntegrationSmokeTest
         actualResult = computeActual("SHOW CREATE TABLE \"test_show_create_table'2\"");
         assertEquals(getOnlyElement(actualResult.getOnlyColumnAsSet()), createTableSql);
     }
+    @Test
+    public void testShowCreateSchema()
+    {
+        String createSchemaSql = "CREATE SCHEMA show_create_hive_schema";
+        assertUpdate(createSchemaSql);
+        String expectedShowCreateSchema = "CREATE SCHEMA show_create_hive_schema\n" +
+                "WITH (\n" +
+                "   location = '.*show_create_hive_schema'\n" +
+                ")";
+
+        MaterializedResult actualResult = computeActual("SHOW CREATE SCHEMA show_create_hive_schema");
+        assertThat(getOnlyElement(actualResult.getOnlyColumnAsSet()).toString().matches(expectedShowCreateSchema));
+
+        assertQueryFails(format("SHOW CREATE SCHEMA %s.%s", getSession().getCatalog().get(), ""), ".*mismatched input '.'. Expecting: <EOF>");
+        assertQueryFails(format("SHOW CREATE SCHEMA %s.%s.%s", getSession().getCatalog().get(), "show_create_hive_schema", "tabletest"), ".*Too many parts in schema name: hive.show_create_hive_schema.tabletest");
+        assertQueryFails(format("SHOW CREATE SCHEMA %s", "schema_not_exist"), ".*Schema 'hive.schema_not_exist' does not exist");
+        assertUpdate("DROP SCHEMA show_create_hive_schema");
+    }
 
     @Test
     public void testTextfileAmbiguousTimestamp()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.HdfsContext;
@@ -98,6 +99,7 @@ import static com.facebook.presto.hive.HiveStatisticsUtil.updatePartitionStatist
 import static com.facebook.presto.hive.HiveUtil.decodeViewData;
 import static com.facebook.presto.hive.HiveUtil.encodeViewData;
 import static com.facebook.presto.hive.HiveUtil.hiveColumnHandles;
+import static com.facebook.presto.hive.SchemaProperties.getDatabaseProperties;
 import static com.facebook.presto.hive.SchemaProperties.getLocation;
 import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege.DELETE;
 import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege.INSERT;
@@ -246,6 +248,17 @@ public class IcebergHiveMetadata
     public List<String> listSchemaNames(ConnectorSession session)
     {
         return metastore.getAllDatabases(getMetastoreContext(session));
+    }
+
+    @Override
+    public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
+    {
+        MetastoreContext metastoreContext = getMetastoreContext(session);
+        Optional<Database> database = metastore.getDatabase(metastoreContext, schemaName.getSchemaName());
+        if (database.isPresent()) {
+            return getDatabaseProperties(database.get());
+        }
+        throw new SchemaNotFoundException(schemaName.getSchemaName());
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
@@ -21,9 +21,11 @@ import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.iceberg.ManifestFileCache;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.cache.CacheBuilder;
 import org.apache.iceberg.Table;
+import org.testng.annotations.Test;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -31,7 +33,9 @@ import java.nio.file.Path;
 import static com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore.memoizeMetastore;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIcebergSmokeHive
         extends IcebergDistributedSmokeTestBase
@@ -66,5 +70,24 @@ public class TestIcebergSmokeHive
                 new ManifestFileCache(CacheBuilder.newBuilder().build(), false, 0, 1024),
                 session,
                 SchemaTableName.valueOf(schema + "." + tableName));
+    }
+
+    @Test
+    public void testShowCreateSchema()
+    {
+        String createSchemaSql = "CREATE SCHEMA show_create_iceberg_schema";
+        assertUpdate(createSchemaSql);
+        String expectedShowCreateSchema = "CREATE SCHEMA show_create_iceberg_schema\n" +
+                "WITH (\n" +
+                "   location = '.*show_create_iceberg_schema'\n" +
+                ")";
+
+        MaterializedResult actualResult = computeActual("SHOW CREATE SCHEMA show_create_iceberg_schema");
+        assertThat(getOnlyElement(actualResult.getOnlyColumnAsSet()).toString().matches(expectedShowCreateSchema));
+
+        assertQueryFails(format("SHOW CREATE SCHEMA %s.%s", getSession().getCatalog().get(), ""), ".*mismatched input '.'. Expecting: <EOF>");
+        assertQueryFails(format("SHOW CREATE SCHEMA %s.%s.%s", getSession().getCatalog().get(), "show_create_iceberg_schema", "tabletest"), ".*Too many parts in schema name: iceberg.show_create_iceberg_schema.tabletest");
+        assertQueryFails(format("SHOW CREATE SCHEMA %s", "schema_not_exist"), ".*Schema 'iceberg.schema_not_exist' does not exist");
+        assertUpdate("DROP SCHEMA show_create_iceberg_schema");
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -96,6 +96,12 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
+    public Map<String, Object> getSchemaProperties(Session session, CatalogSchemaName schemaName)
+    {
+        return delegate.getSchemaProperties(session, schemaName);
+    }
+
+    @Override
     public Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName)
     {
         return delegate.getSystemTable(session, tableName);

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -76,6 +76,11 @@ public interface Metadata
 
     List<String> listSchemaNames(Session session, String catalogName);
 
+    /**
+     * Gets the schema properties for the specified schema.
+     */
+    Map<String, Object> getSchemaProperties(Session session, CatalogSchemaName schemaName);
+
     Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName);
 
     /**

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -141,6 +141,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Map<String, Object> getSchemaProperties(Session session, CatalogSchemaName schemaName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<TableHandle> getTableHandleForStatisticsCollection(Session session, QualifiedObjectName tableName, Map<String, Object> analyzeProperties)
     {
         throw new UnsupportedOperationException();

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -118,6 +118,7 @@ statement
     | EXPLAIN ANALYZE? VERBOSE?
         ('(' explainOption (',' explainOption)* ')')? statement        #explain
     | SHOW CREATE TABLE qualifiedName                                  #showCreateTable
+    | SHOW CREATE SCHEMA qualifiedName                                 #showCreateSchema
     | SHOW CREATE VIEW qualifiedName                                   #showCreateView
     | SHOW CREATE MATERIALIZED VIEW qualifiedName                      #showCreateMaterializedView
     | SHOW CREATE FUNCTION qualifiedName types?                        #showCreateFunction

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -858,6 +858,10 @@ public final class SqlFormatter
                 builder.append("SHOW CREATE TABLE ")
                         .append(formatName(node.getName()));
             }
+            else if (node.getType() == ShowCreate.Type.SCHEMA) {
+                builder.append("SHOW CREATE SCHEMA ")
+                        .append(formatName(node.getName()));
+            }
             else if (node.getType() == ShowCreate.Type.VIEW) {
                 builder.append("SHOW CREATE VIEW ")
                         .append(formatName(node.getName()));

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -376,6 +376,12 @@ class AstBuilder
     }
 
     @Override
+    public Node visitShowCreateSchema(SqlBaseParser.ShowCreateSchemaContext context)
+    {
+        return new ShowCreate(getLocation(context), ShowCreate.Type.SCHEMA, getQualifiedName(context.qualifiedName()));
+    }
+
+    @Override
     public Node visitShowCreateFunction(SqlBaseParser.ShowCreateFunctionContext context)
     {
         Optional<List<String>> parameterTypes = context.types() == null ? Optional.empty() : Optional.of(getTypes(context.types()));

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreate.java
@@ -28,6 +28,7 @@ public class ShowCreate
     public enum Type
     {
         TABLE,
+        SCHEMA,
         VIEW,
         MATERIALIZED_VIEW
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -126,6 +126,7 @@ import com.facebook.presto.sql.tree.SetRole;
 import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
+import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.ShowCreateFunction;
 import com.facebook.presto.sql.tree.ShowFunctions;
 import com.facebook.presto.sql.tree.ShowGrants;
@@ -195,6 +196,7 @@ import static com.facebook.presto.sql.tree.RoutineCharacteristics.Determinism.NO
 import static com.facebook.presto.sql.tree.RoutineCharacteristics.Language.SQL;
 import static com.facebook.presto.sql.tree.RoutineCharacteristics.NullCallClause.CALLED_ON_NULL_INPUT;
 import static com.facebook.presto.sql.tree.RoutineCharacteristics.NullCallClause.RETURNS_NULL_ON_NULL_INPUT;
+import static com.facebook.presto.sql.tree.ShowCreate.Type.SCHEMA;
 import static com.facebook.presto.sql.tree.SortItem.NullOrdering.UNDEFINED;
 import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
 import static com.facebook.presto.sql.tree.SortItem.Ordering.DESCENDING;
@@ -771,6 +773,12 @@ public class TestSqlParser
         assertStatement(
                 "SHOW CREATE FUNCTION x.y.z(int, double)",
                 new ShowCreateFunction(QualifiedName.of("x", "y", "z"), Optional.of(ImmutableList.of("int", "double"))));
+    }
+
+    @Test
+    public void testShowCreateSchema()
+    {
+        assertStatement("SHOW CREATE SCHEMA x.y", new ShowCreate(SCHEMA, QualifiedName.of("x", "y")));
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.connector;
 
+import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
@@ -83,6 +84,14 @@ public interface ConnectorMetadata
      * Returns the schemas provided by this connector.
      */
     List<String> listSchemaNames(ConnectorSession session);
+
+    /**
+     * Gets the schema properties for the specified schema.
+     */
+    default Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support schema properties");
+    }
 
     /**
      * Returns a table handle for the specified table name, or null if the connector does not contain the table.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.connector.classloader;
 
+import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
@@ -211,6 +212,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.listSchemaNames(session);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSchemaProperties(session, schemaName);
         }
     }
 


### PR DESCRIPTION
## Description
Add support for SHOW CREATE SCHEMA
- Add SQL Support for `SHOW CREATE SCHEMA`
- Add support for ` SHOW CREATE SCHEMA` in hive & iceberg connector

## Motivation and Context
There was no way to check schema properties. So this SQL support will provide a way to check properties like `location` for schema

## Impact

SQL support for `SHOW CREATE SCHEMA` from a schema :
```
presto> SHOW CREATE SCHEMA hive.sf1;
                  Create Schema
    -----------------------------------------
     CREATE SCHEMA hive.sf1
     WITH (
        location = 'hdfs://localhost:9000/user/hive/warehouse/sf1.db'
     )
    (1 row)
```

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add DDL SQL support for ``SHOW CREATE SCHEMA``.

```

