### PR TITLE
Add configurable Parquet Data Anonymization feature

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonClientConfig.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonClientConfig.java
@@ -46,6 +46,8 @@ public class HiveCommonClientConfig
     private boolean readNullMaskedParquetEncryptedValueEnabled;
     private boolean useParquetColumnNames;
     private boolean zstdJniDecompressionEnabled;
+    private boolean isParquetAnonymizationEnabled;
+    private String parquetAnonymizationManagerClass;
 
     public NodeSelectionStrategy getNodeSelectionStrategy()
     {
@@ -283,5 +285,31 @@ public class HiveCommonClientConfig
     {
         this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
         return this;
+    }
+
+    @Config("hive.enable-parquet-anonymization")
+    @ConfigDescription("enable parquet anonymization")
+    public HiveCommonClientConfig setParquetAnonymizationEnabled(boolean isParquetAnonymizationEnabled)
+    {
+        this.isParquetAnonymizationEnabled = isParquetAnonymizationEnabled;
+        return this;
+    }
+
+    public boolean isParquetAnonymizationEnabled()
+    {
+        return this.isParquetAnonymizationEnabled;
+    }
+
+    @Config("hive.parquet-anonymization-manager-class")
+    @ConfigDescription("Anonymization manager class, must be set if parquet anonymization is enabled")
+    public HiveCommonClientConfig setParquetAnonymizationManagerClass(String parquetAnonymizationManagerClass)
+    {
+        this.parquetAnonymizationManagerClass = parquetAnonymizationManagerClass;
+        return this;
+    }
+
+    public String getParquetAnonymizationManagerClass()
+    {
+        return this.parquetAnonymizationManagerClass;
     }
 }

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonSessionProperties.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveCommonSessionProperties.java
@@ -61,6 +61,8 @@ public class HiveCommonSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_USE_COLUMN_NAMES = "parquet_use_column_names";
     public static final String READ_MASKED_VALUE_ENABLED = "read_null_masked_parquet_encrypted_value_enabled";
+    public static final String ENABLE_PARQUET_ANONYMIZATION = "enable_parquet_anonymization";
+    public static final String PARQUET_ANONYMIZATION_MANAGER_CLASS = "parquet_anonymization_manager_class";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -177,6 +179,16 @@ public class HiveCommonSessionProperties
                         READ_MASKED_VALUE_ENABLED,
                         "Return null when access is denied for an encrypted parquet column",
                         hiveCommonClientConfig.getReadNullMaskedParquetEncryptedValue(),
+                        false),
+                booleanProperty(
+                        ENABLE_PARQUET_ANONYMIZATION,
+                        "Is parquet anonymization enabled",
+                        hiveCommonClientConfig.isParquetAnonymizationEnabled(),
+                        false),
+                stringProperty(
+                        PARQUET_ANONYMIZATION_MANAGER_CLASS,
+                        "Parquet anonymization manager class",
+                        hiveCommonClientConfig.getParquetAnonymizationManagerClass(),
                         false));
     }
 
@@ -285,6 +297,16 @@ public class HiveCommonSessionProperties
     public static boolean getReadNullMaskedParquetEncryptedValue(ConnectorSession session)
     {
         return session.getProperty(READ_MASKED_VALUE_ENABLED, Boolean.class);
+    }
+
+    public static boolean isParquetAnonymizationEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ENABLE_PARQUET_ANONYMIZATION, Boolean.class);
+    }
+
+    public static String getParquetAnonymizationManagerClass(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_ANONYMIZATION_MANAGER_CLASS, String.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive-common/src/test/java/com/facebook/presto/hive/TestHiveCommonClientConfig.java
+++ b/presto-hive-common/src/test/java/com/facebook/presto/hive/TestHiveCommonClientConfig.java
@@ -47,7 +47,9 @@ public class TestHiveCommonClientConfig
                 .setZstdJniDecompressionEnabled(false)
                 .setParquetBatchReaderVerificationEnabled(false)
                 .setParquetBatchReadOptimizationEnabled(false)
-                .setReadNullMaskedParquetEncryptedValue(false));
+                .setReadNullMaskedParquetEncryptedValue(false)
+                .setParquetAnonymizationEnabled(false)
+                .setParquetAnonymizationManagerClass(null));
     }
 
     @Test
@@ -72,6 +74,9 @@ public class TestHiveCommonClientConfig
                 .put("hive.enable-parquet-batch-reader-verification", "true")
                 .put("hive.parquet-batch-read-optimization-enabled", "true")
                 .put("hive.read-null-masked-parquet-encrypted-value-enabled", "true")
+                .put("hive.enable-parquet-anonymization", "true")
+                .put("hive.parquet-anonymization-manager-class",
+                        "org.apache.parquet.anonymization.TestAnonymizationManager")
                 .build();
 
         HiveCommonClientConfig expected = new HiveCommonClientConfig()
@@ -92,7 +97,9 @@ public class TestHiveCommonClientConfig
                 .setZstdJniDecompressionEnabled(true)
                 .setParquetBatchReaderVerificationEnabled(true)
                 .setParquetBatchReadOptimizationEnabled(true)
