### PR TITLE
Add a config flag `tpcds.use-varchar-type` in Presto - Java TPC-DS Connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/tpcds.rst
+++ b/presto-docs/src/main/sphinx/connector/tpcds.rst
@@ -66,4 +66,6 @@ Property Name                                      Description                  
 ================================================== ========================================================================== ==============================
 ``tpcds.splits-per-node``                          Number of data splits generated per Presto worker node when querying       Number of available processors
                                                    data from the TPCDS connector.
+
+``tpcds.use-varchar-type``                         Toggle all char columns to varchar in the TPC-DS connector.                false
 ================================================== ========================================================================== ==============================

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveNativeLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveNativeLogicalPlanner.java
@@ -25,8 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
-import java.util.Optional;
-
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
 import static com.facebook.presto.hive.HiveSessionProperties.PARTIAL_AGGREGATION_PUSHDOWN_ENABLED;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
@@ -47,7 +45,7 @@ public class TestHiveNativeLogicalPlanner
         return HiveQueryRunner.createQueryRunner(
                 ImmutableList.of(ORDERS),
                 ImmutableMap.of("native-execution-enabled", "true"),
-                Optional.empty());
+                ImmutableMap.of("tpcds.use-varchar-type", "true"));
     }
 
     @Test

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/S3HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/S3HiveQueryRunner.java
@@ -60,6 +60,7 @@ public final class S3HiveQueryRunner
                                         hiveEndpoint.getPort()),
                                 new MetastoreClientConfig(),
                                 HDFS_ENVIRONMENT),
-                        new HivePartitionMutator())));
+                        new HivePartitionMutator())),
+                ImmutableMap.of());
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -149,22 +149,7 @@ public final class IcebergQueryRunner
             Optional<Path> dataDirectory)
             throws Exception
     {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, addJmxPlugin, nodeCount, externalWorkerLauncher, dataDirectory, false, Optional.empty());
-    }
-
-    public static DistributedQueryRunner createIcebergQueryRunner(
-            Map<String, String> extraProperties,
-            Map<String, String> extraConnectorProperties,
-            FileFormat format,
-            boolean createTpchTables,
-            boolean addJmxPlugin,
-            OptionalInt nodeCount,
-            Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher,
-            Optional<Path> dataDirectory,
-            boolean addStorageFormatToPath)
-            throws Exception
-    {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, addJmxPlugin, nodeCount, externalWorkerLauncher, dataDirectory, addStorageFormatToPath, Optional.empty());
+        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, addJmxPlugin, nodeCount, externalWorkerLauncher, dataDirectory, false, Optional.empty(), ImmutableMap.of());
     }
 
     public static DistributedQueryRunner createIcebergQueryRunner(
@@ -177,7 +162,24 @@ public final class IcebergQueryRunner
             Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher,
             Optional<Path> dataDirectory,
             boolean addStorageFormatToPath,
-            Optional<String> schemaName)
+            Map<String, String> tpcdsProperties)
+            throws Exception
+    {
+        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, addJmxPlugin, nodeCount, externalWorkerLauncher, dataDirectory, addStorageFormatToPath, Optional.empty(), tpcdsProperties);
+    }
+
+    public static DistributedQueryRunner createIcebergQueryRunner(
+            Map<String, String> extraProperties,
+            Map<String, String> extraConnectorProperties,
+            FileFormat format,
+            boolean createTpchTables,
+            boolean addJmxPlugin,
+            OptionalInt nodeCount,
+            Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher,
+            Optional<Path> dataDirectory,
+            boolean addStorageFormatToPath,
+            Optional<String> schemaName,
+            Map<String, String> tpcdsProperties)
             throws Exception
     {
         setupLogging();
@@ -198,7 +200,7 @@ public final class IcebergQueryRunner
         queryRunner.createCatalog("tpch", "tpch");
 
         queryRunner.installPlugin(new TpcdsPlugin());
-        queryRunner.createCatalog("tpcds", "tpcds");
+        queryRunner.createCatalog("tpcds", "tpcds", tpcdsProperties);
 
         queryRunner.getServers().forEach(server -> {
             MBeanServer mBeanServer = MBeanServerFactory.newMBeanServer();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
@@ -120,7 +120,8 @@ public class TestIcebergSmokeRestNestedNamespace
                 Optional.empty(),
                 Optional.of(warehouseLocation.toPath()),
                 false,
-                Optional.of("ns1.ns2"));
+                Optional.of("ns1.ns2"),
+                ImmutableMap.of());
 
         // additional catalog for testing nested namespace disabled
         icebergQueryRunner.createCatalog(ICEBERG_NESTED_NAMESPACE_DISABLED_CATALOG, "iceberg",

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpcdsQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpcdsQueries.java
@@ -91,24 +91,15 @@ public abstract class AbstractTestNativeTpcdsQueries
                 case "PARQUET":
                 case "ORC":
                     queryRunner.execute(session, "CREATE TABLE call_center AS " +
-                            "SELECT cc_call_center_sk, cast(cc_call_center_id as varchar) as cc_call_center_id, cc_rec_start_date, cc_rec_end_date, " +
-                            "   cc_closed_date_sk, cc_open_date_sk, cc_name, cc_class, cc_employees, cc_sq_ft, cast(cc_hours as varchar) as cc_hours, " +
-                            "   cc_manager, cc_mkt_id, cast(cc_mkt_class as varchar) as cc_mkt_class, cc_mkt_desc, cc_market_manager,  " +
-                            "   cc_division, cc_division_name, cc_company, cast(cc_company_name as varchar) as cc_company_name," +
-                            "   cast(cc_street_number as varchar ) as cc_street_number, cc_street_name, cast(cc_street_type as varchar) as cc_street_type, " +
-                            "   cast(cc_suite_number as varchar) as cc_suite_number, cc_city, cc_county, cast(cc_state as varchar) as cc_state, " +
-                            "   cast(cc_zip as varchar) as cc_zip, cc_country, cc_gmt_offset, cc_tax_percentage " +
-                            "FROM tpcds.tiny.call_center");
+                            "SELECT * FROM tpcds.tiny.call_center");
                     break;
                 case "DWRF":
                     queryRunner.execute(session, "CREATE TABLE call_center AS " +
-                            "SELECT cc_call_center_sk, cast(cc_call_center_id as varchar) as cc_call_center_id, cast(cc_rec_start_date as varchar) as cc_rec_start_date, " +
-                            "   cast(cc_rec_end_date as varchar) as cc_rec_end_date, cc_closed_date_sk, cc_open_date_sk, cc_name, cc_class, cc_employees, cc_sq_ft," +
-                            "   cast(cc_hours as varchar) as cc_hours, cc_manager, cc_mkt_id, cast(cc_mkt_class as varchar) as cc_mkt_class, cc_mkt_desc, cc_market_manager, " +
-                            "   cc_division, cc_division_name, cc_company, cast(cc_company_name as varchar) as cc_company_name," +
-                            "   cast(cc_street_number as varchar ) as cc_street_number, cc_street_name, cast(cc_street_type as varchar) as cc_street_type, " +
-                            "   cast(cc_suite_number as varchar) as cc_suite_number, cc_city, cc_county, cast(cc_state as varchar) as cc_state, " +
-                            "   cast(cc_zip as varchar) as cc_zip, cc_country, cc_gmt_offset, cc_tax_percentage " +
+                            "SELECT cc_call_center_sk, cc_call_center_id, cast(cc_rec_start_date as varchar) as cc_rec_start_date, " +
+                            "   cast(cc_rec_end_date as varchar) as cc_rec_end_date, cc_closed_date_sk, cc_open_date_sk, cc_name, cc_class, " +
+                            "   cc_employees, cc_sq_ft, cc_hours, cc_manager, cc_mkt_id, cc_mkt_class, cc_mkt_desc, cc_market_manager, cc_division, " +
+                            "   cc_division_name, cc_company, cc_company_name, cc_street_number, cc_street_name, cc_street_type, cc_suite_number, " +
+                            "   cc_city, cc_county, cc_state, cc_zip, cc_country, cc_gmt_offset, cc_tax_percentage " +
                             "FROM tpcds.tiny.call_center");
                     break;
             }
