### PR TITLE
[Iceberg] deprecate old table property names

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -123,7 +123,6 @@ import static com.facebook.presto.hive.MetadataUtils.getCombinedRemainingPredica
 import static com.facebook.presto.hive.MetadataUtils.getDiscretePredicates;
 import static com.facebook.presto.hive.MetadataUtils.getPredicate;
 import static com.facebook.presto.hive.MetadataUtils.getSubfieldPredicate;
-import static com.facebook.presto.hive.metastore.MetastoreUtil.TABLE_COMMENT;
 import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.DATA_SEQUENCE_NUMBER_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.DATA_SEQUENCE_NUMBER_COLUMN_METADATA;
@@ -137,19 +136,9 @@ import static com.facebook.presto.iceberg.IcebergMetadataColumn.UPDATE_ROW_DATA;
 import static com.facebook.presto.iceberg.IcebergPartitionType.ALL;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
-import static com.facebook.presto.iceberg.IcebergTableProperties.COMMIT_RETRIES;
-import static com.facebook.presto.iceberg.IcebergTableProperties.DELETE_MODE;
-import static com.facebook.presto.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
-import static com.facebook.presto.iceberg.IcebergTableProperties.FORMAT_VERSION;
 import static com.facebook.presto.iceberg.IcebergTableProperties.LOCATION_PROPERTY;
-import static com.facebook.presto.iceberg.IcebergTableProperties.METADATA_DELETE_AFTER_COMMIT;
-import static com.facebook.presto.iceberg.IcebergTableProperties.METADATA_PREVIOUS_VERSIONS_MAX;
-import static com.facebook.presto.iceberg.IcebergTableProperties.METRICS_MAX_INFERRED_COLUMN;
 import static com.facebook.presto.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableProperties.SORTED_BY_PROPERTY;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getCommitRetries;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getFormatVersion;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getWriteDataLocation;
 import static com.facebook.presto.iceberg.IcebergTableType.CHANGELOG;
 import static com.facebook.presto.iceberg.IcebergTableType.DATA;
 import static com.facebook.presto.iceberg.IcebergTableType.EQUALITY_DELETES;
@@ -157,26 +146,22 @@ import static com.facebook.presto.iceberg.IcebergUtil.MIN_FORMAT_VERSION_FOR_DEL
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getDeleteMode;
 import static com.facebook.presto.iceberg.IcebergUtil.getFileFormat;
-import static com.facebook.presto.iceberg.IcebergUtil.getMetadataPreviousVersionsMax;
-import static com.facebook.presto.iceberg.IcebergUtil.getMetricsMaxInferredColumn;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitionFields;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitionKeyColumnHandles;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitionSpecsIncludingValidData;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitions;
 import static com.facebook.presto.iceberg.IcebergUtil.getSnapshotIdTimeOperator;
 import static com.facebook.presto.iceberg.IcebergUtil.getSortFields;
-import static com.facebook.presto.iceberg.IcebergUtil.getSplitSize;
 import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
-import static com.facebook.presto.iceberg.IcebergUtil.getUpdateMode;
 import static com.facebook.presto.iceberg.IcebergUtil.getViewComment;
-import static com.facebook.presto.iceberg.IcebergUtil.isMetadataDeleteAfterCommit;
-import static com.facebook.presto.iceberg.IcebergUtil.parseFormatVersion;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
 import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetLocation;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetSchema;
 import static com.facebook.presto.iceberg.IcebergUtil.validateTableMode;
+import static com.facebook.presto.iceberg.IcebergWarningCode.SORT_COLUMN_TRANSFORM_NOT_SUPPORTED_WARNING;
+import static com.facebook.presto.iceberg.IcebergWarningCode.USE_OF_DEPRECATED_TABLE_PROPERTY;
 import static com.facebook.presto.iceberg.PartitionFields.getPartitionColumnName;
 import static com.facebook.presto.iceberg.PartitionFields.getTransformTerm;
 import static com.facebook.presto.iceberg.PartitionFields.toPartitionFields;
@@ -196,7 +181,6 @@ import static com.facebook.presto.iceberg.optimizer.IcebergPlanOptimizer.getEnfo
 import static com.facebook.presto.iceberg.util.StatisticsUtil.calculateBaseTableStatistics;
 import static com.facebook.presto.iceberg.util.StatisticsUtil.calculateStatisticsConsideringLayout;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
-import static com.facebook.presto.spi.StandardWarningCode.SORT_COLUMN_TRANSFORM_NOT_SUPPORTED_WARNING;
 import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Verify.verify;
@@ -211,16 +195,8 @@ import static org.apache.iceberg.RowLevelOperationMode.MERGE_ON_READ;
 import static org.apache.iceberg.SnapshotSummary.DELETED_RECORDS_PROP;
 import static org.apache.iceberg.SnapshotSummary.REMOVED_EQ_DELETES_PROP;
 import static org.apache.iceberg.SnapshotSummary.REMOVED_POS_DELETES_PROP;
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL_DEFAULT;
-import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED;
-import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS;
-import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
-import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
-import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
-import static org.apache.iceberg.TableProperties.UPDATE_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 
 public abstract class IcebergAbstractMetadata
@@ -236,6 +212,7 @@ public abstract class IcebergAbstractMetadata
     protected final FilterStatsCalculatorService filterStatsCalculatorService;
     protected Transaction transaction;
     protected final StatisticsFileCache statisticsFileCache;
+    protected final IcebergTableProperties tableProperties;
 
     private final StandardFunctionResolution functionResolution;
     private final ConcurrentMap<SchemaTableName, Table> icebergTables = new ConcurrentHashMap<>();
@@ -247,7 +224,8 @@ public abstract class IcebergAbstractMetadata
             JsonCodec<CommitTaskData> commitTaskCodec,
             NodeVersion nodeVersion,
             FilterStatsCalculatorService filterStatsCalculatorService,
-            StatisticsFileCache statisticsFileCache)
+            StatisticsFileCache statisticsFileCache,
+            IcebergTableProperties tableProperties)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
@@ -256,6 +234,7 @@ public abstract class IcebergAbstractMetadata
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.statisticsFileCache = requireNonNull(statisticsFileCache, "statisticsFileCache is null");
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
     }
 
     protected final Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
