### PR TITLE
Fix push error by updating token for presto stable release workflow

### DIFF
--- a/.github/workflows/presto-stable-release.yml
+++ b/.github/workflows/presto-stable-release.yml
@@ -30,7 +30,7 @@ jobs:
           git config --global --add safe.directory ${{github.workspace}}
           git config --global user.email "oss-release-bot@prestodb.io"
           git config --global user.name "oss-release-bot"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ secrets.PRESTODB_CI_TOKEN }}@github.com/${{ github.repository }}
           git config pull.rebase false
 
       - name: Set Maven version
@@ -42,6 +42,7 @@ jobs:
         run: |
           PRESTO_RELEASE_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
             -Dexpression=project.version -q -ntp -DforceStdout | tail -n 1)
+          echo "PRESTO_RELEASE_VERSION=$PRESTO_RELEASE_VERSION"
           echo "PRESTO_RELEASE_VERSION=$PRESTO_RELEASE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Update version in master


### PR DESCRIPTION
## Description
In the action log => https://github.com/prestodb/presto/actions/runs/12926891450, there is an error about push to protected branch.
```
 * [new tag]         0.291 -> 0.291
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'https://github.com/prestodb/presto'
Error: Process completed with exit code 1.
```

## Motivation and Context
The error caused by the token generated by github action not have the permissions to perform branch push. It probably requires an github app to be in the list of `Restrict who can push to matching branches` and provide the token. 
I tried with the personal tokens(either fine or classic), but it doesn't work.
@ethanyzhang helped to added the secret with name PRESTODB_CI_TOKEN
Since it works with the jenkins pipeline. I'd like to update the workflow to try it. 

## Impact
The action itself and the project settings

## Test Plan
Test the action after updated

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

