### PR TITLE
Exclude query_view_spa.html from build

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,6 @@ To update Presto Console after making changes, run:
 
     yarn --cwd presto-ui/src install
 
-If no JavaScript dependencies have changed (i.e., no changes to `package.json`), it is faster to run:
-
-    yarn --cwd presto-ui/src run package
-
 To simplify iteration, you can also run in `watch` mode, which automatically re-compiles when
 changes to source files are detected:
 

--- a/presto-ui/src/components/PageTitle.jsx
+++ b/presto-ui/src/components/PageTitle.jsx
@@ -156,13 +156,13 @@ export class PageTitle extends React.Component<Props, State> {
                                 <li>
                                     <span className="navbar-cluster-info">
                                         <span className="uppercase">Version</span><br/>
-                                        <span className="text" id="version-number">{isOffline() ? 'N/A' : info.nodeVersion.version}</span>
+                                        <span className="text" id="version-number">{isOffline() ? 'N/A' : info?.nodeVersion?.version}</span>
                                     </span>
                                 </li>
                                 <li>
                                     <span className="navbar-cluster-info">
                                         <span className="uppercase">Environment</span><br/>
-                                        <span className="text" id="environment">{isOffline() ? 'N/A' : info.environment}</span>
+                                        <span className="text" id="environment">{isOffline() ? 'N/A' : info?.environment}</span>
                                     </span>
                                 </li>
                                 <li>
@@ -172,7 +172,7 @@ export class PageTitle extends React.Component<Props, State> {
                                         {this.renderStatusLight()}
                                          </span>
                                         &nbsp;
-                                        <span className="text" id="uptime">{isOffline() ? 'Offline' : info.uptime}</span>
+                                        <span className="text" id="uptime">{isOffline() ? 'Offline' : info?.uptime}</span>
                                     </span>
                                 </li>
                             </ul>

--- a/presto-ui/src/components/PageTitle.jsx
+++ b/presto-ui/src/components/PageTitle.jsx
@@ -46,6 +46,11 @@ function ClusterResourceGroupNavBar({titles, urls, current = 0} : Props) {
         <>{navBarItems}</>
     );
 }
+
+function isOffline() {
+    return window.location.protocol === 'file:';
+}
+
 export class PageTitle extends React.Component<Props, State> {
     timeoutId: TimeoutID;
 
@@ -98,7 +103,15 @@ export class PageTitle extends React.Component<Props, State> {
     }
 
     componentDidMount() {
-        this.refreshLoop();
+        if ( isOffline() ) {
+            this.setState({
+                noConnection: true,
+                lightShown: true,
+            });
+        }
+        else {
+            this.refreshLoop();
+        }
     }
 
     renderStatusLight(): any {
@@ -115,7 +128,7 @@ export class PageTitle extends React.Component<Props, State> {
 
     render(): any {
         const info = this.state.info;
-        if (!info) {
+        if (!isOffline() && !info) {
             return null;
         }
 
@@ -137,19 +150,19 @@ export class PageTitle extends React.Component<Props, State> {
                         </div>
                         <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
                             <span className="navbar-toggler-icon"></span>
-                            </button>
+                        </button>
                         <div id="navbar" className="navbar-collapse collapse">
                             <ul className="nav navbar-nav navbar-right ms-auto">
                                 <li>
                                     <span className="navbar-cluster-info">
                                         <span className="uppercase">Version</span><br/>
-                                        <span className="text" id="version-number">{info.nodeVersion.version}</span>
+                                        <span className="text" id="version-number">{isOffline() ? 'N/A' : info.nodeVersion.version}</span>
                                     </span>
                                 </li>
                                 <li>
                                     <span className="navbar-cluster-info">
                                         <span className="uppercase">Environment</span><br/>
-                                        <span className="text" id="environment">{info.environment}</span>
+                                        <span className="text" id="environment">{isOffline() ? 'N/A' : info.environment}</span>
                                     </span>
                                 </li>
                                 <li>
@@ -159,7 +172,7 @@ export class PageTitle extends React.Component<Props, State> {
                                         {this.renderStatusLight()}
                                          </span>
                                         &nbsp;
-                                        <span className="text" id="uptime">{info.uptime}</span>
+                                        <span className="text" id="uptime">{isOffline() ? 'Offline' : info.uptime}</span>
                                     </span>
                                 </li>
                             </ul>

--- a/presto-ui/src/package.json
+++ b/presto-ui/src/package.json
@@ -41,6 +41,9 @@
     "install": "webpack --env=production --config webpack.config.js",
     "watch": "webpack --config webpack.config.js --watch",
     "serve": "webpack serve --config webpack.config.js",
+    "build:spa": "webpack --config webpack.config.js --env production --env config=spa",
+    "serve:spa": "webpack serve --config webpack.config.js --env config=spa",
+    "watch:spa": "webpack --config webpack.config.js --env config=spa --watch",
     "analyze": "webpack --env=production --config webpack.config.js --profile --json > stats.json && mv stats.json ../target/webapp/ && npx webpack-bundle-analyzer ../target/webapp/stats.json"
   },
   "resolutions": {

--- a/presto-ui/src/webpack.config.js
+++ b/presto-ui/src/webpack.config.js
@@ -74,6 +74,20 @@ module.exports = (env) => {
         },
     };
 
+    const devServer = {
+        static: {
+            directory: path.join(__dirname, '..', outputDir),
+        },
+        proxy: [
+            {
+                context: ['/v1'],
+                target: `http://${apiHost}:${apiPort}`,
+                // secure: false, // when using http
+                // changeOrigin: true, // Modify the Origin header to match the target
+            },
+        ],
+    }
+
     const mainConfig = {
         ...baseConfig,
         entry: {
@@ -86,6 +100,7 @@ module.exports = (env) => {
             'timeline': './timeline.jsx',
             'res_groups': './res_groups.jsx',
             'sql_client': './sql_client.jsx',
+            'dev/query_viewer': './query_viewer.jsx',
             ...baseConfig.entry,
         },
         optimization: {
@@ -110,19 +125,7 @@ module.exports = (env) => {
                 },
             },
         },
-        devServer: {
-            static: {
-                directory: path.join(__dirname, '..', outputDir),
-            },
-            proxy: [
-                {
-                    context: ['/v1'],
-                    target: `http://${apiHost}:${apiPort}`,
-                    // secure: false, // when using http
-                    // changeOrigin: true, // Modify the Origin header to match the target
-                },
-            ],
-        },
+        devServer,
     };
 
     const spaConfig = {
@@ -156,5 +159,15 @@ module.exports = (env) => {
             splitChunks: false,
         }
     };
-    return [mainConfig, spaConfig]
+
+    if (env.config === 'all') {
+        return [mainConfig, spaConfig];
+    }
+    if (env.config === 'spa') {
+        return {
+            ...spaConfig,
+            devServer,
+        }
+    }
+    return mainConfig;
 };


### PR DESCRIPTION
## Description
For issue https://github.com/prestodb/presto/issues/24593

Changes:
1. Exclude query_view_spa.html from build
2. Add command `yarn build:spa`, `yarn serve:spa`, `yarn watch:spa` for development and build locally
3. Fix the url '/ui/dev` not open the default index.html  (fix in the java file)
4. Fix/Adjust UI for query_view_spa.html (works as offline page) as screenshot below ( removed the API call, and fixed the header, show as Offline under UPTIME)
![image](https://github.com/user-attachments/assets/60f984ea-2c3e-4081-b198-6008ecf30a7e)


## Motivation and Context
The query_view_spa.html can not be open in the presto server by using URL like http://localhost:8080/ui/dev/query_view_spa.html 
The cause is that from 0.291, the CSP is added in presto http server.
So the urls of external javascript/css files in query_view_spa.html will be blocked.
That is why we exlcude this page from build.
To open the query, user can open url like http://localhost:8080/ui/dev/ (which will open the index.html)
The query_view_spa.html page can be kept for offline use. User has to build it locally.

## Impact
Presto UI, URL mapping for `/ui/dev/`, `/ui/dev`

## Test Plan
Local test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

