### PR TITLE
[Docs]Fix link breaks caused by `##` in Iceberg document

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -271,7 +271,7 @@ Configuration Properties
 .. note::
 
     The Iceberg connector supports configuration options for
-    `Amazon S3 <https://prestodb.io/docs/current/connector/hive.html##amazon-s3-configuration>`_
+    `Amazon S3 <https://prestodb.io/docs/current/connector/hive.html#amazon-s3-configuration>`_
     as a Hive connector.
 
 The following configuration properties are available for all catalog types:


### PR DESCRIPTION
## Description

This PR fix the link breaks in Iceberg document for `Amazon S3`, which is caused by `##` in the link address.

## Motivation and Context

N/A

## Impact

Now, by clicking on `Amazon S3`, we can directly locate the corresponding configuration section of `Amazon S3`.

## Test Plan

N/A

## Contributor checklist

```
== NO RELEASE NOTE ==
```