-                .setReadNullMaskedParquetEncryptedValue(true);
+                .setReadNullMaskedParquetEncryptedValue(true)
+                .setParquetAnonymizationEnabled(true)
+                .setParquetAnonymizationManagerClass("org.apache.parquet.anonymization.TestAnonymizationManager");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
@@ -291,7 +291,7 @@ public class BenchmarkParquetPageSource
                 fields.add(ColumnIOConverter.constructField(getTypeFromTypeSignature(), messageColumnIO.getChild(i)));
             }
 
-            ParquetReader parquetReader = new ParquetReader(messageColumnIO, parquetMetadata.getBlocks(), Optional.empty(), dataSource, newSimpleAggregatedMemoryContext(), new DataSize(16, MEGABYTE), batchReadEnabled, enableVerification, null, null, false, Optional.empty());
+            ParquetReader parquetReader = new ParquetReader(messageColumnIO, parquetMetadata.getBlocks(), Optional.empty(), dataSource, newSimpleAggregatedMemoryContext(), new DataSize(16, MEGABYTE), batchReadEnabled, enableVerification, null, null, false, Optional.empty(), Optional.empty());
             return new ParquetPageSource(parquetReader, Collections.nCopies(channelCount, type), fields, columnNames, new RuntimeStats());
         }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -530,7 +530,7 @@ public class ParquetTester
         assertPageSource(types, valuesByField, pageSource, Optional.empty());
     }
 
-    private static void assertPageSource(List<Type> types, Iterator<?>[] valuesByField, ConnectorPageSource pageSource, Optional<Long> maxReadBlockSize)
+    static void assertPageSource(List<Type> types, Iterator<?>[] valuesByField, ConnectorPageSource pageSource, Optional<Long> maxReadBlockSize)
     {
         Page page;
         while ((page = pageSource.getNextPage()) != null) {
@@ -550,7 +550,7 @@ public class ParquetTester
         }
     }
 
