### PR TITLE
[native] Add S3 metrics reporting

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -252,4 +252,7 @@ Users can enable collection of worker level metrics by setting the property:
 * **Default value:** ``false``
 
   When true, the default behavior is a no-op. There is a prior setup that must be done before enabling this flag. To enable
-  metrics collection in Prometheus Data Format refer `here <https://github.com/prestodb/presto/tree/master/presto-native-execution#build-prestissimo>`_. 
+  metrics collection in Prometheus Data Format refer `here <https://github.com/prestodb/presto/tree/master/presto-native-execution#build-prestissimo>`_.
+
+  When enabled and Presto C++ workers interact with the S3 filesystem, additional runtime metrics are collected.
+  For a detailed list of these metrics, see `runtime metrics <https://facebookincubator.github.io/velox/monitoring/metrics.html#s3-filesystem>`_.

--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -255,4 +255,4 @@ Users can enable collection of worker level metrics by setting the property:
   metrics collection in Prometheus Data Format see `Worker Metrics Collection <https://github.com/prestodb/presto/tree/master/presto-native-execution#worker-metrics-collection>`_.
 
   When enabled and Presto C++ workers interact with the S3 filesystem, additional runtime metrics are collected.
-  For a detailed list of these metrics, see `runtime metrics <https://facebookincubator.github.io/velox/monitoring/metrics.html#s3-filesystem>`_.
+  For a detailed list of these metrics, see `S3 FileSystem <https://facebookincubator.github.io/velox/monitoring/metrics.html#s3-filesystem>`_.

--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -252,7 +252,7 @@ Users can enable collection of worker level metrics by setting the property:
 * **Default value:** ``false``
 
   When true, the default behavior is a no-op. There is a prior setup that must be done before enabling this flag. To enable
-  metrics collection in Prometheus Data Format refer `here <https://github.com/prestodb/presto/tree/master/presto-native-execution#build-prestissimo>`_.
+  metrics collection in Prometheus Data Format see `Worker Metrics Collection <https://github.com/prestodb/presto/tree/master/presto-native-execution#worker-metrics-collection>`_.
 
   When enabled and Presto C++ workers interact with the S3 filesystem, additional runtime metrics are collected.
   For a detailed list of these metrics, see `runtime metrics <https://facebookincubator.github.io/velox/monitoring/metrics.html#s3-filesystem>`_.

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1371,6 +1371,7 @@ void PrestoServer::unregisterFileReadersAndWriters() {
 void PrestoServer::registerStatsCounters() {
   registerPrestoMetrics();
   velox::registerVeloxMetrics();
+  velox::filesystems::registerS3Metrics();
 }
 
 std::string PrestoServer::getLocalIp() const {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

This PR introduced S3 file system metrics reporting in Prestissimo.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Presto Java provides PrestoS3FileSystemStats to collect and report the metrics related to S3 file system operations, and this PR is to fill the gap between Presto Java and Prestissimo. 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== RELEASE NOTES ==
Prestissimo (native Execution) Changes
* Add runtime metrics collection for S3 Filesystem.

