### PR TITLE
Handle listTables for non-existing schema in IcebergNativeMetadata

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -83,6 +83,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -178,10 +179,15 @@ public class IcebergNativeMetadata
                     .collect(toList());
         }
 
-        return catalogFactory.getCatalog(session).listTables(toIcebergNamespace(schemaName, catalogFactory.isNestedNamespaceEnabled()))
-                .stream()
-                .map(tableIdentifier -> toPrestoSchemaTableName(tableIdentifier, catalogFactory.isNestedNamespaceEnabled()))
-                .collect(toList());
+        try {
+            return catalogFactory.getCatalog(session).listTables(toIcebergNamespace(schemaName, catalogFactory.isNestedNamespaceEnabled()))
+                    .stream()
+                    .map(tableIdentifier -> toPrestoSchemaTableName(tableIdentifier, catalogFactory.isNestedNamespaceEnabled()))
+                    .collect(toImmutableList());
+        }
+        catch (NoSuchNamespaceException e) {
+            return ImmutableList.of();
+        }
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2318,6 +2318,7 @@ public abstract class IcebergDistributedTestBase
         assertQuery("SELECT table_name FROM iceberg.information_schema.tables WHERE table_schema ='test_schema2'", "VALUES 'iceberg_t3', 'iceberg_t4'");
         //query on non-existing schema
         assertQueryReturnsEmptyResult("SELECT table_name FROM iceberg.information_schema.tables WHERE table_schema = 'NON_EXISTING_SCHEMA'");
+        assertQueryReturnsEmptyResult("SELECT table_name FROM iceberg.information_schema.tables WHERE table_schema = 'non_existing_schema'");
 
         assertQuerySucceeds("DROP TABLE ICEBERG.TEST_SCHEMA1.ICEBERG_T1");
         assertQuerySucceeds("DROP TABLE ICEBERG.TEST_SCHEMA1.ICEBERG_T2");


### PR DESCRIPTION
## Description
Handle listTables for non-existing schema in IcebergNativeMetadata

## Motivation and Context
[IcebergHiveMetadata](https://github.com/prestodb/presto/blob/master/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java#L254) returns an empty list instead of exception when the non-existing schema is queried. But currently in IcebergNativeMetadata 

Here iceberg is configured as a `Hadoop` (Native) catalog of Iceberg. 

```
presto> SELECT table_name FROM iceberg.information_schema.tables WHERE table_schema = 'non';
Query 20250222_203015_00002_jwvp3 failed: Namespace does not exist: non
org.apache.iceberg.exceptions.NoSuchNamespaceException: Namespace does not exist: non
        at org.apache.iceberg.hadoop.HadoopCatalog.listTables(HadoopCatalog.java:199)
        at com.facebook.presto.iceberg.IcebergNativeMetadata.listTables(IcebergNativeMetadata.java:179)
        at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.listTables(ClassLoaderSafeConnectorMetadata.java:266)
        at com.facebook.presto.metadata.MetadataManager.listTables(MetadataManager.java:551)
        at com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.lambda$calculatePrefixesWithTableName$7(InformationSchemaMetadata.java:302)
        at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:271)
        at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
        at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
        at com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.calculatePrefixesWithTableName(InformationSchemaMetadata.java:306)
        at com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.getTableLayoutForConstraint(InformationSchemaMetadata.java:239)
        at com.facebook.presto.metadata.MetadataManager.getLayout(MetadataManager.java:381)
        at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout.pushPredicateIntoTableScan(PickTableLayout.java:308)
        at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout.pushPredicateIntoTableScan(PickTableLayout.java:253)
        at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout$PickTableLayoutForPredicate.apply(PickTableLayout.java:137)
        at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout$PickTableLayoutForPredicate.apply(PickTableLayout.java:102)
        at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:237)
        at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:189)
        at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:151)
        at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:281)
        at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:153)
        at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:281)
        at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:153)
        at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.optimize(IterativeOptimizer.java:138)
        at com.facebook.presto.sql.Optimizer.validateAndOptimizePlan(Optimizer.java:112)
        at com.facebook.presto.execution.SqlQueryExecution.lambda$doCreateLogicalPlanAndOptimize$5(SqlQueryExecution.java:586)
        at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
        at com.facebook.presto.execution.SqlQueryExecution.doCreateLogicalPlanAndOptimize(SqlQueryExecution.java:584)
        at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
        at com.facebook.presto.execution.SqlQueryExecution.createLogicalPlanAndOptimize(SqlQueryExecution.java:555)
        at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:483)
        at com.facebook.presto.$gen.Presto_null__testversion____20250222_201911_1.run(Unknown Source)
        at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:319)
        at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:213)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

## Impact
Maintain same behaviour in Iceberg Native catalog as Iceberg Hive catalog.

After Change -

```
presto> SELECT table_name FROM iceberg.information_schema.tables WHERE table_schema = 'non';
 table_name 
------------
(0 rows)

```

## Test Plan
Test added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```