### PR TITLE
[native] Expose getting base directory

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -351,6 +351,11 @@ void TaskManager::setBaseSpillDirectory(const std::string& baseSpillDirectory) {
       [&](auto& baseSpillDir) { baseSpillDir = baseSpillDirectory; });
 }
 
+std::string TaskManager::getBaseSpillDirectory() const {
+  return baseSpillDir_.withRLock(
+      [](const auto& baseSpillDir) { return baseSpillDir; });
+}
+
 bool TaskManager::emptyBaseSpillDirectory() const {
   return baseSpillDir_.withRLock(
       [](const auto& baseSpillDir) { return baseSpillDir.empty(); });

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -42,6 +42,8 @@ class TaskManager {
 
   bool emptyBaseSpillDirectory() const;
 
+  std::string getBaseSpillDirectory() const;
+
   /// Sets the time (ms) that a task is considered to be old for cleanup since
   /// its completion.
   void setOldTaskCleanUpMs(int32_t oldTaskCleanUpMs);

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -1221,6 +1221,11 @@ TEST_P(TaskManagerTest, timeoutOutOfOrderRequests) {
           .getVia(eventBase));
 }
 
+TEST_P(TaskManagerTest, getBaseSpillDirectory) {
+  taskManager_->setBaseSpillDirectory("dummy");
+  EXPECT_EQ("dummy", taskManager_->getBaseSpillDirectory());
+}
+
 TEST_P(TaskManagerTest, aggregationSpill) {
   // NOTE: we need to write more than one batches to each file (source split) to
   // trigger spill.


### PR DESCRIPTION
## Description
Expose getting base directory

## Motivation and Context
We'd like the ability to expose the base directory for cases when we want to apply operations like TTL or other metadata ops on it.

## Impact
Exposes a new API in TaskManager

## Test Plan
Added simple unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

