### PR TITLE
[native] Add clang installation to dependency image and update image

### DIFF
--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -11,7 +11,7 @@ jobs:
   prestocpp-linux-build-engine:
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.291-20250108164449-87d82ed
+      image: prestodb/presto-native-dependency:0.292-20250204112033-cf8ba84
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
       CC: /usr/bin/clang-15
@@ -50,10 +50,6 @@ jobs:
 
       - name: Disk space consumption before build
         run: df
-
-      - name: Install Clang
-        run: |
-          presto-native-execution/velox/scripts/setup-centos9.sh install_clang15
 
       - name: Build engine
         run: |

--- a/presto-native-execution/scripts/dockerfiles/README.md
+++ b/presto-native-execution/scripts/dockerfiles/README.md
@@ -4,7 +4,7 @@
 
 There are two kinds of Dockerfiles:
 1) A platform specific file to build dependencies. Current supported platforms are:
-   1) Centos-8-stream with gcc9.
+   1) Centos-9-stream with gcc12. Clang15 is also installed.
    2) Ubuntu-22.04 with gcc11.
 2) A platform-agnostic file to build Prestissimo runtime on top of the dependency image.
 ### Dependency Dockerfiles

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -22,5 +22,6 @@ COPY velox/scripts /velox/scripts
 RUN mkdir build && \
     (cd build && ../scripts/setup-centos.sh && \
                  ../velox/scripts/setup-adapters.sh && \
-                 ../scripts/setup-adapters.sh ) && \
+                 ../scripts/setup-adapters.sh && \
+                 ../velox/scripts/setup-centos9.sh install_clang15) && \
     rm -rf build


### PR DESCRIPTION
PR #24479 switched the debug CI build to Clang to save more disk space. Clang is installed as part of the CI steps but it is better to have it present in the dependency image. The other change was made to unblock PRs due to failing CI pipelines.

In addition, the dependency image is updated with the change made in this PR.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

