### PR TITLE
Fix push error for presto stable release workflow

### DIFF
--- a/.github/workflows/presto-stable-release.yml
+++ b/.github/workflows/presto-stable-release.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout Presto source
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.PRESTODB_CI_TOKEN }}
           ref: master
           show-progress: false
 
@@ -30,7 +31,6 @@ jobs:
           git config --global --add safe.directory ${{github.workspace}}
           git config --global user.email "oss-release-bot@prestodb.io"
           git config --global user.name "oss-release-bot"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git config pull.rebase false
 
       - name: Set Maven version
@@ -42,6 +42,7 @@ jobs:
         run: |
           PRESTO_RELEASE_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
             -Dexpression=project.version -q -ntp -DforceStdout | tail -n 1)
+          echo "PRESTO_RELEASE_VERSION=$PRESTO_RELEASE_VERSION"
           echo "PRESTO_RELEASE_VERSION=$PRESTO_RELEASE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Update version in master

--- a/.github/workflows/presto-stable-release.yml
+++ b/.github/workflows/presto-stable-release.yml
@@ -13,7 +13,15 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout Presto source
+      - name: Check actor
+        if: ${{ github.actor != 'prestodb-ci' }}
+        run: echo "Unauthorized actor. Please login with prestodb-ci to run this action." && exit 1
+
+      - name: Check branch
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: echo "Invalid branch. This action can only be run on the master branch." && exit 1
+
+      - name: Checkout presto source
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PRESTODB_CI_TOKEN }}
@@ -26,14 +34,14 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      - name: Configure Git
+      - name: Configure git
         run: |
           git config --global --add safe.directory ${{github.workspace}}
           git config --global user.email "oss-release-bot@prestodb.io"
           git config --global user.name "oss-release-bot"
           git config pull.rebase false
 
-      - name: Set Maven version
+      - name: Set maven version
         run: |
           unset MAVEN_CONFIG && ./mvnw versions:set -DremoveSnapshot -ntp
 


### PR DESCRIPTION
## Description
In the action log => https://github.com/prestodb/presto/actions/runs/12926891450, there is an error about push to protected branch.
```
 * [new tag]         0.291 -> 0.291
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'https://github.com/prestodb/presto'
Error: Process completed with exit code 1.
```

## Motivation and Context

The error caused by the token generated by github action not have the permissions to perform branch push.

@ethanyzhang helped to added the secret with name PRESTODB_CI_TOKEN

This account must be in the list of the option "Restrict who can push to matching branches" and "Allow specified actors to bypass required pull requests". Or maybe in the list of bypass rule.

Tested with my repo => https://github.com/unix280/presto/actions/workflows/presto-stable-release.yml

## Impact
The action itself and the project settings

## Test Plan
Test the action after updated

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

