### PR TITLE
[native]: Add operator override for xxhash64, combine_hash internal functions

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -72,6 +72,12 @@ std::string mapScalarFunction(const std::string& name) {
       {"presto.default.$operator$subscript",
        util::addDefaultNamespacePrefix(
            prestoDefaultNamespacePrefix, "subscript")},
+      {"presto.default.$operator$xx_hash_64", 
+       util::addDefaultNamespacePrefix(
+           prestoDefaultNamespacePrefix, "xxhash64_internal")},
+      {"presto.default.combine_hash", 
+       util::addDefaultNamespacePrefix(
+           prestoDefaultNamespacePrefix, "combine_hash_internal")},
       // Special form function overrides.
       {"presto.default.in", "in"},
   };


### PR DESCRIPTION
Summary: Add operator override for xxhash64 and combine_hash internal operators to unblock join prefilter optimization for Presto native execution. 

Differential Revision: D68917161


