### PR TITLE
Optimize how we merge multiple operatorStats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -42,6 +43,7 @@ import static com.facebook.presto.common.RuntimeMetricName.TASK_SCHEDULED_TIME_N
 import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static com.facebook.presto.execution.StageExecutionState.FINISHED;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.airlift.units.Duration.succinctDuration;
 import static java.lang.Math.max;
@@ -71,186 +73,84 @@ public class StageExecutionInfo
             int finishedLifespans,
             int totalLifespans)
     {
-        int totalTasks = taskInfos.size();
-        int runningTasks = 0;
-        int completedTasks = 0;
-
-        int totalDrivers = 0;
-        int queuedDrivers = 0;
-        int runningDrivers = 0;
-        int blockedDrivers = 0;
-        int completedDrivers = 0;
-
-        double cumulativeUserMemory = 0;
-        double cumulativeTotalMemory = 0;
-        long userMemoryReservation = 0;
-        long totalMemoryReservation = 0;
-
-        long totalScheduledTime = 0;
-        long totalCpuTime = 0;
-        long retriedCpuTime = 0;
-        long totalBlockedTime = 0;
-
-        long totalAllocation = 0;
-
-        long rawInputDataSize = 0;
-        long rawInputPositions = 0;
-
-        long processedInputDataSize = 0;
-        long processedInputPositions = 0;
-
-        long bufferedDataSize = 0;
-        long outputDataSize = 0;
-        long outputPositions = 0;
-
-        long physicalWrittenDataSize = 0;
-
-        int fullGcCount = 0;
-        int fullGcTaskCount = 0;
-        int minFullGcSec = 0;
-        int maxFullGcSec = 0;
-        int totalFullGcSec = 0;
-
-        boolean fullyBlocked = true;
-        Set<BlockedReason> blockedReasons = new HashSet<>();
-
-        Map<String, OperatorStats> operatorToStats = new HashMap<>();
-        RuntimeStats mergedRuntimeStats = new RuntimeStats();
-        mergedRuntimeStats.mergeWith(stageRuntimeStats);
-
-        List<TaskStats> allTaskStats = new ArrayList<>();
+        TaskStatsAggregator taskStatsAggregator = new TaskStatsAggregator(taskInfos.size(), stageRuntimeStats);
 
         for (TaskInfo taskInfo : taskInfos) {
             TaskState taskState = taskInfo.getTaskStatus().getState();
             if (taskState.isDone()) {
-                completedTasks++;
+                taskStatsAggregator.increaseCompleteTaskCount(1);
             }
             else {
-                runningTasks++;
+                taskStatsAggregator.increaseRunningTaskCount(1);
             }
 
             TaskStats taskStats = taskInfo.getStats();
-            allTaskStats.add(taskStats);
 
             if (state == FINISHED && taskInfo.getTaskStatus().getState() == TaskState.FAILED) {
-                retriedCpuTime += taskStats.getTotalCpuTimeInNanos();
+                taskStatsAggregator.increaseRetriedCpuTime(taskStats.getTotalCpuTimeInNanos());
             }
 
             if (!taskState.isDone()) {
-                fullyBlocked &= taskStats.isFullyBlocked();
-                blockedReasons.addAll(taskStats.getBlockedReasons());
+                taskStatsAggregator.updateFullyBlocked(taskStats.isFullyBlocked());
+                taskStatsAggregator.addNewBlockedReasons(taskStats.getBlockedReasons());
             }
 
-            bufferedDataSize += taskInfo.getOutputBuffers().getTotalBufferedBytes();
-        }
-
-        for (TaskStats taskStats : allTaskStats) {
-            totalDrivers += taskStats.getTotalDrivers();
-            queuedDrivers += taskStats.getQueuedDrivers();
-            runningDrivers += taskStats.getRunningDrivers();
-            blockedDrivers += taskStats.getBlockedDrivers();
-            completedDrivers += taskStats.getCompletedDrivers();
-
-            cumulativeUserMemory += taskStats.getCumulativeUserMemory();
-            cumulativeTotalMemory += taskStats.getCumulativeTotalMemory();
-
-            long taskUserMemory = taskStats.getUserMemoryReservationInBytes();
-            long taskSystemMemory = taskStats.getSystemMemoryReservationInBytes();
-            userMemoryReservation += taskUserMemory;
-            totalMemoryReservation += taskUserMemory + taskSystemMemory;
-
-            totalScheduledTime += taskStats.getTotalScheduledTimeInNanos();
-            totalCpuTime += taskStats.getTotalCpuTimeInNanos();
-            totalBlockedTime += taskStats.getTotalBlockedTimeInNanos();
-
-            totalAllocation += taskStats.getTotalAllocationInBytes();
-
-            rawInputDataSize += taskStats.getRawInputDataSizeInBytes();
-            rawInputPositions += taskStats.getRawInputPositions();
-
-            processedInputDataSize += taskStats.getProcessedInputDataSizeInBytes();
-            processedInputPositions += taskStats.getProcessedInputPositions();
-
-            outputDataSize += taskStats.getOutputDataSizeInBytes();
-            outputPositions += taskStats.getOutputPositions();
-
-            physicalWrittenDataSize += taskStats.getPhysicalWrittenDataSizeInBytes();
-
-            fullGcCount += taskStats.getFullGcCount();
-            fullGcTaskCount += taskStats.getFullGcCount() > 0 ? 1 : 0;
-
-            int gcSec = toIntExact(MILLISECONDS.toSeconds(taskStats.getFullGcTimeInMillis()));
-            totalFullGcSec += gcSec;
-            minFullGcSec = min(minFullGcSec, gcSec);
-            maxFullGcSec = max(maxFullGcSec, gcSec);
-
-            for (PipelineStats pipeline : taskStats.getPipelines()) {
-                for (OperatorStats operatorStats : pipeline.getOperatorSummaries()) {
-                    String id = pipeline.getPipelineId() + "." + operatorStats.getOperatorId();
-                    operatorToStats.compute(id, (k, v) -> v == null ? operatorStats : v.add(operatorStats));
-                }
-            }
-            mergedRuntimeStats.mergeWith(taskStats.getRuntimeStats());
-            mergedRuntimeStats.addMetricValue(DRIVER_COUNT_PER_TASK, NONE, taskStats.getTotalDrivers());
-            mergedRuntimeStats.addMetricValue(TASK_ELAPSED_TIME_NANOS, NANO, taskStats.getElapsedTimeInNanos());
-            mergedRuntimeStats.addMetricValueIgnoreZero(TASK_QUEUED_TIME_NANOS, NANO, taskStats.getQueuedTimeInNanos());
-            mergedRuntimeStats.addMetricValue(TASK_SCHEDULED_TIME_NANOS, NANO, taskStats.getTotalScheduledTimeInNanos());
-            mergedRuntimeStats.addMetricValueIgnoreZero(TASK_BLOCKED_TIME_NANOS, NANO, taskStats.getTotalBlockedTimeInNanos());
+            taskStatsAggregator.increaseBufferedDataSize(taskInfo.getOutputBuffers().getTotalBufferedBytes());
+            taskStatsAggregator.processTaskStats(taskStats);
         }
 
         StageExecutionStats stageExecutionStats = new StageExecutionStats(
                 schedulingComplete,
                 getSplitDistribution,
 
-                totalTasks,
-                runningTasks,
-                completedTasks,
+                taskStatsAggregator.totalTaskCount,
+                taskStatsAggregator.runningTaskCount,
+                taskStatsAggregator.completedTaskCount,
 
                 totalLifespans,
                 finishedLifespans,
 
-                totalDrivers,
-                queuedDrivers,
-                runningDrivers,
-                blockedDrivers,
-                completedDrivers,
+                taskStatsAggregator.totalDrivers,
+                taskStatsAggregator.queuedDrivers,
+                taskStatsAggregator.runningDrivers,
+                taskStatsAggregator.blockedDrivers,
+                taskStatsAggregator.completedDrivers,
 
-                cumulativeUserMemory,
-                cumulativeTotalMemory,
-                succinctBytes(userMemoryReservation),
-                succinctBytes(totalMemoryReservation),
+                taskStatsAggregator.cumulativeUserMemory,
+                taskStatsAggregator.cumulativeTotalMemory,
+                succinctBytes(taskStatsAggregator.userMemoryReservation),
+                succinctBytes(taskStatsAggregator.totalMemoryReservation),
                 peakUserMemoryReservation,
                 peakNodeTotalMemoryReservation,
-                succinctDuration(totalScheduledTime, NANOSECONDS),
-                succinctDuration(totalCpuTime, NANOSECONDS),
-                succinctDuration(retriedCpuTime, NANOSECONDS),
-                succinctDuration(totalBlockedTime, NANOSECONDS),
-                fullyBlocked && runningTasks > 0,
-                blockedReasons,
+                succinctDuration(taskStatsAggregator.totalScheduledTime, NANOSECONDS),
+                succinctDuration(taskStatsAggregator.totalCpuTime, NANOSECONDS),
+                succinctDuration(taskStatsAggregator.retriedCpuTime, NANOSECONDS),
+                succinctDuration(taskStatsAggregator.totalBlockedTime, NANOSECONDS),
+                taskStatsAggregator.fullyBlocked && taskStatsAggregator.runningTaskCount > 0,
+                taskStatsAggregator.blockedReasons,
 
-                succinctBytes(totalAllocation),
+                succinctBytes(taskStatsAggregator.totalAllocation),
 
-                succinctBytes(rawInputDataSize),
-                rawInputPositions,
-                succinctBytes(processedInputDataSize),
-                processedInputPositions,
-                succinctBytes(bufferedDataSize),
-                succinctBytes(outputDataSize),
-                outputPositions,
-                succinctBytes(physicalWrittenDataSize),
+                succinctBytes(taskStatsAggregator.rawInputDataSize),
+                taskStatsAggregator.rawInputPositions,
+                succinctBytes(taskStatsAggregator.processedInputDataSize),
+                taskStatsAggregator.processedInputPositions,
+                succinctBytes(taskStatsAggregator.bufferedDataSize),
+                succinctBytes(taskStatsAggregator.outputDataSize),
+                taskStatsAggregator.outputPositions,
+                succinctBytes(taskStatsAggregator.physicalWrittenDataSize),
 
                 new StageGcStatistics(
                         stageExecutionId.getStageId().getId(),
                         stageExecutionId.getId(),
-                        totalTasks,
-                        fullGcTaskCount,
-                        minFullGcSec,
-                        maxFullGcSec,
-                        totalFullGcSec,
-                        (int) (1.0 * totalFullGcSec / fullGcCount)),
-
-                ImmutableList.copyOf(operatorToStats.values()),
-                mergedRuntimeStats);
+                        taskStatsAggregator.totalTaskCount,
+                        taskStatsAggregator.fullGcTaskCount,
+                        taskStatsAggregator.minFullGcSec,
+                        taskStatsAggregator.maxFullGcSec,
+                        taskStatsAggregator.totalFullGcSec,
+                        (int) (1.0 * taskStatsAggregator.totalFullGcSec / taskStatsAggregator.fullGcCount)),
+                taskStatsAggregator.getOperatorSummaries(),
+                taskStatsAggregator.getMergedRuntimeStats());
 
         return new StageExecutionInfo(
                 state,
@@ -301,12 +201,198 @@ public class StageExecutionInfo
         return state.isDone() && tasks.stream().allMatch(taskInfo -> taskInfo.getTaskStatus().getState().isDone());
     }
 
