### PR TITLE
Add action to finalize release branch and tag

### DIFF
--- a/.github/workflows/presto-release-tag-finalize.yml
+++ b/.github/workflows/presto-release-tag-finalize.yml
@@ -1,0 +1,50 @@
+name: Presto Stable Release Tag Finalize
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: 'Release tag (e.g., 0.291)'
+        required: true
+      release-notes-commit:
+        description: 'Commit hash containing release notes'
+        required: true
+
+env:
+  RELEASE_BRANCH: release-${{ github.event.inputs.release-tag }}
+  RELEASE_TAG: ${{ github.event.inputs.release-tag }}
+  RELEASE_NOTES_COMMIT: ${{ github.event.inputs.release-notes-commit }}
+
+jobs:
+  finalize-release:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          token: ${{ secrets.PRESTODB_CI_TOKEN }}
+          fetch-depth: 0
+          fetch-tags: true
+          show-progress: false
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "ci@lists.prestodb.io"
+          git config --global user.name "prestodb-ci"
+          git config pull.rebase false
+
+      - name: Cherry-pick release notes
+        run: |
+          git cherry-pick ${{ env.RELEASE_NOTES_COMMIT }}
+
+      - name: Delete existing release tag
+        run: |
+          git push origin :${{ env.RELEASE_TAG }} || true
+          git tag -d ${{ env.RELEASE_TAG }} || true
+
+      - name: Create new release tag
+        run: |
+          git tag -a ${{ env.RELEASE_TAG }} -m "release ${{ env.RELEASE_TAG }}"
+          git push origin ${{ env.RELEASE_BRANCH }} --tags


### PR DESCRIPTION
## Description
Step 3 in https://github.com/prestodb/presto/wiki/Stable-release-process-(every-2-months)

> Step 3: clean up the tag

* on GitHub web, delete the tag for this release
* in your local git repo, on the release branch (e.g. branch release-0.289), delete the local tag via `git tag -d TAG`, where `TAG` is the tag name of the tag you just deleted from the web UI.
* Copy release notes merged on master into the release branch, e.g. `git checkout release-0.289;git cherry-pick SHA;git push upstream release-0.289`, where `SHA` is the commit ID of the release notes merge.
* Tag this branch with 0.289: `git tag -a TAG -m "release TAG"`, where `TAG` is the tag name of the tag you just deleted from the web UI.
* push to Github remote: git push; `git push upstream refs/tags/TAG`, where `TAG` is the tag name of the tag you just deleted from the web UI.


## Motivation and Context
Migration manual step to automation

## Impact
Release

## Test Plan
https://github.com/unix280/presto/actions/runs/13307048054/job/37160320834

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