@@ -721,10 +700,10 @@ public abstract class IcebergAbstractMetadata
     protected ImmutableMap<String, Object> createMetadataProperties(Table icebergTable, ConnectorSession session)
     {
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
-        properties.put(FILE_FORMAT_PROPERTY, getFileFormat(icebergTable));
+        properties.put(TableProperties.DEFAULT_FILE_FORMAT, getFileFormat(icebergTable));
 
         int formatVersion = ((BaseTable) icebergTable).operations().current().formatVersion();
-        properties.put(FORMAT_VERSION, String.valueOf(formatVersion));
+        properties.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
 
         if (!icebergTable.spec().fields().isEmpty()) {
             properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
@@ -738,13 +717,12 @@ public abstract class IcebergAbstractMetadata
         if (!isNullOrEmpty(writeDataLocation)) {
             properties.put(WRITE_DATA_LOCATION, writeDataLocation);
         }
-
-        properties.put(DELETE_MODE, getDeleteMode(icebergTable));
-        properties.put(UPDATE_MODE, getUpdateMode(icebergTable));
-        properties.put(METADATA_PREVIOUS_VERSIONS_MAX, getMetadataPreviousVersionsMax(icebergTable));
-        properties.put(METADATA_DELETE_AFTER_COMMIT, isMetadataDeleteAfterCommit(icebergTable));
-        properties.put(METRICS_MAX_INFERRED_COLUMN, getMetricsMaxInferredColumn(icebergTable));
-        properties.put(SPLIT_SIZE, getSplitSize(icebergTable));
+        properties.put(TableProperties.DELETE_MODE, IcebergUtil.getDeleteMode(icebergTable));
+        properties.put(TableProperties.UPDATE_MODE, IcebergUtil.getUpdateMode(icebergTable));
+        properties.put(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, IcebergUtil.getMetadataPreviousVersionsMax(icebergTable));
+        properties.put(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, IcebergUtil.isMetadataDeleteAfterCommit(icebergTable));
+        properties.put(TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS, IcebergUtil.getMetricsMaxInferredColumn(icebergTable));
+        properties.put(TableProperties.SPLIT_SIZE, IcebergUtil.getSplitSize(icebergTable));
 
         SortOrder sortOrder = icebergTable.sortOrder();
         // TODO: Support sort column transforms (https://github.com/prestodb/presto/issues/24250)
@@ -1016,7 +994,7 @@ public abstract class IcebergAbstractMetadata
             throw new PrestoException(NOT_SUPPORTED, format("This connector only supports delete where one or more partitions are deleted entirely for table versions older than %d", MIN_FORMAT_VERSION_FOR_DELETE));
         }
         if (getDeleteMode(icebergTable) == RowLevelOperationMode.COPY_ON_WRITE) {
-            throw new PrestoException(NOT_SUPPORTED, "This connector only supports delete where one or more partitions are deleted entirely. Configure delete_mode table property to allow row level deletions.");
+            throw new PrestoException(NOT_SUPPORTED, "This connector only supports delete where one or more partitions are deleted entirely. Configure write.delete.mode table property to allow row level deletions.");
         }
         validateTableMode(session, icebergTable);
         transaction = icebergTable.newTransaction();
@@ -1147,76 +1125,34 @@ public abstract class IcebergAbstractMetadata
 
         UpdateProperties updateProperties = transaction.updateProperties();
         for (Map.Entry<String, Object> entry : properties.entrySet()) {
-            switch (entry.getKey()) {
-                case COMMIT_RETRIES:
-                    updateProperties.set(TableProperties.COMMIT_NUM_RETRIES, String.valueOf(entry.getValue()));
-                    break;
-                case SPLIT_SIZE:
-                    updateProperties.set(TableProperties.SPLIT_SIZE, entry.getValue().toString());
-                    break;
-                default:
-                    throw new PrestoException(NOT_SUPPORTED, "Updating property " + entry.getKey() + " is not supported currently");
+            if (!tableProperties.getUpdatableProperties()
+                    .contains(entry.getKey())) {
+                throw new PrestoException(NOT_SUPPORTED, "Updating property " + entry.getKey() + " is not supported currently");
             }
+            String propertyName = entry.getKey();
+            if (tableProperties.getDeprecatedProperties().containsKey(entry.getKey())) {
+                String newPropertyKey = tableProperties.getDeprecatedProperties().get(entry.getKey());
+                PrestoWarning warning = getPrestoWarning(newPropertyKey, propertyName);
+                session.getWarningCollector().add(warning);
+                propertyName = newPropertyKey;
+            }
+            updateProperties.set(propertyName, String.valueOf(entry.getValue()));
         }
 
         updateProperties.commit();
         transaction.commitTransaction();
     }
 
-    protected Map<String, String> populateTableProperties(ConnectorTableMetadata tableMetadata, com.facebook.presto.iceberg.FileFormat fileFormat, ConnectorSession session)
+    private static PrestoWarning getPrestoWarning(String newPropertyKey, String propertyName)
     {
-        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(16);
-
-        String writeDataLocation = getWriteDataLocation(tableMetadata.getProperties());
-        if (!isNullOrEmpty(writeDataLocation)) {
-            propertiesBuilder.put(WRITE_DATA_LOCATION, writeDataLocation);
+        PrestoWarning warning;
+        if (newPropertyKey == null) {
+            warning = new PrestoWarning(USE_OF_DEPRECATED_TABLE_PROPERTY, format("Property \"%s\" is deprecated and will be completely removed in a future version. Avoid using immediately.", propertyName));
         }
         else {
-            Optional<String> dataLocation = getDataLocationBasedOnWarehouseDataDir(tableMetadata.getTable());
-            dataLocation.ifPresent(location -> propertiesBuilder.put(WRITE_DATA_LOCATION, location));
+            warning = new PrestoWarning(USE_OF_DEPRECATED_TABLE_PROPERTY, format("Property \"%s\" has been renamed to \"%s\". This will become an error in future versions.", propertyName, newPropertyKey));
         }
-
-        Integer commitRetries = getCommitRetries(tableMetadata.getProperties());
-        propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
-        propertiesBuilder.put(COMMIT_NUM_RETRIES, String.valueOf(commitRetries));
-        switch (fileFormat) {
-            case PARQUET:
-                propertiesBuilder.put(PARQUET_COMPRESSION, getCompressionCodec(session).getParquetCompressionCodec().get().toString());
-                break;
-            case ORC:
-                propertiesBuilder.put(ORC_COMPRESSION, getCompressionCodec(session).getOrcCompressionKind().name());
-                break;
-        }
-        if (tableMetadata.getComment().isPresent()) {
-            propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
-        }
-
-        String formatVersion = getFormatVersion(tableMetadata.getProperties());
-        verify(formatVersion != null, "Format version cannot be null");
-        propertiesBuilder.put(TableProperties.FORMAT_VERSION, formatVersion);
-
-        if (parseFormatVersion(formatVersion) < MIN_FORMAT_VERSION_FOR_DELETE) {
-            propertiesBuilder.put(TableProperties.DELETE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
-            propertiesBuilder.put(TableProperties.UPDATE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
-        }
-        else {
-            RowLevelOperationMode deleteMode = IcebergTableProperties.getDeleteMode(tableMetadata.getProperties());
-            propertiesBuilder.put(TableProperties.DELETE_MODE, deleteMode.modeName());
-            RowLevelOperationMode updateMode = IcebergTableProperties.getUpdateMode(tableMetadata.getProperties());
-            propertiesBuilder.put(TableProperties.UPDATE_MODE, updateMode.modeName());
-        }
-
-        Integer metadataPreviousVersionsMax = IcebergTableProperties.getMetadataPreviousVersionsMax(tableMetadata.getProperties());
-        propertiesBuilder.put(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, String.valueOf(metadataPreviousVersionsMax));
-
-        Boolean metadataDeleteAfterCommit = IcebergTableProperties.isMetadataDeleteAfterCommit(tableMetadata.getProperties());
-        propertiesBuilder.put(METADATA_DELETE_AFTER_COMMIT_ENABLED, String.valueOf(metadataDeleteAfterCommit));
-
-        Integer metricsMaxInferredColumn = IcebergTableProperties.getMetricsMaxInferredColumn(tableMetadata.getProperties());
-        propertiesBuilder.put(METRICS_MAX_INFERRED_COLUMN_DEFAULTS, String.valueOf(metricsMaxInferredColumn));
-
-        propertiesBuilder.put(SPLIT_SIZE, String.valueOf(IcebergTableProperties.getTargetSplitSize(tableMetadata.getProperties())));
-        return propertiesBuilder.build();
+        return warning;
     }
 
     /**

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -115,15 +115,12 @@ import static com.facebook.presto.iceberg.HiveTableOperations.STORAGE_FORMAT;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getHiveStatisticsMergeStrategy;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getSortOrder;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getTableLocation;
 import static com.facebook.presto.iceberg.IcebergTableType.DATA;
 import static com.facebook.presto.iceberg.IcebergUtil.createIcebergViewProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.isIcebergTable;
+import static com.facebook.presto.iceberg.IcebergUtil.populateTableProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetProperties;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
@@ -175,9 +172,10 @@ public class IcebergHiveMetadata
             FilterStatsCalculatorService filterStatsCalculatorService,
             IcebergHiveTableOperationsConfig hiveTableOeprationsConfig,
             StatisticsFileCache statisticsFileCache,
-            ManifestFileCache manifestFileCache)
+            ManifestFileCache manifestFileCache,
+            IcebergTableProperties tableProperties)
     {
-        super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, nodeVersion, filterStatsCalculatorService, statisticsFileCache);
+        super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties);
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.hiveTableOeprationsConfig = requireNonNull(hiveTableOeprationsConfig, "hiveTableOperationsConfig is null");
@@ -318,14 +316,14 @@ public class IcebergHiveMetadata
 
         Schema schema = toIcebergSchema(tableMetadata.getColumns());
 
-        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
+        PartitionSpec partitionSpec = parsePartitionFields(schema, tableProperties.getPartitioning(tableMetadata.getProperties()));
 
         MetastoreContext metastoreContext = getMetastoreContext(session);
         Database database = metastore.getDatabase(metastoreContext, schemaName)
                 .orElseThrow(() -> new SchemaNotFoundException(schemaName));
 
         HdfsContext hdfsContext = new HdfsContext(session, schemaName, tableName);
-        String targetPath = getTableLocation(tableMetadata.getProperties());
+        String targetPath = tableProperties.getTableLocation(tableMetadata.getProperties());
         if (targetPath == null) {
             Optional<String> location = database.getLocation();
             if (!location.isPresent() || location.get().isEmpty()) {
@@ -351,9 +349,9 @@ public class IcebergHiveMetadata
         if (operations.current() != null) {
             throw new TableAlreadyExistsException(schemaTableName);
         }
-        SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()));
-        FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());
-        TableMetadata metadata = newTableMetadata(schema, partitionSpec, sortOrder, targetPath, populateTableProperties(tableMetadata, fileFormat, session));
+        SortOrder sortOrder = parseSortFields(schema, tableProperties.getSortOrder(tableMetadata.getProperties()));
+        FileFormat fileFormat = tableProperties.getFileFormat(session, tableMetadata.getProperties());
+        TableMetadata metadata = newTableMetadata(schema, partitionSpec, sortOrder, targetPath, populateTableProperties(this, tableMetadata, tableProperties, fileFormat, session));
         transaction = createTableTransaction(tableName, operations, metadata);
 
         return new IcebergOutputTableHandle(

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
@@ -42,6 +42,7 @@ public class IcebergHiveMetadataFactory
     final IcebergHiveTableOperationsConfig operationsConfig;
     final StatisticsFileCache statisticsFileCache;
     final ManifestFileCache manifestFileCache;
+    final IcebergTableProperties tableProperties;
 
     @Inject
     public IcebergHiveMetadataFactory(
@@ -55,7 +56,8 @@ public class IcebergHiveMetadataFactory
             FilterStatsCalculatorService filterStatsCalculatorService,
             IcebergHiveTableOperationsConfig operationsConfig,
             StatisticsFileCache statisticsFileCache,
-            ManifestFileCache manifestFileCache)
+            ManifestFileCache manifestFileCache,
+            IcebergTableProperties tableProperties)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -68,6 +70,7 @@ public class IcebergHiveMetadataFactory
         this.operationsConfig = requireNonNull(operationsConfig, "operationsConfig is null");
         this.statisticsFileCache = requireNonNull(statisticsFileCache, "statisticsFileCache is null");
         this.manifestFileCache = requireNonNull(manifestFileCache, "manifestFileCache is null");
+        this.tableProperties = requireNonNull(tableProperties, "icebergTableProperties is null");
     }
 
     public ConnectorMetadata create()
@@ -83,6 +86,7 @@ public class IcebergHiveMetadataFactory
                 filterStatsCalculatorService,
                 operationsConfig,
                 statisticsFileCache,
-                manifestFileCache);
+                manifestFileCache,
+                tableProperties);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -61,16 +61,13 @@ import java.util.stream.Stream;
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getSortOrder;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getTableLocation;
 import static com.facebook.presto.iceberg.IcebergTableType.DATA;
 import static com.facebook.presto.iceberg.IcebergUtil.VIEW_OWNER;
 import static com.facebook.presto.iceberg.IcebergUtil.createIcebergViewProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergView;
+import static com.facebook.presto.iceberg.IcebergUtil.populateTableProperties;
 import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
 import static com.facebook.presto.iceberg.PartitionSpecConverter.toPrestoPartitionSpec;
 import static com.facebook.presto.iceberg.SchemaConverter.toPrestoSchema;
@@ -109,9 +106,10 @@ public class IcebergNativeMetadata
             CatalogType catalogType,
             NodeVersion nodeVersion,
             FilterStatsCalculatorService filterStatsCalculatorService,
-            StatisticsFileCache statisticsFileCache)
+            StatisticsFileCache statisticsFileCache,
+            IcebergTableProperties tableProperties)
     {
-        super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, nodeVersion, filterStatsCalculatorService, statisticsFileCache);
+        super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties);
         this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
         this.catalogType = requireNonNull(catalogType, "catalogType is null");
         this.warehouseDataDir = Optional.ofNullable(catalogFactory.getCatalogWarehouseDataDir());
@@ -316,27 +314,26 @@ public class IcebergNativeMetadata
 
         Schema schema = toIcebergSchema(tableMetadata.getColumns());
 
-        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
-        FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());
+        PartitionSpec partitionSpec = parsePartitionFields(schema, tableProperties.getPartitioning(tableMetadata.getProperties()));
+        FileFormat fileFormat = tableProperties.getFileFormat(session, tableMetadata.getProperties());
 
         try {
             TableIdentifier tableIdentifier = toIcebergTableIdentifier(schemaTableName, catalogFactory.isNestedNamespaceEnabled());
-            String targetPath = getTableLocation(tableMetadata.getProperties());
-            Map<String, String> tableProperties = populateTableProperties(tableMetadata, fileFormat, session);
+            String targetPath = tableProperties.getTableLocation(tableMetadata.getProperties());
             if (!isNullOrEmpty(targetPath)) {
                 transaction = catalogFactory.getCatalog(session).newCreateTableTransaction(
                         tableIdentifier,
                         schema,
                         partitionSpec,
                         targetPath,
-                        tableProperties);
+                        populateTableProperties(this, tableMetadata, tableProperties, fileFormat, session));
             }
             else {
                 transaction = catalogFactory.getCatalog(session).newCreateTableTransaction(
                         tableIdentifier,
                         schema,
                         partitionSpec,
-                        tableProperties);
+                        populateTableProperties(this, tableMetadata, tableProperties, fileFormat, session));
             }
         }
         catch (AlreadyExistsException e) {
@@ -345,7 +342,7 @@ public class IcebergNativeMetadata
 
         Table icebergTable = transaction.table();
         ReplaceSortOrder replaceSortOrder = transaction.replaceSortOrder();
-        SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()));
+        SortOrder sortOrder = parseSortFields(schema, tableProperties.getSortOrder(tableMetadata.getProperties()));
         List<SortField> sortFields = getSupportedSortFields(icebergTable.schema(), sortOrder);
         for (SortField sortField : sortFields) {
             if (sortField.getSortOrder().isAscending()) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
@@ -38,6 +38,7 @@ public class IcebergNativeMetadataFactory
     final NodeVersion nodeVersion;
     final FilterStatsCalculatorService filterStatsCalculatorService;
     final StatisticsFileCache statisticsFileCache;
+    final IcebergTableProperties tableProperties;
 
     @Inject
     public IcebergNativeMetadataFactory(
@@ -49,7 +50,8 @@ public class IcebergNativeMetadataFactory
             JsonCodec<CommitTaskData> commitTaskCodec,
             NodeVersion nodeVersion,
             FilterStatsCalculatorService filterStatsCalculatorService,
-            StatisticsFileCache statisticsFileCache)
+            StatisticsFileCache statisticsFileCache,
+            IcebergTableProperties tableProperties)
     {
         this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -61,10 +63,11 @@ public class IcebergNativeMetadataFactory
         this.catalogType = config.getCatalogType();
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.statisticsFileCache = requireNonNull(statisticsFileCache, "statisticsFileCache is null");
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
     }
 
     public ConnectorMetadata create()
     {
-        return new IcebergNativeMetadata(catalogFactory, typeManager, functionResolution, rowExpressionService, commitTaskCodec, catalogType, nodeVersion, filterStatsCalculatorService, statisticsFileCache);
+        return new IcebergNativeMetadata(catalogFactory, typeManager, functionResolution, rowExpressionService, commitTaskCodec, catalogType, nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -14,8 +14,14 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.session.PropertyMetadata;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.TableProperties;
 
@@ -24,50 +30,96 @@ import javax.inject.Inject;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.iceberg.IcebergWarningCode.USE_OF_DEPRECATED_TABLE_PROPERTY;
 import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.longProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 
 public class IcebergTableProperties
 {
+    /**
+     * Please use  {@link TableProperties#DEFAULT_FILE_FORMAT}
+     */
+    @Deprecated
     public static final String FILE_FORMAT_PROPERTY = "format";
     public static final String PARTITIONING_PROPERTY = "partitioning";
-
     public static final String SORTED_BY_PROPERTY = "sorted_by";
     public static final String LOCATION_PROPERTY = "location";
+
+    /**
+     * Please use  {@link TableProperties#FORMAT_VERSION}
+     */
+    @Deprecated
     public static final String FORMAT_VERSION = "format_version";
+    /**
+     * Please use  {@link TableProperties#COMMIT_NUM_RETRIES}
+     */
+    @Deprecated
     public static final String COMMIT_RETRIES = "commit_retries";
+    /**
+     * Please use  {@link TableProperties#DELETE_MODE}
+     */
+    @Deprecated
     public static final String DELETE_MODE = "delete_mode";
+    /**
+     * Please use  {@link TableProperties#METADATA_PREVIOUS_VERSIONS_MAX}
+     */
+    @Deprecated
     public static final String METADATA_PREVIOUS_VERSIONS_MAX = "metadata_previous_versions_max";
+    /**
+     * Please use  {@link TableProperties#METADATA_DELETE_AFTER_COMMIT_ENABLED}
+     */
+    @Deprecated
     public static final String METADATA_DELETE_AFTER_COMMIT = "metadata_delete_after_commit";
+    /**
+     * Please use  {@link TableProperties#METRICS_MAX_INFERRED_COLUMN_DEFAULTS}
+     */
+    @Deprecated
     public static final String METRICS_MAX_INFERRED_COLUMN = "metrics_max_inferred_column";
     public static final String TARGET_SPLIT_SIZE = TableProperties.SPLIT_SIZE;
+
+    private static final String DEPRECATION_WARNING_MESSAGE = "The table property \"%s\" has been " +
+            "deprecated. Please migrate to using \"%s\". This will become an error in future versions";
+
+    private static final BiMap<String, String> DEPRECATED_PROPERTIES = ImmutableBiMap.<String, String>builder()
+            .put(FILE_FORMAT_PROPERTY, TableProperties.DEFAULT_FILE_FORMAT)
+            .put(FORMAT_VERSION, TableProperties.FORMAT_VERSION)
+            .put(COMMIT_RETRIES, TableProperties.COMMIT_NUM_RETRIES)
+            .put(DELETE_MODE, TableProperties.DELETE_MODE)
+            .put(METADATA_PREVIOUS_VERSIONS_MAX, TableProperties.METADATA_PREVIOUS_VERSIONS_MAX)
+            .put(METADATA_DELETE_AFTER_COMMIT, TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED)
+            .put(METRICS_MAX_INFERRED_COLUMN, TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS)
+            .build();
+
+    private static final Set<String> UPDATABLE_PROPERTIES = ImmutableSet.<String>builder()
+            .add(COMMIT_RETRIES)
+            .add(COMMIT_NUM_RETRIES)
+            .add(TARGET_SPLIT_SIZE)
+            .build();
+
     private static final String DEFAULT_FORMAT_VERSION = "2";
 
     private final List<PropertyMetadata<?>> tableProperties;
     private final List<PropertyMetadata<?>> columnProperties;
+    private final Map<String, PropertyMetadata<?>> deprecatedPropertyMetadata;
 
     @Inject
     public IcebergTableProperties(IcebergConfig icebergConfig)
     {
-        tableProperties = ImmutableList.<PropertyMetadata<?>>builder()
-                .add(new PropertyMetadata<>(
-                        FILE_FORMAT_PROPERTY,
-                        "File format for the table",
-                        createUnboundedVarcharType(),
-                        FileFormat.class,
-                        icebergConfig.getFileFormat(),
-                        false,
-                        value -> FileFormat.valueOf(((String) value).toUpperCase(ENGLISH)),
-                        value -> value.toString()))
+        List<PropertyMetadata<?>> properties = ImmutableList.<PropertyMetadata<?>>builder()
                 .add(new PropertyMetadata<>(
                         PARTITIONING_PROPERTY,
                         "Partition transforms",
@@ -93,23 +145,32 @@ public class IcebergTableProperties
                         false,
                         value -> (List<?>) value,
                         value -> value))
+                .add(new PropertyMetadata<>(
+                        TableProperties.DEFAULT_FILE_FORMAT,
+                        "File format for the table",
+                        createUnboundedVarcharType(),
+                        FileFormat.class,
+                        icebergConfig.getFileFormat(),
+                        false,
+                        value -> FileFormat.valueOf(((String) value).toUpperCase(ENGLISH)),
+                        Enum::toString))
                 .add(stringProperty(
                         WRITE_DATA_LOCATION,
                         "File system location URI for the table's data and delete files",
                         null,
                         false))
                 .add(stringProperty(
-                        FORMAT_VERSION,
+                        TableProperties.FORMAT_VERSION,
                         "Format version for the table",
                         DEFAULT_FORMAT_VERSION,
                         false))
                 .add(integerProperty(
-                        COMMIT_RETRIES,
+                        TableProperties.COMMIT_NUM_RETRIES,
                         "Determines the number of attempts in case of concurrent upserts and deletes",
                         TableProperties.COMMIT_NUM_RETRIES_DEFAULT,
                         false))
                 .add(new PropertyMetadata<>(
-                        DELETE_MODE,
+                        TableProperties.DELETE_MODE,
                         "Delete mode for the table",
                         createUnboundedVarcharType(),
                         RowLevelOperationMode.class,
@@ -118,17 +179,17 @@ public class IcebergTableProperties
                         value -> RowLevelOperationMode.fromName((String) value),
                         RowLevelOperationMode::modeName))
                 .add(integerProperty(
-                        METADATA_PREVIOUS_VERSIONS_MAX,
+                        TableProperties.METADATA_PREVIOUS_VERSIONS_MAX,
                         "The max number of old metadata files to keep in metadata log",
                         icebergConfig.getMetadataPreviousVersionsMax(),
                         false))
                 .add(booleanProperty(
-                        METADATA_DELETE_AFTER_COMMIT,
+                        TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED,
                         "Whether enables to delete the oldest metadata file after commit",
                         icebergConfig.isMetadataDeleteAfterCommit(),
                         false))
                 .add(integerProperty(
-                        METRICS_MAX_INFERRED_COLUMN,
+                        TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS,
                         "The maximum number of columns for which metrics are collected",
                         icebergConfig.getMetricsMaxInferredColumn(),
                         false))
@@ -145,6 +206,24 @@ public class IcebergTableProperties
                         "Desired size of split to generate during query scan planning",
                         TableProperties.SPLIT_SIZE_DEFAULT,
                         false))
+                .build();
+
+        deprecatedPropertyMetadata = properties.stream()
+                .filter(prop -> DEPRECATED_PROPERTIES.inverse().containsKey(prop.getName()))
+                .map(prop -> new PropertyMetadata<>(
+                        DEPRECATED_PROPERTIES.inverse().get(prop.getName()),
+                        prop.getDescription(),
+                        prop.getSqlType(),
+                        (Class<Object>) prop.getJavaType(),
+                        prop.getDefaultValue(),
+                        true,
+                        (Function<Object, Object>) prop.getDecoder(),
+                        (Function<Object, Object>) prop.getEncoder()))
+                .collect(toImmutableMap(property -> property.getName(), property -> property));
+
+        tableProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .addAll(properties)
+                .addAll(deprecatedPropertyMetadata.values().iterator())
                 .build();
 
         columnProperties = ImmutableList.of(stringProperty(
@@ -164,26 +243,40 @@ public class IcebergTableProperties
         return columnProperties;
     }
 
-    public static FileFormat getFileFormat(Map<String, Object> tableProperties)
+    public Set<String> getUpdatableProperties()
     {
-        return (FileFormat) tableProperties.get(FILE_FORMAT_PROPERTY);
+        return UPDATABLE_PROPERTIES;
+    }
+
+    /**
+     * @return a map of deprecated property name to new property name, or null if the property is
+     * removed entirely.
+     */
+    public Map<String, String> getDeprecatedProperties()
+    {
+        return DEPRECATED_PROPERTIES;
+    }
+
+    public FileFormat getFileFormat(ConnectorSession session, Map<String, Object> tableProperties)
+    {
+        return (FileFormat) getTablePropertyWithDeprecationWarning(session, tableProperties, TableProperties.DEFAULT_FILE_FORMAT);
     }
 
     @SuppressWarnings("unchecked")
-    public static List<String> getPartitioning(Map<String, Object> tableProperties)
+    public List<String> getPartitioning(Map<String, Object> tableProperties)
     {
         List<String> partitioning = (List<String>) tableProperties.get(PARTITIONING_PROPERTY);
         return partitioning == null ? ImmutableList.of() : ImmutableList.copyOf(partitioning);
     }
 
     @SuppressWarnings("unchecked")
-    public static List<String> getSortOrder(Map<String, Object> tableProperties)
+    public List<String> getSortOrder(Map<String, Object> tableProperties)
     {
         List<String> sortedBy = (List<String>) tableProperties.get(SORTED_BY_PROPERTY);
         return sortedBy == null ? ImmutableList.of() : ImmutableList.copyOf(sortedBy);
     }
 
-    public static String getTableLocation(Map<String, Object> tableProperties)
+    public String getTableLocation(Map<String, Object> tableProperties)
     {
         return (String) tableProperties.get(LOCATION_PROPERTY);
     }
@@ -193,43 +286,68 @@ public class IcebergTableProperties
         return (String) tableProperties.get(WRITE_DATA_LOCATION);
     }
 
-    public static String getFormatVersion(Map<String, Object> tableProperties)
+    public String getFormatVersion(ConnectorSession session, Map<String, Object> tableProperties)
     {
-        return (String) tableProperties.get(FORMAT_VERSION);
+        return (String) getTablePropertyWithDeprecationWarning(session, tableProperties, TableProperties.FORMAT_VERSION);
     }
 
-    public static Integer getCommitRetries(Map<String, Object> tableProperties)
+    public Integer getCommitRetries(ConnectorSession session, Map<String, Object> tableProperties)
     {
-        return (Integer) tableProperties.get(COMMIT_RETRIES);
+        return (Integer) getTablePropertyWithDeprecationWarning(session, tableProperties, TableProperties.COMMIT_NUM_RETRIES);
     }
 
-    public static RowLevelOperationMode getDeleteMode(Map<String, Object> tableProperties)
+    public RowLevelOperationMode getDeleteMode(ConnectorSession session, Map<String, Object> tableProperties)
     {
-        return (RowLevelOperationMode) tableProperties.get(DELETE_MODE);
+        return (RowLevelOperationMode) getTablePropertyWithDeprecationWarning(session, tableProperties, TableProperties.DELETE_MODE);
     }
 
-    public static Integer getMetadataPreviousVersionsMax(Map<String, Object> tableProperties)
+    public Integer getMetadataPreviousVersionsMax(ConnectorSession session, Map<String, Object> tableProperties)
     {
-        return (Integer) tableProperties.get(METADATA_PREVIOUS_VERSIONS_MAX);
+        return (Integer) getTablePropertyWithDeprecationWarning(session, tableProperties, TableProperties.METADATA_PREVIOUS_VERSIONS_MAX);
     }
 
-    public static Boolean isMetadataDeleteAfterCommit(Map<String, Object> tableProperties)
+    public Boolean isMetadataDeleteAfterCommit(ConnectorSession session, Map<String, Object> tableProperties)
     {
-        return (Boolean) tableProperties.get(METADATA_DELETE_AFTER_COMMIT);
+        return (Boolean) getTablePropertyWithDeprecationWarning(session, tableProperties, TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED);
     }
 
-    public static Integer getMetricsMaxInferredColumn(Map<String, Object> tableProperties)
+    public Integer getMetricsMaxInferredColumn(ConnectorSession session, Map<String, Object> tableProperties)
     {
-        return (Integer) tableProperties.get(METRICS_MAX_INFERRED_COLUMN);
+        return (Integer) getTablePropertyWithDeprecationWarning(session, tableProperties, TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS);
     }
 
-    public static RowLevelOperationMode getUpdateMode(Map<String, Object> tableProperties)
+    public RowLevelOperationMode getUpdateMode(Map<String, Object> tableProperties)
     {
-        return (RowLevelOperationMode) tableProperties.get(UPDATE_MODE);
+        return (RowLevelOperationMode) tableProperties.get(TableProperties.UPDATE_MODE);
     }
 
     public static Long getTargetSplitSize(Map<String, Object> tableProperties)
     {
         return (Long) tableProperties.get(TableProperties.SPLIT_SIZE);
+    }
+
+    @VisibleForTesting
+    protected Object getTablePropertyWithDeprecationWarning(ConnectorSession session, Map<String, Object> tableProperties, String keyName)
+    {
+        String deprecatedProperty = DEPRECATED_PROPERTIES.inverse().get(keyName);
+        if (deprecatedProperty == null) {
+            return tableProperties.get(keyName);
+        }
+
+        // If the deprecated property returns the default value, the user may not have set it
+        // intentionally. Return the value using the newer key name. This is OK because the
+        // deprecated property names have the same defaults as the new names.
+        PropertyMetadata<?> deprecatedPropertyData = deprecatedPropertyMetadata.get(deprecatedProperty);
+        if (!tableProperties.containsKey(deprecatedProperty) || deprecatedPropertyData.getDefaultValue().equals(tableProperties.get(deprecatedProperty))) {
+            return tableProperties.get(keyName);
+        }
+
+        // deprecated property did not use the default value, warn the user about the deprecation
+        Object value = tableProperties.get(deprecatedProperty);
+        session.getWarningCollector()
+                .add(new PrestoWarning(
+                        USE_OF_DEPRECATED_TABLE_PROPERTY,
+                        format(DEPRECATION_WARNING_MESSAGE, deprecatedProperty, keyName)));
+        return value;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergWarningCode.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergWarningCode.java
@@ -11,28 +11,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spi;
+package com.facebook.presto.iceberg;
 
-public enum StandardWarningCode
+import com.facebook.presto.spi.WarningCode;
+import com.facebook.presto.spi.WarningCodeSupplier;
+
+public enum IcebergWarningCode
         implements WarningCodeSupplier
 {
-    TOO_MANY_STAGES(0x0000_0001),
-    PARSER_WARNING(0x0000_0002),
-    PERFORMANCE_WARNING(0x0000_0003),
-    SEMANTIC_WARNING(0x0000_0004),
-    REDUNDANT_ORDER_BY(0x0000_0005),
-    PARTIAL_RESULT_WARNING(0x0000_0006),
-    MULTIPLE_ORDER_BY(0x0000_0007),
-    DEFAULT_SAMPLE_FUNCTION(0x0000_0008),
-    SAMPLED_FIELDS(0x0000_0009),
-    MULTIPLE_TABLE_METADATA(0x0000_0010),
-    UTILIZED_COLUMN_ANALYSIS_FAILED(0x0000_0011),
+    SORT_COLUMN_TRANSFORM_NOT_SUPPORTED_WARNING(1),
+    USE_OF_DEPRECATED_TABLE_PROPERTY(2)
     /**/;
+
+    public static final int WARNING_CODE_MASK = 0x0200_0000;
+
     private final WarningCode warningCode;
 
-    StandardWarningCode(int code)
+    IcebergWarningCode(int code)
     {
-        warningCode = new WarningCode(code, name());
+        warningCode = new WarningCode(code + WARNING_CODE_MASK, name());
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergParquetDereferencePushDown.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergParquetDereferencePushDown.java
@@ -21,6 +21,7 @@ import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.iceberg.IcebergAbstractMetadata;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
 import com.facebook.presto.iceberg.IcebergTableHandle;
+import com.facebook.presto.iceberg.IcebergTableProperties;
 import com.facebook.presto.iceberg.IcebergTransactionManager;
 import com.facebook.presto.parquet.rule.ParquetDereferencePushDown;
 import com.facebook.presto.spi.ColumnHandle;
@@ -37,7 +38,6 @@ import java.util.stream.Collectors;
 import static com.facebook.presto.iceberg.FileFormat.PARQUET;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.getSynthesizedIcebergColumnHandle;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isParquetDereferencePushdownEnabled;
-import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
 import static com.facebook.presto.iceberg.TypeConverter.toHiveType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -48,16 +48,19 @@ public class IcebergParquetDereferencePushDown
 {
     private final IcebergTransactionManager transactionManager;
     private final TypeManager typeManager;
+    private final IcebergTableProperties tableProperties;
 
     @Inject
     public IcebergParquetDereferencePushDown(
             IcebergTransactionManager transactionManager,
             RowExpressionService rowExpressionService,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            IcebergTableProperties tableProperties)
     {
         super(rowExpressionService);
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
     }
 
     @Override
@@ -73,7 +76,7 @@ public class IcebergParquetDereferencePushDown
         ConnectorMetadata metadata = transactionManager.get(tableHandle.getTransaction());
         checkState(metadata instanceof IcebergAbstractMetadata, "metadata must be IcebergAbstractMetadata");
 
-        return PARQUET == getFileFormat(metadata.getTableMetadata(session, tableHandle.getConnectorHandle()).getProperties());
+        return PARQUET == tableProperties.getFileFormat(session, metadata.getTableMetadata(session, tableHandle.getConnectorHandle()).getProperties());
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg.optimizer;
 
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.iceberg.IcebergTableProperties;
 import com.facebook.presto.iceberg.IcebergTransactionManager;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
@@ -39,6 +40,7 @@ public class IcebergPlanOptimizerProvider
             RowExpressionService rowExpressionService,
             StandardFunctionResolution functionResolution,
             FunctionMetadataManager functionMetadataManager,
+            IcebergTableProperties tableProperties,
             TypeManager typeManager)
     {
         requireNonNull(transactionManager, "transactionManager is null");
@@ -49,12 +51,12 @@ public class IcebergPlanOptimizerProvider
         this.planOptimizers = ImmutableSet.of(
                 new IcebergPlanOptimizer(functionResolution, rowExpressionService, functionMetadataManager, transactionManager),
                 new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, typeManager),
-                new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager));
+                new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager, tableProperties));
         this.logicalPlanOptimizers = ImmutableSet.of(
                 new IcebergPlanOptimizer(functionResolution, rowExpressionService, functionMetadataManager, transactionManager),
                 new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, typeManager),
                 new IcebergMetadataOptimizer(functionMetadataManager, typeManager, transactionManager, rowExpressionService, functionResolution),
-                new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager),
+                new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager, tableProperties),
                 new IcebergEqualityDeleteAsJoin(functionResolution, transactionManager, typeManager));
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -28,6 +28,8 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.assertions.Assert;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Table;
@@ -37,6 +39,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -47,7 +50,15 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
+import static com.facebook.presto.iceberg.IcebergTableProperties.COMMIT_RETRIES;
+import static com.facebook.presto.iceberg.IcebergTableProperties.DELETE_MODE;
+import static com.facebook.presto.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
+import static com.facebook.presto.iceberg.IcebergTableProperties.FORMAT_VERSION;
+import static com.facebook.presto.iceberg.IcebergTableProperties.METADATA_DELETE_AFTER_COMMIT;
+import static com.facebook.presto.iceberg.IcebergTableProperties.METADATA_PREVIOUS_VERSIONS_MAX;
+import static com.facebook.presto.iceberg.IcebergTableProperties.METRICS_MAX_INFERRED_COLUMN;
 import static com.facebook.presto.iceberg.IcebergUtil.MIN_FORMAT_VERSION_FOR_DELETE;
