### PR TITLE
checking updated snappy version with new hive-dwrf release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,13 @@
         <air.javadoc.lint>-missing</air.javadoc.lint>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <modules>
         <module>presto-atop</module>
         <module>presto-spi</module>
@@ -970,9 +977,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.facebook.hive</groupId>
-                <artifactId>hive-dwrf</artifactId>
-                <version>0.8.5</version>
+                <groupId>com.github.namya28</groupId>
+                <artifactId>presto-hive-dwrf</artifactId>
+                <version>snappy0.5</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,16 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>

--- a/presto-hive-metastore/pom.xml
+++ b/presto-hive-metastore/pom.xml
@@ -129,7 +129,6 @@
         <dependency>
             <groupId>com.github.namya28</groupId>
             <artifactId>presto-hive-dwrf</artifactId>
-            <version>snappy0.5</version>
         </dependency>
 
         <dependency>

--- a/presto-hive-metastore/pom.xml
+++ b/presto-hive-metastore/pom.xml
@@ -127,8 +127,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.facebook.hive</groupId>
-            <artifactId>hive-dwrf</artifactId>
+            <groupId>com.github.namya28</groupId>
+            <artifactId>presto-hive-dwrf</artifactId>
+            <version>snappy0.5</version>
         </dependency>
 
         <dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -45,7 +45,6 @@
         <dependency>
             <groupId>com.github.namya28</groupId>
             <artifactId>presto-hive-dwrf</artifactId>
-            <version>snappy0.5</version>
         </dependency>
 
         <dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -43,8 +43,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.facebook.hive</groupId>
-            <artifactId>hive-dwrf</artifactId>
+            <groupId>com.github.namya28</groupId>
+            <artifactId>presto-hive-dwrf</artifactId>
+            <version>snappy0.5</version>
         </dependency>
 
         <dependency>

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -159,7 +159,6 @@
         <dependency>
             <groupId>com.github.namya28</groupId>
             <artifactId>presto-hive-dwrf</artifactId>
-            <version>snappy0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -157,8 +157,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.facebook.hive</groupId>
-            <artifactId>hive-dwrf</artifactId>
+            <groupId>com.github.namya28</groupId>
+            <artifactId>presto-hive-dwrf</artifactId>
+            <version>snappy0.5</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Description
This is a draft PR to ensure a green CI run before merging the changes to snappy version in hive-dwrf repo. 
The link to the PR: https://github.com/prestodb/presto-hive-dwrf/pull/7
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

