### PR TITLE
Add support for multiple query event listeners

### DIFF
--- a/presto-docs/src/main/sphinx/develop/event-listener.rst
+++ b/presto-docs/src/main/sphinx/develop/event-listener.rst
@@ -46,3 +46,14 @@ Example configuration file:
     event-listener.name=custom-event-listener
     custom-property1=custom-value1
     custom-property2=custom-value2
+
+Multiple Event Listeners
+------------------------
+
+Multiple instances of the same, or different event listeners can be
+installed and configured by setting ``event-listener.config-files``
+to a comma separated list of config files.
+
+.. code-block:: none
+
+    event-listener.config-files=etc/event-listener.properties,etc/event-listener-second.properties

--- a/presto-main/src/main/java/com/facebook/presto/eventlistener/EventListenerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/eventlistener/EventListenerConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.eventlistener;
+
+import com.facebook.airlift.configuration.Config;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.File;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class EventListenerConfig
+{
+    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+    private List<File> eventListenerFiles = ImmutableList.of();
+
+    @NotNull
+    public List<File> getEventListenerFiles()
+    {
+        return eventListenerFiles;
+    }
+
+    @Config("event-listener.config-files")
+    public EventListenerConfig setEventListenerFiles(String eventListenerFiles)
+    {
+        this.eventListenerFiles = SPLITTER.splitToList(eventListenerFiles).stream()
+                .map(File::new)
+                .collect(toImmutableList());
+        return this;
+    }
+
+    public EventListenerConfig setEventListenerFiles(List<File> eventListenerFiles)
+    {
+        this.eventListenerFiles = ImmutableList.copyOf(eventListenerFiles);
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/eventlistener/EventListenerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/eventlistener/EventListenerModule.java
@@ -17,12 +17,17 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
 public class EventListenerModule
         implements Module
 {
     @Override
     public void configure(Binder binder)
     {
+        configBinder(binder).bindConfig(EventListenerConfig.class);
         binder.bind(EventListenerManager.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(EventListenerManager.class).withGeneratedName();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -181,7 +181,7 @@ public class PrestoServer
             }
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
             injector.getInstance(PrestoAuthenticatorManager.class).loadPrestoAuthenticator();
-            injector.getInstance(EventListenerManager.class).loadConfiguredEventListener();
+            injector.getInstance(EventListenerManager.class).loadConfiguredEventListeners();
             injector.getInstance(TempStorageManager.class).loadTempStorages();
             injector.getInstance(QueryPrerequisitesManager.class).loadQueryPrerequisites();
             injector.getInstance(NodeTtlFetcherManager.class).loadNodeTtlFetcher();

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -38,6 +38,7 @@ import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.dispatcher.QueryPrerequisitesManagerModule;
+import com.facebook.presto.eventlistener.EventListenerConfig;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryManager;
@@ -324,6 +325,7 @@ public class TestingPrestoServer
                     binder.bind(TestingTempStorageManager.class).in(Scopes.SINGLETON);
                     binder.bind(AccessControlManager.class).to(TestingAccessControlManager.class).in(Scopes.SINGLETON);
                     binder.bind(EventListenerManager.class).to(TestingEventListenerManager.class).in(Scopes.SINGLETON);
+                    binder.bind(EventListenerConfig.class).in(Scopes.SINGLETON);
                     binder.bind(TempStorageManager.class).to(TestingTempStorageManager.class).in(Scopes.SINGLETON);
                     binder.bind(AccessControl.class).to(AccessControlManager.class).in(Scopes.SINGLETON);
                     binder.bind(ShutdownAction.class).to(TestShutdownAction.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -51,6 +51,7 @@ import com.facebook.presto.cost.StatsNormalizer;
 import com.facebook.presto.cost.TaskCountEstimator;
 import com.facebook.presto.dispatcher.NoOpQueryManager;
 import com.facebook.presto.dispatcher.QueryPrerequisitesManager;
+import com.facebook.presto.eventlistener.EventListenerConfig;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.AlterFunctionTask;
 import com.facebook.presto.execution.CommitTask;
@@ -542,7 +543,7 @@ public class LocalQueryRunner
                 accessControl,
                 new PasswordAuthenticatorManager(),
                 new PrestoAuthenticatorManager(new SecurityConfig()),
-                new EventListenerManager(),
+                new EventListenerManager(new EventListenerConfig()),
                 blockEncodingManager,
                 new TestingTempStorageManager(),
                 new QueryPrerequisitesManager(),

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingEventListenerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingEventListenerManager.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.testing;
 
+import com.facebook.presto.eventlistener.EventListenerConfig;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
@@ -22,6 +23,7 @@ import com.facebook.presto.spi.eventlistener.QueryProgressEvent;
 import com.facebook.presto.spi.eventlistener.QueryUpdatedEvent;
 import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,6 +32,12 @@ public class TestingEventListenerManager
         extends EventListenerManager
 {
     private final AtomicReference<Optional<EventListener>> configuredEventListener = new AtomicReference<>(Optional.empty());
+
+    @Inject
+    public TestingEventListenerManager(EventListenerConfig config)
+    {
+        super(config);
+    }
 
     @Override
     public void addEventListenerFactory(EventListenerFactory eventListenerFactory)

--- a/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
+++ b/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
@@ -20,6 +20,7 @@ import com.facebook.presto.cost.HistoryBasedOptimizationConfig;
 import com.facebook.presto.cost.HistoryBasedPlanStatisticsManager;
 import com.facebook.presto.event.QueryMonitor;
 import com.facebook.presto.event.QueryMonitorConfig;
+import com.facebook.presto.eventlistener.EventListenerConfig;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.ClusterSizeMonitor;
 import com.facebook.presto.execution.ExecutionFailureInfo;
@@ -464,7 +465,7 @@ public class TestLocalDispatchQuery
 
     private EventListenerManager createEventListenerManager(CountingEventListener countingEventListener)
     {
-        EventListenerManager eventListenerManager = new EventListenerManager();
+        EventListenerManager eventListenerManager = new EventListenerManager(new EventListenerConfig());
         eventListenerManager.addEventListenerFactory(new TestEventListenerFactory(countingEventListener));
         eventListenerManager.loadConfiguredEventListener(ImmutableMap.of("event-listener.name", TestEventListenerFactory.NAME));
         return eventListenerManager;

--- a/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.eventlistener;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+public class TestEventListenerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(EventListenerConfig.class)
+                .setEventListenerFiles(""));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("event-listener.config-files", "a,b,c")
+                .build();
+
+        EventListenerConfig expected = new EventListenerConfig()
+                .setEventListenerFiles("a,b,c");
+        assertFullMapping(properties, expected);
+
+        ImmutableList.Builder<File> filesBuilder = ImmutableList.builder();
+        filesBuilder.add(new File("a"), new File("b"), new File("c"));
+        //Test List version
+        expected = new EventListenerConfig()
+                .setEventListenerFiles(filesBuilder.build());
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
@@ -1,0 +1,549 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.eventlistener;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
+import com.facebook.presto.common.resourceGroups.QueryType;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.eventlistener.CTEInformation;
+import com.facebook.presto.spi.eventlistener.EventListener;
+import com.facebook.presto.spi.eventlistener.EventListenerFactory;
+import com.facebook.presto.spi.eventlistener.OperatorStatistics;
+import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
+import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
+import com.facebook.presto.spi.eventlistener.QueryContext;
+import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryFailureInfo;
+import com.facebook.presto.spi.eventlistener.QueryIOMetadata;
+import com.facebook.presto.spi.eventlistener.QueryInputMetadata;
+import com.facebook.presto.spi.eventlistener.QueryMetadata;
+import com.facebook.presto.spi.eventlistener.QueryOutputMetadata;
+import com.facebook.presto.spi.eventlistener.QueryStatistics;
+import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
+import com.facebook.presto.spi.eventlistener.SplitFailureInfo;
+import com.facebook.presto.spi.eventlistener.SplitStatistics;
+import com.facebook.presto.spi.eventlistener.StageStatistics;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.prestospark.PrestoSparkExecutionContext;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.spi.session.ResourceEstimates;
+import com.facebook.presto.spi.statistics.PlanStatisticsWithSourceInfo;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+@Test
+public class TestEventListenerManager
+{
+    private static final Logger log = Logger.get(TestEventListenerManager.class);
+    private final EventsCapture generatedEvents = new EventsCapture();
+
+    @Test
+    public void testMultipleEventListeners() throws IOException
+    {
+        Path tempFile1 = Files.createTempFile("listener1_", ".properties");
+        Path tempFile2 = Files.createTempFile("listener2_", ".properties");
+        Path tempFile3 = Files.createTempFile("listener3_", ".properties");
+
+        writeProperties(tempFile1, "event-listener.name", "wxd-event-listener1");
+        writeProperties(tempFile2, "event-listener.name", "wxd-event-listener2");
+        writeProperties(tempFile3, "event-listener.name", "wxd-event-listener3");
+
+        EventListenerConfig config = new EventListenerConfig()
+                .setEventListenerFiles(tempFile1.toFile().getPath() + "," + tempFile2.toFile().getPath() + "," + tempFile3.toFile().getPath());
+        EventListenerManager eventListenerManager = new EventListenerManager(config);
+        TestingEventListener testingEventListener = new TestingEventListener(generatedEvents);
+        eventListenerManager.addEventListenerFactory(new TestEventListenerFactory(testingEventListener, "wxd-event-listener1"));
+        eventListenerManager.addEventListenerFactory(new TestEventListenerFactory(testingEventListener, "wxd-event-listener2"));
+        eventListenerManager.addEventListenerFactory(new TestEventListenerFactory(testingEventListener, "wxd-event-listener3"));
+        eventListenerManager.loadConfiguredEventListeners();
+
+        QueryCreatedEvent queryCreatedEvent = createDummyQueryCreatedEvent();
+        eventListenerManager.queryCreated(queryCreatedEvent);
+        QueryCompletedEvent queryCompletedEvent = createDummyQueryCompletedEvent();
+        eventListenerManager.queryCompleted(queryCompletedEvent);
+        SplitCompletedEvent splitCompletedEvent = createDummySplitCompletedEvent();
+        eventListenerManager.splitCompleted(splitCompletedEvent);
+
+        assertEquals(generatedEvents.getQueryCreatedEvents().size(), 3);
+        assertEquals(generatedEvents.getQueryCompletedEvents().size(), 3);
+        assertEquals(generatedEvents.getSplitCompletedEvents().size(), 3);
+        generatedEvents.getQueryCreatedEvents().forEach(event -> assertEquals(event, queryCreatedEvent));
+        generatedEvents.getQueryCompletedEvents().forEach(event -> assertEquals(event, queryCompletedEvent));
+        generatedEvents.getSplitCompletedEvents().forEach(event -> assertEquals(event, splitCompletedEvent));
+
+        tryDeleteFile(tempFile1);
+        tryDeleteFile(tempFile2);
+        tryDeleteFile(tempFile3);
+    }
+
+    @Test
+    public void testEventListenerNotRegistered() throws IOException
+    {
+        Path tempFile1 = Files.createTempFile("listener1_", ".properties");
+        Path tempFile2 = Files.createTempFile("listener2_", ".properties");
+
+        writeProperties(tempFile1, "event-listener.name", "wxd-event-listener1");
+        writeProperties(tempFile2, "event-listener.name", "wxd-event-listener2");
+        EventListenerConfig config = new EventListenerConfig().setEventListenerFiles(tempFile1.toFile().getPath() + "," + tempFile2.toFile().getPath());
+
+        EventListenerManager eventListenerManager = new EventListenerManager(config);
+        TestingEventListener testingEventListener = new TestingEventListener(generatedEvents);
+        eventListenerManager.addEventListenerFactory(new TestEventListenerFactory(testingEventListener, "wxd-event-listener1"));
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> {
+            eventListenerManager.loadConfiguredEventListeners();
+        });
+
+        String expectedMessage = "Event listener wxd-event-listener2 is not registered";
+        assertEquals(exception.getMessage(), expectedMessage);
+    }
+
+    private void writeProperties(Path filePath, String key, String value)
+            throws IOException
+    {
+        Properties properties = new Properties();
+        properties.setProperty(key, value);
+
+        try (FileOutputStream outputStream = new FileOutputStream(filePath.toFile())) {
+            properties.store(outputStream, "Test Properties");
+        }
+    }
+
+    public static QueryCreatedEvent createDummyQueryCreatedEvent()
+    {
+        QueryMetadata metadata = createDummyQueryMetadata();
+        QueryContext context = createDummyQueryContext();
+        return new QueryCreatedEvent(Instant.now(), context, metadata);
+    }
+
+    public static QueryCompletedEvent createDummyQueryCompletedEvent()
+    {
+        QueryMetadata metadata = createDummyQueryMetadata();
+        QueryStatistics statistics = createDummyQueryStatistics();
+        QueryContext context = createDummyQueryContext();
+        QueryIOMetadata ioMetadata = createDummyQueryIoMetadata();
+        Optional<QueryFailureInfo> failureInfo = Optional.empty();
+        List<PrestoWarning> warnings = new ArrayList<>();
+        Optional<QueryType> queryType = Optional.empty();
+        List<String> failedTasks = new ArrayList<>();
+        Instant createTime = Instant.now();
+        Instant executionStartTime = Instant.now().minusSeconds(10);
+        Instant endTime = Instant.now().plusSeconds(10);
+        List<StageStatistics> stageStatistics = new ArrayList<>();
+        List<OperatorStatistics> operatorStatistics = new ArrayList<>();
+        List<PlanStatisticsWithSourceInfo> planStatisticsRead = new ArrayList<>();
+        List<PlanStatisticsWithSourceInfo> planStatisticsWritten = new ArrayList<>();
+        Map<PlanNodeId, Map<PlanCanonicalizationStrategy, String>> planNodeHash = new HashMap<>();
+        Map<PlanCanonicalizationStrategy, String> canonicalPlan = new HashMap<>();
+        Optional<String> statsEquivalentPlan = Optional.empty();
+        Optional<String> expandedQuery = Optional.empty();
+        List<PlanOptimizerInformation> optimizerInformation = new ArrayList<>();
+        List<CTEInformation> cteInformationList = new ArrayList<>();
+        Set<String> scalarFunctions = new HashSet<>();
+        Set<String> aggregateFunctions = new HashSet<>();
+        Set<String> windowFunctions = new HashSet<>();
+        Optional<PrestoSparkExecutionContext> prestoSparkExecutionContext = Optional.empty();
+        Map<PlanCanonicalizationStrategy, String> hboPlanHash = new HashMap<>();
+        Optional<Map<PlanNodeId, PlanNode>> planIdNodeMap = Optional.ofNullable(new HashMap<>());
+
+        return new QueryCompletedEvent(
+                metadata,
+                statistics,
+                context,
+                ioMetadata,
+                failureInfo,
+                warnings,
+                queryType,
+                failedTasks,
+                createTime,
+                executionStartTime,
+                endTime,
+                stageStatistics,
+                operatorStatistics,
+                planStatisticsRead,
+                planStatisticsWritten,
+                planNodeHash,
+                canonicalPlan,
+                statsEquivalentPlan,
+                expandedQuery,
+                optimizerInformation,
+                cteInformationList,
+                scalarFunctions,
+                aggregateFunctions,
+                windowFunctions,
+                prestoSparkExecutionContext,
+                hboPlanHash,
+                planIdNodeMap);
+    }
+
+    public static QueryStatistics createDummyQueryStatistics()
+    {
+        Duration cpuTime = Duration.ofMillis(1000);
+        Duration retriedCpuTime = Duration.ofMillis(500);
+        Duration wallTime = Duration.ofMillis(2000);
+        Duration waitingForPrerequisitesTime = Duration.ofMillis(300);
+        Duration queuedTime = Duration.ofMillis(1500);
+        Duration waitingForResourcesTime = Duration.ofMillis(600);
+        Duration semanticAnalyzingTime = Duration.ofMillis(700);
+        Duration columnAccessPermissionCheckingTime = Duration.ofMillis(200);
+        Duration dispatchingTime = Duration.ofMillis(1200);
+        Duration planningTime = Duration.ofMillis(2500);
+        Optional<Duration> analysisTime = Optional.of(Duration.ofMillis(1800));
+        Duration executionTime = Duration.ofMillis(3500);
+
+        int peakRunningTasks = 5;
+        long peakUserMemoryBytes = 500000000L;
+        long peakTotalNonRevocableMemoryBytes = 800000000L;
+        long peakTaskUserMemory = 100000000L;
+        long peakTaskTotalMemory = 200000000L;
+        long peakNodeTotalMemory = 120000000L;
+        long shuffledBytes = 10000000L;
+        long shuffledRows = 200000L;
+        long totalBytes = 30000000L;
+        long totalRows = 400000L;
+        long outputBytes = 5000000L;
+        long outputRows = 60000L;
+        long writtenOutputBytes = 7000000L;
+        long writtenOutputRows = 80000L;
+        long writtenIntermediateBytes = 9000000L;
+        long spilledBytes = 1000000L;
+        double cumulativeMemory = 150.5;
+        double cumulativeTotalMemory = 200.5;
+        int completedSplits = 100;
+        boolean complete = true;
+        RuntimeStats runtimeStats = new RuntimeStats();
+        return new QueryStatistics(
+                cpuTime,
+                retriedCpuTime,
+                wallTime,
+                waitingForPrerequisitesTime,
+                queuedTime,
+                waitingForResourcesTime,
+                semanticAnalyzingTime,
+                columnAccessPermissionCheckingTime,
+                dispatchingTime,
+                planningTime,
+                analysisTime,
+                executionTime,
+                peakRunningTasks,
+                peakUserMemoryBytes,
+                peakTotalNonRevocableMemoryBytes,
+                peakTaskUserMemory,
+                peakTaskTotalMemory,
+                peakNodeTotalMemory,
+                shuffledBytes,
+                shuffledRows,
+                totalBytes,
+                totalRows,
+                outputBytes,
+                outputRows,
+                writtenOutputBytes,
+                writtenOutputRows,
+                writtenIntermediateBytes,
+                spilledBytes,
+                cumulativeMemory,
+                cumulativeTotalMemory,
+                completedSplits,
+                complete,
+                runtimeStats);
+    }
+
+    private static QueryMetadata createDummyQueryMetadata()
+    {
+        String queryId = "20250216_173945_00000_9r4vt";
+        Optional<String> transactionId = Optional.of("dummy-transaction-id");
+        String query = "SELECT * FROM dummy_table";
+        String queryHash = "dummy-query-hash";
+        Optional<String> preparedQuery = Optional.of("PREPARE SELECT * FROM dummy_table");
+        String queryState = "COMPLETED";
+        URI uri = URI.create("http://localhost/query/dummy-query-id");
+        Optional<String> plan = Optional.of("dummy-plan");
+        Optional<String> jsonPlan = Optional.of("{\"plan\": \"dummy-plan\"}");
+        Optional<String> graphvizPlan = Optional.of("digraph {node1 -> node2}");
+        Optional<String> payload = Optional.of("dummy-payload");
+        List<String> runtimeOptimizedStages = new ArrayList<>(Arrays.asList("stage1", "stage2"));
+        Optional<String> tracingId = Optional.of("dummy-tracing-id");
+
+        return new QueryMetadata(
+                queryId,
+                transactionId,
+                query,
+                queryHash,
+                preparedQuery,
+                queryState,
+                uri,
+                plan,
+                jsonPlan,
+                graphvizPlan,
+                payload,
+                runtimeOptimizedStages,
+                tracingId);
+    }
+
+    private static QueryContext createDummyQueryContext()
+    {
+        String user = "dummyUser";
+        String serverAddress = "127.0.0.1";
+        String serverVersion = "testversion";
+        String environment = "testing";
+        String workerType = "worker-1";
+
+        Optional<String> principal = Optional.of("dummyPrincipal");
+        Optional<String> remoteClientAddress = Optional.of("192.168.1.100");
+        Optional<String> userAgent = Optional.of("Mozilla/5.0");
+        Optional<String> clientInfo = Optional.of("Dummy Client Info");
+        Optional<String> source = Optional.empty();
+        Optional<String> catalog = Optional.of("dummyCatalog");
+        Optional<String> schema = Optional.of("dummySchema");
+        Optional<ResourceGroupId> resourceGroupId = Optional.of(new ResourceGroupId("dummyGroupId"));
+
+        Set<String> clientTags = new HashSet<>(Arrays.asList("tag1", "tag2", "tag3"));
+
+        Map<String, String> sessionProperties = new HashMap<>();
+        sessionProperties.put("property1", "value1");
+        sessionProperties.put("property2", "value2");
+
+        ResourceEstimates resourceEstimates = new ResourceEstimates(
+                Optional.of(new io.airlift.units.Duration(1200, TimeUnit.SECONDS)),
+                Optional.of(new io.airlift.units.Duration(1200, TimeUnit.SECONDS)),
+                Optional.of(new io.airlift.units.DataSize(2, DataSize.Unit.GIGABYTE)),
+                Optional.of(new io.airlift.units.DataSize(2, DataSize.Unit.GIGABYTE)));
+        return new QueryContext(
+                user,
+                principal,
+                remoteClientAddress,
+                userAgent,
+                clientInfo,
+                clientTags,
+                source,
+                catalog,
+                schema,
+                resourceGroupId,
+                sessionProperties,
+                resourceEstimates,
+                serverAddress,
+                serverVersion,
+                environment,
+                workerType);
+    }
+
+    private static QueryIOMetadata createDummyQueryIoMetadata()
+    {
+        List<QueryInputMetadata> inputs = new ArrayList<>();
+        QueryInputMetadata queryInputMetadata = getQueryInputMetadata();
+        inputs.add(queryInputMetadata);
+        QueryOutputMetadata outputMetadata = new QueryOutputMetadata(
+                "dummyCatalog",
+                "dummySchema",
+                "dummyTable",
+                Optional.of("dummyConnectorMetadata"),
+                Optional.of(true),
+                "dummySerializedCommitOutput");
+        return new QueryIOMetadata(inputs, Optional.of(outputMetadata));
+    }
+
+    private static QueryInputMetadata getQueryInputMetadata()
+    {
+        String catalogName = "dummyCatalog";
+        String schema = "dummySchema";
+        String table = "dummyTable";
+        String serializedCommitOutput = "commitOutputDummy";
+        List<String> columns = new ArrayList<>(Arrays.asList("column1", "column2", "column3"));
+        Optional<Object> connectorInfo = Optional.of(new Object());
+        return new QueryInputMetadata(
+                catalogName,
+                schema,
+                table,
+                columns,
+                connectorInfo,
+                Optional.empty(),
+                serializedCommitOutput);
+    }
+
+    private static SplitCompletedEvent createDummySplitCompletedEvent()
+    {
+        Instant now = Instant.now();
+        Instant startTimeDummy = now.minusSeconds(100);
+        Instant endTimeDummy = now.minusSeconds(50);
+        SplitStatistics stats = createDummySplitStatistics();
+        SplitFailureInfo failureInfo = new SplitFailureInfo("Error", "Dummy failure message");
+        return new SplitCompletedEvent(
+                "query123",
+                "stage456",
+                "stageExec789",
+                "task012",
+                now,
+                Optional.of(startTimeDummy),
+                Optional.of(endTimeDummy),
+                stats,
+                Optional.of(failureInfo),
+                "dummyPayload");
+    }
+
+    private static SplitStatistics createDummySplitStatistics()
+    {
+        Duration cpuTime = Duration.ofSeconds(500);
+        Duration wallTime = Duration.ofSeconds(1000);
+        Duration queuedTime = Duration.ofSeconds(120);
+        Duration completedReadTime = Duration.ofSeconds(800);
+
+        long completedPositions = 1500;
+        long completedDataSizeBytes = 10000000L;
+
+        Optional<Duration> timeToFirstByte = Optional.of(Duration.ofSeconds(10));
+        Optional<Duration> timeToLastByte = Optional.empty();
+
+        return new SplitStatistics(
+                cpuTime,
+                wallTime,
+                queuedTime,
+                completedReadTime,
+                completedPositions,
+                completedDataSizeBytes,
+                timeToFirstByte,
+                timeToLastByte);
+    }
+
+    private static void tryDeleteFile(Path path)
+    {
+        try {
+            File file = new File(path.toUri());
+            if (file.exists()) {
+                Files.delete(file.toPath());
+            }
+        }
+        catch (IOException e) {
+            log.error(e, "Could not delete file found at [%s]", path);
+        }
+    }
+
+    private static class TestEventListenerFactory
+            implements EventListenerFactory
+    {
+        public static String name;
+        private final TestingEventListener testingEventListener;
+
+        public TestEventListenerFactory(TestingEventListener testingEventListener, String name)
+        {
+            this.testingEventListener = requireNonNull(testingEventListener, "testingEventListener is null");
+            this.name = name;
+        }
+
+        @Override
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public EventListener create(Map<String, String> config)
+        {
+            return testingEventListener;
+        }
+    }
+
+    private static class TestingEventListener
+            implements EventListener
+    {
+        private final EventsCapture eventsCapture;
+
+        public TestingEventListener(EventsCapture eventsCapture)
+        {
+            this.eventsCapture = eventsCapture;
+        }
+
+        @Override
+        public void queryCreated(QueryCreatedEvent queryCreatedEvent)
+        {
+            eventsCapture.addQueryCreated(queryCreatedEvent);
+        }
+
+        @Override
+        public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
+        {
+            eventsCapture.addQueryCompleted(queryCompletedEvent);
+        }
+
+        @Override
+        public void splitCompleted(SplitCompletedEvent splitCompletedEvent)
+        {
+            eventsCapture.addSplitCompleted(splitCompletedEvent);
+        }
+    }
+
+    private static class EventsCapture
+    {
+        private final ImmutableList.Builder<QueryCreatedEvent> queryCreatedEvents = ImmutableList.builder();
+        private final ImmutableList.Builder<QueryCompletedEvent> queryCompletedEvents = ImmutableList.builder();
+        private final ImmutableList.Builder<SplitCompletedEvent> splitCompletedEvents = ImmutableList.builder();
+
+        public synchronized void addQueryCreated(QueryCreatedEvent event)
+        {
+            queryCreatedEvents.add(event);
+        }
+
+        public synchronized void addQueryCompleted(QueryCompletedEvent event)
+        {
+            queryCompletedEvents.add(event);
+        }
+
+        public synchronized void addSplitCompleted(SplitCompletedEvent event)
+        {
+            splitCompletedEvents.add(event);
+        }
+
+        public List<QueryCreatedEvent> getQueryCreatedEvents()
+        {
+            return queryCreatedEvents.build();
+        }
+
+        public List<QueryCompletedEvent> getQueryCompletedEvents()
+        {
+            return queryCompletedEvents.build();
+        }
+
+        public List<SplitCompletedEvent> getSplitCompletedEvents()
+        {
+            return splitCompletedEvents.build();
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.dispatcher.NoOpQueryManager;
 import com.facebook.presto.event.SplitMonitor;
+import com.facebook.presto.eventlistener.EventListenerConfig;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
@@ -201,7 +202,7 @@ public final class TaskTestUtils
     public static SplitMonitor createTestSplitMonitor()
     {
         return new SplitMonitor(
-                new EventListenerManager(),
+                new EventListenerManager(new EventListenerConfig()),
                 new JsonObjectMapperProvider().get());
     }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add support for multiple query event listeners to allow multiple plugins to handle events independently.
Cherry-pick of  https://github.com/trinodb/trino/pull/3128

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Issue : https://github.com/prestodb/presto/issues/24454

## Test Plan
<!---Please fill in how you tested your change-->


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Add support for multiple query event listeners.

```