@@ -119,9 +110,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "catalog_page")) {
             queryRunner.execute(session, "CREATE TABLE catalog_page AS " +
-                    "SELECT cp_catalog_page_sk, cast(cp_catalog_page_id as varchar) as cp_catalog_page_id, cp_start_date_sk, cp_end_date_sk, " +
-                    "   cp_department, cp_catalog_number, cp_catalog_page_number, cp_description, cp_type " +
-                    "FROM tpcds.tiny.catalog_page");
+                    "SELECT * FROM tpcds.tiny.catalog_page");
         }
     }
 
@@ -143,13 +132,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "customer")) {
             queryRunner.execute(session, "CREATE TABLE customer AS " +
-                    "SELECT c_customer_sk, cast(c_customer_id as varchar) as c_customer_id, c_current_cdemo_sk, c_current_hdemo_sk, " +
-                    "   c_current_addr_sk, c_first_shipto_date_sk, c_first_sales_date_sk, cast(c_salutation as varchar) as c_salutation, " +
-                    "   cast(c_first_name as varchar) as c_first_name, cast(c_last_name as varchar) as c_last_name, " +
-                    "   cast(c_preferred_cust_flag as varchar) as c_preferred_cust_flag, c_birth_day, c_birth_month, c_birth_year, " +
-                    "   c_birth_country, cast(c_login as varchar) as c_login, cast(c_email_address as varchar) as c_email_address,  " +
-                    "   c_last_review_date_sk " +
-                    "FROM tpcds.tiny.customer");
+                    "SELECT * FROM tpcds.tiny.customer");
         }
     }
 
@@ -157,11 +140,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "customer_address")) {
             queryRunner.execute(session, "CREATE TABLE customer_address AS " +
-                    "SELECT ca_address_sk, cast(ca_address_id as varchar) as ca_address_id, cast(ca_street_number as varchar) as ca_street_number,  " +
-                    "   ca_street_name, cast(ca_street_type as varchar) as ca_street_type, cast(ca_suite_number as varchar) as ca_suite_number,  " +
-                    "   ca_city, ca_county, cast(ca_state as varchar) as ca_state, cast(ca_zip as varchar) as ca_zip, " +
-                    "   ca_country, ca_gmt_offset, cast(ca_location_type as varchar) as ca_location_type " +
-                    "FROM tpcds.tiny.customer_address");
+                    "SELECT * FROM tpcds.tiny.customer_address");
         }
     }
 
