### PR TITLE
[native] Switch to use Clang for the Linux debug build in the CI

### DIFF
--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -14,6 +14,8 @@ jobs:
       image: prestodb/presto-native-dependency:0.291-20250108164449-87d82ed
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
+      CC: /usr/bin/clang-15
+      CXX: /usr/bin/clang++-15
     steps:
       - uses: actions/checkout@v4
 
@@ -49,9 +51,12 @@ jobs:
       - name: Disk space consumption before build
         run: df
 
+      - name: Install Clang
+        run: |
+          presto-native-execution/velox/scripts/setup-centos9.sh install_clang15
+
       - name: Build engine
         run: |
-          source /opt/rh/gcc-toolset-12/enable
           cd presto-native-execution
           cmake \
             -B _build/debug \

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -107,6 +107,12 @@ add_executable(presto_server PrestoMain.cpp)
 target_link_libraries(presto_server presto_server_lib velox_hive_connector
                       velox_tpch_connector)
 
+# Clang requires explicit linking with libatomic.
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
+   AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 15)
+  target_link_libraries(presto_server atomic)
+endif()
+
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   add_library(presto_server_remote_function JsonSignatureParser.cpp
                                             RemoteFunctionRegisterer.cpp)

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -53,6 +53,12 @@ target_link_libraries(
   GTest::gtest
   GTest::gtest_main)
 
+# Clang requires explicit linking with libatomic.
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
+   AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 15)
+  target_link_libraries(presto_server_test atomic)
+endif()
+
 set_property(TARGET presto_server_test PROPERTY JOB_POOL_LINK
                                                 presto_link_job_pool)
 


### PR DESCRIPTION
Using GCC12.1 results in consuming more disk space than available in the github runners.

Tests show that Clang debug builds generate much smaller libraries for the velox submodule - around 12GB+ vs 7.4G. And for presto itself it is 3GB vs 1.6GB.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

