### PR TITLE
Add safe eventloop to stage execution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SafeEventLoopGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SafeEventLoopGroup.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.log.Logger;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/***
+ *  One observation about event loop is if submitted task fails, it could kill the thread but the event loop group will not create a new one.
+ *  Here, we wrap it as safe event loop so that if any submitted job fails, we chose to log the error and fail the entire task.
+ */
+
+public class SafeEventLoopGroup
+        extends DefaultEventLoopGroup
+{
+    private static final Logger log = Logger.get(SafeEventLoopGroup.class);
+
+    public SafeEventLoopGroup(int nThreads, ThreadFactory threadFactory)
+    {
+        super(nThreads, threadFactory);
+    }
+
+    @Override
+    protected EventLoop newChild(Executor executor, Object... args)
+    {
+        return new SafeEventLoop(this, executor);
+    }
+
+    public static class SafeEventLoop
+            extends DefaultEventLoop
+    {
+        public SafeEventLoop(EventLoopGroup parent, Executor executor)
+        {
+            super(parent, executor);
+        }
+
+        @Override
+        protected void run()
+        {
+            do {
+                Runnable task = takeTask();
+                if (task != null) {
+                    try {
+                        runTask(task);
+                    }
+                    catch (Throwable t) {
+                        log.error("Error running task on event loop", t);
+                    }
+                    updateLastExecutionTime();
+                }
+            }
+            while (!this.confirmShutdown());
+        }
+
+        public void execute(Runnable task, Consumer<Throwable> failureHandler)
+        {
+            requireNonNull(task, "task is null");
+            this.execute(() -> {
+                try {
+                    task.run();
+                }
+                catch (Throwable t) {
+                    log.error("Error executing task on event loop", t);
+                    if (failureHandler != null) {
+                        failureHandler.accept(t);
+                    }
+                }
+            });
+        }
+
+        public <T> void execute(Supplier<T> task, Consumer<T> successHandler, Consumer<Throwable> failureHandler)
+        {
+            requireNonNull(task, "task is null");
+            this.execute(() -> {
+                try {
+                    T result = task.get();
+                    if (successHandler != null) {
+                        successHandler.accept(result);
+                    }
+                }
+                catch (Throwable t) {
+                    log.error("Error executing task on event loop", t);
+                    if (failureHandler != null) {
+                        failureHandler.accept(t);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageExecutionStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageExecutionStateMachine.java
@@ -16,14 +16,18 @@ package com.facebook.presto.execution;
 import com.facebook.presto.execution.scheduler.SplitSchedulerStats;
 import com.facebook.presto.spi.QueryId;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.channel.EventLoopGroup;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
-import static java.util.concurrent.Executors.newCachedThreadPool;
+import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -33,248 +37,298 @@ public class TestStageExecutionStateMachine
     private static final StageExecutionId STAGE_ID = new StageExecutionId(new StageId(new QueryId("query"), 0), 0);
     private static final SQLException FAILED_CAUSE = new SQLException("FAILED");
 
-    private final ExecutorService executor = newCachedThreadPool();
+    private final EventLoopGroup eventLoopGroup = new SafeEventLoopGroup(Runtime.getRuntime().availableProcessors(),
+            new ThreadFactoryBuilder().setNameFormat("test-event-loop-%s").setDaemon(true).build());
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
-        executor.shutdownNow();
+        eventLoopGroup.shutdownGracefully();
     }
 
     @Test
     public void testBasicStateChanges()
     {
-        StageExecutionStateMachine stateMachine = createStageStateMachine();
-        assertState(stateMachine, StageExecutionState.PLANNED);
+        SafeEventLoopGroup.SafeEventLoop stageEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
+        StageExecutionStateMachine stateMachine = createStageStateMachine(stageEventLoop);
 
-        assertTrue(stateMachine.transitionToScheduling());
-        assertState(stateMachine, StageExecutionState.SCHEDULING);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.PLANNED);
 
-        assertTrue(stateMachine.transitionToScheduled());
-        assertState(stateMachine, StageExecutionState.SCHEDULED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.SCHEDULING);
 
-        assertTrue(stateMachine.transitionToRunning());
-        assertState(stateMachine, StageExecutionState.RUNNING);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.SCHEDULED);
 
-        assertTrue(stateMachine.transitionToFinished());
-        assertState(stateMachine, StageExecutionState.FINISHED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.RUNNING);
+
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFinished);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.FINISHED);
     }
 
     @Test
     public void testPlanned()
     {
-        StageExecutionStateMachine stateMachine = createStageStateMachine();
-        assertState(stateMachine, StageExecutionState.PLANNED);
+        SafeEventLoopGroup.SafeEventLoop stageEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
+        StageExecutionStateMachine stateMachine = createStageStateMachine(stageEventLoop);
 
-        stateMachine = createStageStateMachine();
-        assertTrue(stateMachine.transitionToScheduling());
-        assertState(stateMachine, StageExecutionState.SCHEDULING);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.PLANNED);
 
-        stateMachine = createStageStateMachine();
-        assertTrue(stateMachine.transitionToRunning());
-        assertState(stateMachine, StageExecutionState.RUNNING);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.SCHEDULING);
 
-        stateMachine = createStageStateMachine();
-        assertTrue(stateMachine.transitionToFinished());
-        assertState(stateMachine, StageExecutionState.FINISHED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.RUNNING);
 
-        stateMachine = createStageStateMachine();
-        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, StageExecutionState.FAILED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFinished);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.FINISHED);
 
