### PR TITLE
Use builder pattern for IcebergQueryRunner

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHadoopCatalog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHadoopCatalog.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.google.common.collect.ImmutableMap;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
@@ -27,12 +26,9 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
-import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
-import static com.facebook.presto.iceberg.FileFormat.PARQUET;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.openjdk.jmh.annotations.Mode.AverageTime;
 import static org.openjdk.jmh.annotations.Scope.Benchmark;
@@ -50,14 +46,11 @@ public class BenchmarkIcebergHadoopCatalog
     public DistributedQueryRunner getQueryRunner()
     {
         try {
-            return createIcebergQueryRunner(
-                    ImmutableMap.of(),
-                    ImmutableMap.of("iceberg.catalog.type", HADOOP.name()),
-                    PARQUET,
-                    false,
-                    true,
-                    OptionalInt.of(1),
-                    Optional.empty());
+            return IcebergQueryRunner.builder()
+                    .setCatalogType(HADOOP)
+                    .setNodeCount(OptionalInt.of(4))
+                    .build()
+                    .getQueryRunner();
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHiveCatalog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergHiveCatalog.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.google.common.collect.ImmutableMap;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
@@ -27,11 +26,9 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
-import java.util.Optional;
 import java.util.OptionalInt;
 
-import static com.facebook.presto.iceberg.FileFormat.PARQUET;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.openjdk.jmh.annotations.Mode.AverageTime;
 import static org.openjdk.jmh.annotations.Scope.Benchmark;
@@ -49,14 +46,10 @@ public class BenchmarkIcebergHiveCatalog
     public DistributedQueryRunner getQueryRunner()
     {
         try {
-            return createIcebergQueryRunner(
-                    ImmutableMap.of(),
-                    ImmutableMap.of(),
-                    PARQUET,
-                    false,
-                    true,
-                    OptionalInt.of(1),
-                    Optional.empty());
+            return IcebergQueryRunner.builder()
+                    .setCatalogType(HIVE)
+                    .setNodeCount(OptionalInt.of(1))
+                    .build().getQueryRunner();
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -23,7 +23,6 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.assertions.Assert;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
-import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.UpdateProperties;
 import org.intellij.lang.annotations.Language;
@@ -74,7 +73,7 @@ public abstract class IcebergDistributedSmokeTestBase
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), catalogType);
+        return IcebergQueryRunner.builder().setCatalogType(catalogType).build().getQueryRunner();
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -193,7 +193,10 @@ public abstract class IcebergDistributedTestBase
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), catalogType, extraConnectorProperties);
+        return IcebergQueryRunner.builder()
+                .setCatalogType(catalogType)
+                .setExtraConnectorProperties(extraConnectorProperties)
+                .build().getQueryRunner();
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -46,20 +46,25 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
 import static com.facebook.airlift.log.Level.ERROR;
 import static com.facebook.airlift.log.Level.WARN;
 import static com.facebook.presto.hive.HiveTestUtils.getDataDirectoryPath;
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
+import static com.facebook.presto.iceberg.FileFormat.PARQUET;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 public final class IcebergQueryRunner
 {
@@ -69,181 +74,198 @@ public final class IcebergQueryRunner
     public static final String TEST_DATA_DIRECTORY = "iceberg_data";
     public static final MetastoreContext METASTORE_CONTEXT = new MetastoreContext("test_user", "test_queryId", Optional.empty(), Collections.emptySet(), Optional.empty(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER, WarningCollector.NOOP, new RuntimeStats());
 
-    private IcebergQueryRunner() {}
+    private DistributedQueryRunner queryRunner;
+    private Map<String, Map<String, String>> icebergCatalogs;
 
-    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, Optional<Path> dataDirectory)
-            throws Exception
+    private IcebergQueryRunner(DistributedQueryRunner queryRunner, Map<String, Map<String, String>> icebergCatalogs)
     {
-        return createIcebergQueryRunner(extraProperties, ImmutableMap.of(), dataDirectory);
+        this.queryRunner = requireNonNull(queryRunner, "queryRunner is null");
+        this.icebergCatalogs = new ConcurrentHashMap<>(requireNonNull(icebergCatalogs, "icebergCatalogs is null"));
     }
 
-    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, CatalogType catalogType)
-            throws Exception
+    public DistributedQueryRunner getQueryRunner()
     {
-        return createIcebergQueryRunner(extraProperties, ImmutableMap.of("iceberg.catalog.type", catalogType.name()), Optional.empty());
+        return queryRunner;
     }
 
-    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, CatalogType catalogType, Map<String, String> extraConnectorProperties)
-            throws Exception
+    public Map<String, Map<String, String>> getIcebergCatalogs()
     {
-        return createIcebergQueryRunner(
-                extraProperties,
-                ImmutableMap.<String, String>builder()
-                        .putAll(extraConnectorProperties)
-                        .put("iceberg.catalog.type", catalogType.name())
-                        .build(),
-                Optional.empty());
+        return icebergCatalogs;
     }
 