@@ -169,10 +148,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "customer_demographics")) {
             queryRunner.execute(session, "CREATE TABLE customer_demographics AS " +
-                    "SELECT cd_demo_sk, cast(cd_gender as varchar) as cd_gender, cast(cd_marital_status as varchar) as cd_marital_status,  " +
-                    "   cast(cd_education_status as varchar) as cd_education_status, cd_purchase_estimate,  " +
-                    "   cast(cd_credit_rating as varchar) as cd_credit_rating, cd_dep_count, cd_dep_employed_count, cd_dep_college_count " +
-                    "FROM tpcds.tiny.customer_demographics");
+                    "SELECT * FROM tpcds.tiny.customer_demographics");
         }
     }
 
@@ -183,26 +159,13 @@ public abstract class AbstractTestNativeTpcdsQueries
                 case "PARQUET":
                 case "ORC":
                     queryRunner.execute(session, "CREATE TABLE date_dim AS " +
-                            "SELECT d_date_sk, cast(d_date_id as varchar) as d_date_id, d_date, " +
-                            "   d_month_seq, d_week_seq, d_quarter_seq, d_year, d_dow, d_moy, d_dom, d_qoy, d_fy_year, " +
-                            "   d_fy_quarter_seq, d_fy_week_seq, cast(d_day_name as varchar) as d_day_name, cast(d_quarter_name as varchar) as d_quarter_name, " +
-                            "   cast(d_holiday as varchar) as d_holiday,  cast(d_weekend as varchar) as d_weekend, " +
-                            "   cast(d_following_holiday as varchar) as d_following_holiday, d_first_dom, d_last_dom, d_same_day_ly, d_same_day_lq,  " +
-                            "   cast(d_current_day as varchar) as d_current_day, cast(d_current_week as varchar) as d_current_week, " +
-                            "   cast(d_current_month as varchar) as d_current_month,  cast(d_current_quarter as varchar) as d_current_quarter, " +
-                            "   cast(d_current_year as varchar) as d_current_year " +
-                            "FROM tpcds.tiny.date_dim");
+                            "SELECT * FROM tpcds.tiny.date_dim");
                     break;
                 case "DWRF":
                     queryRunner.execute(session, "CREATE TABLE date_dim AS " +
-                            "SELECT d_date_sk, cast(d_date_id as varchar) as d_date_id, cast(d_date as varchar) as d_date, " +
-                            "   d_month_seq, d_week_seq, d_quarter_seq, d_year, d_dow, d_moy, d_dom, d_qoy, d_fy_year, " +
-                            "   d_fy_quarter_seq, d_fy_week_seq, cast(d_day_name as varchar) as d_day_name, cast(d_quarter_name as varchar) as d_quarter_name, " +
-                            "   cast(d_holiday as varchar) as d_holiday,  cast(d_weekend as varchar) as d_weekend, " +
-                            "   cast(d_following_holiday as varchar) as d_following_holiday, d_first_dom, d_last_dom, d_same_day_ly, d_same_day_lq,  " +
-                            "   cast(d_current_day as varchar) as d_current_day, cast(d_current_week as varchar) as d_current_week, " +
-                            "   cast(d_current_month as varchar) as d_current_month,  cast(d_current_quarter as varchar) as d_current_quarter, " +
-                            "   cast(d_current_year as varchar) as d_current_year " +
+                            "SELECT d_date_sk, d_date_id, cast(d_date as varchar) as d_date, d_month_seq, d_week_seq, d_quarter_seq, d_year, d_dow, d_moy, d_dom, d_qoy, d_fy_year, " +
+                            "   d_fy_quarter_seq, d_fy_week_seq, d_day_name, d_quarter_name, d_holiday,  d_weekend, d_following_holiday, d_first_dom, " +
+                            "   d_last_dom, d_same_day_ly, d_same_day_lq, d_current_day, d_current_week, d_current_month,  d_current_quarter, d_current_year " +
                             "FROM tpcds.tiny.date_dim");
                     break;
             }
@@ -213,8 +176,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "household_demographics")) {
             queryRunner.execute(session, "CREATE TABLE household_demographics AS " +
-                    "SELECT hd_demo_sk, hd_income_band_sk, cast(hd_buy_potential as varchar) as hd_buy_potential, hd_dep_count, hd_vehicle_count " +
-                    "FROM tpcds.tiny.household_demographics");
+                    "SELECT * FROM tpcds.tiny.household_demographics");
         }
     }
 
