### PR TITLE
Plan checker sessionPass ConnectorSession to PlanChecker

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1235,6 +1235,12 @@ public abstract class AbstractTestHiveClient
             {
                 return session.getRuntimeStats();
             }
+
+            @Override
+            public ConnectorSession forConnectorId(ConnectorId connectorId)
+            {
+                return this;
+            }
         };
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -199,4 +199,10 @@ public class FullConnectorSession
     {
         return session.getRuntimeStats();
     }
+
+    @Override
+    public ConnectorSession forConnectorId(ConnectorId connectorId)
+    {
+        return new FullConnectorSession(session, identity);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
@@ -87,7 +87,7 @@ public final class PlanChecker
         checkers.get(Stage.FINAL).forEach(checker -> checker.validate(planNode, session, metadata, warningCollector));
         for (PlanCheckerProvider provider : planCheckerProviderManager.getPlanCheckerProviders()) {
             for (com.facebook.presto.spi.plan.PlanChecker checker : provider.getFinalPlanCheckers()) {
-                checker.validate(planNode, warningCollector);
+                checker.validate(planNode, warningCollector, session.toConnectorSession());
             }
         }
     }
@@ -97,7 +97,7 @@ public final class PlanChecker
         checkers.get(Stage.INTERMEDIATE).forEach(checker -> checker.validate(planNode, session, metadata, warningCollector));
         for (PlanCheckerProvider provider : planCheckerProviderManager.getPlanCheckerProviders()) {
             for (com.facebook.presto.spi.plan.PlanChecker checker : provider.getIntermediatePlanCheckers()) {
-                checker.validate(planNode, warningCollector);
+                checker.validate(planNode, warningCollector, session.toConnectorSession());
             }
         }
     }
