### PR TITLE
Custom scheduler plugin support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
         <module>presto-native-sidecar-plugin</module>
         <module>presto-base-arrow-flight</module>
         <module>presto-function-server</module>
+        <module>presto-router-example-plugin-scheduler</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginInstaller.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginInstaller.java
@@ -15,10 +15,13 @@ package com.facebook.presto.server;
 
 import com.facebook.presto.spi.CoordinatorPlugin;
 import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.RouterPlugin;
 
 public interface PluginInstaller
 {
     void installPlugin(Plugin plugin);
 
     void installCoordinatorPlugin(CoordinatorPlugin plugin);
+
+    default void installRouterPlugin(RouterPlugin plugin){};
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.CoordinatorPlugin;
 import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.RouterPlugin;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
@@ -139,6 +140,7 @@ public class PluginManagerUtil
                 pluginServicesFile,
                 parent);
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(pluginClassLoader)) {
+            loadPlugin(pluginClassLoader, RouterPlugin.class, pluginInstaller);
             loadPlugin(pluginClassLoader, CoordinatorPlugin.class, pluginInstaller);
             loadPlugin(pluginClassLoader, Plugin.class, pluginInstaller);
         }
@@ -164,6 +166,9 @@ public class PluginManagerUtil
             }
             else if (plugin instanceof CoordinatorPlugin) {
                 pluginInstaller.installCoordinatorPlugin((CoordinatorPlugin) plugin);
+            }
+            else if (plugin instanceof RouterPlugin) {
+                pluginInstaller.installRouterPlugin((RouterPlugin) plugin);
             }
             else {
                 log.warn("Unknown plugin type: %s", plugin.getClass().getName());

--- a/presto-router-example-plugin-scheduler/README.md
+++ b/presto-router-example-plugin-scheduler/README.md
@@ -1,0 +1,22 @@
+# Example - Presto Router Custom Scheduler Plugin
+This package contains an example of a custom scheduler plugin.
+
+## Add the Custom Scheduler Plugin to the Presto Router
+Place the plugin jar and all the dependent jars for the plugin in the `plugin` directory relative to the Presto install directory.
+
+The configuration file for this plugin must be `etc/router-config/router-scheduler.properties`.  
+In `router-scheduler.properties`, set the name of the custom scheduler factory.  
+For example, use the following line to set the custom scheduler factory name to `metricsBased`.  
+``router-scheduler.name=metricsBased``
+
+The scheduler name must be set to `CUSTOM_PLUGIN_SCHEDULER` in `etc/router-config.json`.  
+    ``scheduler``: ``CUSTOM_PLUGIN_SCHEDULER``
+
+## Main Classes:
+* `RouterSchedulerPlugin` - Custom Scheduler Plugin class to be loaded by the Router plugin manager.  
+  This class implements the interface `com.facebook.presto.spi.RouterPlugin`.
+* `MetricsBasedSchedulerFactory` - Factory for creating specific custom scheduler.  
+  This class implements the interface `com.facebook.presto.spi.SchedulerFactory`.
+* `MetricsBasedScheduler` - Example custom scheduler implementing the scheduling logic for clusters.  
+  This class implements the interface `com.facebook.presto.spi.router.Scheduler`.  
+  Similar classes can be added implementing specific custom scheduling logic.

--- a/presto-router-example-plugin-scheduler/pom.xml
+++ b/presto-router-example-plugin-scheduler/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.293-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.facebook.presto.router</groupId>
+    <artifactId>presto-router-example-plugin-scheduler</artifactId>
+    <version>0.293-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>presto-router-example-plugin-scheduler</name>
+    <description>Presto-router example custom plugin scheduler</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <!-- test dependencies-->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <!-- Build configurations -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check-spi-dependencies</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/presto-router-example-plugin-scheduler/src/main/java/com/facebook/presto/router/scheduler/MetricsBasedScheduler.java
+++ b/presto-router-example-plugin-scheduler/src/main/java/com/facebook/presto/router/scheduler/MetricsBasedScheduler.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.router.scheduler;
+
+import com.facebook.presto.spi.router.ClusterInfo;
+import com.facebook.presto.spi.router.Scheduler;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Comparator.comparingLong;
+
+/**
+ * Metrics based scheduler uses coordinator and/or worker metrics for scheduling decisions.
+ */
+public class MetricsBasedScheduler
+        implements Scheduler
+{
+    private Map<URI, ClusterInfo> clusterInfos;
+
+    @Override
+    public Optional<URI> getDestination(String user)
+    {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the destination cluster URI with the fewest number of active and queued queries.
+     */
+    @Override
+    public Optional<URI> getDestination(String user, String query)
+    {
+        if (clusterInfos != null && !clusterInfos.isEmpty()) {
+            //Cluster with the fewest number of queries will be returned
+            return clusterInfos.entrySet().stream()
+                    .min(comparingLong(entry -> entry.getValue().getRunningQueries() + entry.getValue().getQueuedQueries()))
+                    .map(Map.Entry::getKey);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void setCandidates(List<URI> candidates) {}
+
+    @Override
+    public void setClusterInfos(Map<URI, ClusterInfo> clusterInfos)
+    {
+        this.clusterInfos = clusterInfos;
+    }
+}

--- a/presto-router-example-plugin-scheduler/src/main/java/com/facebook/presto/router/scheduler/MetricsBasedSchedulerFactory.java
+++ b/presto-router-example-plugin-scheduler/src/main/java/com/facebook/presto/router/scheduler/MetricsBasedSchedulerFactory.java
@@ -13,12 +13,25 @@
  */
 package com.facebook.presto.router.scheduler;
 
-public enum SchedulerType
+import com.facebook.presto.spi.router.Scheduler;
+import com.facebook.presto.spi.router.SchedulerFactory;
+
+import java.util.Map;
+
+public class MetricsBasedSchedulerFactory
+        implements SchedulerFactory
 {
-    RANDOM_CHOICE,
-    ROUND_ROBIN,
-    USER_HASH,
-    WEIGHTED_RANDOM_CHOICE,
-    WEIGHTED_ROUND_ROBIN,
-    CUSTOM_PLUGIN_SCHEDULER
+    public static final String METRICS_BASED = "metricsBased";
+
+    @Override
+    public String getName()
+    {
+        return METRICS_BASED;
+    }
+
+    @Override
+    public Scheduler create(Map<String, String> config)
+    {
+        return new MetricsBasedScheduler();
+    }
 }

--- a/presto-router-example-plugin-scheduler/src/main/java/com/facebook/presto/router/scheduler/RouterSchedulerPlugin.java
+++ b/presto-router-example-plugin-scheduler/src/main/java/com/facebook/presto/router/scheduler/RouterSchedulerPlugin.java
@@ -13,12 +13,16 @@
  */
 package com.facebook.presto.router.scheduler;
 
-public enum SchedulerType
+import com.facebook.presto.spi.RouterPlugin;
+import com.facebook.presto.spi.router.SchedulerFactory;
+import com.google.common.collect.ImmutableList;
+
+public class RouterSchedulerPlugin
+        implements RouterPlugin
 {
-    RANDOM_CHOICE,
-    ROUND_ROBIN,
-    USER_HASH,
-    WEIGHTED_RANDOM_CHOICE,
-    WEIGHTED_ROUND_ROBIN,
-    CUSTOM_PLUGIN_SCHEDULER
+    @Override
+    public Iterable<SchedulerFactory> getSchedulerFactories()
+    {
+        return ImmutableList.of(new MetricsBasedSchedulerFactory());
+    }
 }

--- a/presto-router-example-plugin-scheduler/src/main/provisio/plugin.xml
+++ b/presto-router-example-plugin-scheduler/src/main/provisio/plugin.xml
@@ -1,0 +1,4 @@
+<assembly>
+    <artifactSet to="/" ref="runtime.classpath" />
+    <archive name="${project.artifactId}-${project.version}.zip" />
+</assembly>

--- a/presto-router-example-plugin-scheduler/src/main/resources/META-INF/services/com.facebook.presto.spi.RouterPlugin
+++ b/presto-router-example-plugin-scheduler/src/main/resources/META-INF/services/com.facebook.presto.spi.RouterPlugin
@@ -1,0 +1,1 @@
+com.facebook.presto.router.scheduler.RouterSchedulerPlugin

--- a/presto-router-example-plugin-scheduler/src/test/java/com/facebook/presto/router/scheduler/TestMetricsBasedScheduler.java
+++ b/presto-router-example-plugin-scheduler/src/test/java/com/facebook/presto/router/scheduler/TestMetricsBasedScheduler.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.router.scheduler;
+
+import com.facebook.presto.spi.router.ClusterInfo;
+import com.facebook.presto.spi.router.Scheduler;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestMetricsBasedScheduler
+{
+    private final Map<URI, ClusterInfo> clusterInfos = new HashMap<>();
+
+    private static class MockRemoteClusterInfo
+            implements ClusterInfo
+    {
+        private final long runningQueries;
+        private final long queuedQueries;
+
+        MockRemoteClusterInfo(long runningQueries, long queuedQueries)
+        {
+            this.runningQueries = runningQueries;
+            this.queuedQueries = queuedQueries;
+        }
+
+        @Override
+        public long getRunningQueries()
+        {
+            return runningQueries;
+        }
+
+        @Override
+        public long getQueuedQueries()
+        {
+            return queuedQueries;
+        }
+
+        @Override
+        public long getBlockedQueries()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getActiveWorkers()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getRunningDrivers()
+        {
+            return 0;
+        }
+    }
+
+    @Test
+    public void testMetricsBasedScheduler()
+            throws Exception
+    {
+        Scheduler scheduler = new MetricsBasedScheduler();
+
+        URI uri1 = new URI("192.168.0.1");
+        URI uri2 = new URI("192.168.0.2");
+        URI uri3 = new URI("192.168.0.3");
+
+        clusterInfos.put(uri1, new MockRemoteClusterInfo(10, 10));
+        clusterInfos.put(uri2, new MockRemoteClusterInfo(20, 20));
+        clusterInfos.put(uri3, new MockRemoteClusterInfo(30, 30));
+        scheduler.setClusterInfos(clusterInfos);
+        URI target = scheduler.getDestination("test", null).orElseThrow(AssertionError::new);
+        assertEquals(target, uri1);
+
+        clusterInfos.put(uri1, new MockRemoteClusterInfo(20, 20));
+        clusterInfos.put(uri2, new MockRemoteClusterInfo(10, 10));
+        clusterInfos.put(uri3, new MockRemoteClusterInfo(30, 30));
+        scheduler.setClusterInfos(clusterInfos);
+        target = scheduler.getDestination("test", null).orElseThrow(AssertionError::new);
+        assertEquals(target, uri2);
+
+        clusterInfos.put(uri1, new MockRemoteClusterInfo(20, 20));
+        clusterInfos.put(uri2, new MockRemoteClusterInfo(30, 30));
+        clusterInfos.put(uri3, new MockRemoteClusterInfo(10, 10));
+        scheduler.setClusterInfos(clusterInfos);
+        target = scheduler.getDestination("test", null).orElseThrow(AssertionError::new);
+        assertEquals(target, uri3);
+
+        scheduler.setClusterInfos(new HashMap<>());
+        target = scheduler.getDestination("test", null).orElse(new URI("invalid"));
+        assertEquals(target, new URI("invalid"));
+    }
+}

--- a/presto-router/etc/router-config/router-scheduler.properties
+++ b/presto-router/etc/router-config/router-scheduler.properties
@@ -1,0 +1,1 @@
+router-scheduler.name=metricsBased

--- a/presto-router/src/main/java/com/facebook/presto/router/PrestoRouter.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/PrestoRouter.java
@@ -34,6 +34,8 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import org.weakref.jmx.guice.MBeanModule;
 
+import java.util.Optional;
+
 public class PrestoRouter
 {
     private PrestoRouter()
@@ -55,14 +57,13 @@ public class PrestoRouter
                 .add(new TraceTokenModule())
                 .add(new EventModule())
                 .add(new RouterSecurityModule())
-                .add(new RouterModule())
+                .add(new RouterModule(Optional.empty()))
                 .add(extraModules)
                 .build());
 
         Logger log = Logger.get(RouterModule.class);
         try {
             Injector injector = app.initialize();
-            injector.getInstance(RouterPluginManager.class).loadPlugins();
             injector.getInstance(ClientRequestFilterManager.class).loadClientRequestFilters();
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
             injector.getInstance(PrestoAuthenticatorManager.class).loadPrestoAuthenticator();

--- a/presto-router/src/main/java/com/facebook/presto/router/RouterModule.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/RouterModule.java
@@ -26,6 +26,7 @@ import com.facebook.presto.router.predictor.ForQueryCpuPredictor;
 import com.facebook.presto.router.predictor.ForQueryMemoryPredictor;
 import com.facebook.presto.router.predictor.PredictorManager;
 import com.facebook.presto.router.predictor.RemoteQueryFactory;
+import com.facebook.presto.router.scheduler.CustomSchedulerManager;
 import com.facebook.presto.server.PluginManagerConfig;
 import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.server.WebUiResource;
@@ -34,6 +35,7 @@ import com.google.inject.Scopes;
 import io.airlift.units.Duration;
 
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.airlift.concurrent.Threads.threadsNamed;
@@ -57,14 +59,28 @@ public class RouterModule
     private static final String UI_PATH = "/ui";
     private static final String ROUTER_UI = "router_ui";
     private static final String INDEX_HTML = "index.html";
+    private final Optional<CustomSchedulerManager> customSchedulerManager;
+
+    public RouterModule(Optional<CustomSchedulerManager> customSchedulerManager)
+    {
+        this.customSchedulerManager = customSchedulerManager;
+    }
 
     @Override
     protected void setup(Binder binder)
     {
         ServerConfig serverConfig = buildConfigObject(ServerConfig.class);
 
+        binder.bind(RouterPluginManager.class).in(Scopes.SINGLETON);
         httpServerBinder(binder).bindResource(UI_PATH, ROUTER_UI).withWelcomeFile(INDEX_HTML);
         configBinder(binder).bindConfig(RouterConfig.class);
+
+        if (customSchedulerManager.isPresent()) {
+            binder.bind(CustomSchedulerManager.class).toInstance(customSchedulerManager.get());
+        }
+        else {
+            binder.bind(CustomSchedulerManager.class).in(Scopes.SINGLETON);
+        }
 
         configBinder(binder).bindConfig(RemoteStateConfig.class);
         binder.bind(ScheduledExecutorService.class).annotatedWith(ForClusterManager.class).toInstance(newSingleThreadScheduledExecutor(threadsNamed("cluster-config")));
@@ -88,6 +104,8 @@ public class RouterModule
         binder.bind(RemoteQueryFactory.class).in(Scopes.SINGLETON);
 
         binder.bind(RouterPluginManager.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(PluginManagerConfig.class);
+
         configBinder(binder).bindConfig(PluginManagerConfig.class);
 
         bindHttpClient(binder, QUERY_PREDICTOR, ForQueryCpuPredictor.class, IDLE_TIMEOUT_SECOND, PREDICTOR_REQUEST_TIMEOUT_SECOND);

--- a/presto-router/src/main/java/com/facebook/presto/router/cluster/RemoteClusterInfo.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/cluster/RemoteClusterInfo.java
@@ -14,8 +14,8 @@
 package com.facebook.presto.router.cluster;
 
 import com.facebook.airlift.http.client.HttpClient;
-import com.facebook.airlift.log.Logger;
 import com.facebook.presto.router.RouterConfig;
+import com.facebook.presto.spi.router.ClusterInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -24,10 +24,9 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class RemoteClusterInfo
-        extends RemoteState
+        extends RemoteState implements ClusterInfo
 {
     private static final ObjectMapper mapper = new ObjectMapper();
-    private static final Logger log = Logger.get(RemoteClusterInfo.class);
     private static final String RUNNING_QUERIES = "runningQueries";
     private static final String BLOCKED_QUERIES = "blockedQueries";
     private static final String QUEUED_QUERIES = "queuedQueries";
@@ -56,26 +55,31 @@ public class RemoteClusterInfo
         runningDrivers.set(fields.get(RUNNING_DRIVERS));
     }
 
+    @Override
     public long getRunningQueries()
     {
         return runningQueries.get();
     }
 
+    @Override
     public long getBlockedQueries()
     {
         return blockedQueries.get();
     }
 
+    @Override
     public long getQueuedQueries()
     {
         return queuedQueries.get();
     }
 
+    @Override
     public long getActiveWorkers()
     {
         return activeWorkers.get();
     }
 
+    @Override
     public long getRunningDrivers()
     {
         return runningDrivers.get();

--- a/presto-router/src/main/java/com/facebook/presto/router/cluster/RequestInfo.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/cluster/RequestInfo.java
@@ -35,12 +35,14 @@ public class RequestInfo
     private final String user;
     private final Optional<String> source;
     private final List<String> clientTags;
+    private final String query;
 
     public RequestInfo(HttpServletRequest servletRequest, String query)
     {
         this.user = parseHeader(servletRequest, PRESTO_USER);
         this.source = Optional.ofNullable(parseHeader(servletRequest, PRESTO_SOURCE));
         this.clientTags = requireNonNull(parseClientTags(servletRequest), "clientTags is null");
+        this.query = query;
     }
 
     public String getUser()
@@ -51,6 +53,11 @@ public class RequestInfo
     public Optional<String> getSource()
     {
         return source;
+    }
+
+    public String getQuery()
+    {
+        return query;
     }
 
     public List<String> getClientTags()

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/CustomSchedulerManager.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/CustomSchedulerManager.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.router.scheduler;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.router.RouterPluginManager;
+import com.facebook.presto.spi.router.Scheduler;
+import com.facebook.presto.spi.router.SchedulerFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class CustomSchedulerManager
+{
+    private static final Logger log = Logger.get(CustomSchedulerManager.class);
+    public static final File ROUTER_SCHEDULER_PROPERTIES = new File("etc/router-config/router-scheduler.properties");
+
+    private final File configFile;
+    private static final String NAME_PROPERTY = "router-scheduler.name";
+
+    private final Map<String, SchedulerFactory> factories = new ConcurrentHashMap<>();
+    private Scheduler scheduler;
+
+    @Inject
+    public CustomSchedulerManager(RouterPluginManager routerPluginManager)
+    {
+        try {
+            routerPluginManager.loadPlugins();
+            List<SchedulerFactory> factoryList = routerPluginManager.getRegisteredSchedulerFactoryList();
+            for (SchedulerFactory factory : factoryList) {
+                addSchedulerFactory(factory);
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        this.configFile = ROUTER_SCHEDULER_PROPERTIES;
+    }
+
+    @VisibleForTesting
+    public CustomSchedulerManager(List<SchedulerFactory> schedulerFactoryList, File configFile)
+    {
+        for (SchedulerFactory factory : schedulerFactoryList) {
+            addSchedulerFactory(factory);
+        }
+        this.configFile = configFile;
+    }
+
+    public void addSchedulerFactory(SchedulerFactory factory)
+    {
+        checkArgument(factories.putIfAbsent(factory.getName(), factory) == null,
+                "Presto Router Scheduler '%s' is already registered", factory.getName());
+    }
+
+    public void loadScheduler()
+    {
+        File configFileLocation = configFile.getAbsoluteFile();
+        Map<String, String> properties;
+        try {
+            properties = new HashMap<>(loadProperties(configFileLocation));
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Unable to load properties from config file", e);
+        }
+
+        String name = properties.remove(NAME_PROPERTY);
+        checkArgument(!isNullOrEmpty(name),
+                "Router scheduler configuration %s does not contain %s", configFileLocation, NAME_PROPERTY);
+
+        log.info("-- Loading Presto Router Scheduler %s --", name);
+        SchedulerFactory factory = factories.get(name);
+        checkState(factory != null, "Presto Router Scheduler %s is not registered", name);
+        this.scheduler = factory.create(ImmutableMap.copyOf(properties));
+        log.info("-- Loaded Presto Router Scheduler %s --", name);
+    }
+
+    public Scheduler getScheduler()
+    {
+        checkState(scheduler != null, "scheduler was not loaded");
+        return scheduler;
+    }
+}

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/RandomChoiceScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/RandomChoiceScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.Scheduler;
 
 import java.net.URI;
 import java.util.List;

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/RoundRobinScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/RoundRobinScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.Scheduler;
 
 import javax.annotation.concurrent.GuardedBy;
 
@@ -57,6 +58,7 @@ public class RoundRobinScheduler
         }
     }
 
+    @Override
     public void setCandidates(List<URI> candidates)
     {
         this.candidates = candidates;

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/SchedulerFactory.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/SchedulerFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.router.Scheduler;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
@@ -21,10 +22,12 @@ import static java.util.Objects.requireNonNull;
 public class SchedulerFactory
 {
     private final SchedulerType schedulerType;
+    private final CustomSchedulerManager schedulerManager;
 
-    public SchedulerFactory(SchedulerType schedulerType)
+    public SchedulerFactory(SchedulerType schedulerType, CustomSchedulerManager schedulerManager)
     {
         this.schedulerType = requireNonNull(schedulerType, "schedulerType is null");
+        this.schedulerManager = requireNonNull(schedulerManager, "schedulerManager is null");
     }
 
     public Scheduler create()
@@ -40,6 +43,9 @@ public class SchedulerFactory
                 return new RoundRobinScheduler();
             case WEIGHTED_ROUND_ROBIN:
                 return new WeightedRoundRobinScheduler();
+            case CUSTOM_PLUGIN_SCHEDULER:
+                schedulerManager.loadScheduler();
+                return schedulerManager.getScheduler();
         }
         throw new PrestoException(NOT_SUPPORTED, "Unsupported router scheduler type " + schedulerType);
     }

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/UserHashScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/UserHashScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.Scheduler;
 
 import java.net.URI;
 import java.util.List;

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/WeightedRandomChoiceScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/WeightedRandomChoiceScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.Scheduler;
 
 import java.net.URI;
 import java.util.Collection;

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/WeightedRoundRobinScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/WeightedRoundRobinScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.Scheduler;
 
 import java.net.URI;
 import java.util.Collection;

--- a/presto-router/src/main/java/com/facebook/presto/router/spec/SelectorRuleSpec.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/spec/SelectorRuleSpec.java
@@ -17,6 +17,7 @@ import com.facebook.presto.router.cluster.RequestInfo;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -84,7 +85,8 @@ public class SelectorRuleSpec
             }
         }
 
-        if (clientTags.isPresent() && !requestInfo.getClientTags().containsAll(clientTags.get())) {
+        if (clientTags.isPresent() &&
+                !new HashSet<>(requestInfo.getClientTags()).containsAll(clientTags.get())) {
             return Optional.empty();
         }
 

--- a/presto-router/src/test/java/com/facebook/presto/router/BarrierClusterManager.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/BarrierClusterManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.router;
 import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.presto.router.cluster.ClusterManager;
 import com.facebook.presto.router.cluster.RemoteInfoFactory;
+import com.facebook.presto.router.scheduler.CustomSchedulerManager;
 
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
@@ -27,9 +28,9 @@ public class BarrierClusterManager
 {
     private final CyclicBarrier barrier;
 
-    public BarrierClusterManager(RouterConfig config, RemoteInfoFactory remoteInfoFactory, CyclicBarrier barrier, LifeCycleManager lifeCycleManager)
+    public BarrierClusterManager(RouterConfig config, RemoteInfoFactory remoteInfoFactory, CyclicBarrier barrier, LifeCycleManager lifeCycleManager, CustomSchedulerManager schedulerManager)
     {
-        super(config, remoteInfoFactory, lifeCycleManager);
+        super(config, remoteInfoFactory, lifeCycleManager, schedulerManager);
         this.barrier = barrier;
         startConfigReloadTaskFileWatcher();
     }

--- a/presto-router/src/test/java/com/facebook/presto/router/TestCustomSchedulerManager.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestCustomSchedulerManager.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.router;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.http.server.HttpServerInfo;
+import com.facebook.airlift.http.server.testing.TestingHttpServerModule;
+import com.facebook.airlift.jaxrs.JaxrsModule;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.log.Logging;
+import com.facebook.airlift.node.testing.TestingNodeModule;
+import com.facebook.presto.router.scheduler.CustomSchedulerManager;
+import com.facebook.presto.router.security.RouterSecurityModule;
+import com.facebook.presto.router.spec.GroupSpec;
+import com.facebook.presto.router.spec.RouterSpec;
+import com.facebook.presto.router.spec.SelectorRuleSpec;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.router.Scheduler;
+import com.facebook.presto.spi.router.SchedulerFactory;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.router.TestClusterManager.runAndAssertQueryResults;
+import static com.facebook.presto.router.scheduler.SchedulerType.CUSTOM_PLUGIN_SCHEDULER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestCustomSchedulerManager
+{
+    private static final int NUM_CLUSTERS = 3;
+    private static List<TestingPrestoServer> prestoServers;
+    private HttpServerInfo httpServerInfo;
+    private File configFile;
+    private CustomSchedulerManager schedulerManager;
+    private static List<URI> serverURIs;
+    private static Path tempPluginSchedulerConfigFile;
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Logging.initialize();
+
+        // Set up servers
+        ImmutableList.Builder<TestingPrestoServer> builder = ImmutableList.builder();
+        for (int i = 0; i < NUM_CLUSTERS; ++i) {
+            builder.add(createPrestoServer());
+        }
+        prestoServers = builder.build();
+
+        configFile = getRouterConfigFile(prestoServers);
+
+        tempPluginSchedulerConfigFile = Files.createTempFile("router-scheduler-mock", ".properties");
+        String schedulerName = "router-scheduler.name=mock";
+        Files.write(tempPluginSchedulerConfigFile, schedulerName.getBytes());
+
+        SchedulerFactory mockSchedulerFactory = new MockSchedulerFactory();
+        CustomSchedulerManager customSchedulerManager = new CustomSchedulerManager(ImmutableList.of(mockSchedulerFactory), tempPluginSchedulerConfigFile.toFile());
+
+        Bootstrap app = new Bootstrap(
+                new TestingNodeModule("test"),
+                new TestingHttpServerModule(),
+                new JsonModule(),
+                new JaxrsModule(true),
+                new RouterSecurityModule(),
+                new RouterModule(Optional.of(customSchedulerManager)));
+
+        Injector injector = app.doNotInitializeLogging()
+                .setRequiredConfigurationProperty("router.config-file", configFile.getAbsolutePath())
+                .setRequiredConfigurationProperty("presto.version", "test")
+                .quiet().initialize();
+
+        httpServerInfo = injector.getInstance(HttpServerInfo.class);
+        schedulerManager = injector.getInstance(CustomSchedulerManager.class);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDownServer()
+            throws Exception
+    {
+        for (TestingPrestoServer prestoServer : prestoServers) {
+            prestoServer.close();
+        }
+    }
+
+    static class MockSchedulerFactory
+            implements SchedulerFactory
+    {
+        public static final String MOCK = "mock";
+
+        @Override
+        public String getName()
+        {
+            return MOCK;
+        }
+
+        @Override
+        public Scheduler create(Map<String, String> config)
+        {
+            return new MockScheduler();
+        }
+    }
+
+    public static class MockScheduler
+            implements Scheduler
+    {
+        private List<URI> candidates;
+        private int requestsMade;
+
+        @Override
+        public Optional<URI> getDestination(String user)
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<URI> getDestination(String user, String query)
+        {
+            ++requestsMade;
+            return Optional.of(candidates.get(0));
+        }
+
+        @Override
+        public void setCandidates(List<URI> candidates)
+        {
+            this.candidates = candidates;
+        }
+
+        public int getRequestsMade()
+        {
+            return requestsMade;
+        }
+    }
+
+    public static File getRouterConfigFile(List<TestingPrestoServer> servers)
+            throws IOException
+    {
+        Path path = Files.createTempFile("temp-config", ".json");
+        serverURIs = servers.stream()
+                .map(TestingPrestoServer::getBaseUrl)
+                .collect(Collectors.toList());
+        RouterSpec spec = new RouterSpec(ImmutableList.of(new GroupSpec("all", serverURIs, Optional.empty(), Optional.empty())),
+                ImmutableList.of(new SelectorRuleSpec(Optional.empty(), Optional.empty(), Optional.empty(), "all")),
+                Optional.of(CUSTOM_PLUGIN_SCHEDULER), Optional.empty(), Optional.empty());
+        JsonCodec<RouterSpec> codec = jsonCodec(RouterSpec.class);
+        Files.write(path, codec.toBytes(spec));
+        return path.toFile();
+    }
+
+    private static TestingPrestoServer createPrestoServer()
+            throws Exception
+    {
+        TestingPrestoServer server = new TestingPrestoServer();
+        server.installPlugin(new TpchPlugin());
+        server.createCatalog("tpch", "tpch");
+        server.refreshNodes();
+
+        return server;
+    }
+
+    public void testQuery()
+            throws Exception
+    {
+        runAndAssertQueryResults(httpServerInfo.getHttpUri());
+
+        MockScheduler mockScheduler = (MockScheduler) schedulerManager.getScheduler();
+        assertEquals(mockScheduler.getRequestsMade(), 1);
+    }
+
+    @Test
+    public void testCustomScheduler()
+            throws Exception
+    {
+        schedulerManager.loadScheduler();
+        Scheduler scheduler = schedulerManager.getScheduler();
+        scheduler.setCandidates(serverURIs);
+
+        URI target = scheduler.getDestination("test", null).orElse(new URI("invalid"));
+        assertTrue(serverURIs.contains(target));
+    }
+
+    @DataProvider(name = "schedulerNameProvider")
+    public Object[][] schedulerNameProvider()
+    {
+        return new Object[][]{
+                {"router-scheduler.name=RANDOM"},
+                {"router-scheduler.name=METRICS"},
+                {"router-scheduler.name=MOCK"}
+        };
+    }
+
+    @Test(dataProvider = "schedulerNameProvider", expectedExceptions = IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "Presto Router Scheduler.*is not registered")
+    public void testCustomSchedulerFail(String schedulerName)
+            throws Exception
+    {
+        Files.write(tempPluginSchedulerConfigFile, schedulerName.getBytes());
+        schedulerManager.loadScheduler();
+    }
+}

--- a/presto-router/src/test/java/com/facebook/presto/router/TestHealthChecks.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestHealthChecks.java
@@ -79,7 +79,7 @@ public class TestHealthChecks
                 new JaxrsModule(true),
                 new ServerSecurityModule(),
                 new ClientRequestFilterModule(),
-                new RouterModule());
+                new RouterModule(Optional.empty()));
 
         Injector injector = app.doNotInitializeLogging()
                 .setRequiredConfigurationProperty("router.config-file", tempFile.getAbsolutePath())

--- a/presto-router/src/test/java/com/facebook/presto/router/TestPredictorManager.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestPredictorManager.java
@@ -39,6 +39,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.router.TestingRouterUtil.getConfigFile;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
@@ -75,7 +76,7 @@ public class TestPredictorManager
                 new TestingHttpServerModule(),
                 new JsonModule(),
                 new JaxrsModule(true),
-                new RouterModule());
+                new RouterModule(Optional.empty()));
 
         Injector injector = app
                 .doNotInitializeLogging()

--- a/presto-router/src/test/java/com/facebook/presto/router/TestRouterAuthentication.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestRouterAuthentication.java
@@ -50,6 +50,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Base64;
+import java.util.Optional;
 
 import static com.facebook.presto.router.TestingRouterUtil.createPrestoServer;
 import static com.facebook.presto.router.TestingRouterUtil.getConfigFile;
@@ -123,7 +124,7 @@ public class TestRouterAuthentication
                 new JsonModule(),
                 new JaxrsModule(true),
                 new RouterSecurityModule(),
-                new RouterModule());
+                new RouterModule(Optional.empty()));
 
         Injector injector = app.doNotInitializeLogging()
                 .setRequiredConfigurationProperty("router.config-file", configFile.getAbsolutePath())

--- a/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
@@ -15,10 +15,10 @@ package com.facebook.presto.router;
 
 import com.facebook.presto.router.scheduler.RandomChoiceScheduler;
 import com.facebook.presto.router.scheduler.RoundRobinScheduler;
-import com.facebook.presto.router.scheduler.Scheduler;
 import com.facebook.presto.router.scheduler.UserHashScheduler;
 import com.facebook.presto.router.scheduler.WeightedRandomChoiceScheduler;
 import com.facebook.presto.router.scheduler.WeightedRoundRobinScheduler;
+import com.facebook.presto.spi.router.Scheduler;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/presto-router/src/test/java/com/facebook/presto/router/TestSelectors.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestSelectors.java
@@ -124,7 +124,7 @@ public class TestSelectors
                 .add(new JsonModule())
                 .add(new JaxrsModule(true))
                 .add(new ServerSecurityModule())
-                .add(new RouterModule())
+                .add(new RouterModule(Optional.empty()))
                 .build());
 
         Injector injector = app.doNotInitializeLogging()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/RouterPlugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/RouterPlugin.java
@@ -11,14 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.router.scheduler;
+package com.facebook.presto.spi;
 
-public enum SchedulerType
+import com.facebook.presto.spi.router.SchedulerFactory;
+
+import static java.util.Collections.emptyList;
+
+public interface RouterPlugin
 {
-    RANDOM_CHOICE,
-    ROUND_ROBIN,
-    USER_HASH,
-    WEIGHTED_RANDOM_CHOICE,
-    WEIGHTED_ROUND_ROBIN,
-    CUSTOM_PLUGIN_SCHEDULER
+    default Iterable<SchedulerFactory> getSchedulerFactories()
+    {
+        return emptyList();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/router/ClusterInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/router/ClusterInfo.java
@@ -11,14 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.router.scheduler;
+package com.facebook.presto.spi.router;
 
-public enum SchedulerType
+public interface ClusterInfo
 {
-    RANDOM_CHOICE,
-    ROUND_ROBIN,
-    USER_HASH,
-    WEIGHTED_RANDOM_CHOICE,
-    WEIGHTED_ROUND_ROBIN,
-    CUSTOM_PLUGIN_SCHEDULER
+    long getRunningQueries();
+
+    long getBlockedQueries();
+
+    long getQueuedQueries();
+
+    long getActiveWorkers();
+
+    long getRunningDrivers();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/router/Scheduler.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/router/Scheduler.java
@@ -11,24 +11,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.router.scheduler;
-
-import com.facebook.presto.spi.PrestoException;
+package com.facebook.presto.spi.router;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
-
 public interface Scheduler
 {
     /**
-     * Schedules a request from a user to a concrete candidate. Returns the
+     * Schedules a query from a user to a concrete candidate. Returns the
      * URI of this candidate.
      */
     Optional<URI> getDestination(String user);
+
+    /**
+     * Schedules a query from a user to a concrete candidate. Returns the
+     * URI of this candidate.
+     * TODO : Refactor to use a RequestInfo POJO and remove the extra getDestination variant
+     */
+    default Optional<URI> getDestination(String user, String query)
+    {
+        return Optional.empty();
+    };
 
     /**
      * Sets the candidates with the list of URIs for scheduling.
@@ -36,15 +42,17 @@ public interface Scheduler
     void setCandidates(List<URI> candidates);
 
     /**
+     * Sets remote cluster infos for each cluster.
+     */
+    default void setClusterInfos(Map<URI, ClusterInfo> clusterInfos) {}
+
+    /**
+     * Sets the candidate group name
+     */
+    default void setCandidateGroupName(String candidateGroupName) {}
+
+    /**
      * Sets the weights of candidates with a hash map object.
      */
-    default void setWeights(Map<URI, Integer> weights)
-    {
-        throw new PrestoException(NOT_SUPPORTED, "This scheduler does not support setting weights");
-    }
-
-    default void setCandidateGroupName(String candidateGroupName)
-    {
-        throw new PrestoException(NOT_SUPPORTED, "This scheduler does not support setting candidateGroupName");
-    }
+    default void setWeights(Map<URI, Integer> weights) {}
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/router/SchedulerFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/router/SchedulerFactory.java
@@ -11,14 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.router.scheduler;
+package com.facebook.presto.spi.router;
 
-public enum SchedulerType
+import java.util.Map;
+
+public interface SchedulerFactory
 {
-    RANDOM_CHOICE,
-    ROUND_ROBIN,
-    USER_HASH,
-    WEIGHTED_RANDOM_CHOICE,
-    WEIGHTED_ROUND_ROBIN,
-    CUSTOM_PLUGIN_SCHEDULER
+    String getName();
+
+    Scheduler create(Map<String, String> config);
 }


### PR DESCRIPTION
## Description
Custom scheduler plugin support.
Example custom scheduler plugin - Metrics based custom scheduler plugin

## Motivation and Context
Support for implementation of third party custom schedulers to be used by Presto router.
Example custom scheduler plugin - Metrics based custom scheduler plugin. Schedules cluster with lowest number of queries (running + queued queries).

## Impact


## Test Plan


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for custom scheduler plugin
* Add example custom scheduler plugin - Metrics based custom scheduler plugin
```



