### PR TITLE
Fix flaky Iceberg parquet metadata cache test

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergParquetMetadataCaching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergParquetMetadataCaching.java
@@ -45,7 +45,7 @@ public class TestIcebergParquetMetadataCaching
                 PARQUET,
                 false,
                 true,
-                OptionalInt.of(2),
+                OptionalInt.of(1),
                 Optional.empty());
     }
 


### PR DESCRIPTION
## Description
Fixes flaky test described in https://github.com/prestodb/presto/issues/22422

## Motivation and Context
It seems jmx metrics may get mixed up if we are using the query runner and multiple workers. The jmx metrics are bound to coordinator cache object only and owing to the very tiny data read in the test query, if the coordinator doesn't process any split, it will just report zero metrics. So, making the number of nodes to only 1, so this problem is eliminated.

## Impact
No impact

## Test Plan

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