-    public static StageExecutionInfo unscheduledExecutionInfo(int stageId, boolean isQueryDone)
+    private static class OperatorKey
     {
-        return new StageExecutionInfo(
-                isQueryDone ? StageExecutionState.ABORTED : StageExecutionState.PLANNED,
-                StageExecutionStats.zero(stageId),
-                ImmutableList.of(),
-                Optional.empty());
+        private final int pipelineId;
+        private final int operatorId;
+
+        public OperatorKey(int pipelineId, int operatorId)
+        {
+            this.pipelineId = pipelineId;
+            this.operatorId = operatorId;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            OperatorKey that = (OperatorKey) o;
+            return pipelineId == that.pipelineId && operatorId == that.operatorId;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(pipelineId, operatorId);
+        }
+    }
+
+    private static class TaskStatsAggregator
+    {
+        private final int totalTaskCount;
+        private int runningTaskCount;
+        private int completedTaskCount;
+        private long retriedCpuTime;
+        private long bufferedDataSize;
+
+        private boolean fullyBlocked = true;
+        private final Set<BlockedReason> blockedReasons = new HashSet<>();
+
+        private int totalDrivers;
+        private int queuedDrivers;
+        private int runningDrivers;
+        private int blockedDrivers;
+        private int completedDrivers;
+
+        private double cumulativeUserMemory;
+        private double cumulativeTotalMemory;
+        private long userMemoryReservation;
+        private long totalMemoryReservation;
+
+        private long totalScheduledTime;
+        private long totalCpuTime;
+        private long totalBlockedTime;
+
+        private long totalAllocation;
+
+        private long rawInputDataSize;
+        private long rawInputPositions;
+
+        private long processedInputDataSize;
+        private long processedInputPositions;
+
+        private long outputDataSize;
+        private long outputPositions;
+
+        private long physicalWrittenDataSize;
+
+        private int fullGcCount;
+        private int fullGcTaskCount;
+        private int minFullGcSec;
+        private int maxFullGcSec;
+        private int totalFullGcSec;
+
+        private final RuntimeStats mergedRuntimeStats = new RuntimeStats();
+        private final Map<OperatorKey, List<OperatorStats>> operatorStatsByKey = new HashMap<>();
+
+        public TaskStatsAggregator(int totalTaskCount, RuntimeStats stageRuntimeStats)
+        {
+            this.totalTaskCount = totalTaskCount;
+            this.mergedRuntimeStats.mergeWith(stageRuntimeStats);
+        }
+
+        public void processTaskStats(TaskStats taskStats)
+        {
+            totalDrivers += taskStats.getTotalDrivers();
+            queuedDrivers += taskStats.getQueuedDrivers();
+            runningDrivers += taskStats.getRunningDrivers();
+            blockedDrivers += taskStats.getBlockedDrivers();
+            completedDrivers += taskStats.getCompletedDrivers();
+
+            cumulativeUserMemory += taskStats.getCumulativeUserMemory();
+            cumulativeTotalMemory += taskStats.getCumulativeTotalMemory();
+
+            long taskUserMemory = taskStats.getUserMemoryReservationInBytes();
+            long taskSystemMemory = taskStats.getSystemMemoryReservationInBytes();
+            userMemoryReservation += taskUserMemory;
+            totalMemoryReservation += taskUserMemory + taskSystemMemory;
+
+            totalScheduledTime += taskStats.getTotalScheduledTimeInNanos();
+            totalCpuTime += taskStats.getTotalCpuTimeInNanos();
+            totalBlockedTime += taskStats.getTotalBlockedTimeInNanos();
+
+            totalAllocation += taskStats.getTotalAllocationInBytes();
+
+            rawInputDataSize += taskStats.getRawInputDataSizeInBytes();
+            rawInputPositions += taskStats.getRawInputPositions();
+
+            processedInputDataSize += taskStats.getProcessedInputDataSizeInBytes();
+            processedInputPositions += taskStats.getProcessedInputPositions();
+
+            outputDataSize += taskStats.getOutputDataSizeInBytes();
+            outputPositions += taskStats.getOutputPositions();
+
+            physicalWrittenDataSize += taskStats.getPhysicalWrittenDataSizeInBytes();
+
+            fullGcCount += taskStats.getFullGcCount();
+            fullGcTaskCount += taskStats.getFullGcCount() > 0 ? 1 : 0;
+
+            int gcSec = toIntExact(MILLISECONDS.toSeconds(taskStats.getFullGcTimeInMillis()));
+            totalFullGcSec += gcSec;
+            minFullGcSec = min(minFullGcSec, gcSec);
+            maxFullGcSec = max(maxFullGcSec, gcSec);
+
+            updateOperatorStats(taskStats);
+            updateRuntimeStats(taskStats);
+        }
+
+        private void updateOperatorStats(TaskStats taskStats)
+        {
+            // Collect all operator stats by their key
+            for (PipelineStats pipeline : taskStats.getPipelines()) {
+                for (OperatorStats operatorStats : pipeline.getOperatorSummaries()) {
+                    operatorStatsByKey.computeIfAbsent(new OperatorKey(pipeline.getPipelineId(), operatorStats.getOperatorId()), k -> new ArrayList<>()).add(operatorStats);
+                }
+            }
+        }
+
+        private void updateRuntimeStats(TaskStats taskStats)
+        {
+            mergedRuntimeStats.mergeWith(taskStats.getRuntimeStats());
+            mergedRuntimeStats.addMetricValue(DRIVER_COUNT_PER_TASK, NONE, taskStats.getTotalDrivers());
+            mergedRuntimeStats.addMetricValue(TASK_ELAPSED_TIME_NANOS, NANO, taskStats.getElapsedTimeInNanos());
+            mergedRuntimeStats.addMetricValueIgnoreZero(TASK_QUEUED_TIME_NANOS, NANO, taskStats.getQueuedTimeInNanos());
+            mergedRuntimeStats.addMetricValue(TASK_SCHEDULED_TIME_NANOS, NANO, taskStats.getTotalScheduledTimeInNanos());
+            mergedRuntimeStats.addMetricValueIgnoreZero(TASK_BLOCKED_TIME_NANOS, NANO, taskStats.getTotalBlockedTimeInNanos());
+        }
+
+        public RuntimeStats getMergedRuntimeStats()
+        {
+            return mergedRuntimeStats;
+        }
+
+        public List<OperatorStats> getOperatorSummaries()
+        {
+            return operatorStatsByKey.values().stream()
+                    .map(OperatorStats::merge)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(toImmutableList());
+        }
+
+        public void increaseRunningTaskCount(int count)
+        {
+            runningTaskCount += count;
+        }
+
+        public void increaseCompleteTaskCount(int count)
+        {
+            completedTaskCount += count;
+        }
+
+        public void increaseRetriedCpuTime(long time)
+        {
+            retriedCpuTime += time;
+        }
+
+        public void updateFullyBlocked(boolean blocked)
+        {
+            fullyBlocked &= blocked;
+        }
+
+        public void addNewBlockedReasons(Set<BlockedReason> reasons)
+        {
+            blockedReasons.addAll(reasons);
+        }
+
+        public void increaseBufferedDataSize(long bytes)
+        {
+            bufferedDataSize += bytes;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -23,19 +23,19 @@ import com.facebook.presto.memory.QueryContextVisitor;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.memory.context.MemoryTrackingContext;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ListMultimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -46,9 +46,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 @ThreadSafe
 public class PipelineContext
@@ -93,7 +95,7 @@ public class PipelineContext
 
     private final AtomicLong physicalWrittenDataSize = new AtomicLong();
 
-    private final ConcurrentMap<Integer, OperatorStats> operatorSummaries = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Integer, OperatorStats> operatorStatsById = new ConcurrentHashMap<>();
 
     private final MemoryTrackingContext pipelineMemoryContext;
 
@@ -199,10 +201,10 @@ public class PipelineContext
 
         totalAllocation.getAndAdd(driverStats.getTotalAllocation().toBytes());
 
-        // merge the operator stats into the operator summary
         List<OperatorStats> operators = driverStats.getOperatorStats();
         for (OperatorStats operator : operators) {
-            operatorSummaries.compute(operator.getOperatorId(), (operatorId, summaryStats) -> summaryStats == null ? operator : summaryStats.add(operator));
+            operatorStatsById.compute(operator.getOperatorId(),
+                    (operatorId, summaryStats) -> summaryStats == null ? operator : OperatorStats.merge(ImmutableList.of(operator, summaryStats)).orElse(null));
         }
 
         rawInputDataSize.update(driverStats.getRawInputDataSize().toBytes());
@@ -378,9 +380,11 @@ public class PipelineContext
         boolean hasUnfinishedDrivers = false;
         boolean unfinishedDriversFullyBlocked = true;
 
-        TreeMap<Integer, OperatorStats> operatorSummaries = new TreeMap<>(this.operatorSummaries);
-        ListMultimap<Integer, OperatorStats> runningOperators = ArrayListMultimap.create();
         ImmutableList.Builder<DriverStats> drivers = ImmutableList.builderWithExpectedSize(driverContexts.size());
+        // Make deep copy of each list
+        Map<Integer, List<OperatorStats>> operatorStatsById = this.operatorStatsById.entrySet().stream()
+                .collect(toMap(Map.Entry::getKey, e -> new ArrayList<>(Arrays.asList(e.getValue()))));
+
         for (DriverContext driverContext : driverContexts) {
             DriverStats driverStats = driverContext.getDriverStats();
             drivers.add(driverStats);
@@ -402,7 +406,7 @@ public class PipelineContext
             totalAllocation += driverStats.getTotalAllocation().toBytes();
 
             for (OperatorStats operatorStats : driverStats.getOperatorStats()) {
-                runningOperators.put(operatorStats.getOperatorId(), operatorStats);
+                operatorStatsById.computeIfAbsent(operatorStats.getOperatorId(), k -> new ArrayList<>()).add(operatorStats);
             }
 
             rawInputDataSize += driverStats.getRawInputDataSize().toBytes();
@@ -415,26 +419,6 @@ public class PipelineContext
             outputPositions += driverStats.getOutputPositions();
 
             physicalWrittenDataSize += driverStats.getPhysicalWrittenDataSize().toBytes();
-        }
-
-        // merge the running operator stats into the operator summary
-        for (Integer operatorId : runningOperators.keySet()) {
-            List<OperatorStats> runningStats = runningOperators.get(operatorId);
-            if (runningStats.isEmpty()) {
-                continue;
-            }
-            OperatorStats current = operatorSummaries.get(operatorId);
-            OperatorStats combined;
-            if (current != null) {
-                combined = current.add(runningStats);
-            }
-            else {
-                combined = runningStats.get(0);
-                if (runningStats.size() > 1) {
-                    combined = combined.add(runningStats.subList(1, runningStats.size()));
-                }
-            }
-            operatorSummaries.put(operatorId, combined);
         }
 
         PipelineStatus pipelineStatus = pipelineStatusBuilder.build();
@@ -486,7 +470,11 @@ public class PipelineContext
 
                 physicalWrittenDataSize,
 
-                ImmutableList.copyOf(operatorSummaries.values()),
+                operatorStatsById.values().stream()
+                        .map(OperatorStats::merge)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .collect(toImmutableList()),
                 drivers.build());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -32,6 +32,7 @@ import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 
 public class TestOperatorStats
@@ -41,10 +42,10 @@ public class TestOperatorStats
     private static final String TEST_METRIC_NAME = "test_metric";
     private static final RuntimeMetric TEST_RUNTIME_METRIC_1 = new RuntimeMetric(TEST_METRIC_NAME, NONE, 10, 2, 9, 1);
     private static final RuntimeMetric TEST_RUNTIME_METRIC_2 = new RuntimeMetric(TEST_METRIC_NAME, NONE, 5, 2, 3, 2);
-    private static final DynamicFilterStats TEST_DYNAMIC_FILTER_STATS_1 = new DynamicFilterStats(new HashSet<>(Arrays.asList(new PlanNodeId[] {new PlanNodeId("1"),
-            new PlanNodeId("2")})));
-    private static final DynamicFilterStats TEST_DYNAMIC_FILTER_STATS_2 = new DynamicFilterStats(new HashSet<>(Arrays.asList(new PlanNodeId[] {new PlanNodeId("2"),
-            new PlanNodeId("3")})));
+    private static final DynamicFilterStats TEST_DYNAMIC_FILTER_STATS_1 = new DynamicFilterStats(new HashSet<>(Arrays.asList(new PlanNodeId("1"),
+            new PlanNodeId("2"))));
+    private static final DynamicFilterStats TEST_DYNAMIC_FILTER_STATS_2 = new DynamicFilterStats(new HashSet<>(Arrays.asList(new PlanNodeId("2"),
+            new PlanNodeId("3"))));
 
     public static final OperatorStats EXPECTED = new OperatorStats(
             0,
@@ -229,16 +230,16 @@ public class TestOperatorStats
     }
 
     @Test
-    public void testAdd()
+    public void testMergeWithNonMergeableInfo()
     {
-        OperatorStats actual = EXPECTED.add(ImmutableList.of(EXPECTED, EXPECTED));
+        OperatorStats actual = OperatorStats.merge(ImmutableList.of(EXPECTED, EXPECTED, EXPECTED)).get();
 
         assertEquals(actual.getStageId(), 0);
         assertEquals(actual.getStageExecutionId(), 10);
         assertEquals(actual.getOperatorId(), 41);
         assertEquals(actual.getOperatorType(), "test");
 
-        assertEquals(actual.getTotalDrivers(), 3 * 1);
+        assertEquals(actual.getTotalDrivers(), 3);
         assertEquals(actual.getAddInputCalls(), 3 * 2);
         assertEquals(actual.getAddInputWall(), new Duration(3 * 3, NANOSECONDS));
         assertEquals(actual.getAddInputCpu(), new Duration(3 * 4, NANOSECONDS));
@@ -279,16 +280,16 @@ public class TestOperatorStats
     }
 
     @Test
-    public void testAddMergeable()
+    public void testMergeWithMergeableInfo()
     {
-        OperatorStats actual = MERGEABLE.add(ImmutableList.of(MERGEABLE, MERGEABLE));
+        OperatorStats actual = OperatorStats.merge(ImmutableList.of(MERGEABLE, MERGEABLE, MERGEABLE)).get();
 
         assertEquals(actual.getStageId(), 0);
         assertEquals(actual.getStageExecutionId(), 10);
         assertEquals(actual.getOperatorId(), 41);
         assertEquals(actual.getOperatorType(), "test");
 
-        assertEquals(actual.getTotalDrivers(), 3 * 1);
+        assertEquals(actual.getTotalDrivers(), 3);
         assertEquals(actual.getAddInputCalls(), 3 * 2);
         assertEquals(actual.getAddInputWall(), new Duration(3 * 3, NANOSECONDS));
         assertEquals(actual.getAddInputCpu(), new Duration(3 * 4, NANOSECONDS));
@@ -328,5 +329,12 @@ public class TestOperatorStats
         expectedMetric.mergeWith(TEST_RUNTIME_METRIC_2);
         assertRuntimeMetricEquals(actual.getRuntimeStats().getMetric(TEST_METRIC_NAME), expectedMetric);
         assertEquals(actual.getDynamicFilterStats().getProducerNodeIds(), TEST_DYNAMIC_FILTER_STATS_2.getProducerNodeIds());
+    }
+
+    @Test
+    public void testMergeEmptyCollection()
+    {
+        Optional<OperatorStats> merged = OperatorStats.merge(ImmutableList.of());
+        assertFalse(merged.isPresent());
     }
 }


### PR DESCRIPTION
## Description
1. Thanks to @arhimondr who observed that GC could take too much cpu to clean up memory during heavy load
<img width="1401" alt="Screenshot 2025-01-21 at 21 55 30" src="https://github.com/user-attachments/assets/878540d7-d5f3-435c-80d1-b8172b137e84" />

2. This pr will be the first of a series of optimization to improve how objects are being created along the critical path.
3. This pr optimizes how we merge multiple operatorStats without creating temporary/intermediate objects

## Motivation and Context
1. The original code will create temporary objects every time we add two OperatorStats together (with same id) using v.add(operatorStats) and this intermediate object will be discarded when it is used to merge with next OperatorStats object, This PR groups all operatorStats by their id and then merge them together in one go.
2. Refactoring the code by moving local variables into a dedicated class so that we can easily use one loop within the _create_ method to aggregate all necessary metrics.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. local hiveQueryRunner works fine
2. Internal verifier tests passed

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Optimizations
* Improve how we merge multiple operator stats together. :pr:`24414`
* Improve metrics creation by refactoring local variables to a dedicated class. :pr:`24414`


```


