### PR TITLE
fixed hive view uuid type parsing

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -227,6 +227,9 @@ public final class HiveType
     public static HiveType valueOf(String hiveTypeName)
     {
         requireNonNull(hiveTypeName, "hiveTypeName is null");
+        if (hiveTypeName.equals(HIVE_UUID.getTypeInfo().getTypeName())) {
+            return HIVE_UUID;
+        }
         return toHiveType(getTypeInfoFromTypeString(hiveTypeName));
     }
 


### PR DESCRIPTION
## Description

Currently, creation of VIEW with UUID on hive catalog throws exception

```
create or replace view "hive"."dbcert_hive".vuuid as 
SELECT * FROM ( 
 VALUES 
 (cast(0 as integer), null), 
 (cast(1 as integer), UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59') 
) AS t (rum, c1);

```


This PR fixes UUID type parsing while VIEW creation, selection on Hive

## Motivation and Context
Presto is failing to recognize UUID as a valid Hive type, leading to a type resolution failure.

`cannot construct instance of com.facebook.presto.hive.HiveType, problem: Error: type expected at the position 0 of uuid'but uuid is found.`

## Test Plan
Added a test for hive and iceberg where we create the view with uuid column and select from that view.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix Hive ``UUID`` type parsing

```

