### PR TITLE
Fix GH Actions for doc-only PR

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -2,6 +2,8 @@ name: arrow flight tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
 
 env:
   CONTINUOUS_INTEGRATION: true
@@ -12,22 +14,8 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            codechange:
-               - '!presto-docs/**'
   test:
     runs-on: ubuntu-latest
-    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -42,13 +30,11 @@ jobs:
     steps:
       # Checkout the code only if there are changes in the relevant files
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
 
       # Set up Java and dependencies for the build environment
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: 8
@@ -58,12 +44,10 @@ jobs:
 
       # Install dependencies for the target module
       - name: Maven Install
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl ${{ matrix.modules }}
 
       # Run Maven tests for the target module
       - name: Maven Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -pl ${{ matrix.modules }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,11 +76,13 @@ jobs:
         with:
           show-progress: false
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: 8
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven Install
         if: needs.changes.outputs.codechange == 'true'


### PR DESCRIPTION
## Description
When there is no code change, some steps in the GA workflow are not able to be performed and cause failures. Put the `if condition` to check the code change in those steps. For non-required tests, use `paths-ignore` to skip the test directly.

## Motivation and Context
fix the GH action error when a PR contains only document changes.
example failures: 
- https://github.com/prestodb/presto/actions/runs/13273735011/job/37058943327?pr=24534
- https://github.com/prestodb/presto/actions/runs/13273734993/job/37063671179?pr=24534

## Impact
doc-only PR can't be merged and need this fix

## Test Plan
verify the doc-only PR after this PR is merged

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

