### PR TITLE
Upgrade vulnerable version of reload4j and aws-java-sdk dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.38</dep.slice.version>
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>
-        <dep.aws-sdk.version>1.12.560</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.12.782</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -16,7 +16,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.accumulo.version>1.10.1</dep.accumulo.version>
         <dep.curator.version>2.12.0</dep.curator.version>
-        <dep.reload4j.version>1.2.22</dep.reload4j.version>
+        <dep.log4j.version>2.24.3</dep.log4j.version>
     </properties>
 
     <dependencyManagement>
@@ -265,20 +265,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>ch.qos.reload4j</groupId>
-            <artifactId>reload4j</artifactId>
-            <version>${dep.reload4j.version}</version>
-        </dependency>
-
-        <!-- log4j removed from  reload4j version 1.2.18.4-->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>2.24.3</version>
-            <scope>test</scope>
-        </dependency>
-
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -314,6 +300,26 @@
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${dep.log4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${dep.log4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>${dep.log4j.version}</version>
         </dependency>
 
         <!-- for testing -->
@@ -398,21 +404,4 @@
             </build>
         </profile>
     </profiles>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.basepom.maven</groupId>
-                <artifactId>duplicate-finder-maven-plugin</artifactId>
-                <configuration>
-                    <ignoredResourcePatterns>
-                        <ignoredResourcePattern>org/apache/log4j/xml/log4j.dtd</ignoredResourcePattern>
-                    </ignoredResourcePatterns>
-                    <ignoredClassPatterns>
-                        <ignoredClassPattern>org.apache.log4j.*</ignoredClassPattern>
-                    </ignoredClassPatterns>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -16,7 +16,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.accumulo.version>1.10.1</dep.accumulo.version>
         <dep.curator.version>2.12.0</dep.curator.version>
-        <dep.reload4j.version>1.2.18.3</dep.reload4j.version>
+        <dep.reload4j.version>1.2.22</dep.reload4j.version>
     </properties>
 
     <dependencyManagement>
@@ -271,6 +271,14 @@
             <version>${dep.reload4j.version}</version>
         </dependency>
 
+        <!-- log4j removed from  reload4j version 1.2.18.4-->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.24.3</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -390,4 +398,21 @@
             </build>
         </profile>
     </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>org/apache/log4j/xml/log4j.dtd</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                    <ignoredClassPatterns>
+                        <ignoredClassPattern>org.apache.log4j.*</ignoredClassPattern>
+                    </ignoredClassPatterns>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## Description
1. Upgrade the aws-java-sdk version to 1.12.782 to fix the ion-java vulnerability - [CVE-2024-21634](https://nvd.nist.gov/vuln/detail/cve-2024-21634)
2. Remove the reload4j dependency to fix the vulnerability [WS-2022-0467](https://www.mend.io/vulnerability-database/WS-2022-0467)

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/9c7d2123-9049-4c25-99d3-735a55fa9fae" />

Log4j was removed from the reload4j version 1.2.18.4. Therefore, if we upgrade this dependency, it will cause a **Cannot instantiate class** TestNGException in the Presto-accum module test classes. To resolve this issue, we are adding the latest version of the [Apache Log4j 1.x Compatibility API](https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-1.2-api).

## Motivation and Context
To resolve the vulnerability issues on the aws-java-sdk  and reload4j dependencies. 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes

* Upgrade aws-java-sdk version to 1.12.782 in response to `CVE-2024-21634 <https://nvd.nist.gov/vuln/detail/cve-2024-21634>`_. 
* Remove reload4j dependency in response to `WS-2022-0467 <https://www.mend.io/vulnerability-database/WS-2022-0467>`_. 

```

