### PR TITLE
Add support to disable task update size tracking

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -51,6 +51,7 @@ public class TaskManagerConfig
     private boolean statisticsCpuTimerEnabled = true;
     private boolean perOperatorAllocationTrackingEnabled;
     private boolean taskAllocationTrackingEnabled;
+    private boolean taskUpdateSizeTrackingEnabled = true;
     private DataSize maxPartialAggregationMemoryUsage = new DataSize(16, Unit.MEGABYTE);
     private DataSize maxLocalExchangeBufferSize = new DataSize(32, Unit.MEGABYTE);
     private DataSize maxIndexMemoryUsage = new DataSize(64, Unit.MEGABYTE);
@@ -664,6 +665,18 @@ public class TaskManagerConfig
     public TaskManagerConfig setHighMemoryTaskKillerStrategy(HighMemoryTaskKillerStrategy highMemoryTaskKillerStrategy)
     {
         this.highMemoryTaskKillerStrategy = highMemoryTaskKillerStrategy;
+        return this;
+    }
+
+    public boolean isTaskUpdateSizeTrackingEnabled()
+    {
+        return taskUpdateSizeTrackingEnabled;
+    }
+
+    @Config("task.update-size-tracking-enabled")
+    public TaskManagerConfig setTaskUpdateSizeTrackingEnabled(boolean taskUpdateSizeTrackingEnabled)
+    {
+        this.taskUpdateSizeTrackingEnabled = taskUpdateSizeTrackingEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -94,6 +94,7 @@ public class HttpRemoteTaskFactory
     private final MetadataManager metadataManager;
     private final QueryManager queryManager;
     private final DecayCounter taskUpdateRequestSize;
+    private final boolean taskUpdateSizeTrackingEnabled;
     private final EventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(Runtime.getRuntime().availableProcessors(),
             new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build())
     {
@@ -180,6 +181,7 @@ public class HttpRemoteTaskFactory
         this.queryManager = queryManager;
 
         this.taskUpdateRequestSize = new DecayCounter(ExponentialDecay.oneMinute());
+        this.taskUpdateSizeTrackingEnabled = taskConfig.isTaskUpdateSizeTrackingEnabled();
     }
 
     @Managed
@@ -239,6 +241,7 @@ public class HttpRemoteTaskFactory
                 metadataManager,
                 queryManager,
                 taskUpdateRequestSize,
+                taskUpdateSizeTrackingEnabled,
                 handleResolver,
                 connectorTypeSerdeManager,
                 schedulerStatsTracker,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -77,7 +77,8 @@ public class TestTaskManagerConfig
                 .setHighMemoryTaskKillerStrategy(HighMemoryTaskKillerStrategy.FREE_MEMORY_ON_FULL_GC)
                 .setHighMemoryTaskKillerGCReclaimMemoryThreshold(0.01)
                 .setHighMemoryTaskKillerFrequentFullGCDurationThreshold(new Duration(1, SECONDS))
-                .setHighMemoryTaskKillerHeapMemoryThreshold(0.9));
+                .setHighMemoryTaskKillerHeapMemoryThreshold(0.9)
+                .setTaskUpdateSizeTrackingEnabled(true));
     }
 
     @Test
@@ -125,6 +126,7 @@ public class TestTaskManagerConfig
                 .put("experimental.task.high-memory-task-killer-reclaim-memory-threshold", "0.8")
                 .put("experimental.task.high-memory-task-killer-frequent-full-gc-duration-threshold", "2s")
                 .put("experimental.task.high-memory-task-killer-heap-memory-threshold", "0.8")
+                .put("task.update-size-tracking-enabled", "false")
                 .build();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -168,7 +170,8 @@ public class TestTaskManagerConfig
                 .setHighMemoryTaskKillerStrategy(HighMemoryTaskKillerStrategy.FREE_MEMORY_ON_FREQUENT_FULL_GC)
                 .setHighMemoryTaskKillerGCReclaimMemoryThreshold(0.8)
                 .setHighMemoryTaskKillerFrequentFullGCDurationThreshold(new Duration(2, SECONDS))
-                .setHighMemoryTaskKillerHeapMemoryThreshold(0.8);
+                .setHighMemoryTaskKillerHeapMemoryThreshold(0.8)
+                .setTaskUpdateSizeTrackingEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
Add support to disable task update size tracking

## Motivation and Context
During some profiling, when the cluster is running hot, there is contention when trying to update the taskupdate size stats, as it is a synchronized method. So this PR is to have the ability to disable this task update size tracking. 

## Impact
None

## Test Plan
Existing tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

