### PR TITLE
Upgrade org.apache.ratis dependency to address CVE-2020-15250

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dep.testcontainers.version>1.18.3</dep.testcontainers.version>
         <dep.docker-java.version>3.3.0</dep.docker-java.version>
         <dep.jayway.version>2.9.0</dep.jayway.version>
-        <dep.ratis.version>2.2.0</dep.ratis.version>
+        <dep.ratis.version>3.1.3</dep.ratis.version>
         <dep.errorprone.version>2.28.0</dep.errorprone.version>
         <dep.guava.version>32.1.0-jre</dep.guava.version>
         <dep.jackson.version>2.15.4</dep.jackson.version>
@@ -2051,6 +2051,12 @@
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.ratis</groupId>
+                <artifactId>ratis-metrics-default</artifactId>
+                <version>${dep.ratis.version}</version>
             </dependency>
 
             <dependency>

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -338,7 +338,12 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
-        
+
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-metrics-default</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -375,6 +380,10 @@
                         <dependency>
                             <groupId>org.apache.ratis</groupId>
                             <artifactId>ratis-server-api</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-metrics-default</artifactId>
                         </dependency>
                     </ignoredDependencies>
                 </configuration>


### PR DESCRIPTION
## Description
Upgrade the org.apache.ratis dependency from version 2.2.0 to 3.1.3 to avoiding CVE issues.

CVE-2020-15250


## Motivation and Context
Upgrading the org.apache.ratis dependency from version 2.2.0 to 3.1.3 to  to reduce the risk of introducing new security flaws

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade org.apache.ratis  to 3.1.3 in response to `CVE-2020-15250<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250>`_. 