-    private static void assertRecordCursor(List<Type> types, Iterator<?>[] valuesByField, RecordCursor cursor)
+    static void assertRecordCursor(List<Type> types, Iterator<?>[] valuesByField, RecordCursor cursor)
     {
         while (cursor.advanceNextPosition()) {
             for (int field = 0; field < types.size(); field++) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestAnonymizedParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestAnonymizedParquetReader.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.airlift.testing.TempFile;
+import com.facebook.presto.hive.FileFormatDataSourceStats;
+import com.facebook.presto.hive.HiveBatchPageSourceFactory;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveCommonClientConfig;
+import com.facebook.presto.hive.HiveStorageFormat;
+import com.facebook.presto.parquet.cache.MetadataReader;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.RecordPageSource;
+import com.facebook.presto.testing.TestingConnectorSession;
+import io.airlift.units.DataSize;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.parquet.anonymization.TestAnonymizationManager;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_AND_TYPE_MANAGER;
+import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_RESOLUTION;
+import static com.facebook.presto.hive.HiveTestUtils.HIVE_CLIENT_CONFIG;
+import static com.facebook.presto.hive.HiveTestUtils.METASTORE_CLIENT_CONFIG;
+import static com.facebook.presto.hive.HiveTestUtils.createTestHdfsEnvironment;
+import static com.facebook.presto.hive.HiveTestUtils.getAllSessionProperties;
+import static com.facebook.presto.hive.benchmark.FileFormat.createPageSource;
+import static com.facebook.presto.hive.parquet.ParquetTester.assertPageSource;
+import static com.facebook.presto.hive.parquet.ParquetTester.assertRecordCursor;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Iterables.cycle;
+import static com.google.common.collect.Iterables.limit;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.ZSTD;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestAnonymizedParquetReader
+{
+    // number of rows to expand test data and test with
+    private static final int TEST_ROWS = 9753;
+    private static final List<String> COLUMN_NAMES = asList("id", "last_name");
+    private static final List<com.facebook.presto.common.type.Type> COLUMN_TYPES = asList(INTEGER, VARCHAR);
+    private static final List<List<?>> values = asList(
+            asList(10, 20, null, 30),
+            asList("Johnson", "Priyanka", "Zhou", "", null));
+    private static final List<List<?>> expect = asList(
+            asList(10, 20, null, 30),
+            asList("Johnson", "Priyanka", "Zhou", "", null));
+    private static final List<List<?>> anonymizedExpect = asList(
+            asList(10, 20, null, 30),
+            asList("J****", "P****", "Z****", "", null));
+
+    @Test
+    public void writeAndReadParquet() throws Exception
+    {
+        MessageType schema = new MessageType("schema",
+                asList(new PrimitiveType(Type.Repetition.OPTIONAL, INT32, "id"),
+                        new PrimitiveType(Type.Repetition.OPTIONAL, BINARY, "last_name")));
+        List<BiConsumer<Group, Object>> groupAdd =
+                asList((g, v) -> g.add(COLUMN_NAMES.get(0), (Integer) v),
+                        (g, v) -> g.add(COLUMN_NAMES.get(1), (String) v));
+        // Expand provided values/expect to more rows
+        List<Iterable<?>> testValues = values.stream().map(column -> limit(cycle(column), TEST_ROWS))
+                .collect(Collectors.toList());
+        List<Iterable<?>> testExpect = expect.stream().map(column -> limit(cycle(column), TEST_ROWS))
+                .collect(Collectors.toList());
+        List<Iterable<?>> testAnonymizedExpect = anonymizedExpect.stream().map(column -> limit(cycle(column), TEST_ROWS))
+                .collect(Collectors.toList());
+        try (TempFile tmp = new TempFile()) {
+            File file = tmp.file();
+            checkArgument(COLUMN_TYPES.size() == groupAdd.size());
+            writeParquet(file, schema, groupAdd, iterators(testValues));
+            // No anonymization, read should match original values
+            assertRead(file, COLUMN_TYPES, COLUMN_NAMES, testExpect);
+            // Read anonymized values for the last name column
+            assertReadAnonymized(file, COLUMN_TYPES, COLUMN_NAMES, testAnonymizedExpect);
+        }
+    }
+
+    @Test
+    public void testAnonymizeNonStringColumns() throws Exception
+    {
+        MessageType schema = new MessageType("schema",
+                asList(new PrimitiveType(Type.Repetition.OPTIONAL, INT32, "age")));
+        List<BiConsumer<Group, Object>> groupAdd =
+                asList((g, v) -> g.add("age", (Integer) v));
+        List<List<?>> nonStringValues = asList(asList(10, 20, null, 30));
+        List<List<?>> nonStringExpected = asList(asList(10, 20, null, 30));
+        List<List<?>> nonStringAnonymizedExpected = asList(asList(10, 20, null, 30));
+        // Expand provided values/expect to more rows
+        List<Iterable<?>> testValues = nonStringValues.stream().map(column -> limit(cycle(column), TEST_ROWS))
+                .collect(Collectors.toList());
+        List<Iterable<?>> testExpect = nonStringExpected.stream().map(column -> limit(cycle(column), TEST_ROWS))
+                .collect(Collectors.toList());
+        List<Iterable<?>> testAnonymizedExpect = nonStringAnonymizedExpected.stream().map(column -> limit(cycle(column), TEST_ROWS))
+                .collect(Collectors.toList());
+        List<com.facebook.presto.common.type.Type> nonStringColumnTypes = asList(INTEGER);
+        List<String> nonStringColumnNames = asList("age");
+        try (TempFile tmp = new TempFile()) {
+            File file = tmp.file();
+            checkArgument(nonStringColumnTypes.size() == groupAdd.size());
+            writeParquet(file, schema, groupAdd, iterators(testValues));
+            // No anonymization, read should match original values
+            assertRead(file, nonStringColumnTypes, nonStringColumnNames, testExpect);
+            // Read anonymized values for the last name column
+            assertReadAnonymized(file, nonStringColumnTypes, nonStringColumnNames, testAnonymizedExpect);
+        }
+        catch (UnsupportedOperationException e) {
+            // Verify the exception message
+            assertEquals(e.getMessage(), "Only string column anonymization is supported. Column age is of type INT32");
+        }
+    }
+
+    void writeParquet(
+            File outputFile,
+            MessageType schema,
+            List<BiConsumer<Group, Object>> groupAdd,
+            Iterator<?>[] values)
+            throws Exception
+    {
+        JobConf jobConf = new JobConf();
+        GroupWriteSupport.setSchema(schema, jobConf);
+        try (ParquetWriter<Group> writer = ExampleParquetWriter
+                .builder(new Path(outputFile.toURI()))
+                .withWriteMode(OVERWRITE)
+                .withType(schema)
+                .withCompressionCodec(ZSTD)
+                .withConf(jobConf)
+                .withDictionaryEncoding(true)
+                .build()) {
+            SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+            while (stream(values).allMatch(Iterator::hasNext)) {
+                Group group = groupFactory.newGroup();
+                for (int i = 0; i < values.length; i++) {
+                    Object value = values[i].next();
+                    if (value == null) {
+                        continue;
+                    }
+                    groupAdd.get(i).accept(group, value);
+                }
+                writer.write(group);
+            }
+        }
+    }
+
+    void assertRead(File file,
+                    List<com.facebook.presto.common.type.Type> types,
+                    List<String> columnNames, List<Iterable<?>> expect)
+            throws Exception
+    {
+        HiveClientConfig config = new HiveClientConfig()
+                .setHiveStorageFormat(HiveStorageFormat.PARQUET);
+        HiveCommonClientConfig commonConfig = new HiveCommonClientConfig()
+                .setUseParquetColumnNames(true)
+                .setParquetMaxReadBlockSize(new DataSize(1_000, DataSize.Unit.BYTE));
+        ConnectorSession session = new TestingConnectorSession(getAllSessionProperties(config, commonConfig));
+        HiveBatchPageSourceFactory pageSourceFactory = getPageSourceFactory();
+        try (ConnectorPageSource connectorPageSource = createPageSource(
+                pageSourceFactory, session, file, columnNames, types, HiveStorageFormat.PARQUET, 0L)) {
+            Iterator<?>[] expected = iterators(expect);
+            if (connectorPageSource instanceof RecordPageSource) {
+                assertRecordCursor(
+                        types, expected, ((RecordPageSource) connectorPageSource).getCursor());
+            }
+            else {
+                assertPageSource(types, expected, connectorPageSource, Optional.empty());
+            }
+            assertFalse(stream(expected).anyMatch(Iterator::hasNext));
+        }
+    }
+
+    void assertReadAnonymized(File file,
+                              List<com.facebook.presto.common.type.Type> types,
+                              List<String> columnNames, List<Iterable<?>> expect)
+            throws Exception
+    {
+        HiveClientConfig config = new HiveClientConfig()
+                .setHiveStorageFormat(HiveStorageFormat.PARQUET);
+        HiveCommonClientConfig commonConfig = new HiveCommonClientConfig()
+                .setUseParquetColumnNames(true)
+                .setParquetMaxReadBlockSize(new DataSize(1_000, DataSize.Unit.BYTE))
+                // Enable anonymization read
+                .setParquetAnonymizationEnabled(true)
+                .setParquetAnonymizationManagerClass(TestAnonymizationManager.class.getName());
+        ConnectorSession session = new TestingConnectorSession(getAllSessionProperties(config, commonConfig));
+        HiveBatchPageSourceFactory pageSourceFactory = getPageSourceFactory();
+        try (ConnectorPageSource connectorPageSource = createPageSource(
+                pageSourceFactory, session, file, columnNames, types, HiveStorageFormat.PARQUET, 0L)) {
+            Iterator<?>[] expected = iterators(expect);
+            if (connectorPageSource instanceof RecordPageSource) {
+                assertRecordCursor(
+                        types, expected, ((RecordPageSource) connectorPageSource).getCursor());
+            }
+            else {
+                assertPageSource(types, expected, connectorPageSource, Optional.empty());
+            }
+            assertFalse(stream(expected).anyMatch(Iterator::hasNext));
+        }
+    }
+
+    Iterator<?>[] iterators(List<Iterable<?>> values)
+    {
+        return values.stream().map(Iterable::iterator).toArray(Iterator[]::new);
+    }
+
+    HiveBatchPageSourceFactory getPageSourceFactory()
+    {
+        // testHdfsEnvironment from this test suite adds auth check
+        return new ParquetPageSourceFactory(
+                FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, createTestHdfsEnvironment(HIVE_CLIENT_CONFIG, METASTORE_CLIENT_CONFIG),
+                new FileFormatDataSourceStats(), new MetadataReader());
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetReaderMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetReaderMemoryTracking.java
@@ -122,6 +122,7 @@ public class TestParquetReaderMemoryTracking
                 null,
                 null,
                 false,
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPageSourceProvider.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiPageSourceProvider.java
@@ -107,7 +107,8 @@ public class HudiPageSourceProvider
                     baseFile.getLength(),
                     dataColumns,
                     TupleDomain.all(), // TODO: predicates
-                    fileFormatDataSourceStats);
+                    fileFormatDataSourceStats,
+                    layout.getTable().getSchemaTableName());
         }
         else if (tableType == HudiTableType.MOR) {
             Properties schema = getHiveSchema(

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/AnonymizedColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/AnonymizedColumnReader.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.parquet.PrimitiveField;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.parquet.anonymization.AnonymizationManager;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.schema.PrimitiveType;
+
+import java.io.IOException;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+
+public class AnonymizedColumnReader
+        implements PrimitiveColumnReader
+{
+    private final PrimitiveColumnReader reader;
+    private final AnonymizationManager anonymizationManager;
+    public AnonymizedColumnReader(
+            PrimitiveColumnReader reader,
+            AnonymizationManager anonymizationManager)
+    {
+        this.reader = reader;
+        this.anonymizationManager = anonymizationManager;
+    }
+    @Override
+    public ColumnChunk read(PrimitiveField field) throws IOException
+    {
+        ColumnChunk originalChunk = reader.read(field);
+        ColumnPath columnPath = ColumnPath.get(field.getDescriptor().getPath());
+        boolean shouldAnonymize = this.anonymizationManager.shouldAnonymize(columnPath);
+        if (!shouldAnonymize) {
+            return originalChunk;
+        }
+        Block originalBlock = originalChunk.getBlock();
+        BlockBuilder newBlockBuilder = field.getType().createBlockBuilder(null, originalBlock.getPositionCount());
+        for (int position = 0; position < originalBlock.getPositionCount(); position++) {
+            if (!originalBlock.isNull(position)) {
+                Type type = field.getType();
+                PrimitiveType primitiveType = field.getDescriptor().getPrimitiveType();
+                if (!primitiveType.getPrimitiveTypeName().equals(BINARY)) {
+                    // TODO: Support other types in this reader to remove this check
+                    String errorMessage = String.format("Only string column anonymization is supported. Column %s is of type %s",
+                            columnPath.toDotString(), primitiveType.getPrimitiveTypeName());
+                    throw new UnsupportedOperationException(errorMessage);
+                }
+                Slice slice = type.getSlice(originalBlock, position);
+                String originalString = slice.toStringUtf8();
+                String anonymizedString = this.anonymizationManager.anonymize(columnPath, originalString);
+                type.writeSlice(newBlockBuilder, Slices.utf8Slice(anonymizedString));
+            }
+            else {
+                newBlockBuilder.appendNull();
+            }
+        }
+        return new ColumnChunk(newBlockBuilder.build(), originalChunk.getDefinitionLevels(),
+                originalChunk.getRepetitionLevels());
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/PrimitiveColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/PrimitiveColumnReader.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import com.facebook.presto.parquet.PrimitiveField;
+
+import java.io.IOException;
+
+interface PrimitiveColumnReader
+{
+    ColumnChunk read(PrimitiveField field)
+            throws IOException;
+}

--- a/presto-parquet/src/main/java/org/apache/parquet/anonymization/AnonymizationManager.java
+++ b/presto-parquet/src/main/java/org/apache/parquet/anonymization/AnonymizationManager.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.anonymization;
+
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+public interface AnonymizationManager
+{
+    String UNSUPPORTED_ERR_MSG = "Anonymization is currently only supported on String types";
+
+    boolean shouldAnonymize(ColumnPath columnPath);
+
+    String anonymize(ColumnPath columnPath, String value);
+
+    default float anonymize(ColumnPath columnPath, float value)
+    {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MSG);
+    }
+
+    default int anonymize(ColumnPath columnPath, int value)
+    {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MSG);
+    }
+
+    default double anonymize(ColumnPath columnPath, double value)
+    {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MSG);
+    }
+
+    default long anonymize(ColumnPath columnPath, long value)
+    {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MSG);
+    }
+
+    default boolean anonymize(ColumnPath columnPath, boolean value)
+    {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MSG);
+    }
+}