@@ -241,23 +203,13 @@ public abstract class AbstractTestNativeTpcdsQueries
                 case "PARQUET":
                 case "ORC":
                     queryRunner.execute(session, "CREATE TABLE item AS " +
-                            "SELECT i_item_sk, cast(i_item_id as varchar) as i_item_id, i_rec_start_date, i_rec_end_date, " +
-                            "   i_item_desc, i_current_price, i_wholesale_cost, i_brand_id, cast(i_brand as varchar) as i_brand, " +
-                            "   i_class_id,  cast(i_class as varchar) as i_class, i_category_id, cast(i_category as varchar) as i_category, i_manufact_id, " +
-                            "   cast(i_manufact as varchar) as i_manufact, cast(i_size as varchar) as i_size, cast(i_formulation as varchar) as i_formulation, " +
-                            "   cast(i_color as varchar) as i_color, cast(i_units as varchar) as i_units, cast(i_container as varchar) as i_container, i_manager_id, " +
-                            "   cast(i_product_name as varchar) as i_product_name " +
-                            "FROM tpcds.tiny.item");
+                            "SELECT * FROM tpcds.tiny.item");
                     break;
                 case "DRWF":
                     queryRunner.execute(session, "CREATE TABLE item AS " +
-                            "SELECT i_item_sk, cast(i_item_id as varchar) as i_item_id, cast(i_rec_start_date as varchar) as i_rec_start_date, " +
-                            "   cast(i_rec_end_date as varchar) as i_rec_end_date, i_item_desc, cast(i_current_price as double) as i_current_price, " +
-                            "   cast(i_wholesale_cost as double) as i_wholesale_cost, i_brand_id, cast(i_brand as varchar) as i_brand, " +
-                            "   i_class_id,  cast(i_class as varchar) as i_class, i_category_id, cast(i_category as varchar) as i_category, i_manufact_id, " +
-                            "   cast(i_manufact as varchar) as i_manufact, cast(i_size as varchar) as i_size, cast(i_formulation as varchar) as i_formulation, " +
-                            "   cast(i_color as varchar) as i_color, cast(i_units as varchar) as i_units, cast(i_container as varchar) as i_container, i_manager_id, " +
-                            "   cast(i_product_name as varchar) as i_product_name " +
+                            "SELECT i_item_sk, i_item_id, cast(i_rec_start_date as varchar) as i_rec_start_date, cast(i_rec_end_date as varchar) as i_rec_end_date, " +
+                            "   i_item_desc, i_current_price, i_wholesale_cost, i_brand_id, i_brand, i_class_id,  i_class, i_category_id, " +
+                            "   i_category, i_manufact_id, i_manufact, i_size, i_formulation, i_color, i_units, i_container, i_manager_id, i_product_name " +
                             "FROM tpcds.tiny.item");
                     break;
             }
@@ -268,14 +220,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "promotion")) {
             queryRunner.execute(session, "CREATE TABLE promotion AS " +
-                    "SELECT p_promo_sk, cast(p_promo_id as varchar) as p_promo_id, p_start_date_sk, p_end_date_sk, p_item_sk, " +
-                    "   p_cost, p_response_targe, cast(p_promo_name as varchar) as p_promo_name, " +
-                    "   cast(p_channel_dmail as varchar) as p_channel_dmail, cast(p_channel_email as varchar) as p_channel_email, " +
-                    "   cast(p_channel_catalog as varchar) as p_channel_catalog, cast(p_channel_tv as varchar) as p_channel_tv, " +
-                    "   cast(p_channel_radio as varchar) as p_channel_radio, cast(p_channel_press as varchar) as p_channel_press, " +
-                    "   cast(p_channel_event as varchar) as p_channel_event, cast(p_channel_demo as varchar) as p_channel_demo, p_channel_details, " +
-                    "   cast(p_purpose as varchar) as p_purpose, cast(p_discount_active as varchar) as p_discount_active " +
-                    "FROM tpcds.tiny.promotion");
+                    "SELECT * FROM tpcds.tiny.promotion");
         }
     }
 
@@ -283,8 +228,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "reason")) {
             queryRunner.execute(session, "CREATE TABLE reason AS " +
-                    "SELECT r_reason_sk, cast(r_reason_id as varchar) as r_reason_id, cast(r_reason_desc as varchar) as r_reason_desc " +
-                    "FROM tpcds.tiny.reason");
+                    "SELECT * FROM tpcds.tiny.reason");
         }
     }
 
@@ -292,9 +236,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "ship_mode")) {
             queryRunner.execute(session, "CREATE TABLE ship_mode AS " +
-                    "SELECT sm_ship_mode_sk, cast(sm_ship_mode_id as varchar) as sm_ship_mode_id, cast(sm_type as varchar) as sm_type, " +
-                    "   cast(sm_code as varchar) as sm_code, cast(sm_carrier as varchar) as sm_carrier, cast(sm_contract as varchar) as sm_contract " +
-                    "FROM tpcds.tiny.ship_mode");
+                    "SELECT * FROM tpcds.tiny.ship_mode");
         }
     }
 
