### PR TITLE
[native] Enable additional Spark tests in CI

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -237,7 +237,7 @@ jobs:
           export TESTCLASSES=${TESTCLASSES#,}
           # Override the possible test classes with test classes known to pass from the previous CI.
           # A number of newly added tests are flaky and are disabled.
-          export TESTCLASSES=TestPrestoSparkExpressionCompiler,TestPrestoSparkNativeJoinQueries,TestPrestoSparkSqlFunctions,TestPrestoSparkNativeTpchQueries,TestPrestoSparkNativeArrayFunctionQueries,TestPrestoSparkNativeGeneralQueries
+          export TESTCLASSES=TestPrestoSparkExpressionCompiler,TestPrestoSparkNativeBitwiseFunctionQueries,TestPrestoSparkNativeTpchConnectorQueries,TestPrestoSparkNativeSimpleQueries,TestPrestoSparkSqlFunctions,TestPrestoSparkNativeTpchQueries,TestPrestoSparkNativeArrayFunctionQueries
           echo "TESTCLASSES = $TESTCLASSES"
           mvn test \
             ${MAVEN_TEST} \


### PR DESCRIPTION
A few more tests are passing in the CI and are not flaky. The flaky tests are excluded and have issues opened.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