--- a/presto-parquet/src/main/java/org/apache/parquet/anonymization/AnonymizationManagerFactory.java
+++ b/presto-parquet/src/main/java/org/apache/parquet/anonymization/AnonymizationManagerFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.anonymization;
+
+import com.facebook.presto.spi.PrestoException;
+import org.apache.hadoop.conf.Configuration;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class AnonymizationManagerFactory
+{
+    private AnonymizationManagerFactory() {}
+
+    public static Optional<AnonymizationManager> getAnonymizationManager(String managerClassName,
+                                                                         Configuration conf,
+                                                                         String tableName)
+            throws PrestoException
+    {
+        try {
+            managerClassName = managerClassName == null ? "" : managerClassName.trim();
+
+            if (managerClassName.isEmpty()) {
+                throw new IllegalStateException("Anonymization manager class not specified");
+            }
+
+            Class<?> clazz = Class.forName(managerClassName);
+
+            // Ensure the class implements AnonymizationManager
+            if (!AnonymizationManager.class.isAssignableFrom(clazz)) {
+                throw new IllegalStateException("Invalid anonymization manager class: " + managerClassName);
+            }
+
+            @SuppressWarnings("unchecked")
+            Class<? extends AnonymizationManager> managerClass =
+                    (Class<? extends AnonymizationManager>) clazz;
+
+            // Instantiate using the static create method
+            Method createMethod = managerClass.getMethod("create", Configuration.class, String.class);
+            AnonymizationManager manager = (AnonymizationManager) createMethod.invoke(null, conf, tableName);
+
+            return Optional.of(manager);
+        }
+        catch (InvocationTargetException e) {
+            Throwable targetException = e.getTargetException();
+            throw new IllegalStateException("Failed to create anonymization manager: " + targetException.getMessage(), targetException);
+        }
+        catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Anonymization manager class not found: " + e.getMessage(), e);
+        }
+        catch (Exception e) {
+            throw new IllegalStateException("Failed to create anonymization manager: " + e.getMessage(), e);
+        }
+    }
+}