-    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, Map<String, String> extraConnectorProperties)
-            throws Exception
+    public void addCatalog(String name, Map<String, String> properties)
     {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, Optional.empty());
+        queryRunner.createCatalog(name, "iceberg", properties);
+        icebergCatalogs.put(name, properties);
     }
 
-    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, Map<String, String> extraConnectorProperties, Optional<Path> dataDirectory)
-            throws Exception
+    public static Builder builder()
     {
-        FileFormat defaultFormat = new IcebergConfig().getFileFormat();
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, defaultFormat, true, dataDirectory);
+        return new Builder();
     }
 
-    public static DistributedQueryRunner createIcebergQueryRunner(Map<String, String> extraProperties, Map<String, String> extraConnectorProperties, FileFormat format)
-            throws Exception
+    public static class Builder
     {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, true, Optional.empty());
-    }
+        private Builder() {}
 
-    public static DistributedQueryRunner createIcebergQueryRunner(
-            Map<String, String> extraProperties,
-            Map<String, String> extraConnectorProperties,
-            FileFormat format,
-            boolean createTpchTables,
-            Optional<Path> dataDirectory)
-            throws Exception
-    {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, false, OptionalInt.empty(), dataDirectory);
-    }
+        private CatalogType catalogType = HIVE;
+        private Map<String, Map<String, String>> icebergCatalogs = new HashMap<>();
+        private Map<String, String> extraProperties = new HashMap<>();
+        private Map<String, String> extraConnectorProperties = new HashMap<>();
+        private Map<String, String> tpcdsProperties = new HashMap<>();
+        private FileFormat format = PARQUET;
+        private boolean createTpchTables = true;
+        private boolean addJmxPlugin = true;
+        private OptionalInt nodeCount = OptionalInt.of(4);
+        private Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher = Optional.empty();
+        private Optional<Path> dataDirectory = Optional.empty();
+        private boolean addStorageFormatToPath;
+        private Optional<String> schemaName = Optional.empty();
 
