### PR TITLE
[Parquet]Fix writing columns with all null values after row group flush

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ArrayColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ArrayColumnWriter.java
@@ -85,8 +85,8 @@ public class ArrayColumnWriter
     }
 
     @Override
-    public void reset()
+    public void resetChunk()
     {
-        elementWriter.reset();
+        elementWriter.resetChunk();
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ColumnWriter.java
@@ -34,7 +34,7 @@ public interface ColumnWriter
 
     long getRetainedBytes();
 
-    void reset();
+    void resetChunk();
 
     class BufferData
     {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/MapColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/MapColumnWriter.java
@@ -89,9 +89,9 @@ public class MapColumnWriter
     }
 
     @Override
-    public void reset()
+    public void resetChunk()
     {
-        keyWriter.reset();
-        valueWriter.reset();
+        keyWriter.resetChunk();
+        valueWriter.resetChunk();
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -188,7 +188,7 @@ public class ParquetWriter
         if (bufferedBytes >= writerOption.getMaxRowGroupSize()) {
             columnWriters.forEach(ColumnWriter::close);
             flush();
-            columnWriters.forEach(ColumnWriter::reset);
+            columnWriters.forEach(ColumnWriter::resetChunk);
             rows = 0;
         }
     }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriters.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriters.java
@@ -48,6 +48,7 @@ import org.apache.parquet.schema.PrimitiveType;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -156,7 +157,7 @@ class ParquetWriters
                 case PARQUET_1_0:
                     return new PrimitiveColumnWriterV1(prestoType,
                             columnDescriptor,
-                            getValueWriter(parquetProperties.newValuesWriter(columnDescriptor), prestoType, columnDescriptor.getPrimitiveType()),
+                            getValueWriter(() -> parquetProperties.newValuesWriter(columnDescriptor), prestoType, columnDescriptor.getPrimitiveType()),
                             parquetProperties.newDefinitionLevelWriter(columnDescriptor),
                             parquetProperties.newRepetitionLevelWriter(columnDescriptor),
                             compressionCodecName,
@@ -164,7 +165,7 @@ class ParquetWriters
                 case PARQUET_2_0:
                     return new PrimitiveColumnWriterV2(prestoType,
                             columnDescriptor,
-                            getValueWriter(parquetProperties.newValuesWriter(columnDescriptor), prestoType, columnDescriptor.getPrimitiveType()),
+                            getValueWriter(() -> parquetProperties.newValuesWriter(columnDescriptor), prestoType, columnDescriptor.getPrimitiveType()),
                             parquetProperties.newDefinitionLevelEncoder(columnDescriptor),
                             parquetProperties.newRepetitionLevelEncoder(columnDescriptor),
                             compressionCodecName,
@@ -187,43 +188,43 @@ class ParquetWriters
         }
     }
 
-    private static PrimitiveValueWriter getValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    private static PrimitiveValueWriter getValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, Type type, PrimitiveType parquetType)
     {
         if (BOOLEAN.equals(type)) {
-            return new BooleanValueWriter(valuesWriter, parquetType);
+            return new BooleanValueWriter(valuesWriterSupplier, parquetType);
         }
         if (INTEGER.equals(type) || SMALLINT.equals(type) || TINYINT.equals(type)) {
-            return new IntegerValueWriter(valuesWriter, type, parquetType);
+            return new IntegerValueWriter(valuesWriterSupplier, type, parquetType);
         }
         if (type instanceof DecimalType) {
-            return new DecimalValueWriter(valuesWriter, type, parquetType);
+            return new DecimalValueWriter(valuesWriterSupplier, type, parquetType);
         }
         if (DATE.equals(type)) {
-            return new DateValueWriter(valuesWriter, parquetType);
+            return new DateValueWriter(valuesWriterSupplier, parquetType);
         }
         if (BIGINT.equals(type)) {
-            return new BigintValueWriter(valuesWriter, type, parquetType);
+            return new BigintValueWriter(valuesWriterSupplier, type, parquetType);
         }
         if (DOUBLE.equals(type)) {
-            return new DoubleValueWriter(valuesWriter, parquetType);
+            return new DoubleValueWriter(valuesWriterSupplier, parquetType);
         }
         if (REAL.equals(type)) {
-            return new RealValueWriter(valuesWriter, parquetType);
+            return new RealValueWriter(valuesWriterSupplier, parquetType);
         }
         if (TIMESTAMP.equals(type)) {
-            return new TimestampValueWriter(valuesWriter, type, parquetType);
+            return new TimestampValueWriter(valuesWriterSupplier, type, parquetType);
         }
         if (TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
-            return new TimestampWithTimezoneValueWriter(valuesWriter, type, parquetType);
+            return new TimestampWithTimezoneValueWriter(valuesWriterSupplier, type, parquetType);
         }
         if (TIME.equals(type)) {
-            return new TimeValueWriter(valuesWriter, type, parquetType);
+            return new TimeValueWriter(valuesWriterSupplier, type, parquetType);
         }
         if (UUID.equals(type)) {
-            return new UuidValuesWriter(valuesWriter, parquetType);
+            return new UuidValuesWriter(valuesWriterSupplier, parquetType);
         }
         if (type instanceof VarcharType || type instanceof CharType || type instanceof VarbinaryType) {
-            return new CharValueWriter(valuesWriter, type, parquetType);
+            return new CharValueWriter(valuesWriterSupplier, type, parquetType);
         }
         throw new PrestoException(NOT_SUPPORTED, format("Unsupported type for Parquet writer: %s", type));
     }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
