### PR TITLE
Upgrade libthrift to 0.14.1 due CVE-2020-13949

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1468,7 +1468,7 @@
             <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
-                <version>0.9.3-1</version>
+                <version>0.14.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>
@@ -1477,6 +1477,10 @@
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>
                         <artifactId>httpclient</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.tomcat.embed</groupId>
+                        <artifactId>tomcat-embed-core</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -19,6 +19,17 @@
         <dep.reload4j.version>1.2.18.3</dep.reload4j.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <!-- libthrift >= 0.14.1 not compatible with accumulo-minicluster 1.x -->
+                <version>0.9.3-1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.accumulo</groupId>

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/Transport.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/Transport.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore.thrift;
 
 import com.facebook.presto.hive.authentication.HiveMetastoreAuthentication;
 import com.google.common.net.HostAndPort;
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
@@ -216,6 +217,27 @@ public final class Transport
             catch (TTransportException e) {
                 throw rewriteException(e, address);
             }
+        }
+
+        // Methods added in libthrift 0.14.0 and not present in Hive Metastore <= 3.1.2
+        @Override
+        public TConfiguration getConfiguration()
+        {
+            return TConfiguration.DEFAULT;
+        }
+
+        @Override
+        public void updateKnownMessageSize(long size)
+                throws TTransportException
+        {
+            // noop: method added in libthrift 0.14.0 and not present in Hive Metastore <= 3.1.2
+        }
+
+        @Override
+        public void checkReadBytesAvailable(long numBytes)
+                throws TTransportException
+        {
+            // noop: method added in libthrift 0.14.0 and not present in Hive Metastore <= 3.1.2
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.authentication;
 
 import com.facebook.presto.hive.ForHiveMetastore;
 import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.hive.metastore.security.DelegationTokenIdentifier;
 import org.apache.hadoop.hive.thrift.client.TUGIAssumingTransport;
@@ -24,6 +25,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.thrift.transport.TSaslClientTransport;
 import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
 
 import javax.inject.Inject;
 import javax.security.auth.callback.Callback;
@@ -40,6 +42,7 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static javax.security.sasl.Sasl.QOP;
@@ -97,6 +100,9 @@ public class KerberosHiveMetastoreAuthentication
         }
         catch (IOException ex) {
             throw new UncheckedIOException(ex);
+        }
+        catch (TTransportException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
     }
 
@@ -174,6 +180,9 @@ public class KerberosHiveMetastoreAuthentication
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+        catch (TTransportException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
     }
 }


### PR DESCRIPTION
## Description
Fix CVE-2018-1320, CVE-2019-0205, CVE-2019-0210 and CVE-2020-13949.

The version chosen is 0.14.1, although more recent versions exist, because it does not have CRITICAL and HIGH severity CVEs and has been tested in several scenarios with different versions of Hive Metastore.

Fix for #18026
## Motivation and Context
The PR upgrades libthrift version to address known CVEs.

Exception made for Accumulo connector, since the version of Accumulo used is not compatible with newer versions of libthrift.


## Impact
Dependency org.apache.thrift:libthrift:0.9.3 has four HIGH vulnerabilities:

https://nvd.nist.gov/vuln/detail/CVE-2018-1320
https://nvd.nist.gov/vuln/detail/CVE-2019-0205
https://nvd.nist.gov/vuln/detail/CVE-2019-0210
https://nvd.nist.gov/vuln/detail/CVE-2020-13949


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Upgrade libthrift to 0.14.1 in response to `CVE-2020-13949 <https://github.com/advisories/GHSA-g2fg-mr77-6vrm>`_
