### PR TITLE
[native] Convert few more Velox operator names to Presto.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -103,6 +103,24 @@ std::string toPrestoOperatorType(const std::string& operatorType) {
   if (operatorType == "TableWrite") {
     return "TableWriterOperator";
   }
+  if (operatorType == "HashProbe") {
+    return "LookupJoinOperator";
+  }
+  if (operatorType == "HashBuild") {
+    return "HashBuilderOperator";
+  }
+  if (operatorType == "TableWriteMerge") {
+    return "TableWriterMergeOperator";
+  }
+  if (operatorType == "Unnest") {
+    return "UnnestOperator";
+  }
+  if (operatorType == "LocalPartition") {
+    return "LocalExchangeSourceOperator";
+  }
+  if (operatorType == "LocalExchange") {
+    return "LocalExchangeSinkOperator";
+  }
   return operatorType;
 }
 


### PR DESCRIPTION
## Description
In Prestissimo we convert some Velox operator names to Presto operator names to leverage the logic Presto has when processing query/operator stats.
Here we add few more conversions as we've noticed that the difference in naming prevents some tools from operating properly.

## Test Plan
Existing unit test.
Ran a query with the new binary to observe the feature that didn't work before now works.

```
== NO RELEASE NOTE ==
```

