### PR TITLE
[Iceberg]Fix jmx metrics overwrite each other between nodes in query runner

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnectorFactory.java
@@ -18,6 +18,8 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 
+import javax.management.MBeanServer;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Optional;
@@ -27,6 +29,13 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
 public class IcebergConnectorFactory
         implements ConnectorFactory
 {
+    private final MBeanServer mBeanServer;
+
+    public IcebergConnectorFactory(MBeanServer mBeanServer)
+    {
+        this.mBeanServer = mBeanServer;
+    }
+
     @Override
     public String getName()
     {
@@ -45,8 +54,8 @@ public class IcebergConnectorFactory
         ClassLoader classLoader = IcebergConnectorFactory.class.getClassLoader();
         try {
             return (Connector) classLoader.loadClass(InternalIcebergConnectorFactory.class.getName())
-                    .getMethod("createConnector", String.class, Map.class, ConnectorContext.class, Optional.class)
-                    .invoke(null, catalogName, config, context, Optional.empty());
+                    .getMethod("createConnector", String.class, Map.class, ConnectorContext.class, Optional.class, MBeanServer.class)
+                    .invoke(null, catalogName, config, context, Optional.empty(), mBeanServer);
         }
         catch (InvocationTargetException e) {
             Throwable targetException = e.getTargetException();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
@@ -19,15 +19,30 @@ import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import javax.management.MBeanServer;
+
+import java.lang.management.ManagementFactory;
 import java.util.Set;
 
 public class IcebergPlugin
         implements Plugin
 {
+    private final MBeanServer mBeanServer;
+
+    public IcebergPlugin()
+    {
+        this(ManagementFactory.getPlatformMBeanServer());
+    }
+
+    public IcebergPlugin(MBeanServer mBeanServer)
+    {
+        this.mBeanServer = mBeanServer;
+    }
+
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new IcebergConnectorFactory());
+        return ImmutableList.of(new IcebergConnectorFactory(mBeanServer));
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
@@ -57,7 +57,6 @@ import org.weakref.jmx.guice.MBeanModule;
 
 import javax.management.MBeanServer;
 
-import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +71,8 @@ public final class InternalIcebergConnectorFactory
             String catalogName,
             Map<String, String> config,
             ConnectorContext context,
-            Optional<ExtendedHiveMetastore> metastore)
+            Optional<ExtendedHiveMetastore> metastore,
+            MBeanServer mBeanServer)
     {
         ClassLoader classLoader = InternalIcebergConnectorFactory.class.getClassLoader();
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
@@ -88,8 +88,7 @@ public final class InternalIcebergConnectorFactory
                     new CachingModule(),
                     new HiveCommonModule(),
                     binder -> {
-                        MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
-                        binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(platformMBeanServer));
+                        binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(mBeanServer));
                         binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConnectorFactory.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConnectorFactory.java
@@ -18,6 +18,7 @@ import com.facebook.presto.testing.TestingConnectorContext;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.lang.management.ManagementFactory;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -38,7 +39,7 @@ public class TestIcebergConnectorFactory
 
     private static void createConnector(Map<String, String> config)
     {
-        ConnectorFactory factory = new IcebergConnectorFactory();
+        ConnectorFactory factory = new IcebergConnectorFactory(ManagementFactory.getPlatformMBeanServer());
         factory.create("iceberg-test", config, new TestingConnectorContext())
                 .shutdown();
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergParquetMetadataCaching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergParquetMetadataCaching.java
@@ -45,7 +45,7 @@ public class TestIcebergParquetMetadataCaching
                 PARQUET,
                 false,
                 true,
-                OptionalInt.of(1),
+                OptionalInt.of(2),
                 Optional.empty());
     }
 


### PR DESCRIPTION
## Description

Coordinator and workers in the query runner will impact each other's jmx metrics (it seems that one will overwrite the other), so we met the problem described in issue #22422. The core reason is that, all nodes in the query runner have the same MBeanServer instance and then registered their own parquet metadata cacheStatsMBean into this singleton MBeanServer.

This PR fix this problem by injecting seperate MBeanServers for different coordinators and workers.

## Motivation and Context

Eliminate various problems that may arise from the overwriting of jmx metrics in query runner based testing

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

