### PR TITLE
Revert event loop related changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,12 +249,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport</artifactId>
-                <version>${dep.netty.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-testing-docker</artifactId>
                 <version>${project.version}</version>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -512,11 +512,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -517,11 +517,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server.remotetask;
 
+import com.facebook.airlift.concurrent.SetThreadName;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.HttpUriBuilder;
 import com.facebook.airlift.http.client.Request;
@@ -76,11 +77,11 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.sun.management.ThreadMXBean;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import io.netty.channel.EventLoop;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import java.lang.management.ManagementFactory;
 import java.net.URI;
@@ -93,10 +94,15 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static com.facebook.airlift.http.client.HttpStatus.NO_CONTENT;
@@ -125,11 +131,11 @@ import static com.facebook.presto.util.Failures.toFailure;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.util.concurrent.Futures.addCallback;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.lang.Math.addExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -137,22 +143,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-/**
- * Represents a task running on a remote worker.
- * <p>
- * This class now uses an event loop concurrency model to eliminate the need for explicit synchronization:
- * <ul>
- * <li>All mutable state access and modifications are performed on a single dedicated event loop thread</li>
- * <li>External threads submit operations to the event loop using {@code taskEventLoop.execute()}</li>
- * <li>The event loop serializes all operations, eliminating race conditions without using locks</li>
- * </ul>
- * <p>
- * Key benefits of this approach:
- * <ul>
- * <li>Improved performance by creating fewer event processing threads to support running more tasks</li>
- * <li>Simplified reasoning about concurrent operations since they are serialized</li>
- * </ul>
- */
 public final class HttpRemoteTask
         implements RemoteTask
 {
@@ -171,33 +161,47 @@ public final class HttpRemoteTask
     private final Set<PlanNodeId> tableScanPlanNodeIds;
     private final Set<PlanNodeId> remoteSourcePlanNodeIds;
 
-    private long nextSplitId;
+    private final AtomicLong nextSplitId = new AtomicLong();
 
     private final Duration maxErrorDuration;
     private final RemoteTaskStats stats;
     private final TaskInfoFetcher taskInfoFetcher;
     private final ContinuousTaskStatusFetcher taskStatusFetcher;
 
+    @GuardedBy("this")
     private final LongArrayList taskUpdateTimeline = new LongArrayList();
+    @GuardedBy("this")
     private Future<?> currentRequest;
+    @GuardedBy("this")
     private long currentRequestStartNanos;
+    @GuardedBy("this")
     private long currentRequestLastTaskUpdate;
 
+    @GuardedBy("this")
     private final SetMultimap<PlanNodeId, ScheduledSplit> pendingSplits = HashMultimap.create();
+    @GuardedBy("this")
     private volatile int pendingSourceSplitCount;
+    @GuardedBy("this")
     private volatile long pendingSourceSplitsWeight;
+    @GuardedBy("this")
     private final SetMultimap<PlanNodeId, Lifespan> pendingNoMoreSplitsForLifespan = HashMultimap.create();
+    @GuardedBy("this")
     // The keys of this map represent all plan nodes that have "no more splits".
     // The boolean value of each entry represents whether the "no more splits" notification is pending delivery to workers.
     private final Map<PlanNodeId, Boolean> noMoreSplits = new HashMap<>();
-    private OutputBuffers outputBuffers;
+    @GuardedBy("this")
+    private final AtomicReference<OutputBuffers> outputBuffers = new AtomicReference<>();
     private final FutureStateChange<?> whenSplitQueueHasSpace = new FutureStateChange<>();
-    private volatile boolean splitQueueHasSpace;
+    @GuardedBy("this")
+    private boolean splitQueueHasSpace = true;
+    @GuardedBy("this")
     private OptionalLong whenSplitQueueHasSpaceThreshold = OptionalLong.empty();
 
     private final boolean summarizeTaskInfo;
 
     private final HttpClient httpClient;
+    private final Executor executor;
+    private final ScheduledExecutorService errorScheduledExecutor;
 
     private final Codec<TaskInfo> taskInfoCodec;
     //Json codec required for TaskUpdateRequest endpoint which uses JSON and returns a TaskInfo
@@ -207,13 +211,13 @@ public final class HttpRemoteTask
 
     private final RequestErrorTracker updateErrorTracker;
 
-    private boolean needsUpdate = true;
-    private boolean sendPlan = true;
+    private final AtomicBoolean needsUpdate = new AtomicBoolean(true);
+    private final AtomicBoolean sendPlan = new AtomicBoolean(true);
 
     private final NodeStatsTracker nodeStatsTracker;
 
-    private boolean started;
-    private boolean aborting;
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicBoolean aborting = new AtomicBoolean(false);
 
     private final boolean binaryTransportEnabled;
     private final boolean thriftTransportEnabled;
@@ -231,8 +235,6 @@ public final class HttpRemoteTask
     private final boolean taskUpdateSizeTrackingEnabled;
     private final SchedulerStatsTracker schedulerStatsTracker;
 
-    private final EventLoop taskEventLoop;
-
     public HttpRemoteTask(
             Session session,
             TaskId taskId,
@@ -243,6 +245,9 @@ public final class HttpRemoteTask
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
             HttpClient httpClient,
+            Executor executor,
+            ScheduledExecutorService updateScheduledExecutor,
+            ScheduledExecutorService errorScheduledExecutor,
             Duration maxErrorDuration,
             Duration taskStatusRefreshMaxWait,
             Duration taskInfoRefreshMaxWait,
@@ -268,8 +273,7 @@ public final class HttpRemoteTask
             boolean taskUpdateSizeTrackingEnabled,
             HandleResolver handleResolver,
             ConnectorTypeSerdeManager connectorTypeSerdeManager,
-            SchedulerStatsTracker schedulerStatsTracker,
-            EventLoop taskEventLoop)
+            SchedulerStatsTracker schedulerStatsTracker)
     {
         requireNonNull(session, "session is null");
         requireNonNull(taskId, "taskId is null");
@@ -279,6 +283,7 @@ public final class HttpRemoteTask
         requireNonNull(planFragment, "planFragment is null");
         requireNonNull(outputBuffers, "outputBuffers is null");
         requireNonNull(httpClient, "httpClient is null");
+        requireNonNull(executor, "executor is null");
         requireNonNull(taskStatusCodec, "taskStatusCodec is null");
         requireNonNull(taskInfoCodec, "taskInfoCodec is null");
         requireNonNull(taskUpdateRequestCodec, "taskUpdateRequestCodec is null");
@@ -295,119 +300,122 @@ public final class HttpRemoteTask
         requireNonNull(connectorTypeSerdeManager, "connectorTypeSerdeManager is null");
         requireNonNull(taskUpdateRequestSize, "taskUpdateRequestSize cannot be null");
         requireNonNull(schedulerStatsTracker, "schedulerStatsTracker is null");
-        requireNonNull(taskEventLoop, "taskEventLoop is null");
 
-        this.taskEventLoop = taskEventLoop;
-        this.taskId = taskId;
-        this.taskLocation = location;
-        this.remoteTaskLocation = remoteLocation;
-        this.session = session;
-        this.nodeId = nodeId;
-        this.planFragment = planFragment;
-        this.outputBuffers = outputBuffers;
-        this.httpClient = httpClient;
-        this.summarizeTaskInfo = summarizeTaskInfo;
-        this.taskInfoCodec = taskInfoCodec;
-        this.taskInfoJsonCodec = taskInfoJsonCodec;
-        this.taskUpdateRequestCodec = taskUpdateRequestCodec;
-        this.planFragmentCodec = planFragmentCodec;
-        this.updateErrorTracker = taskRequestErrorTracker(taskId, location, maxErrorDuration, taskEventLoop, "updating task");
-        this.nodeStatsTracker = requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
-        this.maxErrorDuration = maxErrorDuration;
-        this.stats = stats;
-        this.binaryTransportEnabled = binaryTransportEnabled;
-        this.thriftTransportEnabled = thriftTransportEnabled;
-        this.taskInfoThriftTransportEnabled = taskInfoThriftTransportEnabled;
-        this.thriftProtocol = thriftProtocol;
-        this.connectorTypeSerdeManager = connectorTypeSerdeManager;
-        this.handleResolver = handleResolver;
-        this.tableWriteInfo = tableWriteInfo;
-        this.maxTaskUpdateSizeInBytes = maxTaskUpdateSizeInBytes;
-        this.maxTaskUpdateDataSize = DataSize.succinctBytes(this.maxTaskUpdateSizeInBytes);
-        this.maxUnacknowledgedSplits = getMaxUnacknowledgedSplitsPerTask(session);
-        checkArgument(maxUnacknowledgedSplits > 0, "maxUnacknowledgedSplits must be > 0, found: %s", maxUnacknowledgedSplits);
+        try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
+            this.taskId = taskId;
+            this.taskLocation = location;
+            this.remoteTaskLocation = remoteLocation;
+            this.session = session;
+            this.nodeId = nodeId;
+            this.planFragment = planFragment;
+            this.outputBuffers.set(outputBuffers);
+            this.httpClient = httpClient;
+            this.executor = executor;
+            this.errorScheduledExecutor = errorScheduledExecutor;
+            this.summarizeTaskInfo = summarizeTaskInfo;
+            this.taskInfoCodec = taskInfoCodec;
+            this.taskInfoJsonCodec = taskInfoJsonCodec;
+            this.taskUpdateRequestCodec = taskUpdateRequestCodec;
+            this.planFragmentCodec = planFragmentCodec;
+            this.updateErrorTracker = taskRequestErrorTracker(taskId, location, maxErrorDuration, errorScheduledExecutor, "updating task");
+            this.nodeStatsTracker = requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
+            this.maxErrorDuration = maxErrorDuration;
+            this.stats = stats;
+            this.binaryTransportEnabled = binaryTransportEnabled;
+            this.thriftTransportEnabled = thriftTransportEnabled;
+            this.taskInfoThriftTransportEnabled = taskInfoThriftTransportEnabled;
+            this.thriftProtocol = thriftProtocol;
+            this.connectorTypeSerdeManager = connectorTypeSerdeManager;
+            this.handleResolver = handleResolver;
+            this.tableWriteInfo = tableWriteInfo;
+            this.maxTaskUpdateSizeInBytes = maxTaskUpdateSizeInBytes;
+            this.maxTaskUpdateDataSize = DataSize.succinctBytes(this.maxTaskUpdateSizeInBytes);
+            this.maxUnacknowledgedSplits = getMaxUnacknowledgedSplitsPerTask(session);
+            checkArgument(maxUnacknowledgedSplits > 0, "maxUnacknowledgedSplits must be > 0, found: %s", maxUnacknowledgedSplits);
 
-        this.tableScanPlanNodeIds = ImmutableSet.copyOf(planFragment.getTableScanSchedulingOrder());
-        this.remoteSourcePlanNodeIds = planFragment.getRemoteSourceNodes().stream()
-                .map(PlanNode::getId)
-                .collect(toImmutableSet());
-        this.taskUpdateRequestSize = taskUpdateRequestSize;
-        this.taskUpdateSizeTrackingEnabled = taskUpdateSizeTrackingEnabled;
-        this.schedulerStatsTracker = schedulerStatsTracker;
+            this.tableScanPlanNodeIds = ImmutableSet.copyOf(planFragment.getTableScanSchedulingOrder());
+            this.remoteSourcePlanNodeIds = planFragment.getRemoteSourceNodes().stream()
+                    .map(PlanNode::getId)
+                    .collect(toImmutableSet());
+            this.taskUpdateRequestSize = taskUpdateRequestSize;
+            this.taskUpdateSizeTrackingEnabled = taskUpdateSizeTrackingEnabled;
+            this.schedulerStatsTracker = schedulerStatsTracker;
 
-        for (Entry<PlanNodeId, Split> entry : requireNonNull(initialSplits, "initialSplits is null").entries()) {
-            ScheduledSplit scheduledSplit = new ScheduledSplit(nextSplitId++, entry.getKey(), entry.getValue());
-            pendingSplits.put(entry.getKey(), scheduledSplit);
+            for (Entry<PlanNodeId, Split> entry : requireNonNull(initialSplits, "initialSplits is null").entries()) {
+                ScheduledSplit scheduledSplit = new ScheduledSplit(nextSplitId.getAndIncrement(), entry.getKey(), entry.getValue());
+                pendingSplits.put(entry.getKey(), scheduledSplit);
+            }
+            int pendingSourceSplitCount = 0;
+            long pendingSourceSplitsWeight = 0;
+            for (PlanNodeId planNodeId : planFragment.getTableScanSchedulingOrder()) {
+                Collection<Split> tableScanSplits = initialSplits.get(planNodeId);
+                if (tableScanSplits != null && !tableScanSplits.isEmpty()) {
+                    pendingSourceSplitCount += tableScanSplits.size();
+                    pendingSourceSplitsWeight = addExact(pendingSourceSplitsWeight, SplitWeight.rawValueSum(tableScanSplits, Split::getSplitWeight));
+                }
+            }
+            this.pendingSourceSplitCount = pendingSourceSplitCount;
+            this.pendingSourceSplitsWeight = pendingSourceSplitsWeight;
+
+            List<BufferInfo> bufferStates = outputBuffers.getBuffers()
+                    .keySet().stream()
+                    .map(outputId -> new BufferInfo(outputId, false, 0, 0, PageBufferInfo.empty()))
+                    .collect(toImmutableList());
+
+            TaskInfo initialTask = createInitialTask(taskId, location, bufferStates, new TaskStats(DateTime.now(), null), nodeId);
+
+            this.taskStatusFetcher = new ContinuousTaskStatusFetcher(
+                    this::failTask,
+                    taskId,
+                    initialTask.getTaskStatus(),
+                    taskStatusRefreshMaxWait,
+                    taskStatusCodec,
+                    executor,
+                    httpClient,
+                    maxErrorDuration,
+                    errorScheduledExecutor,
+                    stats,
+                    binaryTransportEnabled,
+                    thriftTransportEnabled,
+                    thriftProtocol);
+
+            this.taskInfoFetcher = new TaskInfoFetcher(
+                    this::failTask,
+                    initialTask,
+                    httpClient,
+                    taskInfoUpdateInterval,
+                    taskInfoRefreshMaxWait,
+                    taskInfoCodec,
+                    metadataUpdatesCodec,
+                    maxErrorDuration,
+                    summarizeTaskInfo,
+                    executor,
+                    updateScheduledExecutor,
+                    errorScheduledExecutor,
+                    stats,
+                    binaryTransportEnabled,
+                    taskInfoThriftTransportEnabled,
+                    session,
+                    metadataManager,
+                    queryManager,
+                    handleResolver,
+                    connectorTypeSerdeManager,
+                    thriftProtocol);
+
+            taskStatusFetcher.addStateChangeListener(newStatus -> {
+                TaskState state = newStatus.getState();
+                if (state.isDone()) {
+                    cleanUpTask();
+                }
+                else {
+                    updateTaskStats();
+                    updateSplitQueueSpace();
+                }
+            });
+
+            updateTaskStats();
+            updateSplitQueueSpace();
         }
-        int pendingSourceSplitCount = 0;
-        long pendingSourceSplitsWeight = 0;
-        for (PlanNodeId planNodeId : planFragment.getTableScanSchedulingOrder()) {
-            Collection<Split> tableScanSplits = initialSplits.get(planNodeId);
-            if (tableScanSplits != null && !tableScanSplits.isEmpty()) {
-                pendingSourceSplitCount += tableScanSplits.size();
-                pendingSourceSplitsWeight = addExact(pendingSourceSplitsWeight, SplitWeight.rawValueSum(tableScanSplits, Split::getSplitWeight));
-            }
-        }
-        this.pendingSourceSplitCount = pendingSourceSplitCount;
-        this.pendingSourceSplitsWeight = pendingSourceSplitsWeight;
-
-        List<BufferInfo> bufferStates = outputBuffers.getBuffers()
-                .keySet().stream()
-                .map(outputId -> new BufferInfo(outputId, false, 0, 0, PageBufferInfo.empty()))
-                .collect(toImmutableList());
-
-        TaskInfo initialTask = createInitialTask(taskId, location, bufferStates, new TaskStats(DateTime.now(), null), nodeId);
-
-        this.taskStatusFetcher = new ContinuousTaskStatusFetcher(
-                this::failTask,
-                taskId,
-                initialTask.getTaskStatus(),
-                taskStatusRefreshMaxWait,
-                taskStatusCodec,
-                taskEventLoop,
-                httpClient,
-                maxErrorDuration,
-                stats,
-                binaryTransportEnabled,
-                thriftTransportEnabled,
-                thriftProtocol);
-
-        this.taskInfoFetcher = new TaskInfoFetcher(
-                this::failTask,
-                initialTask,
-                httpClient,
-                taskInfoUpdateInterval,
-                taskInfoRefreshMaxWait,
-                taskInfoCodec,
-                metadataUpdatesCodec,
-                maxErrorDuration,
-                summarizeTaskInfo,
-                taskEventLoop,
-                stats,
-                binaryTransportEnabled,
-                taskInfoThriftTransportEnabled,
-                session,
-                metadataManager,
-                queryManager,
-                handleResolver,
-                connectorTypeSerdeManager,
-                thriftProtocol);
-
-        taskStatusFetcher.addStateChangeListener(newStatus -> {
-            verify(taskEventLoop.inEventLoop());
-
-            TaskState state = newStatus.getState();
-            if (state.isDone()) {
-                cleanUpTask();
-            }
-            else {
-                updateTaskStats();
-                updateSplitQueueSpace();
-            }
-        });
-
-        updateTaskStats();
-        taskEventLoop.execute(this::updateSplitQueueSpace);
     }
 
     public PlanFragment getPlanFragment()
@@ -448,18 +456,18 @@ public final class HttpRemoteTask
     @Override
     public void start()
     {
-        taskEventLoop.execute(() -> {
+        try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
             // to start we just need to trigger an update
-            started = true;
+            started.set(true);
             scheduleUpdate();
 
             taskStatusFetcher.start();
             taskInfoFetcher.start();
-        });
+        }
     }
 
     @Override
