### PR TITLE
Fix loading chunk errors in query_view_spa.html

### DIFF
--- a/presto-ui/src/preload.js
+++ b/presto-ui/src/preload.js
@@ -1,0 +1,9 @@
+const path = window.location.pathname;
+
+// when access the page /dev/query_viewer_spa.html page
+if ( path.indexOf("/dev/") >= 0 ){
+    __webpack_public_path__ = "../";
+}
+else {
+    __webpack_public_path__ = "./";
+}

--- a/presto-ui/src/query_viewer_spa.js
+++ b/presto-ui/src/query_viewer_spa.js
@@ -1,0 +1,2 @@
+import "./preload";
+import "./query_viewer";

--- a/presto-ui/src/webpack.config.js
+++ b/presto-ui/src/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = (env) => {
             'index': './index.jsx',
             'query': './query.jsx',
             'plan': './plan.jsx',
-            'query_viewer': {import: './query_viewer.jsx', filename: path.join(outputDir, 'dev', '[name].js')},
+            'query_viewer': {import: './query_viewer_spa.js', filename: path.join('dev', '[name].js')},
             'embedded_plan': './embedded_plan.jsx',
             'stage': './stage.jsx',
             'worker': './worker.jsx',
@@ -109,6 +109,7 @@ module.exports = (env) => {
                         test: /[\\/]node_modules[\\/]/,
                         priority: -10,
                         reuseExistingChunk: true,
+                        filename: '[name].vendor.js',
                     },
                     default: {
                         minChunks: 2,


### PR DESCRIPTION
## Description
After the pages optimized with chunk spliting, the pages under `/dev/` directory not working anymore. It show errors about loading chunks. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Because the pages under `/dev` is not the same level with other pages, the webpack need adjust publicPath, so that the chunks of dependecies can be loaded from correct URL. 

Because the pages  are in both `/` and `/dev/`, so we can not set publicPath for both. Need adjust the publicPath using __webpack_public_path__ at runtime.


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
UI pages/build, especially the pages under '/dev/' folder

## Test Plan
Build & test UI in dev/prod env 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

