### PR TITLE
add mysql compatible function bit_length

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -28,6 +28,10 @@ String Functions
     some languages. Specifically, this will return incorrect results for
     Lithuanian, Turkish and Azeri.
 
+.. function:: bit_length(string) -> boolean
+
+    Returns the count of bits for the given ``string``.
+
 .. function:: chr(n) -> varchar
 
     Returns the Unicode code point ``n`` as a single character string.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -104,6 +104,15 @@ public final class StringFunctions
         return x;
     }
 
+    @Description("count of bits for the given string")
+    @ScalarFunction("bit_length")
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.BIGINT)
+    public static long bitLength(@SqlType("varchar(x)") Slice slice)
+    {
+        return (long) slice.length() * 8;
+    }
+
     @Description("greedily removes occurrences of a pattern in a string")
     @ScalarFunction
     @LiteralParameters({"x", "y"})

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -137,6 +137,16 @@ public class TestStringFunctions
     }
 
     @Test
+    public void testBitLength()
+    {
+        assertFunction("BIT_LENGTH('')", BIGINT, 0L);
+        assertFunction("BIT_LENGTH('hello')", BIGINT, 40L);
+        // Test bit_length for non-ASCII
+        assertFunction("BIT_LENGTH('hell o\u00EF')", BIGINT, 64L);
+        assertFunction("BIT_LENGTH('中123')", BIGINT, 48L);
+    }
+
+    @Test
     public void testCharLength()
     {
         assertFunction("LENGTH(CAST('hello' AS CHAR(5)))", BIGINT, 5L);


### PR DESCRIPTION
## Description
Add a mysql compatible function bit_length, it returns the count of bits for the given string.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add a MySQL-compatible function ``bit_length`` that returns the count of bits for the given string.


