### PR TITLE
[docs] Add Lateral join support in sql/select.rst

### DIFF
--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -833,6 +833,20 @@ so a cross join between the two tables produces 125 rows::
     ...
     (125 rows)
 
+Lateral
+^^^^^^^
+
+Subqueries appearing in the FROM clause can be preceded by the keyword ``LATERAL``. This allows them to reference columns provided by preceding ``FROM`` items.
+
+INNER and LEFT OUTER lateral joins are supported in Presto.
+
+.. code-block:: none
+
+    SELECT name, x, y
+    FROM nation
+    CROSS JOIN LATERAL (SELECT name || ' :-' AS x)
+    CROSS JOIN LATERAL (SELECT x || ')' AS y);
+
 Qualifying Column Names
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description
Add documentation that lateral joins are supported in Presto to steveburnett-select-lateral. 

## Motivation and Context
Fixes #21075.

## Impact
Documentation.

## Test Plan
Local doc build. 

Screenshot of new text from local doc build (Qualifying Column Names heading and opening text already present, included in screenshot for context). 

<img width="1045" alt="Screenshot 2025-02-04 at 4 24 39 PM" src="https://github.com/user-attachments/assets/a4b1a470-74c5-40e0-b99e-086c0ce28b32" />

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

