### PR TITLE
[docs] Add python and go to /clients

### DIFF
--- a/presto-docs/src/main/sphinx/clients.rst
+++ b/presto-docs/src/main/sphinx/clients.rst
@@ -9,3 +9,5 @@ Presto Clients
     clients/presto-console
     clients/dbeaver
     clients/superset
+    clients/python
+    clients/go

--- a/presto-docs/src/main/sphinx/clients/go.rst
+++ b/presto-docs/src/main/sphinx/clients/go.rst
@@ -1,0 +1,7 @@
+=========
+Go Client
+=========
+
+See the `README <https://github.com/prestodb/presto-go-client/blob/master/README.md>`_ 
+for the `presto-go-client <https://github.com/prestodb/presto-go-client>`_ GitHub repostitory. 
+

--- a/presto-docs/src/main/sphinx/clients/python.rst
+++ b/presto-docs/src/main/sphinx/clients/python.rst
@@ -1,0 +1,5 @@
+=============
+Python Client
+=============
+
+See the `README <https://github.com/prestodb/presto-python-client/blob/master/README.md>`_  for the `presto-python-client <https://github.com/prestodb/presto-python-client>`_ GitHub repository.


### PR DESCRIPTION
## Description
Add pages for the python and go Presto clients to the Presto documentation.

## Motivation and Context
The python and go clients are mentioned nowhere in the Presto documentation. Readers might not know they exist - I didn't know about them until a few days ago myself. Adding pages for the clients helps readers new to Presto to work with Presto in ways they might prefer to.

The new pages intentionally do not repeat information from the READMEs of the python and go repositories because we want to avoid the problem of maintaining the same information repeated in two (or more) places and the chance of those repetitions becoming out of date. If we want to add new information to these new pages, or move information from the READMEs to these new pages, we can do so at a later date.

## Impact
Documentation.

## Test Plan
Local doc build, viewed changed and new pages, tested and verified working links.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

