### PR TITLE
Package all resources into query_view_spa.html

### DIFF
--- a/presto-ui/src/components/QueryPlanView.jsx
+++ b/presto-ui/src/components/QueryPlanView.jsx
@@ -114,7 +114,7 @@ export default function PlanView({show, data}) {
             widgets.current.svg = d3.select("#plan-canvas");
         }
         updateD3Graph();
-        $('[data-bs-toggle="tooltip"]')?.tooltip()
+        $('[data-bs-toggle="tooltip"]')?.tooltip?.()
     }, [data, show]);
 
     return (

--- a/presto-ui/src/components/QueryViewer.jsx
+++ b/presto-ui/src/components/QueryViewer.jsx
@@ -23,7 +23,7 @@ import StaticQueryHeader from './StaticQueryHeader';
 // A form to select a JSON file and read
 const FileForm = ({ onChange }) => (
     <div className="row">
-        <div className="col-4 offset-1 fs-6">
+        <div className="col-4 offset-1 fs-6 mb-2">
             <div id="title">Select a JSON file of SQL query to process</div>
             <form id='form' className="form-inline">
                 <div className="form-group">

--- a/presto-ui/src/components/StaticQueryHeader.jsx
+++ b/presto-ui/src/components/StaticQueryHeader.jsx
@@ -121,7 +121,7 @@ export default function StaticQueryHeader({ query, tabs, switchTab, tabIndex = 0
                         </a>
                     </h3>
                 </div>
-                <div className="col-6">
+                <div className="col-6 d-flex justify-content-end">
                     <nav className="nav nav-tabs">
                         <QueryHeaderTabs tabs={tabs} current={state.tab} clickHandler={clickHandler} />
                     </nav>

--- a/presto-ui/src/package.json
+++ b/presto-ui/src/package.json
@@ -40,7 +40,8 @@
   "scripts": {
     "install": "webpack --env=production --config webpack.config.js",
     "watch": "webpack --config webpack.config.js --watch",
-    "serve": "webpack serve --config webpack.config.js"
+    "serve": "webpack serve --config webpack.config.js",
+    "analyze": "webpack --env=production --config webpack.config.js --profile --json > stats.json && mv stats.json ../target/webapp/ && npx webpack-bundle-analyzer ../target/webapp/stats.json"
   },
   "resolutions": {
     "d3-color": "3.1.0"

--- a/presto-ui/src/query_viewer.jsx
+++ b/presto-ui/src/query_viewer.jsx
@@ -1,8 +1,6 @@
 import { createRoot } from 'react-dom/client';
-import lazy from "./lazy";
+import QueryViewer from "./components/QueryViewer";
 import { PageTitle } from "./components/PageTitle";
-
-const QueryViewer = lazy('QueryViewer');
 
 const title = createRoot(document.getElementById('title'));
 title.render(<PageTitle titles={["Query Viewer"]} path='..'/>);

--- a/presto-ui/src/webpack.config.js
+++ b/presto-ui/src/webpack.config.js
@@ -142,7 +142,7 @@ module.exports = (env) => {
             ...baseConfig.plugins,
             new HtmlWebpackPlugin({
                 inject: 'body',
-                filename: path.join(__dirname, '..', outputDir, 'dev', 'query_viewer_spa.html'),
+                filename: path.join('dev', 'query_viewer_spa.html'),
                 template: 'templates/query_viewer.html',
                 chunks: [
                     'query_viewer',

--- a/presto-ui/src/webpack.config.js
+++ b/presto-ui/src/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = (env) => {
     const apiHost = env.apiHost || 'localhost';
     const apiPort = env.apiPort || '8080';
     const outputDir = 'target/webapp';
-    return {
+    const baseConfig = {
         entry: {
             'index': './index.jsx',
             'query': './query.jsx',
@@ -23,6 +23,7 @@ module.exports = (env) => {
             'timeline': './timeline.jsx',
             'res_groups': './res_groups.jsx',
             'sql_client': './sql_client.jsx',
+            'bootstrap_css': path.join(__dirname, 'static', 'vendor', 'bootstrap', 'css', 'bootstrap.min.external-fonts.css'),
             'css_loader': path.join(__dirname, 'static', 'vendor', 'css-loaders', 'loader.css'),
             'css_presto': path.join(__dirname, 'static', 'assets', 'presto.css'),
         },
@@ -30,29 +31,13 @@ module.exports = (env) => {
             // substitutes `require('vis-timeline/standalone')` to `global.vis`
             'vis-timeline/standalone': 'vis',
         },
-                plugins: [
-                    new CopyPlugin({
-                        patterns: [
-                            {from: "static", to: path.join(__dirname, "..", outputDir)},
-                        ]
-                    }),
-                    new HtmlWebpackPlugin({
-                        inject: 'body',
-                        filename: path.join(__dirname, '..', outputDir, 'dev', 'query_viewer_spa.html'),
-                        template: 'templates/query_viewer.html',
-                        chunks: [
-                            'query_viewer',
-                            'css_loader',
-                            'css_presto',
-                        ]
-                    }),
-                    new HtmlInlineScriptPlugin({
-                        htmlMatchPattern: [/query_viewer_spa.html$/],
-                        assetPreservePattern: [
-                            /.*.js$/,
-                        ]
-                    }),
-                ],
+        plugins: [
+            new CopyPlugin({
+                patterns: [
+                    {from: "static", to: path.join(__dirname, "..", outputDir)},
+                ]
+            }),
+        ],
         mode,
         module: {
             rules: [
@@ -97,6 +82,25 @@ module.exports = (env) => {
                     extractComments: false,
                 }),
                 '...'],
+        },
+    };
+
+    const mainConfig = {
+        ...baseConfig,
+        entry: {
+            ...baseConfig.entry,
+            'index': './index.jsx',
+            'query': './query.jsx',
+            'plan': './plan.jsx',
+            'embedded_plan': './embedded_plan.jsx',
+            'stage': './stage.jsx',
+            'worker': './worker.jsx',
+            'timeline': './timeline.jsx',
+            'res_groups': './res_groups.jsx',
+            'sql_client': './sql_client.jsx',
+        },
+        optimization: {
+            ...baseConfig.optimization,
             splitChunks: {
                 chunks: 'async',
                 maxSize: 244000,
@@ -107,6 +111,7 @@ module.exports = (env) => {
                         test: /[\\/]node_modules[\\/]/,
                         priority: -10,
                         reuseExistingChunk: true,
+                        filename: '[name].vendor.js',
                     },
                     default: {
                         minChunks: 2,
@@ -130,4 +135,37 @@ module.exports = (env) => {
             ],
         },
     };
+
+    const spaConfig = {
+        ...baseConfig,
+        plugins: [
+            ...baseConfig.plugins,
+            new HtmlWebpackPlugin({
+                inject: 'body',
+                filename: path.join(__dirname, '..', outputDir, 'dev', 'query_viewer_spa.html'),
+                template: 'templates/query_viewer.html',
+                chunks: [
+                    'query_viewer',
+                    'bootstrap_css',
+                    'css_loader',
+                    'css_presto',
+                ]
+            }),
+            new HtmlInlineScriptPlugin({
+                htmlMatchPattern: [/query_viewer_spa.html$/],
+                assetPreservePattern: [
+                    /.*.js$/,
+                ]
+            }),
+        ],
+        entry: {
+            ...baseConfig.entry,
+            'query_viewer': {import: './query_viewer.jsx', filename: path.join('dev', '[name].js')},
+        },
+        optimization: {
+            ...baseConfig.optimization,
+            splitChunks: false,
+        }
+    };
+    return [mainConfig, spaConfig]
 };

--- a/presto-ui/src/webpack.config.js
+++ b/presto-ui/src/webpack.config.js
@@ -13,17 +13,6 @@ module.exports = (env) => {
     const outputDir = 'target/webapp';
     const baseConfig = {
         entry: {
-            'index': './index.jsx',
-            'query': './query.jsx',
-            'plan': './plan.jsx',
-            'query_viewer': {import: './query_viewer.jsx', filename: path.join('dev', '[name].js')},
-            'embedded_plan': './embedded_plan.jsx',
-            'stage': './stage.jsx',
-            'worker': './worker.jsx',
-            'timeline': './timeline.jsx',
-            'res_groups': './res_groups.jsx',
-            'sql_client': './sql_client.jsx',
-            'bootstrap_css': path.join(__dirname, 'static', 'vendor', 'bootstrap', 'css', 'bootstrap.min.external-fonts.css'),
             'css_loader': path.join(__dirname, 'static', 'vendor', 'css-loaders', 'loader.css'),
             'css_presto': path.join(__dirname, 'static', 'assets', 'presto.css'),
         },
@@ -88,7 +77,6 @@ module.exports = (env) => {
     const mainConfig = {
         ...baseConfig,
         entry: {
-            ...baseConfig.entry,
             'index': './index.jsx',
             'query': './query.jsx',
             'plan': './plan.jsx',
@@ -98,6 +86,7 @@ module.exports = (env) => {
             'timeline': './timeline.jsx',
             'res_groups': './res_groups.jsx',
             'sql_client': './sql_client.jsx',
+            ...baseConfig.entry,
         },
         optimization: {
             ...baseConfig.optimization,
@@ -159,8 +148,8 @@ module.exports = (env) => {
             }),
         ],
         entry: {
-            ...baseConfig.entry,
             'query_viewer': {import: './query_viewer.jsx', filename: path.join('dev', '[name].js')},
+            ...baseConfig.entry,
         },
         optimization: {
             ...baseConfig.optimization,


### PR DESCRIPTION
## Description
After the pages optimized with chunk spliting, the query_viewer_spa.html will use split chunks instead of packing all resources as SPA page.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
The pages under dev folder should not use split chunks, so that they can be easily adopted by other system. 

The fix will introduce 2 set of configurations (mainConfig and spaConfig) to make both SPA and non SPA pages working as expected.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
UI pages/build, especially the pages under '/dev/' folder

## Test Plan
Build & test UI in dev/prod env 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

