### PR TITLE
[native] Deprecate query level cache config

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -184,17 +184,6 @@ disabled if ``connector.num-io-threads-hw-multiplier`` is set to zero.
 
 Whether async data cache is enabled.
 
-``query-data-cache-enabled-default``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* **Type** ``bool``
-* **Default value:** ``true``
-
-If ``true``, SSD cache is enabled by default and is disabled only if
-``node_selection_strategy`` is present and set to ``NO_PREFERENCE``.
-Otherwise, SSD cache is disabled by default and is enabled if
-``node_selection_strategy`` is present and set to ``SOFT_AFFINITY`` or ``HARD_AFFINITY``.
-
 ``async-cache-ssd-gb``
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -94,37 +94,6 @@ void updateVeloxConfigs(
   }
 }
 
-void updateVeloxConnectorConfigs(
-    std::unordered_map<
-        std::string,
-        std::unordered_map<std::string, std::string>>& connectorConfigStrings) {
-  const auto& systemConfig = SystemConfig::instance();
-  for (auto& entry : connectorConfigStrings) {
-    auto& connectorConfig = entry.second;
-    // If queryDataCacheEnabledDefault is true, when `node_selection_strategy`
-    // is
-    //       not set                             retain cache
-    //       SOFT_AFFINITY                       retain cache
-    //       HARD_AFFINITY                       retain cache
-    //       NO_PREFERENCE                       do not retain cache
-    // If queryDataCacheEnabledDefault is false, when `node_selection_strategy`
-    // is
-    //       not set                             do not retain cache
-    //       SOFT_AFFINITY                       retain cache
-    //       HARD_AFFINITY                       retain cache
-    //       NO_PREFERENCE                       do not retain cache
-    connectorConfig.emplace(
-        connector::hive::HiveConfig::kCacheNoRetentionSession,
-        systemConfig->queryDataCacheEnabledDefault() ? "false" : "true");
-    auto it = connectorConfig.find("node_selection_strategy");
-    if (it != connectorConfig.end()) {
-      connectorConfig[connector::hive::HiveConfig::kCacheNoRetentionSession] =
-          (it->second != "SOFT_AFFINITY" && it->second != "HARD_AFFINITY")
-          ? "true"
-          : "false";
-    }
-  }
-}
 } // namespace
 
 QueryContextManager::QueryContextManager(
@@ -157,7 +126,6 @@ std::shared_ptr<core::QueryCtx> QueryContextManager::findOrCreateQueryCtx(
   }
 
   updateVeloxConfigs(configStrings);
-  updateVeloxConnectorConfigs(connectorConfigStrings);
 
   std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
       connectorConfigs;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -180,7 +180,6 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kNativeSidecar, false),
           BOOL_PROP(kAsyncDataCacheEnabled, true),
           NUM_PROP(kAsyncCacheSsdGb, 0),
-          BOOL_PROP(kQueryDataCacheEnabledDefault, true),
           NUM_PROP(kAsyncCacheSsdCheckpointGb, 0),
           STR_PROP(kAsyncCacheSsdPath, "/mnt/flash/async_cache."),
           NUM_PROP(kAsyncCacheMaxSsdWriteRatio, 0.7),
@@ -473,10 +472,6 @@ uint64_t SystemConfig::asyncCacheSsdGb() const {
 
 bool SystemConfig::asyncDataCacheEnabled() const {
   return optionalProperty<bool>(kAsyncDataCacheEnabled).value();
-}
-
-bool SystemConfig::queryDataCacheEnabledDefault() const {
-  return optionalProperty<bool>(kQueryDataCacheEnabledDefault).value();
 }
 
 uint64_t SystemConfig::asyncCacheSsdCheckpointGb() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -327,12 +327,6 @@ class SystemConfig : public ConfigBase {
 
   static constexpr std::string_view kAsyncDataCacheEnabled{
       "async-data-cache-enabled"};
-  /// If true, SSD cache is enabled by default and is disabled only if
-  /// `node_selection_strategy` is present and set to `NO_PREFERENCE`.
-  /// Otherwise, SSD cache is disabled by default and is enabled if
-  /// `node_selection_strategy` is present and set to `SOFT_AFFINITY`.
-  static constexpr std::string_view kQueryDataCacheEnabledDefault{
-      "query-data-cache-enabled-default"};
   static constexpr std::string_view kAsyncCacheSsdGb{"async-cache-ssd-gb"};
   static constexpr std::string_view kAsyncCacheSsdCheckpointGb{
       "async-cache-ssd-checkpoint-gb"};


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Remove ``query-data-cache-enabled-default`` configuration property, which is no longer needed as per-split fine-grained cache control has been introduced. :pr:`24372 `
```