-        stateMachine = createStageStateMachine();
-        assertTrue(stateMachine.transitionToAborted());
-        assertState(stateMachine, StageExecutionState.ABORTED);
+        stateMachine = createStageStateMachine(stageEventLoop);
 
-        stateMachine = createStageStateMachine();
-        assertTrue(stateMachine.transitionToCanceled());
-        assertState(stateMachine, StageExecutionState.CANCELED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFailed, FAILED_CAUSE);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.FAILED);
+
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToAborted);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.ABORTED);
+
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToCanceled);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.CANCELED);
     }
 
     @Test
     public void testScheduling()
     {
-        StageExecutionStateMachine stateMachine = createStageStateMachine();
-        assertTrue(stateMachine.transitionToScheduling());
-        assertState(stateMachine, StageExecutionState.SCHEDULING);
+        SafeEventLoopGroup.SafeEventLoop stageEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
+        StageExecutionStateMachine stateMachine = createStageStateMachine(stageEventLoop);
 
-        assertFalse(stateMachine.transitionToScheduling());
-        assertState(stateMachine, StageExecutionState.SCHEDULING);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.SCHEDULING);
 
-        assertTrue(stateMachine.transitionToScheduled());
-        assertState(stateMachine, StageExecutionState.SCHEDULED);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.SCHEDULING);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToScheduling();
-        assertTrue(stateMachine.transitionToRunning());
-        assertState(stateMachine, StageExecutionState.RUNNING);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.SCHEDULED);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToScheduling();
-        assertTrue(stateMachine.transitionToFinished());
-        assertState(stateMachine, StageExecutionState.FINISHED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.RUNNING);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToScheduling();
-        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, StageExecutionState.FAILED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFinished);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.FINISHED);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToScheduling();
-        assertTrue(stateMachine.transitionToAborted());
-        assertState(stateMachine, StageExecutionState.ABORTED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFailed, FAILED_CAUSE);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.FAILED);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToScheduling();
-        assertTrue(stateMachine.transitionToCanceled());
-        assertState(stateMachine, StageExecutionState.CANCELED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToAborted);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.ABORTED);
+
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToCanceled);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.CANCELED);
     }
 
     @Test
     public void testScheduled()
     {
-        StageExecutionStateMachine stateMachine = createStageStateMachine();
-        assertTrue(stateMachine.transitionToScheduled());
-        assertState(stateMachine, StageExecutionState.SCHEDULED);
+        SafeEventLoopGroup.SafeEventLoop stageEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
+        StageExecutionStateMachine stateMachine = createStageStateMachine(stageEventLoop);
 
-        assertFalse(stateMachine.transitionToScheduling());
-        assertState(stateMachine, StageExecutionState.SCHEDULED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.SCHEDULED);
 
-        assertFalse(stateMachine.transitionToScheduled());
-        assertState(stateMachine, StageExecutionState.SCHEDULED);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.SCHEDULED);
 
