### PR TITLE
Add publish presto release action and fix cut release action

### DIFF
--- a/.github/workflows/presto-publish-release.yml
+++ b/.github/workflows/presto-publish-release.yml
@@ -1,0 +1,111 @@
+name: Publish Presto Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      RELEASE_BRANCH:
+        description: 'Release branch (e.g., release-0.290)'
+        required: true
+      RELEASE_VERSION:
+        description: 'Release version (e.g., 0.290)'
+        required: true
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 300  # 5 hours
+
+    env:
+      NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+
+    steps:
+      - name: Setup JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential git gpg python3 python3-venv
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.RELEASE_BRANCH }}
+          token: ${{ secrets.PRESTODB_CI_TOKEN }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "ci@lists.prestodb.io"
+          git config --global user.name "prestodb-ci"
+          git checkout ${{ github.event.inputs.RELEASE_VERSION }}
+          git log --pretty="format:%ce: %s" -5
+
+      - name: Import GPG key
+        run: |
+          echo "${{ secrets.GPG_SECRET }}" > ${{ github.workspace }}/secret-key.gpg
+          chmod 600 ${{ github.workspace }}/secret-key.gpg
+          gpg --import --batch ${{ github.workspace }}/secret-key.gpg
+          rm -f ${{ github.workspace }}/secret-key.gpg
+          gpg --list-secret-keys
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+        env:
+          GPG_TTY: $(tty)
+
+      - name: Create Maven Settings
+        run: |
+          cat > ${{ github.workspace }}/settings.xml << 'EOL'
+          <settings>
+            <servers>
+              <server>
+                <id>sonatype-nexus-snapshots</id>
+                <username>${env.NEXUS_USERNAME}</username>
+                <password>${env.NEXUS_PASSWORD}</password>
+              </server>
+              <server>
+                <id>sonatype.snapshots</id>
+                <username>${env.NEXUS_USERNAME}</username>
+                <password>${env.NEXUS_PASSWORD}</password>
+              </server>
+              <server>
+                <id>ossrh</id>
+                <username>${env.NEXUS_USERNAME}</username>
+                <password>${env.NEXUS_PASSWORD}</password>
+              </server>
+            </servers>
+            <profiles>
+              <profile>
+                <id>nexus</id>
+                <!--Enable snapshots for the built in central repo to direct -->
+                <!--all requests to nexus via the mirror -->
+              </profile>
+            </profiles>
+            <activeProfiles>
+              <activeProfile>nexus</activeProfile>
+            </activeProfiles>
+          </settings>
+          EOL
+
+      - name: Release Maven Artifacts
+        run: |
+          unset MAVEN_CONFIG
+          ./mvnw -s ${{ github.workspace }}/settings.xml -V -B -U -e -T1C deploy \
+            -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" \
+            -Dmaven.wagon.http.retryHandler.count=8 \
+            -DskipTests \
+            -DstagingProfileId=28a0d8c4350ed \
+            -DkeepStagingRepositoryOnFailure=true \
+            -DkeepStagingRepositoryOnCloseRuleFailure=true \
+            -DautoReleaseAfterClose=true \
+            -DstagingProgressTimeoutMinutes=60 \
+            -Poss-release \
+            -Pdeploy-to-ossrh \
+            -pl '!presto-test-coverage'
+        env:
+          GPG_TTY: $(tty)

--- a/.github/workflows/presto-release-cut.yml
+++ b/.github/workflows/presto-release-cut.yml
@@ -1,11 +1,10 @@
-name: Presto Stable Release Workflow
+name: Cut Presto Stable Release
 
 on:
   workflow_dispatch:
 
 jobs:
-  presto-release:
-    name: Presto Stable Release Workflow
+  cut-stable-release:
     runs-on: ubuntu-latest
     environment: release
 
@@ -60,11 +59,15 @@ jobs:
             -DautoVersionSubmodules \
             -DdevelopmentVersion=${{ env.PRESTO_RELEASE_VERSION }} \
             -DreleaseVersion=${{ env.PRESTO_RELEASE_VERSION }}
+          grep -m 1 "<version>" pom.xml
+          git log --pretty="format:%ce: %s" -5
           git push --follow-tags origin master
 
       - name: Push release branch
         env:
           PRESTO_RELEASE_VERSION: ${{ steps.get-version.outputs.PRESTO_RELEASE_VERSION }}
         run: |
-          git checkout -b release-${{ env.PRESTO_RELEASE_VERSION }}
+          git checkout ${{ env.PRESTO_RELEASE_VERSION }}
+          git switch -c release-${{ env.PRESTO_RELEASE_VERSION }}
+          git log --pretty="format:%ce: %s" -3
           git push origin release-${{ env.PRESTO_RELEASE_VERSION }}

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Presto Release
+name: Publish Presto Stable Release
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ on:
         required: true
 
 jobs:
-  publish-release:
+  publish-stable-release:
     runs-on: ubuntu-latest
     environment: release
     timeout-minutes: 300  # 5 hours


### PR DESCRIPTION
## Description
Added github action to publish presto release to maven repo
Fixed the wrong release branch commit issue in cut release action
Refactor the file names as group by using `presto-release-` as prefix.

## Motivation and Context
Migrate existing jenkins pipline to github action

## Impact
Release & repo settings

## Test Plan
TBD in next release

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