+import static com.facebook.presto.iceberg.IcebergWarningCode.USE_OF_DEPRECATED_TABLE_PROPERTY;
 import static com.facebook.presto.iceberg.procedure.RegisterTableProcedure.METADATA_FOLDER_NAME;
 import static com.facebook.presto.iceberg.procedure.RegisterTableProcedure.getFileSystem;
 import static com.facebook.presto.iceberg.procedure.RegisterTableProcedure.resolveLatestMetadataLocation;
@@ -102,7 +113,7 @@ public abstract class IcebergDistributedSmokeTestBase
         assertQuerySucceeds("ALTER TABLE test_timestamp_with_timezone ADD COLUMN y timestamp with time zone");
         dropTable(getSession(), "test_timestamp_with_timezone");
 
-        assertQueryFails("CREATE TABLE test_timestamp_with_timezone (x) WITH ( format = 'ORC') AS SELECT TIMESTAMP '1969-12-01 00:00:00.000000 UTC'", "Unsupported Type: timestamp with time zone");
+        assertQueryFails("CREATE TABLE test_timestamp_with_timezone (x) WITH ( \"write.format.default\" = 'ORC') AS SELECT TIMESTAMP '1969-12-01 00:00:00.000000 UTC'", "Unsupported Type: timestamp with time zone");
     }
 
     @Test
@@ -150,14 +161,14 @@ public abstract class IcebergDistributedSmokeTestBase
                         "   \"comment\" varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   delete_mode = 'merge-on-read',\n" +
-                        "   format = 'PARQUET',\n" +
-                        "   format_version = '2',\n" +
+                        "   \"format-version\" = '2',\n" +
                         "   location = '%s',\n" +
-                        "   metadata_delete_after_commit = false,\n" +
-                        "   metadata_previous_versions_max = 100,\n" +
-                        "   metrics_max_inferred_column = 100,\n" +
                         "   \"read.split.target-size\" = 134217728,\n" +
+                        "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                        "   \"write.format.default\" = 'PARQUET',\n" +
+                        "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                        "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                        "   \"write.metadata.previous-versions-max\" = 100,\n" +
                         "   \"write.update.mode\" = 'merge-on-read'\n" +
                         ")", schemaName, getLocation(schemaName, "orders")));
     }
@@ -223,15 +234,15 @@ public abstract class IcebergDistributedSmokeTestBase
                     "   \"b\" varchar\n" +
                     ")\n" +
                     "WITH (\n" +
-                    "   delete_mode = 'merge-on-read',\n" +
-                    "   format = 'PARQUET',\n" +
-                    "   format_version = '2',\n" +
+                    "   \"format-version\" = '2',\n" +
                     "   location = '%s',\n" +
