### PR TITLE
Make ArrowFlightConfig verifyServer true by default

### DIFF
--- a/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowFlightConfig.java
+++ b/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowFlightConfig.java
@@ -18,9 +18,9 @@ import com.facebook.airlift.configuration.Config;
 public class ArrowFlightConfig
 {
     private String server;
-    private Boolean verifyServer;
+    private boolean verifyServer = true;
     private String flightServerSSLCertificate;
-    private Boolean arrowFlightServerSslEnabled;
+    private boolean arrowFlightServerSslEnabled;
     private Integer arrowFlightPort;
 
     public String getFlightServerName()
@@ -35,13 +35,13 @@ public class ArrowFlightConfig
         return this;
     }
 
-    public Boolean getVerifyServer()
+    public boolean getVerifyServer()
     {
         return verifyServer;
     }
 
     @Config("arrow-flight.server.verify")
-    public ArrowFlightConfig setVerifyServer(Boolean verifyServer)
+    public ArrowFlightConfig setVerifyServer(boolean verifyServer)
     {
         this.verifyServer = verifyServer;
         return this;
@@ -71,13 +71,13 @@ public class ArrowFlightConfig
         return this;
     }
 
-    public Boolean getArrowFlightServerSslEnabled()
+    public boolean getArrowFlightServerSslEnabled()
     {
         return arrowFlightServerSslEnabled;
     }
 
     @Config("arrow-flight.server-ssl-enabled")
-    public ArrowFlightConfig setArrowFlightServerSslEnabled(Boolean arrowFlightServerSslEnabled)
+    public ArrowFlightConfig setArrowFlightServerSslEnabled(boolean arrowFlightServerSslEnabled)
     {
         this.arrowFlightServerSslEnabled = arrowFlightServerSslEnabled;
         return this;

--- a/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/BaseArrowFlightClientHandler.java
+++ b/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/BaseArrowFlightClientHandler.java
@@ -53,11 +53,11 @@ public abstract class BaseArrowFlightClientHandler
     protected FlightClient createFlightClient()
     {
         Location location;
-        if (config.getArrowFlightServerSslEnabled() != null && !config.getArrowFlightServerSslEnabled()) {
-            location = Location.forGrpcInsecure(config.getFlightServerName(), config.getArrowFlightPort());
+        if (config.getArrowFlightServerSslEnabled()) {
+            location = Location.forGrpcTls(config.getFlightServerName(), config.getArrowFlightPort());
         }
         else {
-            location = Location.forGrpcTls(config.getFlightServerName(), config.getArrowFlightPort());
+            location = Location.forGrpcInsecure(config.getFlightServerName(), config.getArrowFlightPort());
         }
         return createFlightClient(location);
     }
@@ -67,10 +67,8 @@ public abstract class BaseArrowFlightClientHandler
         try {
             Optional<InputStream> trustedCertificate = Optional.empty();
             FlightClient.Builder flightClientBuilder = FlightClient.builder(allocator, location);
-            if (config.getVerifyServer() != null && !config.getVerifyServer()) {
-                flightClientBuilder.verifyServer(false);
-            }
-            else if (config.getFlightServerSSLCertificate() != null) {
+            flightClientBuilder.verifyServer(config.getVerifyServer());
+            if (config.getFlightServerSSLCertificate() != null) {
                 trustedCertificate = Optional.of(newInputStream(Paths.get(config.getFlightServerSSLCertificate())));
                 flightClientBuilder.trustedCertificates(trustedCertificate.get()).useTls();
             }

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/ArrowFlightQueryRunner.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/ArrowFlightQueryRunner.java
@@ -71,8 +71,7 @@ public class ArrowFlightQueryRunner
                     .putAll(catalogProperties)
                     .put("arrow-flight.server", "localhost")
                     .put("arrow-flight.server-ssl-enabled", "true")
-                    .put("arrow-flight.server-ssl-certificate", "src/test/resources/server.crt")
-                    .put("arrow-flight.server.verify", "true");
+                    .put("arrow-flight.server-ssl-certificate", "src/test/resources/server.crt");
 
             queryRunner.createCatalog("arrowflight", "arrow-flight", properties.build());
 

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightEchoQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightEchoQueries.java
@@ -410,7 +410,7 @@ public class TestArrowFlightEchoQueries
     private static FlightClient createFlightClient(BufferAllocator allocator) throws IOException
     {
         InputStream trustedCertificate = new ByteArrayInputStream(Files.readAllBytes(Paths.get("src/test/resources/server.crt")));
-        return FlightClient.builder(allocator, getServerLocation()).verifyServer(true).useTls().trustedCertificates(trustedCertificate).build();
+        return FlightClient.builder(allocator, getServerLocation()).useTls().trustedCertificates(trustedCertificate).build();
     }
 
     private void addTableToServer(FlightClient client, VectorSchemaRoot root, String tableName)

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/testingConnector/TestingArrowFlightPlugin.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/testingConnector/TestingArrowFlightPlugin.java
@@ -21,6 +21,6 @@ public class TestingArrowFlightPlugin
 {
     public TestingArrowFlightPlugin()
     {
-        super("arrow", new TestingArrowModule(), new JsonModule());
+        super("arrow-flight", new TestingArrowModule(), new JsonModule());
     }
 }


### PR DESCRIPTION
## Description
The ArrowFlightConfig verifyServer was currently defaulting to NULL, we should explicitly set the default to "true" so that when a certificate is supplied in the config, the client will verify the server. See discussion at https://github.com/prestodb/presto/pull/24504#discussion_r1946194232

Also to make integration testing with the native Arrow connector, this adjusts the testing Arrow connector and catalog name to arrow-flight and arrowflight to match. A test property can be supplied to set worker count to 0 for the testing ArrowFlightQueryRunner to run with native workers.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
The verifyServer config should be a concrete value to ensure the client connection is secure.

Aligning with native Arrow Flight connector in progress at https://github.com/prestodb/presto/pull/24504 will make integration testing easier.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
The ArrowFlightConfig verifyServer and server-ssl-enabled are no longer nullable and verifyServer will default to "true".

## Test Plan
<!---Please fill in how you tested your change-->
Existing tests run with the new connector name and ignore the worker count override to use the default.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

