### PR TITLE
[native] Trigger presto-native-sidecar-plugin test workflow when changes occur

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - 'presto-native-execution/**'
+      - 'presto-native-sidecar-plugin/**'
       - '.github/workflows/prestocpp-linux-build-and-unit-test.yml'
   push:
     branches:


### PR DESCRIPTION
## Description
Trigger `presto-native-sidecar-plugin` test workflow when changes occur.
The prestocpp build and tests needs to be triggered to test any change to the files in the directory.


## Motivation and Context
On changes made in the `presto-native-sidecar-plugin` module, `prestocpp-linux-presto-sidecar-tests` should run in the CI. However, `prestocpp-linux-presto-sidecar-tests` is dependent on the job `prestocpp-linux-build-for-test` which only runs if there are changes in the `presto-native-execution` module. 

## Impact
No impact


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