-    public static DistributedQueryRunner createIcebergQueryRunner(
-            Map<String, String> extraProperties,
-            Map<String, String> extraConnectorProperties,
-            FileFormat format,
-            boolean createTpchTables,
-            boolean addJmxPlugin,
-            OptionalInt nodeCount,
-            Optional<Path> dataDirectory)
-            throws Exception
-    {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, addJmxPlugin, nodeCount, Optional.empty(), dataDirectory);
-    }
-
-    public static DistributedQueryRunner createIcebergQueryRunner(
-            Map<String, String> extraProperties,
-            Map<String, String> extraConnectorProperties,
-            FileFormat format,
-            boolean createTpchTables,
-            boolean addJmxPlugin,
-            OptionalInt nodeCount,
-            Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher,
-            Optional<Path> dataDirectory)
-            throws Exception
-    {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, addJmxPlugin, nodeCount, externalWorkerLauncher, dataDirectory, false, Optional.empty(), ImmutableMap.of());
-    }
-
-    public static DistributedQueryRunner createIcebergQueryRunner(
-            Map<String, String> extraProperties,
-            Map<String, String> extraConnectorProperties,
-            FileFormat format,
-            boolean createTpchTables,
-            boolean addJmxPlugin,
-            OptionalInt nodeCount,
-            Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher,
-            Optional<Path> dataDirectory,
-            boolean addStorageFormatToPath,
-            Map<String, String> tpcdsProperties)
-            throws Exception
-    {
-        return createIcebergQueryRunner(extraProperties, extraConnectorProperties, format, createTpchTables, addJmxPlugin, nodeCount, externalWorkerLauncher, dataDirectory, addStorageFormatToPath, Optional.empty(), tpcdsProperties);
-    }
-
-    public static DistributedQueryRunner createIcebergQueryRunner(
-            Map<String, String> extraProperties,
-            Map<String, String> extraConnectorProperties,
-            FileFormat format,
-            boolean createTpchTables,
-            boolean addJmxPlugin,
-            OptionalInt nodeCount,
-            Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher,
-            Optional<Path> dataDirectory,
-            boolean addStorageFormatToPath,
-            Optional<String> schemaName,
-            Map<String, String> tpcdsProperties)
-            throws Exception
-    {
-        setupLogging();
-
-        Session session = testSessionBuilder()
-                .setCatalog(ICEBERG_CATALOG)
-                .setSchema(schemaName.orElse("tpch"))
-                .build();
-
-        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
-                .setExtraProperties(extraProperties)
-                .setDataDirectory(dataDirectory)
-                .setNodeCount(nodeCount.orElse(4))
-                .setExternalWorkerLauncher(externalWorkerLauncher)
-                .build();
-
-        queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
-
-        queryRunner.installPlugin(new TpcdsPlugin());
-        queryRunner.createCatalog("tpcds", "tpcds", tpcdsProperties);
-
-        queryRunner.getServers().forEach(server -> {
-            MBeanServer mBeanServer = MBeanServerFactory.newMBeanServer();
-            server.installPlugin(new IcebergPlugin(mBeanServer));
-            if (addJmxPlugin) {
-                server.installPlugin(new JmxPlugin(mBeanServer));
-            }
-        });
-
-        String catalogType = extraConnectorProperties.getOrDefault("iceberg.catalog.type", HIVE.name());
-        Path icebergDataDirectory = getIcebergDataDirectoryPath(queryRunner.getCoordinator().getDataDirectory(), catalogType, format, addStorageFormatToPath);
-
-        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
-                .put("iceberg.file-format", format.name())
-                .putAll(getConnectorProperties(CatalogType.valueOf(catalogType), icebergDataDirectory))
-                .putAll(extraConnectorProperties)
-                .build();
-
-        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
-
-        if (addJmxPlugin) {
-            queryRunner.createCatalog("jmx", "jmx");
+        public Builder setFormat(FileFormat format)
+        {
+            this.format = format;
+            return this;
         }
 
-        if (catalogType.equals(HIVE.name())) {
-            ExtendedHiveMetastore metastore = getFileHiveMetastore(icebergDataDirectory);
-            if (!metastore.getDatabase(METASTORE_CONTEXT, "tpch").isPresent()) {
-                queryRunner.execute("CREATE SCHEMA tpch");
+        public Builder setExternalWorkerLauncher(Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher)
+        {
+            this.externalWorkerLauncher = externalWorkerLauncher;
+            return this;
+        }
+
+        public Builder setSchemaName(String schemaName)
+        {
+            this.schemaName = Optional.of(schemaName);
+            return this;
+        }
+
+        public Builder setCreateTpchTables(boolean createTpchTables)
+        {
+            this.createTpchTables = createTpchTables;
+            return this;
+        }
+
+        public Builder setAddJmxPlugin(boolean addJmxPlugin)
+        {
+            this.addJmxPlugin = addJmxPlugin;
+            return this;
+        }
+
+        public Builder setNodeCount(OptionalInt nodeCount)
+        {
+            this.nodeCount = nodeCount;
+            return this;
+        }
+
+        public Builder setExtraProperties(Map<String, String> extraProperties)
+        {
+            this.extraProperties = extraProperties;
+            return this;
+        }
+
+        public Builder setCatalogType(CatalogType catalogType)
+        {
+            this.catalogType = catalogType;
+            return this;
+        }
+
+        public Builder setDataDirectory(Optional<Path> dataDirectory)
+        {
+            this.dataDirectory = dataDirectory;
+            return this;
+        }
+
+        public Builder setExtraConnectorProperties(Map<String, String> extraConnectorProperties)
+        {
+            this.extraConnectorProperties = extraConnectorProperties;
+            return this;
+        }
+
+        public Builder setAddStorageFormatToPath(boolean addStorageFormatToPath)
+        {
+            this.addStorageFormatToPath = addStorageFormatToPath;
+            return this;
+        }
+
+        public Builder setTpcdsProperties(Map<String, String> tpcdsProperties)
+        {
+            this.tpcdsProperties = tpcdsProperties;
+            return this;
+        }
+
+        public IcebergQueryRunner build()
+                throws Exception
+        {
+            setupLogging();
+
+            checkArgument(!extraConnectorProperties.containsKey("iceberg.catalog.type"), "extraConnectorProperties cannot contain iceberg.catalog.type");
+            checkArgument(!extraConnectorProperties.containsKey("iceberg.file-format"), "extraConnectorProperties cannot contain iceberg.file-format");
+
+            ImmutableMap.Builder<String, Map<String, String>> icebergCatalogs = ImmutableMap.builder();
+
+            Session session = testSessionBuilder()
+                    .setCatalog(ICEBERG_CATALOG)
+                    .setSchema(schemaName.orElse("tpch"))
+                    .build();
+
+            DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                    .setExtraProperties(extraProperties)
+                    .setDataDirectory(dataDirectory)
+                    .setNodeCount(nodeCount.orElse(4))
+                    .setExternalWorkerLauncher(externalWorkerLauncher)
+                    .build();
+
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            queryRunner.installPlugin(new TpcdsPlugin());
+            queryRunner.createCatalog("tpcds", "tpcds", tpcdsProperties);
+
+            queryRunner.getServers().forEach(server -> {
+                MBeanServer mBeanServer = MBeanServerFactory.newMBeanServer();
+                server.installPlugin(new IcebergPlugin(mBeanServer));
+                if (addJmxPlugin) {
+                    server.installPlugin(new JmxPlugin(mBeanServer));
+                }
+            });
+
+            Path icebergDataDirectory = getIcebergDataDirectoryPath(queryRunner.getCoordinator().getDataDirectory(), catalogType.name(), format, addStorageFormatToPath);
+
+            Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                    .put("iceberg.file-format", format.name())
+                    .put("iceberg.catalog.type", catalogType.name())
+                    .putAll(getConnectorProperties(catalogType, icebergDataDirectory))
+                    .putAll(extraConnectorProperties)
+                    .build();
+
+            queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
+            icebergCatalogs.put(ICEBERG_CATALOG, icebergProperties);
+
+            if (addJmxPlugin) {
+                queryRunner.createCatalog("jmx", "jmx");
             }
-            if (!metastore.getDatabase(METASTORE_CONTEXT, "tpcds").isPresent()) {
+
+            if (catalogType == HIVE) {
+                ExtendedHiveMetastore metastore = getFileHiveMetastore(icebergDataDirectory);
+                if (!metastore.getDatabase(METASTORE_CONTEXT, "tpch").isPresent()) {
+                    queryRunner.execute("CREATE SCHEMA tpch");
+                }
+                if (!metastore.getDatabase(METASTORE_CONTEXT, "tpcds").isPresent()) {
+                    queryRunner.execute("CREATE SCHEMA tpcds");
+                }
+            }
+            else {
+                queryRunner.execute("CREATE SCHEMA tpch");
                 queryRunner.execute("CREATE SCHEMA tpcds");
             }
-        }
-        else {
-            queryRunner.execute("CREATE SCHEMA tpch");
-            queryRunner.execute("CREATE SCHEMA tpcds");
-        }
 
-        if (createTpchTables) {
-            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables(), true);
-        }
+            if (createTpchTables) {
+                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables(), true);
+            }
 
-        return queryRunner;
+            return new IcebergQueryRunner(queryRunner, icebergCatalogs.build());
+        }
     }
 
     private static ExtendedHiveMetastore getFileHiveMetastore(Path dataDirectory)
@@ -263,7 +285,7 @@ public final class IcebergQueryRunner
         return icebergCatalogDirectory;
     }
 