-    public void addSplits(Multimap<PlanNodeId, Split> splitsBySource)
+    public synchronized void addSplits(Multimap<PlanNodeId, Split> splitsBySource)
     {
         requireNonNull(splitsBySource, "splitsBySource is null");
 
@@ -468,79 +476,71 @@ public final class HttpRemoteTask
             return;
         }
 
-        taskEventLoop.execute(() -> {
-            boolean updateNeeded = false;
-            for (Entry<PlanNodeId, Collection<Split>> entry : splitsBySource.asMap().entrySet()) {
-                PlanNodeId sourceId = entry.getKey();
-                Collection<Split> splits = entry.getValue();
-                boolean isTableScanSource = tableScanPlanNodeIds.contains(sourceId);
+        boolean needsUpdate = false;
+        for (Entry<PlanNodeId, Collection<Split>> entry : splitsBySource.asMap().entrySet()) {
+            PlanNodeId sourceId = entry.getKey();
+            Collection<Split> splits = entry.getValue();
+            boolean isTableScanSource = tableScanPlanNodeIds.contains(sourceId);
 
-                checkState(!noMoreSplits.containsKey(sourceId), "noMoreSplits has already been set for %s", sourceId);
-                int added = 0;
-                long addedWeight = 0;
-                for (Split split : splits) {
-                    if (pendingSplits.put(sourceId, new ScheduledSplit(nextSplitId++, sourceId, split))) {
-                        if (isTableScanSource) {
-                            added++;
-                            addedWeight = addExact(addedWeight, split.getSplitWeight().getRawValue());
-                        }
+            checkState(!noMoreSplits.containsKey(sourceId), "noMoreSplits has already been set for %s", sourceId);
+            int added = 0;
+            long addedWeight = 0;
+            for (Split split : splits) {
+                if (pendingSplits.put(sourceId, new ScheduledSplit(nextSplitId.getAndIncrement(), sourceId, split))) {
+                    if (isTableScanSource) {
+                        added++;
+                        addedWeight = addExact(addedWeight, split.getSplitWeight().getRawValue());
                     }
                 }
-                if (isTableScanSource) {
-                    pendingSourceSplitCount += added;
-                    pendingSourceSplitsWeight = addExact(pendingSourceSplitsWeight, addedWeight);
-                    updateTaskStats();
-                }
-                updateNeeded = true;
             }
-            updateSplitQueueSpace();
-
-            if (updateNeeded) {
-                needsUpdate = true;
-                scheduleUpdate();
+            if (isTableScanSource) {
+                pendingSourceSplitCount += added;
+                pendingSourceSplitsWeight = addExact(pendingSourceSplitsWeight, addedWeight);
+                updateTaskStats();
             }
-        });
-    }
-
-    @Override
-    public void noMoreSplits(PlanNodeId sourceId)
-    {
-        taskEventLoop.execute(() -> {
-            if (noMoreSplits.containsKey(sourceId)) {
-                return;
-            }
-
-            noMoreSplits.put(sourceId, true);
             needsUpdate = true;
+        }
+        updateSplitQueueSpace();
+
+        if (needsUpdate) {
+            this.needsUpdate.set(true);
             scheduleUpdate();
-        });
+        }
     }
 
     @Override
-    public void noMoreSplits(PlanNodeId sourceId, Lifespan lifespan)
+    public synchronized void noMoreSplits(PlanNodeId sourceId)
     {
-        taskEventLoop.execute(() -> {
-            if (pendingNoMoreSplitsForLifespan.put(sourceId, lifespan)) {
-                needsUpdate = true;
-                scheduleUpdate();
-            }
-        });
+        if (noMoreSplits.containsKey(sourceId)) {
+            return;
+        }
+
+        noMoreSplits.put(sourceId, true);
+        needsUpdate.set(true);
+        scheduleUpdate();
     }
 
     @Override
-    public void setOutputBuffers(OutputBuffers newOutputBuffers)
+    public synchronized void noMoreSplits(PlanNodeId sourceId, Lifespan lifespan)
+    {
+        if (pendingNoMoreSplitsForLifespan.put(sourceId, lifespan)) {
+            needsUpdate.set(true);
+            scheduleUpdate();
+        }
+    }
+
+    @Override
+    public synchronized void setOutputBuffers(OutputBuffers newOutputBuffers)
     {
         if (getTaskStatus().getState().isDone()) {
             return;
         }
 
-        taskEventLoop.execute(() -> {
-            if (newOutputBuffers.getVersion() > outputBuffers.getVersion()) {
-                outputBuffers = newOutputBuffers;
-                needsUpdate = true;
-                scheduleUpdate();
-            }
-        });
+        if (newOutputBuffers.getVersion() > outputBuffers.get().getVersion()) {
+            outputBuffers.set(newOutputBuffers);
+            needsUpdate.set(true);
+            scheduleUpdate();
+        }
     }
 
     @Override
@@ -558,7 +558,7 @@ public final class HttpRemoteTask
                 taskId,
                 remoteSourceUri,
                 maxErrorDuration,
-                taskEventLoop,
+                errorScheduledExecutor,
                 "Remove exchange remote source");
 
         SettableFuture<?> future = SettableFuture.create();
@@ -576,8 +576,6 @@ public final class HttpRemoteTask
             @Override
             public void onSuccess(@Nullable StatusResponse response)
             {
-                verify(taskEventLoop.inEventLoop());
-
                 if (response == null) {
                     throw new PrestoException(GENERIC_INTERNAL_ERROR, "Request failed with null response");
                 }
@@ -590,8 +588,6 @@ public final class HttpRemoteTask
             @Override
             public void onFailure(Throwable failedReason)
             {
-                verify(taskEventLoop.inEventLoop());
-
                 if (failedReason instanceof RejectedExecutionException && httpClient.isClosed()) {
                     log.error("Unable to destroy exchange source at %s. HTTP client is closed", request.getUri());
                     future.setException(failedReason);
@@ -611,12 +607,12 @@ public final class HttpRemoteTask
                     doRemoveRemoteSource(errorTracker, request, future);
                 }
                 else {
-                    errorRateLimit.addListener(() -> doRemoveRemoteSource(errorTracker, request, future), taskEventLoop);
+                    errorRateLimit.addListener(() -> doRemoveRemoteSource(errorTracker, request, future), errorScheduledExecutor);
                 }
             }
         };
 
-        addCallback(httpClient.executeAsync(request, createStatusResponseHandler()), callback, taskEventLoop);
+        addCallback(httpClient.executeAsync(request, createStatusResponseHandler()), callback, directExecutor());
     }
 
     @Override
@@ -683,7 +679,9 @@ public final class HttpRemoteTask
     @Override
     public void addStateChangeListener(StateChangeListener<TaskStatus> stateChangeListener)
     {
-        taskStatusFetcher.addStateChangeListener(stateChangeListener);
+        try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
+            taskStatusFetcher.addStateChangeListener(stateChangeListener);
+        }
     }
 
     @Override
