### PR TITLE
Add evb violation counter for exchange client and http server IO threadpool

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -240,6 +240,8 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kEnableRuntimeMetricsCollection, false),
           BOOL_PROP(kPlanValidatorFailOnNestedLoopJoin, false),
           STR_PROP(kPrestoDefaultNamespacePrefix, "presto.default"),
+          NUM_PROP(kExchangeIoEvbViolationThresholdMs, 1000),
+          NUM_PROP(kHttpSrvIoEvbViolationThresholdMs, 1000),
       };
 }
 
@@ -761,6 +763,16 @@ bool SystemConfig::enableRuntimeMetricsCollection() const {
 
 std::string SystemConfig::prestoDefaultNamespacePrefix() const {
   return optionalProperty(kPrestoDefaultNamespacePrefix).value().append(".");
+}
+
+int32_t SystemConfig::exchangeIoEvbViolationThresholdMs() const {
+  return optionalProperty<int32_t>(kExchangeIoEvbViolationThresholdMs)
+      .value();
+}
+
+int32_t SystemConfig::httpSrvIoEvbViolationThresholdMs() const {
+  return optionalProperty<int32_t>(kHttpSrvIoEvbViolationThresholdMs)
+      .value();
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -144,7 +144,7 @@ class ConfigBase {
  protected:
   ConfigBase()
       : config_(std::make_unique<velox::config::ConfigBase>(
-            std::unordered_map<std::string, std::string>())){};
+            std::unordered_map<std::string, std::string>())) {};
 
   // Check if all properties are registered.
   void checkRegisteredProperties(
@@ -659,6 +659,11 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kPrestoDefaultNamespacePrefix{
       "presto.default-namespace"};
 
+  static constexpr std::string_view kExchangeIoEvbViolationThresholdMs{
+      "exchange.io-evb-violation-threshold-ms"};
+  static constexpr std::string_view kHttpSrvIoEvbViolationThresholdMs{
+      "http-server.io-evb-violation-threshold-ms"};
+
   SystemConfig();
 
   virtual ~SystemConfig() = default;
@@ -898,6 +903,10 @@ class SystemConfig : public ConfigBase {
 
   bool prestoNativeSidecar() const;
   std::string prestoDefaultNamespacePrefix() const;
+
+  int32_t exchangeIoEvbViolationThresholdMs() const;
+
+  int32_t httpSrvIoEvbViolationThresholdMs() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -130,6 +130,10 @@ void registerPrestoMetrics() {
       99,
       100);
 
+  DEFINE_METRIC(kCounterExchangeIoEvbViolation, facebook::velox::StatType::COUNT);
+
+  DEFINE_METRIC(kCounterHttpServerIoEvbViolation, facebook::velox::StatType::COUNT);
+
   // NOTE: Metrics type exporting for thread pool executor counters are in
   // PeriodicTaskManager because they have dynamic names and report configs. The
   // following counters have their type exported there:

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -170,6 +170,12 @@ constexpr std::string_view kCounterThreadPoolNumTotalTasksFormat{
 constexpr std::string_view kCounterThreadPoolMaxIdleTimeNsFormat{
     "presto_cpp.{}.max_idle_time_ns"};
 
+/// ================== EVB Counters ====================
+constexpr folly::StringPiece kCounterExchangeIoEvbViolation{
+    "presto_cpp.exchange_io_evb_violation_count"};
+constexpr folly::StringPiece kCounterHttpServerIoEvbViolation{
+    "presto_cpp.http_server_io_evb_violation_count"};
+
 /// ================== Memory Pushback Counters =================
 
 /// Number of times memory pushback mechanism is triggered.


### PR DESCRIPTION
When prestissimo worker is busy on CPU, we observed delays in exchange connection.
Add evb violation for exchange client IO thread pool  and exchange server IO thread pool 
to give us better visibility.

```
== NO RELEASE NOTE ==
```