@@ -200,10 +200,10 @@ public abstract class PrimitiveColumnWriter
     }
 
     @Override
-    public void reset()
+    public void resetChunk()
     {
         pageBuffer.clear();
-        primitiveValueWriter.reset();
+        primitiveValueWriter.resetChunk();
         closed = false;
 
         totalCompressedSize = 0;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/StructColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/StructColumnWriter.java
@@ -99,8 +99,8 @@ public class StructColumnWriter
     }
 
     @Override
-    public void reset()
+    public void resetChunk()
     {
-        columnWriters.forEach(ColumnWriter::reset);
+        columnWriters.forEach(ColumnWriter::resetChunk);
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/BigintValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/BigintValueWriter.java
@@ -18,6 +18,8 @@ import com.facebook.presto.common.type.Type;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static java.util.Objects.requireNonNull;
 
 public class BigintValueWriter
@@ -25,9 +27,9 @@ public class BigintValueWriter
 {
     private final Type type;
 
-    public BigintValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    public BigintValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, Type type, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
         this.type = requireNonNull(type, "type is null");
     }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/BooleanValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/BooleanValueWriter.java
@@ -18,17 +18,13 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
-import static java.util.Objects.requireNonNull;
 
 public class BooleanValueWriter
         extends PrimitiveValueWriter
 {
-    private final ValuesWriter valuesWriter;
-
     public BooleanValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
     {
         super(parquetType, valuesWriter);
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
     }
 
     @Override
@@ -37,7 +33,7 @@ public class BooleanValueWriter
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!block.isNull(i)) {
                 boolean value = BOOLEAN.getBoolean(block, i);
-                valuesWriter.writeBoolean(value);
+                getValueWriter().writeBoolean(value);
                 getStatistics().updateStats(value);
             }
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/BooleanValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/BooleanValueWriter.java
@@ -17,14 +17,16 @@ import com.facebook.presto.common.block.Block;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 
 public class BooleanValueWriter
         extends PrimitiveValueWriter
 {
-    public BooleanValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
+    public BooleanValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/CharValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/CharValueWriter.java
@@ -20,6 +20,8 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static java.util.Objects.requireNonNull;
 
 public class CharValueWriter
@@ -27,9 +29,9 @@ public class CharValueWriter
 {
     private final Type type;
 
-    public CharValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    public CharValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, Type type, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
         this.type = requireNonNull(type, "type is null");
     }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/CharValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/CharValueWriter.java
@@ -25,13 +25,11 @@ import static java.util.Objects.requireNonNull;
 public class CharValueWriter
         extends PrimitiveValueWriter
 {
-    private final ValuesWriter valuesWriter;
     private final Type type;
 
     public CharValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
     {
         super(parquetType, valuesWriter);
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
         this.type = requireNonNull(type, "type is null");
     }
 
@@ -42,7 +40,7 @@ public class CharValueWriter
             if (!block.isNull(i)) {
                 Slice slice = type.getSlice(block, i);
                 Binary binary = Binary.fromConstantByteBuffer(slice.toByteBuffer());
-                valuesWriter.writeBytes(binary);
+                getValueWriter().writeBytes(binary);
                 getStatistics().updateStats(binary);
             }
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DateValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DateValueWriter.java
@@ -18,17 +18,13 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
 import static com.facebook.presto.common.type.DateType.DATE;
-import static java.util.Objects.requireNonNull;
 
 public class DateValueWriter
         extends PrimitiveValueWriter
 {
-    private final ValuesWriter valuesWriter;
-
     public DateValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
     {
         super(parquetType, valuesWriter);
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
     }
 
     @Override
@@ -37,7 +33,7 @@ public class DateValueWriter
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
                 int value = (int) DATE.getLong(block, position);
-                valuesWriter.writeInteger(value);
+                getValueWriter().writeInteger(value);
                 getStatistics().updateStats(value);
             }
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DateValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DateValueWriter.java
@@ -17,14 +17,16 @@ import com.facebook.presto.common.block.Block;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static com.facebook.presto.common.type.DateType.DATE;
 
 public class DateValueWriter
         extends PrimitiveValueWriter
 {
-    public DateValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
+    public DateValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DecimalValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DecimalValueWriter.java
@@ -24,6 +24,7 @@ import org.apache.parquet.schema.PrimitiveType;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,9 +33,9 @@ public class DecimalValueWriter
 {
     private final DecimalType decimalType;
 
-    public DecimalValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    public DecimalValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, Type type, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
         this.decimalType = (DecimalType) requireNonNull(type, "type is null");
     }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DoubleValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DoubleValueWriter.java
@@ -17,14 +17,16 @@ import com.facebook.presto.common.block.Block;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 
 public class DoubleValueWriter
         extends PrimitiveValueWriter
 {
-    public DoubleValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
+    public DoubleValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DoubleValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/DoubleValueWriter.java
@@ -18,17 +18,13 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
-import static java.util.Objects.requireNonNull;
 
 public class DoubleValueWriter
         extends PrimitiveValueWriter
 {
-    private final ValuesWriter valuesWriter;
-
     public DoubleValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
     {
         super(parquetType, valuesWriter);
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
     }
 
     @Override
@@ -37,7 +33,7 @@ public class DoubleValueWriter
         for (int i = 0; i < block.getPositionCount(); ++i) {
             if (!block.isNull(i)) {
                 double value = DOUBLE.getDouble(block, i);
-                valuesWriter.writeDouble(value);
+                getValueWriter().writeDouble(value);
                 getStatistics().updateStats(value);
             }
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/IntegerValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/IntegerValueWriter.java
@@ -18,6 +18,8 @@ import com.facebook.presto.common.type.Type;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static java.util.Objects.requireNonNull;
 
 public class IntegerValueWriter
@@ -25,9 +27,9 @@ public class IntegerValueWriter
 {
     private final Type type;
 
-    public IntegerValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    public IntegerValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, Type type, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
         this.type = requireNonNull(type, "type is null");
     }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/PrimitiveValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/PrimitiveValueWriter.java
@@ -21,6 +21,8 @@ import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static java.util.Objects.requireNonNull;
 
 public abstract class PrimitiveValueWriter
@@ -28,12 +30,14 @@ public abstract class PrimitiveValueWriter
 {
     private Statistics<?> statistics;
     private final PrimitiveType parquetType;
-    private final ValuesWriter valuesWriter;
+    private final Supplier<ValuesWriter> valuesWriterSupplier;
+    private ValuesWriter valuesWriter;
 
-    public PrimitiveValueWriter(PrimitiveType parquetType, ValuesWriter valuesWriter)
+    public PrimitiveValueWriter(PrimitiveType parquetType, Supplier<ValuesWriter> valuesWriterSupplier)
     {
         this.parquetType = requireNonNull(parquetType, "parquetType is null");
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
+        this.valuesWriterSupplier = requireNonNull(valuesWriterSupplier, "valuesWriterSupplier is null");
+        this.valuesWriter = this.valuesWriterSupplier.get();
         this.statistics = Statistics.createStats(parquetType);
     }
 
@@ -74,6 +78,12 @@ public abstract class PrimitiveValueWriter
     public void reset()
     {
         valuesWriter.reset();
+        this.statistics = Statistics.createStats(parquetType);
+    }
+
+    public void resetChunk()
+    {
+        valuesWriter = valuesWriterSupplier.get();
         this.statistics = Statistics.createStats(parquetType);
     }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/RealValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/RealValueWriter.java
@@ -17,6 +17,8 @@ import com.facebook.presto.common.block.Block;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static com.facebook.presto.common.type.RealType.REAL;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
@@ -24,9 +26,9 @@ import static java.lang.Math.toIntExact;
 public class RealValueWriter
         extends PrimitiveValueWriter
 {
-    public RealValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
+    public RealValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/RealValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/RealValueWriter.java
@@ -20,17 +20,13 @@ import org.apache.parquet.schema.PrimitiveType;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
-import static java.util.Objects.requireNonNull;
 
 public class RealValueWriter
         extends PrimitiveValueWriter
 {
-    private final ValuesWriter valuesWriter;
-
     public RealValueWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
     {
         super(parquetType, valuesWriter);
-        this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
     }
 
     @Override
@@ -39,7 +35,7 @@ public class RealValueWriter
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!block.isNull(i)) {
                 float value = intBitsToFloat(toIntExact(REAL.getLong(block, i)));
-                valuesWriter.writeFloat(value);
+                getValueWriter().writeFloat(value);
                 getStatistics().updateStats(value);
             }
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/TimeValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/TimeValueWriter.java
@@ -19,6 +19,8 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -28,9 +30,9 @@ public class TimeValueWriter
     private final Type type;
     private final boolean writeMicroseconds;
 
-    public TimeValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    public TimeValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, Type type, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
         this.type = requireNonNull(type, "type is null");
         this.writeMicroseconds = parquetType.isPrimitive() && parquetType.getOriginalType() == OriginalType.TIME_MICROS;
     }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/TimestampValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/TimestampValueWriter.java
@@ -19,6 +19,8 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -28,9 +30,9 @@ public class TimestampValueWriter
     private final Type type;
     private final boolean writeMicroseconds;
 
-    public TimestampValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    public TimestampValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, Type type, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
         this.type = requireNonNull(type, "type is null");
         this.writeMicroseconds = parquetType.isPrimitive() && parquetType.getOriginalType() == OriginalType.TIMESTAMP_MICROS;
     }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/TimestampWithTimezoneValueWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/TimestampWithTimezoneValueWriter.java
@@ -19,6 +19,8 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 
+import java.util.function.Supplier;
+
 import static com.facebook.presto.common.type.DateTimeEncoding.unpackMillisUtc;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -29,9 +31,9 @@ public class TimestampWithTimezoneValueWriter
     private final Type type;
     private final boolean writeMicroseconds;
 
-    public TimestampWithTimezoneValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    public TimestampWithTimezoneValueWriter(Supplier<ValuesWriter> valuesWriterSupplier, Type type, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
         this.type = requireNonNull(type, "type is null");
         this.writeMicroseconds = parquetType.isPrimitive() && parquetType.getOriginalType() == OriginalType.TIMESTAMP_MICROS;
     }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/UuidValuesWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/valuewriter/UuidValuesWriter.java
@@ -22,6 +22,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.function.Supplier;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
@@ -32,9 +33,9 @@ public class UuidValuesWriter
     private final ByteBuffer writeBuffer = ByteBuffer.allocate(2 * SIZE_OF_LONG)
             .order(ByteOrder.BIG_ENDIAN);
 
-    public UuidValuesWriter(ValuesWriter valuesWriter, PrimitiveType parquetType)
+    public UuidValuesWriter(Supplier<ValuesWriter> valuesWriterSupplier, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
+        super(parquetType, valuesWriterSupplier);
     }
 
     @Override


### PR DESCRIPTION
## Description

This PR fix a bug in parquet which cased the flaky #22907. The direct reason is, when Parquet writes a data page with a column that is all null right after row group level flush, the handling of that column is incorrect: its encoding still uses dictionary encoding, but no dictionary page is output.

The core reason is, we shouldn't simply `reset` and reuse the `ValuesWriter`s after each row group level flush, it's different from the behavior after each data page level flush. We should close and re-create `ValuesWriter`'s after each row group level flush. See Parquet's comment for `ValuesWriterFactory` [here](https://github.com/apache/parquet-java/blob/92354f6be7ee3b5930c82408102b10a6b2b5f3c2/parquet-column/src/main/java/org/apache/parquet/column/values/factory/ValuesWriterFactory.java#L35). It seems that Parquet is designed this way.


## Motivation and Context

Fix #22907 

## Impact

N/A

## Test Plan

 - Newly added test case `TestParquetWriter.testWriteAllNullDataPageAfterRowGroupFlush()` which can reproduce the issue without this change.
 - Set the invocation count for `testSingleLevelSchemaArrayOfArrayOfStructOfArray()` to 1024, and make sure the issue do not appear anymore.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