-        assertTrue(stateMachine.transitionToRunning());
-        assertState(stateMachine, StageExecutionState.RUNNING);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.SCHEDULED);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToScheduled();
-        assertTrue(stateMachine.transitionToFinished());
-        assertState(stateMachine, StageExecutionState.FINISHED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.RUNNING);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToScheduled();
-        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, StageExecutionState.FAILED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFinished);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.FINISHED);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToScheduled();
-        assertTrue(stateMachine.transitionToAborted());
-        assertState(stateMachine, StageExecutionState.ABORTED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFailed, FAILED_CAUSE);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.FAILED);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToScheduled();
-        assertTrue(stateMachine.transitionToCanceled());
-        assertState(stateMachine, StageExecutionState.CANCELED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToAborted);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.ABORTED);
+
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToCanceled);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.CANCELED);
     }
 
     @Test
     public void testRunning()
     {
-        StageExecutionStateMachine stateMachine = createStageStateMachine();
-        assertTrue(stateMachine.transitionToRunning());
-        assertState(stateMachine, StageExecutionState.RUNNING);
+        SafeEventLoopGroup.SafeEventLoop stageEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
+        StageExecutionStateMachine stateMachine = createStageStateMachine(stageEventLoop);
 
-        assertFalse(stateMachine.transitionToScheduling());
-        assertState(stateMachine, StageExecutionState.RUNNING);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.RUNNING);
 
-        assertFalse(stateMachine.transitionToScheduled());
-        assertState(stateMachine, StageExecutionState.RUNNING);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.RUNNING);
 
-        assertFalse(stateMachine.transitionToRunning());
-        assertState(stateMachine, StageExecutionState.RUNNING);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.RUNNING);
 
-        assertTrue(stateMachine.transitionToFinished());
-        assertState(stateMachine, StageExecutionState.FINISHED);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.RUNNING);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToRunning();
-        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, StageExecutionState.FAILED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFinished);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.FINISHED);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToRunning();
-        assertTrue(stateMachine.transitionToAborted());
-        assertState(stateMachine, StageExecutionState.ABORTED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFailed, FAILED_CAUSE);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.FAILED);
 
-        stateMachine = createStageStateMachine();
-        stateMachine.transitionToRunning();
-        assertTrue(stateMachine.transitionToCanceled());
-        assertState(stateMachine, StageExecutionState.CANCELED);
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToAborted);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.ABORTED);
+
+        stateMachine = createStageStateMachine(stageEventLoop);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToCanceled);
+        assertState(stageEventLoop, stateMachine, StageExecutionState.CANCELED);
     }
 
     @Test
     public void testFinished()
     {
-        StageExecutionStateMachine stateMachine = createStageStateMachine();
+        SafeEventLoopGroup.SafeEventLoop stageEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
+        StageExecutionStateMachine stateMachine = createStageStateMachine(stageEventLoop);
 
-        assertTrue(stateMachine.transitionToFinished());
-        assertFinalState(stateMachine, StageExecutionState.FINISHED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFinished);
+        assertFinalState(stageEventLoop, stateMachine, StageExecutionState.FINISHED);
     }
 
     @Test
     public void testFailed()
     {
-        StageExecutionStateMachine stateMachine = createStageStateMachine();
+        SafeEventLoopGroup.SafeEventLoop stageEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
+        StageExecutionStateMachine stateMachine = createStageStateMachine(stageEventLoop);
 
-        assertTrue(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertFinalState(stateMachine, StageExecutionState.FAILED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToFailed, FAILED_CAUSE);
+        assertFinalState(stageEventLoop, stateMachine, StageExecutionState.FAILED);
     }
 
     @Test
     public void testAborted()
     {
-        StageExecutionStateMachine stateMachine = createStageStateMachine();
+        SafeEventLoopGroup.SafeEventLoop stageEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
+        StageExecutionStateMachine stateMachine = createStageStateMachine(stageEventLoop);
 
-        assertTrue(stateMachine.transitionToAborted());
-        assertFinalState(stateMachine, StageExecutionState.ABORTED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToAborted);
+        assertFinalState(stageEventLoop, stateMachine, StageExecutionState.ABORTED);
     }
 
     @Test
     public void testCanceled()
     {
-        StageExecutionStateMachine stateMachine = createStageStateMachine();
+        SafeEventLoopGroup.SafeEventLoop stageEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
+        StageExecutionStateMachine stateMachine = createStageStateMachine(stageEventLoop);
 
-        assertTrue(stateMachine.transitionToCanceled());
-        assertFinalState(stateMachine, StageExecutionState.CANCELED);
+        assertTrueOnEventLoop(stageEventLoop, stateMachine::transitionToCanceled);
+        assertFinalState(stageEventLoop, stateMachine, StageExecutionState.CANCELED);
     }
 
-    private static void assertFinalState(StageExecutionStateMachine stateMachine, StageExecutionState expectedState)
+    private static void assertFinalState(SafeEventLoopGroup.SafeEventLoop stageEventLoop, StageExecutionStateMachine stateMachine, StageExecutionState expectedState)
     {
         assertTrue(expectedState.isDone());
 
-        assertState(stateMachine, expectedState);
+        assertState(stageEventLoop, stateMachine, expectedState);
 
-        assertFalse(stateMachine.transitionToScheduling());
-        assertState(stateMachine, expectedState);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToScheduling);
+        assertState(stageEventLoop, stateMachine, expectedState);
 
-        assertFalse(stateMachine.transitionToScheduled());
-        assertState(stateMachine, expectedState);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToScheduled);
+        assertState(stageEventLoop, stateMachine, expectedState);
 
