### PR TITLE
Make the number of task event loop configurable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -70,7 +70,7 @@ public class QueryManagerConfig
     private int queryManagerExecutorPoolSize = 5;
 
     private Duration remoteTaskMaxErrorDuration = new Duration(5, TimeUnit.MINUTES);
-    private int remoteTaskMaxCallbackThreads = 1000;
+    private int remoteTaskMaxCallbackThreads = Runtime.getRuntime().availableProcessors();
 
     private String queryExecutionPolicy = "all-at-once";
     private Duration queryMaxRunTime = new Duration(100, TimeUnit.DAYS);

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -95,15 +95,7 @@ public class HttpRemoteTaskFactory
     private final QueryManager queryManager;
     private final DecayCounter taskUpdateRequestSize;
     private final boolean taskUpdateSizeTrackingEnabled;
-    private final EventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(Runtime.getRuntime().availableProcessors(),
-            new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build())
-    {
-        @Override
-        protected EventLoop newChild(Executor executor, Object... args)
-        {
-            return new SafeEventLoop(this, executor);
-        }
-    };
+    private final EventLoopGroup eventLoopGroup;
 
     @Inject
     public HttpRemoteTaskFactory(
@@ -182,6 +174,15 @@ public class HttpRemoteTaskFactory
 
         this.taskUpdateRequestSize = new DecayCounter(ExponentialDecay.oneMinute());
         this.taskUpdateSizeTrackingEnabled = taskConfig.isTaskUpdateSizeTrackingEnabled();
+        this.eventLoopGroup = new DefaultEventLoopGroup(config.getRemoteTaskMaxCallbackThreads(),
+                new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build())
+        {
+            @Override
+            protected EventLoop newChild(Executor executor, Object... args)
+            {
+                return new SafeEventLoop(this, executor);
+            }
+        };
     }
 
     @Managed

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -59,7 +59,7 @@ public class TestQueryManagerConfig
                 .setQueryManagerExecutorPoolSize(5)
                 .setRemoteTaskMinErrorDuration(new Duration(5, TimeUnit.MINUTES))
                 .setRemoteTaskMaxErrorDuration(new Duration(5, TimeUnit.MINUTES))
-                .setRemoteTaskMaxCallbackThreads(1000)
+                .setRemoteTaskMaxCallbackThreads(Runtime.getRuntime().availableProcessors())
                 .setQueryExecutionPolicy("all-at-once")
                 .setQueryMaxRunTime(new Duration(100, TimeUnit.DAYS))
                 .setQueryMaxExecutionTime(new Duration(100, TimeUnit.DAYS))


### PR DESCRIPTION
## Description
1. This pr makes the number of task event loop within the group configurable via the configuration file

## Motivation and Context
1. We saw event loop can get blocked while the underlying http connections are also being blocked
2. This pr makes the number of event loop configurable to reduce the chance of getting blocked while still uses the number of cores as default value

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. Deployed in pnb2_verifier_t1_1 with a configuration value of 500 for query replay
2. Confirm the config is updated
<img width="997" alt="Screenshot 2025-02-13 at 20 58 51" src="https://github.com/user-attachments/assets/17af06ae-318d-45ef-a385-9c63f41d9782" />

4. Confirm 500 task event loop are being used in coordinator
<img width="1278" alt="Screenshot 2025-02-13 at 21 42 10" src="https://github.com/user-attachments/assets/18e8b865-2262-47bb-9627-fe2850ff8721" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Make the number of task event loop configurable via a configuration file
```



