### PR TITLE
Remove synchronization for updateFinalTaskInfo()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -718,13 +718,13 @@ public final class SqlStageExecution
                 failedTasks.size() < allTasks.size() * maxFailedTaskPercentage;
     }
 
-    private synchronized void updateFinalTaskInfo(TaskInfo finalTaskInfo)
+    private void updateFinalTaskInfo(TaskInfo finalTaskInfo)
     {
         runningTasks.remove(finalTaskInfo.getTaskId());
         checkAllTaskFinal();
     }
 
-    private synchronized void checkAllTaskFinal()
+    private void checkAllTaskFinal()
     {
         if (stateMachine.getState().isDone() && runningTasks.isEmpty()) {
             if (getFragment().getStageExecutionDescriptor().isStageGroupedExecution()) {


### PR DESCRIPTION
## Description
Remove redundant synchronization for updateFinalTaskInfo()

## Motivation and Context
During lock profiling we observed that there is some contention when calling SqlStageExecution.updateFinalTaskInfo(). runningTasks used inside this method is a thread safe hashset. Also the stateMachine.setAllTasksFinal() is thread safe, as it acquires locks before execution. So its safe to remove the "synchronized" for updateFinalTaskInfo().
<img width="512" alt="langThread run (100)" src="https://github.com/user-attachments/assets/a8fece75-9fe4-4592-aebb-f17a0637c4b1" />

## Impact
None

## Test Plan
Existing unit tests and verifier testing.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

