### PR TITLE
Include Table Metadata in Operator Logs

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -274,7 +274,8 @@ public class QueryMonitor
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 Optional.empty(),
-                ImmutableMap.of()));
+                ImmutableMap.of(),
+                Optional.empty()));
 
         logQueryTimeline(queryInfo);
     }
@@ -316,7 +317,8 @@ public class QueryMonitor
                         queryInfo.getAggregateFunctions(),
                         queryInfo.getWindowFunctions(),
                         queryInfo.getPrestoSparkExecutionContext(),
-                        getPlanHash(queryInfo.getPlanCanonicalInfo(), historyBasedPlanStatisticsTracker.getStatsEquivalentPlanRootNode(queryInfo.getQueryId()))));
+                        getPlanHash(queryInfo.getPlanCanonicalInfo(), historyBasedPlanStatisticsTracker.getStatsEquivalentPlanRootNode(queryInfo.getQueryId())),
+                        Optional.of(queryInfo.getPlanIdNodeMap())));
 
         logQueryTimeline(queryInfo);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.eventlistener;
 import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.prestospark.PrestoSparkExecutionContext;
 import com.facebook.presto.spi.statistics.PlanStatisticsWithSourceInfo;
@@ -57,6 +58,7 @@ public class QueryCompletedEvent
     private final Set<String> windowFunctions;
     private final Optional<PrestoSparkExecutionContext> prestoSparkExecutionContext;
     private final Map<PlanCanonicalizationStrategy, String> hboPlanHash;
+    private final Optional<Map<PlanNodeId, PlanNode>> planIdNodeMap;
 
     public QueryCompletedEvent(
             QueryMetadata metadata,
@@ -84,7 +86,8 @@ public class QueryCompletedEvent
             Set<String> aggregateFunctions,
             Set<String> windowFunctions,
             Optional<PrestoSparkExecutionContext> prestoSparkExecutionContext,
-            Map<PlanCanonicalizationStrategy, String> hboPlanHash)
+            Map<PlanCanonicalizationStrategy, String> hboPlanHash,
+            Optional<Map<PlanNodeId, PlanNode>> planNodeIdMap)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.statistics = requireNonNull(statistics, "statistics is null");
@@ -112,6 +115,7 @@ public class QueryCompletedEvent
         this.windowFunctions = requireNonNull(windowFunctions, "windowFunctions is null");
         this.prestoSparkExecutionContext = requireNonNull(prestoSparkExecutionContext, "prestoSparkExecutionContext is null");
         this.hboPlanHash = requireNonNull(hboPlanHash, "planHash is null");
+        this.planIdNodeMap = requireNonNull(planNodeIdMap, "planNodeIdMap is null");
     }
 
     public QueryMetadata getMetadata()
@@ -242,5 +246,10 @@ public class QueryCompletedEvent
     public Map<PlanCanonicalizationStrategy, String> getHboPlanHash()
     {
         return hboPlanHash;
+    }
+
+    public Optional<Map<PlanNodeId, PlanNode>> getPlanNodeIdMap()
+    {
+        return planIdNodeMap;
     }
 }


### PR DESCRIPTION
# Summary

Include the query's  `planIdNodeMap` in the query's `QueryCompletedEvent`.

The main motivation is that this allows looking relevant details in the `queryCompleted` of an Event Listener. This is useful to e.g. enrich logs

# Testing Plan

In my opinion, there is nothing worth making an automated test for.

My testing consisted of using a debugger to confirm that everything is getting populated as I expect when I submit queries. 