### PR TITLE
Add ability to dynamically add/remove catalogs without restarting Presto

### DIFF
--- a/presto-docs/src/main/sphinx/rest.rst
+++ b/presto-docs/src/main/sphinx/rest.rst
@@ -12,4 +12,5 @@ This chapter outlines the REST API resources available in Presto.
     rest/stage
     rest/statement
     rest/task
+    rest/catalog
 

--- a/presto-docs/src/main/sphinx/rest/catalog.rst
+++ b/presto-docs/src/main/sphinx/rest/catalog.rst
@@ -1,0 +1,130 @@
+================
+Catalog Resource
+================
+
+.. function:: GET /v1/catalog
+
+   Returns a list of all catalogs currently registered.
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Vary: Accept-Encoding, User-Agent
+      Content-Type: application/json
+      X-Content-Type-Options: nosniff
+      Content-Length: 73
+
+      ["system","tpch","tpcds","tpchstandard","hive","hive_bucketed","tpch_1"]
+
+.. function:: POST /v1/catalog/{catalogName}
+
+   Submits a catalog to register.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+     POST /v1/catalog/tpch_1 HTTP/1.1
+     Host: 127.0.0.1:8080
+     Accept: */*
+     X-Presto-Prefix-Url: PREFIX
+     X-Presto-User: PRESTO_USER
+     User-Agent: StatementClient/0.55-SNAPSHOT
+     Content-Type: application/json
+     Content-Length: 88
+
+     {
+          "connector.name": "tpch",
+          "tpch.splits-per-node": "4"
+     }
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Content-Type: application/json
+      Content-Length: 0
+
+.. function:: GET /v1/catalog/{catalogName}/status
+
+   Returns the status of a requested catalog.
+
+   The possible result status values are ``catalog_in_use``, ``catalog_not_in_use``, ``catalog_not_found``.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /v1/catalog/system/status HTTP/1.1
+      Host: 127.0.0.1:8080
+      Accept: */*
+      X-Presto-Prefix-Url: PREFIX
+      X-Presto-User: PRESTO_USER
+      User-Agent: StatementClient/0.55-SNAPSHOT
+      Content-Type: application/json
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+      X-Content-Type-Options: nosniff
+      Vary: Accept-Encoding, User-Agent
+
+      {"message":"The given catalog system is currently in use","status":"catalog_in_use"}
+
+.. function:: DELETE /v1/catalog/{catalogName}
+
+   Removes a catalog.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      DELETE /v1/catalog/tpch_1 HTTP/1.1
+      Host: 127.0.0.1:8080
+      Accept: */*
+      X-Presto-Prefix-Url: PREFIX
+      X-Presto-User: PRESTO_USER
+      User-Agent: StatementClient/0.55-SNAPSHOT
+      Content-Type: application/json
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content
+
+.. function:: POST /v1/catalog/{catalogName}
+
+   Updates a catalog with new parameters.
+
+   Possible responses are 201, 204, 409.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      PUT /v1/catalog/tpch_1 HTTP/1.1
+      Host: 127.0.0.1:8080
+      Accept: */*
+      X-Presto-Prefix-Url: PREFIX
+      X-Presto-User: PRESTO_USER
+      User-Agent: StatementClient/0.55-SNAPSHOT
+      Content-Type: application/json
+      Content-Length: 88
+
+      {
+           "connector.name": "tpch",
+           "tpch.splits-per-node": "4"
+      }
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticCatalogStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticCatalogStore.java
@@ -15,6 +15,7 @@ package com.facebook.presto.metadata;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.connector.ConnectorManager;
+import com.facebook.presto.spi.ConnectorId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -86,23 +87,12 @@ public class StaticCatalogStore
         catalogsLoaded.set(true);
     }
 
