### PR TITLE
Fix duplicate TABLE_TYPE listing for view from system.jdbc.tables

### DIFF
--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
@@ -188,6 +188,41 @@ public class TestJdbcConnection
     }
 
     @Test
+    public void testTableType()
+            throws SQLException
+    {
+        try (Connection connection = createConnection()) {
+            assertThat(connection.getCatalog()).isEqualTo("hive");
+            assertThat(connection.getSchema()).isEqualTo("default");
+
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE TABLE test_table_type (x bigint)");
+                statement.execute("CREATE VIEW table_type_view AS SELECT * FROM test_table_type");
+                ResultSet rs = statement.executeQuery("SELECT TABLE_NAME, TABLE_TYPE FROM system.jdbc.tables WHERE TABLE_SCHEM = 'default' AND TABLE_NAME = 'table_type_view'");
+                int rowCount = 0;
+                while (rs.next()) {
+                    assertEquals(rs.getString("TABLE_NAME"), "table_type_view");
+                    assertEquals(rs.getString("TABLE_TYPE"), "VIEW");
+                    rowCount++;
+                }
+                assertEquals(rowCount, 1);
+
+                rowCount = 0;
+                rs = statement.executeQuery("SELECT TABLE_NAME, TABLE_TYPE FROM system.jdbc.tables WHERE TABLE_SCHEM = 'default' AND TABLE_NAME = 'test_table_type'");
+                while (rs.next()) {
+                    assertEquals(rs.getString("TABLE_NAME"), "test_table_type");
+                    assertEquals(rs.getString("TABLE_TYPE"), "TABLE");
+                    rowCount++;
+                }
+                assertEquals(rowCount, 1);
+
+                statement.execute("DROP TABLE test_table_type");
+                statement.execute("DROP VIEW table_type_view");
+            }
+        }
+    }
+
+    @Test
     public void testRollback()
             throws SQLException
     {


### PR DESCRIPTION
## Description
Fix duplicate TABLE_TYPE listing for view from system.jdbc.tables

## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/22953

Currently, TABLE_TYPE of views are getting listed twice as `TABLE` and `VIEW` when `system.jdbc.tables` is queried -

`nation1_prestoview` is a view here, 
```
presto> SELECT TABLE_CAT, TABLE_SCHEM, TABLE_NAME, TABLE_TYPE, REMARKS, TYPE_CAT, TYPE_SCHEM, TYPE_NAME, SELF_REFERENCING_COL_NAME, REF_GENERATION FROM system.jdbc.tables WHERE TABLE_NAME='nation1_prestoview';
 TABLE_CAT |  TABLE_SCHEM   |     TABLE_NAME     | TABLE_TYPE | REMARKS | TYPE_CAT | TYPE_SCHEM | TYPE_NAME | SELF_REFERENCING_COL_NAME | REF_GENERATION 
-----------+----------------+--------------------+------------+---------+----------+------------+-----------+---------------------------+----------------
 hive      | reetika_testdb | nation1_prestoview | TABLE      | NULL    | NULL     | NULL       | NULL      | NULL                      | NULL           
 hive      | reetika_testdb | nation1_prestoview | VIEW       | NULL    | NULL     | NULL       | NULL      | NULL                      | NULL           
(2 rows)

```

## Impact
Fixes https://github.com/prestodb/presto/issues/22953

## Test Plan
Added test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