-                    "   metadata_delete_after_commit = false,\n" +
-                    "   metadata_previous_versions_max = 100,\n" +
-                    "   metrics_max_inferred_column = 100,\n" +
                     "   \"read.split.target-size\" = 134217728,\n" +
                     "   \"write.data.path\" = '%s',\n" +
+                    "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                    "   \"write.format.default\" = 'PARQUET',\n" +
+                    "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                    "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                    "   \"write.metadata.previous-versions-max\" = 100,\n" +
                     "   \"write.update.mode\" = 'merge-on-read'\n" +
                     ")";
             assertThat(computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue())
@@ -286,7 +297,7 @@ public abstract class IcebergDistributedSmokeTestBase
         String afterTheDecimalPoint = "09876543210987654321098765432109876543".substring(0, scale);
         String decimalValue = format("%s.%s", beforeTheDecimalPoint, afterTheDecimalPoint);
 
-        assertUpdate(session, format("CREATE TABLE %s (x %s) WITH (format = '%s')", tableName, decimalType, format.name()));
+        assertUpdate(session, format("CREATE TABLE %s (x %s) WITH (\"write.format.default\" = '%s')", tableName, decimalType, format.name()));
         assertUpdate(session, format("INSERT INTO %s (x) VALUES (CAST('%s' AS %s))", tableName, decimalValue, decimalType), 1);
         assertQuery(session, format("SELECT * FROM %s", tableName), format("SELECT CAST('%s' AS %s)", decimalValue, decimalType));
         dropTable(session, tableName);
@@ -364,7 +375,7 @@ public abstract class IcebergDistributedSmokeTestBase
                 ", _date DATE" +
                 ") " +
                 "WITH (" +
-                "format = '" + fileFormat + "', " +
+                "\"write.format.default\" = '" + fileFormat + "', " +
                 "partitioning = ARRAY[" +
                 "  '_string'," +
                 "  '_integer'," +
@@ -425,7 +436,7 @@ public abstract class IcebergDistributedSmokeTestBase
                 ", _date DATE" +
                 ") " +
                 "WITH (" +
-                "format = '" + fileFormat + "', " +
+                "\"write.format.default\" = '" + fileFormat + "', " +
                 "partitioning = ARRAY['_date']" +
                 ")";
 
@@ -455,7 +466,7 @@ public abstract class IcebergDistributedSmokeTestBase
                 ", _date DATE" +
                 ") " +
                 "WITH (" +
-                "format = '" + fileFormat + "', " +
+                "\"write.format.default\" = '" + fileFormat + "', " +
                 "partitioning = ARRAY[" +
                 "  '_string'," +
                 "  '_integer'," +
@@ -501,7 +512,7 @@ public abstract class IcebergDistributedSmokeTestBase
         @Language("SQL") String createTable = "" +
                 "CREATE TABLE test_create_partitioned_table_as_" + fileFormat.toString().toLowerCase(ENGLISH) + " " +
                 "WITH (" +
-                "format = '" + fileFormat + "', " +
+                "\"write.format.default\" = '" + fileFormat + "', " +
                 "partitioning = ARRAY['ORDER_STATUS', 'Ship_Priority', 'Bucket(order_key,9)']" +
                 ") " +
                 "AS " +
@@ -517,15 +528,15 @@ public abstract class IcebergDistributedSmokeTestBase
                         "   \"order_status\" varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   delete_mode = 'merge-on-read',\n" +
-                        "   format = '" + fileFormat + "',\n" +
-                        "   format_version = '2',\n" +
+                        "   \"format-version\" = '2',\n" +
                         "   location = '%s',\n" +
-                        "   metadata_delete_after_commit = false,\n" +
-                        "   metadata_previous_versions_max = 100,\n" +
-                        "   metrics_max_inferred_column = 100,\n" +
                         "   partitioning = ARRAY['order_status','ship_priority','bucket(order_key, 9)'],\n" +
                         "   \"read.split.target-size\" = 134217728,\n" +
+                        "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                        "   \"write.format.default\" = '" + fileFormat + "',\n" +
+                        "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                        "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                        "   \"write.metadata.previous-versions-max\" = 100,\n" +
                         "   \"write.update.mode\" = 'merge-on-read'\n" +
                         ")",
                 getSession().getCatalog().get(),
@@ -555,7 +566,7 @@ public abstract class IcebergDistributedSmokeTestBase
         // create iceberg table partitioned by column of ShortDecimalType, and insert some data
         assertUpdate(session, "drop table if exists test_partition_columns_short_decimal");
         assertUpdate(session, format("create table test_partition_columns_short_decimal(a bigint, b decimal(9, 2))" +
-                " with (format = '%s', partitioning = ARRAY['b'])", format.name()));
+                " with (\"write.format.default\" = '%s', partitioning = ARRAY['b'])", format.name()));
         assertUpdate(session, "insert into test_partition_columns_short_decimal values(1, 12.31), (2, 133.28)", 2);
         assertQuery(session, "select * from test_partition_columns_short_decimal", "values(1, 12.31), (2, 133.28)");
 
@@ -581,7 +592,7 @@ public abstract class IcebergDistributedSmokeTestBase
         // create iceberg table partitioned by column of ShortDecimalType, and insert some data
         assertUpdate(session, "drop table if exists test_partition_columns_long_decimal");
         assertUpdate(session, format("create table test_partition_columns_long_decimal(a bigint, b decimal(20, 2))" +
-                " with (format = '%s', partitioning = ARRAY['b'])", format.name()));
+                " with (\"write.format.default\" = '%s', partitioning = ARRAY['b'])", format.name()));
         assertUpdate(session, "insert into test_partition_columns_long_decimal values(1, 11111111111111112.31), (2, 133.28)", 2);
         assertQuery(session, "select * from test_partition_columns_long_decimal", "values(1, 11111111111111112.31), (2, 133.28)");
 
@@ -607,7 +618,7 @@ public abstract class IcebergDistributedSmokeTestBase
     public void testTruncateShortDecimalTransform(Session session, FileFormat format)
     {
         assertUpdate(session, format("CREATE TABLE test_truncate_decimal_transform (d DECIMAL(9, 2), b BIGINT)" +
-                " WITH (format = '%s', partitioning = ARRAY['truncate(d, 10)'])", format.name()));
+                " WITH (\"write.format.default\" = '%s', partitioning = ARRAY['truncate(d, 10)'])", format.name()));
         String select = "SELECT d_trunc, row_count, d.min, d.max FROM \"test_truncate_decimal_transform$partitions\"";
 
         assertUpdate(session, "INSERT INTO test_truncate_decimal_transform VALUES" +
@@ -646,7 +657,7 @@ public abstract class IcebergDistributedSmokeTestBase
     public void testTruncateLongDecimalTransform(Session session, FileFormat format)
     {
         assertUpdate(session, format("CREATE TABLE test_truncate_long_decimal_transform (d DECIMAL(20, 2), b BIGINT)" +
-                " WITH (format = '%s', partitioning = ARRAY['truncate(d, 10)'])", format.name()));
+                " WITH (\"write.format.default\" = '%s', partitioning = ARRAY['truncate(d, 10)'])", format.name()));
         String select = "SELECT d_trunc, row_count, d.min, d.max FROM \"test_truncate_long_decimal_transform$partitions\"";
 
         assertUpdate(session, "INSERT INTO test_truncate_long_decimal_transform VALUES" +
@@ -711,8 +722,8 @@ public abstract class IcebergDistributedSmokeTestBase
                 ")\n" +
                 "COMMENT '%s'\n" +
                 "WITH (\n" +
-                "   format = 'ORC',\n" +
-                "   format_version = '2'\n" +
+                "   \"write.format.default\" = 'ORC',\n" +
+                "   \"format-version\" = '2'\n" +
                 ")";
 
         assertUpdate(format(createTable, schemaName, "test table comment"));
@@ -723,14 +734,14 @@ public abstract class IcebergDistributedSmokeTestBase
                 ")\n" +
                 "COMMENT '%s'\n" +
                 "WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'ORC',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'ORC',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")";
         String createTableSql = format(createTableTemplate, schemaName, "test table comment", getLocation(schemaName, "test_table_comments"));
@@ -786,7 +797,7 @@ public abstract class IcebergDistributedSmokeTestBase
 
     private void testSchemaEvolution(Session session, FileFormat fileFormat)
     {
-        assertUpdate(session, "CREATE TABLE test_schema_evolution_drop_end (col0 INTEGER, col1 INTEGER, col2 INTEGER) WITH (format = '" + fileFormat + "')");
+        assertUpdate(session, "CREATE TABLE test_schema_evolution_drop_end (col0 INTEGER, col1 INTEGER, col2 INTEGER) WITH (\"write.format.default\" = '" + fileFormat + "')");
         assertUpdate(session, "INSERT INTO test_schema_evolution_drop_end VALUES (0, 1, 2)", 1);
         assertQuery(session, "SELECT * FROM test_schema_evolution_drop_end", "VALUES(0, 1, 2)");
         assertUpdate(session, "ALTER TABLE test_schema_evolution_drop_end DROP COLUMN col2");
@@ -797,7 +808,7 @@ public abstract class IcebergDistributedSmokeTestBase
         assertQuery(session, "SELECT * FROM test_schema_evolution_drop_end", "VALUES(0, 1, NULL), (3, 4, 5)");
         dropTable(session, "test_schema_evolution_drop_end");
 
-        assertUpdate(session, "CREATE TABLE test_schema_evolution_drop_middle (col0 INTEGER, col1 INTEGER, col2 INTEGER) WITH (format = '" + fileFormat + "')");
+        assertUpdate(session, "CREATE TABLE test_schema_evolution_drop_middle (col0 INTEGER, col1 INTEGER, col2 INTEGER) WITH (\"write.format.default\" = '" + fileFormat + "')");
         assertUpdate(session, "INSERT INTO test_schema_evolution_drop_middle VALUES (0, 1, 2)", 1);
         assertQuery(session, "SELECT * FROM test_schema_evolution_drop_middle", "VALUES(0, 1, 2)");
         assertUpdate(session, "ALTER TABLE test_schema_evolution_drop_middle DROP COLUMN col1");
@@ -814,17 +825,17 @@ public abstract class IcebergDistributedSmokeTestBase
         Session session = getSession();
         String schemaName = session.getSchema().get();
 
-        assertUpdate(session, "CREATE TABLE test_create_table_like_original (col1 INTEGER, aDate DATE) WITH(format = 'PARQUET', partitioning = ARRAY['aDate'])");
+        assertUpdate(session, "CREATE TABLE test_create_table_like_original (col1 INTEGER, aDate DATE) WITH(\"write.format.default\" = 'PARQUET', partitioning = ARRAY['aDate'])");
         assertEquals(getTablePropertiesString("test_create_table_like_original"), format("WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'PARQUET',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   partitioning = ARRAY['adate'],\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'PARQUET',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")", getLocation(schemaName, "test_create_table_like_original")));
 
@@ -835,28 +846,28 @@ public abstract class IcebergDistributedSmokeTestBase
 
         assertUpdate(session, "CREATE TABLE test_create_table_like_copy1 (LIKE test_create_table_like_original)");
         assertEquals(getTablePropertiesString("test_create_table_like_copy1"), format("WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'PARQUET',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'PARQUET',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")", getLocation(schemaName, "test_create_table_like_copy1")));
         dropTable(session, "test_create_table_like_copy1");
 
         assertUpdate(session, "CREATE TABLE test_create_table_like_copy2 (LIKE test_create_table_like_original EXCLUDING PROPERTIES)");
         assertEquals(getTablePropertiesString("test_create_table_like_copy2"), format("WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'PARQUET',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'PARQUET',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")", getLocation(schemaName, "test_create_table_like_copy2")));
         dropTable(session, "test_create_table_like_copy2");
@@ -864,31 +875,31 @@ public abstract class IcebergDistributedSmokeTestBase
         if (!catalogType.equals(HADOOP)) {
             assertUpdate(session, "CREATE TABLE test_create_table_like_copy3 (LIKE test_create_table_like_original INCLUDING PROPERTIES)");
             assertEquals(getTablePropertiesString("test_create_table_like_copy3"), format("WITH (\n" +
-                            "   delete_mode = 'merge-on-read',\n" +
-                            "   format = 'PARQUET',\n" +
-                            "   format_version = '2',\n" +
+                            "   \"format-version\" = '2',\n" +
                             "   location = '%s',\n" +
-                            "   metadata_delete_after_commit = false,\n" +
-                            "   metadata_previous_versions_max = 100,\n" +
-                            "   metrics_max_inferred_column = 100,\n" +
                             "   partitioning = ARRAY['adate'],\n" +
                             "   \"read.split.target-size\" = 134217728,\n" +
+                            "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                            "   \"write.format.default\" = 'PARQUET',\n" +
+                            "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                            "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                            "   \"write.metadata.previous-versions-max\" = 100,\n" +
                             "   \"write.update.mode\" = 'merge-on-read'\n" +
                             ")",
                     getLocation(schemaName, "test_create_table_like_original")));
             dropTable(session, "test_create_table_like_copy3");
 
-            assertUpdate(session, "CREATE TABLE test_create_table_like_copy4 (LIKE test_create_table_like_original INCLUDING PROPERTIES) WITH (format = 'ORC')");
+            assertUpdate(session, "CREATE TABLE test_create_table_like_copy4 (LIKE test_create_table_like_original INCLUDING PROPERTIES) WITH (\"write.format.default\" = 'ORC')");
             assertEquals(getTablePropertiesString("test_create_table_like_copy4"), format("WITH (\n" +
-                            "   delete_mode = 'merge-on-read',\n" +
-                            "   format = 'ORC',\n" +
-                            "   format_version = '2',\n" +
+                            "   \"format-version\" = '2',\n" +
                             "   location = '%s',\n" +
-                            "   metadata_delete_after_commit = false,\n" +
-                            "   metadata_previous_versions_max = 100,\n" +
-                            "   metrics_max_inferred_column = 100,\n" +
                             "   partitioning = ARRAY['adate'],\n" +
                             "   \"read.split.target-size\" = 134217728,\n" +
+                            "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                            "   \"write.format.default\" = 'ORC',\n" +
+                            "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                            "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                            "   \"write.metadata.previous-versions-max\" = 100,\n" +
                             "   \"write.update.mode\" = 'merge-on-read'\n" +
                             ")",
                     getLocation(schemaName, "test_create_table_like_original")));
@@ -896,17 +907,17 @@ public abstract class IcebergDistributedSmokeTestBase
         }
         else {
             assertUpdate(session, "CREATE TABLE test_create_table_like_copy5 (LIKE test_create_table_like_original INCLUDING PROPERTIES)" +
-                    " WITH (location = '', format = 'ORC')");
+                    " WITH (location = '', \"write.format.default\" = 'ORC')");
             assertEquals(getTablePropertiesString("test_create_table_like_copy5"), format("WITH (\n" +
-                            "   delete_mode = 'merge-on-read',\n" +
-                            "   format = 'ORC',\n" +
-                            "   format_version = '2',\n" +
+                            "   \"format-version\" = '2',\n" +
                             "   location = '%s',\n" +
-                            "   metadata_delete_after_commit = false,\n" +
-                            "   metadata_previous_versions_max = 100,\n" +
-                            "   metrics_max_inferred_column = 100,\n" +
                             "   partitioning = ARRAY['adate'],\n" +
                             "   \"read.split.target-size\" = 134217728,\n" +
+                            "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                            "   \"write.format.default\" = 'ORC',\n" +
+                            "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                            "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                            "   \"write.metadata.previous-versions-max\" = 100,\n" +
                             "   \"write.update.mode\" = 'merge-on-read'\n" +
                             ")",
                     getLocation(schemaName, "test_create_table_like_copy5")));
@@ -930,8 +941,8 @@ public abstract class IcebergDistributedSmokeTestBase
         @Language("SQL") String createTable = "" +
                 "CREATE TABLE test_create_table_with_format_version_" + formatVersion + " " +
                 "WITH (" +
-                "format = 'PARQUET', " +
-                "format_version = '" + formatVersion + "'" +
+                "\"write.format.default\" = 'PARQUET', " +
+                "\"format-version\" = '" + formatVersion + "'" +
                 ") " +
                 "AS " +
                 "SELECT orderkey AS order_key, shippriority AS ship_priority, orderstatus AS order_status " +
@@ -948,22 +959,22 @@ public abstract class IcebergDistributedSmokeTestBase
                         "   \"order_status\" varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   delete_mode = '%s',\n" +
-                        "   format = 'PARQUET',\n" +
-                        "   format_version = '%s',\n" +
+                        "   \"format-version\" = '%s',\n" +
                         "   location = '%s',\n" +
-                        "   metadata_delete_after_commit = false,\n" +
-                        "   metadata_previous_versions_max = 100,\n" +
-                        "   metrics_max_inferred_column = 100,\n" +
                         "   \"read.split.target-size\" = 134217728,\n" +
+                        "   \"write.delete.mode\" = '%s',\n" +
+                        "   \"write.format.default\" = 'PARQUET',\n" +
+                        "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                        "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                        "   \"write.metadata.previous-versions-max\" = 100,\n" +
                         "   \"write.update.mode\" = '%s'\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
                 "test_create_table_with_format_version_" + formatVersion,
-                defaultDeleteMode,
                 formatVersion,
                 getLocation(getSession().getSchema().get(), "test_create_table_with_format_version_" + formatVersion),
+                defaultDeleteMode,
                 defaultDeleteMode);
 
         MaterializedResult actualResult = computeActual("SHOW CREATE TABLE test_create_table_with_format_version_" + formatVersion);
@@ -999,7 +1010,7 @@ public abstract class IcebergDistributedSmokeTestBase
 
     private void testPredicating(Session session, FileFormat fileFormat)
     {
-        assertUpdate(session, "CREATE TABLE test_predicating_on_real (col REAL) WITH (format = '" + fileFormat + "')");
+        assertUpdate(session, "CREATE TABLE test_predicating_on_real (col REAL) WITH (\"write.format.default\" = '" + fileFormat + "')");
         assertUpdate(session, "INSERT INTO test_predicating_on_real VALUES 1.2", 1);
         assertQuery(session, "SELECT * FROM test_predicating_on_real WHERE col = 1.2", "VALUES 1.2");
         dropTable(session, "test_predicating_on_real");
@@ -1022,7 +1033,7 @@ public abstract class IcebergDistributedSmokeTestBase
         String select = "SELECT d_trunc, row_count, d.min AS d_min, d.max AS d_max, b.min AS b_min, b.max AS b_max FROM \"test_truncate_transform$partitions\"";
 
         assertUpdate(session, format("CREATE TABLE test_truncate_transform (d VARCHAR, b BIGINT)" +
-                " WITH (format = '%s', partitioning = ARRAY['truncate(d, 2)'])", format.name()));
+                " WITH (\"write.format.default\" = '%s', partitioning = ARRAY['truncate(d, 2)'])", format.name()));
 
         String insertSql = "INSERT INTO test_truncate_transform VALUES" +
                 "('abcd', 1)," +
@@ -1059,7 +1070,7 @@ public abstract class IcebergDistributedSmokeTestBase
         String select = "SELECT d_bucket, row_count, d.min AS d_min, d.max AS d_max, b.min AS b_min, b.max AS b_max FROM \"test_bucket_transform$partitions\"";
 
         assertUpdate(session, format("CREATE TABLE test_bucket_transform (d VARCHAR, b BIGINT)" +
-                " WITH (format = '%s', partitioning = ARRAY['bucket(d, 2)'])", format.name()));
+                " WITH (\"write.format.default\" = '%s', partitioning = ARRAY['bucket(d, 2)'])", format.name()));
         String insertSql = "INSERT INTO test_bucket_transform VALUES" +
                 "('abcd', 1)," +
                 "('abxy', 2)," +