-    private static Map<String, String> getConnectorProperties(CatalogType icebergCatalogType, Path icebergDataDirectory)
+    public static Map<String, String> getConnectorProperties(CatalogType icebergCatalogType, Path icebergDataDirectory)
     {
         switch (icebergCatalogType) {
             case HADOOP:
@@ -324,7 +346,11 @@ public final class IcebergQueryRunner
         Map<String, String> properties = ImmutableMap.of("http-server.http.port", "8080");
         DistributedQueryRunner queryRunner = null;
         try {
-            queryRunner = createIcebergQueryRunner(properties, dataDirectory);
+            queryRunner = builder()
+                    .setExtraProperties(properties)
+                    .setDataDirectory(dataDirectory)
+                    .build()
+                    .getQueryRunner();
         }
         catch (Throwable t) {
             log.error(t);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
@@ -57,7 +57,10 @@ public abstract class TestIcebergDistributedQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), catalogType, extraConnectorProperties);
+        return IcebergQueryRunner.builder()
+                .setCatalogType(catalogType)
+                .setExtraConnectorProperties(extraConnectorProperties)
+                .build().getQueryRunner();
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -87,7 +87,6 @@ import static com.facebook.presto.iceberg.IcebergAbstractMetadata.isEntireColumn
 import static com.facebook.presto.iceberg.IcebergColumnHandle.getSynthesizedIcebergColumnHandle;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.isPushedDownSubfield;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.PARQUET_DEREFERENCE_PUSHDOWN_ENABLED;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
@@ -130,7 +129,10 @@ public class TestIcebergLogicalPlanner
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(ImmutableMap.of("experimental.pushdown-subfields-enabled", "true"), ImmutableMap.of());
+        return IcebergQueryRunner.builder()
+                .setExtraProperties(ImmutableMap.of("experimental.pushdown-subfields-enabled", "true"))
+                .build()
+                .getQueryRunner();
     }
 
     @DataProvider(name = "push_down_filter_enabled")

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergParquetMetadataCaching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergParquetMetadataCaching.java
@@ -21,11 +21,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.Optional;
 import java.util.OptionalInt;
 
