### PR TITLE
[native] Expose an API to clean up async data cache on node

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -53,6 +53,30 @@ Other HTTP endpoints include:
 
 The request/response flow of Presto C++ is identical to Java workers. The tasks or new splits are registered via `TaskUpdateRequest`. Resource utilization and query progress are sent to the coordinator via task endpoints.
 
+* GET: /v1/operation/server/clearCache?type=memory: It clears the memory cache on worker node. Here is an example:
+
+  .. sourcecode:: http
+
+   curl -X GET "http://localhost:7777/v1/operation/server/clearCache?type=memory"
+
+   Cleared memory cache
+
+* GET: /v1/operation/server/clearCache?type=ssd: It clears the ssd cache on worker node. Here is an example:
+
+  .. sourcecode:: http
+
+   curl -X GET "http://localhost:7777/v1/operation/server/clearCache?type=ssd"
+
+   Cleared ssd cache
+
+* GET: /v1/operation/server/writeSsd: It writes data from memory cache to the ssd cache on worker node. Here is an example:
+
+  .. sourcecode:: http
+
+   curl -X GET "http://localhost:7777/v1/operation/server/writeSsd"
+
+   Succeeded write ssd cache
+
 Remote Function Execution
 -------------------------
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
@@ -34,7 +34,7 @@ public class HiveExternalWorkerQueryRunner
         javaQueryRunner.close();
 
         // Launch distributed runner.
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(false, false);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(false, false, false, false);
         Thread.sleep(10);
         Logger log = Logger.get(DistributedQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeApiEndpointUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeApiEndpointUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class NativeApiEndpointUtils
+{
+    private NativeApiEndpointUtils() {}
+    public static Map<String, Long> fetchScalarLongMetrics(String serverAndPort, String apiEndpoint, String requestMethod) throws Exception
+    {
+        String apiUrl = serverAndPort + apiEndpoint;
+        URL url = new URL(apiUrl);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod(requestMethod);
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+
+        Map<String, Long> metrics = new HashMap<>();
+        Pattern metricPattern = Pattern.compile("^(\\w+)(?:\\{.*?\\})?\\s+(\\d+)$");
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                Matcher matcher = metricPattern.matcher(line);
+                if (matcher.matches()) {
+                    String metricName = matcher.group(1);
+                    long metricValue = Long.parseLong(matcher.group(2));
+                    metrics.put(metricName, metricValue);
+                }
+            }
+        }
+        finally {
+            connection.disconnect();
+        }
+
+        return metrics;
+    }
+
+    public static int sendWorkerRequest(String serverAndPort, String endPoint)
+    {
+        try {
+            URL url = new URL(serverAndPort + endPoint);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Accept", "application/json");
+            return connection.getResponseCode();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            return 500;
+        }
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.nativeworker.NativeApiEndpointUtils.fetchScalarLongMetrics;
+import static com.facebook.presto.nativeworker.NativeApiEndpointUtils.sendWorkerRequest;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createCustomer;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+public class TestPrestoNativeAsyncDataCacheCleanupAPI
+        extends AbstractTestQueryFramework
+{
+    private static final String memoryCacheCleanupEndPoint = "/v1/operation/server/clearCache?type=memory";
+    private static final String ssdCacheCleanupEndPoint = "/v1/operation/server/clearCache?type=ssd";
+    private static final String metricsEndPoint = "/v1/info/metrics";
+    private static final String writeToSsdEndPoint = "/v1/operation/server/writeSsd";
+
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createQueryRunner(true, false, true, true);
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createCustomer(queryRunner);
+    }
+
+    @Test
+    public void testAsyncDataCacheCleanup() throws Exception
+    {
+        Session session = Session.builder(super.getSession())
+                .setCatalogSessionProperty("hive", "node_selection_strategy", "SOFT_AFFINITY")
+                .build();
+
+        QueryRunner queryRunner = getQueryRunner();
+        DistributedQueryRunner distributedQueryRunner = (DistributedQueryRunner) queryRunner;
+        Set<InternalNode> workerNodes = getWorkerNodes(distributedQueryRunner);
+
+        // 1. Collect initial cache metrics
+        Metrics initialMetrics = collectCacheMetrics(workerNodes, metricsEndPoint);
+        assertEquals(0, initialMetrics.memoryCacheHits, "Cache hits should be zero initially.");
+        assertEquals(0, initialMetrics.memoryCacheEntries, "Cache entries should be zero initially.");
+
+        // 2. Execute queries to populate cache
+        for (int i = 0; i < 4; i++) {
+            queryRunner.execute(session, "SELECT count(*) FROM customer");
+        }
+        TimeUnit.SECONDS.sleep(60); // Sleep to allow cache updates
+
+        // 3. Collect cache metrics after queries
+        Metrics populatedMetrics = collectCacheMetrics(workerNodes, metricsEndPoint);
+        assertNotEquals(0, populatedMetrics.memoryCacheHits, "Cache should have hits after queries.");
+        assertNotEquals(0, populatedMetrics.memoryCacheEntries, "Cache should have entries after queries.");
+
+        // 4. Write cache data to ssd
+        workerNodes.parallelStream().forEach(worker -> {
+            int responseCode = sendWorkerRequest(worker.getInternalUri().toString(), writeToSsdEndPoint);
+            assertEquals(200, responseCode, "Expected a 200 OK response for writing to ssd cache.");
+        });
+        TimeUnit.SECONDS.sleep(60); // Sleep to allow cache updates
+
+        // 5. Collect SSD metrics after ssd write
+        Metrics ssdMetrics = collectCacheMetrics(workerNodes, metricsEndPoint);
+        assertNotEquals(0, ssdMetrics.ssdCacheWriteEntries, "SSD Cache should have write entries after write API call.");
+        assertEquals(0, ssdMetrics.ssdCacheReadEntries, "SSD Cache should have 0 read entries currently.");
+
+        // 6. Trigger memory async cache cleanup
+        workerNodes.parallelStream().forEach(worker -> {
+            int responseCode = sendWorkerRequest(worker.getInternalUri().toString(), memoryCacheCleanupEndPoint);
+            assertEquals(200, responseCode, "Expected a 200 OK response for cache cleanup.");
+        });
+        TimeUnit.SECONDS.sleep(60); // Sleep to allow cache updates
+
+        // 7. Validate memory cache is cleared
+        Metrics finalMetrics = collectCacheMetrics(workerNodes, metricsEndPoint);
+        assertEquals(0, finalMetrics.memoryCacheEntries, "Cache should be empty after cleanup.");
+
+        // 8. Execute queries to read from SSD cache
+        for (int i = 0; i < 4; i++) {
+            queryRunner.execute(session, "SELECT count(*) FROM customer");
+        }
+        TimeUnit.SECONDS.sleep(60); // Sleep to allow cache updates
+
+        // 9. Collect SSD metrics to check read entries metrics
+        Metrics populatedSsdMetrics = collectCacheMetrics(workerNodes, metricsEndPoint);
+        assertNotEquals(0, populatedSsdMetrics.ssdCacheReadEntries, "SSD Cache should have non-zero read entries.");
+
+        // 10. Trigger SSD cache clean up
+        workerNodes.parallelStream().forEach(worker -> {
+            int responseCode = sendWorkerRequest(worker.getInternalUri().toString(), ssdCacheCleanupEndPoint);
+            assertEquals(200, responseCode, "Expected a 200 OK response for cache cleanup.");
+        });
+        TimeUnit.SECONDS.sleep(60); // Sleep to allow cache updates
+
+        // 11. Validate SSD cache is cleared
+        Metrics finalSSDCacheMetrics = collectCacheMetrics(workerNodes, metricsEndPoint);
+        assertEquals(0, finalSSDCacheMetrics.ssdCacheCachedEntries, "SSD Cache should be empty after cleanup.");
+    }
+
+    private Metrics collectCacheMetrics(Set<InternalNode> workerNodes, String endpoint)
+            throws Exception
+    {
+        int memoryCacheHits = 0;
+        int memoryCacheEntries = 0;
+        int ssdCacheReadEntries = 0;
+        int ssdCacheWriteEntries = 0;
+        int ssdCacheCachedEntries = 0;
+
+        for (InternalNode worker : workerNodes) {
+            Map<String, Long> metrics = fetchScalarLongMetrics(worker.getInternalUri().toString(), endpoint, "GET");
+            memoryCacheHits += metrics.get("velox_memory_cache_num_hits");
+            memoryCacheEntries += metrics.get("velox_memory_cache_num_entries");
+            ssdCacheReadEntries += metrics.get("velox_ssd_cache_read_entries");
+            ssdCacheWriteEntries += metrics.get("velox_ssd_cache_written_entries");
+            ssdCacheCachedEntries += metrics.get("velox_ssd_cache_cached_entries");
+        }
+        return new Metrics(memoryCacheHits, memoryCacheEntries, ssdCacheReadEntries, ssdCacheWriteEntries, ssdCacheCachedEntries);
+    }
+
+    private static class Metrics
+    {
+        final int memoryCacheHits;
+        final int memoryCacheEntries;
+        final int ssdCacheReadEntries;
+        final int ssdCacheWriteEntries;
+        final int ssdCacheCachedEntries;
+
+        Metrics(int memoryCacheHits, int memoryCacheEntries, int ssdCacheReadEntries, int ssdCacheWriteEntries, int ssdCacheCachedEntries)
+        {
+            this.memoryCacheHits = memoryCacheHits;
+            this.memoryCacheEntries = memoryCacheEntries;
+            this.ssdCacheReadEntries = ssdCacheReadEntries;
+            this.ssdCacheWriteEntries = ssdCacheWriteEntries;
+            this.ssdCacheCachedEntries = ssdCacheCachedEntries;
+        }
+    }
+
+    private boolean isCoordinator(DistributedQueryRunner distributedQueryRunner, InternalNode node)
+    {
+        return distributedQueryRunner.getCoordinator().getNodeManager().getCoordinators().contains(node);
+    }
+
+    private Set<InternalNode> getWorkerNodes(DistributedQueryRunner queryRunner)
+    {
+        return queryRunner.getCoordinator()
+                .getNodeManager()
+                .getAllNodes()
+                .getActiveNodes()
+                .stream()
+                .filter(node -> !isCoordinator(queryRunner, node))
+                .collect(Collectors.toSet());
+    }
+
+    @Test
+    public void testAsyncDataCacheCleanupApiFormat()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        DistributedQueryRunner distributedQueryRunner = (DistributedQueryRunner) queryRunner;
+        Set<InternalNode> workerNodes = getWorkerNodes(distributedQueryRunner);
+        InternalNode workerNode = workerNodes.iterator().next();
+
+        int responseCode = sendWorkerRequest(workerNode.getInternalUri().toString(), memoryCacheCleanupEndPoint);
+        assertEquals(responseCode, 200, "Expected a 200 OK response for valid shutdown request");
+
+        String invalidEndPoint = "/v1/operation/server/clearCacheNonExisting?name=hive&id=hive";
+        responseCode = sendWorkerRequest(workerNode.getInternalUri().toString(), invalidEndPoint);
+        assertEquals(responseCode, 500);
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeSystemQueriesSingleNode.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeSystemQueriesSingleNode.java
@@ -31,7 +31,9 @@ public class TestPrestoNativeSystemQueriesSingleNode
                 Optional.empty(),
                 false,
                 false,
-                true);
+                true,
+                false,
+                false);
     }
 
     @Override

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/NativeSidecarPluginQueryRunner.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/NativeSidecarPluginQueryRunner.java
@@ -38,7 +38,7 @@ public class NativeSidecarPluginQueryRunner
         javaQueryRunner.close();
 
         // Launch distributed runner.
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(false, true);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(false, true, false, false);
         setupNativeSidecarPlugin(queryRunner);
         Thread.sleep(10);
         Logger log = Logger.get(DistributedQueryRunner.class);

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -60,7 +60,7 @@ public class TestNativeSidecarPlugin
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(true, true);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(true, true, false, false);
         setupNativeSidecarPlugin(queryRunner);
         return queryRunner;
     }


### PR DESCRIPTION
## Description
Adding e2e tests for existing cache APIs

## Motivation and Context

Adding e2e tests for existing cache APIs

## Impact
Adding e2e tests for existing cache APIs -

```
curl -X GET "http://localhost:7777/v1/operation/server/clearCache?type=memory"
   
curl -X GET "http://localhost:7777/v1/operation/server/clearCache?type=ssd"

curl -X GET "http://localhost:7777/v1/operation/server/writeSsd"
```

## Test Plan
Test Added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