@@ -1119,7 +1130,7 @@ public abstract class IcebergDistributedSmokeTestBase
                 ", str ROW(id INTEGER , vc VARCHAR)" +
                 ", dt DATE)" +
                 " WITH (partitioning = ARRAY['int']," +
-                " format = '" + fileFormat + "'" +
+                " \"write.format.default\" = '" + fileFormat + "'" +
                 ")";
 
         assertUpdate(session, createTable);
@@ -1146,7 +1157,7 @@ public abstract class IcebergDistributedSmokeTestBase
                 ", str ROW(id INTEGER, vc VARCHAR, arr ARRAY(INTEGER))" +
                 ", vc VARCHAR)" +
                 " WITH (partitioning = ARRAY['int']," +
-                " format = '" + fileFormat + "'" +
+                " \"write.format.default\" = '" + fileFormat + "'" +
                 ")";
 
         assertUpdate(session, createTable2);
@@ -1187,7 +1198,7 @@ public abstract class IcebergDistributedSmokeTestBase
         String tableName = format("test_%s_by_time", partitioned ? "partitioned" : "selected");
         try {
             String partitioning = partitioned ? ", partitioning = ARRAY['x']" : "";
-            assertUpdate(format("CREATE TABLE %s (x TIME, y BIGINT) WITH (format = '%s'%s)", tableName, format, partitioning));
+            assertUpdate(format("CREATE TABLE %s (x TIME, y BIGINT) WITH (\"write.format.default\" = '%s'%s)", tableName, format, partitioning));
             assertUpdate(format("INSERT INTO %s VALUES (TIME '10:12:34', 12345)", tableName), 1);
             assertQuery(format("SELECT COUNT(*) FROM %s", tableName), "SELECT 1");
             assertQuery(format("SELECT x FROM %s", tableName), "SELECT CAST('10:12:34' AS TIME)");
@@ -1322,7 +1333,7 @@ public abstract class IcebergDistributedSmokeTestBase
 
     protected void createTableWithMergeOnRead(Session session, String schema, String tableName)
     {
-        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer) WITH (format_version = '2')");
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer) WITH (\"format-version\" = '2')");
 
         CatalogManager catalogManager = getDistributedQueryRunner().getCoordinator().getCatalogManager();
         ConnectorId connectorId = catalogManager.getCatalog(ICEBERG_CATALOG).get().getConnectorId();
@@ -1673,7 +1684,7 @@ public abstract class IcebergDistributedSmokeTestBase
         // Test with default delete_mode i.e. merge-on-read
         String tableNameMor = "test_delete_mor";
 
-        assertUpdate("CREATE TABLE " + tableNameMor + " (id integer, value integer) WITH (format_version = '2')");
+        assertUpdate("CREATE TABLE " + tableNameMor + " (id integer, value integer) WITH (\"format-version\" = '2')");
         assertUpdate("INSERT INTO " + tableNameMor + " VALUES (1, 10)", 1);
         assertUpdate("INSERT INTO " + tableNameMor + " VALUES (2, 13)", 1);
         assertUpdate("INSERT INTO " + tableNameMor + " VALUES (3, 5)", 1);
@@ -1685,9 +1696,9 @@ public abstract class IcebergDistributedSmokeTestBase
 
         // Test with delete_mode set to copy-on-write
         String tableNameCow = "test_delete_cow";
-        @Language("RegExp") String errorMessage = "This connector only supports delete where one or more partitions are deleted entirely. Configure delete_mode table property to allow row level deletions.";
+        @Language("RegExp") String errorMessage = "This connector only supports delete where one or more partitions are deleted entirely. Configure write.delete.mode table property to allow row level deletions.";
 
-        assertUpdate("CREATE TABLE " + tableNameCow + " (id integer, value integer) WITH (format_version = '2', delete_mode = 'copy-on-write')");
+        assertUpdate("CREATE TABLE " + tableNameCow + " (id integer, value integer) WITH (\"format-version\" = '2', \"write.delete.mode\" = 'copy-on-write')");
         assertUpdate("INSERT INTO " + tableNameCow + " VALUES (1, 5)", 1);
         assertQuery("SELECT * FROM " + tableNameCow, "VALUES (1, 5)");
         assertQueryFails("DELETE FROM " + tableNameCow + " WHERE value = 5", errorMessage);
@@ -1703,7 +1714,7 @@ public abstract class IcebergDistributedSmokeTestBase
         // Test with default delete_mode i.e. merge-on-read:
         String tableNameMor = "test_delete_partitioned_mor";
 
-        assertUpdate("CREATE TABLE " + tableNameMor + " (id integer, value integer) WITH (format_version = '2', partitioning = Array['id'])");
+        assertUpdate("CREATE TABLE " + tableNameMor + " (id integer, value integer) WITH (\"format-version\" = '2', partitioning = Array['id'])");
         assertUpdate("INSERT INTO " + tableNameMor + " VALUES (1, 10)", 1);
         assertUpdate("INSERT INTO " + tableNameMor + " VALUES (2, 13)", 1);
         assertUpdate("INSERT INTO " + tableNameMor + " VALUES (3, 5)", 1);
@@ -1723,9 +1734,9 @@ public abstract class IcebergDistributedSmokeTestBase
 
         // Test with delete_mode set to copy-on-write
         String tableNameCow = "test_delete_partitioned_cow";
-        @Language("RegExp") String errorMessage = "This connector only supports delete where one or more partitions are deleted entirely. Configure delete_mode table property to allow row level deletions.";
+        @Language("RegExp") String errorMessage = "This connector only supports delete where one or more partitions are deleted entirely. Configure write.delete.mode table property to allow row level deletions.";
 
-        assertUpdate("CREATE TABLE " + tableNameCow + " (id integer, value integer) WITH (format_version = '2', partitioning = Array['id'], delete_mode = 'copy-on-write')");
+        assertUpdate("CREATE TABLE " + tableNameCow + " (id integer, value integer) WITH (\"format-version\" = '2', partitioning = Array['id'], \"write.delete.mode\" = 'copy-on-write')");
         assertUpdate("INSERT INTO " + tableNameCow + " VALUES (1, 10)", 1);
         assertUpdate("INSERT INTO " + tableNameCow + " VALUES (2, 1)", 1);
         assertUpdate("INSERT INTO " + tableNameCow + " VALUES (3, 5)", 1);
@@ -1747,7 +1758,7 @@ public abstract class IcebergDistributedSmokeTestBase
 
         Session session = getSession();
 
-        assertUpdate("CREATE TABLE " + tableName + " (a integer, b varchar) WITH (format_version = '2')");
+        assertUpdate("CREATE TABLE " + tableName + " (a integer, b varchar) WITH (\"format-version\" = '2')");
         assertUpdate("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002'), (3, '1003')", 3);
         assertQuery("SELECT * FROM " + tableName, "VALUES (1, '1001'), (2, '1002'), (3, '1003')");
         assertUpdate("DELETE FROM " + tableName + " WHERE b = '1001'", 1);
@@ -1776,7 +1787,7 @@ public abstract class IcebergDistributedSmokeTestBase
         Session session = getSession();
 
         String errorMessage = format("This connector only supports delete where one or more partitions are deleted entirely for table versions older than %d", MIN_FORMAT_VERSION_FOR_DELETE);
-        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer) WITH (format_version = '1', partitioning = Array['id'])");
+        assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer) WITH (\"format-version\" = '1', partitioning = Array['id'])");
         assertUpdate("INSERT INTO " + tableName + " VALUES (1, 10)", 1);
         assertUpdate("INSERT INTO " + tableName + " VALUES (2, 1)", 1);
         assertUpdate("INSERT INTO " + tableName + " VALUES (3, 5)", 1);
