### PR TITLE
Upgrade to actions/setup-java@v4

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -46,28 +46,15 @@ jobs:
         with:
           show-progress: false
 
-      # Set up Java for the build environment
+      # Set up Java and dependencies for the build environment
       - uses: actions/setup-java@v4
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: 8
-
-      # Cache Maven dependencies to speed up the build
-      - name: Cache local Maven repository
-        if: needs.changes.outputs.codechange == 'true'
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-
-      # Resolve Maven dependencies (if cache is not found)
-      - name: Populate Maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true' && needs.changes.outputs.codechange == 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
 
       # Install dependencies for the target module
       - name: Maven Install

--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -47,7 +47,7 @@ jobs:
           show-progress: false
 
       # Set up Java for the build environment
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,25 +30,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 8
       - name: Install LaTeX dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra latexmk tex-gyre texlive-xetex fonts-freefont-otf xindy
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
+      - uses: actions/setup-java@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress
+          distribution: 'temurin'
+          java-version: 8
+          cache: 'maven'
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -46,17 +46,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Install Hive Module
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -98,17 +90,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Install Hive Module
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -44,17 +44,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -30,17 +30,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies  --no-transfer-progress -P ci && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Maven Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -125,20 +125,10 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8'
-
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+          java-version: 8
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
 
       - name: Maven install
         env:
@@ -208,18 +198,13 @@ jobs:
       - name: Check Java
         run: java --version
 
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
+      - uses: actions/setup-java@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+          distribution: 'temurin'
+          java-version: 8
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
 
       - name: Maven install
         env:
@@ -289,19 +274,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '8'
-
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
 
       - name: Maven install
         env:

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -50,17 +50,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Maven install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -50,17 +50,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Maven install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -101,17 +93,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Maven install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -53,7 +53,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           echo "=== AFTER ==="
           df -h
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -57,17 +57,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Install SingleStore Module
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -45,17 +45,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -45,20 +45,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       # Workaround for Ubuntu 24 and mysql to find the dependent library (https://github.com/prestodb/presto/issues/24327)
       - name: Create symlink for libaio.so.1
         run: sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress && .github/bin/download_nodejs
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
         if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,22 +76,12 @@ jobs:
         with:
           show-progress: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Cache local Maven repository
-        if: needs.changes.outputs.codechange == 'true'
-        id: cache-maven
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-2-
-      - name: Populate maven cache
-        if: steps.cache-maven.outputs.cache-hit != 'true' && needs.changes.outputs.codechange == 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress && .github/bin/download_nodejs
+          cache: 'maven'
+      - name: Download nodejs to maven cache
+        run: .github/bin/download_nodejs
       - name: Maven Install
         if: needs.changes.outputs.codechange == 'true'
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -2684,57 +2684,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>de.qaware.maven</groupId>
-                <artifactId>go-offline-maven-plugin</artifactId>
-                <version>1.2.8</version>
-                <configuration>
-                    <dynamicDependencies>
-                        <DynamicDependency>
-                            <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-testng</artifactId>
-                            <version>3.0.0-M7</version>
-                            <repositoryType>PLUGIN</repositoryType>
-                        </DynamicDependency>
-                        <DynamicDependency>
-                            <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-junit4</artifactId>
-                            <version>3.0.0-M7</version>
-                            <repositoryType>PLUGIN</repositoryType>
-                        </DynamicDependency>
-                        <DynamicDependency>
-                            <groupId>com.google.protobuf</groupId>
-                            <artifactId>protoc</artifactId>
-                            <version>3.0.0</version>
-                            <classifier>${os.detected.classifier}</classifier>
-                            <type>exe</type>
-                            <repositoryType>PLUGIN</repositoryType>
-                        </DynamicDependency>
-                        <DynamicDependency>
-                            <groupId>io.grpc</groupId>
-                            <artifactId>protoc-gen-grpc-java</artifactId>
-                            <version>1.0.0</version>
-                            <classifier>${os.detected.classifier}</classifier>
-                            <type>exe</type>
-                            <repositoryType>PLUGIN</repositoryType>
-                        </DynamicDependency>
-                        <DynamicDependency>
-                            <groupId>com.querydsl</groupId>
-                            <artifactId>querydsl-apt</artifactId>
-                            <version>4.2.1</version>
-                            <classifier>jpa</classifier>
-                            <repositoryType>MAIN</repositoryType>
-                        </DynamicDependency>
-                        <DynamicDependency>
-                            <groupId>org.flywaydb</groupId>
-                            <artifactId>flyway-commandline</artifactId>
-                            <version>4.0.3</version>
-                            <type>zip</type>
-                            <repositoryType>MAIN</repositoryType>
-                        </DynamicDependency>
-                    </dynamicDependencies>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>


### PR DESCRIPTION
## Description

Since #24493 was merged I was looking at CI and noticed that `setup-java` is also quite old. This PR upgrades to setup-java@v4 and removes the home-grown go-offline+cache solution in favor of the built-in solution. Internally they use actions/cache and it also simplifies the CI configs. The new cache key is the hash of all pom files in the project. 

The caching behavior is actually slightly different than before. Previously we would restore the cache using two cache keys: one with a hash of the pom files, and one without any hash, such as `linux-maven-2-`. This downside of this approach is that the cache grows over time because when you restore from a cache which doesn't used a hash of the POMs, and make a dependency update, the cache may be saved again that contains both old dependency and new dependencies.

When I compare the size of cache hits on our actions, I see that our current cache size [is quite large](https://github.com/prestodb/presto/actions/runs/13037238038/job/36370602879?pr=24456#step:4:20)!

```
Run actions/cache@v2
Received 251658240 of 900086244 (28.0%), 240.0 MBs/sec
Received 532676608 of 900086244 (59.2%), 254.0 MBs/sec
Received 805306368 of 900086244 (89.5%), 256.1 MBs/sec
Received 900086244 of 900086244 (100.0%), 209.3 MBs/sec
Cache Size: ~858 MB (900086244 B)
```

Compared to restoring fresh caches with [this PR](https://github.com/prestodb/presto/actions/runs/13193474967/job/36830812486?pr=24512#step:4:42):

```
Run actions/setup-java@v4
Installed distributions
Creating settings.xml with server-id: github
Writing to /home/runner/.m2/settings.xml
Received 209715200 of 426035899 (49.2%), 198.6 MBs/sec
Cache Size: ~406 MB (426035899 B)
```

Materially, it doesn't make a huge difference in time when cache restores take on the order of a few seconds, but it may save on some storage costs.


## Motivation and Context

Less complex CI pipelines and access to newer java versions

## Release Notes

```
== NO RELEASE NOTE ==
```