@@ -107,15 +107,18 @@ public final class PlanChecker
         checkers.get(Stage.FRAGMENT).forEach(checker -> checker.validateFragment(planFragment, session, metadata, warningCollector));
         for (PlanCheckerProvider provider : planCheckerProviderManager.getPlanCheckerProviders()) {
             for (com.facebook.presto.spi.plan.PlanChecker checker : provider.getFragmentPlanCheckers()) {
-                checker.validateFragment(new SimplePlanFragment(
-                        planFragment.getId(),
-                        planFragment.getRoot(),
-                        planFragment.getVariables(),
-                        planFragment.getPartitioning(),
-                        planFragment.getTableScanSchedulingOrder(),
-                        planFragment.getPartitioningScheme(),
-                        planFragment.getStageExecutionDescriptor(),
-                        planFragment.isOutputTableWriterFragment()), warningCollector);
+                checker.validateFragment(
+                        new SimplePlanFragment(
+                                planFragment.getId(),
+                                planFragment.getRoot(),
+                                planFragment.getVariables(),
+                                planFragment.getPartitioning(),
+                                planFragment.getTableScanSchedulingOrder(),
+                                planFragment.getPartitioningScheme(),
+                                planFragment.getStageExecutionDescriptor(),
+                                planFragment.isOutputTableWriterFragment()),
+                        warningCollector,
+                        session.toConnectorSession());
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.execution.QueryIdGenerator;
+import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.WarningCollector;
@@ -222,6 +223,26 @@ public class TestingConnectorSession
     public RuntimeStats getRuntimeStats()
     {
         return new RuntimeStats();
+    }
+
+    @Override
+    public ConnectorSession forConnectorId(ConnectorId connectorId)
+    {
+        return new TestingConnectorSession(
+                sqlFunctionProperties.getSessionUser(),
+                identity,
+                source,
+                traceToken,
+                timeZoneKey,
+                locale,
+                startTime,
+                ImmutableList.copyOf(properties.values()),
+                propertyValues,
+                sqlFunctionProperties.isLegacyRowFieldOrdinalAccessEnabled(),
+                clientInfo,
+                clientTags,
+                schema,
+                sessionFunctions);
     }
 
     @Override

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sidecar.nativechecker;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
@@ -61,13 +62,13 @@ public final class NativePlanChecker
     }
 
     @Override
-    public void validate(PlanNode planNode, WarningCollector warningCollector)
+    public void validate(PlanNode planNode, WarningCollector warningCollector, ConnectorSession session)
     {
         // NO-OP, only validating fragments
     }
 
     @Override
-    public void validateFragment(SimplePlanFragment planFragment, WarningCollector warningCollector)
+    public void validateFragment(SimplePlanFragment planFragment, WarningCollector warningCollector, ConnectorSession session)
     {
         if (!planFragment.getPartitioning().isCoordinatorOnly() && !isInternalSystemConnector(planFragment.getRoot())) {
             runValidation(planFragment);

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestPlanCheckerProvider.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestPlanCheckerProvider.java
@@ -93,7 +93,7 @@ public class TestPlanCheckerProvider
             PlanConversionResponse responseOk = new PlanConversionResponse(ImmutableList.of());
             String responseOkString = PLAN_CONVERSION_RESPONSE_JSON_CODEC.toJson(responseOk);
             server.enqueue(new MockResponse().setBody(responseOkString));
-            checker.validateFragment(fragment, null);
+            checker.validateFragment(fragment, null, null);
 
             String errorMessage = "native conversion error";
             ErrorCode errorCode = StandardErrorCode.NOT_SUPPORTED.toErrorCode();
@@ -101,7 +101,7 @@ public class TestPlanCheckerProvider
             String responseErrorString = PLAN_CONVERSION_RESPONSE_JSON_CODEC.toJson(responseError);
             server.enqueue(new MockResponse().setResponseCode(500).setBody(responseErrorString));
             PrestoException error = expectThrows(PrestoException.class,
-                    () -> checker.validateFragment(fragment, null));
+                    () -> checker.validateFragment(fragment, null, null));
             assertEquals(error.getErrorCode(), errorCode);
             assertTrue(error.getMessage().contains(errorMessage));
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -66,4 +66,10 @@ public interface ConnectorSession
     WarningCollector getWarningCollector();
 
     RuntimeStats getRuntimeStats();
+
+    /**
+     * returns a ConnectorSession for a specific ConnectorId
+     * @return
+     */
+    ConnectorSession forConnectorId(ConnectorId connectorId);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanChecker.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanChecker.java
@@ -14,14 +14,15 @@
 
 package com.facebook.presto.spi.plan;
 
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.WarningCollector;
 
 public interface PlanChecker
 {
-    void validate(PlanNode planNode, WarningCollector warningCollector);
+    void validate(PlanNode planNode, WarningCollector warningCollector, ConnectorSession session);
 
-    default void validateFragment(SimplePlanFragment planFragment, WarningCollector warningCollector)
+    default void validateFragment(SimplePlanFragment planFragment, WarningCollector warningCollector, ConnectorSession session)
     {
-        validate(planFragment.getRoot(), warningCollector);
+        validate(planFragment.getRoot(), warningCollector, session);
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
@@ -130,6 +130,12 @@ public final class TestingSession
         {
             return new RuntimeStats();
         }
+
+        @Override
+        public ConnectorSession forConnectorId(ConnectorId connectorId)
+        {
+            return this;
+        }
     };
 
     private TestingSession() {}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TriggerFailurePlanChecker.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TriggerFailurePlanChecker.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.WarningCollector;
@@ -36,7 +37,7 @@ public class TriggerFailurePlanChecker
     }
 
     @Override
-    public void validate(PlanNode planNode, WarningCollector warningCollector)
+    public void validate(PlanNode planNode, WarningCollector warningCollector, ConnectorSession session)
     {
         if (triggerValidationFailure.get()) {
             throw new PrestoException(FAILURE_ERROR_CODE, FAILURE_MESSAGE);


### PR DESCRIPTION
## Description
Pass ConnectorSession to PlanChecker and add ConnectorSession.forConnectorId() method.


## Motivation and Context
We have a planchecker that calls out to get connector metadata for the tablescan, and so we need to pass the connector session through to those calls

## Impact
Updates the plan checker SPI


## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

SPI Changes
* Add ConnectorSession as an argument to PlanChecker.validate and PlanChecker.validateFragment 
```

