### PR TITLE
[native] fix(iceberg): Date partition value parse issue

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
@@ -1409,12 +1409,18 @@ IcebergPrestoToVeloxConnector::toVeloxColumnHandle(
   // TODO(imjalpreet): Modify 'hiveType' argument of the 'HiveColumnHandle'
   //  constructor similar to how Hive Connector is handling for bucketing
   velox::type::fbhive::HiveTypeParser hiveTypeParser;
+  auto type = stringToType(icebergColumn->type, typeParser);
+  connector::hive::HiveColumnHandle::ColumnParseParameters columnParseParameters;
+  if (type->isDate()) {
+    columnParseParameters.partitionDateValueFormat = connector::hive::HiveColumnHandle::ColumnParseParameters::kDaysSinceEpoch;
+  }
   return std::make_unique<connector::hive::HiveColumnHandle>(
       icebergColumn->columnIdentity.name,
       toHiveColumnType(icebergColumn->columnType),
-      stringToType(icebergColumn->type, typeParser),
-      stringToType(icebergColumn->type, typeParser),
-      toRequiredSubfields(icebergColumn->requiredSubfields));
+      type,
+      type,
+      toRequiredSubfields(icebergColumn->requiredSubfields),
+      columnParseParameters);
 }
 
 std::unique_ptr<velox::connector::ConnectorTableHandle>


### PR DESCRIPTION
## Description
Fixes https://github.com/prestodb/presto/issues/24371

## Motivation and Context
Filter on date column fails in Iceberg since the value returned by Iceberg API is in daysSinceEpoch but we assume its in ISO format "YYYY-MM-DD" and try to convert it to daysSinceEpoch. Velox side changes are merged in https://github.com/facebookincubator/velox/pull/12126

## Impact
None. 

## Test Plan
Added tests in TestPrestoNativeIcebergGeneralQueries.java

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Fix Iceberg date column filtering
```