-    private void loadCatalog(File file)
-            throws Exception
+    public ConnectorId loadCatalog(String catalogName, Map<String, String> properties)
     {
-        String catalogName = Files.getNameWithoutExtension(file.getName());
-
-        log.info("-- Loading catalog properties %s --", file);
-        Map<String, String> properties = loadProperties(file);
-        checkState(properties.containsKey("connector.name"), "Catalog configuration %s does not contain connector.name", file.getAbsoluteFile());
-
-        loadCatalog(catalogName, properties);
-    }
-
-    private void loadCatalog(String catalogName, Map<String, String> properties)
-    {
+        ConnectorId connectorId = null;
         if (disabledCatalogs.contains(catalogName)) {
             log.info("Skipping disabled catalog %s", catalogName);
-            return;
+            return connectorId;
         }
 
         log.info("-- Loading catalog %s --", catalogName);
@@ -120,8 +110,26 @@ public class StaticCatalogStore
 
         checkState(connectorName != null, "Configuration for catalog %s does not contain connector.name", catalogName);
 
-        connectorManager.createConnection(catalogName, connectorName, connectorProperties.build());
+        connectorId = connectorManager.createConnection(catalogName, connectorName, connectorProperties.build());
         log.info("-- Added catalog %s using connector %s --", catalogName, connectorName);
+        return connectorId;
+    }
+
+    public void dropConnection(String catalogName)
+    {
+        connectorManager.dropConnection(catalogName);
+    }
+
+    private void loadCatalog(File file)
+            throws Exception
+    {
+        String catalogName = Files.getNameWithoutExtension(file.getName());
+
+        log.info("-- Loading catalog properties %s --", file);
+        Map<String, String> properties = loadProperties(file);
+        checkState(properties.containsKey("connector.name"), "Catalog configuration %s does not contain connector.name", file.getAbsoluteFile());
+
+        loadCatalog(catalogName, properties);
     }
 
     private static List<File> listFiles(File installedPluginsDir)

