### PR TITLE
Upgrade caniuse-lite to fix browserslist warnings during build

### DIFF
--- a/presto-ui/src/yarn.lock
+++ b/presto-ui/src/yarn.lock
@@ -1669,9 +1669,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001541:
-  version "1.0.30001561"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz#752f21f56f96f1b1a52e97aae98c57c562d5d9da"
-  integrity sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==
+  version "1.0.30001692"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz"
+  integrity sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

In issue https://github.com/prestodb/presto/issues/22744, there is a warning about browserslist
```
[INFO] yarn install v1.22.22
[INFO] [1/5] Validating package.json...
[INFO] [2/5] Resolving packages...
[INFO] success Already up-to-date.
[INFO] $ webpack --env=production --config webpack.config.js
[INFO] Browserslist: caniuse-lite is outdated. Please run:
[INFO]   npx update-browserslist-db@latest
[INFO]   Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
build

## Test Plan
<!---Please fill in how you tested your change-->
build

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

