### PR TITLE
[docs] Add documentation to note "-gb" Prestissimo Configs are using GiB units and not gB units

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -12,6 +12,10 @@ For information on catalog configuration properties, see :doc:`Connectors </conn
 
 For information on Presto C++ session properties, see :doc:`properties-session`.
 
+NOTE: While some of the configuration properties below with "-gb" in their names 
+show gigabytes (gB; 1 gB equals 1000000000 B), it is actually 
+gibibytes (GiB; 1 GiB equals 1073741824 B).
+
 .. contents::
     :local:
     :backlinks: none


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add documentation to note "-gb" Prestissimo Configs are using GiB units and not gB units

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
"-gb" Prestissimo configs like `system-memory-gb` are actually using GiB units and not gB units. This documentation will help clarify any confusion from users.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Documentation
* Add documentation to note "-gb" Prestissimo Configs are using GiB units and not gB units.
```


