### PR TITLE
Security Fix: Okio CVE-2023-3635 + OkHttp Jar Update 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dep.slice.version>0.38</dep.slice.version>
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>
         <dep.aws-sdk.version>1.12.782</dep.aws-sdk.version>
-        <dep.okhttp.version>3.9.0</dep.okhttp.version>
+        <dep.okhttp.version>4.12.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>1.40</dep.drift.version>
@@ -216,6 +216,19 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-jvm</artifactId>
+                <version>3.6.0</version>
+            </dependency>
+
+             <!-- pull up to the version used in okio-jvm to avoid conlict with okhttp-* -->
+             <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>1.9.10</version>
+             </dependency>
+
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -117,4 +117,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredUnusedDeclaredDependencies>
+                        <!-- This is needed to keep Okio in the build and prevent conflicts with OkHttp and Kotlin dependencies. -->
+                        <ignoredUnusedDeclaredDependency>com.squareup.okio:okio-jvm</ignoredUnusedDeclaredDependency>
+                    </ignoredUnusedDeclaredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-client/src/main/java/com/facebook/presto/client/JsonResponse.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/JsonResponse.java
@@ -24,7 +24,6 @@ import okhttp3.ResponseBody;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -146,11 +145,6 @@ public final class JsonResponse<T>
             return new JsonResponse<>(response.code(), response.message(), response.headers(), body);
         }
         catch (IOException e) {
-            // OkHttp throws this after clearing the interrupt status
-            // TODO: remove after updating to Okio 1.15.0+
-            if ((e instanceof InterruptedIOException) && "thread interrupted".equals(e.getMessage())) {
-                Thread.currentThread().interrupt();
-            }
             throw new UncheckedIOException(e);
         }
     }

--- a/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
@@ -16,6 +16,7 @@ package com.facebook.presto.client;
 import com.facebook.airlift.security.pem.PemReader;
 import com.google.common.base.CharMatcher;
 import com.google.common.net.HostAndPort;
+import okhttp.internal.tls.LegacyHostnameVerifier;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Credentials;
@@ -237,6 +238,7 @@ public final class OkHttpUtil
             sslContext.init(keyManagers, new TrustManager[] {trustManager}, null);
 
             clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
