### PR TITLE
Record CPU time on various planning stages

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -50,6 +50,9 @@ public class RuntimeMetricName
     public static final String SCAN_STAGE_SCHEDULER_CPU_TIME_NANOS = "scanStageSchedulerCpuTimeNanos";
     public static final String SCAN_STAGE_SCHEDULER_WALL_TIME_NANOS = "scanStageSchedulerWallTimeNanos";
     public static final String SCAN_STAGE_SCHEDULER_BLOCKED_TIME_NANOS = "scanStageSchedulerBlockedTimeNanos";
+    public static final String ANALYZE_TIME_NANOS = "analyzeTimeNanos";
+    public static final String PLAN_AND_OPTIMIZE_TIME_NANOS = "planAndOptimizeTimeNanos";
+    public static final String CREATE_SCHEDULER_TIME_NANOS = "createSchedulerTimeNanos";
     public static final String LOGICAL_PLANNER_TIME_NANOS = "logicalPlannerTimeNanos";
     public static final String OPTIMIZER_TIME_NANOS = "optimizerTimeNanos";
     public static final String GET_CANONICAL_INFO_TIME_NANOS = "getCanonicalInfoTimeNanos";

--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
@@ -19,6 +19,8 @@ import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,6 +36,8 @@ import static java.util.Objects.requireNonNull;
 @ThriftStruct
 public class RuntimeStats
 {
+    private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+
     private final ConcurrentMap<String, RuntimeMetric> metrics = new ConcurrentHashMap<>();
 
     public RuntimeStats()
@@ -130,7 +134,7 @@ public class RuntimeStats
         stats.getMetrics().forEach((name, newMetric) -> metrics.computeIfAbsent(name, k -> new RuntimeMetric(name, newMetric.getUnit())).set(newMetric));
     }
 
-    public <V> V profileNanos(String tag, Supplier<V> supplier)
+    public <V> V recordWallTime(String tag, Supplier<V> supplier)
     {
         long startTime = System.nanoTime();
         V result = supplier.get();
@@ -138,10 +142,34 @@ public class RuntimeStats
         return result;
     }
 
