### PR TITLE
Reformat files in the Iceberg connector

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -516,9 +516,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>com.facebook.presto</groupId>
-          <artifactId>presto-parser</artifactId>
-          <scope>test</scope>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-parser</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HdfsInputFile.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HdfsInputFile.java
@@ -83,7 +83,8 @@ public class HdfsInputFile
         }
 
         @Override
-        public int read() throws IOException
+        public int read()
+                throws IOException
         {
             return delegate.read();
         }
@@ -96,19 +97,22 @@ public class HdfsInputFile
         }
 
         @Override
-        public long getPos() throws IOException
+        public long getPos()
+                throws IOException
         {
             return delegate.getPos();
         }
 
         @Override
-        public void seek(long newPos) throws IOException
+        public void seek(long newPos)
+                throws IOException
         {
             delegate.seek(newPos);
         }
 
         @Override
-        public void close() throws IOException
+        public void close()
+                throws IOException
         {
             delegate.close();
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -181,15 +181,16 @@ public class HiveTableOperations
     {
         if (commitLockCache == null) {
             commitLockCache = CacheBuilder.newBuilder()
-                .expireAfterAccess(evictionTimeout, TimeUnit.MILLISECONDS)
-                .build(
-                    new CacheLoader<String, ReentrantLock>() {
-                        @Override
-                        public ReentrantLock load(String fullName)
-                        {
-                            return new ReentrantLock();
-                        }
-                    });
+                    .expireAfterAccess(evictionTimeout, TimeUnit.MILLISECONDS)
+                    .build(
+                            new CacheLoader<String, ReentrantLock>()
+                            {
+                                @Override
+                                public ReentrantLock load(String fullName)
+                                {
+                                    return new ReentrantLock();
+                                }
+                            });
         }
     }
 
@@ -304,11 +305,11 @@ public class HiveTableOperations
             PrestoPrincipal owner = new PrestoPrincipal(USER, table.getOwner());
             PrincipalPrivileges privileges = new PrincipalPrivileges(
                     ImmutableMultimap.<String, HivePrivilegeInfo>builder()
-                        .put(table.getOwner(), new HivePrivilegeInfo(SELECT, true, owner, owner))
-                        .put(table.getOwner(), new HivePrivilegeInfo(INSERT, true, owner, owner))
-                        .put(table.getOwner(), new HivePrivilegeInfo(UPDATE, true, owner, owner))
-                        .put(table.getOwner(), new HivePrivilegeInfo(DELETE, true, owner, owner))
-                        .build(),
+                            .put(table.getOwner(), new HivePrivilegeInfo(SELECT, true, owner, owner))
+                            .put(table.getOwner(), new HivePrivilegeInfo(INSERT, true, owner, owner))
+                            .put(table.getOwner(), new HivePrivilegeInfo(UPDATE, true, owner, owner))
+                            .put(table.getOwner(), new HivePrivilegeInfo(DELETE, true, owner, owner))
+                            .build(),
                     ImmutableMultimap.of());
             if (base == null) {
                 metastore.createTable(metastoreContext, table, privileges, emptyList());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -878,10 +878,10 @@ public final class IcebergUtil
      * @param requestedSchema If provided, only delete files with this schema will be provided
      */
     public static CloseableIterable<DeleteFile> getDeleteFiles(Table table,
-                                                               long snapshot,
-                                                               TupleDomain<IcebergColumnHandle> filter,
-                                                               Optional<Set<Integer>> requestedPartitionSpec,
-                                                               Optional<Set<Integer>> requestedSchema)
+            long snapshot,
+            TupleDomain<IcebergColumnHandle> filter,
+            Optional<Set<Integer>> requestedPartitionSpec,
+            Optional<Set<Integer>> requestedSchema)
     {
         Expression filterExpression = toIcebergExpression(filter);
         CloseableIterable<FileScanTask> fileTasks = table.newScan().useSnapshot(snapshot).filter(filterExpression).planFiles();
@@ -1057,9 +1057,9 @@ public final class IcebergUtil
         private DeleteFile currentFile;
 
         private DeleteFilesIterator(Map<Integer, PartitionSpec> partitionSpecsById,
-                                    CloseableIterator<FileScanTask> fileTasks,
-                                    Optional<Set<Integer>> requestedPartitionSpec,
-                                    Optional<Set<Integer>> requestedSchema)
+                CloseableIterator<FileScanTask> fileTasks,
+                Optional<Set<Integer>> requestedPartitionSpec,
+                Optional<Set<Integer>> requestedSchema)
         {
             this.partitionSpecsById = partitionSpecsById;
             this.fileTasks = fileTasks;
@@ -1253,8 +1253,8 @@ public final class IcebergUtil
 
     /**
      * Get the metadata location for target {@link Table},
-     *  considering iceberg table properties {@code WRITE_METADATA_LOCATION}
-     * */
+     * considering iceberg table properties {@code WRITE_METADATA_LOCATION}
+     */
     public static String metadataLocation(Table icebergTable)
     {
         String metadataLocation = icebergTable.properties().get(TableProperties.WRITE_METADATA_LOCATION);
@@ -1269,8 +1269,8 @@ public final class IcebergUtil
 
     /**
      * Get the data location for target {@link Table},
-     *  considering iceberg table properties {@code WRITE_DATA_LOCATION}, {@code OBJECT_STORE_PATH} and {@code WRITE_FOLDER_STORAGE_LOCATION}
-     * */
+     * considering iceberg table properties {@code WRITE_DATA_LOCATION}, {@code OBJECT_STORE_PATH} and {@code WRITE_FOLDER_STORAGE_LOCATION}
+     */
     public static String dataLocation(Table icebergTable)
     {
         Map<String, String> properties = icebergTable.properties();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -141,10 +141,10 @@ public class PartitionTable
     private List<ColumnMetadata> getColumnMetadata(List<Types.NestedField> columns)
     {
         return columns.stream().map(column -> new ColumnMetadata(column.name(),
-                RowType.from(ImmutableList.of(
-                        new RowType.Field(Optional.of("min"), toPrestoType(column.type(), typeManager)),
-                        new RowType.Field(Optional.of("max"), toPrestoType(column.type(), typeManager)),
-                        new RowType.Field(Optional.of("null_count"), BIGINT)))))
+                        RowType.from(ImmutableList.of(
+                                new RowType.Field(Optional.of("min"), toPrestoType(column.type(), typeManager)),
+                                new RowType.Field(Optional.of("max"), toPrestoType(column.type(), typeManager)),
+                                new RowType.Field(Optional.of("null_count"), BIGINT)))))
                 .collect(toImmutableList());
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
@@ -61,6 +61,7 @@ public final class PartitionTransforms
     private static final DateTimeField MONTH_OF_YEAR_UTC = getInstanceUTC().monthOfYear();
     public static final int MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
     public static final int MILLISECONDS_PER_DAY = MILLISECONDS_PER_HOUR * 24;
+
     private PartitionTransforms() {}
 
     /**
@@ -550,9 +551,9 @@ public final class PartitionTransforms
         private final ValueTransform valueTransform;
 
         public ColumnTransform(String transformName,
-                               Type type,
-                               Function<Block, Block> transform,
-                               ValueTransform valueTransform)
+                Type type,
+                Function<Block, Block> transform,
+                ValueTransform valueTransform)
         {
             this.transformName = requireNonNull(transformName, "transformName is null");
             this.type = requireNonNull(type, "resultType is null");

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergTableForMetricsConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PrestoIcebergTableForMetricsConfig.java
@@ -50,7 +50,7 @@ import static org.apache.iceberg.SortOrder.unsorted;
 
 /**
  * This is a dummy class required for {@link org.apache.iceberg.MetricsConfig#forTable}
- * */
+ */
 public class PrestoIcebergTableForMetricsConfig
         implements Table
 {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SortField.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SortField.java
@@ -33,6 +33,7 @@ public class SortField
         this.sourceColumnId = sourceColumnId;
         this.sortOrder = requireNonNull(sortOrder, "sortOrder is null");
     }
+
     public static SortField fromIceberg(org.apache.iceberg.SortField sortField)
     {
         SortOrder sortOrder;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergFilterPushdown.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergFilterPushdown.java
@@ -153,7 +153,7 @@ public class IcebergFilterPushdown
             Optional<Set<IcebergColumnHandle>> requestedColumns = currentLayoutHandle.map(layout -> ((IcebergTableLayoutHandle) layout).getRequestedColumns()).orElse(Optional.empty());
 
             TupleDomain<ColumnHandle> partitionColumnPredicate = TupleDomain.withColumnDomains(Maps.filterKeys(
-                            constraint.getSummary().getDomains().get(), Predicates.in(partitionColumns)));
+                    constraint.getSummary().getDomains().get(), Predicates.in(partitionColumns)));
 
             List<HivePartition> partitions = getPartitions(
                     typeManager,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergMetadataOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergMetadataOptimizer.java
@@ -90,10 +90,10 @@ public class IcebergMetadataOptimizer
     private final StandardFunctionResolution functionResolution;
 
     public IcebergMetadataOptimizer(FunctionMetadataManager functionMetadataManager,
-                                    TypeManager typeManager,
-                                    IcebergTransactionManager icebergTransactionManager,
-                                    RowExpressionService rowExpressionService,
-                                    StandardFunctionResolution functionResolution)
+            TypeManager typeManager,
+            IcebergTransactionManager icebergTransactionManager,
+            RowExpressionService rowExpressionService,
+            StandardFunctionResolution functionResolution)
     {
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -131,13 +131,13 @@ public class IcebergMetadataOptimizer
         private final List<Predicate<FunctionHandle>> allowedFunctionsPredicates;
 
         private Optimizer(ConnectorSession connectorSession,
-                          PlanNodeIdAllocator idAllocator,
-                          FunctionMetadataManager functionMetadataManager,
-                          TypeManager typeManager,
-                          IcebergTransactionManager icebergTransactionManager,
-                          RowExpressionService rowExpressionService,
-                          StandardFunctionResolution functionResolution,
-                          int rowsForMetadataOptimizationThreshold)
+                PlanNodeIdAllocator idAllocator,
+                FunctionMetadataManager functionMetadataManager,
+                TypeManager typeManager,
+                IcebergTransactionManager icebergTransactionManager,
+                RowExpressionService rowExpressionService,
+                StandardFunctionResolution functionResolution,
+                int rowsForMetadataOptimizationThreshold)
         {
             checkArgument(rowsForMetadataOptimizationThreshold >= 0, "The value of `rowsForMetadataOptimizationThreshold` should not less than 0");
             this.connectorSession = connectorSession;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizer.java
@@ -87,9 +87,9 @@ public class IcebergPlanOptimizer
     private final IcebergTransactionManager transactionManager;
 
     IcebergPlanOptimizer(StandardFunctionResolution functionResolution,
-                         RowExpressionService rowExpressionService,
-                         FunctionMetadataManager functionMetadataManager,
-                         IcebergTransactionManager transactionManager)
+            RowExpressionService rowExpressionService,
+            FunctionMetadataManager functionMetadataManager,
+            IcebergTransactionManager transactionManager)
     {
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
@@ -190,10 +190,10 @@ public class IcebergPlanOptimizer
 
             // Get predicate expression on entire columns that could not be enforced by iceberg table
             TupleDomain<RowExpression> nonPartitionColumnPredicate = TupleDomain.withColumnDomains(
-                    Maps.filterKeys(
-                            entireColumnDomain.transform(icebergColumnHandle -> (ColumnHandle) icebergColumnHandle)
-                                    .getDomains().get(),
-                            Predicates.not(Predicates.in(enforcedColumns))))
+                            Maps.filterKeys(
+                                    entireColumnDomain.transform(icebergColumnHandle -> (ColumnHandle) icebergColumnHandle)
+                                            .getDomains().get(),
+                                    Predicates.not(Predicates.in(enforcedColumns))))
                     .transform(columnHandle -> new Subfield(columnHandleToNameMapping.get(columnHandle), ImmutableList.of()))
                     .transform(subfield -> subfieldExtractor.toRowExpression(subfield, columnTypes.get(subfield.getRootName())));
             RowExpression nonPartitionColumn = rowExpressionService.getDomainTranslator().toPredicate(nonPartitionColumnPredicate);
@@ -374,13 +374,13 @@ public class IcebergPlanOptimizer
                 !field.transform().isIdentity()) {
             TimestampType timestampType = (TimestampType) sourceType;
             first = adjustTimestampForPartitionTransform(
-                            session.getSqlFunctionProperties(),
-                            timestampType,
-                            first);
+                    session.getSqlFunctionProperties(),
+                    timestampType,
+                    first);
             second = adjustTimestampForPartitionTransform(
-                            session.getSqlFunctionProperties(),
-                            timestampType,
-                            second);
+                    session.getSqlFunctionProperties(),
+                    timestampType,
+                    second);
         }
         Object firstTransformed = transform.getValueTransform().apply(nativeValueToBlock(sourceType, first), 0);
         Object secondTransformed = transform.getValueTransform().apply(nativeValueToBlock(sourceType, second), 0);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RemoveOrphanFiles.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RemoveOrphanFiles.java
