### PR TITLE
Remove synchronized access for PlanFragment.bytesForTaskSerialization()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
@@ -165,7 +165,7 @@ public class PlanFragment
 
     // Serialize this plan fragment with the provided codec, caching the results
     // This should be used when serializing the fragment to send to worker nodes.
-    public synchronized byte[] bytesForTaskSerialization(Codec<PlanFragment> codec)
+    public byte[] bytesForTaskSerialization(Codec<PlanFragment> codec)
     {
         requireNonNull(codec, "codec is null");
         if (cachedSerialization != null) {


### PR DESCRIPTION
## Description
Remove synchronized access for PlanFragment.bytesForTaskSerialization() to reduce contention

## Motivation and Context
During lock profiling when coordinator is running hot, we observed contention for PlanFragment.bytesForTaskSerialization(). This method does not need synchronized access. byte[] cachedSerialization is gated by " @GuardedBy("this")" so its thread safe. Also once the serialized plan is cached, making only one thread access it a time makes no sense. 
<img width="540" alt="langThread run (100)" src="https://github.com/user-attachments/assets/29c8f751-c9a5-4442-babf-32fddc0fac65" />


## Impact
None

## Test Plan
existing unit tests and verifier testing

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

