### PR TITLE
Remove duplicate mapping from iceberg docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1777,8 +1777,6 @@ Map of Iceberg types to the relevant PrestoDB types:
     - ``TIMESTAMP``
   * - ``TIMESTAMP``
     - ``TIMESTAMP_WITH_TIMEZONE``
-  * - ``STRING``
-    - ``VARCHAR``
   * - ``UUID``
     - ``UUID``
   * - ``LIST``


### PR DESCRIPTION
## Description
The string varchar type mapping is included twice in iceberg.rst


## Release Notes

```
== NO RELEASE NOTE ==
```