### PR TITLE
[native] Respect summarize flag in TaskResource

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -161,9 +161,9 @@ struct PrestoTask {
     return updateStatusLocked();
   }
 
-  protocol::TaskInfo updateInfo() {
+  protocol::TaskInfo updateInfo(bool summarize) {
     std::lock_guard<std::mutex> l(mutex);
-    return updateInfoLocked();
+    return updateInfoLocked(summarize);
   }
 
   /// Turns the task numbers (per state) into a string.
@@ -172,7 +172,7 @@ struct PrestoTask {
 
   /// Invoked to update presto task status from the updated velox task stats.
   protocol::TaskStatus updateStatusLocked();
-  protocol::TaskInfo updateInfoLocked();
+  protocol::TaskInfo updateInfoLocked(bool summarize);
 
   folly::dynamic toJson() const;
 
@@ -191,7 +191,8 @@ struct PrestoTask {
   void updateExecutionInfoLocked(
       const velox::exec::TaskStats& veloxTaskStats,
       const protocol::TaskStatus& prestoTaskStatus,
-      std::unordered_map<std::string, velox::RuntimeMetric>& taskRuntimeStats);
+      std::unordered_map<std::string, velox::RuntimeMetric>& taskRuntimeStats,
+      bool includePipelineStats);
 
   void updateMemoryInfoLocked(
       const velox::exec::TaskStats& veloxTaskStats,

--- a/presto-native-execution/presto_cpp/main/SystemConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/SystemConnector.cpp
@@ -167,7 +167,7 @@ RowVectorPtr SystemDataSource::getTaskResults() {
   std::vector<protocol::TaskInfo> taskInfos;
   taskInfos.reserve(numRows);
   for (const auto& taskEntry : taskMap) {
-    taskInfos.push_back(taskEntry.second->updateInfo());
+    taskInfos.push_back(taskEntry.second->updateInfo(true));
   }
 
   auto result = std::dynamic_pointer_cast<RowVector>(

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -58,12 +58,14 @@ class TaskManager {
   std::unique_ptr<protocol::TaskInfo> createOrUpdateErrorTask(
       const protocol::TaskId& taskId,
       const std::exception_ptr& exception,
+      bool summarize,
       long startProcessCpuTime);
 
   std::unique_ptr<protocol::TaskInfo> createOrUpdateTask(
       const protocol::TaskId& taskId,
       const protocol::TaskUpdateRequest& updateRequest,
       const velox::core::PlanFragment& planFragment,
+      bool summarize,
       std::shared_ptr<velox::core::QueryCtx> queryCtx,
       long startProcessCpuTime);
 
@@ -71,6 +73,7 @@ class TaskManager {
       const protocol::TaskId& taskId,
       const protocol::BatchTaskUpdateRequest& batchUpdateRequest,
       const velox::core::PlanFragment& planFragment,
+      bool summarize,
       std::shared_ptr<velox::core::QueryCtx> queryCtx,
       long startProcessCpuTime);
 
@@ -84,9 +87,8 @@ class TaskManager {
       const std::unordered_map<int64_t, std::shared_ptr<ResultRequest>>&
           resultRequests);
 
-  std::unique_ptr<protocol::TaskInfo> deleteTask(
-      const protocol::TaskId& taskId,
-      bool abort);
+  std::unique_ptr<protocol::TaskInfo>
+  deleteTask(const protocol::TaskId& taskId, bool abort, bool summarize);
 
   /// Remove old Finished, Cancelled, Failed and Aborted tasks.
   /// Old is being defined by the lifetime of the task.
@@ -180,6 +182,7 @@ class TaskManager {
       const velox::core::PlanFragment& planFragment,
       const std::vector<protocol::TaskSource>& sources,
       const protocol::OutputBuffers& outputBuffers,
+      bool summarize,
       std::shared_ptr<velox::core::QueryCtx> queryCtx,
       long startProcessCpuTime);
 

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -204,36 +204,41 @@ proxygen::RequestHandler* TaskResource::acknowledgeResults(
 }
 
 proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
-    proxygen::HTTPMessage* /*message*/,
+    proxygen::HTTPMessage* message,
     const std::vector<std::string>& pathMatch,
     const std::function<std::unique_ptr<protocol::TaskInfo>(
         const protocol::TaskId& taskId,
         const std::string& updateJson,
+        const bool summarize,
         long startProcessCpuTime)>& createOrUpdateFunc) {
   protocol::TaskId taskId = pathMatch[1];
+  bool summarize = message->hasQueryParam("summarize");
   return new http::CallbackRequestHandler(
-      [this, taskId, createOrUpdateFunc](
+      [this, taskId, summarize, createOrUpdateFunc](
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& body,
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         folly::via(
             httpSrvCpuExecutor_,
-            [this, &body, taskId, createOrUpdateFunc]() {
+            [this, &body, taskId, summarize, createOrUpdateFunc]() {
               const auto startProcessCpuTimeNs = util::getProcessCpuTimeNs();
               std::string updateJson = util::extractMessageBody(body);
 
               std::unique_ptr<protocol::TaskInfo> taskInfo;
               try {
                 taskInfo = createOrUpdateFunc(
-                    taskId, updateJson, startProcessCpuTimeNs);
+                    taskId, updateJson, summarize, startProcessCpuTimeNs);
               } catch (const velox::VeloxException& e) {
                 // Creating an empty task, putting errors inside so that next
                 // status fetch from coordinator will catch the error and well
                 // categorize it.
                 try {
                   taskInfo = taskManager_.createOrUpdateErrorTask(
-                      taskId, std::current_exception(), startProcessCpuTimeNs);
+                      taskId,
+                      std::current_exception(),
+                      summarize,
+                      startProcessCpuTimeNs);
                 } catch (const velox::VeloxUserError& e) {
                   throw;
                 }
@@ -271,6 +276,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateBatchTask(
       pathMatch,
       [&](const protocol::TaskId& taskId,
           const std::string& updateJson,
+          const bool summarize,
           long startProcessCpuTime) {
         protocol::BatchTaskUpdateRequest batchUpdateRequest =
             json::parse(updateJson);
@@ -308,6 +314,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateBatchTask(
             taskId,
             batchUpdateRequest,
             planFragment,
+            summarize,
             std::move(queryCtx),
             startProcessCpuTime);
       });
@@ -321,6 +328,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTask(
       pathMatch,
       [&](const protocol::TaskId& taskId,
           const std::string& updateJson,
+          const bool summarize,
           long startProcessCpuTime) {
         protocol::TaskUpdateRequest updateRequest = json::parse(updateJson);
         velox::core::PlanFragment planFragment;
@@ -344,6 +352,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTask(
             taskId,
             updateRequest,
             planFragment,
+            summarize,
             std::move(queryCtx),
             startProcessCpuTime);
       });
@@ -358,18 +367,19 @@ proxygen::RequestHandler* TaskResource::deleteTask(
     abort =
         message->getQueryParam(protocol::PRESTO_ABORT_TASK_URL_PARAM) == "true";
   }
+  bool summarize = message->hasQueryParam("summarize");
 
   return new http::CallbackRequestHandler(
-      [this, taskId, abort](
+      [this, taskId, abort, summarize](
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
           proxygen::ResponseHandler* downstream,
           std::shared_ptr<http::CallbackRequestHandlerState> handlerState) {
         folly::via(
             httpSrvCpuExecutor_,
-            [this, taskId, abort, downstream]() {
+            [this, taskId, abort, downstream, summarize]() {
               std::unique_ptr<protocol::TaskInfo> taskInfo;
-              taskInfo = taskManager_.deleteTask(taskId, abort);
+              taskInfo = taskManager_.deleteTask(taskId, abort, summarize);
               return std::move(taskInfo);
             })
             .via(folly::EventBaseManager::get()->getEventBase())

--- a/presto-native-execution/presto_cpp/main/TaskResource.h
+++ b/presto-native-execution/presto_cpp/main/TaskResource.h
@@ -75,6 +75,7 @@ class TaskResource {
       const std::function<std::unique_ptr<protocol::TaskInfo>(
           const protocol::TaskId&,
           const std::string&,
+          const bool,
           long)>& createOrUpdateFunc);
 
   proxygen::RequestHandler* deleteTask(

--- a/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
@@ -175,6 +175,7 @@ TEST_F(ServerOperationTest, taskEndpoint) {
             taskId,
             {},
             planFragment,
+            true,
             taskManager->getQueryContextManager()->findOrCreateQueryCtx(
                 taskId, updateRequest.session),
             0);
@@ -215,7 +216,7 @@ TEST_F(ServerOperationTest, taskEndpoint) {
 
   // Cleanup and shutdown
   for (const auto& taskId : taskIds) {
-    taskManager->deleteTask(taskId, true);
+    taskManager->deleteTask(taskId, true, true);
   }
   taskManager->shutdown();
   connector::unregisterConnector("test-hive");


### PR DESCRIPTION
## Description

When summarize flag is set do not send detailed per-pipeline stats (same as in Java implementation) to save CPU on serialization / deserialization


## Motivation and Context

A significantly higher CPU utilization on coordinator for native workers is observed due to ignored "summarize" flag.

## Impact

Lower CPU utilization and GC activity on coordinator for Prestissimo deployments

## Test Plan

Unit test

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve coordinator task management performance. :pr:`24369`
```

