### PR TITLE
Update begin delete

### DIFF
--- a/presto-docs/src/main/sphinx/develop/delete-and-update.rst
+++ b/presto-docs/src/main/sphinx/develop/delete-and-update.rst
@@ -106,7 +106,7 @@ A connector implementing ``DELETE`` must specify three ``ConnectorMetadata`` met
 
 * ``beginDelete()``::
 
-    ConnectorTableHandle beginDelete(
+    ConnectorDeleteTableHandle beginDelete(
          ConnectorSession session,
          ConnectorTableHandle tableHandle)
 
@@ -116,7 +116,7 @@ A connector implementing ``DELETE`` must specify three ``ConnectorMetadata`` met
   ``beginDelete()`` performs any orchestration needed in the connector to start processing the ``DELETE``.
   This orchestration varies from connector to connector.
 
-  ``beginDelete()`` returns a ``ConnectorTableHandle`` with any added information the connector needs when the handle
+  ``beginDelete()`` returns a ``ConnectorDeleteTableHandle`` with any added information the connector needs when the handle
   is passed back to ``finishDelete()`` and the split generation machinery.  For most connectors, the returned table
   handle contains a flag identifying the table handle as a table handle for a ``DELETE`` operation.
 
@@ -124,7 +124,7 @@ A connector implementing ``DELETE`` must specify three ``ConnectorMetadata`` met
 
       void finishDelete(
           ConnectorSession session,
-          ConnectorTableHandle tableHandle,
+          ConnectoDeleteTableHandle tableHandle,
           Collection<Slice> fragments)
 
   During ``DELETE`` processing, the Presto engine accumulates the ``Slice`` collections returned by ``UpdatablePageSource.finish()``.

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -43,6 +43,7 @@ import com.facebook.presto.hive.metastore.thrift.ThriftMetastoreUtil;
 import com.facebook.presto.hive.statistics.HiveStatisticsProvider;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
 import com.facebook.presto.spi.ConnectorNewTableLayout;
@@ -2517,7 +2518,7 @@ public class HiveMetadata
     }
 
     @Override
