### PR TITLE
Upgrade the jar org.apache.commons:commons-text:1.10.0 to 1.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dep.snakeyaml.version>2.0</dep.snakeyaml.version>
         <dep.jetty.version>9.4.56.v20240826</dep.jetty.version>
         <dep.gson.version>2.11.0</dep.gson.version>
-        <dep.commons.lang3.version>3.14.0</dep.commons.lang3.version>
+        <dep.commons.lang3.version>3.17.0</dep.commons.lang3.version>
         <dep.guice.version>5.1.0</dep.guice.version>
         <dep.arrow.version>17.0.0</dep.arrow.version>
 
@@ -1511,7 +1511,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.10.0</version>
+                <version>1.13.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
Upgrade the org.apache.commons:commons-text dependency from version 1.10.0 to 1.13.0 to avoiding CVE issues.
As part of this , upgraded commons.lang3  - 3.14.0 to 3.17.0 

## Motivation and Context
Upgrading the org.apache.commons:commons-text dependency from version 1.10.0 to 1.13.0  to reduce the risk of introducing new security flaws

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security
* Upgrade commons-text  to 1.13.0 in response to `CVE-2024-47554<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554>`_. 


