### PR TITLE
Changed delta connector API in documentation

### DIFF
--- a/presto-docs/src/main/sphinx/connector/deltalake.rst
+++ b/presto-docs/src/main/sphinx/connector/deltalake.rst
@@ -7,7 +7,7 @@ Overview
 
 This connector allows reading `Delta Lake <https://delta.io/>`_
 tables in Presto. The connector uses the
-`Delta Standalone Library (DSR) <https://github.com/delta-io/connectors/wiki/Delta-Standalone-Reader>`_
+`Delta Kernel API <https://docs.delta.io/latest/delta-kernel.html>`_
 provided by Delta Lake project to read the table metadata.
 
 Configuration


### PR DESCRIPTION
## Description
Previously the documentation linked to the previously used delta API. If implemented, the new API will be linked.


## Motivation and Context
Old link was provided

## Impact
None

## Test Plan
None

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

