### PR TITLE
Update the error type for ARRAY_NULL_ELEMENT_MSG

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.common.type;
 
-import com.facebook.presto.common.NotSupportedException;
+import com.facebook.presto.common.InvalidFunctionArgumentException;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import io.airlift.slice.Slice;
@@ -189,7 +189,7 @@ public final class TypeUtils
     static void checkElementNotNull(boolean isNull, String errorMsg)
     {
         if (isNull) {
-            throw new NotSupportedException(errorMsg);
+            throw new InvalidFunctionArgumentException(errorMsg);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -34,6 +34,7 @@ import java.lang.invoke.MethodHandle;
 import java.util.List;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
@@ -174,7 +175,7 @@ public final class TypeUtils
     public static void checkElementNotNull(boolean isNull, String errorMsg)
     {
         if (isNull) {
-            throw new PrestoException(NOT_SUPPORTED, errorMsg);
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, errorMsg);
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -710,13 +710,13 @@ public class TestArrayOperators
     @Test
     public void testArrayMinWithNullInFirstArrayIsCompared()
     {
-        assertInvalidFunction("ARRAY_MIN(ARRAY [ARRAY[1, NULL], ARRAY[1, 2]])", NOT_SUPPORTED);
+        assertInvalidFunction("ARRAY_MIN(ARRAY [ARRAY[1, NULL], ARRAY[1, 2]])", INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test
     public void testArrayMinWithNullInSecondArrayIsCompared()
     {
-        assertInvalidFunction("ARRAY_MIN(ARRAY [ARRAY[1, 2], ARRAY[1, NULL]])", NOT_SUPPORTED);
+        assertInvalidFunction("ARRAY_MIN(ARRAY [ARRAY[1, 2], ARRAY[1, NULL]])", INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test
@@ -764,13 +764,13 @@ public class TestArrayOperators
     @Test
     public void testArrayMaxWithNullInFirstArrayIsCompared()
     {
-        assertInvalidFunction("ARRAY_MAX(ARRAY [ARRAY[1, NULL], ARRAY[1, 2]])", NOT_SUPPORTED);
+        assertInvalidFunction("ARRAY_MAX(ARRAY [ARRAY[1, NULL], ARRAY[1, 2]])", INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test
     public void testArrayMaxWithNullInSecondArrayIsCompared()
     {
-        assertInvalidFunction("ARRAY_MAX(ARRAY [ARRAY[1, 2], ARRAY[1, NULL]])", NOT_SUPPORTED);
+        assertInvalidFunction("ARRAY_MAX(ARRAY [ARRAY[1, 2], ARRAY[1, NULL]])", INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test
@@ -1145,7 +1145,7 @@ public class TestArrayOperators
         assertInvalidFunction(
                 "ARRAY_SORT(ARRAY[ARRAY[1], ARRAY[null]])",
                 INVALID_FUNCTION_ARGUMENT,
-                "Array contains elements not supported for comparison");
+                "ARRAY comparison not supported for arrays with null elements");
         assertInvalidFunction(
                 "ARRAY_SORT(ARRAY[ROW(1), ROW(null)])",
                 INVALID_FUNCTION_ARGUMENT,

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -692,7 +692,7 @@ public class TestRowOperators
         assertInvalidFunction("row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0])) > row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0]))",
                 SemanticErrorCode.TYPE_MISMATCH, "line 1:64: '>' cannot be applied to row(boolean,array(integer),map(integer,double)), row(boolean,array(integer),map(integer,double))");
 
-        assertInvalidFunction("row(1, CAST(NULL AS INTEGER)) < row(1, 2)", StandardErrorCode.NOT_SUPPORTED);
+        assertInvalidFunction("row(1, CAST(NULL AS INTEGER)) < row(1, 2)", StandardErrorCode.INVALID_FUNCTION_ARGUMENT);
 
         assertComparisonCombination("row(1.0E0, ARRAY [1,2,3], row(2, 2.0E0))", "row(1.0E0, ARRAY [1,3,3], row(2, 2.0E0))");
         assertComparisonCombination("row(TRUE, ARRAY [1])", "row(TRUE, ARRAY [1, 2])");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3234,6 +3234,36 @@ public abstract class AbstractTestQueries
 
         // test try with null
         assertQuery("SELECT TRY(1 / x) FROM (SELECT NULL as x)", "SELECT NULL");
+
+        // Test try with map method and value parameter is optional and argument is an array with null,
+        // the error should be suppressed and just return null.
+        assertQuery("SELECT\n" +
+                "    TRY(map_keys_by_top_n_values(c0, BIGINT '6455219767830808341'))\n" +
+                "FROM (\n" +
+                "    VALUES\n" +
+                "        MAP(\n" +
+                "            ARRAY[1, 2], ARRAY[\n" +
+                "                ARRAY[1, null],\n" +
+                "                ARRAY[1, null]\n" +
+                "            ]\n" +
+                "        )\n" +
+                ") t(c0)", "SELECT NULL");
+
+        assertQuery("SELECT\n" +
+                "    TRY(map_keys_by_top_n_values(c0, BIGINT '6455219767830808341'))\n" +
+                "FROM (\n" +
+                "    VALUES\n" +
+                "        MAP(\n" +
+                "            ARRAY[1, 2], ARRAY[\n" +
+                "                ARRAY[null, null],\n" +
+                "                ARRAY[1, 2]\n" +
+                "            ]\n" +
+                "        )\n" +
+                ") t(c0)", "SELECT NULL");
+
+        // Test try with array method with an input array containing null values.
+        // the error should be suppressed and just return null.
+        assertQuery("SELECT TRY(ARRAY_MAX(ARRAY [ARRAY[1, NULL], ARRAY[1, 2]]))", "SELECT NULL");
     }
 
     @Test


### PR DESCRIPTION
## Description
Update the error type for ARRAY_NULL_ELEMENT_MSG to INVALID_FUNCTION_ARGUMENT in order to suppress the error for try(map_keys_by_top_n_values ...) when the value is an array with null.

This issue is also a continuation of our previous discussion, which can be found here: https://github.com/prestodb/presto/issues/23150#issuecomment-2261057958

## Motivation and Context
Addressing the discrepancy with the try function related to map_keys_by_top_n_values. In Presto, we throw a NOT_SUPPORTED error (20250214_205756_02064_7wui9) 
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/a5b882ee-867d-4acc-b1c6-3027b42d5876" />
Whereas in Prestissimo, the error is suppressed, and null is returned.
The reason the try block isn't catching these errors is that Presto is using an incorrect error code when throwing exceptions for those functions. Specifically, it is throwing NOT_SUPPORTED errors instead of INVALID_FUNCTION_ARGUMENT errors. The try code does not catch NOT_SUPPORTED errors, and the try function does not catch these errors as shown in [TryFunction.java from lines 166 to 170](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/scalar/TryFunction.java#L166-L170).

## Impact
Low impact

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```

== NO RELEASE NOTE ==