--- a/presto-parquet/src/main/java/org/apache/parquet/anonymization/TestAnonymizationManager.java
+++ b/presto-parquet/src/main/java/org/apache/parquet/anonymization/TestAnonymizationManager.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.anonymization;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+/**
+ * This is a test implementation of the AnonymizationManager interface.
+ * It will anonymize any column named "last_name" by taking the first letter of the value
+ * and replacing the rest with stars.
+ * It is used for testing purposes only.
+ */
+public class TestAnonymizationManager
+        implements AnonymizationManager
+{
+    public static AnonymizationManager create(Configuration conf, String tableName)
+    {
+        return new TestAnonymizationManager();
+    }
+
+    @Override
+    public boolean shouldAnonymize(ColumnPath columnPath)
+    {
+        // Matches last_name
+        return columnPath.toDotString().equals("last_name");
+    }
+
+    @Override
+    public String anonymize(ColumnPath columnPath, String value)
+    {
+        // This is a trivial anonymization method for testing purposes
+        if (shouldAnonymize(columnPath)) {
+            if (value == null || value.isEmpty()) {
+                return value;
+            }
+            // Take first letter of value and star the rest
+            return value.charAt(0) + "****";
+        }
+        return value;
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
@@ -309,7 +309,7 @@ public class BenchmarkParquetReader
 
             this.field = ColumnIOConverter.constructField(getType(), messageColumnIO.getChild(0)).get();
 
-            return new ParquetReader(messageColumnIO, parquetMetadata.getBlocks(), Optional.empty(), dataSource, newSimpleAggregatedMemoryContext(), new DataSize(16, MEGABYTE), enableBatchReader, enableVerification, null, null, false, Optional.empty());
+            return new ParquetReader(messageColumnIO, parquetMetadata.getBlocks(), Optional.empty(), dataSource, newSimpleAggregatedMemoryContext(), new DataSize(16, MEGABYTE), enableBatchReader, enableVerification, null, null, false, Optional.empty(), Optional.empty());
         }
 
         protected boolean getNullability()

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkDecimalColumnBatchReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/BenchmarkDecimalColumnBatchReader.java
@@ -440,6 +440,7 @@ public class BenchmarkDecimalColumnBatchReader
                     null,
                     null,
                     false,
+                    Optional.empty(),
                     Optional.empty());
         }
 

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestAnonymizedColumnReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestAnonymizedColumnReader.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.parquet.PrimitiveField;
+import com.facebook.presto.parquet.RichColumnDescriptor;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.parquet.anonymization.AnonymizationManager;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.schema.PrimitiveType;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class TestAnonymizedColumnReader
+{
+    private PrimitiveField binaryField;
+    private PrimitiveField longField;
+
+    private FakePrimitiveColumnReader delegateReader;
+    private FakeAnonymizationManager anonymizationManager;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        delegateReader = new FakePrimitiveColumnReader();
+        anonymizationManager = new FakeAnonymizationManager();
+
+        PrimitiveType binaryPrimitiveType = new PrimitiveType(
+                PrimitiveType.Repetition.OPTIONAL,
+                BINARY,
+                "string_col");
+
+        PrimitiveType longPrimitiveType = new PrimitiveType(
+                PrimitiveType.Repetition.OPTIONAL,
+                INT64,
+                "long_col");
+
+        binaryField = new PrimitiveField(
+                VarcharType.VARCHAR,
+                0,
+                0,
+                false,
+                new RichColumnDescriptor(
+                        new org.apache.parquet.column.ColumnDescriptor(
+                                new String[]{"string_col"}, BINARY, 0, 0),
+                        binaryPrimitiveType),
+                0);
+
+        longField = new PrimitiveField(
+                VarcharType.VARCHAR,
+                0,
+                0,
+                false,
+                new RichColumnDescriptor(
+                        new org.apache.parquet.column.ColumnDescriptor(
+                                new String[]{"long_col"}, INT64, 0, 0),
+                        longPrimitiveType),
+                1);
+    }
+
+    /**
+     * Test that anonymization occurs for a BINARY column
+     * when the manager indicates it should be anonymized.
+     */
+    @Test
+    public void testAnonymizeStringColumn() throws IOException
+    {
+        // Indicate the manager should anonymize "string_col"
+        anonymizationManager.setShouldAnonymize("string_col", true);
+        // Provide a simple transformation for demonstration
+        anonymizationManager.setAnonymizeMapping("string_col", "alice", "masked_alice");
+        anonymizationManager.setAnonymizeMapping("string_col", "bob", "masked_bob");
+
+        // Build a block with two string values
+        BlockBuilder blockBuilder = VarcharType.VARCHAR.createBlockBuilder(null, 2);
+        VarcharType.VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice("alice"));
+        VarcharType.VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice("bob"));
+        Block inputBlock = blockBuilder.build();
+
+        ColumnChunk delegateChunk = new ColumnChunk(inputBlock, new int[2], new int[2]);
+        delegateReader.setChunkToReturn(delegateChunk);
+
+        AnonymizedColumnReader anonymizedReader = new AnonymizedColumnReader(delegateReader, anonymizationManager);
+        ColumnChunk resultChunk = anonymizedReader.read(binaryField);
+
+        assertEquals(delegateReader.getReadCallCount(), 1);
+
+        Block resultBlock = resultChunk.getBlock();
+        assertEquals(resultBlock.getPositionCount(), 2);
+        Slice slice0 = VarcharType.VARCHAR.getSlice(resultBlock, 0);
+        Slice slice1 = VarcharType.VARCHAR.getSlice(resultBlock, 1);
+
+        assertEquals(slice0.toStringUtf8(), "masked_alice");
+        assertEquals(slice1.toStringUtf8(), "masked_bob");
+    }
+
+    /**
+     * Test that if manager says "do not anonymize," the data is unchanged.
+     */
+    @Test
+    public void testNoAnonymizationOnStringColumn() throws IOException
+    {
+        // Mark "string_col" as not to be anonymized
+        anonymizationManager.setShouldAnonymize("string_col", false);
+
+        // Build a block with one string
+        BlockBuilder blockBuilder = VarcharType.VARCHAR.createBlockBuilder(null, 1);
+        VarcharType.VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice("some_value"));
+        Block inputBlock = blockBuilder.build();
+
+        ColumnChunk delegateChunk = new ColumnChunk(inputBlock, new int[1], new int[1]);
+        delegateReader.setChunkToReturn(delegateChunk);
+        AnonymizedColumnReader anonymizedReader = new AnonymizedColumnReader(delegateReader, anonymizationManager);
+        ColumnChunk resultChunk = anonymizedReader.read(binaryField);
+
+        assertEquals(delegateReader.getReadCallCount(), 1);
+
+        // Check data is intact
+        Block resultBlock = resultChunk.getBlock();
+        assertEquals(resultBlock.getPositionCount(), 1);
+        Slice slice = VarcharType.VARCHAR.getSlice(resultBlock, 0);
+        assertEquals(slice.toStringUtf8(), "some_value");
+    }
+
+    /**
+     * Test that reading a non-BINARY field that "should be anonymized"
+     * triggers an exception in the current implementation.
+     */
+    @Test
+    public void testAnonymizeUnsupportedTypeThrowsException() throws IOException
+    {
+        // Indicate we want to anonymize "long_col"
+        anonymizationManager.setShouldAnonymize("long_col", true);
+
+        // Create a block with one row, for demonstration
+        BlockBuilder blockBuilder = VarcharType.VARCHAR.createBlockBuilder(null, 1);
+        VarcharType.VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice("12345"));
+        Block inputBlock = blockBuilder.build();
+
+        // Provide to delegate
+        ColumnChunk delegateChunk = new ColumnChunk(inputBlock, new int[1], new int[1]);
+        delegateReader.setChunkToReturn(delegateChunk);
+
+        // Wrap in anonymized reader
+        AnonymizedColumnReader anonymizedReader = new AnonymizedColumnReader(delegateReader, anonymizationManager);
+
+        // We expect an UnsupportedOperationException because AnonymizedColumnReader
+        // currently only supports BINARY.
+        assertThrows(UnsupportedOperationException.class, () -> anonymizedReader.read(longField));
+    }
+
+    /**
+     * Fake implementation of PrimitiveColumnReader that lets us
+     * specify a single ColumnChunk to return and track how many times
+     * read(...) has been called.
+     */
+    private static class FakePrimitiveColumnReader
+            implements PrimitiveColumnReader
+    {
+        private ColumnChunk chunkToReturn;
+        private int readCallCount;
+
+        public void setChunkToReturn(ColumnChunk chunk)
+        {
+            this.chunkToReturn = chunk;
+        }
+
+        public int getReadCallCount()
+        {
+            return readCallCount;
+        }
+
+        @Override
+        public ColumnChunk read(PrimitiveField field) throws IOException
+        {
+            readCallCount++;
+            return chunkToReturn;
+        }
+    }
+
+    /**
+     * A simple test/dummy AnonymizationManager that holds a map
+     * of (column -> shouldAnonymize), plus an optional map of
+     * (column + originalValue -> anonymizedValue).
+     */
+    private static class FakeAnonymizationManager
+            implements AnonymizationManager
+    {
+        // For each column name, store whether it should be anonymized
+        private final Map<String, Boolean> anonymizeMap = new HashMap<>();
+        // For each (columnName + originalValue), store the anonymized text
+        private final Map<String, Map<String, String>> columnValueMapping = new HashMap<>();
+
+        public void setShouldAnonymize(String columnName, boolean shouldAnonymize)
+        {
+            anonymizeMap.put(columnName, shouldAnonymize);
+        }
+
+        public void setAnonymizeMapping(String columnName, String original, String anonymized)
+        {
+            columnValueMapping.computeIfAbsent(columnName, k -> new HashMap<>()).put(original, anonymized);
+        }
+
+        @Override
+        public boolean shouldAnonymize(ColumnPath columnPath)
+        {
+            // e.g., columnPath.toDotString() => "string_col" / "long_col"
+            return anonymizeMap.getOrDefault(columnPath.toDotString(), false);
+        }
+
+        @Override
+        public String anonymize(ColumnPath columnPath, String value)
+        {
+            String columnName = columnPath.toDotString();
+            if (!columnValueMapping.containsKey(columnName)) {
+                // If no mapping is defined, just do a trivial replacement
+                return "MASKED_" + value;
+            }
+            return columnValueMapping.get(columnName).getOrDefault(value, "MASKED_" + value);
+        }
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestEncryption.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestEncryption.java
@@ -539,6 +539,7 @@ public class TestEncryption
                 null,
                 null,
                 false,
-                fileDecryptor);
+                fileDecryptor,
+                Optional.empty());
     }
 }

