### PR TITLE
[native] Add disk usage output to CI

### DIFF
--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -46,6 +46,9 @@ jobs:
           find . -name tests | xargs rm -r
           find . -name test | xargs rm -rf
 
+      - name: Disk space consumption before build
+        run: df
+
       - name: Build engine
         run: |
           source /opt/rh/gcc-toolset-12/enable
@@ -71,6 +74,9 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DMAX_LINK_JOBS=4
           ninja -C _build/debug -j 4
+
+      - name: Disk space consumption after build
+        run: df
 
       - name: Ccache after
         run: ccache -s


### PR DESCRIPTION
The Linux debug build consumes a lot of disk space and occasionally the worker can run out of disk space. This adds some more information on the disk space consumption and availability to keep an eye on it.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

