### PR TITLE
[Iceberg] Fix bugs in Iceberg statistics caching

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -195,9 +195,9 @@ public class IcebergCommonModule
                 .<StatisticsFileCacheKey, ColumnStatistics>weigher((key, entry) -> (int) entry.getEstimatedSize())
                 .recordStats()
                 .build();
-        CacheStatsMBean bean = new CacheStatsMBean(delegate);
-        exporter.export(generatedNameOf(StatisticsFileCache.class, connectorId), bean);
-        return new StatisticsFileCache(delegate);
+        StatisticsFileCache statisticsFileCache = new StatisticsFileCache(delegate);
+        exporter.export(generatedNameOf(StatisticsFileCache.class, connectorId), statisticsFileCache);
+        return statisticsFileCache;
     }
 
     @ForCachingHiveMetastore

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
@@ -658,6 +658,7 @@ public class TableStatisticsMaker
             statisticsFileCache.put(new StatisticsFileCacheKey(file, key), value);
             finalResult.put(key, value);
         });
+        finalResult.putAll(cachedStats);
         return finalResult.build();
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/statistics/StatisticsFileCache.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/statistics/StatisticsFileCache.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg.statistics;
 
 import com.facebook.airlift.stats.DistributionStat;
+import com.facebook.presto.hive.CacheStatsMBean;
 import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.google.common.cache.Cache;
 import com.google.common.cache.ForwardingCache.SimpleForwardingCache;
@@ -25,10 +26,19 @@ public class StatisticsFileCache
 {
     private final DistributionStat fileSizes = new DistributionStat();
     private final DistributionStat columnCounts = new DistributionStat();
+    private final CacheStatsMBean cacheStats;
 
     public StatisticsFileCache(Cache<StatisticsFileCacheKey, ColumnStatistics> delegate)
     {
         super(delegate);
+        cacheStats = new CacheStatsMBean(delegate);
+    }
+
+    @Managed
+    @Nested
+    public CacheStatsMBean getCacheStats()
+    {
+        return cacheStats;
     }
 
     @Managed


### PR DESCRIPTION
## Description

This PR has two commits which fixes two minor bugs in statistics file caching. The first is related to returning wrong statistics on partial cache misses. The second as to do with missing stats in the reported JMX statistics on the StatisticsFileCache object.

## Motivation and Context

Bug fixes. See commit messages for details

## Impact

- New JMX metrics now appear for the StatisticsFileCache bean

## Test Plan

- Added test for partial miss bug fix. It fails without the fix.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix bug with missing statistics when the statistics file cache has a partial miss
```