@@ -1797,7 +1808,7 @@ public abstract class IcebergDistributedSmokeTestBase
         String tableName = "test_empty_partition_spec_table";
         try {
             // Create a table with no partition
-            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (format_version = '" + version + "', delete_mode = '" + mode + "')");
+            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (\"format-version\" = '" + version + "', \"write.delete.mode\" = '" + mode + "')");
 
             // Do not insert data, and evaluate the partition spec by adding a partition column `c`
             assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN c INTEGER WITH (partitioning = 'identity')");
@@ -1821,7 +1832,7 @@ public abstract class IcebergDistributedSmokeTestBase
         String tableName = "test_data_deleted_partition_spec_table";
         try {
             // Create a table with partition column `a`, and insert some data under this partition spec
-            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (format_version = '" + version + "', delete_mode = '" + mode + "', partitioning = ARRAY['a'])");
+            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (\"format-version\" = '" + version + "', \"write.delete.mode\" = '" + mode + "', partitioning = ARRAY['a'])");
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002')", 2);
 
             // Then evaluate the partition spec by adding a partition column `c`, and insert some data under the new partition spec
@@ -1868,7 +1879,7 @@ public abstract class IcebergDistributedSmokeTestBase
         Session session = sessionForTimezone("UTC", true);
         String tableName = "test_hour_transform_timestamp";
         try {
-            assertUpdate(session, "CREATE TABLE " + tableName + " (d TIMESTAMP, b BIGINT) WITH (format_version = '" + version + "', delete_mode = '" + mode + "', partitioning = ARRAY['hour(d)'])");
+            assertUpdate(session, "CREATE TABLE " + tableName + " (d TIMESTAMP, b BIGINT) WITH (\"format-version\" = '" + version + "', \"write.delete.mode\" = '" + mode + "', partitioning = ARRAY['hour(d)'])");
             assertUpdate(session, "INSERT INTO " + tableName + " VALUES (NULL, 101), (TIMESTAMP '1969-01-01 00:01:02.123', 10), (TIMESTAMP '1969-12-31 13:14:02.001', 11), (TIMESTAMP '1970-01-01 08:10:21.000', 1)", 4);
             assertQuery(session, "SELECT * FROM " + tableName, "VALUES (NULL, 101), (TIMESTAMP '1969-01-01 00:01:02.123', 10), (TIMESTAMP '1969-12-31 13:14:02.001', 11), (TIMESTAMP '1970-01-01 08:10:21.000', 1)");
 
@@ -1890,7 +1901,7 @@ public abstract class IcebergDistributedSmokeTestBase
         Session session = sessionForTimezone("UTC", true);
         String tableName = "test_day_transform_timestamp";
         try {
-            assertUpdate(session, "CREATE TABLE " + tableName + " (d TIMESTAMP, b BIGINT) WITH (format_version = '" + version + "', delete_mode = '" + mode + "', partitioning = ARRAY['day(d)'])");
+            assertUpdate(session, "CREATE TABLE " + tableName + " (d TIMESTAMP, b BIGINT) WITH (\"format-version\" = '" + version + "', \"write.delete.mode\" = '" + mode + "', partitioning = ARRAY['day(d)'])");
             assertUpdate(session, "INSERT INTO " + tableName + " VALUES (NULL, 101), (TIMESTAMP '1969-01-01 00:01:02.123', 10), (TIMESTAMP '1969-12-31 13:14:02.001', 11), (TIMESTAMP '1970-01-01 08:10:21.000', 1)", 4);
             assertQuery(session, "SELECT * FROM " + tableName, "VALUES (NULL, 101), (TIMESTAMP '1969-01-01 00:01:02.123', 10), (TIMESTAMP '1969-12-31 13:14:02.001', 11), (TIMESTAMP '1970-01-01 08:10:21.000', 1)");
 
@@ -1911,7 +1922,7 @@ public abstract class IcebergDistributedSmokeTestBase
     {
         String tableName = "test_month_transform_date";
         try {
-            assertUpdate("CREATE TABLE " + tableName + " (d DATE, b BIGINT) WITH (format_version = '" + version + "', delete_mode = '" + mode + "', partitioning = ARRAY['month(d)'])");
+            assertUpdate("CREATE TABLE " + tableName + " (d DATE, b BIGINT) WITH (\"format-version\" = '" + version + "', \"write.delete.mode\" = '" + mode + "', partitioning = ARRAY['month(d)'])");
             assertUpdate("INSERT INTO " + tableName + " VALUES (NULL, 101), (DATE '1958-03-02', 10), (DATE '1969-08-31', 11), (DATE '1970-08-01', 1)", 4);
             assertQuery("SELECT * FROM " + tableName, "VALUES (NULL, 101), (DATE '1958-03-02', 10), (DATE '1969-08-31', 11), (DATE '1970-08-01', 1)");
 
@@ -1932,7 +1943,7 @@ public abstract class IcebergDistributedSmokeTestBase
     {
         String tableName = "test_year_transform_date";
         try {
-            assertUpdate("CREATE TABLE " + tableName + " (d DATE, b BIGINT) WITH (format_version = '" + version + "', delete_mode = '" + mode + "', partitioning = ARRAY['year(d)'])");
+            assertUpdate("CREATE TABLE " + tableName + " (d DATE, b BIGINT) WITH (\"format-version\" = '" + version + "', \"write.delete.mode\" = '" + mode + "', partitioning = ARRAY['year(d)'])");
             assertUpdate("INSERT INTO " + tableName + " VALUES (NULL, 101), (DATE '1958-03-02', 10), (DATE '1969-08-31', 11), (DATE '1970-08-01', 1)", 4);
             assertQuery("SELECT * FROM " + tableName, "VALUES (NULL, 101), (DATE '1958-03-02', 10), (DATE '1969-08-31', 11), (DATE '1970-08-01', 1)");
 
@@ -1953,7 +1964,7 @@ public abstract class IcebergDistributedSmokeTestBase
     {
         String tableName = "test_truncate_transform";
         try {
-            assertUpdate("CREATE TABLE " + tableName + " (c VARCHAR, d DECIMAL(9, 2), b BIGINT) WITH (format_version = '" + version + "', delete_mode = '" + mode + "', partitioning = ARRAY['truncate(c, 2)', 'truncate(d, 10)'])");
+            assertUpdate("CREATE TABLE " + tableName + " (c VARCHAR, d DECIMAL(9, 2), b BIGINT) WITH (\"format-version\" = '" + version + "', \"write.delete.mode\" = '" + mode + "', partitioning = ARRAY['truncate(c, 2)', 'truncate(d, 10)'])");
             assertUpdate("INSERT INTO " + tableName + " VALUES (NULL, 11.59, 101), ('abcd', 12.34, 10), ('abxy', NULL, 11), ('Kielce', 12.30, 1), ('Kiev', 0.05, 2)", 5);
             assertQuery("SELECT * FROM " + tableName, "VALUES (NULL, 11.59, 101), ('abcd', 12.34, 10), ('abxy', NULL, 11), ('Kielce', 12.30, 1), ('Kiev', 0.05, 2)");
 
@@ -1991,9 +2002,9 @@ public abstract class IcebergDistributedSmokeTestBase
     {
         Session session = getSession();
         String tableName = "test_invalid_property_update";
-        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 varchar) WITH(commit_retries = 4)");
-        assertThatThrownBy(() -> assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES (format = 'PARQUET')"))
-                .hasMessage("Updating property format is not supported currently");
+        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 varchar) WITH(\"commit.retry.num-retries\" = 4)");
+        assertThatThrownBy(() -> assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES (\"write.format.default\" = 'PARQUET')"))
+                .hasMessage("Updating property write.format.default is not supported currently");
         assertUpdate("DROP TABLE " + tableName);
     }
 
@@ -2002,7 +2013,7 @@ public abstract class IcebergDistributedSmokeTestBase
     {
         Session session = getSession();
         String tableName = "test_random_property_update";
-        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 varchar) WITH(commit_retries = 4)");
+        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 varchar) WITH(\"commit.retry.num-retries\" = 4)");
         assertThatThrownBy(() -> assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES (some_config = 2)"))
                 .hasMessage("Catalog 'iceberg' does not support table property 'some_config'");
         assertUpdate("DROP TABLE " + tableName);
@@ -2013,10 +2024,10 @@ public abstract class IcebergDistributedSmokeTestBase
     {
         Session session = getSession();
         String tableName = "test_commit_retries_update";
-        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 varchar) WITH(commit_retries = 4)");
+        assertUpdate(session, "CREATE TABLE " + tableName + " (c1 integer, c2 varchar) WITH(\"commit.retry.num-retries\" = 4)");
         assertQuery("SELECT value FROM \"" + tableName + "$properties\" WHERE key = 'commit.retry.num-retries'", "VALUES 4");
-        assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES (commit_retries = 5)");
-        assertUpdate("ALTER TABLE IF EXISTS " + tableName + " SET PROPERTIES (commit_retries = 6)");
+        assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES (\"commit.retry.num-retries\" = 5)");
+        assertUpdate("ALTER TABLE IF EXISTS " + tableName + " SET PROPERTIES (\"commit.retry.num-retries\" = 6)");
         assertQuery("SELECT value FROM \"" + tableName + "$properties\" WHERE key = 'commit.retry.num-retries'", "VALUES 6");
         assertUpdate("DROP TABLE " + tableName);
     }
@@ -2024,8 +2035,8 @@ public abstract class IcebergDistributedSmokeTestBase
     @Test
     public void testUpdateNonExistentTable()
     {
-        assertQuerySucceeds("ALTER TABLE IF EXISTS non_existent_test_table1 SET PROPERTIES (commit_retries = 6)");
-        assertQueryFails("ALTER TABLE non_existent_test_table2 SET PROPERTIES (commit_retries = 6)",
+        assertQuerySucceeds("ALTER TABLE IF EXISTS non_existent_test_table1 SET PROPERTIES (\"commit.retry.num-retries\" = 6)");
+        assertQueryFails("ALTER TABLE non_existent_test_table2 SET PROPERTIES (\"commit.retry.num-retries\" = 6)",
                 format("Table does not exist: iceberg.%s.non_existent_test_table2", getSession().getSchema().get()));
     }
 
@@ -2046,5 +2057,48 @@ public abstract class IcebergDistributedSmokeTestBase
                 session,
                 fileSystem,
                 metadataDir).getName();
+    }
+
+    @Test
+    public void testDeprecatedTablePropertiesCreateTable()
+    {
+        Map<String, String> deprecatedProperties = ImmutableMap.<String, String>builder()
+                .put(FILE_FORMAT_PROPERTY, "'ORC'")
+                .put(FORMAT_VERSION, "'1'")
+                .put(COMMIT_RETRIES, "1234")
+                .put(DELETE_MODE, "'copy-on-write'")
+                .put(METADATA_PREVIOUS_VERSIONS_MAX, "567")
+                .put(METADATA_DELETE_AFTER_COMMIT, "true")
+                .put(METRICS_MAX_INFERRED_COLUMN, "123")
+                .build();
+        deprecatedProperties.forEach((oldProperty, value) -> {
+            Session session = Session.builder(getSession()).build();
+            String tableName = "test_deprecated_table_properties_" + oldProperty;
+            DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
+            MaterializedResult result = queryRunner.execute(session, "CREATE TABLE " + tableName + " (c1 integer) WITH (" + oldProperty + " = " + value + ")");
+            assertEquals(result.getWarnings().size(), 1);
+            assertTrue(result.getWarnings().stream()
+                    .anyMatch(code -> code.getWarningCode().equals(USE_OF_DEPRECATED_TABLE_PROPERTY.toWarningCode())));
+            assertUpdate(session, "DROP TABLE " + tableName);
+        });
+    }
+
+    @Test
+    public void testDeprecatedTablePropertiesAlterTable()
+    {
+        Map<String, String> deprecatedProperties = ImmutableMap.<String, String>builder()
+                .put(COMMIT_RETRIES, "1234")
+                .build();
+        deprecatedProperties.forEach((oldProperty, value) -> {
+            Session session = Session.builder(getSession()).build();
+            String tableName = "test_deprecated_table_properties_" + oldProperty;
+            DistributedQueryRunner queryRunner = (DistributedQueryRunner) getQueryRunner();
+            assertQuerySucceeds(session, "CREATE TABLE " + tableName + " (c1 integer) WITH (" + oldProperty + " = " + value + ")");
+            MaterializedResult result = queryRunner.execute(session, "ALTER TABLE " + tableName + " SET PROPERTIES (" + oldProperty + " = " + value + ")");
+            assertEquals(result.getWarnings().size(), 1);
+            assertTrue(result.getWarnings().stream()
+                    .anyMatch(code -> code.getWarningCode().equals(USE_OF_DEPRECATED_TABLE_PROPERTY.toWarningCode())));
+            assertUpdate(session, "DROP TABLE " + tableName);
+        });
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -208,14 +208,14 @@ public abstract class IcebergDistributedTestBase
     public void testDeleteOnV1Table()
     {
         // Test delete all rows
-        long totalCount = (long) getQueryRunner().execute("CREATE TABLE test_delete with (format_version = '1') as select * from lineitem")
+        long totalCount = (long) getQueryRunner().execute("CREATE TABLE test_delete with (\"format-version\" = '1') as select * from lineitem")
                 .getOnlyValue();
         assertUpdate("DELETE FROM test_delete", totalCount);
         assertEquals(getQueryRunner().execute("SELECT count(*) FROM test_delete").getOnlyValue(), 0L);
         assertQuerySucceeds("DROP TABLE test_delete");
 
         // Test delete whole partitions identified by one partition column
-        totalCount = (long) getQueryRunner().execute("CREATE TABLE test_partitioned_drop WITH (format_version = '1', partitioning = ARRAY['bucket(orderkey, 2)', 'linenumber', 'linestatus']) as select * from lineitem")
+        totalCount = (long) getQueryRunner().execute("CREATE TABLE test_partitioned_drop WITH (\"format-version\" = '1', partitioning = ARRAY['bucket(orderkey, 2)', 'linenumber', 'linestatus']) as select * from lineitem")
                 .getOnlyValue();
         long countPart1 = (long) getQueryRunner().execute("SELECT count(*) FROM test_partitioned_drop where linenumber = 1").getOnlyValue();
         assertUpdate("DELETE FROM test_partitioned_drop WHERE linenumber = 1", countPart1);
@@ -229,7 +229,7 @@ public abstract class IcebergDistributedTestBase
         assertQuerySucceeds("DROP TABLE test_partitioned_drop");
 
         // Test delete whole partitions identified by two partition columns
-        totalCount = (long) getQueryRunner().execute("CREATE TABLE test_partitioned_drop WITH (format_version = '1', partitioning = ARRAY['bucket(orderkey, 2)', 'linenumber', 'linestatus']) as select * from lineitem")
+        totalCount = (long) getQueryRunner().execute("CREATE TABLE test_partitioned_drop WITH (\"format-version\" = '1', partitioning = ARRAY['bucket(orderkey, 2)', 'linenumber', 'linestatus']) as select * from lineitem")
                 .getOnlyValue();
         long countPart1F = (long) getQueryRunner().execute("SELECT count(*) FROM test_partitioned_drop where linenumber = 1 and linestatus = 'F'").getOnlyValue();
         assertUpdate("DELETE FROM test_partitioned_drop WHERE linenumber = 1 and linestatus = 'F'", countPart1F);
@@ -247,7 +247,7 @@ public abstract class IcebergDistributedTestBase
 
         String errorMessage1 = "This connector only supports delete where one or more partitions are deleted entirely for table versions older than 2";
         // Do not support delete with filters on non-identity partition column on v1 table
-        assertUpdate("CREATE TABLE test_partitioned_drop WITH (format_version = '1', partitioning = ARRAY['bucket(orderkey, 2)', 'linenumber', 'linestatus']) as select * from lineitem", totalCount);
+        assertUpdate("CREATE TABLE test_partitioned_drop WITH (\"format-version\" = '1', partitioning = ARRAY['bucket(orderkey, 2)', 'linenumber', 'linestatus']) as select * from lineitem", totalCount);
         assertQueryFails("DELETE FROM test_partitioned_drop WHERE orderkey = 1", errorMessage1);
 
         // Do not allow delete data at specified snapshot
@@ -500,7 +500,7 @@ public abstract class IcebergDistributedTestBase
     {
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
         try {
-            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (format_version = '2', delete_mode = 'merge-on-read')");
+            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (\"format-version\" = '2', \"write.delete.mode\" = 'merge-on-read')");
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002'), (3, '1003')", 3);
 
             // execute row level deletion
@@ -581,7 +581,7 @@ public abstract class IcebergDistributedTestBase
     {
         try {
             // create iceberg table partitioned by column of TimestampType, and insert some data
-            assertQuerySucceeds(session, format("create table test_partition_columns(a bigint, b timestamp) with (partitioning = ARRAY['b'], format = '%s')", fileFormat.name()));
+            assertQuerySucceeds(session, format("create table test_partition_columns(a bigint, b timestamp) with (partitioning = ARRAY['b'], \"write.format.default\" = '%s')", fileFormat.name()));
             assertQuerySucceeds(session, "insert into test_partition_columns values(1, timestamp '1984-12-08 00:10:00'), (2, timestamp '2001-01-08 12:01:01')");
 
             // validate return data of TimestampType
@@ -728,7 +728,7 @@ public abstract class IcebergDistributedTestBase
             String comma = Strings.isNullOrEmpty(columns.trim()) ? "" : ", ";
 
             // The columns number of `test_stats_with_column_limits` for which metrics are collected is set to `columnCount`
-            assertUpdate("CREATE TABLE test_stats_with_column_limits (column_0 int, column_1 varchar, " + columns + comma + "column_10001 varchar) with(metrics_max_inferred_column = " + columnCount + ")");
+            assertUpdate("CREATE TABLE test_stats_with_column_limits (column_0 int, column_1 varchar, " + columns + comma + "column_10001 varchar) with(\"write.metadata.metrics.max-inferred-column-defaults\" = " + columnCount + ")");
             assertTrue(getQueryRunner().tableExists(getSession(), "test_stats_with_column_limits"));
             List<String> columnNames = IntStream.iterate(0, i -> i + 1).limit(columnCount)
                     .mapToObj(idx -> "column_" + idx).collect(Collectors.toList());
@@ -1104,7 +1104,7 @@ public abstract class IcebergDistributedTestBase
             throws Exception
     {
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        assertUpdate("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
         Table icebergTable = updateTable(tableName);
         String dataFilePath = (String) computeActual("SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1").getOnlyValue();
 
@@ -1143,7 +1143,7 @@ public abstract class IcebergDistributedTestBase
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
         try {
-            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (format = '" + fileFormat + "', partitioning=ARRAY['a'])");
+            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (\"write.format.default\" = '" + fileFormat + "', partitioning=ARRAY['a'])");
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002'), (2, '1010'), (3, '1003')", 4);
 
             Table icebergTable = updateTable(tableName);
@@ -1182,7 +1182,7 @@ public abstract class IcebergDistributedTestBase
     {
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_equality_delete" + randomTableSuffix();
-        assertUpdate(session, "CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
+        assertUpdate(session, "CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTable(tableName);
 
         writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L));
@@ -1198,7 +1198,7 @@ public abstract class IcebergDistributedTestBase
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         // Specify equality delete filter with different column order from table definition
         String tableName = "test_v2_equality_delete_different_order" + randomTableSuffix();
-        assertUpdate(session, "CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
+        assertUpdate(session, "CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTable(tableName);
 
         writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L, "name", "ARGENTINA"));
@@ -1215,7 +1215,7 @@ public abstract class IcebergDistributedTestBase
         Session disable = deleteAsJoinEnabled(false);
         // Specify equality delete filter with different column order from table definition
         String tableName = "test_v2_equality_delete_different_order" + randomTableSuffix();
-        assertUpdate(session, "CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
+        assertUpdate(session, "CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTable(tableName);
 
         writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L, "name", "ARGENTINA"));
@@ -1233,7 +1233,7 @@ public abstract class IcebergDistributedTestBase
     {
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        assertUpdate("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
         Table icebergTable = updateTable(tableName);
         String dataFilePath = (String) computeActual("SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1").getOnlyValue();
 
@@ -1254,7 +1254,7 @@ public abstract class IcebergDistributedTestBase
     {
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_equality_delete" + randomTableSuffix();
-        assertUpdate(session, "CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['nationkey'], format = '" + fileFormat + "') " + " AS SELECT * FROM tpch.tiny.nation", 25);
+        assertUpdate(session, "CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['nationkey'], \"write.format.default\" = '" + fileFormat + "') " + " AS SELECT * FROM tpch.tiny.nation", 25);
         Table icebergTable = updateTable(tableName);
         writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L, "nationkey", 1L), ImmutableMap.of("nationkey", 1L));
         assertQuery(session, "SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey != 1 or nationkey != 1 ");
@@ -1267,7 +1267,7 @@ public abstract class IcebergDistributedTestBase
     {
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "', partitioning = ARRAY['nationkey']) AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        assertUpdate("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "', partitioning = ARRAY['nationkey']) AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
         Table icebergTable = updateTable(tableName);
 
         List<Long> partitions = Arrays.asList(1L, 2L, 3L, 17L, 24L);
@@ -1286,7 +1286,7 @@ public abstract class IcebergDistributedTestBase
     {
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "', partitioning = ARRAY['bucket(nationkey,100)']) AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        assertUpdate("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "', partitioning = ARRAY['bucket(nationkey,100)']) AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
         Table icebergTable = updateTable(tableName);
 
         PartitionTransforms.ColumnTransform columnTransform = PartitionTransforms.getColumnTransform(icebergTable.spec().fields().get(0), BIGINT);
@@ -1311,7 +1311,7 @@ public abstract class IcebergDistributedTestBase
     {
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        assertUpdate("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
         Table icebergTable = updateTable(tableName);
 
         writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 0L, "name", "ALGERIA"));
@@ -1327,7 +1327,7 @@ public abstract class IcebergDistributedTestBase
     {
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        assertUpdate("CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
         Table icebergTable = updateTable(tableName);
 
         writeEqualityDeleteToNationTable(icebergTable, ImmutableMap.of("regionkey", 1L));
@@ -1346,7 +1346,7 @@ public abstract class IcebergDistributedTestBase
     {
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
-        assertUpdate(session, "CREATE TABLE " + tableName + " with (format = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
+        assertUpdate(session, "CREATE TABLE " + tableName + " with (\"write.format.default\" = '" + fileFormat + "') AS SELECT * FROM tpch.tiny.nation order by nationkey", 25);
         Table icebergTable = updateTable(tableName);
         String dataFilePath = (String) computeActual("SELECT file_path FROM \"" + tableName + "$files\" LIMIT 1").getOnlyValue();
 
@@ -1377,7 +1377,7 @@ public abstract class IcebergDistributedTestBase
     {
         Session session = deleteAsJoinEnabled(joinRewriteEnabled);
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
-        assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (format = '" + fileFormat + "')");
+        assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (\"write.format.default\" = '" + fileFormat + "')");
         assertUpdate("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002'), (3, '1003')", 3);
 
         Table icebergTable = updateTable(tableName);
@@ -1537,7 +1537,7 @@ public abstract class IcebergDistributedTestBase
     {
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
         try {
-            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (format_version = '2', delete_mode = 'merge-on-read')");
+            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (\"format-version\" = '2', \"write.delete.mode\" = 'merge-on-read')");
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002'), (3, '1003')", 3);
 
             // execute row level deletion
@@ -1619,7 +1619,7 @@ public abstract class IcebergDistributedTestBase
     {
         String tableName = "test_v2_row_delete_" + randomTableSuffix();
         try {
-            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (format_version = '2', delete_mode = 'merge-on-read', partitioning = ARRAY['a'])");
+            assertUpdate("CREATE TABLE " + tableName + "(a int, b varchar) WITH (\"format-version\" = '2', \"write.delete.mode\" = 'merge-on-read', partitioning = ARRAY['a'])");
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002'), (3, '1003')", 3);
 
             // execute row level deletion
@@ -1657,7 +1657,7 @@ public abstract class IcebergDistributedTestBase
         String tableName = "test_empty_partition_spec_table";
         try {
             // Create a table with no partition
-            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (format_version = '2', delete_mode = 'merge-on-read')");
+            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (\"format-version\" = '2', \"write.delete.mode\" = 'merge-on-read')");
 
             // Do not insert data, and evaluate the partition spec by adding a partition column `c`
             assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN c INTEGER WITH (partitioning = 'identity')");
@@ -1688,7 +1688,7 @@ public abstract class IcebergDistributedTestBase
         String tableName = "test_data_deleted_partition_spec_table";
         try {
             // Create a table with partition column `a`, and insert some data under this partition spec
-            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (format_version = '2', delete_mode = 'merge-on-read', partitioning = ARRAY['a'])");
+            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (\"format-version\" = '2', \"write.delete.mode\" = 'merge-on-read', partitioning = ARRAY['a'])");
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002')", 2);
 
             Table icebergTable = loadTable(tableName);
@@ -1737,7 +1737,7 @@ public abstract class IcebergDistributedTestBase
             // Create a table with setting properties that maintain only 1 previous metadata version in current metadata,
             //  and delete unuseful metadata files after each commit
             assertUpdate("CREATE TABLE " + settingTableName + " (a INTEGER, b VARCHAR)" +
-                    " WITH (metadata_previous_versions_max = 1, metadata_delete_after_commit = true)");
+                    " WITH (\"write.metadata.previous-versions-max\" = 1, \"write.metadata.delete-after-commit.enabled\" = true)");
 
             // Create a table with default table properties that maintain 100 previous metadata versions in current metadata,
             //  and do not automatically delete any metadata files
@@ -1889,7 +1889,7 @@ public abstract class IcebergDistributedTestBase
                     "   c_array ARRAY(BIGINT), " +
                     "   c_map MAP(VARCHAR, INT), " +
                     "   c_row ROW(a INT, b VARCHAR) " +
-                    ") WITH (format = 'PARQUET')", tmpTableName));
+                    ") WITH (\"write.format.default\" = 'PARQUET')", tmpTableName));
 
             assertUpdate(format("" +
                     "INSERT INTO %s " +

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -650,7 +650,7 @@ public class TestIcebergLogicalPlanner
         String tableName = "test_empty_partition_spec_table";
         try {
             // Create a table with no partition
-            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (format_version = '1')");
+            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (\"format-version\" = '1')");
 
             // Do not insert data, and evaluate the partition spec by adding a partition column `c`
             assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN c INTEGER WITH (partitioning = 'identity')");
@@ -688,7 +688,7 @@ public class TestIcebergLogicalPlanner
         String tableName = "test_data_deleted_partition_spec_table";
         try {
             // Create a table with partition column `a`, and insert some data under this partition spec
-            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (format_version = '1', partitioning = ARRAY['a'])");
+            assertUpdate("CREATE TABLE " + tableName + " (a INTEGER, b VARCHAR) WITH (\"format-version\" = '1', partitioning = ARRAY['a'])");
             assertUpdate("INSERT INTO " + tableName + " VALUES (1, '1001'), (2, '1002')", 2);
 
             // Then evaluate the partition spec by adding a partition column `c`, and insert some data under the new partition spec
@@ -1781,7 +1781,7 @@ public class TestIcebergLogicalPlanner
                 "id bigint, " +
                 "x row(a bigint, b varchar, c double, d row(d1 bigint, d2 double))," +
                 "y array(row(a bigint, b varchar, c double, d row(d1 bigint, d2 double)))) " +
-                "with (format = 'PARQUET')");
+                "with (\"write.format.default\" = 'PARQUET')");
         assertUpdate("INSERT INTO test_pushdown_nestedcolumn_parquet(id, x) VALUES(1, (11, 'abcd', 1.1, (1, 5.0)))", 1);
 
         assertParquetDereferencePushDown("SELECT x.a FROM test_pushdown_nestedcolumn_parquet",

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergOrcMetricsCollection.java
@@ -79,7 +79,7 @@ public class TestIcebergOrcMetricsCollection
     @Test
     public void testBasic()
     {
-        assertUpdate("CREATE TABLE orders WITH (format = 'ORC') AS SELECT * FROM tpch.tiny.orders", 15000);
+        assertUpdate("CREATE TABLE orders WITH (\"write.format.default\" = 'ORC') AS SELECT * FROM tpch.tiny.orders", 15000);
         MaterializedResult materializedResult = computeActual("SELECT * FROM \"orders$files\"");
         assertEquals(materializedResult.getRowCount(), 1);
         DataFileRecord datafile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
@@ -133,7 +133,7 @@ public class TestIcebergOrcMetricsCollection
     @Test
     public void testWithNulls()
     {
-        assertUpdate("CREATE TABLE test_with_nulls (_integer INTEGER, _real REAL, _string VARCHAR)  WITH (format = 'ORC')");
+        assertUpdate("CREATE TABLE test_with_nulls (_integer INTEGER, _real REAL, _string VARCHAR)  WITH (\"write.format.default\" = 'ORC')");
         assertUpdate("INSERT INTO test_with_nulls VALUES (7, 3.4, 'aaa'), (3, 4.5, 'bbb'), (4, null, 'ccc'), (null, null, 'ddd')", 4);
         MaterializedResult materializedResult = computeActual("SELECT * FROM \"test_with_nulls$files\"");
         assertEquals(materializedResult.getRowCount(), 1);
@@ -154,7 +154,7 @@ public class TestIcebergOrcMetricsCollection
 
         assertUpdate("DROP TABLE test_with_nulls");
 
-        assertUpdate("CREATE TABLE test_all_nulls (_integer INTEGER) WITH (format = 'ORC')");
+        assertUpdate("CREATE TABLE test_all_nulls (_integer INTEGER) WITH (\"write.format.default\" = 'ORC')");
         assertUpdate("INSERT INTO test_all_nulls VALUES null, null, null", 3);
         materializedResult = computeActual("SELECT * FROM \"test_all_nulls$files\"");
         assertEquals(materializedResult.getRowCount(), 1);
@@ -198,7 +198,7 @@ public class TestIcebergOrcMetricsCollection
     @Test
     public void testNestedTypes()
     {
-        assertUpdate("CREATE TABLE test_nested_types (col1 INTEGER, col2 ROW (f1 INTEGER, f2 ARRAY(INTEGER), f3 DOUBLE)) WITH (format = 'ORC')");
+        assertUpdate("CREATE TABLE test_nested_types (col1 INTEGER, col2 ROW (f1 INTEGER, f2 ARRAY(INTEGER), f3 DOUBLE)) WITH (\"write.format.default\" = 'ORC')");
         assertUpdate("INSERT INTO test_nested_types VALUES " +
                 "(7, ROW(3, ARRAY[10, 11, 19], 1.9)), " +
                 "(-9, ROW(4, ARRAY[13, 16, 20], -2.9)), " +

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -82,7 +82,7 @@ public class TestIcebergSystemTables
         assertUpdate("INSERT INTO test_schema.test_table VALUES (3, CAST('2019-09-09' AS DATE)), (4, CAST('2019-09-10' AS DATE)), (5, CAST('2019-09-10' AS DATE))", 3);
         assertQuery("SELECT count(*) FROM test_schema.test_table", "VALUES 6");
 
-        assertUpdate("CREATE TABLE test_schema.test_table_v1 (_bigint BIGINT, _date DATE) WITH (format_version = '1', partitioning = ARRAY['_date'])");
+        assertUpdate("CREATE TABLE test_schema.test_table_v1 (_bigint BIGINT, _date DATE) WITH (\"format-version\" = '1', partitioning = ARRAY['_date'])");
         assertUpdate("INSERT INTO test_schema.test_table_v1 VALUES (0, CAST('2019-09-08' AS DATE)), (1, CAST('2019-09-09' AS DATE)), (2, CAST('2019-09-09' AS DATE))", 3);
         assertUpdate("INSERT INTO test_schema.test_table_v1 VALUES (3, CAST('2019-09-09' AS DATE)), (4, CAST('2019-09-10' AS DATE)), (5, CAST('2019-09-10' AS DATE))", 3);
         assertQuery("SELECT count(*) FROM test_schema.test_table_v1", "VALUES 6");
@@ -97,14 +97,14 @@ public class TestIcebergSystemTables
         assertQuery("SELECT count(*) FROM test_schema.test_table_drop_column", "VALUES 6");
         assertUpdate("ALTER TABLE test_schema.test_table_drop_column DROP COLUMN _varchar");
 
-        assertUpdate("CREATE TABLE test_schema.test_table_orc (_bigint BIGINT) WITH (format_version = '1', format = 'ORC')");
+        assertUpdate("CREATE TABLE test_schema.test_table_orc (_bigint BIGINT) WITH (\"format-version\" = '1', \"write.format.default\" = 'ORC')");
         assertUpdate("INSERT INTO test_schema.test_table_orc VALUES (0), (1), (2)", 3);
 
         assertUpdate("CREATE TABLE test_schema.test_metadata_versions_maintain (_bigint BIGINT)" +
-                " WITH (metadata_previous_versions_max = 1, metadata_delete_after_commit = true)");
+                " WITH (\"write.metadata.previous-versions-max\" = 1, \"write.metadata.delete-after-commit.enabled\" = true)");
 
         assertUpdate("CREATE TABLE test_schema.test_metrics_max_inferred_column (_bigint BIGINT)" +
-                " WITH (metrics_max_inferred_column = 16)");
+                " WITH (\"write.metadata.metrics.max-inferred-column-defaults\" = 16)");
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeOnS3Hadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeOnS3Hadoop.java
@@ -120,15 +120,15 @@ public class TestIcebergSmokeOnS3Hadoop
                     "   \"b\" varchar\n" +
                     ")\n" +
                     "WITH (\n" +
-                    "   delete_mode = 'merge-on-read',\n" +
-                    "   format = 'PARQUET',\n" +
-                    "   format_version = '2',\n" +
+                    "   \"format-version\" = '2',\n" +
                     "   location = '%s',\n" +
-                    "   metadata_delete_after_commit = false,\n" +
-                    "   metadata_previous_versions_max = 100,\n" +
-                    "   metrics_max_inferred_column = 100,\n" +
                     "   \"read.split.target-size\" = 134217728,\n" +
                     "   \"write.data.path\" = '%s',\n" +
+                    "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                    "   \"write.format.default\" = 'PARQUET',\n" +
+                    "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                    "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                    "   \"write.metadata.previous-versions-max\" = 100,\n" +
                     "   \"write.update.mode\" = 'merge-on-read'\n" +
                     ")";
             assertThat(computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue())
@@ -196,16 +196,16 @@ public class TestIcebergSmokeOnS3Hadoop
                 "   \"order_status\" varchar\n" +
                 ")\n" +
                 "WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = '" + fileFormat + "',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   partitioning = ARRAY['order_status','ship_priority','bucket(order_key, 9)'],\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
                 "   \"write.data.path\" = '%s',\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = '%s',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")";
 
@@ -216,7 +216,8 @@ public class TestIcebergSmokeOnS3Hadoop
                         getSession().getSchema().get(),
                         tableName,
                         getLocation(getSession().getSchema().get(), tableName),
-                        getPathBasedOnDataDirectory(getSession().getSchema().get() + "/" + tableName)));
+                        getPathBasedOnDataDirectory(getSession().getSchema().get() + "/" + tableName),
+                        fileFormat));
 
         assertQuery(session, "SELECT * from " + tableName, "SELECT orderkey, shippriority, orderstatus FROM orders");
 
@@ -230,16 +231,16 @@ public class TestIcebergSmokeOnS3Hadoop
         String schemaName = session.getSchema().get();
 
         String tablePropertiesString = "WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'PARQUET',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   partitioning = ARRAY['adate'],\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
                 "   \"write.data.path\" = '%s',\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'PARQUET',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")";
         assertUpdate(session, "CREATE TABLE test_create_table_like_original (col1 INTEGER, aDate DATE) WITH(format = 'PARQUET', partitioning = ARRAY['aDate'])");
@@ -255,15 +256,15 @@ public class TestIcebergSmokeOnS3Hadoop
 
         assertUpdate(session, "CREATE TABLE test_create_table_like_copy1 (LIKE test_create_table_like_original)");
         tablePropertiesString = "WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'PARQUET',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
                 "   \"write.data.path\" = '%s',\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'PARQUET',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")";
         assertEquals(getTablePropertiesString("test_create_table_like_copy1"),
@@ -274,15 +275,15 @@ public class TestIcebergSmokeOnS3Hadoop
 
         assertUpdate(session, "CREATE TABLE test_create_table_like_copy2 (LIKE test_create_table_like_original EXCLUDING PROPERTIES)");
         tablePropertiesString = "WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'PARQUET',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
                 "   \"write.data.path\" = '%s',\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'PARQUET',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")";
         assertEquals(getTablePropertiesString("test_create_table_like_copy2"),
@@ -294,16 +295,16 @@ public class TestIcebergSmokeOnS3Hadoop
         assertUpdate(session, "CREATE TABLE test_create_table_like_copy5 (LIKE test_create_table_like_original INCLUDING PROPERTIES)" +
                 " WITH (location = '', \"write.data.path\" = '', format = 'ORC')");
         tablePropertiesString = "WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'ORC',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   partitioning = ARRAY['adate'],\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
                 "   \"write.data.path\" = '%s',\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'ORC',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")";
         assertEquals(getTablePropertiesString("test_create_table_like_copy5"),
@@ -343,15 +344,15 @@ public class TestIcebergSmokeOnS3Hadoop
                 "   \"order_status\" varchar\n" +
                 ")\n" +
                 "WITH (\n" +
-                "   delete_mode = '%s',\n" +
-                "   format = 'PARQUET',\n" +
-                "   format_version = '%s',\n" +
+                "   \"format-version\" = '%s',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
                 "   \"write.data.path\" = '%s',\n" +
+                "   \"write.delete.mode\" = '%s',\n" +
+                "   \"write.format.default\" = 'PARQUET',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = '%s'\n" +
                 ")";
 
@@ -361,10 +362,10 @@ public class TestIcebergSmokeOnS3Hadoop
                         getSession().getCatalog().get(),
                         getSession().getSchema().get(),
                         tableName,
-                        defaultDeleteMode,
                         formatVersion,
                         getLocation(getSession().getSchema().get(), tableName),
                         getPathBasedOnDataDirectory(getSession().getSchema().get() + "/" + tableName),
+                        defaultDeleteMode,
                         defaultDeleteMode));
 
         dropTable(session, tableName);
@@ -386,15 +387,15 @@ public class TestIcebergSmokeOnS3Hadoop
                 "   \"comment\" varchar\n" +
                 ")\n" +
                 "WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'PARQUET',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
                 "   \"write.data.path\" = '%s',\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'PARQUET',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")";
         assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
@@ -428,15 +429,15 @@ public class TestIcebergSmokeOnS3Hadoop
                 ")\n" +
                 "COMMENT '%s'\n" +
                 "WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'ORC',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
                 "   \"write.data.path\" = '%s',\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'ORC',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")";
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
@@ -43,6 +43,7 @@ import com.facebook.presto.iceberg.IcebergHiveTableOperationsConfig;
 import com.facebook.presto.iceberg.IcebergSessionProperties;
 import com.facebook.presto.iceberg.IcebergTableHandle;
 import com.facebook.presto.iceberg.IcebergTableName;
+import com.facebook.presto.iceberg.IcebergTableProperties;
 import com.facebook.presto.iceberg.IcebergTableType;
 import com.facebook.presto.iceberg.ManifestFileCache;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
@@ -414,7 +415,8 @@ public class TestRenameTableOnFragileFileSystem
                 FILTER_STATS_CALCULATOR_SERVICE,
                 new IcebergHiveTableOperationsConfig(),
                 new StatisticsFileCache(CacheBuilder.newBuilder().build()),
-                new ManifestFileCache(CacheBuilder.newBuilder().build(), false, 0, 1024));
+                new ManifestFileCache(CacheBuilder.newBuilder().build(), false, 0, 1024),
+                new IcebergTableProperties(new IcebergConfig()));
         return icebergHiveMetadataFactory.create();
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
@@ -206,4 +206,10 @@ public class TestIcebergSmokeRest
 
         assertEquals(catalog.properties().get(OAUTH2_SERVER_URI), authEndpoint);
     }
+
+    @Override
+    public void testDeprecatedTablePropertiesCreateTable()
+    {
+        // v1 table create fails due to Iceberg REST catalog bug (see: https://github.com/apache/iceberg/issues/8756)
+    }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
@@ -172,14 +172,14 @@ public class TestIcebergSmokeRestNestedNamespace
                         "   \"comment\" varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   delete_mode = 'merge-on-read',\n" +
-                        "   format = 'PARQUET',\n" +
-                        "   format_version = '2',\n" +
+                        "   \"format-version\" = '2',\n" +
                         "   location = '%s',\n" +
-                        "   metadata_delete_after_commit = false,\n" +
-                        "   metadata_previous_versions_max = 100,\n" +
-                        "   metrics_max_inferred_column = 100,\n" +
                         "   \"read.split.target-size\" = 134217728,\n" +
+                        "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                        "   \"write.format.default\" = 'PARQUET',\n" +
+                        "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                        "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                        "   \"write.metadata.previous-versions-max\" = 100,\n" +
                         "   \"write.update.mode\" = 'merge-on-read'\n" +
                         ")", schemaName, getLocation(schemaName, "orders")));
     }
@@ -199,15 +199,15 @@ public class TestIcebergSmokeRestNestedNamespace
                     "   \"b\" varchar\n" +
                     ")\n" +
                     "WITH (\n" +
-                    "   delete_mode = 'merge-on-read',\n" +
-                    "   format = 'PARQUET',\n" +
-                    "   format_version = '2',\n" +
+                    "   \"format-version\" = '2',\n" +
                     "   location = '%s',\n" +
-                    "   metadata_delete_after_commit = false,\n" +
-                    "   metadata_previous_versions_max = 100,\n" +
-                    "   metrics_max_inferred_column = 100,\n" +
                     "   \"read.split.target-size\" = 134217728,\n" +
                     "   \"write.data.path\" = '%s',\n" +
+                    "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                    "   \"write.format.default\" = 'PARQUET',\n" +
+                    "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                    "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                    "   \"write.metadata.previous-versions-max\" = 100,\n" +
                     "   \"write.update.mode\" = 'merge-on-read'\n" +
                     ")";
             assertThat(computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue())
@@ -231,8 +231,8 @@ public class TestIcebergSmokeRestNestedNamespace
                 ")\n" +
                 "COMMENT '%s'\n" +
                 "WITH (\n" +
-                "   format = 'ORC',\n" +
-                "   format_version = '2'\n" +
+                "   \"write.format.default\" = 'ORC',\n" +
+                "   \"format-version\" = '2'\n" +
                 ")";
 
         assertUpdate(format(createTable, schemaName, "test table comment"));
@@ -243,14 +243,14 @@ public class TestIcebergSmokeRestNestedNamespace
                 ")\n" +
                 "COMMENT '%s'\n" +
                 "WITH (\n" +
-                "   delete_mode = 'merge-on-read',\n" +
-                "   format = 'ORC',\n" +
-                "   format_version = '2',\n" +
+                "   \"format-version\" = '2',\n" +
                 "   location = '%s',\n" +
-                "   metadata_delete_after_commit = false,\n" +
-                "   metadata_previous_versions_max = 100,\n" +
-                "   metrics_max_inferred_column = 100,\n" +
                 "   \"read.split.target-size\" = 134217728,\n" +
+                "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                "   \"write.format.default\" = 'ORC',\n" +
+                "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                "   \"write.metadata.previous-versions-max\" = 100,\n" +
                 "   \"write.update.mode\" = 'merge-on-read'\n" +
                 ")";
         String createTableSql = format(createTableTemplate, schemaName, "test table comment", getLocation(schemaName, "test_table_comments"));
@@ -268,7 +268,7 @@ public class TestIcebergSmokeRestNestedNamespace
         @Language("SQL") String createTable = "" +
                 "CREATE TABLE test_create_partitioned_table_as_%s " +
                 "WITH (" +
-                "format = '%s', " +
+                "\"write.format.default\" = '%s', " +
                 "partitioning = ARRAY['ORDER_STATUS', 'Ship_Priority', 'Bucket(order_key,9)']" +
                 ") " +
                 "AS " +
@@ -284,22 +284,22 @@ public class TestIcebergSmokeRestNestedNamespace
                         "   \"order_status\" varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   delete_mode = 'merge-on-read',\n" +
-                        "   format = '%s',\n" +
-                        "   format_version = '2',\n" +
+                        "   \"format-version\" = '2',\n" +
                         "   location = '%s',\n" +
-                        "   metadata_delete_after_commit = false,\n" +
-                        "   metadata_previous_versions_max = 100,\n" +
-                        "   metrics_max_inferred_column = 100,\n" +
                         "   partitioning = ARRAY['order_status','ship_priority','bucket(order_key, 9)'],\n" +
                         "   \"read.split.target-size\" = 134217728,\n" +
+                        "   \"write.delete.mode\" = 'merge-on-read',\n" +
+                        "   \"write.format.default\" = '%s',\n" +
+                        "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                        "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                        "   \"write.metadata.previous-versions-max\" = 100,\n" +
                         "   \"write.update.mode\" = 'merge-on-read'\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
                 "test_create_partitioned_table_as_" + fileFormatString,
-                fileFormat,
-                getLocation(getSession().getSchema().get(), "test_create_partitioned_table_as_" + fileFormatString));
+                getLocation(getSession().getSchema().get(), "test_create_partitioned_table_as_" + fileFormatString),
+                fileFormat);
 
         MaterializedResult actualResult = computeActual("SHOW CREATE TABLE test_create_partitioned_table_as_" + fileFormatString);
         assertEquals(getOnlyElement(actualResult.getOnlyColumnAsSet()), createTableSql);
@@ -329,8 +329,8 @@ public class TestIcebergSmokeRestNestedNamespace
         @Language("SQL") String createTable = "" +
                 "CREATE TABLE test_create_table_with_format_version_%s " +
                 "WITH (" +
-                "format = 'PARQUET', " +
-                "format_version = '%s'" +
+                "\"write.format.default\" = 'PARQUET', " +
+                "\"format-version\" = '%s'" +
                 ") " +
                 "AS " +
                 "SELECT orderkey AS order_key, shippriority AS ship_priority, orderstatus AS order_status " +
@@ -347,22 +347,22 @@ public class TestIcebergSmokeRestNestedNamespace
                         "   \"order_status\" varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   delete_mode = '%s',\n" +
-                        "   format = 'PARQUET',\n" +
-                        "   format_version = '%s',\n" +
+                        "   \"format-version\" = '%s',\n" +
                         "   location = '%s',\n" +
-                        "   metadata_delete_after_commit = false,\n" +
-                        "   metadata_previous_versions_max = 100,\n" +
-                        "   metrics_max_inferred_column = 100,\n" +
                         "   \"read.split.target-size\" = 134217728,\n" +
+                        "   \"write.delete.mode\" = '%s',\n" +
+                        "   \"write.format.default\" = 'PARQUET',\n" +
+                        "   \"write.metadata.delete-after-commit.enabled\" = false,\n" +
+                        "   \"write.metadata.metrics.max-inferred-column-defaults\" = 100,\n" +
+                        "   \"write.metadata.previous-versions-max\" = 100,\n" +
                         "   \"write.update.mode\" = '%s'\n" +
                         ")",
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
                 "test_create_table_with_format_version_" + formatVersion,
-                defaultDeleteMode,
                 formatVersion,
                 getLocation(getSession().getSchema().get(), "test_create_table_with_format_version_" + formatVersion),
+                defaultDeleteMode,
                 defaultDeleteMode);
 
         MaterializedResult actualResult = computeActual("SHOW CREATE TABLE test_create_table_with_format_version_" + formatVersion);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/session/PropertyMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/session/PropertyMetadata.java
@@ -116,12 +116,22 @@ public final class PropertyMetadata<T>
         return decoder.apply(value);
     }
 
+    public Function<Object, T> getDecoder()
+    {
+        return decoder;
+    }
+
     /**
      * Encodes the Java type value to SQL type object value
      */
     public Object encode(T value)
     {
         return encoder.apply(value);
+    }
+
+    public Function<T, Object> getEncoder()
+    {
+        return encoder;
     }
 
     public static PropertyMetadata<Boolean> booleanProperty(String name, String description, Boolean defaultValue, boolean hidden)


### PR DESCRIPTION
## Description

Deprecates presto-specific table property names in favor of using the Iceberg library property names

## Motivation and Context

Having a separate set of property names for iceberg is confusing for users 

## Impact

- Iceberg library property names can be used, old names can also still be used
- queries which alter table properties or create tables using old property names are given a deprecation warning
- after a few releases, we will remove the old property names

## Test Plan

- new tests verify old and new properties can all be used
- new tests verify warnings are added when any deprecated properties are used

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Deprecate some table property names in favor of property names from the Iceberg library. See :doc:`connector/iceberg.rst`.
```