-    public void profileNanosVoid(String tag, Runnable runnable)
+    public void recordWallTime(String tag, Runnable runnable)
     {
-        long startTime = System.nanoTime();
-        runnable.run();
-        addMetricValueIgnoreZero(tag, NANO, System.nanoTime() - startTime);
+        recordWallTime(tag, () -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    public <V> V recordWallAndCpuTime(String tag, Supplier<V> supplier)
+    {
+        long startWall = System.nanoTime();
+        long startCpu = THREAD_MX_BEAN.getCurrentThreadCpuTime();
+
+        V result = supplier.get();
+
+        long endWall = System.nanoTime();
+        long endCpu = THREAD_MX_BEAN.getCurrentThreadCpuTime();
+
+        addMetricValueIgnoreZero(tag, NANO, endWall - startWall);
+        addMetricValueIgnoreZero(tag + "OnCpu", NANO, endCpu - startCpu);
+        return result;
+    }
+
+    public void recordWallAndCpuTime(String tag, Runnable runnable)
+    {
+        recordWallAndCpuTime(tag, () -> {
+            runnable.run();
+            return null;
+        });
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -202,7 +202,7 @@ public class SemiTransactionalHiveMetastore
         checkReadable();
         Action<TableAndMore> tableAction = tableActions.get(hiveTableHandle.getSchemaTableName());
         if (tableAction == null) {
-            return metastoreContext.getRuntimeStats().profileNanos(GET_TABLE_TIME_NANOS, () -> delegate.getTable(metastoreContext, hiveTableHandle));
+            return metastoreContext.getRuntimeStats().recordWallTime(GET_TABLE_TIME_NANOS, () -> delegate.getTable(metastoreContext, hiveTableHandle));
         }
         switch (tableAction.getType()) {
             case ADD:
@@ -761,7 +761,7 @@ public class SemiTransactionalHiveMetastore
                 resultBuilder.put(partitionNameWithVersion.getPartitionName(), getPartitionFromPartitionAction(partitionAction));
             }
         }
-        Map<String, Optional<Partition>> delegateResult = metastoreContext.getRuntimeStats().profileNanos(GET_PARTITIONS_BY_NAMES_TIME_NANOS, () -> delegate.getPartitionsByNames(metastoreContext, databaseName, tableName, partitionNamesToQuery.build()));
+        Map<String, Optional<Partition>> delegateResult = metastoreContext.getRuntimeStats().recordWallTime(GET_PARTITIONS_BY_NAMES_TIME_NANOS, () -> delegate.getPartitionsByNames(metastoreContext, databaseName, tableName, partitionNamesToQuery.build()));
         resultBuilder.putAll(delegateResult);
 
         cacheLastDataCommitTimes(delegateResult, databaseName, tableName);

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -87,10 +87,13 @@ import static com.facebook.presto.SystemSessionProperties.getQueryAnalyzerTimeou
 import static com.facebook.presto.SystemSessionProperties.isEagerPlanValidationEnabled;
 import static com.facebook.presto.SystemSessionProperties.isLogInvokedFunctionNamesEnabled;
 import static com.facebook.presto.SystemSessionProperties.isSpoolingOutputBufferEnabled;
+import static com.facebook.presto.common.RuntimeMetricName.ANALYZE_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.CREATE_SCHEDULER_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.FRAGMENT_PLAN_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.GET_CANONICAL_INFO_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.LOGICAL_PLANNER_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.OPTIMIZER_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.PLAN_AND_OPTIMIZE_TIME_NANOS;
 import static com.facebook.presto.execution.QueryStateMachine.pruneHistogramsFromStatsAndCosts;
 import static com.facebook.presto.execution.buffer.OutputBuffers.BROADCAST_PARTITION_ID;
 import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
@@ -207,7 +210,9 @@ public class SqlQueryExecution
                     Thread.currentThread(),
                     timeoutThreadExecutor,
                     getQueryAnalyzerTimeout(getSession()))) {
-                this.queryAnalysis = queryAnalyzer.analyze(analyzerContext, preparedQuery);
+                this.queryAnalysis = getSession()
+                        .getRuntimeStats()
+                        .recordWallAndCpuTime(ANALYZE_TIME_NANOS, () -> queryAnalyzer.analyze(analyzerContext, preparedQuery));
             }
 
             stateMachine.setUpdateType(queryAnalysis.getUpdateType());
@@ -482,7 +487,7 @@ public class SqlQueryExecution
                 metadata.beginQuery(getSession(), plan.getConnectors());
 
                 // plan distribution of query
