### PR TITLE
Subclass `FileHiveMetastore` for Iceberg connector

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveModule.java
@@ -18,11 +18,11 @@ import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.PartitionMutator;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
-import com.facebook.presto.hive.metastore.HiveMetastoreModule;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
 import com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
+import com.facebook.presto.iceberg.hive.IcebergHiveMetastoreModule;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 
@@ -48,7 +48,7 @@ public class IcebergHiveModule
     @Override
     public void setup(Binder binder)
     {
-        install(new HiveMetastoreModule(this.connectorId, this.metastore));
+        install(new IcebergHiveMetastoreModule(this.connectorId, this.metastore));
         binder.bind(ExtendedHiveMetastore.class).to(InMemoryCachingHiveMetastore.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(IcebergHiveTableOperationsConfig.class);
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/hive/IcebergFileHiveMetastore.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/hive/IcebergFileHiveMetastore.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.hive;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
+import com.facebook.presto.hive.metastore.file.FileHiveMetastoreConfig;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+
+import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
+import static java.lang.String.format;
+
+@ThreadSafe
+public class IcebergFileHiveMetastore
+        extends FileHiveMetastore
+{
+    private static final Logger LOG = Logger.get(IcebergFileHiveMetastore.class);
+
+    @Inject
+    public IcebergFileHiveMetastore(HdfsEnvironment hdfsEnvironment, FileHiveMetastoreConfig config)
+    {
+        this(hdfsEnvironment, config.getCatalogDirectory(), config.getMetastoreUser());
+    }
+
+    public IcebergFileHiveMetastore(HdfsEnvironment hdfsEnvironment, String catalogDirectory, String metastoreUser)
+    {
+        super(hdfsEnvironment, catalogDirectory, metastoreUser);
+    }
+
+    @Override
+    protected void validateExternalLocation(Path externalLocation, Path catalogDirectory)
+            throws IOException
+    {
+        FileSystem externalFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, externalLocation);
+        if (!externalFileSystem.isDirectory(externalLocation)) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, "External table location does not exist");
+        }
+    }
+
+    @Override
+    protected void validateReplaceTableType(Table originTable, Table newTable)
+    {}
+
+    @Override
+    protected void renameTable(Path originalMetadataDirectory, Path newMetadataDirectory)
+    {
+        Optional<Runnable> rollbackAction = Optional.empty();
+        try {
+            // If the directory `.prestoPermissions` exists, copy it to the new table metadata directory
+            Path originTablePermissionDir = new Path(originalMetadataDirectory, PRESTO_PERMISSIONS_DIRECTORY_NAME);
+            Path newTablePermissionDir = new Path(newMetadataDirectory, PRESTO_PERMISSIONS_DIRECTORY_NAME);
+            if (metadataFileSystem.exists(originTablePermissionDir)) {
+                if (!FileUtil.copy(metadataFileSystem, originTablePermissionDir,
+                        metadataFileSystem, newTablePermissionDir, false, metadataFileSystem.getConf())) {
+                    throw new IOException(format("Could not rename table. Failed to copy directory: %s to %s", originTablePermissionDir, newTablePermissionDir));
+                }
+                else {
+                    rollbackAction = Optional.of(() -> {
+                        try {
+                            metadataFileSystem.delete(newTablePermissionDir, true);
+                        }
+                        catch (IOException e) {
+                            // Ignore the exception and print a warn level log
+                            LOG.warn("Could not delete table permission directory: %s", newTablePermissionDir);
+                        }
+                    });
+                }
+            }
+
+            // Rename file `.prestoSchema` to change it to the new metadata path
+            // This will atomically execute the table renaming behavior
+            Path originMetadataFile = new Path(originalMetadataDirectory, PRESTO_SCHEMA_FILE_NAME);
+            Path newMetadataFile = new Path(newMetadataDirectory, PRESTO_SCHEMA_FILE_NAME);
+            renamePath(originMetadataFile, newMetadataFile,
+                    format("Could not rename table. Failed to rename file %s to %s", originMetadataFile, newMetadataFile));
+
+            // Subsequent action, delete the redundant directory `.prestoPermissions` from the original table metadata path
+            try {
+                metadataFileSystem.delete(new Path(originalMetadataDirectory, PRESTO_PERMISSIONS_DIRECTORY_NAME), true);
+            }
+            catch (IOException e) {
+                // Ignore the exception and print a warn level log
+                LOG.warn("Could not delete table permission directory: %s", originalMetadataDirectory);
+            }
+        }
+        catch (IOException e) {
+            // If table renaming fails and rollback action has already been recorded, perform the rollback action to clean up junk files
+            rollbackAction.ifPresent(Runnable::run);
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/hive/IcebergHiveFileMetastoreModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/hive/IcebergHiveFileMetastoreModule.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.hive;
+
+import com.facebook.presto.hive.ForCachingHiveMetastore;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore;
+import com.facebook.presto.hive.metastore.file.FileHiveMetastoreConfig;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class IcebergHiveFileMetastoreModule
+        implements Module
+{
+    private final String connectorId;
+
+    public IcebergHiveFileMetastoreModule(String connectorId)
+    {
+        this.connectorId = requireNonNull(connectorId, "connectorId is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(FileHiveMetastoreConfig.class);
+        binder.bind(ExtendedHiveMetastore.class).annotatedWith(ForCachingHiveMetastore.class).to(IcebergFileHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(ExtendedHiveMetastore.class).to(InMemoryCachingHiveMetastore.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(ExtendedHiveMetastore.class)
+                .as(generatedNameOf(InMemoryCachingHiveMetastore.class, connectorId));
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/hive/IcebergHiveMetastoreModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/hive/IcebergHiveMetastoreModule.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.hive;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.MetastoreConfig;
+import com.facebook.presto.hive.metastore.glue.GlueMetastoreModule;
+import com.facebook.presto.hive.metastore.thrift.ThriftMetastoreModule;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import java.util.Optional;
+
+import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
+
+public class IcebergHiveMetastoreModule
+        extends AbstractConfigurationAwareModule
+{
+    private final String connectorId;
+    private final Optional<ExtendedHiveMetastore> metastore;
+
+    public IcebergHiveMetastoreModule(String connectorId, Optional<ExtendedHiveMetastore> metastore)
+    {
+        this.connectorId = connectorId;
+        this.metastore = metastore;
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        if (metastore.isPresent()) {
+            binder.bind(ExtendedHiveMetastore.class).toInstance(metastore.get());
+        }
+        else {
+            bindMetastoreModule("thrift", new ThriftMetastoreModule(connectorId));
+            bindMetastoreModule("file", new IcebergHiveFileMetastoreModule(connectorId));
+            bindMetastoreModule("glue", new GlueMetastoreModule(connectorId));
+        }
+    }
+
+    private void bindMetastoreModule(String name, Module module)
+    {
+        install(installModuleIf(
+                MetastoreConfig.class,
+                metastore -> name.equalsIgnoreCase(metastore.getMetastoreType()),
+                module));
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java
@@ -28,7 +28,7 @@ import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
-import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
+import com.facebook.presto.iceberg.hive.IcebergFileHiveMetastore;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.tests.DistributedQueryRunner;
@@ -250,7 +250,7 @@ public final class IcebergQueryRunner
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of(), hiveClientConfig);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
-        return new FileHiveMetastore(hdfsEnvironment, dataDirectory.toFile().toURI().toString(), "test");
+        return new IcebergFileHiveMetastore(hdfsEnvironment, dataDirectory.toFile().toURI().toString(), "test");
     }
 
     public static Path getIcebergDataDirectoryPath(Path dataDirectory, String catalogType, FileFormat format, boolean addStorageFormatToPath)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergDistributedHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergDistributedHive.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.iceberg.hive;
 
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
-import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.iceberg.IcebergDistributedTestBase;
 import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
 import com.facebook.presto.iceberg.IcebergUtil;
@@ -82,7 +81,7 @@ public class TestIcebergDistributedHive
 
     protected ExtendedHiveMetastore getFileHiveMetastore()
     {
-        FileHiveMetastore fileHiveMetastore = new FileHiveMetastore(getHdfsEnvironment(),
+        IcebergFileHiveMetastore fileHiveMetastore = new IcebergFileHiveMetastore(getHdfsEnvironment(),
                 getCatalogDirectory().getPath(),
                 "test");
         return memoizeMetastore(fileHiveMetastore, false, 1000, 0);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
@@ -30,7 +30,6 @@ import com.facebook.presto.hive.HiveHdfsConfiguration;
 import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
-import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.iceberg.CatalogType;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
 import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
@@ -579,7 +578,7 @@ public class TestIcebergHiveStatistics
 
     protected ExtendedHiveMetastore getFileHiveMetastore()
     {
-        FileHiveMetastore fileHiveMetastore = new FileHiveMetastore(getHdfsEnvironment(),
+        IcebergFileHiveMetastore fileHiveMetastore = new IcebergFileHiveMetastore(getHdfsEnvironment(),
                 Optional.of(getCatalogDirectory(HIVE))
                         .filter(File::exists)
                         .map(File::getPath)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
@@ -21,7 +21,6 @@ import com.facebook.presto.hive.HiveHdfsConfiguration;
 import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
-import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
 import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
@@ -68,7 +67,7 @@ public class TestIcebergSmokeHive
 
     protected ExtendedHiveMetastore getFileHiveMetastore()
     {
-        FileHiveMetastore fileHiveMetastore = new FileHiveMetastore(getHdfsEnvironment(),
+        IcebergFileHiveMetastore fileHiveMetastore = new IcebergFileHiveMetastore(getHdfsEnvironment(),
                 getCatalogDirectory().toFile().getPath(),
                 "test");
         return memoizeMetastore(fileHiveMetastore, false, 1000, 0);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
@@ -33,7 +33,6 @@ import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.file.DatabaseMetadata;
-import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.hive.metastore.file.FileHiveMetastoreConfig;
 import com.facebook.presto.hive.metastore.file.TableMetadata;
 import com.facebook.presto.iceberg.CommitTaskData;
@@ -347,7 +346,7 @@ public class TestRenameTableOnFragileFileSystem
     {
         FileHiveMetastoreConfig config = createFileHiveMetastoreConfig();
         TestingHdfsEnvironment hdfsEnvironment = getTestingHdfsEnvironment();
-        FileHiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, config);
+        IcebergFileHiveMetastore metastore = new IcebergFileHiveMetastore(hdfsEnvironment, config);
         IcebergHiveMetadata icebergHiveMetadata = (IcebergHiveMetadata) getIcebergHiveMetadata(metastore);
         ExtendedFileSystem fileSystem = hdfsEnvironment.getFileSystem(connectorSession.getUser(), new Path(originSchemaMetadataPath), new Configuration());
         try {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestIcebergRegisterAndUnregisterProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestIcebergRegisterAndUnregisterProcedure.java
@@ -24,9 +24,9 @@ import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
-import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergPlugin;
+import com.facebook.presto.iceberg.hive.IcebergFileHiveMetastore;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.QueryRunner;
@@ -540,7 +540,7 @@ public class TestIcebergRegisterAndUnregisterProcedure
 
     protected ExtendedHiveMetastore getFileHiveMetastore()
     {
-        FileHiveMetastore fileHiveMetastore = new FileHiveMetastore(getHdfsEnvironment(),
+        IcebergFileHiveMetastore fileHiveMetastore = new IcebergFileHiveMetastore(getHdfsEnvironment(),
                 getCatalogDirectory().toFile().getPath(),
                 "test");
         return memoizeMetastore(fileHiveMetastore, false, 1000, 0);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRemoveOrphanFilesProcedureHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestRemoveOrphanFilesProcedureHive.java
@@ -17,10 +17,10 @@ import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HiveColumnConverterProvider;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.MetastoreContext;
-import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.iceberg.HiveTableOperations;
 import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
 import com.facebook.presto.iceberg.IcebergUtil;
+import com.facebook.presto.iceberg.hive.IcebergFileHiveMetastore;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
@@ -108,7 +108,7 @@ public class TestRemoveOrphanFilesProcedureHive
 
     private ExtendedHiveMetastore getFileHiveMetastore()
     {
-        FileHiveMetastore fileHiveMetastore = new FileHiveMetastore(getHdfsEnvironment(),
+        IcebergFileHiveMetastore fileHiveMetastore = new IcebergFileHiveMetastore(getHdfsEnvironment(),
                 getCatalogDirectory(HIVE).getPath(),
                 "test");
         return memoizeMetastore(fileHiveMetastore, false, 1000, 0);


### PR DESCRIPTION
## Description

Currently, Iceberg connector and Hive connector use the same file based HMS code, however, there are some implementation details that differ between them and need to be special handled. This PR create a dedicated subclass of `FileHiveMetastore` for Iceberg connector, and move the Iceberg specific logic from `FileHiveMetastore` into this dedicated subclass. As discussed in [here](https://github.com/prestodb/presto/pull/24312#discussion_r1901971139).

## Motivation and Context

The modifications of Iceberg specific logic on hive catalog will not affect the `FileHiveMetastore` in `presto-hive-common`.

## Impact

N/A

## Test Plan

 - Make sure the refactor do not affect all existing tests for Hive and Iceberg.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add a dedicated subclass of `FileHiveMetastore` for Iceberg connector to capture and isolate the differences in behavior.
```