@@ -82,7 +82,7 @@ public class RemoveOrphanFiles
 
     @Inject
     public RemoveOrphanFiles(IcebergMetadataFactory metadataFactory,
-                             HdfsEnvironment hdfsEnvironment)
+            HdfsEnvironment hdfsEnvironment)
     {
         this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");

--- a/presto-iceberg/src/main/java/org/apache/iceberg/IcebergLibUtils.java
+++ b/presto-iceberg/src/main/java/org/apache/iceberg/IcebergLibUtils.java
@@ -23,8 +23,8 @@ public class IcebergLibUtils
 
     /**
      * Call the method in Iceberg lib's protected class to set explicitly
-     *  whether to use incremental cleanup when expiring snapshots
-     * */
+     * whether to use incremental cleanup when expiring snapshots
+     */
     public static ExpireSnapshots withIncrementalCleanup(ExpireSnapshots expireSnapshots, boolean incrementalCleanup)
     {
         requireNonNull(expireSnapshots, "expireSnapshots is null");

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -1454,7 +1454,8 @@ public abstract class IcebergDistributedTestBase
     }
 
     @Test
-    public void testWithSortOrder() throws IOException
+    public void testWithSortOrder()
+            throws IOException
     {
         String tableName = "test_create_sorted_table_" + randomTableSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(id int, emp_name varchar) WITH (sorted_by = ARRAY['id'])");
@@ -1465,7 +1466,8 @@ public abstract class IcebergDistributedTestBase
     }
 
     @Test
-    public void testWithDescSortOrder() throws IOException
+    public void testWithDescSortOrder()
+            throws IOException
     {
         String tableName = "test_create_sorted_table_" + randomTableSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(id int, emp_name varchar) WITH (sorted_by = ARRAY['id DESC'])");
@@ -1476,7 +1478,8 @@ public abstract class IcebergDistributedTestBase
     }
 
     @Test
-    public void testWithoutSortOrder() throws IOException
+    public void testWithoutSortOrder()
+            throws IOException
     {
         String tableName = "test_create_unsorted_table_" + randomTableSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(id int, emp_name varchar)");
@@ -1486,7 +1489,8 @@ public abstract class IcebergDistributedTestBase
         }
     }
 