@@ -305,24 +247,15 @@ public abstract class AbstractTestNativeTpcdsQueries
                 case "PARQUET":
                 case "ORC":
                     queryRunner.execute(session, "CREATE TABLE store AS " +
-                            "SELECT s_store_sk, cast(s_store_id as varchar) as s_store_id, s_rec_start_date, s_rec_end_date, " +
-                            "   s_closed_date_sk, s_store_name, s_number_employees, s_floor_space, cast(s_hours as varchar) as s_hours, " +
-                            "   s_manager, s_market_id, s_geography_class, s_market_desc, s_market_manager, s_division_id, s_division_name, " +
-                            "   s_company_id, s_company_name, s_street_number, s_street_name, cast(s_street_type as varchar) as s_street_type, " +
-                            "   cast(s_suite_number as varchar) as s_suite_number, s_city, s_county, cast(s_state as varchar ) as s_state, " +
-                            "   cast(s_zip as varchar) as s_zip, s_country, s_gmt_offset, s_tax_precentage " +
-                            "FROM tpcds.tiny.store");
+                            "SELECT * FROM tpcds.tiny.store");
                     break;
                 case "DRWF":
                     queryRunner.execute(session, "CREATE TABLE store AS " +
-                            "SELECT s_store_sk, cast(s_store_id as varchar) as s_store_id, cast(s_rec_start_date as varchar) as s_rec_start_date, " +
-                            "   cast(s_rec_end_date as varchar) as s_rec_end_date, s_closed_date_sk, s_store_name, s_number_employees, s_floor_space, " +
-                            "   cast(s_hours as varchar) as s_hours, s_manager, s_market_id, s_geography_class, s_market_desc, s_market_manager, " +
-                            "   s_division_id, s_division_name, s_company_id, s_company_name, s_street_number, s_street_name, " +
-                            "   cast(s_street_type as varchar) as s_street_type, cast(s_suite_number as varchar) as s_suite_number, s_city, s_county, " +
-                            "   cast(s_state as varchar ) as s_state, cast(s_zip as varchar) as s_zip, s_country, " +
-                            "   cast(s_gmt_offset as double) as s_gmt_offset, " +
-                            "   cast(s_tax_precentage as double) as s_tax_precentage " +
+                            "SELECT s_store_sk, cast(s_rec_start_date as varchar) as s_rec_start_date, cast(s_rec_end_date as varchar) as s_rec_end_date, " +
+                            "   s_closed_date_sk, s_store_name, s_number_employees, s_floor_space, s_hours, s_manager, s_market_id, s_geography_class, " +
+                            "   s_market_desc, s_market_manager, s_division_id, s_division_name, s_company_id, s_company_name, s_street_number, s_street_name, " +
+                            "   s_street_type, s_suite_number, s_city, s_county, s_state, s_zip, s_country, " +
+                            "   cast(s_gmt_offset as double) as s_gmt_offset, cast(s_tax_precentage as double) as s_tax_precentage " +
                             "FROM tpcds.tiny.store");
                     break;
             }
@@ -349,10 +282,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "time_dim")) {
             queryRunner.execute(session, "CREATE TABLE time_dim AS " +
-                    "SELECT t_time_sk, cast(t_time_id as varchar) as t_time_id, t_time, t_hour, t_minute, t_second,  " +
-                    "   cast(t_am_pm as varchar) as t_am_pm, cast(t_shift as varchar) as t_shift, " +
-                    "   cast(t_sub_shift as varchar) as t_sub_shift, cast(t_meal_time as varchar) as t_meal_time " +
-                    "FROM tpcds.tiny.time_dim");
+                    "SELECT * FROM tpcds.tiny.time_dim");
         }
     }
 
@@ -360,11 +290,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     {
         if (!queryRunner.tableExists(session, "warehouse")) {
             queryRunner.execute(session, "CREATE TABLE warehouse AS " +
-                    "SELECT w_warehouse_sk, cast(w_warehouse_id as varchar) as w_warehouse_id, w_warehouse_name, w_warehouse_sq_ft, " +
-                    "   cast(w_street_number as varchar) as w_street_number, w_street_name, cast(w_street_type as varchar) as w_street_type, " +
-                    "   cast(w_suite_number as varchar) as w_suite_number, w_city, w_county, cast(w_state as varchar) as w_state," +
-                    "   cast(w_zip as varchar) as w_zip, w_country, w_gmt_offset " +
-                    "FROM tpcds.tiny.warehouse");
+                    "SELECT * FROM tpcds.tiny.warehouse");
         }
     }
 
@@ -375,17 +301,14 @@ public abstract class AbstractTestNativeTpcdsQueries
                 case "PARQUET":
                 case "ORC":
                     queryRunner.execute(session, "CREATE TABLE web_page AS " +
-                            "SELECT wp_web_page_sk, cast(wp_web_page_id as varchar) as wp_web_page_id, wp_rec_start_date, wp_rec_end_date, " +
-                            "   wp_creation_date_sk, wp_access_date_sk, cast(wp_autogen_flag as varchar) as wp_autogen_flag, wp_customer_sk, " +
-                            "   wp_url, cast(wp_type as varchar) as wp_type, wp_char_count, wp_link_count, wp_image_count, wp_max_ad_count " +
-                            "FROM tpcds.tiny.web_page");
+                            "SELECT * FROM tpcds.tiny.web_page");
                     break;
                 case "DWRF":
                     queryRunner.execute(session, "CREATE TABLE web_page AS " +
-                            "SELECT wp_web_page_sk, cast(wp_web_page_id as varchar) as wp_web_page_id, cast(wp_rec_start_date as varchar) as wp_rec_start_date, " +
+                            "SELECT wp_web_page_sk, wp_web_page_id, cast(wp_rec_start_date as varchar) as wp_rec_start_date, " +
                             "   cast(wp_rec_end_date as varchar) as wp_rec_end_date, wp_creation_date_sk, wp_access_date_sk, " +
-                            "   cast(wp_autogen_flag as varchar) as wp_autogen_flag, wp_customer_sk, wp_url, cast(wp_type as varchar) as wp_type, " +
-                            "   wp_char_count, wp_link_count, wp_image_count, wp_max_ad_count " +
+                            "   wp_autogen_flag, wp_customer_sk, wp_url, wp_type, wp_char_count, wp_link_count, wp_image_count, " +
+                            "   wp_max_ad_count " +
                             "FROM tpcds.tiny.web_page");
                     break;
             }
