### PR TITLE
Upgrade Jansi dependency to 2.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1397,7 +1397,7 @@
             <dependency>
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
-                <version>1.18</version>
+                <version>2.4.1</version>
             </dependency>
 
             <dependency>

--- a/presto-cli/src/main/java/com/facebook/presto/cli/KeyReader.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/KeyReader.java
@@ -13,13 +13,12 @@
  */
 package com.facebook.presto.cli;
 
+import org.fusesource.jansi.AnsiConsole;
+
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
-import static org.fusesource.jansi.internal.CLibrary.STDIN_FILENO;
-import static org.fusesource.jansi.internal.CLibrary.isatty;
 
 public final class KeyReader
 {
@@ -47,7 +46,10 @@ public final class KeyReader
     private static boolean hasTerminal()
     {
         try {
-            return isatty(STDIN_FILENO) == 1;
+            AnsiConsole.systemInstall();
+            boolean isAnsiSupported = AnsiConsole.isInstalled();
+            AnsiConsole.systemUninstall(); // Uninstall after check
+            return isAnsiSupported;
         }
         catch (Throwable e) {
             return false;


### PR DESCRIPTION
## Description
Upgraded Jansi dependency from 1.18 to 2.4.1 and fixed incompatibility issues.

## Motivation and Context
Addresses [CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Upgrade Jansi Dependency from 1.18 to 2.4.1
```

