### PR TITLE
Fix getting views for Hive metastore 2.3+ 

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -183,6 +183,9 @@ public class ThriftHiveMetastore
     private final boolean isMetastoreAuthenticationEnabled;
     private final boolean deleteFilesOnTableDrop;
 
+    private volatile boolean metastoreKnownToSupportTableParamEqualsPredicate;
+    private volatile boolean metastoreKnownToSupportTableParamLikePredicate;
+
     @Inject
     public ThriftHiveMetastore(HiveCluster hiveCluster, MetastoreClientConfig config, HdfsEnvironment hdfsEnvironment)
     {
@@ -896,11 +899,9 @@ public class ThriftHiveMetastore
             return retry()
                     .stopOn(UnknownDBException.class)
                     .stopOnIllegalExceptions()
-                    .run("getAllViews", stats.getGetAllViews().wrap(() ->
-                            getMetastoreClientThenCall(metastoreContext, client -> {
-                                String filter = HIVE_FILTER_FIELD_PARAMS + PRESTO_VIEW_FLAG + " = \"true\"";
-                                return Optional.of(client.getTableNamesByFilter(databaseName, filter));
-                            })));
+                    .run("getAllViews", stats.getGetAllViews().wrap(() -> {
+                        return Optional.of(getPrestoViews(databaseName));
+                    }));
         }
         catch (UnknownDBException e) {
             return Optional.empty();
@@ -1207,6 +1208,46 @@ public class ThriftHiveMetastore
             storePartitionColumnStatistics(metastoreContext, databaseName, tableName, partitionWithStatistics.getPartitionName(), partitionWithStatistics);
         }
         return EMPTY_RESULT;
+    }
+
+    private List<String> getPrestoViews(String databaseName)
+            throws TException
+    {
+        /*
+         * Thrift call `get_table_names_by_filter` may be translated by Metastore to a SQL query against Metastore database.
+         * Hive 2.3 on some databases uses CLOB for table parameter value column and some databases disallow `=` predicate over
+         * CLOB values. At the same time, they allow `LIKE` predicates over them.
+         */
+        String filterWithEquals = HIVE_FILTER_FIELD_PARAMS + PRESTO_VIEW_FLAG + " = \"true\"";
+        String filterWithLike = HIVE_FILTER_FIELD_PARAMS + PRESTO_VIEW_FLAG + " LIKE \"true\"";
+        if (metastoreKnownToSupportTableParamEqualsPredicate) {
+            try (HiveMetastoreClient client = clientProvider.createMetastoreClient(Optional.empty())) {
+                return client.getTableNamesByFilter(databaseName, filterWithEquals);
+            }
+        }
+        if (metastoreKnownToSupportTableParamLikePredicate) {
+            try (HiveMetastoreClient client = clientProvider.createMetastoreClient(Optional.empty())) {
+                return client.getTableNamesByFilter(databaseName, filterWithLike);
+            }
+        }
+        try (HiveMetastoreClient client = clientProvider.createMetastoreClient(Optional.empty())) {
+            List<String> views = client.getTableNamesByFilter(databaseName, filterWithEquals);
+            metastoreKnownToSupportTableParamEqualsPredicate = true;
+            return views;
+        }
+        catch (TException | RuntimeException firstException) {
+            try (HiveMetastoreClient client = clientProvider.createMetastoreClient(Optional.empty())) {
+                List<String> views = client.getTableNamesByFilter(databaseName, filterWithLike);
+                metastoreKnownToSupportTableParamLikePredicate = true;
+                return views;
+            }
+            catch (TException | RuntimeException secondException) {
+                if (firstException != secondException) {
+                    firstException.addSuppressed(secondException);
+                }
+            }
+            throw firstException;
+        }
     }
 
     private void addPartitionsWithoutStatistics(MetastoreContext metastoreContext, String databaseName, String tableName, List<Partition> partitions)


### PR DESCRIPTION
On certain databases (e.g. Derby, Oracle) it uses ````CLOB```` and these databases disallow ````=```` predicates over ````CLOB```` values. At the same time, they allow ````LIKE```` predicates over them.

cherry-picked : https://github.com/trinodb/trino/pull/833

## Description

Added a new private method getPrestoViews(String databaseName):

1. Uses get_table_names_by_filter to fetch tables marked as Presto views.
2. Introduced fallback logic:
a. First attempts = predicate on PRESTO_VIEW_FLAG.
b. If it fails, attempts LIKE predicate.
c. Stores successful attempts in metastoreKnownToSupportTableParamEqualsPredicate and metastoreKnownToSupportTableParamLikePredicate.

## Motivation and Context

```Hive 2.3 metastore``` provides more space for table parameter values. On certain databases (e.g. Derby, Oracle) it uses ```CLOB``` and these databases disallow ```=``` predicates over ```CLOB values```. At the same time, they allow ```LIKE``` predicates over them.

This fixes ```SHOW TABLES``` and queries over information_schema.tables.

Also, fixes https://github.com/prestodb/presto/issues/10735, https://github.com/nico-arianto/big-data-local/issues/1.

## Impact

Clob datatype issue resolved.

## Test Plan

checked using presto-cli. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
*  Fix getting views for Hive metastore 2.3+

```