-        assertFalse(stateMachine.transitionToRunning());
-        assertState(stateMachine, expectedState);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToRunning);
+        assertState(stageEventLoop, stateMachine, expectedState);
 
-        assertFalse(stateMachine.transitionToFinished());
-        assertState(stateMachine, expectedState);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToFinished);
+        assertState(stageEventLoop, stateMachine, expectedState);
 
-        assertFalse(stateMachine.transitionToFailed(FAILED_CAUSE));
-        assertState(stateMachine, expectedState);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToFailed, FAILED_CAUSE);
+        assertState(stageEventLoop, stateMachine, expectedState);
 
-        assertFalse(stateMachine.transitionToAborted());
-        assertState(stateMachine, expectedState);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToAborted);
+        assertState(stageEventLoop, stateMachine, expectedState);
 
         // attempt to fail with another exception, which will fail
-        assertFalse(stateMachine.transitionToFailed(new IOException("failure after finish")));
-        assertState(stateMachine, expectedState);
+        assertFalseOnEventLoop(stageEventLoop, stateMachine::transitionToFailed, new IOException("failure after finish"));
+        assertState(stageEventLoop, stateMachine, expectedState);
     }
 
-    private static void assertState(StageExecutionStateMachine stateMachine, StageExecutionState expectedState)
+    private static void assertTrueOnEventLoop(SafeEventLoopGroup.SafeEventLoop stageEventLoop, Supplier<Boolean> task)
+    {
+        SettableFuture<Boolean> future = SettableFuture.create();
+        stageEventLoop.execute(task, future::set, null);
+        assertTrue(getFutureValue(future));
+    }
+
+    private static void assertTrueOnEventLoop(SafeEventLoopGroup.SafeEventLoop stageEventLoop, Function<Throwable, Boolean> task, Throwable t)
+    {
+        SettableFuture<Boolean> future = SettableFuture.create();
+        stageEventLoop.execute(() -> {
+            future.set(task.apply(t));
+        });
+        assertTrue(getFutureValue(future));
+    }
+
+    private static void assertFalseOnEventLoop(SafeEventLoopGroup.SafeEventLoop stageEventLoop, Supplier<Boolean> task)
+    {
+        SettableFuture<Boolean> future = SettableFuture.create();
+        stageEventLoop.execute(task, future::set, null);
+        assertFalse(getFutureValue(future));
+    }
+
+    private static void assertFalseOnEventLoop(SafeEventLoopGroup.SafeEventLoop stageEventLoop, Function<Throwable, Boolean> task, Throwable t)
+    {
+        SettableFuture<Boolean> future = SettableFuture.create();
+        stageEventLoop.execute(() -> {
+            future.set(task.apply(t));
+        });
+        assertFalse(getFutureValue(future));
+    }
+
+    private static void assertState(SafeEventLoopGroup.SafeEventLoop stageEventloop, StageExecutionStateMachine stateMachine, StageExecutionState expectedState)
     {
         assertEquals(stateMachine.getStageExecutionId(), STAGE_ID);
 
         StageExecutionInfo stageExecutionInfo = stateMachine.getStageExecutionInfo(ImmutableList::of, 0, 0);
         assertEquals(stageExecutionInfo.getTasks(), ImmutableList.of());
 
-        assertEquals(stateMachine.getState(), expectedState);
+        SettableFuture<StageExecutionState> future = SettableFuture.create();
+        stageEventloop.execute(stateMachine::getFutureState, future::set, null);
+        assertEquals(getFutureValue(future), expectedState);
         assertEquals(stageExecutionInfo.getState(), expectedState);
 
         if (expectedState == StageExecutionState.FAILED) {
@@ -287,8 +341,8 @@ public class TestStageExecutionStateMachine
         }
     }
 
