### PR TITLE
Use a wrapper for event loop to handle exceptions gracefully

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -510,6 +510,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.Codec;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.smile.SmileCodec;
+import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.DecayCounter;
 import com.facebook.airlift.stats.ExponentialDecay;
 import com.facebook.drift.codec.ThriftCodec;
@@ -49,12 +50,16 @@ import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airlift.units.Duration;
+import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import org.weakref.jmx.Managed;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
+
+import java.util.concurrent.Executor;
 
 import static com.facebook.presto.server.thrift.ThriftCodecWrapper.wrapThriftCodec;
 import static java.lang.Math.toIntExact;
@@ -63,6 +68,7 @@ import static java.util.Objects.requireNonNull;
 public class HttpRemoteTaskFactory
         implements RemoteTaskFactory
 {
+    private static final Logger log = Logger.get(HttpRemoteTaskFactory.class);
     private final HttpClient httpClient;
     private final LocationFactory locationFactory;
     private final Codec<TaskStatus> taskStatusCodec;
@@ -89,7 +95,14 @@ public class HttpRemoteTaskFactory
     private final QueryManager queryManager;
     private final DecayCounter taskUpdateRequestSize;
     private final EventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(Runtime.getRuntime().availableProcessors(),
-            new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build());
+            new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build())
+    {
+        @Override
+        protected EventLoop newChild(Executor executor, Object... args)
+        {
+            return new SafeEventLoop(this, executor);
+        }
+    };
 
     @Inject
     public HttpRemoteTaskFactory(
@@ -194,7 +207,7 @@ public class HttpRemoteTaskFactory
             TableWriteInfo tableWriteInfo,
             SchedulerStatsTracker schedulerStatsTracker)
     {
-        return new HttpRemoteTask(
+        return HttpRemoteTask.createHttpRemoteTask(
                 session,
                 taskId,
                 node.getNodeIdentifier(),
@@ -229,6 +242,37 @@ public class HttpRemoteTaskFactory
                 handleResolver,
                 connectorTypeSerdeManager,
                 schedulerStatsTracker,
-                eventLoopGroup.next());
+                (SafeEventLoop) eventLoopGroup.next());
+    }
+
+    /***
+     *  One observation about event loop is if submitted task fails, it could kill the thread but the event loop group will not create a new one.
+     *  Here, we wrap it as safe event loop so that if any submitted job fails, we chose to log the error and fail the entire task.
+     */
+    static class SafeEventLoop
+            extends DefaultEventLoop
+    {
+        public SafeEventLoop(EventLoopGroup parent, Executor executor)
+        {
+            super(parent, executor);
+        }
+
+        @Override
+        protected void run()
+        {
+            do {
+                Runnable task = takeTask();
+                if (task != null) {
+                    try {
+                        runTask(task);
+                    }
+                    catch (Throwable t) {
+                        log.error("Error executing task on event loop", t);
+                    }
+                    updateLastExecutionTime();
+                }
+            }
+            while (!this.confirmShutdown());
+        }
     }
 }


### PR DESCRIPTION
## Description
1. we saw the following error
<img width="1081" alt="Screenshot 2025-01-21 at 16 26 07" src="https://github.com/user-attachments/assets/40faf334-3176-425d-8a5d-8a76c867e0bc" /> and thanks to @arhimondr, the root cause is if running code on event loop and the code throws exception, the event loop thread will be killed but the event loop group will not create a new thread.


## Motivation and Context
1. Use a event loop wrapper to handle exceptions while running httpRemoteTask related jobs on event loop gracefully
2. Also update the code so that we only add listener after the object has been fully constructed.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. Local HiveQueryRunner works great
2. Internal verifier test passed

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Fixs
* Fix how the exceptions thrown from event loop is being handled while performing HttpRemoteTask :pr:`24412`

```