@@ -693,38 +691,29 @@ public final class HttpRemoteTask
     }
 
     @Override
-    public ListenableFuture<?> whenSplitQueueHasSpace(long weightThreshold)
+    public synchronized ListenableFuture<?> whenSplitQueueHasSpace(long weightThreshold)
     {
+        if (whenSplitQueueHasSpaceThreshold.isPresent()) {
+            checkArgument(weightThreshold == whenSplitQueueHasSpaceThreshold.getAsLong(), "Multiple split queue space notification thresholds not supported");
+        }
+        else {
+            whenSplitQueueHasSpaceThreshold = OptionalLong.of(weightThreshold);
+            updateSplitQueueSpace();
+        }
         if (splitQueueHasSpace) {
             return immediateFuture(null);
         }
-        SettableFuture<?> future = SettableFuture.create();
-        taskEventLoop.execute(() -> {
-            if (whenSplitQueueHasSpaceThreshold.isPresent()) {
-                checkArgument(weightThreshold == whenSplitQueueHasSpaceThreshold.getAsLong(), "Multiple split queue space notification thresholds not supported");
-            }
-            else {
-                whenSplitQueueHasSpaceThreshold = OptionalLong.of(weightThreshold);
-                updateSplitQueueSpace();
-            }
-            if (splitQueueHasSpace) {
-                future.set(null);
-            }
-            whenSplitQueueHasSpace.createNewListener().addListener(() -> future.set(null), taskEventLoop);
-        });
-        return future;
+        return whenSplitQueueHasSpace.createNewListener();
     }
 
