### PR TITLE
[docs] Fix formatting in properties.rst and base-arrow-flight.rst

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -83,7 +83,7 @@ be executed within a single node.
 The corresponding session property is :ref:`admin/properties-session:\`\`single_node_execution_enabled\`\``.
 
 ``exclude-invalid-worker-session-properties``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``

--- a/presto-docs/src/main/sphinx/connector/base-arrow-flight.rst
+++ b/presto-docs/src/main/sphinx/connector/base-arrow-flight.rst
@@ -5,7 +5,8 @@ Arrow Flight Connector
 This connector allows querying multiple data sources that are supported by an Arrow Flight server. Flight supports parallel transfers, allowing data to be streamed to or from a cluster of servers simultaneously. Official documentation for Arrow Flight can be found at `Arrow Flight RPC <https://arrow.apache.org/docs/format/Flight.html>`_.
 
 Getting Started with presto-base-arrow-flight module: Essential Abstract Methods for Developers
----------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------
+
 To create a plugin extending the presto-base-arrow-flight module, you need to implement certain abstract methods that are specific to your use case. Below are the required classes and their purposes:
 
 - ``BaseArrowFlightClientHandler.java``


### PR DESCRIPTION
## Description
Fixed incorrect heading formatting lines in [admin/properties.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/admin/properties.rst) and [connector/base-arrow-flight.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/connector/base-arrow-flight.rst).

## Motivation and Context
Incorrectly formatted headers generate warnings in doc builds. Fixing them reduces the warnings generated during doc builds. 

## Impact
Fewer warnings during doc builds. 

## Test Plan
Local doc builds. 

Before changes were made: 

```
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/connector/base-arrow-flight.rst:8: WARNING: Title underline too short.

Getting Started with presto-base-arrow-flight module: Essential Abstract Methods for Developers
---------------------------------------------------------------------------------


/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/admin/properties.rst:86: WARNING: Title underline too short.

``exclude-invalid-worker-session-properties``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

After changes were made, these warnings did not appear in a local doc build. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

