### PR TITLE
Fix compilation failure after merging AddExchangeBeforeGroupId

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -929,7 +929,7 @@ public class PlanOptimizers
                 ruleStats,
                 statsCalculator,
                 costCalculator,
-                new AddExchangesBelowPartialAggregationOverGroupIdRuleSet(taskCountEstimator, taskManagerConfig, metadata).rules()));
+                new AddExchangesBelowPartialAggregationOverGroupIdRuleSet(taskCountEstimator, taskManagerConfig, metadata, featuresConfig.isNativeExecutionEnabled()).rules()));
 
         builder.add(new IterativeOptimizer(
                 metadata,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddExchangesBelowPartialAggregationOverGroupIdRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddExchangesBelowPartialAggregationOverGroupIdRuleSet.java
@@ -130,15 +130,18 @@ public class AddExchangesBelowPartialAggregationOverGroupIdRuleSet
     private final TaskCountEstimator taskCountEstimator;
     private final DataSize maxPartialAggregationMemoryUsage;
     private final Metadata metadata;
+    private final boolean nativeExecution;
 
     public AddExchangesBelowPartialAggregationOverGroupIdRuleSet(
             TaskCountEstimator taskCountEstimator,
             TaskManagerConfig taskManagerConfig,
-            Metadata metadata)
+            Metadata metadata,
+            boolean nativeExecution)
     {
         this.taskCountEstimator = requireNonNull(taskCountEstimator, "taskCountEstimator is null");
         this.maxPartialAggregationMemoryUsage = taskManagerConfig.getMaxPartialAggregationMemoryUsage();
         this.metadata = metadata;
+        this.nativeExecution = nativeExecution;
     }
 
     public Set<Rule<?>> rules()
@@ -355,7 +358,7 @@ public class AddExchangesBelowPartialAggregationOverGroupIdRuleSet
             List<StreamProperties> inputProperties = resolvedPlanNode.getSources().stream()
                     .map(source -> derivePropertiesRecursively(source, context))
                     .collect(toImmutableList());
-            return deriveProperties(resolvedPlanNode, inputProperties, metadata, context.getSession());
+            return deriveProperties(resolvedPlanNode, inputProperties, metadata, context.getSession(), nativeExecution);
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestAddExchangesBelowPartialAggregationOverGroupIdRuleSet.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestAddExchangesBelowPartialAggregationOverGroupIdRuleSet.java
@@ -62,7 +62,8 @@ public class TestAddExchangesBelowPartialAggregationOverGroupIdRuleSet
         return new AddExchangesBelowPartialAggregationOverGroupIdRuleSet(
                 taskCountEstimator,
                 taskManagerConfig,
-                ruleTester.getMetadata()
+                ruleTester.getMetadata(),
+                false
         ).belowExchangeRule();
     }
 
@@ -73,7 +74,8 @@ public class TestAddExchangesBelowPartialAggregationOverGroupIdRuleSet
         return new AddExchangesBelowPartialAggregationOverGroupIdRuleSet(
                 taskCountEstimator,
                 taskManagerConfig,
-                ruleTester.getMetadata()
+                ruleTester.getMetadata(),
+                false
         ).belowProjectionRule();
     }
 


### PR DESCRIPTION
Fixes compilation failure due to #24047  not being rebased before #24468 was merged



## Release Notes

```
== NO RELEASE NOTE ==
```