-import static com.facebook.presto.iceberg.FileFormat.PARQUET;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -36,17 +33,15 @@ public class TestIcebergParquetMetadataCaching
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(
-                ImmutableMap.of(),
-                ImmutableMap.of(
-                        "iceberg.parquet.metadata-cache-enabled", "true",
-                        "iceberg.parquet.metadata-cache-size", "100MB",
-                        "iceberg.parquet.metadata-cache-ttl-since-last-access", "1h"),
-                PARQUET,
-                false,
-                true,
-                OptionalInt.of(2),
-                Optional.empty());
+        return IcebergQueryRunner.builder()
+                .setExtraConnectorProperties(
+                        ImmutableMap.of(
+                                "iceberg.parquet.metadata-cache-enabled", "true",
+                                "iceberg.parquet.metadata-cache-size", "100MB",
+                                "iceberg.parquet.metadata-cache-ttl-since-last-access", "1h"))
+                .setNodeCount(OptionalInt.of(2))
+                .build()
+                .getQueryRunner();
     }
 
     @BeforeClass

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
@@ -29,18 +29,15 @@ import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.TableProperties;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.TARGET_SPLIT_SIZE;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
@@ -58,7 +55,7 @@ public class TestIcebergSplitManager
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(ImmutableMap.of(), Optional.empty());
+        return IcebergQueryRunner.builder().build().getQueryRunner();
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableChangelog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableChangelog.java
@@ -16,7 +16,6 @@ package com.facebook.presto.iceberg;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -24,7 +23,7 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 
 public class TestIcebergTableChangelog
         extends AbstractTestQueryFramework
@@ -33,7 +32,10 @@ public class TestIcebergTableChangelog
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(ImmutableMap.of(), CatalogType.HADOOP);
+        return IcebergQueryRunner.builder()
+                .setCatalogType(HADOOP)
+                .build()
+                .getQueryRunner();
     }
 
     private long[] snapshots = new long[0];

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
@@ -21,14 +21,12 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
-import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
 
 import static com.facebook.presto.hive.HiveCommonSessionProperties.PARQUET_BATCH_READ_OPTIMIZATION_ENABLED;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -38,7 +36,7 @@ public class TestIcebergTypes
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(ImmutableMap.of(), ImmutableMap.of());
+        return IcebergQueryRunner.builder().build().getQueryRunner();
     }
 
     @DataProvider(name = "testTimestampWithTimezone")

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
@@ -34,6 +34,7 @@ import com.facebook.presto.iceberg.CatalogType;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
 import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
 import com.facebook.presto.iceberg.IcebergMetadataColumn;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.Metadata;
@@ -53,7 +54,6 @@ import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
-import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -85,7 +85,6 @@ import static com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore.me
 import static com.facebook.presto.iceberg.CatalogType.HIVE;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.TEST_DATA_DIRECTORY;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.HIVE_METASTORE_STATISTICS_MERGE_STRATEGY;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.STATISTICS_KLL_SKETCH_K_PARAMETER;
@@ -108,11 +107,16 @@ import static org.testng.Assert.assertTrue;
 public class TestIcebergHiveStatistics
         extends AbstractTestQueryFramework
 {
+    private IcebergQueryRunner icebergQueryRunner;
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(ImmutableMap.of(), ImmutableMap.of("iceberg.hive-statistics-merge-strategy", NUMBER_OF_DISTINCT_VALUES.name()));
+        icebergQueryRunner = IcebergQueryRunner.builder()
+                .setExtraConnectorProperties(ImmutableMap.of("iceberg.hive-statistics-merge-strategy", NUMBER_OF_DISTINCT_VALUES.name()))
+                .build();
+        return icebergQueryRunner.getQueryRunner();
     }
 
     private static final Set<String> NUMERIC_ORDERS_COLUMNS = ImmutableSet.<String>builder()
