### PR TITLE
Upgrade org.apache.logging.log4j:log4j-core and log4j-api libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <air.test.thread-count>2</air.test.thread-count>
         <air.test.jvmsize>4g</air.test.jvmsize>
         <grpc.version>1.68.0</grpc.version>
+        <dep.log4j.version>2.24.3</dep.log4j.version>
 
         <air.javadoc.lint>-missing</air.javadoc.lint>
     </properties>
@@ -231,6 +232,20 @@
                 <version>${dep.netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${dep.log4j.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${dep.log4j.version}</version>
+                <scope>runtime</scope>
             </dependency>
 
             <dependency>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.log4j.version>2.17.1</dep.log4j.version>
     </properties>
 
     <repositories>
@@ -178,14 +177,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>${dep.log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${dep.log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -12,7 +12,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.log4j.version>2.17.1</dep.log4j.version>
         <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
     </properties>
 
@@ -173,14 +172,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>${dep.log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${dep.log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
## Description
Upgraded org.apache.logging.log4j:log4j-core from 2.17.1 to 2.24.3 
Upgraded org.apache.logging.log4j:log4j-api from 2.17.1 to 2.24.3


## Motivation and Context
Addresses below CVEs

<img width="1167" alt="Screenshot 2025-02-06 at 4 55 39 PM" src="https://github.com/user-attachments/assets/009b49e7-6ada-4817-b28a-94e25d52fc64" />

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist
- [ ] Please make sure your submission complies with our [co
ntributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
*  Upgraded org.apache.logging.log4j:log4j-core from 2.17.1 to 2.24.3 in response to `CVE-2024-47554<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554>`
*  Upgraded org.apache.logging.log4j:log4j-api from 2.17.1 to 2.24.3 in response to `CVE-2024-47554 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554>`
