### PR TITLE
Migrate presto stable release pipeline from jenkins to github actions

### DIFF
--- a/.github/workflows/presto-stable-release.yml
+++ b/.github/workflows/presto-stable-release.yml
@@ -1,0 +1,64 @@
+name: Presto Stable Release Workflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+  presto-release:
+    name: Presto Stable Release Workflow
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout Presto source
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          show-progress: false
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Configure Git
+        run: |
+          git config --global --add safe.directory ${{github.workspace}}
+          git config --global user.email "oss-release-bot@prestodb.io"
+          git config --global user.name "oss-release-bot"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git config pull.rebase false
+
+      - name: Set Maven version
+        run: |
+          unset MAVEN_CONFIG && ./mvnw versions:set -DremoveSnapshot -ntp
+
+      - name: Get Presto release version
+        id: get-version
+        run: |
+          PRESTO_RELEASE_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+            -Dexpression=project.version -q -ntp -DforceStdout | tail -n 1)
+          echo "PRESTO_RELEASE_VERSION=$PRESTO_RELEASE_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update version in master
+        env:
+          PRESTO_RELEASE_VERSION: ${{ steps.get-version.outputs.PRESTO_RELEASE_VERSION }}
+        run: |
+          git reset --hard
+          unset MAVEN_CONFIG && ./mvnw release:prepare --batch-mode \
+            -DskipTests \
+            -DautoVersionSubmodules \
+            -DdevelopmentVersion=${{ env.PRESTO_RELEASE_VERSION }} \
+            -DreleaseVersion=${{ env.PRESTO_RELEASE_VERSION }}
+          git push --follow-tags origin master
+
+      - name: Push release branch
+        env:
+          PRESTO_RELEASE_VERSION: ${{ steps.get-version.outputs.PRESTO_RELEASE_VERSION }}
+        run: |
+          git checkout -b release-${{ env.PRESTO_RELEASE_VERSION }}
+          git push origin release-${{ env.PRESTO_RELEASE_VERSION }}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This PR migrate the Jenkinsfile script from https://github.com/prestodb/presto-release-tools/blob/pipeline-release-stable/Jenkinsfile

Will update versions, and create new stable release branch

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Presto release

## Test Plan
<!---Please fill in how you tested your change-->
Try with new release

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

