### PR TITLE
Add @czentgr as module committer for CI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -156,3 +156,8 @@ CODEOWNERS @prestodb/team-tsc
 /**/*.md @steveburnett @prestodb/committers
 /presto-docs/src/**/connector/iceberg.rst @steveburnett @elharo @hantangwangd @ZacBlanco @prestodb/committers
 
+#####################################################################
+# Presto CI and builds
+/.github @czentgr @prestodb/committers
+/docker @czentgr @prestodb/committers
+


### PR DESCRIPTION
## Description
Add @czentgr as module committer for CI

## Motivation and Context
Ownership and maintenance of CI and builds

## Impact
More committers to approve necessary code

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

```
== NO RELEASE NOTE ==
```

