### PR TITLE
Add javax.annotation-api dependency to presto-grpc-api

### DIFF
--- a/presto-grpc-api/pom.xml
+++ b/presto-grpc-api/pom.xml
@@ -79,6 +79,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-function-namespace-managers-common</artifactId>
             <version>${project.version}</version>
@@ -110,6 +115,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <usedDependencies>
+                        <!-- Used by generated GrpcUdfInvokeGrpc.java, but not picked up by plugin -->
+                        <dependency>javax.annotation:javax.annotation-api</dependency>
+                    </usedDependencies>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Description

Adds explicit dependency on `javax.annotation:javax.annotation-api` in presto-grpc-api.

## Motivation and Context

Fixes build failure with JDK 11. Without this maven fails to compile

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project presto-grpc-api: Compilation failure
[2025-02-01T14:13:20.724Z] [ERROR] /home/jenkins/agent/workspace/nce_pipeline-build-presto-images/presto/presto-grpc-api/target/generated-sources/protobuf/grpc-java/com/facebook/presto/grpc/udf/GrpcUdfInvokeGrpc.java:[7,18] cannot find symbol
[2025-02-01T14:13:20.724Z] [ERROR]   symbol:   class Generated
[2025-02-01T14:13:20.724Z] [ERROR]   location: package javax.annotation

```

## Impact

N/A

## Test Plan

Existing tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

