### PR TITLE
Update pull_request_template.md to remove PR link examples

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -27,12 +27,12 @@ Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki
 == RELEASE NOTES ==
 
 General Changes
-* ... :pr:`12345`
-* ... :pr:`12345`
+* ... 
+* ... 
 
 Hive Connector Changes
-* ... :pr:`12345`
-* ... :pr:`12345`
+* ... 
+* ... 
 ```
 
 If release note is NOT required, use:


### PR DESCRIPTION
## Description
Removed manual PR link examples from [pull_request_template.md](https://github.com/prestodb/presto/blob/master/pull_request_template.md). 

## Motivation and Context
PR #24354 automatically adds links to the PR to the release note, so manually adding PR links to the release note entry for a PR is now redundant. 

I have updated the [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) to remove the examples of manually adding the PR link.

## Impact
New pull requests. 

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