@@ -411,35 +415,40 @@ public class TestIcebergHiveStatistics
     public void testStatisticsCachePartialEviction()
             throws Exception
     {
-        try (DistributedQueryRunner queryRunner = createIcebergQueryRunner(ImmutableMap.of(), ImmutableMap.of("iceberg.max-statistics-file-cache-size", "1024B"))) {
-            Session session = Session.builder(queryRunner.getDefaultSession())
-                    // set histograms enabled
-                    .setSystemProperty(OPTIMIZER_USE_HISTOGRAMS, "true")
-                    .setCatalogSessionProperty("iceberg", STATISTICS_KLL_SKETCH_K_PARAMETER, "32768")
-                    .build();
+        String catalogName = "ice_stat_file_cache";
+        Map<String, String> catalogProperties = ImmutableMap.<String, String>builder().putAll(icebergQueryRunner.getIcebergCatalogs().get("iceberg"))
+                .put("iceberg.max-statistics-file-cache-size", "1024B")
+                .build();
+        getQueryRunner().createCatalog(catalogName, "iceberg", catalogProperties);
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalog(catalogName)
+                // set histograms enabled to increase statistics cache size
+                .setSystemProperty(OPTIMIZER_USE_HISTOGRAMS, "true")
+                .setCatalogSessionProperty(catalogName, STATISTICS_KLL_SKETCH_K_PARAMETER, "32768")
+                .build();
 
-            queryRunner.execute(session, "ANALYZE lineitem");
-            // get table statistics, to populate some of the cache
-            TableStatistics statistics = getTableStatistics(queryRunner, session, "lineitem");
-            RuntimeStats runtimeStats = session.getRuntimeStats();
-            runtimeStats.getMetrics().keySet().stream().filter(name -> name.contains("ColumnCount")).findFirst()
-                    .ifPresent(stat -> assertEquals(32, runtimeStats.getMetric(stat).getSum()));
-            runtimeStats.getMetrics().keySet().stream().filter(name -> name.contains("PuffinFileSize")).findFirst()
-                    .ifPresent(stat -> assertTrue(runtimeStats.getMetric(stat).getSum() > 1024));
-            // get them again to trigger retrieval of _some_ cached statistics
-            statistics = getTableStatistics(queryRunner, session, "lineitem");
-            RuntimeMetric partialMiss = runtimeStats.getMetrics().keySet().stream().filter(name -> name.contains("PartialMiss")).findFirst()
-                    .map(runtimeStats::getMetric)
-                    .orElseThrow(() -> new RuntimeException("partial miss on statistics cache should have occurred"));
-            assertTrue(partialMiss.getCount() > 0);
+        assertQuerySucceeds(session, "ANALYZE lineitem");
+        // get table statistics, to populate some of the cache
+        TableStatistics statistics = getTableStatistics(getQueryRunner(), session, "lineitem");
+        assertTrue(statistics.getColumnStatistics().values().stream().map(ColumnStatistics::getHistogram).anyMatch(Optional::isPresent));
+        RuntimeStats runtimeStats = session.getRuntimeStats();
+        runtimeStats.getMetrics().keySet().stream().filter(name -> name.contains("ColumnCount")).findFirst()
+                .ifPresent(stat -> assertEquals(runtimeStats.getMetric(stat).getSum(), 32));
+        runtimeStats.getMetrics().keySet().stream().filter(name -> name.contains("PuffinFileSize")).findFirst()
+                .ifPresent(stat -> assertTrue(runtimeStats.getMetric(stat).getSum() > 1024));
+        // get them again to trigger retrieval of _some_ cached statistics
+        statistics = getTableStatistics(getQueryRunner(), session, "lineitem");
+        RuntimeMetric partialMiss = runtimeStats.getMetrics().keySet().stream().filter(name -> name.contains("PartialMiss")).findFirst()
+                .map(runtimeStats::getMetric)
+                .orElseThrow(() -> new RuntimeException("partial miss on statistics cache should have occurred"));
+        assertTrue(partialMiss.getCount() > 0);
 
-            statistics.getColumnStatistics().forEach((handle, stats) -> {
-                assertFalse(stats.getDistinctValuesCount().isUnknown());
-                if (isKllHistogramSupportedType(((IcebergColumnHandle) handle).getType())) {
-                    assertTrue(stats.getHistogram().isPresent());
-                }
-            });
-        }
+        statistics.getColumnStatistics().forEach((handle, stats) -> {
+            assertFalse(stats.getDistinctValuesCount().isUnknown());
+            if (isKllHistogramSupportedType(((IcebergColumnHandle) handle).getType())) {
+                assertTrue(stats.getHistogram().isPresent());
+            }
+        });
     }
 
     private TableStatistics getScanStatsEstimate(Session session, @Language("SQL") String sql)
@@ -504,7 +513,7 @@ public class TestIcebergHiveStatistics
         Metadata meta = queryRunner.getMetadata();
         return meta.getTableHandleForStatisticsCollection(
                 session,
-                new QualifiedObjectName("iceberg", "tpch", tableName.toLowerCase(Locale.US)),
+                new QualifiedObjectName(session.getCatalog().get(), session.getSchema().get(), tableName.toLowerCase(Locale.US)),
                 Collections.emptyMap()).get();
     }
 
@@ -516,7 +525,7 @@ public class TestIcebergHiveStatistics
     private static TableHandle getTableHandle(QueryRunner queryRunner, String tableName, Session session)
     {
         MetadataResolver resolver = queryRunner.getMetadata().getMetadataResolver(session);
-        return resolver.getTableHandle(new QualifiedObjectName("iceberg", "tpch", tableName.toLowerCase(Locale.US))).get();
+        return resolver.getTableHandle(new QualifiedObjectName(session.getCatalog().get(), session.getSchema().get(), tableName.toLowerCase(Locale.US))).get();
     }
 
     private static Map<String, ColumnHandle> getColumnHandles(QueryRunner queryRunner, String tableName, Session session)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/NessieTestUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/NessieTestUtil.java