--- a/presto-main/src/main/java/com/facebook/presto/server/CatalogResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CatalogResource.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.discovery.client.Announcer;
+import com.facebook.airlift.discovery.client.ServiceAnnouncement;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.connector.ConnectorTypeSerdeManager;
+import com.facebook.presto.execution.Input;
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.metadata.Catalog;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.metadata.StaticCatalogStore;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static com.facebook.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
+import static com.facebook.presto.server.CatalogResource.CatalogOperation.ADD;
+import static com.facebook.presto.server.CatalogResource.CatalogOperation.REMOVE;
+import static com.facebook.presto.server.CatalogResource.CatalogOperation.UPDATE;
+import static com.facebook.presto.server.PrestoServer.getPrestoAnnouncement;
+import static com.facebook.presto.server.security.RoleType.ADMIN;
+import static com.facebook.presto.server.security.RoleType.USER;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.nullToEmpty;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.OK;
+
+@Path("/v1/catalog")
+@RolesAllowed({USER, ADMIN})
+public class CatalogResource
+{
+    private static final Logger log = Logger.get(CatalogResource.class);
+    private final StaticCatalogStore catalogStore;
+    private final ConnectorTypeSerdeManager connectorTypeSerdeManager;
+    private final Announcer announcer;
+    private final CatalogManager catalogManager;
+    private final InternalNodeManager nodeManager;
+    private final FeaturesConfig featuresConfig;
+    private final QueryManager queryManager;
+    private final Predicate<BasicQueryInfo> nonNull = Objects::nonNull;
+    private final Predicate<BasicQueryInfo> isRunning = this::isRunning;
+
+    @Inject
+    public CatalogResource(StaticCatalogStore catalogStore,
+                           Announcer announcer,
+                           CatalogManager catalogManager,
+                           ConnectorTypeSerdeManager connectorTypeSerdeManager,
+                           InternalNodeManager nodeManager,
+                           QueryManager queryManager,
+                           FeaturesConfig featuresConfig)
+    {
+        this.catalogStore = requireNonNull(catalogStore, "catalogStore is null");
+        this.announcer = requireNonNull(announcer, "announcer is null");
+        this.catalogManager = requireNonNull(catalogManager, "catalogManager is null");
+        this.connectorTypeSerdeManager = requireNonNull(connectorTypeSerdeManager, "connectorMetadataUpdateHandleSerdeManager is null");
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
+        this.featuresConfig = requireNonNull(featuresConfig, "featuresConfig is null");
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Response getCatalogList()
+    {
+        final ServiceAnnouncement announcement = getPrestoAnnouncement(announcer.getServiceAnnouncements());
+        final String property = announcement.getProperties().get("connectorIds");
+        List<String> catalogList = Collections.emptyList();
+        if (!isNullOrEmpty(property)) {
+            catalogList = Splitter.on(",").trimResults().omitEmptyStrings().splitToList(property);
+        }
+        return Response.ok(catalogList).build();
+    }
+
+    @GET
+    @Path("/{catalogName:[0-9a-z_]*}/status")
+    @Produces(APPLICATION_JSON)
+    public Response getCatalogStatus(@PathParam("catalogName") String catalogName)
+    {
+        Response.Status status = NOT_FOUND;
+        final Map<String, String> apiResponse = new HashMap<>();
+        ConnectorId connectorId = getCatalogConnectorId(catalogName);
+        if (Objects.nonNull(connectorId)) {
+            final boolean catalogInUse = isCatalogInUse(connectorId);
+            if (catalogInUse) {
+                apiResponse.put("status", "catalog_in_use");
+                apiResponse.put("message", format("The given catalog %s is currently in use", catalogName));
+            }
+            else {
+                apiResponse.put("status", "catalog_not_in_use");
+                apiResponse.put("message", format("The given catalog %s is not in use", catalogName));
+            }
+            status = OK;
+        }
+        else {
+            apiResponse.put("status", "catalog_not_found");
+            apiResponse.put("message", format("The given catalog %s was not found", catalogName));
+            log.info("Catalog ['%s'] Not found", catalogName);
+        }
+        return Response.status(status).entity(apiResponse).build();
+    }
+
+    @POST
+    @Path("/{catalogName:[0-9a-z_]*}")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response addCatalog(@Context HttpServletRequest servletRequest,
+                               @PathParam("catalogName") String catalogName,
+                               Map<String, String> properties) throws WebApplicationException
+    {
+        log.info("addCatalog::%s", catalogName);
+        if (featuresConfig.isRestrictCatalogEndpointsLocally() && !isLocalhost(servletRequest)) {
+            log.info("Blocking non Localhost addCatalog %s", catalogName);
+            return Response.status(FORBIDDEN).build();
+        }
+        return executeCatalogOperation(ADD, catalogName, properties, servletRequest);
+    }
+
+    private ConnectorId registerCatalog(String catalogName, Map<String, String> properties)
+    {
+        return catalogStore.loadCatalog(catalogName, properties);
+    }
+
+    @DELETE
+    @Path("/{catalogName:[0-9a-z_]*}")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response removeCatalog(@Context HttpServletRequest servletRequest,
+                                  @PathParam("catalogName") String catalogName) throws WebApplicationException
+    {
+        log.info("removeCatalog::%s", catalogName);
+        if (featuresConfig.isRestrictCatalogEndpointsLocally() && !isLocalhost(servletRequest)) {
+            log.info("Blocking non Localhost removeCatalog %s", catalogName);
+            return Response.status(FORBIDDEN).build();
+        }
+        return executeCatalogOperation(REMOVE, catalogName, ImmutableMap.of(), servletRequest);
+    }
+
+    @PUT
+    @Path("/{catalogName:[0-9a-z_]*}")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response updateCatalog(@Context HttpServletRequest servletRequest,
+                                  @PathParam("catalogName") String catalogName,
+                                  Map<String, String> properties) throws WebApplicationException
+    {
+        log.info("updateCatalog::%s", catalogName);
+        if (featuresConfig.isRestrictCatalogEndpointsLocally() && !isLocalhost(servletRequest)) {
+            log.info("Blocking non Localhost updateCatalog %s", catalogName);
+            return Response.status(FORBIDDEN).build();
+        }
+        return executeCatalogOperation(UPDATE, catalogName, properties, servletRequest);
+    }
+
+    private synchronized Response executeCatalogOperation(CatalogOperation operation, String catalogName,
+                                             Map<String, String> properties, HttpServletRequest servletRequest)
+    {
+        final Principal principal = servletRequest.getUserPrincipal();
+        Response.Status status;
+        ConnectorId connectorId;
+        switch (operation) {
+            case ADD:
+                status = CONFLICT;
+                if (!isCatalogPresent(catalogName)) {
+                    connectorId = registerCatalog(catalogName, properties);
+                    if (Objects.nonNull(connectorId)) {
+                        updateConnectorIds(connectorId, false);
+                        log.info("Catalog ['%s'] is added to Presto by user ['%s']", catalogName, principal);
+                        status = CREATED;
+                    }
+                }
+                else {
+                    log.info("Catalog ['%s'] is already present in Presto", catalogName);
+                }
+                break;
+            case REMOVE:
+                connectorId = getCatalogConnectorId(catalogName);
+                boolean isCatalogInUse = isCatalogInUse(connectorId);
+                log.info("Remove flow, isCatalogInUse for  ['%s'] - [%s]", catalogName, isCatalogInUse);
+                if (Objects.nonNull(connectorId) && !isCatalogInUse) {
+                    catalogStore.dropConnection(catalogName);
+                    connectorTypeSerdeManager.removeConnectorTypeSerdeProvider(connectorId);
+                    updateConnectorIds(connectorId, true);
+                    log.info("Catalog ['%s'] is removed by user ['%s']", catalogName, principal);
+                    status = NO_CONTENT;
+                }
+                else {
+                    status = CONFLICT;
+                }
+                break;
+            case UPDATE:
+                connectorId = getCatalogConnectorId(catalogName);
+                if (Objects.nonNull(connectorId)) {
+                    catalogStore.dropConnection(catalogName);
+                    connectorTypeSerdeManager.removeConnectorTypeSerdeProvider(connectorId);
+                    updateConnectorIds(connectorId, true);
+                    log.info("Catalog ['%s'] is removed by user ['%s']", catalogName, principal);
+                    status = NO_CONTENT;
+                }
+                else {
+                    log.info("Catalog ['%s'] Not found", catalogName);
+                    status = CREATED;
+                }
+                connectorId = registerCatalog(catalogName, properties);
+                if (Objects.nonNull(connectorId)) {
+                    updateConnectorIds(connectorId, false);
+                    log.info("Catalog ['%s'] is updated by user ['%s']", catalogName, principal);
+                }
+                else {
+                    log.info("Unable to create Connection for catalog ['%s']", catalogName);
+                    status = CONFLICT;
+                }
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported catalog operation: " + operation);
+        }
+        return Response.status(status).build();
+    }
+
+    private boolean isCatalogPresent(String catalogName)
+    {
+        return catalogManager.getCatalog(catalogName).isPresent();
+    }
+
+    private ConnectorId getCatalogConnectorId(String catalogName)
+    {
+        final Optional<Catalog> catalog = catalogManager.getCatalog(catalogName);
+        return catalog.map(Catalog::getConnectorId).orElse(null);
+    }
+
+    private void updateConnectorIds(ConnectorId connectorId, boolean remove)
+    {
+        ServiceAnnouncement announcement = getPrestoAnnouncement(announcer.getServiceAnnouncements());
+        log.debug("announcement::%s", announcement);
+        Map<String, String> properties = new LinkedHashMap<>(announcement.getProperties());
+        log.info("Announcement properties::%s", properties);
+        String property = nullToEmpty(properties.get("connectorIds"));
+        log.info("connectorIds::%s", property);
+        List<String> values = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(property);
+        Set<String> connectorIds = new LinkedHashSet<>(values);
+        if (remove) {
+            //remove existing ConnectorId
+            connectorIds.remove(connectorId.toString());
+        }
+        else {
+            connectorIds.add(connectorId.toString());
+        }
+        properties.put("connectorIds", Joiner.on(',').join(connectorIds));
+        log.info("Updated connectorIds::%s", properties.get("connectorIds"));
+        announcer.removeServiceAnnouncement(announcement.getId());
+        announcer.addServiceAnnouncement(serviceAnnouncement(announcement.getType()).addProperties(properties).build());
+        announcer.forceAnnounce();
+        nodeManager.refreshNodes();
+    }
+
+    private boolean isLocalhost(final HttpServletRequest servletRequest)
+    {
+        try {
+            final InetAddress localAddress = InetAddress.getByName(servletRequest.getLocalAddr());
+            final InetAddress remoteAddress = InetAddress.getByName(servletRequest.getRemoteAddr());
+            log.debug("localAddress::['%s'],remoteAddress::['%s']", localAddress, remoteAddress);
+            return localAddress.isLoopbackAddress() || localAddress.equals(remoteAddress);
+        }
+        catch (UnknownHostException exc) {
+            // Handle exception, possibly log it
+            return false;
+        }
+    }
+    private boolean isCatalogInUse(ConnectorId connectorId)
+    {
+        boolean catalogInUse = queryManager.getQueries().stream()
+                .filter(nonNull.and(isRunning))
+                .map(BasicQueryInfo::getQueryId)
+                .map(queryId -> {
+                    try {
+                        return queryManager.getFullQueryInfo(queryId);
+                    }
+                    catch (NoSuchElementException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .anyMatch(queryInfo ->
+                {
+                    for (Input input : queryInfo.getInputs()) {
+                        if (input.getConnectorId() == connectorId) {
+                            return true;
+                        }
+                    }
+                    return queryInfo.getOutput().isPresent() &&
+                            queryInfo.getOutput().get().getConnectorId().equals(connectorId);
+                });
+        log.info("ConnectorId::['%s'] isCatalogInUse [%s]", connectorId, catalogInUse);
+        return catalogInUse;
+    }
+
+    private Set<ConnectorId> extractConnectorIds(QueryInfo queryInfo)
+    {
+        ImmutableSet.Builder<ConnectorId> connectors = ImmutableSet.builder();
+        for (Input input : queryInfo.getInputs()) {
+            connectors.add(input.getConnectorId());
+        }
+        if (queryInfo.getOutput().isPresent()) {
+            connectors.add(queryInfo.getOutput().get().getConnectorId());
+        }
+        return connectors.build();
+    }
+
+    private boolean isRunning(BasicQueryInfo queryInfo)
+    {
+        return !queryInfo.getState().isDone();
+    }
+
+    enum CatalogOperation
+    {
+        ADD, REMOVE, UPDATE
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -211,6 +211,16 @@ public class PrestoServer
         }
     }
 
+    public static ServiceAnnouncement getPrestoAnnouncement(Set<ServiceAnnouncement> announcements)
+    {
+        for (ServiceAnnouncement announcement : announcements) {
+            if (announcement.getType().equals("presto")) {
+                return announcement;
+            }
+        }
+        throw new IllegalArgumentException("Presto announcement not found: " + announcements);
+    }
+
     protected Iterable<? extends Module> getAdditionalModules()
     {
         return ImmutableList.of();
@@ -279,15 +289,5 @@ public class PrestoServer
         announcer.addServiceAnnouncement(serviceAnnouncement(announcement.getType()).addProperties(properties).build());
 
         announcer.forceAnnounce();
-    }
-
-    private static ServiceAnnouncement getPrestoAnnouncement(Set<ServiceAnnouncement> announcements)
-    {
-        for (ServiceAnnouncement announcement : announcements) {
-            if (announcement.getType().equals("presto")) {
-                return announcement;
-            }
-        }
-        throw new IllegalArgumentException("Presto announcement not found: " + announcements);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -729,6 +729,9 @@ public class ServerMainModule
         jaxrsBinder(binder).bind(StatusResource.class);
         jsonCodecBinder(binder).bindJsonCodec(NodeStatus.class);
 
+        // dynamic catalog resource
+        jaxrsBinder(binder).bind(CatalogResource.class);
+
         // plugin manager
         binder.bind(PluginManager.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(PluginManagerConfig.class);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -299,6 +299,8 @@ public class FeaturesConfig
     private String expressionOptimizerName = DEFAULT_EXPRESSION_OPTIMIZER_NAME;
     private boolean addExchangeBelowPartialAggregationOverGroupId;
 
+    private boolean restrictCatalogEndpointsLocally;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2958,5 +2960,18 @@ public class FeaturesConfig
     public boolean getAddExchangeBelowPartialAggregationOverGroupId()
     {
         return addExchangeBelowPartialAggregationOverGroupId;
+    }
+
+    @Config("restrict-catalog-endpoints-locally")
+    @ConfigDescription("Restrict access to dynamic loading catalog to requests from localhost")
+    public FeaturesConfig setRestrictCatalogEndpointsLocally(boolean restrictCatalogEndpointsLocally)
+    {
+        this.restrictCatalogEndpointsLocally = restrictCatalogEndpointsLocally;
+        return this;
+    }
+
+    public boolean isRestrictCatalogEndpointsLocally()
+    {
+        return restrictCatalogEndpointsLocally;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -55,7 +55,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class TestFeaturesConfig
 {
     @Test
-    public void testDefaults()
+    public void gintestDefaults()
     {
         assertRecordedDefaults(ConfigAssertions.recordDefaults(FeaturesConfig.class)
                 .setCpuCostWeight(75)
@@ -254,7 +254,8 @@ public class TestFeaturesConfig
                 .setEnhancedCTESchedulingEnabled(true)
                 .setExpressionOptimizerName("default")
                 .setExcludeInvalidWorkerSessionProperties(false)
-                .setAddExchangeBelowPartialAggregationOverGroupId(false));
+                .setAddExchangeBelowPartialAggregationOverGroupId(false)
+                .setRestrictCatalogEndpointsLocally(false));
     }
 
     @Test
@@ -458,6 +459,7 @@ public class TestFeaturesConfig
                 .put("expression-optimizer-name", "custom")
                 .put("exclude-invalid-worker-session-properties", "true")
                 .put("optimizer.add-exchange-below-partial-aggregation-over-group-id", "true")
+                .put("restrict-catalog-endpoints-locally", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -658,7 +660,8 @@ public class TestFeaturesConfig
                 .setEnhancedCTESchedulingEnabled(false)
                 .setExpressionOptimizerName("custom")
                 .setExcludeInvalidWorkerSessionProperties(true)
-                .setAddExchangeBelowPartialAggregationOverGroupId(true);
+                .setAddExchangeBelowPartialAggregationOverGroupId(true)
+                .setRestrictCatalogEndpointsLocally(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestCatalogResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestCatalogResource.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.prepareDelete;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.Request.Builder.preparePut;
+import static com.facebook.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREFIX_URL;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_USER;
+import static com.facebook.presto.server.RequestHelpers.setContentTypeHeaders;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestCatalogResource
+{
+    private static final String CATALOG_RESOURCE_URI = "/v1/catalog/%s";
+    private static final JsonCodec<List<String>> LIST_CODEC = listJsonCodec(String.class);
+    private HttpClient client;
+    private DistributedQueryRunner runner;
+    private TestingPrestoServer server;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        client = new JettyHttpClient();
+        runner = createQueryRunner();
+        server = runner.getCoordinator();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(server);
+        closeQuietly(client);
+        server = null;
+        client = null;
+    }
+
+    @Test
+    public void testCatalogResource()
+            throws Exception
+    {
+        final Map<String, String> catalogProperties = getCatalogPropertiesMap();
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve(format(CATALOG_RESOURCE_URI, "tpch_1"))).build();
+
+        // CREATE FLOW
+        Request.Builder requestBuiler = setContentTypeHeaders(false, preparePost());
+        Request request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 201);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 409);
+        validateCatalogDetails(ImmutableSet.of("system", "testing_catalog", "tpch", "tpch_1"));
+
+        // DELETE FLOW
+        requestBuiler = setContentTypeHeaders(false, prepareDelete());
+        request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 204);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 409);
+        validateCatalogDetails(ImmutableSet.of("system", "testing_catalog", "tpch"));
+
+        // UPDATE FLOW
+        requestBuiler = setContentTypeHeaders(false, preparePut());
+        request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 201);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 204);
+        validateCatalogDetails(ImmutableSet.of("system", "testing_catalog", "tpch", "tpch_1"));
+
+        request = prepareGet().setUri(server.getBaseUrl().resolve("/v1/catalog")).build();
+        List<String> catalogList = client.execute(request, createJsonResponseHandler(LIST_CODEC));
+        assertTrue(!catalogList.isEmpty());
+        assertTrue(catalogList.contains("tpch_1"));
+    }
+
+    @Test
+    public void testInvalidCatalogName()
+    {
+        final Map<String, String> catalogProperties = getCatalogPropertiesMap();
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve(format(CATALOG_RESOURCE_URI, "UNKNOWN88"))).build();
+        Request.Builder requestBuiler = setContentTypeHeaders(false, preparePost());
+        Request request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 404);
+    }
+
+    @Test
+    public void testConcurrentQueryRemoveCatalog() throws InterruptedException
+    {
+        final Map<String, String> catalogProperties = getCatalogPropertiesMap();
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve(format(CATALOG_RESOURCE_URI, "tpch_1"))).build();
+        Request.Builder requestBuiler = setContentTypeHeaders(false, preparePost());
+        Request request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 201);
+
+        Function<String, Exception> catalogQueryFunction = (catalog) -> {
+            try {
+                runner.execute("SELECT * FROM " + catalog + ".tiny.orders");
+            }
+            catch (Exception e) {
+                return e;
+            }
+            return null;
+        };
+        ConcurrentQueryRunner<String, Exception> runner = new ConcurrentQueryRunner<>(4, catalogQueryFunction, "tpch_1");
+
+        runner.start();
+        Thread.sleep(1000);
+        requestBuiler = setContentTypeHeaders(false, prepareDelete());
+        request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 409);
+        runner.stop();
+    }
+
+    @Test
+    public void testUnrelatedCatalogRemoval() throws InterruptedException
+    {
+        final Map<String, String> catalogProperties = getCatalogPropertiesMap();
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve(format(CATALOG_RESOURCE_URI, "tpch_3"))).build();
+        Request.Builder requestBuiler = setContentTypeHeaders(false, preparePost());
+        Request request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 201);
+
+        uri = uriBuilderFrom(server.getBaseUrl().resolve(format(CATALOG_RESOURCE_URI, "tpch_4"))).build();
+        requestBuiler = setContentTypeHeaders(false, preparePost());
+        request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 201);
+
+        Function<String, Exception> catalogQueryFunction = (catalog) -> {
+            try {
+                runner.execute("SELECT * FROM " + catalog + ".tiny.orders");
+            }
+            catch (Exception e) {
+                return e;
+            }
+            return null;
+        };
+        ConcurrentQueryRunner<String, Exception> runner = new ConcurrentQueryRunner<>(4, catalogQueryFunction, "tpch_3");
+
+        runner.start();
+        Thread.sleep(1000);
+        requestBuiler = setContentTypeHeaders(false, prepareDelete());
+        request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 204);
+        runner.stop();
+    }
+
+    @Test
+    public void testConcurrentCatalogManipulation() throws InterruptedException
+    {
+        final Map<String, String> catalogProperties = getCatalogPropertiesMap();
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve(format(CATALOG_RESOURCE_URI, "tpch_1"))).build();
+        Request.Builder requestBuiler = setContentTypeHeaders(false, preparePost());
+        Request request = createRequest(requestBuiler, catalogProperties, uri);
+        assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 201);
+        Thread appendThread = new Thread() {
+            public void run()
+            {
+                URI uri = uriBuilderFrom(server.getBaseUrl().resolve(format(CATALOG_RESOURCE_URI, "tpch_2"))).build();
+                Request.Builder requestBuiler = setContentTypeHeaders(false, preparePost());
+                Request request = createRequest(requestBuiler, catalogProperties, uri);
+                assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 201);
+            }
+        };
+
+        Thread deleteThread = new Thread() {
+            public void run()
+            {
+                Request.Builder requestBuiler = setContentTypeHeaders(false, prepareDelete());
+                Request request = createRequest(requestBuiler, catalogProperties, uri);
+                assertEquals(client.execute(request, createStringResponseHandler()).getStatusCode(), 204);
+            }
+        };
+        appendThread.start();
+        deleteThread.start();
+        appendThread.join();
+        deleteThread.join();
+        validateCatalogDetails(ImmutableSet.of("system", "testing_catalog", "tpch", "tpch_2"));
+    }
+
+    private void validateCatalogDetails(Set<String> expectedCatalogs)
+    {
+        MaterializedResult result = runner.execute(runner.getDefaultSession(), "SHOW CATALOGS").toTestTypes();
+        assertTrue(result.getOnlyColumnAsSet().containsAll(expectedCatalogs));
+    }
+
+    private Request createRequest(Request.Builder requestBuiler, Map<String, String> catalogProperties, URI uri)
+    {
+        return requestBuiler.setHeader(PRESTO_USER, "PRESTO_USER")
+                .setHeader(PRESTO_PREFIX_URL, "PREFIX")
+                .setUri(uri)
+                .setBodyGenerator(jsonBodyGenerator(jsonCodec(Map.class), catalogProperties))
+                .build();
+    }
+
+    private static Map<String, String> getCatalogPropertiesMap()
+    {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("connector.name", "tpch");
+        properties.put("tpch.splits-per-node", "4");
+        return properties;
+    }
+    private class ConcurrentQueryRunner<T, R>
+    {
+        private final ExecutorService executorService;
+        private final Function<T, R> function;
+        private final T input;
+        private final int concurrencyLevel;
+
+        public ConcurrentQueryRunner(int concurrencyLevel, Function<T, R> function, T input)
+        {
+            this.executorService = Executors.newFixedThreadPool(concurrencyLevel);
+            this.function = function;
+            this.input = input;
+            this.concurrencyLevel = concurrencyLevel;
+        }
+
+        public void start()
+        {
+            for (int i = 0; i < concurrencyLevel; i++) {
+                submitTask();
+            }
+        }
+
+        private void submitTask()
+        {
+            CompletableFuture.supplyAsync(() -> function.apply(input), executorService).whenComplete((x, y) -> submitTask());
+        }
+
+        public void stop()
+        {
+            executorService.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## Description
Added endpoints to dynamically load catalogs without an engine restart

## Motivation and Context
Previously, catalogs would only be loaded while the engine is starting. 

## Impact
New APIs added:
```
curl -X POST http://localhost:8001/v1/catalog/tpch_1 \
     -H "X-Presto-Prefix-Url: PREFIX" \
     -H "X-Presto-User: PRESTO_USER" \
     -H "User-Agent: StatementClient/0.55-SNAPSHOT" \
     -H "Content-Type: application/json" \
     -d '{
           "connector.name": "tpch",
           "tpch.splits-per-node": "4"
         }'
```

```
curl -v -X GET http://localhost:8001/v1/catalog \
     -H "X-Presto-Prefix-Url: PREFIX" \
     -H "X-Presto-User: PRESTO_USER" \
     -H "User-Agent: StatementClient/0.55-SNAPSHOT" \
     -H "Content-Type: application/json" 
```

```
curl -v -X GET http://localhost:8080/v1/catalog/system/status \
     -H "X-Presto-Prefix-Url: PREFIX" \
     -H "X-Presto-User: PRESTO_USER" \
     -H "User-Agent: StatementClient/0.55-SNAPSHOT" \
     -H "Content-Type: application/json"
```

```
curl -v -X DELETE http://localhost:8080/v1/catalog/tpch_1 \
     -H "X-Presto-Prefix-Url: PREFIX" \
     -H "X-Presto-User: PRESTO_USER" \
     -H "User-Agent: StatementClient/0.55-SNAPSHOT" \
     -H "Content-Type: application/json"
```
```
curl -X PUT http://localhost:8080/v1/catalog/tpch_1 \
     -H "X-Presto-Prefix-Url: PREFIX" \
     -H "X-Presto-User: PRESTO_USER" \
     -H "User-Agent: StatementClient/0.55-SNAPSHOT" \
     -H "Content-Type: application/json" \
     -d '{
           "connector.name": "tpch",
           "tpch.splits-per-node": "4"
         }'
```
## Test Plan
Added test cases

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add endpoints that can dynamically load catalogs

Hive Connector Changes
* Fix for configurations leaks using class loader isolation for Hive connector instances
```

