### PR TITLE
Fix failing variadic functions when sidecar is enabled

### DIFF
--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -127,6 +127,8 @@ public class TestNativeSidecarPlugin
     @Test
     public void testGeneralQueries()
     {
+        assertQuery("SELECT ARRAY['abc']");
+        assertQuery("SELECT ARRAY[1, 2, 3]");
         assertQuery("SELECT substr(comment, 1, 10), length(comment), trim(comment) FROM orders");
         assertQuery("SELECT substr(comment, 1, 10), length(comment), ltrim(comment) FROM orders");
         assertQuery("SELECT substr(comment, 1, 10), length(comment), rtrim(comment) FROM orders");
@@ -170,6 +172,7 @@ public class TestNativeSidecarPlugin
         assertQuery("SELECT checksum(from_unixtime(orderkey, '+01:00')) FROM lineitem WHERE orderkey < 20");
         assertQuerySucceeds("SELECT shuffle(array_sort(quantities)) FROM orders_ex");
         assertQuery("SELECT array_sort(shuffle(quantities)) FROM orders_ex");
+        assertQuery("SELECT orderkey, array_sort(reduce_agg(linenumber, CAST(array[] as ARRAY(INTEGER)), (s, x) -> s || x, (s, s2) -> s || s2)) FROM lineitem group by orderkey");
     }
 
     @Test
@@ -188,8 +191,6 @@ public class TestNativeSidecarPlugin
     {
         assertQueryFails("SELECT array_sort(quantities, (x, y) -> if (x < y, 1, if (x > y, -1, 0))) FROM orders_ex",
                 "line 1:31: Expected a lambda that takes 1 argument\\(s\\) but got 2");
-        assertQueryFails("SELECT orderkey, array_sort(reduce_agg(linenumber, CAST(array[] as ARRAY(INTEGER)), (s, x) -> s || x, (s, s2) -> s || s2)) FROM lineitem group by orderkey",
-                ".*Unexpected parameters \\(array\\(integer\\), array\\(integer\\)\\) for function native.default.concat.*");
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedFunction.java
@@ -160,7 +160,7 @@ public class SqlInvokedFunction
         this.description = requireNonNull(description, "description is null");
         this.routineCharacteristics = requireNonNull(routineCharacteristics, "routineCharacteristics is null");
         this.body = requireNonNull(body, "body is null");
-        this.signature = new Signature(functionName, kind, typeVariableConstraints, emptyList(), returnType, getArgumentTypes(parameters), false);
+        this.signature = new Signature(functionName, kind, typeVariableConstraints, emptyList(), returnType, getArgumentTypes(parameters), variableArity);
         this.functionId = requireNonNull(functionId, "functionId is null");
         this.variableArity = variableArity;
         this.functionVersion = requireNonNull(version, "version is null");


### PR DESCRIPTION
## Description
Fixes a bug where variadic functions were failing when sidecar is enabled.

## Motivation and Context

```
presto> select array['1', '2'];
Query 20250214_211118_00013_ab8m9 failed: Unexpected parameters (varchar(1), varchar(1)) for function native.default.array_constructor. Expected: native.default.array_constructor(t) t, native.default.array_constructor() 

presto> select ARRAY [1, 2];
Query 20250214_203804_00004_riwt8 failed: Unexpected parameters (integer, integer) for function native.default.array_constructor. Expected: native.default.array_constructor(t) t, native.default.array_constructor()
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