@@ -17,8 +17,6 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
-import static com.facebook.presto.iceberg.CatalogType.NESSIE;
-
 public class NessieTestUtil
 {
     private NessieTestUtil()
@@ -27,6 +25,6 @@ public class NessieTestUtil
 
     public static Map<String, String> nessieConnectorProperties(String serverUri)
     {
-        return ImmutableMap.of("iceberg.catalog.type", NESSIE.name(), "iceberg.nessie.uri", serverUri);
+        return ImmutableMap.of("iceberg.nessie.uri", serverUri);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
@@ -69,7 +69,10 @@ public class TestIcebergDistributedNessie
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+        return IcebergQueryRunner.builder()
+                .setCatalogType(NESSIE)
+                .setExtraConnectorProperties(nessieConnectorProperties(nessieContainer.getRestApiUri()))
+                .build().getQueryRunner();
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieCatalogDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieCatalogDistributedQueries.java
@@ -17,7 +17,6 @@ import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.iceberg.TestIcebergDistributedQueries;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
-import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
@@ -56,7 +55,10 @@ public class TestIcebergNessieCatalogDistributedQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+        return IcebergQueryRunner.builder()
+                .setCatalogType(NESSIE)
+                .setExtraConnectorProperties(nessieConnectorProperties(nessieContainer.getRestApiUri()))
+                .build().getQueryRunner();
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.Table;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -95,7 +94,10 @@ public class TestIcebergSmokeNessie
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+        return IcebergQueryRunner.builder()
+                .setCatalogType(NESSIE)
+                .setExtraConnectorProperties(nessieConnectorProperties(nessieContainer.getRestApiUri()))
+                .build().getQueryRunner();
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
@@ -70,6 +71,7 @@ public class TestIcebergSystemTablesNessie
         Session session = testSessionBuilder()
                 .setCatalog(ICEBERG_CATALOG)
                 .build();
+
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
         Path dataDirectory = queryRunner.getCoordinator().getDataDirectory();
@@ -77,6 +79,7 @@ public class TestIcebergSystemTablesNessie
 
         queryRunner.installPlugin(new IcebergPlugin());
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .put("iceberg.catalog.type", String.valueOf(NESSIE))
                 .putAll(nessieConnectorProperties(nessieContainer.getRestApiUri()))
                 .put("iceberg.catalog.warehouse", catalogDirectory.getParent().toFile().toURI().toString())
                 .build();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
@@ -19,7 +19,6 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
-import com.google.common.collect.ImmutableMap;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.NessieConflictException;
@@ -35,6 +34,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
@@ -88,7 +88,10 @@ public class TestNessieMultiBranching
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+        return IcebergQueryRunner.builder()
+                .setCatalogType(NESSIE)
+                .setExtraConnectorProperties(nessieConnectorProperties(nessieContainer.getRestApiUri()))
+                .build().getQueryRunner();
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestExpireSnapshotProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestExpireSnapshotProcedure.java
@@ -57,7 +57,7 @@ public class TestExpireSnapshotProcedure
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), HADOOP, ImmutableMap.of());
+        return IcebergQueryRunner.builder().setCatalogType(HADOOP).build().getQueryRunner();
     }
 
     public void dropTable(String tableName)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestFastForwardBranchProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestFastForwardBranchProcedure.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg.procedure;
 
 import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableMap;
@@ -30,7 +31,6 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static java.lang.String.format;
 
@@ -44,7 +44,10 @@ public class TestFastForwardBranchProcedure
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(ImmutableMap.of(), HADOOP, ImmutableMap.of());
+        return IcebergQueryRunner.builder()
+                .setCatalogType(HADOOP)
+                .build()
+                .getQueryRunner();
     }
 
     public void createTable(String tableName)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRemoveOrphanFilesProcedureBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRemoveOrphanFilesProcedureBase.java
@@ -82,7 +82,10 @@ public abstract class TestRemoveOrphanFilesProcedureBase
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), catalogType, extraConnectorProperties);
+        return IcebergQueryRunner.builder()
+                .setCatalogType(catalogType)
+                .setExtraConnectorProperties(extraConnectorProperties)
+                .build().getQueryRunner();
     }
 
     @DataProvider(name = "timezones")

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRollbackToTimestampProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRollbackToTimestampProcedure.java
@@ -55,7 +55,7 @@ public class TestRollbackToTimestampProcedure
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), HADOOP, ImmutableMap.of());
+        return IcebergQueryRunner.builder().setCatalogType(HADOOP).build().getQueryRunner();
     }
 
     @DataProvider(name = "timezones")

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestSetCurrentSnapshotProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestSetCurrentSnapshotProcedure.java
@@ -45,7 +45,7 @@ public class TestSetCurrentSnapshotProcedure
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), HADOOP, ImmutableMap.of());
+        return IcebergQueryRunner.builder().setCatalogType(HADOOP).build().getQueryRunner();
     }
 
     public void createTable(String tableName)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestSetTablePropertyProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestSetTablePropertyProcedure.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg.procedure;
 
 import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableMap;