-    public ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorDeleteTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector only supports delete where one or more partitions are deleted entirely");
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHandleResolver.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHandleResolver.java
@@ -15,6 +15,7 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.presto.hive.HiveTransactionHandle;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
@@ -60,6 +61,12 @@ public class IcebergHandleResolver
     public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
     {
         return IcebergInsertTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorDeleteTableHandle> getDeleteTableHandleClass()
+    {
+        return IcebergTableHandle.class;
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.hive.BaseHiveTableHandle;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -28,6 +29,7 @@ import static java.util.Objects.requireNonNull;
 
 public class IcebergTableHandle
         extends BaseHiveTableHandle
+            implements ConnectorDeleteTableHandle
 {
     private final IcebergTableName icebergTableName;
     private final boolean snapshotSpecified;

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduHandleResolver.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduHandleResolver.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.kudu;
 
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
@@ -59,6 +60,12 @@ public class KuduHandleResolver
     public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
     {
         return KuduInsertTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorDeleteTableHandle> getDeleteTableHandleClass()
+    {
+        return KuduTableHandle.class;
     }
 
     @Override

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
@@ -20,6 +20,7 @@ import com.facebook.presto.kudu.properties.KuduTableProperties;
 import com.facebook.presto.kudu.properties.PartitionDesign;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
@@ -357,13 +358,13 @@ public class KuduMetadata
     }
 
     @Override
-    public ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorDeleteTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        return tableHandle;
+        return (ConnectorDeleteTableHandle) tableHandle;
     }
 
     @Override
-    public void finishDelete(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
+    public void finishDelete(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
     }
 

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTableHandle.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTableHandle.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.kudu;
 
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -25,7 +26,7 @@ import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class KuduTableHandle
-        implements ConnectorTableHandle
+        implements ConnectorTableHandle, ConnectorDeleteTableHandle
 {
     private final String connectorId;
     private final SchemaTableName schemaTableName;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ExecutionWriterTarget.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ExecutionWriterTarget.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.execution.scheduler;
 
+import com.facebook.presto.metadata.DeleteTableHandle;
 import com.facebook.presto.metadata.InsertTableHandle;
 import com.facebook.presto.metadata.OutputTableHandle;
 import com.facebook.presto.spi.SchemaTableName;
@@ -106,12 +107,12 @@ public abstract class ExecutionWriterTarget
     public static class DeleteHandle
             extends ExecutionWriterTarget
     {
-        private final TableHandle handle;
+        private final DeleteTableHandle handle;
         private final SchemaTableName schemaTableName;
 
         @JsonCreator
         public DeleteHandle(
-                @JsonProperty("handle") TableHandle handle,
+                @JsonProperty("handle") DeleteTableHandle handle,
                 @JsonProperty("schemaTableName") SchemaTableName schemaTableName)
         {
             this.handle = requireNonNull(handle, "handle is null");
@@ -119,7 +120,7 @@ public abstract class ExecutionWriterTarget
         }
 
         @JsonProperty
-        public TableHandle getHandle()
+        public DeleteTableHandle getHandle()
         {
             return handle;
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
@@ -145,7 +145,7 @@ public class TableWriteInfo
     {
         if (writerTarget.isPresent() && writerTarget.get() instanceof ExecutionWriterTarget.DeleteHandle) {
             DeleteNode delete = getOnlyElement(findPlanNodes(plan, DeleteNode.class));
-            return createDeleteScanInfo(delete, writerTarget, metadata, session);
+            return createDeleteScanInfo(delete, metadata, session);
         }
         return Optional.empty();
     }
@@ -154,19 +154,18 @@ public class TableWriteInfo
     {
         if (writerTarget.isPresent() && writerTarget.get() instanceof ExecutionWriterTarget.DeleteHandle) {
             DeleteNode delete = findSinglePlanNode(planNode, DeleteNode.class).get();
-            return createDeleteScanInfo(delete, writerTarget, metadata, session);
+            return createDeleteScanInfo(delete, metadata, session);
         }
         return Optional.empty();
     }
 
-    private static Optional<DeleteScanInfo> createDeleteScanInfo(DeleteNode delete, Optional<ExecutionWriterTarget> writerTarget, Metadata metadata, Session session)
+    private static Optional<DeleteScanInfo> createDeleteScanInfo(DeleteNode delete, Metadata metadata, Session session)
     {
-        TableHandle tableHandle = ((ExecutionWriterTarget.DeleteHandle) writerTarget.get()).getHandle();
         TableScanNode tableScan = getDeleteTableScan(delete);
         TupleDomain<ColumnHandle> originalEnforcedConstraint = tableScan.getEnforcedConstraint();
         TableLayoutResult layoutResult = metadata.getLayout(
                 session,
-                tableHandle,
+                tableScan.getTable(),
                 new Constraint<>(originalEnforcedConstraint),
                 Optional.of(ImmutableSet.copyOf(tableScan.getAssignments().values())));
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -379,13 +379,13 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
-    public TableHandle beginDelete(Session session, TableHandle tableHandle)
+    public DeleteTableHandle beginDelete(Session session, TableHandle tableHandle)
     {
         return delegate.beginDelete(session, tableHandle);
     }
 
     @Override
-    public void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    public void finishDelete(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
         delegate.finishDelete(session, tableHandle, fragments);
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DeleteTableHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DeleteTableHandle.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public final class DeleteTableHandle
+{
+    private final ConnectorId connectorId;
+    private final ConnectorTransactionHandle transactionHandle;
+    private final ConnectorDeleteTableHandle connectorHandle;
+
+    @JsonCreator
+    public DeleteTableHandle(
+            @JsonProperty("connectorId") ConnectorId connectorId,
+            @JsonProperty("transactionHandle") ConnectorTransactionHandle transactionHandle,
+            @JsonProperty("connectorHandle") ConnectorDeleteTableHandle connectorHandle)
+    {
+        this.connectorId = requireNonNull(connectorId, "connectorId is null");
+        this.transactionHandle = requireNonNull(transactionHandle, "transactionHandle is null");
+        this.connectorHandle = requireNonNull(connectorHandle, "connectorHandle is null");
+    }
+
+    @JsonProperty
+    public ConnectorId getConnectorId()
+    {
+        return connectorId;
+    }
+
+    @JsonProperty
+    public ConnectorTransactionHandle getTransactionHandle()
+    {
+        return transactionHandle;
+    }
+
+    @JsonProperty
+    public ConnectorDeleteTableHandle getConnectorHandle()
+    {
+        return connectorHandle;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(connectorId, transactionHandle, connectorHandle);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        DeleteTableHandle o = (DeleteTableHandle) obj;
+        return Objects.equals(this.connectorId, o.connectorId) &&
+                Objects.equals(this.transactionHandle, o.transactionHandle) &&
+                Objects.equals(this.connectorHandle, o.connectorHandle);
+    }
+
+    @Override
+    public String toString()
+    {
+        return connectorId + ":" + connectorHandle;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DeleteTableHandleJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DeleteTableHandleJacksonModule.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
+
+import javax.inject.Inject;
+
+public class DeleteTableHandleJacksonModule
+        extends AbstractTypedJacksonModule<ConnectorDeleteTableHandle>
+{
+    @Inject
+    public DeleteTableHandleJacksonModule(HandleResolver handleResolver)
+    {
+        super(ConnectorDeleteTableHandle.class,
+                handleResolver::getId,
+                handleResolver::getDeleteTableHandleClass);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/HandleJsonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/HandleJsonModule.java
@@ -32,6 +32,7 @@ public class HandleJsonModule
         jsonBinder(binder).addModuleBinding().to(SplitJacksonModule.class);
         jsonBinder(binder).addModuleBinding().to(OutputTableHandleJacksonModule.class);
         jsonBinder(binder).addModuleBinding().to(InsertTableHandleJacksonModule.class);
+        jsonBinder(binder).addModuleBinding().to(DeleteTableHandleJacksonModule.class);
         jsonBinder(binder).addModuleBinding().to(IndexHandleJacksonModule.class);
         jsonBinder(binder).addModuleBinding().to(TransactionHandleJacksonModule.class);
         jsonBinder(binder).addModuleBinding().to(PartitioningHandleJacksonModule.class);

--- a/presto-main/src/main/java/com/facebook/presto/metadata/HandleResolver.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/HandleResolver.java
@@ -16,6 +16,7 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.connector.informationSchema.InformationSchemaHandleResolver;
 import com.facebook.presto.connector.system.SystemHandleResolver;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.ConnectorIndexHandle;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
@@ -114,6 +115,11 @@ public class HandleResolver
         return getId(insertHandle, MaterializedHandleResolver::getInsertTableHandleClass);
     }
 
+    public String getId(ConnectorDeleteTableHandle deleteHandle)
+    {
+        return getId(deleteHandle, MaterializedHandleResolver::getDeleteTableHandleClass);
+    }
+
     public String getId(ConnectorPartitioningHandle partitioningHandle)
     {
         return getId(partitioningHandle, MaterializedHandleResolver::getPartitioningHandleClass);
@@ -169,6 +175,11 @@ public class HandleResolver
         return resolverFor(id).getInsertTableHandleClass().orElseThrow(() -> new IllegalArgumentException("No resolver for " + id));
     }
 
+    public Class<? extends ConnectorDeleteTableHandle> getDeleteTableHandleClass(String id)
+    {
+        return resolverFor(id).getDeleteTableHandleClass().orElseThrow(() -> new IllegalArgumentException("No resolver for " + id));
+    }
+
     public Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass(String id)
     {
         return resolverFor(id).getPartitioningHandleClass().orElseThrow(() -> new IllegalArgumentException("No resolver for " + id));
@@ -214,7 +225,7 @@ public class HandleResolver
             catch (UnsupportedOperationException ignored) {
             }
         }
-        throw new IllegalArgumentException("No connector for handle: " + handle);
+        throw new IllegalArgumentException("No connector for handle: " + handle + " of type " + handle.getClass());
     }
 
     private <T> String getFunctionNamespaceId(T handle, Function<MaterializedFunctionHandleResolver, Optional<Class<? extends T>>> getter)
@@ -240,6 +251,7 @@ public class HandleResolver
         private final Optional<Class<? extends ConnectorIndexHandle>> indexHandle;
         private final Optional<Class<? extends ConnectorOutputTableHandle>> outputTableHandle;
         private final Optional<Class<? extends ConnectorInsertTableHandle>> insertTableHandle;
+        private final Optional<Class<? extends ConnectorDeleteTableHandle>> deleteTableHandle;
         private final Optional<Class<? extends ConnectorPartitioningHandle>> partitioningHandle;
         private final Optional<Class<? extends ConnectorTransactionHandle>> transactionHandle;
         private final Optional<Class<? extends ConnectorMetadataUpdateHandle>> metadataUpdateHandle;
@@ -253,6 +265,7 @@ public class HandleResolver
             indexHandle = getHandleClass(resolver::getIndexHandleClass);
             outputTableHandle = getHandleClass(resolver::getOutputTableHandleClass);
             insertTableHandle = getHandleClass(resolver::getInsertTableHandleClass);
+            deleteTableHandle = getHandleClass(resolver::getDeleteTableHandleClass);
             partitioningHandle = getHandleClass(resolver::getPartitioningHandleClass);
             transactionHandle = getHandleClass(resolver::getTransactionHandleClass);
             metadataUpdateHandle = getHandleClass(resolver::getMetadataUpdateHandleClass);
@@ -303,6 +316,11 @@ public class HandleResolver
             return insertTableHandle;
         }
 
+        public Optional<Class<? extends ConnectorDeleteTableHandle>> getDeleteTableHandleClass()
+        {
+            return deleteTableHandle;
+        }
+
         public Optional<Class<? extends ConnectorPartitioningHandle>> getPartitioningHandleClass()
         {
             return partitioningHandle;
@@ -335,6 +353,7 @@ public class HandleResolver
                     Objects.equals(indexHandle, that.indexHandle) &&
                     Objects.equals(outputTableHandle, that.outputTableHandle) &&
                     Objects.equals(insertTableHandle, that.insertTableHandle) &&
+                    Objects.equals(deleteTableHandle, that.deleteTableHandle) &&
                     Objects.equals(partitioningHandle, that.partitioningHandle) &&
                     Objects.equals(transactionHandle, that.transactionHandle) &&
                     Objects.equals(metadataUpdateHandle, that.metadataUpdateHandle);
@@ -343,7 +362,7 @@ public class HandleResolver
         @Override
         public int hashCode()
         {
-            return Objects.hash(tableHandle, layoutHandle, columnHandle, split, indexHandle, outputTableHandle, insertTableHandle, partitioningHandle, transactionHandle, metadataUpdateHandle);
+            return Objects.hash(tableHandle, layoutHandle, columnHandle, split, indexHandle, outputTableHandle, insertTableHandle, deleteTableHandle, partitioningHandle, transactionHandle, metadataUpdateHandle);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -324,12 +324,12 @@ public interface Metadata
     /**
      * Begin delete query
      */
-    TableHandle beginDelete(Session session, TableHandle tableHandle);
+    DeleteTableHandle beginDelete(Session session, TableHandle tableHandle);
 
     /**
      * Finish delete query
      */
-    void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments);
+    void finishDelete(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments);
 
     /**
      * Begin update query

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -29,6 +29,7 @@ import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
@@ -895,20 +896,19 @@ public class MetadataManager
     }
 
     @Override
-    public TableHandle beginDelete(Session session, TableHandle tableHandle)
+    public DeleteTableHandle beginDelete(Session session, TableHandle tableHandle)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, connectorId);
-        ConnectorTableHandle newHandle = catalogMetadata.getMetadata().beginDelete(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle());
-        return new TableHandle(
+        ConnectorDeleteTableHandle newHandle = catalogMetadata.getMetadata().beginDelete(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle());
+        return new DeleteTableHandle(
                 tableHandle.getConnectorId(),
-                newHandle,
                 tableHandle.getTransaction(),
-                Optional.empty());
+                newHandle);
     }
 
     @Override
-    public void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    public void finishDelete(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -411,13 +411,13 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public TableHandle beginDelete(Session session, TableHandle tableHandle)
+    public DeleteTableHandle beginDelete(Session session, TableHandle tableHandle)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    public void finishDelete(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorDeleteTableHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorDeleteTableHandle.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+@SuppressWarnings("MarkerInterface")
+public interface ConnectorDeleteTableHandle
+{
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorHandleResolver.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorHandleResolver.java
@@ -41,6 +41,11 @@ public interface ConnectorHandleResolver
         throw new UnsupportedOperationException();
     }
 
+    default Class<? extends ConnectorDeleteTableHandle> getDeleteTableHandleClass()
+    {
+        throw new UnsupportedOperationException();
+    }
+
     default Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass()
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
 import com.facebook.presto.spi.ConnectorNewTableLayout;
@@ -528,7 +529,7 @@ public interface ConnectorMetadata
     /**
      * Begin delete query
      */
-    default ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
+    default ConnectorDeleteTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support deletes");
     }
@@ -538,7 +539,7 @@ public interface ConnectorMetadata
      *
      * @param fragments all fragments returned by {@link com.facebook.presto.spi.UpdatablePageSource#finish()}
      */
-    default void finishDelete(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
+    default void finishDelete(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support deletes");
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorPageSinkProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorPageSinkProvider.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.connector;
 
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
@@ -24,4 +25,9 @@ public interface ConnectorPageSinkProvider
     ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, PageSinkContext pageSinkContext);
 
     ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, PageSinkContext pageSinkContext);
+
+    default ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorDeleteTableHandle deleteTableHandle, PageSinkContext pageSinkContext)
+    {
+        throw new UnsupportedOperationException("ConnectorPageSinkProvider does not support connectorDeleteTableHandle");
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
 import com.facebook.presto.spi.ConnectorNewTableLayout;
@@ -585,7 +586,7 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorDeleteTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.beginDelete(session, tableHandle);
@@ -593,7 +594,7 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public void finishDelete(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
+    public void finishDelete(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             delegate.finishDelete(session, tableHandle, fragments);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.connector.classloader;
 
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
@@ -49,6 +50,14 @@ public final class ClassLoaderSafeConnectorPageSinkProvider
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, insertTableHandle, pageSinkContext), classLoader);
+        }
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorDeleteTableHandle deleteTableHandle, PageSinkContext pageSinkContext)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, deleteTableHandle, pageSinkContext), classLoader);
         }
     }
 }


### PR DESCRIPTION
## Description
Changes to separate ConnectorTableHandles for deletes into it's own interface (ConnectorDeleteTableHandle) similar to ConnectorInsertTableHandle

 If you have a connector that is broken by these changes, please refer to the fixes to presto-iceberg as an example. If you do not implement beginDelete, the changes will not affect you.

## Motivation and Context
Please refer to https://github.com/prestodb/presto/issues/24520

## Impact
Metadata, ConnectorMetadata, MetadataManager changed
->downstream affects execution: TableWriteInfo, ExecutionWriterTarget, TableWriterNode
Create 2 new types: ConnectorDeleteTableHandle, DeleteTableHandle
Types Changed: TableWriterNode.DeleteHandle

Also affects finishDelete, getDeleteRowIdColumnHandle types (AbstractMockMetadata, DelegatingMetadataManager)

Other classes affected:
ConnectorPageSinkProvider -> provide new pagesink for deletes?
ConnectorHandleResolver -> provide new getDeleteTableHandleClass method -> HandleResolver implements new ConnectorDeleteTableHandle

All connectors affected, those that implement DELETE will require more changes.
Kudu and iceberg connector both need to change types used for begin/finish delete
Iceberg currently uses IcebergTableHandle which inherits from basehivetablehandle->connectorTableHandle, and we would need to create a separate IcebergTableHandle for deletes  This would eventually apply to update as well if were going to make the code symmetric

## Test Plan
Pass presto-icebergs tests (includes DELETE tests) 
TODO: Integration test's with facebooks internal DELETE

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix OSS connectors affected by changes 
* Add serialization for new types
* Add pagesink for DELETES to support future use
* Update beginDelete to return the new types, and finishDelete to accept the new types

SPI Changes
* Add a separate ConnectorDeleteTableHandle interface for `ConnectorMetadata.beginDelete` and `ConnectorMetadata.finishDelete`, replacing the previous usage of ConnectorTableHandle
* Add DeleteTableHandle support these changes in Metadata

Hive Connector Changes
* Replaced return type of beginDelete

Iceberg Connector Changes
* Fix IcebergTableHandle implementation to work with new types used in begin/finishDelete

Kudu Connector Changes
* Replaced return type of beginDelete

```

