### PR TITLE
Fix iceberg hive metadata listTables for non existent schema

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -185,6 +185,7 @@ public abstract class IcebergAbstractMetadata
         implements ConnectorMetadata
 {
     private static final Logger log = Logger.get(IcebergAbstractMetadata.class);
+    protected static final String INFORMATION_SCHEMA = "information_schema";
 
     protected final TypeManager typeManager;
     protected final JsonCodec<CommitTaskData> commitTaskCodec;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -87,7 +87,6 @@ import static java.util.stream.Collectors.toMap;
 public class IcebergNativeMetadata
         extends IcebergAbstractMetadata
 {
-    private static final String INFORMATION_SCHEMA = "information_schema";
     private static final String VIEW_DIALECT = "presto";
 
     private final IcebergNativeCatalogFactory catalogFactory;

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2218,6 +2218,29 @@ public abstract class IcebergDistributedTestBase
         }
     }
 
+    @Test
+    public void testInformationSchemaQueries()
+    {
+        assertQuerySucceeds("CREATE SCHEMA ICEBERG.TEST_SCHEMA1");
+        assertQuerySucceeds("CREATE SCHEMA ICEBERG.TEST_SCHEMA2");
+        assertQuerySucceeds("CREATE TABLE ICEBERG.TEST_SCHEMA1.ICEBERG_T1(i int)");
+        assertQuerySucceeds("CREATE TABLE ICEBERG.TEST_SCHEMA1.ICEBERG_T2(i int)");
+        assertQuerySucceeds("CREATE TABLE ICEBERG.TEST_SCHEMA2.ICEBERG_T3(i int)");
+        assertQuerySucceeds("CREATE TABLE ICEBERG.TEST_SCHEMA2.ICEBERG_T4(i int)");
+
+        assertQuery("SELECT table_name FROM iceberg.information_schema.tables WHERE table_schema ='test_schema1'", "VALUES 'iceberg_t1', 'iceberg_t2'");
+        assertQuery("SELECT table_name FROM iceberg.information_schema.tables WHERE table_schema ='test_schema2'", "VALUES 'iceberg_t3', 'iceberg_t4'");
+        //query on non-existing schema
+        assertQueryReturnsEmptyResult("SELECT table_name FROM iceberg.information_schema.tables WHERE table_schema = 'NON_EXISTING_SCHEMA'");
+
+        assertQuerySucceeds("DROP TABLE ICEBERG.TEST_SCHEMA1.ICEBERG_T1");
+        assertQuerySucceeds("DROP TABLE ICEBERG.TEST_SCHEMA1.ICEBERG_T2");
+        assertQuerySucceeds("DROP TABLE ICEBERG.TEST_SCHEMA2.ICEBERG_T3");
+        assertQuerySucceeds("DROP TABLE ICEBERG.TEST_SCHEMA2.ICEBERG_T4");
+        assertQuerySucceeds("DROP SCHEMA ICEBERG.TEST_SCHEMA1");
+        assertQuerySucceeds("DROP SCHEMA ICEBERG.TEST_SCHEMA2");
+    }
+
     private void testCheckDeleteFiles(Table icebergTable, int expectedSize, List<FileContent> expectedFileContent)
     {
         // check delete file list


### PR DESCRIPTION
## Description
Fixes Iceberg metadata listTables when `information_schema.tables` is queried for a non-existent schema.

## Motivation and Context
When `information_schema.tables` is queried for a non-existent schema, it returns list of user created schemas as a result, which is wrong. This was because `getAllDatabases` was called unconditionally assuming the schema is 'information_schema'. Example query returning wrong results.

`SELECT table_name FROM iceberg.information_schema.tables WHERE table_schema = 'NON_EXISTING_SCHEMA'`

## Impact
No impact

## Test Plan
Added new test in TestIcebergMetadataListing

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