@@ -415,23 +338,15 @@ public abstract class AbstractTestNativeTpcdsQueries
                 case "PARQUET":
                 case "ORC":
                     queryRunner.execute(session, "CREATE TABLE web_site AS " +
-                            "SELECT web_site_sk, cast(web_site_id as varchar) as web_site_id, web_rec_start_date, web_rec_end_date, web_name, " +
-                            "   web_open_date_sk, web_close_date_sk, web_class, web_manager, web_mkt_id, web_mkt_class, web_mkt_desc, web_market_manager, " +
-                            "   web_company_id, cast(web_company_name as varchar) as web_company_name, cast(web_street_number as varchar) as web_street_number, " +
-                            "   web_street_name, cast(web_street_type as varchar) as web_street_type, " +
-                            "   cast(web_suite_number as varchar) as web_suite_number, web_city, web_county, cast(web_state as varchar) as web_state, " +
-                            "   cast(web_zip as varchar) as web_zip, web_country, web_gmt_offset, web_tax_percentage " +
-                            "FROM tpcds.tiny.web_site");
+                            "SELECT * FROM tpcds.tiny.web_site");
                     break;
                 case "DWRF":
                     queryRunner.execute(session, "CREATE TABLE web_site AS " +
-                            "SELECT web_site_sk, cast(web_site_id as varchar) as web_site_id, cast(web_rec_start_date as varchar) as web_rec_start_date, " +
+                            "SELECT web_site_sk, web_site_id, cast(web_rec_start_date as varchar) as web_rec_start_date, " +
                             "   cast(web_rec_end_date as varchar) as web_rec_end_date, web_name, web_open_date_sk, web_close_date_sk, web_class, " +
-                            "   web_manager, web_mkt_id, web_mkt_class, web_mkt_desc, web_market_manager, web_company_id, cast(web_company_name as varchar) as web_company_name, " +
-                            "   cast(web_street_number as varchar) as web_street_number, web_street_name, cast(web_street_type as varchar) as web_street_type, " +
-                            "   cast(web_suite_number as varchar) as web_suite_number, web_city, web_county, cast(web_state as varchar) as web_state, " +
-                            "   cast(web_zip as varchar) as web_zip, web_country, cast(web_gmt_offset as double) as web_gmt_offset, " +
-                            "   cast(web_tax_percentage as double) as web_tax_percentage " +
+                            "   web_manager, web_mkt_id, web_mkt_class, web_mkt_desc, web_market_manager, web_company_id, web_company_name, " +
+                            "   web_street_number, web_street_name, web_street_type, web_suite_number, web_city, web_county, web_state, as web_zip, web_country, " +
+                            "   cast(web_gmt_offset as double) as web_gmt_offset, cast(web_tax_percentage as double) as web_tax_percentage " +
                             "FROM tpcds.tiny.web_site");
                     break;
             }
@@ -527,7 +442,7 @@ public abstract class AbstractTestNativeTpcdsQueries
     public void testTpcdsQ12()
             throws Exception
     {
-        assertQuery(session, getTpcdsQuery("12"));
+        assertQueryFails(session, getTpcdsQuery("12"), "[\\s\\S]*Division by zero[\\s\\S]*");
     }
 
     @Test

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -64,6 +64,13 @@ public class NativeQueryRunnerUtils
                 .build();
     }
 