-    public boolean isFileSorted(String path, String sortColumnName, String sortOrder) throws IOException
+    public boolean isFileSorted(String path, String sortColumnName, String sortOrder)
+            throws IOException
     {
         Configuration configuration = new Configuration();
         try (ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(), new org.apache.hadoop.fs.Path(path))
@@ -2557,6 +2561,7 @@ public abstract class IcebergDistributedTestBase
         int totalDeleteFiles = Integer.valueOf(map.get(TOTAL_DELETE_FILES_PROP));
         assertEquals(totalDeleteFiles, deleteFilesCount);
     }
+
     @Test
     public void testSortByAllTypes()
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
@@ -54,7 +54,8 @@ public abstract class TestIcebergDistributedQueries
     }
 
     @Override
-    protected QueryRunner createQueryRunner() throws Exception
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
         return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), catalogType, extraConnectorProperties);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
@@ -76,7 +76,8 @@ public class TestIcebergFileWriter
     private ConnectorSession connectorSession;
 
     @BeforeClass
-    public void setup() throws Exception
+    public void setup()
+            throws Exception
     {
         ConnectorId connectorId = new ConnectorId("iceberg");
         SessionPropertyManager sessionPropertyManager = createTestingSessionPropertyManager();
@@ -119,7 +120,8 @@ public class TestIcebergFileWriter
     }
 
     @Test
