### PR TITLE
ArrowFlight module - do not bind class to itself

### DIFF
--- a/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowModule.java
+++ b/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowModule.java
@@ -49,6 +49,6 @@ public class ArrowModule
         binder.bind(ArrowPageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSourceProvider.class).to(ArrowPageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(Connector.class).to(ArrowConnector.class).in(Scopes.SINGLETON);
-        binder.bind(ArrowBlockBuilder.class).to(ArrowBlockBuilder.class).in(Scopes.SINGLETON);
+        binder.bind(ArrowBlockBuilder.class).in(Scopes.SINGLETON);
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Do not bind ArrowBlockBuilder to itself.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
If a connector extending presto-base-arrow-flight does not customise ArrowBlockBuilder and bind the customisation in the connector's module, a runtime error will be thrown because ArrowBlockBuilder is being bound to itself.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No error will be thrown if a concrete implementation of presto-base-arrow-flight does not extend ArrowBlockBuilder.

## Test Plan
<!---Please fill in how you tested your change-->
Tested this change by implementing a concrete connector that doesn't customise ArrowBlockBuilder.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