-                planDistribution(plan);
+                getSession().getRuntimeStats().recordWallAndCpuTime(CREATE_SCHEDULER_TIME_NANOS, () -> createQueryScheduler(plan));
 
                 // transition to starting
                 if (!stateMachine.transitionToStarting()) {
@@ -545,13 +550,22 @@ public class SqlQueryExecution
 
     private PlanRoot createLogicalPlanAndOptimize()
     {
+        return stateMachine.getSession()
+                .getRuntimeStats()
+                .recordWallAndCpuTime(
+                        PLAN_AND_OPTIMIZE_TIME_NANOS,
+                        this::doCreateLogicalPlanAndOptimize);
+    }
+
+    private PlanRoot doCreateLogicalPlanAndOptimize()
+    {
         try {
             // time analysis phase
             stateMachine.beginAnalysis();
 
             PlanNode planNode = stateMachine.getSession()
                     .getRuntimeStats()
-                    .profileNanos(
+                    .recordWallAndCpuTime(
                             LOGICAL_PLANNER_TIME_NANOS,
                             () -> queryAnalyzer.plan(this.analyzerContext, queryAnalysis));
 
@@ -567,14 +581,14 @@ public class SqlQueryExecution
                     costCalculator,
                     false);
 
-            Plan plan = getSession().getRuntimeStats().profileNanos(
+            Plan plan = getSession().getRuntimeStats().recordWallAndCpuTime(
                     OPTIMIZER_TIME_NANOS,
                     () -> optimizer.validateAndOptimizePlan(planNode, OPTIMIZED_AND_VALIDATED));
 
             queryPlan.set(plan);
             stateMachine.setPlanStatsAndCosts(plan.getStatsAndCosts());
             stateMachine.setPlanIdNodeMap(plan.getPlanIdNodeMap());
-            List<CanonicalPlanWithInfo> canonicalPlanWithInfos = getSession().getRuntimeStats().profileNanos(
+            List<CanonicalPlanWithInfo> canonicalPlanWithInfos = getSession().getRuntimeStats().recordWallAndCpuTime(
                     GET_CANONICAL_INFO_TIME_NANOS,
                     () -> getCanonicalInfo(getSession(), plan.getRoot(), planCanonicalInfoProvider));
             stateMachine.setPlanCanonicalInfo(canonicalPlanWithInfos);
@@ -590,7 +604,7 @@ public class SqlQueryExecution
             // fragment the plan
             // the variableAllocator is finally passed to SqlQueryScheduler for runtime cost-based optimizations
             variableAllocator.set(new VariableAllocator(plan.getTypes().allVariables()));
-            SubPlan fragmentedPlan = getSession().getRuntimeStats().profileNanos(
+            SubPlan fragmentedPlan = getSession().getRuntimeStats().recordWallAndCpuTime(
                     FRAGMENT_PLAN_TIME_NANOS,
                     () -> planFragmenter.createSubPlans(stateMachine.getSession(), plan, false, idAllocator, variableAllocator.get(), stateMachine.getWarningCollector()));
 
@@ -620,7 +634,7 @@ public class SqlQueryExecution
         }
     }
 
-    private void planDistribution(PlanRoot plan)
+    private void createQueryScheduler(PlanRoot plan)
     {
         CloseableSplitSourceProvider splitSourceProvider = new CloseableSplitSourceProvider(splitManager::getSplits);
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -1051,7 +1051,7 @@ public class MetadataManager
         ConnectorId connectorId = materializedViewHandle.get().getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
 
-        return session.getRuntimeStats().profileNanos(
+        return session.getRuntimeStats().recordWallTime(
                 GET_MATERIALIZED_VIEW_STATUS_TIME_NANOS,
                 () -> metadata.getMaterializedViewStatus(session.toConnectorSession(connectorId), toSchemaTableName(materializedViewName), baseQueryDomain));
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MetadataExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MetadataExtractor.java
@@ -84,7 +84,7 @@ public class MetadataExtractor
             }
 
             metadataHandle.addViewDefinition(tableName, executor.get().submit(() -> {
-                Optional<ViewDefinition> optionalView = session.getRuntimeStats().profileNanos(
+                Optional<ViewDefinition> optionalView = session.getRuntimeStats().recordWallTime(
                         GET_VIEW_TIME_NANOS,
                         () -> metadataResolver.getView(tableName));
                 if (optionalView.isPresent()) {
@@ -109,7 +109,7 @@ public class MetadataExtractor
             }));
 
             metadataHandle.addMaterializedViewDefinition(tableName, executor.get().submit(() -> {
-                Optional<MaterializedViewDefinition> optionalMaterializedView = session.getRuntimeStats().profileNanos(
+                Optional<MaterializedViewDefinition> optionalMaterializedView = session.getRuntimeStats().recordWallTime(
                         GET_MATERIALIZED_VIEW_TIME_NANOS,
                         () -> metadataResolver.getMaterializedView(tableName));
                 if (optionalMaterializedView.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -1170,7 +1170,7 @@ public class LocalQueryRunner
         QueryAnalysis queryAnalysis = queryAnalyzer.analyze(analyzerContext, preparedQuery);
         checkAccessPermissions(queryAnalysis.getAccessControlReferences());
 
-        PlanNode planNode = session.getRuntimeStats().profileNanos(
+        PlanNode planNode = session.getRuntimeStats().recordWallAndCpuTime(
                 LOGICAL_PLANNER_TIME_NANOS,
                 () -> queryAnalyzer.plan(analyzerContext, queryAnalysis));
 
@@ -1186,7 +1186,7 @@ public class LocalQueryRunner
                 costCalculator,
                 preparedQuery.getWrappedStatement() instanceof Explain);
 
-        return session.getRuntimeStats().profileNanos(
+        return session.getRuntimeStats().recordWallAndCpuTime(
                 OPTIMIZER_TIME_NANOS,
                 () -> optimizer.validateAndOptimizePlan(planNode, stage));
     }

--- a/presto-main/src/main/java/com/facebook/presto/util/MetadataUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/MetadataUtils.java
@@ -60,7 +60,7 @@ public class MetadataUtils
             return metadataHandle.getViewDefinition(viewName);
         }
 
-        return session.getRuntimeStats().profileNanos(
+        return session.getRuntimeStats().recordWallTime(
                 GET_VIEW_TIME_NANOS,
                 () -> metadataResolver.getView(viewName));
     }
@@ -71,14 +71,14 @@ public class MetadataUtils
             return metadataHandle.getMaterializedViewDefinition(viewName);
         }
 
-        return session.getRuntimeStats().profileNanos(
+        return session.getRuntimeStats().recordWallTime(
                 GET_MATERIALIZED_VIEW_TIME_NANOS,
                 () -> metadataResolver.getMaterializedView(viewName));
     }
 
     public static TableColumnMetadata getTableColumnMetadata(Session session, MetadataResolver metadataResolver, QualifiedObjectName tableName)
     {
-        Optional<TableHandle> tableHandle = session.getRuntimeStats().profileNanos(
+        Optional<TableHandle> tableHandle = session.getRuntimeStats().recordWallTime(
                 GET_TABLE_HANDLE_TIME_NANOS,
                 () -> metadataResolver.getTableHandle(tableName));
 
@@ -92,11 +92,11 @@ public class MetadataUtils
             throw new SemanticException(MISSING_TABLE, "Table %s does not exist", tableName);
         }
 
-        Map<String, ColumnHandle> columnHandles = session.getRuntimeStats().profileNanos(
+        Map<String, ColumnHandle> columnHandles = session.getRuntimeStats().recordWallTime(
                 GET_COLUMN_HANDLE_TIME_NANOS,
                 () -> metadataResolver.getColumnHandles(tableHandle.get()));
 
-        List<ColumnMetadata> columnsMetadata = session.getRuntimeStats().profileNanos(
+        List<ColumnMetadata> columnsMetadata = session.getRuntimeStats().recordWallTime(
                 GET_COLUMN_METADATA_TIME_NANOS,
                 () -> metadataResolver.getColumns(tableHandle.get()));
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
@@ -127,7 +127,7 @@ public class PrestoSparkQueryPlanner
                 variableAllocator,
                 sqlParser);
 
-        PlanNode planNode = session.getRuntimeStats().profileNanos(
+        PlanNode planNode = session.getRuntimeStats().recordWallAndCpuTime(
                 LOGICAL_PLANNER_TIME_NANOS,
                 () -> logicalPlanner.plan(analysis));
 
@@ -143,7 +143,7 @@ public class PrestoSparkQueryPlanner
                 costCalculator,
                 false);
 
-        Plan plan = session.getRuntimeStats().profileNanos(
+        Plan plan = session.getRuntimeStats().recordWallAndCpuTime(
                 OPTIMIZER_TIME_NANOS,
                 () -> optimizer.validateAndOptimizePlan(planNode, OPTIMIZED_AND_VALIDATED));
 


### PR DESCRIPTION
## Description

Record additional runtime metrics to help understand planning latency sources.

## Motivation and Context

Recording CPU time will help with attributing latency to RPC activity vs on CPU activity of various planning stages

## Impact

N/A

## Test Plan

CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