-    private StageExecutionStateMachine createStageStateMachine()
+    private StageExecutionStateMachine createStageStateMachine(SafeEventLoopGroup.SafeEventLoop stageEventLoop)
     {
-        return new StageExecutionStateMachine(STAGE_ID, executor, new SplitSchedulerStats(), false);
+        return new StageExecutionStateMachine(STAGE_ID, stageEventLoop, new SplitSchedulerStats(), false);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
@@ -20,6 +20,7 @@ import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.execution.MockRemoteTaskFactory;
 import com.facebook.presto.execution.NodeTaskMap;
 import com.facebook.presto.execution.QueryManagerConfig;
+import com.facebook.presto.execution.SafeEventLoopGroup;
 import com.facebook.presto.execution.SqlStageExecution;
 import com.facebook.presto.execution.StageExecutionId;
 import com.facebook.presto.execution.StageId;
@@ -53,6 +54,8 @@ import com.facebook.presto.util.FinalizerService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.channel.EventLoopGroup;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -73,7 +76,6 @@ import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertTrue;
 
@@ -84,11 +86,14 @@ public class TestAdaptivePhasedExecutionPolicy
     private static final ConnectorId CONNECTOR_ID = new ConnectorId("test");
 
     private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("testAdaptivePhasedExecutionPolicy-%s"));
+    private final EventLoopGroup eventLoopGroup = new SafeEventLoopGroup(Runtime.getRuntime().availableProcessors(),
+            new ThreadFactoryBuilder().setNameFormat("test-loop-%s").setDaemon(true).build());
 
     @AfterClass
     public void tearDownExecutor()
     {
         scheduledExecutor.shutdownNow();
+        eventLoopGroup.shutdownGracefully();
     }
 
     @Test
@@ -124,15 +129,16 @@ public class TestAdaptivePhasedExecutionPolicy
                 .mapToObj(stage -> getStageExecutionAndScheduler(stage, getRemoteSourcePlanNode(new PlanFragmentId(stage))))
                 .collect(toImmutableList());
         return ImmutableList.<StageExecutionAndScheduler>builder()
-            .add(getStageExecutionAndScheduler(0, node))
-            .addAll(exchanges)
-            .build();
+                .add(getStageExecutionAndScheduler(0, node))
+                .addAll(exchanges)
+                .build();
     }
 
     private StageExecutionAndScheduler getStageExecutionAndScheduler(int stage, PlanNode fragementNode)
     {
         PlanFragmentId fragmentId = new PlanFragmentId(stage);
         StageId stageId = new StageId(new QueryId("query"), stage);
+        SafeEventLoopGroup.SafeEventLoop safeEventLoop = (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.next();
         SqlStageExecution stageExecution = createSqlStageExecution(
                 new StageExecutionId(stageId, stage),
                 createPlanFragment(fragmentId, fragementNode),
@@ -140,11 +146,11 @@ public class TestAdaptivePhasedExecutionPolicy
                 TEST_SESSION,
                 true,
                 new NodeTaskMap(new FinalizerService()),
-                newDirectExecutorService(),
                 new NoOpFailureDetector(),
                 new SplitSchedulerStats(),
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
-        StageLinkage stageLinkage = new StageLinkage(fragmentId, (id, tasks, noMoreExchangeLocations) -> {}, ImmutableSet.of());
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                safeEventLoop);
+        StageLinkage stageLinkage = new StageLinkage(stageExecution, (id, tasks, noMoreExchangeLocations) -> {}, ImmutableSet.of());
         StageScheduler stageScheduler = new FixedCountScheduler(stageExecution, ImmutableList.of());
         StageExecutionAndScheduler scheduler = new StageExecutionAndScheduler(stageExecution, stageLinkage, stageScheduler);
         return scheduler;


### PR DESCRIPTION
## Description
1. Continuing our effort of #24288, this pr proposes to use event loop to run stage's execution so that multiple stages can be assigned to the same event loop and a stage's methods will only be executed on the same thread

## Motivation and Context
1. This pr proposes to use a event loop to run stage execution to remove any locking and boost the performance

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. running verifier test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve efficiency of coordinator when running a large number of stage executions.
```