+            clientBuilder.hostnameVerifier(LegacyHostnameVerifier.INSTANCE);
         }
         catch (GeneralSecurityException | IOException e) {
             throw new ClientException("Error setting up SSL: " + e.getMessage(), e);

--- a/presto-client/src/main/java/okhttp/internal/tls/DistinguishedNameParser.java
+++ b/presto-client/src/main/java/okhttp/internal/tls/DistinguishedNameParser.java
@@ -1,0 +1,428 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//CHECKSTYLE:OFF
+package okhttp.internal.tls;
+//CHECKSTYLE:ON
+
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * A distinguished name (DN) parser. This parser only supports extracting a string value from a DN.
+ * It doesn't support values in the hex-string style.
+ *
+ * This class is based on the OkHttp library.The original source can be found here:
+ *[DistinguishedNameParser.java](https://github.com/square/okhttp/blob/83b9dd427535bce39be43a9e8224cdbc352d7427/okhttp/src/main/java/okhttp3/internal/tls/DistinguishedNameParser.java)
+ *
+ */
+final class DistinguishedNameParser
+{
+    private final String dn;
+    private final int length;
+    private int pos;
+    private int beg;
+    private int end;
+
+    /**
+     * Temporary variable to store positions of the currently parsed item.
+     */
+    private int cur;
+
+    /**
+     * Distinguished name characters.
+     */
+    private char[] chars;
+
+    DistinguishedNameParser(X500Principal principal)
+    {
+        // RFC2253 is used to ensure we get attributes in the reverse
+        // order of the underlying ASN.1 encoding, so that the most
+        // significant values of repeated attributes occur first.
+        this.dn = principal.getName(X500Principal.RFC2253);
+        this.length = this.dn.length();
+    }
+
+    // gets next attribute type: (ALPHA 1*keychar) / oid
+    private String nextAT()
+    {
+        for (; pos < length && chars[pos] == ' '; pos++) {
+            // skip preceding space chars, they can present after
+            // comma or semicolon (compatibility with RFC 1779)
+        }
+        if (pos == length) {
+            return null; // reached the end of DN
+        }
+
+        // mark the beginning of attribute type
+        beg = pos;
+
+        // attribute type chars
+        pos++;
+        for (; pos < length && chars[pos] != '=' && chars[pos] != ' '; pos++) {
+            // we don't follow exact BNF syntax here:
+            // accept any char except space and '='
+        }
+        if (pos >= length) {
+            throw new IllegalStateException("Unexpected end of DN: " + dn);
+        }
+
+        // mark the end of attribute type
+        end = pos;
+
+        if (chars[pos] == ' ') {
+            for (; pos < length && chars[pos] != '=' && chars[pos] == ' '; pos++) {
+                // skip trailing space chars between attribute type and '='
+                // (compatibility with RFC 1779)
+            }
+
+            if (chars[pos] != '=' || pos == length) {
+                throw new IllegalStateException("Unexpected end of DN: " + dn);
+            }
+        }
+
+        pos++; //skip '=' char
+
+        for (; pos < length && chars[pos] == ' '; pos++) {
+            // skip space chars between '=' and attribute value
+            // (compatibility with RFC 1779)
+        }
+
+        // in case of oid attribute type skip its prefix: "oid." or "OID."
+        // (compatibility with RFC 1779)
+        if ((end - beg > 4) && (chars[beg + 3] == '.')
+                && (chars[beg] == 'O' || chars[beg] == 'o')
+                && (chars[beg + 1] == 'I' || chars[beg + 1] == 'i')
+                && (chars[beg + 2] == 'D' || chars[beg + 2] == 'd')) {
+            beg += 4;
+        }
+
+        return new String(chars, beg, end - beg);
+    }
+
+    // gets quoted attribute value: QUOTATION *( quotechar / pair ) QUOTATION
+    private String quotedAV()
+    {
+        pos++;
+        beg = pos;
+        end = beg;
+        while (true) {
+            if (pos == length) {
+                throw new IllegalStateException("Unexpected end of DN: " + dn);
+            }
+
+            if (chars[pos] == '"') {
+                // enclosing quotation was found
+                pos++;
+                break;
+            }
+            else if (chars[pos] == '\\') {
+                chars[end] = getEscaped();
+            }
+            else {
+                // shift char: required for string with escaped chars
+                chars[end] = chars[pos];
+            }
+            pos++;
+            end++;
+        }
+
+        for (; pos < length && chars[pos] == ' '; pos++) {
+            // skip trailing space chars before comma or semicolon.
+            // (compatibility with RFC 1779)
+        }
+
+        return new String(chars, beg, end - beg);
+    }
+
+    // gets hex string attribute value: "#" hexstring
+    private String hexAV()
+    {
+        if (pos + 4 >= length) {
+            // encoded byte array  must be not less then 4 c
+            throw new IllegalStateException("Unexpected end of DN: " + dn);
+        }
+
+        beg = pos; // store '#' position
+        pos++;
+        while (true) {
+            // check for end of attribute value
+            // looks for space and component separators
+            if (pos == length || chars[pos] == '+' || chars[pos] == ','
+                    || chars[pos] == ';') {
+                end = pos;
+                break;
+            }
+
+            if (chars[pos] == ' ') {
+                end = pos;
+                pos++;
+                for (; pos < length && chars[pos] == ' '; pos++) {
+                    // skip trailing space chars before comma or semicolon.
+                    // (compatibility with RFC 1779)
+                }
+                break;
+            }
+            else if (chars[pos] >= 'A' && chars[pos] <= 'F') {
+                chars[pos] += 32; //to low case
+            }
+
+            pos++;
+        }
+
+        // verify length of hex string
+        // encoded byte array  must be not less then 4 and must be even number
+        int hexLen = end - beg; // skip first '#' char
+        if (hexLen < 5 || (hexLen & 1) == 0) {
+            throw new IllegalStateException("Unexpected end of DN: " + dn);
+        }
+
+        // get byte encoding from string representation
+        byte[] encoded = new byte[hexLen / 2];
+        for (int i = 0, p = beg + 1; i < encoded.length; p += 2, i++) {
+            encoded[i] = (byte) getByte(p);
+        }
+        return new String(chars, beg, hexLen);
+    }
+    // gets string attribute value: *( stringchar / pair)
+    private String escapedAV()
+    {
+        beg = pos;
+        end = pos;
+        while (true) {
+            if (pos >= length) {
+                // the end of DN has been found
+                return new String(chars, beg, end - beg);
+            }
+
+            switch (chars[pos]) {
+                case '+':
+                case ',':
+                case ';':
+                    // separator char has been found
+                    return new String(chars, beg, end - beg);
+                case '\\':
+                    // escaped char
+                    chars[end++] = getEscaped();
+                    pos++;
+                    break;
+                case ' ':
+                    // need to figure out whether space defines
+                    // the end of attribute value or not
+                    cur = end;
+
+                    pos++;
+                    chars[end++] = ' ';
+
+                    for (; pos < length && chars[pos] == ' '; pos++) {
+                        chars[end++] = ' ';
+                    }
+                    if (pos == length || chars[pos] == ',' || chars[pos] == '+'
+                            || chars[pos] == ';') {
+                        // separator char or the end of DN has been found
+                        return new String(chars, beg, cur - beg);
+                    }
+                    break;
+                default:
+                    chars[end++] = chars[pos];
+                    pos++;
+            }
+        }
+    }
+
+    // returns escaped char
+    private char getEscaped()
+    {
+        pos++;
+        if (pos == length) {
+            throw new IllegalStateException("Unexpected end of DN: " + dn);
+        }
+
+        switch (chars[pos]) {
+            case '"':
+            case '\\':
+            case ',':
+            case '=':
+            case '+':
+            case '<':
+            case '>':
+            case '#':
+            case ';':
+            case ' ':
+            case '*':
+            case '%':
+            case '_':
+                //FIXME: escaping is allowed only for leading or trailing space char
+                return chars[pos];
+            default:
+                // RFC doesn't explicitly say that escaped hex pair is
+                // interpreted as UTF-8 char. It only contains an example of such DN.
+                return getUTF8();
+        }
+    }
+
+    // decodes UTF-8 char
+    // see http://www.unicode.org for UTF-8 bit distribution table
+    private char getUTF8()
+    {
+        int res = getByte(pos);
+        pos++; //FIXME tmp
+
+        if (res < 128) { // one byte: 0-7F
+            return (char) res;
+        }
+        else if (res >= 192 && res <= 247) {
+            int count;
+            if (res <= 223) { // two bytes: C0-DF
+                count = 1;
+                res = res & 0x1F;
+            }
+            else if (res <= 239) { // three bytes: E0-EF
+                count = 2;
+                res = res & 0x0F;
+            }
+            else { // four bytes: F0-F7
+                count = 3;
+                res = res & 0x07;
+            }
+            int b;
+            for (int i = 0; i < count; i++) {
+                pos++;
+                if (pos == length || chars[pos] != '\\') {
+                    return 0x3F; //FIXME failed to decode UTF-8 char - return '?'
+                }
+                pos++;
+
+                b = getByte(pos);
+                pos++; //FIXME tmp
+                if ((b & 0xC0) != 0x80) {
+                    return 0x3F; //FIXME failed to decode UTF-8 char - return '?'
+                }
+
+                res = (res << 6) + (b & 0x3F);
+            }
+            return (char) res;
+        }
+        else {
+            return 0x3F; //FIXME failed to decode UTF-8 char - return '?'
+        }
+    }
+
+    // Returns byte representation of a char pair
+    // The char pair is composed of DN char in
+    // specified 'position' and the next char
+    // According to BNF syntax:
+    // hexchar    = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+    //                    / "a" / "b" / "c" / "d" / "e" / "f"
+    private int getByte(int position)
+    {
+        if (position + 1 >= length) {
+            throw new IllegalStateException("Malformed DN: " + dn);
+        }
+
+        int b1;
+        int b2;
+
+        b1 = chars[position];
+        if (b1 >= '0' && b1 <= '9') {
+            b1 = b1 - '0';
+        }
+        else if (b1 >= 'a' && b1 <= 'f') {
+            b1 = b1 - 87; // 87 = 'a' - 10
+        }
+        else if (b1 >= 'A' && b1 <= 'F') {
+            b1 = b1 - 55; // 55 = 'A' - 10
+        }
+        else {
+            throw new IllegalStateException("Malformed DN: " + dn);
+        }
+
+        b2 = chars[position + 1];
+        if (b2 >= '0' && b2 <= '9') {
+            b2 = b2 - '0';
+        }
+        else if (b2 >= 'a' && b2 <= 'f') {
+            b2 = b2 - 87; // 87 = 'a' - 10
+        }
+        else if (b2 >= 'A' && b2 <= 'F') {
+            b2 = b2 - 55; // 55 = 'A' - 10
+        }
+        else {
+            throw new IllegalStateException("Malformed DN: " + dn);
+        }
+        return (b1 << 4) + b2;
+    }
+
+    /**
+     * Parses the DN and returns the most significant attribute value for an attribute type, or null
+     * if none found.
+     *
+     * @param attributeType attribute type to look for (e.g. "ca")
+     */
+    public String findMostSpecific(String attributeType)
+    {
+        // Initialize internal state.
+        pos = 0;
+        beg = 0;
+        end = 0;
+        cur = 0;
+        chars = dn.toCharArray();
+
+        String attType = nextAT();
+        if (attType == null) {
+            return null;
+        }
+        while (true) {
+            String attValue = "";
+
+            if (pos == length) {
+                return null;
+            }
+            switch (chars[pos]) {
+                case '"':
+                    attValue = quotedAV();
+                    break;
+                case '#':
+                    attValue = hexAV();
+                    break;
+                case '+':
+                case ',':
+                case ';': // compatibility with RFC 1779: semicolon can separate RDNs
+                    //empty attribute value
+                    break;
+                default:
+                    attValue = escapedAV();
+            }
+
+            // Values are ordered from most specific to least specific
+            // due to the RFC2253 formatting. So take the first match
+            // we see.
+            if (attributeType.equalsIgnoreCase(attType)) {
+                return attValue;
+            }
+
+            if (pos >= length) {
+                return null;
+            }
+            if (chars[pos] == ',' || chars[pos] == ';') {
+                //Do nothing
+            } else if (chars[pos] != '+') {
+                throw new IllegalStateException("Malformed DN: " + dn);
+            }
+            pos++;
+            attType = nextAT();
+            if (attType == null) {
+                throw new IllegalStateException("Malformed DN: " + dn);
+            }
+        }
+    }
+}

--- a/presto-client/src/main/java/okhttp/internal/tls/LegacyHostnameVerifier.java
+++ b/presto-client/src/main/java/okhttp/internal/tls/LegacyHostnameVerifier.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//CHECKSTYLE:OFF
+package okhttp.internal.tls;
+//CHECKSTYLE:ON
+import okhttp3.internal.tls.OkHostnameVerifier;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+
+import java.security.cert.Certificate;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public class LegacyHostnameVerifier
+        implements HostnameVerifier
+{
+    private static final int ALT_DNS_NAME = 2;
+    private static final int ALT_IPA_NAME = 7;
+    private static final Pattern VERIFY_AS_IP_ADDRESS = Pattern.compile(
+            "([0-9a-fA-F]*:[0-9a-fA-F:.]*)|([\\d.]+)");
+
+    public static final HostnameVerifier INSTANCE = new LegacyHostnameVerifier();
+
+    private LegacyHostnameVerifier()
+    {
+    }
+
+    @Override
+    public boolean verify(String host, SSLSession session)
+    {
+        if (OkHostnameVerifier.INSTANCE.verify(host, session)) {
+            return true;
+        }
+
+        // the CN cannot be used with IP addresses
+        if (verifyAsIpAddress(host)) {
+            return false;
+        }
+
+        // try to verify using the legacy CN rules
+        try {
+            Certificate[] certificates = session.getPeerCertificates();
+            X509Certificate certificate = (X509Certificate) certificates[0];
+
+            // only use CN if there are no alt names
+            if (!allSubjectAltNames(certificate).isEmpty()) {
+                return false;
+            }
+
+            X500Principal principal = certificate.getSubjectX500Principal();
+            // RFC 2818 advises using the most specific name for matching.
+            String cn = new DistinguishedNameParser(principal).findMostSpecific("cn");
+            if (cn != null) {
+                return verifyHostName(host, cn);
+            }
+
+            return false;
+        }
+        catch (SSLException e) {
+            return false;
+        }
+    }
+
+    static boolean verifyAsIpAddress(String host)
+    {
+        return VERIFY_AS_IP_ADDRESS.matcher(host).matches();
+    }
+
+    /**
+     * Returns true if {@code certificate} matches {@code ipAddress}.
+     */
+    private boolean verifyIpAddress(String ipAddress, X509Certificate certificate)
+    {
+        List<String> altNames = getSubjectAltNames(certificate, ALT_IPA_NAME);
+        for (int i = 0, size = altNames.size(); i < size; i++) {
+            if (ipAddress.equalsIgnoreCase(altNames.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean verifyHostName(String hostName, X509Certificate certificate)
+    {
+        hostName = hostName.toLowerCase(Locale.US);
+        boolean hasDns = false;
+        List<String> altNames = getSubjectAltNames(certificate, ALT_DNS_NAME);
+        for (int i = 0, size = altNames.size(); i < size; i++) {
+            hasDns = true;
+            if (verifyHostName(hostName, altNames.get(i))) {
+                return true;
+            }
+        }
+
+        if (!hasDns) {
+            X500Principal principal = certificate.getSubjectX500Principal();
+            // RFC 2818 advises using the most specific name for matching.
+            String cn = new DistinguishedNameParser(principal).findMostSpecific("cn");
+            if (cn != null) {
+                return verifyHostName(hostName, cn);
+            }
+        }
+
+        return false;
+    }
+
+    public static List<String> allSubjectAltNames(X509Certificate certificate)
+    {
+        List<String> altIpaNames = getSubjectAltNames(certificate, ALT_IPA_NAME);
+        List<String> altDnsNames = getSubjectAltNames(certificate, ALT_DNS_NAME);
+        List<String> result = new ArrayList<>(altIpaNames.size() + altDnsNames.size());
+        result.addAll(altIpaNames);
+        result.addAll(altDnsNames);
+        return result;
+    }
+
+    private static List<String> getSubjectAltNames(X509Certificate certificate, int type)
+    {
+        List<String> result = new ArrayList<>();
+        try {
+            Collection<?> subjectAltNames = certificate.getSubjectAlternativeNames();
+            if (subjectAltNames == null) {
+                return Collections.emptyList();
+            }
+            for (Object subjectAltName : subjectAltNames) {
+                List<?> entry = (List<?>) subjectAltName;
+                if (entry == null || entry.size() < 2) {
+                    continue;
+                }
+                Integer altNameType = (Integer) entry.get(0);
+                if (altNameType == null) {
+                    continue;
+                }
+                if (altNameType == type) {
+                    String altName = (String) entry.get(1);
+                    if (altName != null) {
+                        result.add(altName);
+                    }
+                }
+            }
+            return result;
+        }
+        catch (CertificateParsingException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Returns {@code true} iff {@code hostName} matches the domain name {@code pattern}.
+     *
+     * @param hostName lower-case host name.
+     * @param pattern  domain name pattern from certificate. May be a wildcard pattern such as
+     *                 {@code *.android.com}.
+     */
+    private boolean verifyHostName(String hostName, String pattern)
+    {
+        // Basic sanity checks
+        // Check length == 0 instead of .isEmpty() to support Java 5.
+        if ((hostName == null) || (hostName.length() == 0) || (hostName.startsWith("."))
+                || (hostName.endsWith(".."))) {
+            // Invalid domain name
+            return false;
+        }
+        if ((pattern == null) || (pattern.length() == 0) || (pattern.startsWith("."))
+                || (pattern.endsWith(".."))) {
+            // Invalid pattern/domain name
+            return false;
+        }
+
+        // Normalize hostName and pattern by turning them into absolute domain names if they are not
+        // yet absolute. This is needed because server certificates do not normally contain absolute
+        // names or patterns, but they should be treated as absolute. At the same time, any hostName
+        // presented to this method should also be treated as absolute for the purposes of matching
+        // to the server certificate.
+        //   www.android.com  matches www.android.com
+        //   www.android.com  matches www.android.com.
+        //   www.android.com. matches www.android.com.
+        //   www.android.com. matches www.android.com
+        if (!hostName.endsWith(".")) {
+            hostName += '.';
+        }
+        if (!pattern.endsWith(".")) {
+            pattern += '.';
+        }
+        // hostName and pattern are now absolute domain names.
+
+        pattern = pattern.toLowerCase(Locale.US);
+        // hostName and pattern are now in lower case -- domain names are case-insensitive.
+
+        if (!pattern.contains("*")) {
+            // Not a wildcard pattern -- hostName and pattern must match exactly.
+            return hostName.equals(pattern);
+        }
+        // Wildcard pattern
+
+        // WILDCARD PATTERN RULES:
+        // 1. Asterisk (*) is only permitted in the left-most domain name label and must be the
+        //    only character in that label (i.e., must match the whole left-most label).
+        //    For example, *.example.com is permitted, while *a.example.com, a*.example.com,
+        //    a*b.example.com, a.*.example.com are not permitted.
+        // 2. Asterisk (*) cannot match across domain name labels.
+        //    For example, *.example.com matches test.example.com but does not match
+        //    sub.test.example.com.
+        // 3. Wildcard patterns for single-label domain names are not permitted.
+
+        if ((!pattern.startsWith("*.")) || (pattern.indexOf('*', 1) != -1)) {
+            // Asterisk (*) is only permitted in the left-most domain name label and must be the only
+            // character in that label
+            return false;
+        }
+
+        // Optimization: check whether hostName is too short to match the pattern. hostName must be at
+        // least as long as the pattern because asterisk must match the whole left-most label and
+        // hostName starts with a non-empty label. Thus, asterisk has to match one or more characters.
+        if (hostName.length() < pattern.length()) {
+            // hostName too short to match the pattern.
+            return false;
+        }
+
+        if ("*.".equals(pattern)) {
+            // Wildcard pattern for single-label domain name -- not permitted.
+            return false;
+        }
+
+        // hostName must end with the region of pattern following the asterisk.
+        String suffix = pattern.substring(1);
+        if (!hostName.endsWith(suffix)) {
+            // hostName does not end with the suffix
+            return false;
+        }
+
+        // Check that asterisk did not match across domain name labels.
+        int suffixStartIndexInHostName = hostName.length() - suffix.length();
+        if ((suffixStartIndexInHostName > 0)
+                && (hostName.lastIndexOf('.', suffixStartIndexInHostName - 1) != -1)) {
+            // Asterisk is matching across domain name labels -- not permitted.
+            return false;
+        }
+
+        // hostName matches pattern
+        return true;
+    }
+}

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -256,6 +256,30 @@
                             <dependencyReducedPomLocation>${project.build.directory}/pom.xml</dependencyReducedPomLocation>
                             <relocations>
                                 <relocation>
+                                    <pattern>org.intellij</pattern>
+                                    <shadedPattern>${shadeBase}.org.intellij</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>jvmMain.okio</pattern>
+                                    <shadedPattern>${shadeBase}.jvmMain.okio</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>commonMain.okio</pattern>
+                                    <shadedPattern>${shadeBase}.commonMain.okio</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>kotlin</pattern>
+                                    <shadedPattern>${shadeBase}.kotlin</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.jetbrains.kotlin</pattern>
+                                    <shadedPattern>${shadeBase}.org.jetbrains.kotlin</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.jetbrains.annotations</pattern>
+                                    <shadedPattern>${shadeBase}.org.jetbrains.annotations</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.facebook.presto.client</pattern>
                                     <shadedPattern>${shadeBase}.client</shadedPattern>
                                 </relocation>

--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
@@ -247,6 +247,18 @@
                         <ignoredClassPattern>org.apache.avro.*</ignoredClassPattern>
                         <ignoredClassPattern>org.roaringbitmap.*</ignoredClassPattern>
                     </ignoredClassPatterns>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredUnusedDeclaredDependencies>
+                        <!--  OkHttp pulls in kotlin-stdlib in compile scope, but it is only used in tests here.
+                         Changing its scope causes Maven to flag it as unused, leading to build failures.
+                         We add it here to keep it in compile scope while only using it directly in tests.-->
+                        <ignoredUnusedDeclaredDependency>org.jetbrains:annotations</ignoredUnusedDeclaredDependency>
+                    </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Description
This PR fixes the Okio security vulnerability (CVE-2023-3635) by upgrading from version 1.17.2 to 3.6.0. It also includes an update to the OkHttp jar from 3.9.0 to  4.12.0


## Motivation and Context
A flaw was found in Okio’s GzipSource class that doesn’t handle exceptions properly, allowing potential Denial of Service (DoS) attacks with malformed files.

CVE-2023-3635: [Details](https://access.redhat.com/security/cve/cve-2023-3635)

## Impact
Image Scan showed the vulnerability have been removed.
[correlation-report-ibm-lh-presto-okie check.csv](https://github.ibm.com/lakehouse/presto/files/1411073/correlation-report-ibm-lh-presto-okie.check.csv)
## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [X] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
 == RELEASE NOTES ==
Security Changes
* Upgrade okio to 3.6.0 in response to `CVE-2023-3635 <https://github.com/advisories/GHSA-w33c-445m-f8w7>`. 
* Upgrade okhttp to 4.12.0 in response to `CVE-2023-3635 <https://github.com/advisories/GHSA-w33c-445m-f8w7>`. 
