### PR TITLE
Update gitconfig in the presto stable release pipeline

### DIFF
--- a/.github/workflows/presto-stable-release.yml
+++ b/.github/workflows/presto-stable-release.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Configure git
         run: |
           git config --global --add safe.directory ${{github.workspace}}
-          git config --global user.email "oss-release-bot@prestodb.io"
-          git config --global user.name "oss-release-bot"
+          git config --global user.email "ci@lists.prestodb.io"
+          git config --global user.name "prestodb-ci"
           git config pull.rebase false
 
       - name: Set maven version


### PR DESCRIPTION
## Description
The [commit](https://github.com/prestodb/presto/commit/943868a9183b0824d82651744b65aeef18832f44) pushed by the [Presto Stable Release Workflow](https://github.com/prestodb/presto/actions/runs/12990719178) is owned by `oss-release-bot` which is not exist.

The user and email need to be changed to the `prestodb-ci` account to ensure commits can be tracked easily.

## Motivation and Context

## Impact
Release workflow

## Test Plan
No plan. (To be verified on the next release)

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

