### PR TITLE
[native] Enable node pool type specification when reporting to the coordinator from a C++ worker 

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -30,6 +30,7 @@ std::string announcementBody(
     const std::string& nodeVersion,
     const std::string& environment,
     const std::string& nodeLocation,
+    const std::string& nodePoolType,
     const bool sidecar,
     const std::vector<std::string>& connectorIds) {
   std::string id =
@@ -49,6 +50,7 @@ std::string announcementBody(
            {"coordinator", false},
            {"sidecar", sidecar},
            {"connectorIds", folly::join(',', connectorIds)},
+           {"pool_type", nodePoolType},
            {uriScheme,
             fmt::format("{}://{}:{}", uriScheme, address, port)}}}}}}};
   return body.dump();
@@ -81,6 +83,7 @@ Announcer::Announcer(
     const std::string& environment,
     const std::string& nodeId,
     const std::string& nodeLocation,
+    const std::string& nodePoolType,
     const bool sidecar,
     const std::vector<std::string>& connectorIds,
     const uint64_t maxFrequencyMs,
@@ -99,6 +102,7 @@ Announcer::Announcer(
           nodeVersion,
           environment,
           nodeLocation,
+          nodePoolType,
           sidecar,
           connectorIds)),
       announcementRequest_(

--- a/presto-native-execution/presto_cpp/main/Announcer.h
+++ b/presto-native-execution/presto_cpp/main/Announcer.h
@@ -31,6 +31,7 @@ class Announcer : public PeriodicServiceInventoryManager {
       const std::string& environment,
       const std::string& nodeId,
       const std::string& nodeLocation,
+      const std::string& nodePoolType,
       const bool sidecar,
       const std::vector<std::string>& connectorIds,
       const uint64_t maxFrequencyMs_,

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -241,6 +241,7 @@ void PrestoServer::run() {
       address_ = fmt::format("[{}]", address_);
     }
     nodeLocation_ = nodeConfig->nodeLocation();
+    nodePoolType_ = systemConfig->poolType();
     prestoBuiltinFunctionPrefix_ = systemConfig->prestoDefaultNamespacePrefix();
   } catch (const velox::VeloxUserError& e) {
     PRESTO_STARTUP_LOG(ERROR) << "Failed to start server due to " << e.what();
@@ -576,6 +577,7 @@ void PrestoServer::run() {
           environment_,
           nodeId_,
           nodeLocation_,
+          nodePoolType_,
           systemConfig->prestoNativeSidecar(),
           catalogNames,
           systemConfig->announcementMaxFrequencyMs(),

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -290,6 +290,7 @@ class PrestoServer {
   std::string nodeId_;
   std::string address_;
   std::string nodeLocation_;
+  std::string nodePoolType_;
   folly::SSLContextPtr sslContext_;
   std::string prestoBuiltinFunctionPrefix_;
 };

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -240,6 +240,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kEnableRuntimeMetricsCollection, false),
           BOOL_PROP(kPlanValidatorFailOnNestedLoopJoin, false),
           STR_PROP(kPrestoDefaultNamespacePrefix, "presto.default"),
+          STR_PROP(kPoolType, "DEFAULT"),
       };
 }
 
@@ -288,6 +289,17 @@ folly::Optional<std::string> SystemConfig::httpsClientCertAndKeyPath() const {
 
 std::string SystemConfig::prestoVersion() const {
   return requiredProperty(std::string(kPrestoVersion));
+}
+
+std::string SystemConfig::poolType() const {
+    static const std::unordered_set<std::string> kPoolTypes = {"LEAF", "INTERMEDIATE", "DEFAULT"};
+    static constexpr std::string_view kPoolTypeDefault = "DEFAULT";
+    auto value = optionalProperty<std::string>(kPoolType).value_or(std::string(kPoolTypeDefault));
+    VELOX_USER_CHECK(
+        kPoolTypes.count(value),
+        "{} must be one of 'LEAF', 'INTERMEDIATE', or 'DEFAULT'",
+        kPoolType);
+    return value;
 }
 
 bool SystemConfig::mutableConfig() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -659,6 +659,9 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kPrestoDefaultNamespacePrefix{
       "presto.default-namespace"};
 
+  // Specifies the type of worker pool
+  static constexpr std::string_view kPoolType{"pool-type"};
+
   SystemConfig();
 
   virtual ~SystemConfig() = default;
@@ -898,6 +901,8 @@ class SystemConfig : public ConfigBase {
 
   bool prestoNativeSidecar() const;
   std::string prestoDefaultNamespacePrefix() const;
+
+  std::string poolType() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -173,6 +173,7 @@ TEST_P(AnnouncerTestSuite, basic) {
       "testing",
       "test-node",
       "test-node-location",
+      "DEFAULT",
       true,
       {"hive", "tpch"},
       500 /*milliseconds*/,


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Presto supports splitting workers into leaf and non leaf pools. This was added [here](https://github.com/prestodb/presto/commit/88c548544df80a8d97e60349e2195f42cdea6706).

For this the coordinator needs `worker-isolation-enabled=true` and workers can report their pool_type to the resource manager.

Adding the same configs in presto c++ so that the announcer can report the node type. 

With this (since support was already added in coordinator) one can deploy any combination of native/java workers in LEAF/INTERMEDIATE etc.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan

Tested that setting works and if we set pool_type=LEAF in presto c++ the coordinator will only schedule leaf tasks there

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Enable node pool type specification when reporting to the coordinator from a C++ worker. 


