### PR TITLE
Upgrade io.grpc library to 1.70.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,17 +76,17 @@
         <dep.docker-java.version>3.3.0</dep.docker-java.version>
         <dep.jayway.version>2.9.0</dep.jayway.version>
         <dep.ratis.version>3.1.3</dep.ratis.version>
-        <dep.errorprone.version>2.28.0</dep.errorprone.version>
+        <dep.errorprone.version>2.36.0</dep.errorprone.version>
         <dep.guava.version>32.1.0-jre</dep.guava.version>
         <dep.jackson.version>2.15.4</dep.jackson.version>
-        <dep.j2objc.version>2.8</dep.j2objc.version>
+        <dep.j2objc.version>3.0.0</dep.j2objc.version>
         <dep.avro.version>1.11.4</dep.avro.version>
         <dep.commons.compress.version>1.26.2</dep.commons.compress.version>
         <dep.protobuf-java.version>3.25.5</dep.protobuf-java.version>
         <dep.netty.version>4.1.118.Final</dep.netty.version>
         <dep.snakeyaml.version>2.0</dep.snakeyaml.version>
         <dep.jetty.version>9.4.56.v20240826</dep.jetty.version>
-        <dep.gson.version>2.11.0</dep.gson.version>
+        <dep.gson.version>2.12.1</dep.gson.version>
         <dep.commons.lang3.version>3.17.0</dep.commons.lang3.version>
         <dep.guice.version>5.1.0</dep.guice.version>
         <dep.arrow.version>17.0.0</dep.arrow.version>
@@ -102,7 +102,7 @@
         <air.test.parallel>methods</air.test.parallel>
         <air.test.thread-count>2</air.test.thread-count>
         <air.test.jvmsize>4g</air.test.jvmsize>
-        <grpc.version>1.68.0</grpc.version>
+        <grpc.version>1.70.0</grpc.version>
         <air.javadoc.lint>-missing</air.javadoc.lint>
     </properties>
 
@@ -506,6 +506,36 @@
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-prometheus</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-context</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-protobuf-lite</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-auth</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-alts</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-grpclb</artifactId>
+                <version>${grpc.version}</version>
             </dependency>
 
             <dependency>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -14,7 +14,9 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <grpc.version>1.68.0</grpc.version>
+        <google.auth.library.version>1.33.1</google.auth.library.version>
+        <google.auto.value.version>1.11.0</google.auto.value.version>
+        <google.http.client.version>1.46.3</google.http.client.version>
     </properties>
 
     <dependencyManagement>
@@ -48,7 +50,7 @@
             <dependency>
                 <groupId>com.google.auth</groupId>
                 <artifactId>google-auth-library-oauth2-http</artifactId>
-                <version>1.23.0</version>
+                <version>${google.auth.library.version}</version>
             </dependency>
 
             <dependency>
@@ -92,7 +94,7 @@
             <dependency>
                 <groupId>com.google.auth</groupId>
                 <artifactId>google-auth-library-credentials</artifactId>
-                <version>1.23.0</version>
+                <version>${google.auth.library.version}</version>
             </dependency>
 
             <dependency>
@@ -104,19 +106,19 @@
             <dependency>
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value-annotations</artifactId>
-                <version>1.10.4</version>
+                <version>${google.auto.value.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client</artifactId>
-                <version>1.43.3</version>
+                <version>${google.http.client.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client-gson</artifactId>
-                <version>1.43.3</version>
+                <version>${google.http.client.version}</version>
             </dependency>
 
             <dependency>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <grpc.version>1.68.0</grpc.version>
     </properties>
 
     <dependencies>
@@ -331,7 +330,6 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
-            <version>${grpc.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -351,7 +349,6 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>${grpc.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -375,13 +372,11 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <grpc.version>1.68.0</grpc.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Description

Upgraded io.grpc library from 1.68.0 to 1.70.0.

As part of this upgrade, the following dependencies were updated:
- io.grpc:grpc-protobuf-lite: 1.68.0 → 1.70.0
- io.grpc:grpc-protobuf: 1.53.0 → 1.70.0
- io.grpc:grpc-stub: 1.53.0 → 1.70.0
- io.grpc:grpc-core: 1.53.0 → 1.70.0
- io.grpc:grpc-api: 1.53.0 → 1.70.0
- io.grpc:grpc-netty-shaded:1.69.0 → 1.70.0

Additionally, to resolve upper bound issues, the following dependencies were updated:
- com.google.errorprone:error_prone_annotations: 2.28.0 to 2.36.0
- com.google.auth:google-auth-library-oauth2-http: 1.23.0 to 1.31.0
- com.google.auth:google-auth-library-credentials: 1.23.0 to 1.31.0
- com.google.auto.value:auto-value-annotations: 1.10.4 to 1.11.0
- com.google.http-client:google-http-client: 1.43.3 to 1.45.3
- com.google.http-client:google-http-client-gson: 1.43.3 to 1.45.3
- com.google.j2objc:j2objc-annotations: 2.8 to 3.0.0.

## Motivation and Context
Addresses below CVEs
[CVE-2024-7254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7254) for grpc-protobuf, grpc-protobuf-lite.
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908) and
[CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976) for grpc-core, grpc-stub, grpc-api.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== RELEASE NOTES ==

General Changes
* Upgrade the io.grpc library from version 1.68.0 to 1.70.0 in response to `CVE-2024-7254<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7254>`, `CVE-2020-8908<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908>`
* Upgrade the errrorprone dependency from version 2.28.0 to 2.36.0
