### PR TITLE
Add `Join PrestoDB on Slack` link on document pages

### DIFF
--- a/presto-docs/src/main/sphinx/_templates/partials/toc.html
+++ b/presto-docs/src/main/sphinx/_templates/partials/toc.html
@@ -40,6 +40,14 @@ This file was automatically generated - do not edit
                 Create project issue
             </a>
         </li>
+        <li class="md-nav__item">
+            <a href="https://communityinviter.com/apps/prestodb/prestodb" class="">
+                <span class="md-source__icon  md-icon">
+                    {% include ".icons/fontawesome/brands/slack.svg" %}
+                </span>
+                Join PrestoDB on Slack
+            </a>
+        </li>
     </ul>
     <hr>
     {% set toc = page.toc %}


### PR DESCRIPTION
## Description
Adding a link in the document pages to encourage users to join the PrestoDB Slack when seeking help.

## Motivation and Context
Document pages are where users look for instructions/information when setting up a Presto cluster.
Adding the link to direct users to the Slack channels when encountering any issues would
improve the adoption process.

## Impact
No function impact

## Test Plan
Generate the doc website and check the new link

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