--- a/presto-parquet/src/test/java/org/apache/parquet/anonymization/TestAnonymizationManagerFactory.java
+++ b/presto-parquet/src/test/java/org/apache/parquet/anonymization/TestAnonymizationManagerFactory.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.anonymization;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestAnonymizationManagerFactory
+{
+    private Configuration conf;
+    private static final String TEST_TABLE = "test_table";
+
+    @BeforeClass
+    public void setUp()
+    {
+        conf = new Configuration();
+    }
+
+    // Test valid implementation
+    @Test
+    public void testValidManagerCreation()
+    {
+        Optional<AnonymizationManager> manager = AnonymizationManagerFactory.getAnonymizationManager(
+                ValidTestManager.class.getName(),
+                conf,
+                TEST_TABLE);
+
+        assertTrue(manager.isPresent(), "Manager should be present");
+        assertTrue(manager.get() instanceof ValidTestManager,
+                "Manager should be instance of ValidTestManager");
+    }
+
+    @Test
+    public void testNullManagerClass()
+    {
+        try {
+            AnonymizationManagerFactory.getAnonymizationManager(null, conf, TEST_TABLE);
+            fail("Expected IllegalStateException to be thrown");
+        }
+        catch (IllegalStateException e) {
+            assertEquals("Failed to create anonymization manager:" +
+                    " Anonymization manager class not specified", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testEmptyManagerClass()
+    {
+        try {
+            AnonymizationManagerFactory.getAnonymizationManager("  ", conf, TEST_TABLE);
+            fail("Expected IllegalStateException to be thrown");
+        }
+        catch (IllegalStateException e) {
+            assertEquals("Failed to create anonymization manager:" +
+                    " Anonymization manager class not specified", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNonExistentManagerClass()
+    {
+        String nonExistentClass = "com.nonexistent.Manager";
+        try {
+            AnonymizationManagerFactory.getAnonymizationManager(
+                    nonExistentClass,
+                    conf,
+                    TEST_TABLE);
+            fail("Expected IllegalArgumentException to be thrown");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("Anonymization manager class not found"));
+            assertTrue(e.getCause() instanceof ClassNotFoundException);
+        }
+    }
+
+    @Test
+    public void testInvalidManagerImplementation()
+    {
+        try {
+            AnonymizationManagerFactory.getAnonymizationManager(
+                    String.class.getName(),
+                    conf,
+                    TEST_TABLE);
+            fail("Expected IllegalStateException to be thrown");
+        }
+        catch (IllegalStateException e) {
+            assertEquals("Failed to create anonymization manager:" +
+                            " Invalid anonymization manager class: " + String.class.getName(),
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void testFailingCreateMethod()
+    {
+        try {
+            AnonymizationManagerFactory.getAnonymizationManager(
+                    FailingTestManager.class.getName(),
+                    conf,
+                    TEST_TABLE);
+            fail("Expected IllegalStateException to be thrown");
+        }
+        catch (IllegalStateException e) {
+            assertTrue(e.getMessage().startsWith("Failed to create anonymization manager"));
+            assertTrue(e.getCause() instanceof RuntimeException);
+        }
+    }
+
+    // Valid test implementation
+    public static class ValidTestManager
+            implements AnonymizationManager
+    {
+        public static ValidTestManager create(Configuration conf, String tableName)
+        {
+            return new ValidTestManager();
+        }
+
+        @Override
+        public boolean shouldAnonymize(ColumnPath columnPath)
+        {
+            return false;
+        }
+
+        @Override
+        public String anonymize(ColumnPath columnPath, String value)
+        {
+            return "";
+        }
+    }
+
+    // Implementation with failing create method
+    public static class FailingTestManager
+            implements AnonymizationManager
+    {
+        public static FailingTestManager create(Configuration conf, String tableName)
+        {
+            throw new RuntimeException("Failed to create manager");
+        }
+
+        @Override
+        public boolean shouldAnonymize(ColumnPath columnPath)
+        {
+            return false;
+        }
+
+        @Override
+        public String anonymize(ColumnPath columnPath, String value)
+        {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
## Description
This patch introduces a pluggable data anonymization feature into Presto, enabling on the fly column-level anonymization (e.g., redacting, hashing or any other transformation on sensitive data) when reading Parquet files.

The changes add two new configuration properties (enable-parquet-anonymization and parquet-anonymization-manager-class) and implements a new AnonymizedColumnReader in the Parquet module that is activated when parquet_anonymization is enabled. 

The design allows users to plug in custom anonymization managers to control how specific columns (e.g., PII) are transformed before being returned to the user.

## Motivation and Context
Limiting sensitive data exposure is a growing concern, and we wanted a way to redact / obfuscate certain columns' data by default. 
Particularly we use this for hash anonymization where hashed values can be used to join / count / group by without actually revealing the values. We can also use this to redact (i.e. replace values with *** partially). 

## Impact
New session properties:
enable_parquet_anonymization (boolean) – controls whether anonymization is enabled - default false.
parquet_anonymization_manager_class (string) – specifies the fully qualified class name of the anonymization manager - default empty.

When anonymization is disabled, performance remains unchanged and parquet reading is not affected at all.
When anonymization is enabled, minimal impact based on how many columns have anonymization enabled and what type of transformation your anonymizationManager is doing (i.e hashing values has higher impact while redacting strings "John" -> "J***" is marginal). 

## Test Plan
Added comprehensive tests in TestAnonymizedParquetReader and TestAnonymizedColumnReader to verify that:
Data is correctly anonymized when enabled.
Non-anonymized reads return original values.

We also have deployed this at scale at Uber since October.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Added pluggable data anonymization support for reading Parquet in Presto.
* Added new session properties: `enable_parquet_anonymization` and `parquet_anonymization_manager_class` to control anonymization behavior.
```

