### PR TITLE
[docs] Add documentation for file-based metastore

### DIFF
--- a/presto-docs/src/main/sphinx/connector.rst
+++ b/presto-docs/src/main/sphinx/connector.rst
@@ -17,6 +17,7 @@ from different data sources.
     connector/deltalake
     connector/druid
     connector/elasticsearch
+    connector/file-based-metastore
     connector/googlesheets
     connector/hana
     connector/hive

--- a/presto-docs/src/main/sphinx/connector/file-based-metastore.rst
+++ b/presto-docs/src/main/sphinx/connector/file-based-metastore.rst
@@ -1,0 +1,71 @@
+====================
+File-Based Metastore
+====================
+
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+Overview
+^^^^^^^^
+
+For testing or developing purposes, Presto can be configured to use a local 
+filesystem directory as a Hive Metastore. 
+
+The file-based metastore works only with the following connectors: 
+
+* :doc:`/connector/deltalake`
+* :doc:`/connector/hive`
+* :doc:`/connector/hudi`
+* :doc:`/connector/iceberg`
+
+Configuring a File-Based Metastore
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. In ``etc/catalog/``, find the catalog properties file for the supported 
+   connector. 
+
+2. In the catalog properties file, set the following properties:
+
+.. code-block:: none
+
+    hive.metastore=file
+    hive.metastore.catalog.dir=file:///<catalog-dir>
+
+Replace ``<catalog-dir>`` in the example with the path to a directory on an 
+accessible filesystem.
+
+Using a File-Based Warehouse
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this example, assume the Hive connector is being used, and the properties 
+in the Hive connector catalog file are set to the following:
+
+.. code-block:: none
+
+    connector.name=hive
+    hive.metastore=file
+    hive.metastore.catalog.dir=file:///data/hive_data/
+
+Create a schema
+
+.. code-block:: none
+
+    CREATE SCHEMA hive.warehouse;
+
+This query creates a directory ``warehouse`` in the directory set for 
+``hive.metastore.catalog.dir``, so the path to the new directory is 
+``/data/hive_data/warehouse``.
+
+Create a table with any connector-supported file formats. For example, if the 
+Hive connector is being configured: 
+
+.. code-block:: none
+
+    CREATE TABLE hive.warehouse.orders_csv("order_name" varchar, "quantity" varchar) WITH (format = 'CSV');
+    CREATE TABLE hive.warehouse.orders_parquet("order_name" varchar, "quantity" int) WITH (format = 'PARQUET');
+
+These queries create folders as ``/data/hive_data/warehouse/orders_csv`` and 
+``/data/hive_data/warehouse/orders_parquet``. Users can insert and query 
+from these tables.

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -7,6 +7,8 @@ Deploying Presto
     :backlinks: none
     :depth: 1
 
+.. _Installing Presto:
+
 Installing Presto
 -----------------
 


### PR DESCRIPTION
## Description
Add how to configure Presto to use a file-based hms to [installation/deployment.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/installation/deployment.rst). 

## Motivation and Context
@ethanyzhang suggested this would be a good addition to the Presto documentation in an internal discussion that @nmahadevuni contributed the configuration in. I discussed where such information would fit best in the Presto documentation with @tdcmeehan. 

## Impact
Documentation. Readers wanting to try out Presto quickly can bypass the need for the steps in [Configure Hive MetaStore](https://prestodb.io/docs/current/installation/deployment.html#configure-hive-metastore). 

## Test Plan
Local doc build. Screenshot with existing text above and below included for context. 
<img width="1069" alt="Screenshot 2025-02-06 at 4 41 07 PM" src="https://github.com/user-attachments/assets/553762b1-5f10-49f1-8449-0604bb6803c9" />



## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add documentation for file-based Hive metastore to :doc:`/connector/file-based-metastore`.
```