-    private void updateSplitQueueSpace()
+    private synchronized void updateSplitQueueSpace()
     {
-        verify(taskEventLoop.inEventLoop());
-
         // Must check whether the unacknowledged split count threshold is reached even without listeners registered yet
         splitQueueHasSpace = getUnacknowledgedPartitionedSplitCount() < maxUnacknowledgedSplits &&
                 (!whenSplitQueueHasSpaceThreshold.isPresent() || getQueuedPartitionedSplitsWeight() < whenSplitQueueHasSpaceThreshold.getAsLong());
         // Only trigger notifications if a listener might be registered
         if (splitQueueHasSpace && whenSplitQueueHasSpaceThreshold.isPresent()) {
-            whenSplitQueueHasSpace.complete(null, taskEventLoop);
+            whenSplitQueueHasSpace.complete(null, executor);
         }
     }
 
@@ -743,10 +732,8 @@ public final class HttpRemoteTask
         }
     }
 
-    private void processTaskUpdate(TaskInfo newValue, List<TaskSource> sources)
+    private synchronized void processTaskUpdate(TaskInfo newValue, List<TaskSource> sources)
     {
-        verify(taskEventLoop.inEventLoop());
-
         //Setting the flag as false since TaskUpdateRequest is not on thrift yet.
         //Once it is converted to thrift we can use the isThrift enabled flag here.
         updateTaskInfo(newValue, false);
@@ -783,8 +770,6 @@ public final class HttpRemoteTask
 
     private void onSuccessTaskInfo(TaskInfo result)
     {
-        verify(taskEventLoop.inEventLoop());
-
         try {
             updateTaskInfo(result, taskInfoThriftTransportEnabled);
         }
@@ -797,8 +782,6 @@ public final class HttpRemoteTask
 
     private void updateTaskInfo(TaskInfo taskInfo, boolean isTaskInfoThriftTransportEnabled)
     {
-        verify(taskEventLoop.inEventLoop());
-
         taskStatusFetcher.updateTaskStatus(taskInfo.getTaskStatus());
         if (isTaskInfoThriftTransportEnabled) {
             taskInfo = convertFromThriftTaskInfo(taskInfo, connectorTypeSerdeManager, handleResolver);
@@ -808,7 +791,6 @@ public final class HttpRemoteTask
 
     private void cleanUpLocally()
     {
-        verify(taskEventLoop.inEventLoop());
         // Update the taskInfo with the new taskStatus.
 
         // Generally, we send a cleanup request to the worker, and update the TaskInfo on
@@ -834,8 +816,6 @@ public final class HttpRemoteTask
             Request request,
             Backoff cleanupBackoff)
     {
-        verify(taskEventLoop.inEventLoop());
-
         if (t instanceof RejectedExecutionException && httpClient.isClosed()) {
             logError(t, "Unable to %s task at %s. HTTP client is closed.", action, request.getUri());
             cleanUpLocally();
@@ -855,110 +835,105 @@ public final class HttpRemoteTask
             doScheduleAsyncCleanupRequest(cleanupBackoff, request, action);
         }
         else {
-            taskEventLoop.schedule(() -> doScheduleAsyncCleanupRequest(cleanupBackoff, request, action), delayNanos, NANOSECONDS);
+            errorScheduledExecutor.schedule(() -> doScheduleAsyncCleanupRequest(cleanupBackoff, request, action), delayNanos, NANOSECONDS);
         }
     }
 
-    private void scheduleUpdate()
+    private synchronized void scheduleUpdate()
     {
-        verify(taskEventLoop.inEventLoop());
-
         taskUpdateTimeline.add(System.nanoTime());
-        sendUpdate();
+        executor.execute(this::sendUpdate);
     }
 
-    private void sendUpdate()
+    private synchronized void sendUpdate()
     {
-        taskEventLoop.execute(() -> {
-            TaskStatus taskStatus = getTaskStatus();
-            // don't update if the task hasn't been started yet or if it is already finished
-            if (!started || !needsUpdate || taskStatus.getState().isDone()) {
-                return;
-            }
+        TaskStatus taskStatus = getTaskStatus();
+        // don't update if the task hasn't been started yet or if it is already finished
+        if (!started.get() || !needsUpdate.get() || taskStatus.getState().isDone()) {
+            return;
+        }
 
-            // if there is a request already running, wait for it to complete
-            if (this.currentRequest != null && !this.currentRequest.isDone()) {
-                return;
-            }
+        // if there is a request already running, wait for it to complete
+        if (this.currentRequest != null && !this.currentRequest.isDone()) {
+            return;
+        }
 
-            // if throttled due to error, asynchronously wait for timeout and try again
-            ListenableFuture<?> errorRateLimit = updateErrorTracker.acquireRequestPermit();
-            if (!errorRateLimit.isDone()) {
-                errorRateLimit.addListener(this::sendUpdate, taskEventLoop);
-                return;
-            }
+        // if throttled due to error, asynchronously wait for timeout and try again
+        ListenableFuture<?> errorRateLimit = updateErrorTracker.acquireRequestPermit();
+        if (!errorRateLimit.isDone()) {
+            errorRateLimit.addListener(this::sendUpdate, executor);
+            return;
+        }
 
-            List<TaskSource> sources = getSources();
+        List<TaskSource> sources = getSources();
 
-            Optional<byte[]> fragment = Optional.empty();
-            if (sendPlan) {
-                long start = THREAD_MX_BEAN.getCurrentThreadCpuTime();
-                fragment = Optional.of(planFragment.bytesForTaskSerialization(planFragmentCodec));
-                schedulerStatsTracker.recordTaskPlanSerializedCpuTime(THREAD_MX_BEAN.getCurrentThreadCpuTime() - start);
-            }
-            Optional<TableWriteInfo> writeInfo = sendPlan ? Optional.of(tableWriteInfo) : Optional.empty();
-            TaskUpdateRequest updateRequest = new TaskUpdateRequest(
-                    session.toSessionRepresentation(),
-                    session.getIdentity().getExtraCredentials(),
-                    fragment,
-                    sources,
-                    outputBuffers,
-                    writeInfo);
-            long serializeStartCpuTimeNanos = THREAD_MX_BEAN.getCurrentThreadCpuTime();
-            byte[] taskUpdateRequestJson = taskUpdateRequestCodec.toBytes(updateRequest);
-            schedulerStatsTracker.recordTaskUpdateSerializedCpuTime(THREAD_MX_BEAN.getCurrentThreadCpuTime() - serializeStartCpuTimeNanos);
+        Optional<byte[]> fragment = Optional.empty();
+        if (sendPlan.get()) {
+            long start = THREAD_MX_BEAN.getCurrentThreadCpuTime();
+            fragment = Optional.of(planFragment.bytesForTaskSerialization(planFragmentCodec));
+            schedulerStatsTracker.recordTaskPlanSerializedCpuTime(THREAD_MX_BEAN.getCurrentThreadCpuTime() - start);
+        }
+        Optional<TableWriteInfo> writeInfo = sendPlan.get() ? Optional.of(tableWriteInfo) : Optional.empty();
+        TaskUpdateRequest updateRequest = new TaskUpdateRequest(
+                session.toSessionRepresentation(),
+                session.getIdentity().getExtraCredentials(),
+                fragment,
+                sources,
+                outputBuffers.get(),
+                writeInfo);
+        long serializeStartCpuTimeNanos = THREAD_MX_BEAN.getCurrentThreadCpuTime();
+        byte[] taskUpdateRequestJson = taskUpdateRequestCodec.toBytes(updateRequest);
+        schedulerStatsTracker.recordTaskUpdateSerializedCpuTime(THREAD_MX_BEAN.getCurrentThreadCpuTime() - serializeStartCpuTimeNanos);
 
-            if (taskUpdateRequestJson.length > maxTaskUpdateSizeInBytes) {
-                failTask(new PrestoException(EXCEEDED_TASK_UPDATE_SIZE_LIMIT, getExceededTaskUpdateSizeMessage(taskUpdateRequestJson)));
-                return;
-            }
+        if (taskUpdateRequestJson.length > maxTaskUpdateSizeInBytes) {
+            failTask(new PrestoException(EXCEEDED_TASK_UPDATE_SIZE_LIMIT, getExceededTaskUpdateSizeMessage(taskUpdateRequestJson)));
+        }
 
-            if (taskUpdateSizeTrackingEnabled) {
-                taskUpdateRequestSize.add(taskUpdateRequestJson.length);
+        if (taskUpdateSizeTrackingEnabled) {
+            taskUpdateRequestSize.add(taskUpdateRequestJson.length);
 
-                if (fragment.isPresent()) {
-                    stats.updateWithPlanSize(taskUpdateRequestJson.length);
-                }
-                else {
-                    if (ThreadLocalRandom.current().nextDouble() < UPDATE_WITHOUT_PLAN_STATS_SAMPLE_RATE) {
-                        // This is to keep track of the task update size even when the plan fragment is NOT present
-                        stats.updateWithoutPlanSize(taskUpdateRequestJson.length);
-                    }
-                }
-            }
-
-            HttpUriBuilder uriBuilder = getHttpUriBuilder(taskStatus);
-            Request request = setContentTypeHeaders(binaryTransportEnabled, preparePost())
-                    .setUri(uriBuilder.build())
-                    .setBodyGenerator(createStaticBodyGenerator(taskUpdateRequestJson))
-                    .build();
-
-            ResponseHandler responseHandler;
-            if (binaryTransportEnabled) {
-                responseHandler = createFullSmileResponseHandler((SmileCodec<TaskInfo>) taskInfoCodec);
+            if (fragment.isPresent()) {
+                stats.updateWithPlanSize(taskUpdateRequestJson.length);
             }
             else {
-                responseHandler = createAdaptingJsonResponseHandler((JsonCodec<TaskInfo>) taskInfoJsonCodec);
+                if (ThreadLocalRandom.current().nextDouble() < UPDATE_WITHOUT_PLAN_STATS_SAMPLE_RATE) {
+                    // This is to keep track of the task update size even when the plan fragment is NOT present
+                    stats.updateWithoutPlanSize(taskUpdateRequestJson.length);
+                }
             }
+        }
 
-            updateErrorTracker.startRequest();
+        HttpUriBuilder uriBuilder = getHttpUriBuilder(taskStatus);
+        Request request = setContentTypeHeaders(binaryTransportEnabled, preparePost())
+                .setUri(uriBuilder.build())
+                .setBodyGenerator(createStaticBodyGenerator(taskUpdateRequestJson))
+                .build();
 
-            ListenableFuture<BaseResponse<TaskInfo>> future = httpClient.executeAsync(request, responseHandler);
-            currentRequest = future;
-            currentRequestStartNanos = System.nanoTime();
-            if (!taskUpdateTimeline.isEmpty()) {
-                currentRequestLastTaskUpdate = taskUpdateTimeline.getLong(taskUpdateTimeline.size() - 1);
-            }
+        ResponseHandler responseHandler;
+        if (binaryTransportEnabled) {
+            responseHandler = createFullSmileResponseHandler((SmileCodec<TaskInfo>) taskInfoCodec);
+        }
+        else {
+            responseHandler = createAdaptingJsonResponseHandler((JsonCodec<TaskInfo>) taskInfoJsonCodec);
+        }
 
-            // The needsUpdate flag needs to be set to false BEFORE adding the Future callback since callback might change the flag value
-            // and does so without grabbing the instance lock.
-            needsUpdate = false;
+        updateErrorTracker.startRequest();
 
-            Futures.addCallback(
-                    future,
-                    new SimpleHttpResponseHandler<>(new UpdateResponseHandler(sources), request.getUri(), stats.getHttpResponseStats(), REMOTE_TASK_ERROR),
-                    taskEventLoop);
-        });
+        ListenableFuture<BaseResponse<TaskInfo>> future = httpClient.executeAsync(request, responseHandler);
+        currentRequest = future;
+        currentRequestStartNanos = System.nanoTime();
+        if (!taskUpdateTimeline.isEmpty()) {
+            currentRequestLastTaskUpdate = taskUpdateTimeline.getLong(taskUpdateTimeline.size() - 1);
+        }
+
+        // The needsUpdate flag needs to be set to false BEFORE adding the Future callback since callback might change the flag value
+        // and does so without grabbing the instance lock.
+        needsUpdate.set(false);
+
+        Futures.addCallback(
+                future,
+                new SimpleHttpResponseHandler<>(new UpdateResponseHandler(sources), request.getUri(), stats.getHttpResponseStats(), REMOTE_TASK_ERROR),
+                executor);
     }
 
     private String getExceededTaskUpdateSizeMessage(byte[] taskUpdateRequestJson)
@@ -967,7 +942,7 @@ public final class HttpRemoteTask
         return format("TaskUpdate size of %s has exceeded the limit of %s", taskUpdateSize.toString(), this.maxTaskUpdateDataSize.toString());
     }
 
-    private List<TaskSource> getSources()
+    private synchronized List<TaskSource> getSources()
     {
         return Stream.concat(tableScanPlanNodeIds.stream(), remoteSourcePlanNodeIds.stream())
                 .map(this::getSource)
@@ -975,7 +950,7 @@ public final class HttpRemoteTask
                 .collect(toImmutableList());
     }
 
-    private TaskSource getSource(PlanNodeId planNodeId)
+    private synchronized TaskSource getSource(PlanNodeId planNodeId)
     {
         Set<ScheduledSplit> splits = pendingSplits.get(planNodeId);
         boolean pendingNoMoreSplits = Boolean.TRUE.equals(this.noMoreSplits.get(planNodeId));
@@ -990,9 +965,9 @@ public final class HttpRemoteTask
     }
 
     @Override
-    public void cancel()
+    public synchronized void cancel()
     {
-        taskEventLoop.execute(() -> {
+        try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
             TaskStatus taskStatus = getTaskStatus();
             if (taskStatus.getState().isDone()) {
                 return;
@@ -1007,49 +982,47 @@ public final class HttpRemoteTask
             Request request = builder.setUri(uriBuilder.build())
                     .build();
             scheduleAsyncCleanupRequest(createCleanupBackoff(), request, "cancel");
-        });
+        }
     }
 
-    private void cleanUpTask()
+    private synchronized void cleanUpTask()
     {
-        taskEventLoop.execute(() -> {
-            checkState(getTaskStatus().getState().isDone(), "attempt to clean up a task that is not done yet");
+        checkState(getTaskStatus().getState().isDone(), "attempt to clean up a task that is not done yet");
 
-            // clear pending splits to free memory
-            pendingSplits.clear();
-            pendingSourceSplitCount = 0;
-            pendingSourceSplitsWeight = 0;
-            updateTaskStats();
-            splitQueueHasSpace = true;
-            whenSplitQueueHasSpace.complete(null, taskEventLoop);
+        // clear pending splits to free memory
+        pendingSplits.clear();
+        pendingSourceSplitCount = 0;
+        pendingSourceSplitsWeight = 0;
+        updateTaskStats();
+        splitQueueHasSpace = true;
+        whenSplitQueueHasSpace.complete(null, executor);
 
-            // cancel pending request
-            if (currentRequest != null) {
-                // do not terminate if the request is already running to avoid closing pooled connections
-                currentRequest.cancel(false);
-                currentRequest = null;
-                currentRequestStartNanos = 0;
-            }
+        // cancel pending request
+        if (currentRequest != null) {
+            // do not terminate if the request is already running to avoid closing pooled connections
+            currentRequest.cancel(false);
+            currentRequest = null;
+            currentRequestStartNanos = 0;
+        }
 
-            taskStatusFetcher.stop();
+        taskStatusFetcher.stop();
 
-            // The remote task is likely to get a delete from the PageBufferClient first.
-            // We send an additional delete anyway to get the final TaskInfo
-            HttpUriBuilder uriBuilder = getHttpUriBuilder(getTaskStatus());
-            Request.Builder requestBuilder = setContentTypeHeaders(binaryTransportEnabled, prepareDelete());
-            if (taskInfoThriftTransportEnabled) {
-                requestBuilder = ThriftRequestUtils.prepareThriftDelete(Protocol.BINARY);
-            }
-            Request request = requestBuilder
-                    .setUri(uriBuilder.build())
-                    .build();
+        // The remote task is likely to get a delete from the PageBufferClient first.
+        // We send an additional delete anyway to get the final TaskInfo
+        HttpUriBuilder uriBuilder = getHttpUriBuilder(getTaskStatus());
+        Request.Builder requestBuilder = setContentTypeHeaders(binaryTransportEnabled, prepareDelete());
+        if (taskInfoThriftTransportEnabled) {
+            requestBuilder = ThriftRequestUtils.prepareThriftDelete(Protocol.BINARY);
+        }
+        Request request = requestBuilder
+                .setUri(uriBuilder.build())
+                .build();
 
-            scheduleAsyncCleanupRequest(createCleanupBackoff(), request, "cleanup");
-        });
+        scheduleAsyncCleanupRequest(createCleanupBackoff(), request, "cleanup");
     }
 
     @Override
-    public void abort()
+    public synchronized void abort()
     {
         if (getTaskStatus().getState().isDone()) {
             return;
@@ -1058,11 +1031,11 @@ public final class HttpRemoteTask
         abort(failWith(getTaskStatus(), ABORTED, ImmutableList.of()));
     }
 
-    private void abort(TaskStatus status)
+    private synchronized void abort(TaskStatus status)
     {
-        taskEventLoop.execute(() -> {
-            checkState(status.getState().isDone(), "cannot abort task with an incomplete status");
+        checkState(status.getState().isDone(), "cannot abort task with an incomplete status");
 
+        try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
             taskStatusFetcher.updateTaskStatus(status);
 
             // send abort to task
@@ -1075,44 +1048,39 @@ public final class HttpRemoteTask
             Request request = builder.setUri(uriBuilder.build())
                     .build();
             scheduleAsyncCleanupRequest(createCleanupBackoff(), request, "abort");
-        });
+        }
     }
 
     private void scheduleAsyncCleanupRequest(Backoff cleanupBackoff, Request request, String action)
     {
-        verify(taskEventLoop.inEventLoop());
-
-        if (aborting) {
+        if (!aborting.compareAndSet(false, true)) {
             // Do not initiate another round of cleanup requests if one had been initiated.
             // Otherwise, we can get into an asynchronous recursion here. For example, when aborting a task after REMOTE_TASK_MISMATCH.
             return;
         }
-        aborting = true;
         doScheduleAsyncCleanupRequest(cleanupBackoff, request, action);
     }
 
     private void doScheduleAsyncCleanupRequest(Backoff cleanupBackoff, Request request, String action)
     {
-        verify(taskEventLoop.inEventLoop());
-
         ResponseHandler responseHandler;
         if (taskInfoThriftTransportEnabled) {
             responseHandler = new ThriftResponseHandler(unwrapThriftCodec(taskInfoCodec));
             Futures.addCallback(httpClient.executeAsync(request, responseHandler),
                     new ThriftResponseFutureCallback(action, request, cleanupBackoff),
-                    taskEventLoop);
+                    executor);
         }
         else if (binaryTransportEnabled) {
             responseHandler = createFullSmileResponseHandler((SmileCodec<TaskInfo>) taskInfoCodec);
             Futures.addCallback(httpClient.executeAsync(request, responseHandler),
                     new BaseResponseFutureCallback(action, request, cleanupBackoff),
-                    taskEventLoop);
+                    executor);
         }
         else {
             responseHandler = createAdaptingJsonResponseHandler((JsonCodec<TaskInfo>) taskInfoCodec);
             Futures.addCallback(httpClient.executeAsync(request, responseHandler),
                     new BaseResponseFutureCallback(action, request, cleanupBackoff),
-                    taskEventLoop);
+                    executor);
         }
     }
 
@@ -1121,8 +1089,6 @@ public final class HttpRemoteTask
      */
     private void failTask(Throwable cause)
     {
-        verify(taskEventLoop.inEventLoop());
-
         TaskStatus taskStatus = getTaskStatus();
         if (!taskStatus.getState().isDone()) {
             log.debug(cause, "Remote task %s failed with %s", taskStatus.getSelf(), cause);
@@ -1180,76 +1146,80 @@ public final class HttpRemoteTask
         @Override
         public void success(TaskInfo value)
         {
-            verify(taskEventLoop.inEventLoop());
-
-            try {
-                long oldestTaskUpdateTime = 0;
-                currentRequest = null;
-                sendPlan = value.isNeedsPlan();
-                if (!taskUpdateTimeline.isEmpty()) {
-                    oldestTaskUpdateTime = taskUpdateTimeline.getLong(0);
+            try (SetThreadName ignored = new SetThreadName("UpdateResponseHandler-%s", taskId)) {
+                try {
+                    long oldestTaskUpdateTime = 0;
+                    long currentRequestStartNanos;
+                    synchronized (HttpRemoteTask.this) {
+                        currentRequest = null;
+                        sendPlan.set(value.isNeedsPlan());
+                        currentRequestStartNanos = HttpRemoteTask.this.currentRequestStartNanos;
+                        if (!taskUpdateTimeline.isEmpty()) {
+                            oldestTaskUpdateTime = taskUpdateTimeline.getLong(0);
+                        }
+                        int deliveredUpdates = taskUpdateTimeline.size();
+                        while (deliveredUpdates > 0 && taskUpdateTimeline.getLong(deliveredUpdates - 1) > currentRequestLastTaskUpdate) {
+                            deliveredUpdates--;
+                        }
+                        taskUpdateTimeline.removeElements(0, deliveredUpdates);
+                    }
+                    updateStats(currentRequestStartNanos);
+                    processTaskUpdate(value, sources);
+                    updateErrorTracker.requestSucceeded();
+                    if (oldestTaskUpdateTime != 0) {
+                        schedulerStatsTracker.recordTaskUpdateDeliveredTime(System.nanoTime() - oldestTaskUpdateTime);
+                    }
                 }
-                int deliveredUpdates = taskUpdateTimeline.size();
-                while (deliveredUpdates > 0 && taskUpdateTimeline.getLong(deliveredUpdates - 1) > currentRequestLastTaskUpdate) {
-                    deliveredUpdates--;
+                finally {
+                    sendUpdate();
                 }
-                taskUpdateTimeline.removeElements(0, deliveredUpdates);
-
-                updateStats(currentRequestStartNanos);
-                processTaskUpdate(value, sources);
-                updateErrorTracker.requestSucceeded();
-                if (oldestTaskUpdateTime != 0) {
-                    schedulerStatsTracker.recordTaskUpdateDeliveredTime(System.nanoTime() - oldestTaskUpdateTime);
-                }
-            }
-            finally {
-                sendUpdate();
             }
         }
 
         @Override
         public void failed(Throwable cause)
         {
-            verify(taskEventLoop.inEventLoop());
+            try (SetThreadName ignored = new SetThreadName("UpdateResponseHandler-%s", taskId)) {
+                try {
+                    long currentRequestStartNanos;
+                    synchronized (HttpRemoteTask.this) {
+                        currentRequest = null;
+                        currentRequestStartNanos = HttpRemoteTask.this.currentRequestStartNanos;
+                    }
+                    updateStats(currentRequestStartNanos);
 
-            try {
-                long currentRequestStartNanos;
-                currentRequest = null;
-                currentRequestStartNanos = HttpRemoteTask.this.currentRequestStartNanos;
-                updateStats(currentRequestStartNanos);
+                    // on failure assume we need to update again
+                    needsUpdate.set(true);
 
-                // on failure assume we need to update again
-                needsUpdate = true;
-
-                // if task not already done, record error
-                TaskStatus taskStatus = getTaskStatus();
-                if (!taskStatus.getState().isDone()) {
-                    updateErrorTracker.requestFailed(cause);
+                    // if task not already done, record error
+                    TaskStatus taskStatus = getTaskStatus();
+                    if (!taskStatus.getState().isDone()) {
+                        updateErrorTracker.requestFailed(cause);
+                    }
                 }
-            }
-            catch (Error e) {
-                failTask(e);
-                throw e;
-            }
-            catch (RuntimeException e) {
-                failTask(e);
-            }
-            finally {
-                sendUpdate();
+                catch (Error e) {
+                    failTask(e);
+                    throw e;
+                }
+                catch (RuntimeException e) {
+                    failTask(e);
+                }
+                finally {
+                    sendUpdate();
+                }
             }
         }
 
         @Override
         public void fatal(Throwable cause)
         {
-            verify(taskEventLoop.inEventLoop());
-
-            failTask(cause);
+            try (SetThreadName ignored = new SetThreadName("UpdateResponseHandler-%s", taskId)) {
+                failTask(cause);
+            }
         }
 
         private void updateStats(long currentRequestStartNanos)
         {
-            verify(taskEventLoop.inEventLoop());
             Duration requestRoundTrip = Duration.nanosSince(currentRequestStartNanos);
             stats.updateRoundTripMillis(requestRoundTrip.toMillis());
         }
@@ -1282,14 +1252,12 @@ public final class HttpRemoteTask
         @Override
         public void onSuccess(ThriftResponse<TaskInfo> result)
         {
-            verify(taskEventLoop.inEventLoop());
             onSuccessTaskInfo(result.getValue());
         }
 
         @Override
         public void onFailure(Throwable throwable)
         {
-            verify(taskEventLoop.inEventLoop());
             onFailureTaskInfo(throwable, this.action, this.request, this.cleanupBackoff);
         }
     }
@@ -1311,14 +1279,12 @@ public final class HttpRemoteTask
         @Override
         public void onSuccess(BaseResponse<TaskInfo> result)
         {
-            verify(taskEventLoop.inEventLoop());
             onSuccessTaskInfo(result.getValue());
         }
 
         @Override
         public void onFailure(Throwable throwable)
         {
-            verify(taskEventLoop.inEventLoop());
             onFailureTaskInfo(throwable, this.action, this.request, this.cleanupBackoff);
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.server.remotetask;
 
+import com.facebook.airlift.concurrent.BoundedExecutor;
+import com.facebook.airlift.concurrent.ThreadPoolExecutorMBean;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.Codec;
 import com.facebook.airlift.json.JsonCodec;
@@ -47,18 +49,24 @@ import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.Multimap;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airlift.units.Duration;
-import io.netty.channel.DefaultEventLoopGroup;
-import io.netty.channel.EventLoopGroup;
 import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.server.thrift.ThriftCodecWrapper.wrapThriftCodec;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
 public class HttpRemoteTaskFactory
         implements RemoteTaskFactory
@@ -79,6 +87,11 @@ public class HttpRemoteTaskFactory
     private final ConnectorTypeSerdeManager connectorTypeSerdeManager;
 
     private final Duration taskInfoUpdateInterval;
+    private final ExecutorService coreExecutor;
+    private final Executor executor;
+    private final ThreadPoolExecutorMBean executorMBean;
+    private final ScheduledExecutorService updateScheduledExecutor;
+    private final ScheduledExecutorService errorScheduledExecutor;
     private final RemoteTaskStats stats;
     private final boolean binaryTransportEnabled;
     private final boolean thriftTransportEnabled;
@@ -89,8 +102,6 @@ public class HttpRemoteTaskFactory
     private final QueryManager queryManager;
     private final DecayCounter taskUpdateRequestSize;
     private final boolean taskUpdateSizeTrackingEnabled;
-    private final EventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(Runtime.getRuntime().availableProcessors(),
-            new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build());
 
     @Inject
     public HttpRemoteTaskFactory(
@@ -125,6 +136,10 @@ public class HttpRemoteTaskFactory
         this.taskInfoRefreshMaxWait = taskConfig.getInfoRefreshMaxWait();
         this.handleResolver = handleResolver;
         this.connectorTypeSerdeManager = connectorTypeSerdeManager;
+
+        this.coreExecutor = newCachedThreadPool(daemonThreadsNamed("remote-task-callback-%s"));
+        this.executor = new BoundedExecutor(coreExecutor, config.getRemoteTaskMaxCallbackThreads());
+        this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) coreExecutor);
         this.stats = requireNonNull(stats, "stats is null");
         requireNonNull(communicationConfig, "communicationConfig is null");
         binaryTransportEnabled = communicationConfig.isBinaryTransportEnabled();
@@ -167,8 +182,17 @@ public class HttpRemoteTaskFactory
         this.metadataManager = metadataManager;
         this.queryManager = queryManager;
 
+        this.updateScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("task-info-update-scheduler-%s"));
+        this.errorScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("remote-task-error-delay-%s"));
         this.taskUpdateRequestSize = new DecayCounter(ExponentialDecay.oneMinute());
         this.taskUpdateSizeTrackingEnabled = taskConfig.isTaskUpdateSizeTrackingEnabled();
+    }
+
+    @Managed
+    @Nested
+    public ThreadPoolExecutorMBean getExecutor()
+    {
+        return executorMBean;
     }
 
     @Managed
@@ -180,7 +204,9 @@ public class HttpRemoteTaskFactory
     @PreDestroy
     public void stop()
     {
-        eventLoopGroup.shutdownGracefully();
+        coreExecutor.shutdownNow();
+        updateScheduledExecutor.shutdownNow();
+        errorScheduledExecutor.shutdownNow();
     }
 
     @Override
@@ -206,6 +232,9 @@ public class HttpRemoteTaskFactory
                 initialSplits,
                 outputBuffers,
                 httpClient,
+                executor,
+                updateScheduledExecutor,
+                errorScheduledExecutor,
                 maxErrorDuration,
                 taskStatusRefreshMaxWait,
                 taskInfoRefreshMaxWait,
@@ -231,7 +260,6 @@ public class HttpRemoteTaskFactory
                 taskUpdateSizeTrackingEnabled,
                 handleResolver,
                 connectorTypeSerdeManager,
-                schedulerStatsTracker,
-                eventLoopGroup.next());
+                schedulerStatsTracker);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -17,7 +17,6 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.Codec;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.smile.SmileCodec;
-import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.DecayCounter;
 import com.facebook.airlift.stats.ExponentialDecay;
 import com.facebook.drift.codec.ThriftCodec;
@@ -50,16 +49,12 @@ import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airlift.units.Duration;
-import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.DefaultEventLoopGroup;
-import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import org.weakref.jmx.Managed;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
-
-import java.util.concurrent.Executor;
 
 import static com.facebook.presto.server.thrift.ThriftCodecWrapper.wrapThriftCodec;
 import static java.lang.Math.toIntExact;
@@ -68,7 +63,6 @@ import static java.util.Objects.requireNonNull;
 public class HttpRemoteTaskFactory
         implements RemoteTaskFactory
 {
-    private static final Logger log = Logger.get(HttpRemoteTaskFactory.class);
     private final HttpClient httpClient;
     private final LocationFactory locationFactory;
     private final Codec<TaskStatus> taskStatusCodec;
@@ -95,7 +89,8 @@ public class HttpRemoteTaskFactory
     private final QueryManager queryManager;
     private final DecayCounter taskUpdateRequestSize;
     private final boolean taskUpdateSizeTrackingEnabled;
-    private final EventLoopGroup eventLoopGroup;
+    private final EventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(Runtime.getRuntime().availableProcessors(),
+            new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build());
 
     @Inject
     public HttpRemoteTaskFactory(
@@ -174,15 +169,6 @@ public class HttpRemoteTaskFactory
 
         this.taskUpdateRequestSize = new DecayCounter(ExponentialDecay.oneMinute());
         this.taskUpdateSizeTrackingEnabled = taskConfig.isTaskUpdateSizeTrackingEnabled();
-        this.eventLoopGroup = new DefaultEventLoopGroup(config.getRemoteTaskMaxCallbackThreads(),
-                new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build())
-        {
-            @Override
-            protected EventLoop newChild(Executor executor, Object... args)
-            {
-                return new SafeEventLoop(this, executor);
-            }
-        };
     }
 
     @Managed
@@ -210,7 +196,7 @@ public class HttpRemoteTaskFactory
             TableWriteInfo tableWriteInfo,
             SchedulerStatsTracker schedulerStatsTracker)
     {
-        return HttpRemoteTask.createHttpRemoteTask(
+        return new HttpRemoteTask(
                 session,
                 taskId,
                 node.getNodeIdentifier(),
@@ -246,37 +232,6 @@ public class HttpRemoteTaskFactory
                 handleResolver,
                 connectorTypeSerdeManager,
                 schedulerStatsTracker,
-                (SafeEventLoop) eventLoopGroup.next());
-    }
-
-    /***
-     *  One observation about event loop is if submitted task fails, it could kill the thread but the event loop group will not create a new one.
-     *  Here, we wrap it as safe event loop so that if any submitted job fails, we chose to log the error and fail the entire task.
-     */
-    static class SafeEventLoop
-            extends DefaultEventLoop
-    {
-        public SafeEventLoop(EventLoopGroup parent, Executor executor)
-        {
-            super(parent, executor);
-        }
-
-        @Override
-        protected void run()
-        {
-            do {
-                Runnable task = takeTask();
-                if (task != null) {
-                    try {
-                        runTask(task);
-                    }
-                    catch (Throwable t) {
-                        log.error("Error executing task on event loop", t);
-                    }
-                    updateLastExecutionTime();
-                }
-            }
-            while (!this.confirmShutdown());
-        }
+                eventLoopGroup.next());
     }
 }


### PR DESCRIPTION
## Description
1. we see some issues at certain clusters where workers are not receiving any splits. Reverting the following two prs back to unblock others so I can take time to root cause it.
    a. #24412
    b. #24288 

## Motivation and Context
1. reverting event loop related changes to unblock others.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