+    public static Map<String, String> getNativeWorkerTpcdsProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("tpcds.use-varchar-type", "true")
+                .build();
+    }
+
     /**
      * Creates all tables for local testing, except for bench tables.
      *

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsMetadata.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsMetadata.java
@@ -64,13 +64,16 @@ public class TpcdsMetadata
     private final Set<String> tableNames;
     private final TpcdsTableStatisticsFactory tpcdsTableStatisticsFactory = new TpcdsTableStatisticsFactory();
 
-    public TpcdsMetadata()
+    private final boolean useVarcharType;
+
+    public TpcdsMetadata(boolean useVarcharType)
     {
         ImmutableSet.Builder<String> tableNames = ImmutableSet.builder();
         for (Table tpcdsTable : Table.getBaseTables()) {
             tableNames.add(tpcdsTable.getName().toLowerCase(ENGLISH));
         }
         this.tableNames = tableNames.build();
+        this.useVarcharType = useVarcharType;
     }
 
     @Override
@@ -134,14 +137,14 @@ public class TpcdsMetadata
         Table table = Table.getTable(tpcdsTableHandle.getTableName());
         String schemaName = scaleFactorSchemaName(tpcdsTableHandle.getScaleFactor());
 
-        return getTableMetadata(schemaName, table);
+        return getTableMetadata(schemaName, table, useVarcharType);
     }
 
-    private static ConnectorTableMetadata getTableMetadata(String schemaName, Table tpcdsTable)
+    private static ConnectorTableMetadata getTableMetadata(String schemaName, Table tpcdsTable, boolean useVarcharType)
     {
         ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
         for (Column column : tpcdsTable.getColumns()) {
-            columns.add(new ColumnMetadata(column.getName(), getPrestoType(column.getType())));
+            columns.add(new ColumnMetadata(column.getName(), getPrestoType(column.getType(), useVarcharType)));
         }
         SchemaTableName tableName = new SchemaTableName(schemaName, tpcdsTable.getName());
         return new ConnectorTableMetadata(tableName, columns.build());
@@ -189,7 +192,7 @@ public class TpcdsMetadata
         for (String schemaName : getSchemaNames(session, Optional.ofNullable(prefix.getSchemaName()))) {
             for (Table tpcdsTable : Table.getBaseTables()) {
                 if (prefix.getTableName() == null || tpcdsTable.getName().equals(prefix.getTableName())) {
-                    ConnectorTableMetadata tableMetadata = getTableMetadata(schemaName, tpcdsTable);
+                    ConnectorTableMetadata tableMetadata = getTableMetadata(schemaName, tpcdsTable, useVarcharType);
                     tableColumns.put(new SchemaTableName(schemaName, tpcdsTable.getName()), tableMetadata.getColumns());
                 }
             }
@@ -243,7 +246,7 @@ public class TpcdsMetadata
         }
     }
 
-    public static Type getPrestoType(ColumnType tpcdsType)
+    public static Type getPrestoType(ColumnType tpcdsType, boolean useVarcharType)
     {
         switch (tpcdsType.getBase()) {
             case IDENTIFIER:
@@ -255,6 +258,9 @@ public class TpcdsMetadata
             case DECIMAL:
                 return createDecimalType(tpcdsType.getPrecision().get(), tpcdsType.getScale().get());
             case CHAR:
+                if (useVarcharType) {
+                    return createVarcharType(tpcdsType.getPrecision().get());
+                }
                 return createCharType(tpcdsType.getPrecision().get());
             case VARCHAR:
                 return createVarcharType(tpcdsType.getPrecision().get());

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsRecordSet.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsRecordSet.java
@@ -49,7 +49,9 @@ public class TpcdsRecordSet
 
     private final List<Type> columnTypes;
 
-    public TpcdsRecordSet(Results results, List<Column> columns)
+    private final boolean useVarcharType;
+
+    public TpcdsRecordSet(Results results, List<Column> columns, boolean useVarcharType)
     {
         requireNonNull(results, "results is null");
 
@@ -57,9 +59,10 @@ public class TpcdsRecordSet
         this.columns = ImmutableList.copyOf(columns);
         ImmutableList.Builder<Type> columnTypes = ImmutableList.builder();
         for (Column column : columns) {
-            columnTypes.add(getPrestoType(column.getType()));
+            columnTypes.add(getPrestoType(column.getType(), useVarcharType));
         }
         this.columnTypes = columnTypes.build();
+        this.useVarcharType = useVarcharType;
     }
 
     @Override
@@ -103,7 +106,7 @@ public class TpcdsRecordSet
         @Override
         public Type getType(int field)
         {
-            return getPrestoType(columns.get(field).getType());
+            return getPrestoType(columns.get(field).getType(), useVarcharType);
         }
 
         @Override

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsRecordSetProvider.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsRecordSetProvider.java
@@ -33,6 +33,13 @@ import static com.teradata.tpcds.Table.getTable;
 public class TpcdsRecordSetProvider
         implements ConnectorRecordSetProvider
 {
+    private final boolean useVarcharType;
+
+    public TpcdsRecordSetProvider(boolean useVarcharType)
+    {
+        this.useVarcharType = useVarcharType;
+    }
+
     @Override
     public RecordSet getRecordSet(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorSplit split, List<? extends ColumnHandle> columns)
     {
@@ -63,6 +70,6 @@ public class TpcdsRecordSetProvider
                 .withTable(table)
                 .withNoSexism(noSexism);
         Results results = constructResults(table, session);
-        return new TpcdsRecordSet(results, builder.build());
+        return new TpcdsRecordSet(results, builder.build(), useVarcharType);
     }
 }

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/AbstractTestTpcds.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/AbstractTestTpcds.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpcds;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.IntStream.range;
+
+public abstract class AbstractTestTpcds
+        extends AbstractTestQueryFramework
+{
+    @Test
+    public void testSelect()
+    {
+        MaterializedResult actual = computeActual(
+                "SELECT c_first_name, c_last_name, ca_address_sk, ca_gmt_offset " +
+                        "FROM customer JOIN customer_address ON c_current_addr_sk = ca_address_sk " +
+                        "WHERE ca_address_sk = 4");
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                // note that c_first_name and c_last_name are both of type CHAR(X) so the results
+                // are padded with whitespace
+                .row("James               ", "Brown                         ", 4L, new BigDecimal("-7.00"))
+                .build();
+        assertEquals(expected, actual);
+
+        actual = computeActual(
+                "SELECT c_first_name, c_last_name " +
+                        "FROM customer JOIN customer_address ON c_current_addr_sk = ca_address_sk " +
+                        "WHERE ca_address_sk = 4 AND ca_gmt_offset = DECIMAL '-7.00'");
+        expected = resultBuilder(getSession(), actual.getTypes())
+                .row("James               ", "Brown                         ")
+                .build();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testLargeInWithShortDecimal()
+    {
+        // TODO add a test with long decimal
+        String longValues = range(0, 5000)
+                .mapToObj(Integer::toString)
+                .collect(joining(", "));
+
+        assertQuery("SELECT typeof(i_current_price) FROM item LIMIT 1", "VALUES 'decimal(7,2)'"); // decimal(7,2) is a short decimal
+        assertQuerySucceeds("SELECT i_current_price FROM item WHERE i_current_price IN (" + longValues + ")");
+        assertQuerySucceeds("SELECT i_current_price FROM item WHERE i_current_price NOT IN (" + longValues + ")");
+        assertQuerySucceeds("SELECT i_current_price FROM item WHERE i_current_price IN (i_wholesale_cost, " + longValues + ")");
+        assertQuerySucceeds("SELECT i_current_price FROM item WHERE i_current_price NOT IN (i_wholesale_cost, " + longValues + ")");
+    }
+}

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
@@ -45,7 +45,7 @@ public class TestTpcdsMetadataStatistics
 {
     private static final EstimateAssertion estimateAssertion = new EstimateAssertion(0.01);
     private static final ConnectorSession session = null;
-    private final TpcdsMetadata metadata = new TpcdsMetadata();
+    private final TpcdsMetadata metadata = new TpcdsMetadata(false);
 
     @Test
     public void testNoTableStatsForNotSupportedSchema()

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsRecordSet.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsRecordSet.java
@@ -64,7 +64,7 @@ public class TestTpcdsRecordSet
                 CC_NAME,            // Varchar
                 CC_STATE,           // CharType
                 CC_TAX_PERCENTAGE); // Decimal
-        RecordSet recordSet = new TpcdsRecordSet(constructResults(table, session), columns);
+        RecordSet recordSet = new TpcdsRecordSet(constructResults(table, session), columns, false);
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(
                 BIGINT,
                 INTEGER,
@@ -77,7 +77,7 @@ public class TestTpcdsRecordSet
                 DV_CREATE_DATE, // Date
                 DV_CREATE_TIME, // Time
                 DV_VERSION);    // Varchar
-        recordSet = new TpcdsRecordSet(constructResults(table, session), columns);
+        recordSet = new TpcdsRecordSet(constructResults(table, session), columns, false);
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(
                 DATE,
                 TIME,
@@ -85,7 +85,7 @@ public class TestTpcdsRecordSet
 
         table = getTable(DBGEN_VERSION.getName());
         columns = ImmutableList.of();
-        recordSet = new TpcdsRecordSet(constructResults(table, session), columns);
+        recordSet = new TpcdsRecordSet(constructResults(table, session), columns, false);
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of());
     }
 
@@ -94,7 +94,7 @@ public class TestTpcdsRecordSet
     {
         Table table = getTable(CALL_CENTER.getName());
         Results result = constructResults(table, session);
-        RecordSet recordSet = new TpcdsRecordSet(result, ImmutableList.copyOf(table.getColumns()));
+        RecordSet recordSet = new TpcdsRecordSet(result, ImmutableList.copyOf(table.getColumns()), false);
 
         try (RecordCursor cursor = recordSet.cursor()) {
             if (cursor.advanceNextPosition()) {

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsWithCharColumnsAsChar.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsWithCharColumnsAsChar.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpcds;
+
+import com.facebook.presto.testing.QueryRunner;
+
+public class TestTpcdsWithCharColumnsAsChar
+        extends AbstractTestTpcds
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return TpcdsQueryRunner.createQueryRunner();
+    }
+}

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TpcdsQueryRunner.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TpcdsQueryRunner.java
@@ -39,7 +39,13 @@ public final class TpcdsQueryRunner
         return createQueryRunner(extraProperties, ImmutableMap.of());
     }
 
-    public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties, Map<String, String> coordinatorProperties)
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties, Map<String, String> tpcdsProperties)
+            throws Exception
+    {
+        return createQueryRunner(extraProperties, tpcdsProperties, ImmutableMap.of());
+    }
+
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties, Map<String, String> tpcdsProperties, Map<String, String> coordinatorProperties)
             throws Exception
     {
         Session session = testSessionBuilder()
@@ -56,7 +62,7 @@ public final class TpcdsQueryRunner
 
         try {
             queryRunner.installPlugin(new TpcdsPlugin());
-            queryRunner.createCatalog("tpcds", "tpcds");
+            queryRunner.createCatalog("tpcds", "tpcds", tpcdsProperties);
             return queryRunner;
         }
         catch (Exception e) {

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/statistics/TableStatisticsRecorder.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/statistics/TableStatisticsRecorder.java
@@ -41,7 +41,7 @@ class TableStatisticsRecorder
                 .withNoSexism(false);
 
         List<Column> columns = ImmutableList.copyOf(table.getColumns());
-        RecordCursor recordCursor = new TpcdsRecordSet(Results.constructResults(table, session), columns)
+        RecordCursor recordCursor = new TpcdsRecordSet(Results.constructResults(table, session), columns, false)
                 .cursor();
 
         List<ColumnStatisticsRecorder> statisticsRecorders = createStatisticsRecorders(columns);


### PR DESCRIPTION
## Description
Add a config flag `tpcds.use-varchar-type` in Presto - Java TPC-DS Connector
## Motivation and Context
Resolves: #24362
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

TPC-DS Connector Changes
* Add config property ``tpcds.use-varchar-type`` to allow toggling of char columns to varchar columns.

```

