### PR TITLE
Refactor log4j-core and log4j-api dependencies out of root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,6 @@
         <air.test.thread-count>2</air.test.thread-count>
         <air.test.jvmsize>4g</air.test.jvmsize>
         <grpc.version>1.68.0</grpc.version>
-        <dep.log4j.version>2.24.3</dep.log4j.version>
-
         <air.javadoc.lint>-missing</air.javadoc.lint>
     </properties>
 
@@ -232,20 +230,6 @@
                 <version>${dep.netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${dep.log4j.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>${dep.log4j.version}</version>
-                <scope>runtime</scope>
             </dependency>
 
             <dependency>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <dep.log4j.version>2.24.3</dep.log4j.version>
     </properties>
 
     <repositories>
@@ -177,12 +178,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
+            <version>${dep.log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <version>${dep.log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
+        <dep.log4j.version>2.24.3</dep.log4j.version>
     </properties>
 
     <dependencies>
@@ -172,12 +173,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
+            <version>${dep.log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <version>${dep.log4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
## Description
revert of PR: https://github.com/prestodb/presto/pull/24507(https://github.com/prestodb/presto/pull/24507)

Upgrading module specific dependencies.

## Motivation and Context
![image](https://github.com/user-attachments/assets/8a90ebd9-35b4-4550-9d4b-2990eb421b94)


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
*  refactored org.apache.logging.log4j:log4j-core out of root POM
*  refactored org.apache.logging.log4j:log4j-api out if root POM