-    public void testWriteParquetFileWithLogicalTypes() throws Exception
+    public void testWriteParquetFileWithLogicalTypes()
+            throws Exception
     {
         Path path = new Path(createTempDir().getAbsolutePath() + "/test.parquet");
         Schema icebergSchema = toIcebergSchema(ImmutableList.of(

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMetadataListing.java
@@ -40,6 +40,7 @@ public class TestIcebergMetadataListing
         extends AbstractTestQueryFramework
 {
     private static final int TEST_TIMEOUT = 10_000;
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -126,7 +127,7 @@ public class TestIcebergMetadataListing
      * when refreshing Iceberg table metadata. If this test fails, check the refreshFromMetadataLocation method
      * in HiveTableOperations.
      */
-    @Test (timeOut = TEST_TIMEOUT)
+    @Test(timeOut = TEST_TIMEOUT)
     public void testTableDropWithMissingMetadata()
     {
         assertQuerySucceeds("CREATE SCHEMA hive.test_metadata_schema");
@@ -170,6 +171,7 @@ public class TestIcebergMetadataListing
         assertUpdate("DROP TABLE iceberg.test_rename_view_schema.iceberg_test_table");
         assertQuerySucceeds("DROP SCHEMA IF EXISTS iceberg.test_rename_view_schema");
     }
+
     @Test
     public void testRenameViewIfNotExists()
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
@@ -174,10 +174,10 @@ public class TestIcebergSplitManager
     }
 
     private void validateSplitsPlannedForSql(SplitManager splitManager,
-                                            TransactionManager transactionManager,
-                                            boolean filterPushdown,
-                                            String sql,
-                                            int expectedSplitCount)
+            TransactionManager transactionManager,
+            boolean filterPushdown,
+            String sql,
+            int expectedSplitCount)
     {
         Session session = sessionWithFilterPushdown(filterPushdown);
         List<TableScanNode> tableScanNodes = getTableScanFromOptimizedPlanOfSql(sql, session);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableVersion.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableVersion.java
@@ -147,6 +147,7 @@ public class TestIcebergTableVersion
         return (long) computeActual("SELECT snapshot_id FROM " + schemaName + "." + "\"" + tableName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1")
                 .getOnlyValue();
     }
+
     private String getLatestTimestampId(String tableName)
     {
         return (String) computeActual("SELECT cast(made_current_at as varchar) FROM " + schemaName + "." + "\"" + tableName + "$history\" ORDER BY made_current_at DESC LIMIT 1")

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTypes.java
@@ -35,7 +35,8 @@ import static org.testng.Assert.assertTrue;
 public class TestIcebergTypes
         extends AbstractTestQueryFramework
 {
-    protected QueryRunner createQueryRunner() throws Exception
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
         return createIcebergQueryRunner(ImmutableMap.of(), ImmutableMap.of());
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestSortFieldUtils.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestSortFieldUtils.java
@@ -65,6 +65,7 @@ public class TestSortFieldUtils
         assertParse("order_key ASC NULLS FIRST", sortOrder(builder -> builder.asc("order_key", NullOrder.NULLS_FIRST)));
         assertParse("order_key ASC NULLS LAST", sortOrder(builder -> builder.asc("order_key", NullOrder.NULLS_LAST)));
     }
+
     @Test
     public void testParseDesc()
     {
@@ -101,6 +102,7 @@ public class TestSortFieldUtils
         assertParse("\"OrDER_keY\" Asc NullS LAst", sortOrder(builder -> builder.asc("order_key", NullOrder.NULLS_LAST)));
         assertParse("\"OrDER_keY\" Desc NullS FIrsT", sortOrder(builder -> builder.desc("order_key", NullOrder.NULLS_FIRST)));
     }
+
     @Test
     public void testParseQuoted()
     {
@@ -110,6 +112,7 @@ public class TestSortFieldUtils
         assertParse("\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\" ASC    NULLS   LAST    ", sortOrder(builder -> builder.asc("\"another\" \"quoted\" \"field\"", NullOrder.NULLS_LAST)));
         assertParse("\"\"\"another\"\" \"\"quoted\"\" \"\"field\"\"\" DESC NULLS FIRST", sortOrder(builder -> builder.desc("\"another\" \"quoted\" \"field\"", NullOrder.NULLS_FIRST)));
     }
+
     @Test
     public void testDoesNotParse()
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
@@ -70,7 +70,8 @@ public class TestNessieMultiBranching
     }
 
     @AfterMethod
-    public void resetData() throws NessieNotFoundException, NessieConflictException
+    public void resetData()
+            throws NessieNotFoundException, NessieConflictException
     {
         Branch defaultBranch = nessieApiV1.getDefaultBranch();
         for (Reference r : nessieApiV1.getAllReferences().get().getReferences()) {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestIcebergRegisterAndUnregisterProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestIcebergRegisterAndUnregisterProcedure.java
@@ -74,9 +74,9 @@ public class TestIcebergRegisterAndUnregisterProcedure
             throws Exception
     {
         session = testSessionBuilder()
-            .setCatalog(ICEBERG_CATALOG)
-            .setSchema(TEST_SCHEMA)
-            .build();
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema(TEST_SCHEMA)
+                .build();
 
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
@@ -537,6 +537,7 @@ public class TestIcebergRegisterAndUnregisterProcedure
                 hiveClientConfig);
         return new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
     }
+
     protected ExtendedHiveMetastore getFileHiveMetastore()
     {
         FileHiveMetastore fileHiveMetastore = new FileHiveMetastore(getHdfsEnvironment(),

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
@@ -125,9 +125,9 @@ public class TestIcebergSmokeRestNestedNamespace
         // additional catalog for testing nested namespace disabled
         icebergQueryRunner.createCatalog(ICEBERG_NESTED_NAMESPACE_DISABLED_CATALOG, "iceberg",
                 new ImmutableMap.Builder<String, String>()
-                .putAll(restConnectorProperties)
-                .put("iceberg.rest.nested.namespace.enabled", "false")
-                .build());
+                        .putAll(restConnectorProperties)
+                        .put("iceberg.rest.nested.namespace.enabled", "false")
+                        .build());
 
         return icebergQueryRunner;
     }


### PR DESCRIPTION

## Description

Reformatting to match style guidelines

## Motivation and Context

As a part of the project, we have a set of checkstyle guidelines. Generally we recommend developers to use IntelliJ for Java development. If you use the official style guidelines and format with the provided style rules within IntelliJ there are a number of files in the Iceberg connector which don't follow the official formatting rules. Maven checkstyle isn't capable of finding them all automatically.

The changes in this commit are the result of running IntelliJ's reformat procedure on all the files in the Iceberg connector using Presto's officially-provided style rules.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