@@ -30,7 +31,6 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static java.lang.String.format;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE_DEFAULT;
@@ -46,7 +46,7 @@ public class TestSetTablePropertyProcedure
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(ImmutableMap.of(), HADOOP, ImmutableMap.of());
+        return IcebergQueryRunner.builder().setCatalogType(HADOOP).build().getQueryRunner();
     }
 
     public void createTable(String tableName)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestTestUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestTestUtil.java
@@ -40,7 +40,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.facebook.presto.iceberg.CatalogType.REST;
 import static com.facebook.presto.iceberg.IcebergDistributedTestBase.getHdfsEnvironment;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.CatalogProperties.URI;
@@ -56,7 +55,7 @@ public class IcebergRestTestUtil
 
     public static Map<String, String> restConnectorProperties(String serverUri)
     {
-        return ImmutableMap.of("iceberg.catalog.type", REST.name(), "iceberg.rest.uri", serverUri);
+        return ImmutableMap.of("iceberg.rest.uri", serverUri);
     }
 
     public static TestingHttpServer getRestServer(String location)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergDistributedRest.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergDistributedRest.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg.rest;
 import com.facebook.airlift.http.server.testing.TestingHttpServer;
 import com.facebook.presto.Session;
 import com.facebook.presto.iceberg.IcebergDistributedTestBase;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableMap;
@@ -27,12 +28,9 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
-import static com.facebook.presto.iceberg.FileFormat.PARQUET;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
@@ -92,14 +90,12 @@ public class TestIcebergDistributedRest
                 .put("iceberg.rest.session.type", SessionType.USER.name())
                 .build();
 
-        return createIcebergQueryRunner(
-                ImmutableMap.of(),
-                connectorProperties,
-                PARQUET,
-                true,
-                false,
-                OptionalInt.empty(),
-                Optional.of(warehouseLocation.toPath()));
+        return IcebergQueryRunner.builder()
+                .setExtraConnectorProperties(connectorProperties)
+                .setCatalogType(REST)
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .build()
+                .getQueryRunner();
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCatalogDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCatalogDistributedQueries.java
@@ -14,20 +14,18 @@
 package com.facebook.presto.iceberg.rest;
 
 import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.iceberg.TestIcebergDistributedQueries;
 import com.facebook.presto.testing.QueryRunner;
-import com.google.common.collect.ImmutableMap;
 import org.assertj.core.util.Files;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import java.io.File;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
 import static com.facebook.presto.iceberg.FileFormat.PARQUET;
-import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -73,14 +71,13 @@ public class TestIcebergRestCatalogDistributedQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createIcebergQueryRunner(
-                ImmutableMap.of(),
-                restConnectorProperties(serverUri),
-                PARQUET,
-                true,
-                false,
-                OptionalInt.empty(),
-                Optional.of(warehouseLocation.toPath()));
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setExtraConnectorProperties(restConnectorProperties(serverUri))
+                .setFormat(PARQUET)
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .build()
+                .getQueryRunner();
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
@@ -27,7 +27,6 @@ import com.facebook.presto.iceberg.IcebergQueryRunner;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.QueryRunner;
-import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.assertj.core.util.Files;
@@ -37,10 +36,8 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
-import static com.facebook.presto.iceberg.FileFormat.PARQUET;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.rest.AuthenticationType.OAUTH2;
@@ -100,14 +97,11 @@ public class TestIcebergSmokeRest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.createIcebergQueryRunner(
-                ImmutableMap.of(),
-                restConnectorProperties(serverUri),
-                PARQUET,
-                true,
-                false,
-                OptionalInt.empty(),
-                Optional.of(warehouseLocation.toPath()));
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setExtraConnectorProperties(restConnectorProperties(serverUri))
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .build().getQueryRunner();
     }
 
     protected IcebergNativeCatalogFactory getCatalogFactory(IcebergRestConfig restConfig)


### PR DESCRIPTION
## Description

Currently we create IcebergQueryRunner through a complicated set of method with various overloads. We tend to just create a new constructor/method for every time we need to set a separate property which can make figuring out
the arguments you're trying to explicitly change for a query runner more difficult to determine.

This change instead introduces a class which uses builder pattern to make it easier to add new features and use.

## Motivation and Context

Simpler and easier to understand query runner.

## Impact

N/A. Testing only

## Test Plan

Existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

