### PR TITLE
fix Update json_extract to Produce Canonicalized Output

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
@@ -37,6 +37,7 @@ public class SqlFunctionProperties
     private final boolean legacyJsonCast;
     private final Map<String, String> extraCredentials;
     private final boolean warnOnCommonNanPatterns;
+    private final boolean canonicalizedJsonExtract;
 
     private SqlFunctionProperties(
             boolean parseDecimalLiteralAsDouble,
@@ -50,7 +51,8 @@ public class SqlFunctionProperties
             boolean fieldNamesInJsonCastEnabled,
             boolean legacyJsonCast,
             Map<String, String> extraCredentials,
-            boolean warnOnCommonNanPatterns)
+            boolean warnOnCommonNanPatterns,
+            boolean canonicalizedJsonExtract)
     {
         this.parseDecimalLiteralAsDouble = parseDecimalLiteralAsDouble;
         this.legacyRowFieldOrdinalAccessEnabled = legacyRowFieldOrdinalAccessEnabled;
@@ -64,6 +66,7 @@ public class SqlFunctionProperties
         this.legacyJsonCast = legacyJsonCast;
         this.extraCredentials = requireNonNull(extraCredentials, "extraCredentials is null");
         this.warnOnCommonNanPatterns = warnOnCommonNanPatterns;
+        this.canonicalizedJsonExtract = canonicalizedJsonExtract;
     }
 
     public boolean isParseDecimalLiteralAsDouble()
@@ -127,6 +130,9 @@ public class SqlFunctionProperties
         return warnOnCommonNanPatterns;
     }
 
+    public boolean isCanonicalizedJsonExtract()
+    { return canonicalizedJsonExtract; }
+
     @Override
     public boolean equals(Object o)
     {
@@ -146,7 +152,8 @@ public class SqlFunctionProperties
                 Objects.equals(sessionLocale, that.sessionLocale) &&
                 Objects.equals(sessionUser, that.sessionUser) &&
                 Objects.equals(extraCredentials, that.extraCredentials) &&
-                Objects.equals(legacyJsonCast, that.legacyJsonCast);
+                Objects.equals(legacyJsonCast, that.legacyJsonCast) &&
+                Objects.equals(canonicalizedJsonExtract, that.legacyJsonCast);
     }
 
     @Override
@@ -154,7 +161,7 @@ public class SqlFunctionProperties
     {
         return Objects.hash(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, timeZoneKey,
                 legacyTimestamp, legacyMapSubscript, sessionStartTime, sessionLocale, sessionUser,
-                extraCredentials, legacyJsonCast);
+                extraCredentials, legacyJsonCast, canonicalizedJsonExtract);
     }
 
     public static Builder builder()
@@ -176,6 +183,7 @@ public class SqlFunctionProperties
         private boolean legacyJsonCast;
         private Map<String, String> extraCredentials = emptyMap();
         private boolean warnOnCommonNanPatterns;
+        private boolean canonicalizedJsonExtract;
 
         private Builder() {}
 
@@ -251,6 +259,12 @@ public class SqlFunctionProperties
             return this;
         }
 
+        public Builder setCanonicalizedJsonExtract(boolean canonicalizedJsonExtract)
+        {
+            this.canonicalizedJsonExtract = canonicalizedJsonExtract;
+            return this;
+        }
+
         public SqlFunctionProperties build()
         {
             return new SqlFunctionProperties(
@@ -265,7 +279,8 @@ public class SqlFunctionProperties
                     fieldNamesInJsonCastEnabled,
                     legacyJsonCast,
                     extraCredentials,
-                    warnOnCommonNanPatterns);
+                    warnOnCommonNanPatterns,
+                    canonicalizedJsonExtract);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -57,6 +57,7 @@ import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.LEGACY_JSON_CAST;
+import static com.facebook.presto.SystemSessionProperties.isCanonicalizedJsonExtract;
 import static com.facebook.presto.SystemSessionProperties.isFieldNameInJsonCastEnabled;
 import static com.facebook.presto.SystemSessionProperties.isLegacyMapSubscript;
 import static com.facebook.presto.SystemSessionProperties.isLegacyRowFieldOrdinalAccessEnabled;
@@ -481,6 +482,7 @@ public final class Session
                 .setLegacyJsonCast(legacyJsonCast)
                 .setExtraCredentials(identity.getExtraCredentials())
                 .setWarnOnCommonNanPatterns(warnOnCommonNanPatterns(this))
+                .setCanonicalizedJsonExtract(isCanonicalizedJsonExtract(this))
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -305,6 +305,7 @@ public final class SystemSessionProperties
     public static final String REWRITE_CASE_TO_MAP_ENABLED = "rewrite_case_to_map_enabled";
     public static final String FIELD_NAMES_IN_JSON_CAST_ENABLED = "field_names_in_json_cast_enabled";
     public static final String LEGACY_JSON_CAST = "legacy_json_cast";
+    public static final String CANONICALIZED_JSON_EXTRACT = "canonicalized_json_extract";
     public static final String PULL_EXPRESSION_FROM_LAMBDA_ENABLED = "pull_expression_from_lambda_enabled";
     public static final String REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION = "rewrite_constant_array_contains_to_in_expression";
     public static final String INFER_INEQUALITY_PREDICATES = "infer_inequality_predicates";
@@ -1635,6 +1636,11 @@ public final class SystemSessionProperties
                         LEGACY_JSON_CAST,
                         "Keep the legacy json cast behavior, do not reserve the case for field names when casting to row type",
                         functionsConfig.isLegacyJsonCast(),
+                        true),
+                booleanProperty(
+                        CANONICALIZED_JSON_EXTRACT,
+                        "Extracts json data in a canonicalized manner, and raises a PrestoException when encountering invalid json structures within the input json path",
+                        functionsConfig.isCanonicalizedJsonExtract(),
                         true),
                 booleanProperty(
                         OPTIMIZE_JOIN_PROBE_FOR_EMPTY_BUILD_RUNTIME,
@@ -3173,5 +3179,10 @@ public final class SystemSessionProperties
     public static boolean isEnabledAddExchangeBelowGroupId(Session session)
     {
         return session.getSystemProperty(ADD_EXCHANGE_BELOW_PARTIAL_AGGREGATION_OVER_GROUP_ID, Boolean.class);
+    }
+
+    public static boolean isCanonicalizedJsonExtract(Session session)
+    {
+        return session.getSystemProperty(CANONICALIZED_JSON_EXTRACT, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
@@ -435,51 +435,51 @@ public final class JsonFunctions
     @SqlNullable
     @LiteralParameters("x")
     @SqlType("varchar(x)")
-    public static Slice varcharJsonExtractScalar(@SqlType("varchar(x)") Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
+    public static Slice varcharJsonExtractScalar(SqlFunctionProperties properties, @SqlType("varchar(x)") Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
     {
-        return JsonExtract.extract(json, jsonPath.getScalarExtractor());
+        return JsonExtract.extract(json, jsonPath.getScalarExtractor(), properties);
     }
 
     @ScalarFunction
     @SqlNullable
     @SqlType(StandardTypes.VARCHAR)
-    public static Slice jsonExtractScalar(@SqlType(StandardTypes.JSON) Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
+    public static Slice jsonExtractScalar(SqlFunctionProperties properties, @SqlType(StandardTypes.JSON) Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
     {
-        return JsonExtract.extract(json, jsonPath.getScalarExtractor());
+        return JsonExtract.extract(json, jsonPath.getScalarExtractor(), properties);
     }
 
     @ScalarFunction("json_extract")
     @LiteralParameters("x")
     @SqlNullable
     @SqlType(StandardTypes.JSON)
-    public static Slice varcharJsonExtract(@SqlType("varchar(x)") Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
+    public static Slice varcharJsonExtract(SqlFunctionProperties properties, @SqlType("varchar(x)") Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
     {
-        return JsonExtract.extract(json, jsonPath.getObjectExtractor());
+        return JsonExtract.extract(json, jsonPath.getObjectExtractor(), properties);
     }
 
     @ScalarFunction
     @SqlNullable
     @SqlType(StandardTypes.JSON)
-    public static Slice jsonExtract(@SqlType(StandardTypes.JSON) Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
+    public static Slice jsonExtract(SqlFunctionProperties properties, @SqlType(StandardTypes.JSON) Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
     {
-        return JsonExtract.extract(json, jsonPath.getObjectExtractor());
+        return JsonExtract.extract(json, jsonPath.getObjectExtractor(), properties);
     }
 
     @ScalarFunction("json_size")
     @LiteralParameters("x")
     @SqlNullable
     @SqlType(StandardTypes.BIGINT)
-    public static Long varcharJsonSize(@SqlType("varchar(x)") Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
+    public static Long varcharJsonSize(SqlFunctionProperties properties, @SqlType("varchar(x)") Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
     {
-        return JsonExtract.extract(json, jsonPath.getSizeExtractor());
+        return JsonExtract.extract(json, jsonPath.getSizeExtractor(), properties);
     }
 
     @ScalarFunction
     @SqlNullable
     @SqlType(StandardTypes.BIGINT)
-    public static Long jsonSize(@SqlType(StandardTypes.JSON) Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
+    public static Long jsonSize(SqlFunctionProperties properties, @SqlType(StandardTypes.JSON) Slice json, @SqlType(JsonPathType.NAME) JsonPath jsonPath)
     {
-        return JsonExtract.extract(json, jsonPath.getSizeExtractor());
+        return JsonExtract.extract(json, jsonPath.getSizeExtractor(), properties);
     }
 
     public static Object getJsonObjectValue(Type valueType, SqlFunctionProperties properties, Block block, int position)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonPath.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonPath.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.spi.PrestoException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,7 +43,6 @@ public class JsonPath
     {
         return new JsonExtract.JsonExtractor<Slice>()
         {
-            @Override
             public Slice extract(InputStream inputStream)
                     throws IOException
             {
@@ -52,6 +52,13 @@ public class JsonPath
                 }
                 return utf8Slice(node.asText());
             }
+
+            @Override
+            public Slice extract(InputStream inputStream, SqlFunctionProperties properties)
+                    throws IOException
+            {
+                return extract(inputStream);
+            }
         };
     }
 
@@ -59,7 +66,6 @@ public class JsonPath
     {
         return new JsonExtract.JsonExtractor<Slice>()
         {
-            @Override
             public Slice extract(InputStream inputStream)
                     throws IOException
             {
@@ -69,6 +75,13 @@ public class JsonPath
                 }
                 return utf8Slice(node.toString());
             }
+
+            @Override
+            public Slice extract(InputStream inputStream, SqlFunctionProperties properties)
+                    throws IOException
+            {
+                return extract(inputStream);
+            }
         };
     }
 
@@ -76,7 +89,6 @@ public class JsonPath
     {
         return new JsonExtract.JsonExtractor<Long>()
         {
-            @Override
             public Long extract(InputStream inputStream)
                     throws IOException
             {
@@ -85,6 +97,13 @@ public class JsonPath
                     return null;
                 }
                 return (long) node.size(); // Jackson correctly returns 0 for scalar nodes
+            }
+
+            @Override
+            public Long extract(InputStream inputStream, SqlFunctionProperties properties)
+                    throws IOException
+            {
+                return extract(inputStream);
             }
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FunctionsConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FunctionsConfig.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggGroupImplementation;
 import com.facebook.presto.operator.aggregation.histogram.HistogramGroupImplementation;
 import com.facebook.presto.operator.aggregation.multimapagg.MultimapAggGroupImplementation;
+import com.facebook.presto.spi.function.Description;
 
 import javax.validation.constraints.Min;
 
@@ -47,6 +48,7 @@ public class FunctionsConfig
     private boolean warnOnPossibleNans;
     private boolean legacyCharToVarcharCoercion;
     private boolean legacyJsonCast = true;
+    private boolean canonicalizedJsonExtract;
     private String defaultNamespacePrefix = JAVA_BUILTIN_NAMESPACE.toString();
 
     @Config("deprecated.legacy-array-agg")
@@ -306,6 +308,19 @@ public class FunctionsConfig
     public boolean isLegacyJsonCast()
     {
         return legacyJsonCast;
+    }
+
+    @Config("canonicalized-json-extract")
+    @Description("Extracts json data in a canonicalized manner, and raises a PrestoException when encountering invalid json structures within the input json path")
+    public FunctionsConfig setCanonicalizedJsonExtract(boolean canonicalizedJsonExtract)
+    {
+        this.canonicalizedJsonExtract = canonicalizedJsonExtract;
+        return this;
+    }
+
+    public boolean isCanonicalizedJsonExtract()
+    {
+        return canonicalizedJsonExtract;
     }
 
     @Config("presto.default-namespace")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonExtract.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonExtract.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.DriverYieldSignal;
+import com.facebook.presto.operator.project.PageProcessor;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.gen.PageFunctionCompiler;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.facebook.presto.testing.TestingSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.runner.options.WarmupMode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.JsonType.JSON;
+import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.operator.scalar.FunctionAssertions.createExpression;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static java.util.Collections.emptyMap;
+import static java.util.Locale.ENGLISH;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(10)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkJsonExtract
+{
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final Metadata METADATA = createTestMetadataManager();
+    private static final Session TEST_SESSION = TestingSession.testSessionBuilder().build();
+    public static final ConnectorSession SESSION = new TestingConnectorSession(ImmutableList.of());
+
+    private static final int POSITION_COUNT = 100_000;
+    private static final int ARRAY_SIZE = 20;
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    private PageProcessor pageProcessor;
+    private Page inputPage;
+    private Map<String, Type> symbolTypes;
+    private Map<VariableReferenceExpression, Integer> sourceLayout;
+
+    @Param({"true", "false"})
+    boolean isCanonicalizedJsonExtract;
+
+    @Setup
+    public void setup()
+    {
+        VariableReferenceExpression variable = new VariableReferenceExpression(Optional.empty(), VARCHAR.getDisplayName().toLowerCase(ENGLISH) + "0", VARCHAR);
+        symbolTypes = ImmutableMap.of(variable.getName(), VARCHAR);
+        sourceLayout = ImmutableMap.of(variable, 0);
+        inputPage = new Page(createChannel());
+        List<RowExpression> projections = ImmutableList.of(rowExpression("json_extract(varchar0, '$.key1')"), rowExpression("json_extract(varchar0, '$.key2')"));
+        MetadataManager metadata = createTestMetadataManager();
+        PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(metadata, 0);
+        ExpressionCompiler expressionCompiler = new ExpressionCompiler(metadata, pageFunctionCompiler);
+        pageProcessor = expressionCompiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.empty(), projections).get();
+    }
+
+    @Benchmark
+    public List<Optional<Page>> computePage()
+    {
+        SqlFunctionProperties sqlFunctionProperties = SqlFunctionProperties.builder()
+                .setTimeZoneKey(UTC_KEY)
+                .setLegacyTimestamp(true)
+                .setSessionStartTime(0)
+                .setSessionLocale(ENGLISH).setSessionUser("user")
+                .setCanonicalizedJsonExtract(isCanonicalizedJsonExtract)
+                .build();
+
+        return ImmutableList.copyOf(
+                pageProcessor.process(
+                        sqlFunctionProperties,
+                        new DriverYieldSignal(),
+                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                        inputPage));
+    }
+
+    private RowExpression rowExpression(String value)
+    {
+        Expression expression = createExpression(TEST_SESSION, value, METADATA, TypeProvider.copyOf(symbolTypes));
+        Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyMap(), WarningCollector.NOOP);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionAndTypeManager(), TEST_SESSION);
+        RowExpressionOptimizer optimizer = new RowExpressionOptimizer(METADATA);
+        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+    }
+
+    private static Block createChannel()
+    {
+        BlockBuilder blockBuilder = JSON.createBlockBuilder(null, BenchmarkJsonExtract.POSITION_COUNT);
+        for (int position = 0; position < BenchmarkJsonExtract.POSITION_COUNT; position++) {
+            try (SliceOutput jsonSlice = new DynamicSliceOutput(20 * BenchmarkJsonExtract.ARRAY_SIZE)) {
+                jsonSlice.appendByte('{');
+                int k1Index = ThreadLocalRandom.current().nextInt(ARRAY_SIZE);
+                int k2Index = ThreadLocalRandom.current().nextInt(ARRAY_SIZE);
+                while (k2Index == k1Index) {
+                    k2Index = ThreadLocalRandom.current().nextInt(ARRAY_SIZE);
+                }
+
+                for (int i = 0; i < ARRAY_SIZE; i++) {
+                    String key;
+                    if (i == k1Index) {
+                        key = "key1";
+                    }
+                    else if (i == k2Index) {
+                        key = "key2";
+                    }
+                    else {
+                        key = generateRandomKey(ThreadLocalRandom.current().nextInt(5) + 1);
+                    }
+                    jsonSlice.appendBytes("\"".getBytes());
+                    jsonSlice.appendBytes(key.getBytes());
+                    jsonSlice.appendBytes("\"".getBytes());
+                    jsonSlice.appendByte(':');
+                    String value;
+                    if (key.equals("key1") || key.equals("key2") || (ThreadLocalRandom.current().nextInt(10) & 1) == 0) {
+                        value = generateNestedJsonValue();
+                    }
+                    else {
+                        value = generateRandomJsonValue();
+                    }
+                    jsonSlice.appendBytes(value.getBytes());
+                    if (i < ARRAY_SIZE - 1) {
+                        jsonSlice.appendByte(','); // Add a comma between JSON objects
+                    }
+                }
+
+                jsonSlice.appendByte('}');
+                JSON.writeSlice(blockBuilder, jsonSlice.slice());
+            }
+            catch (Exception ignore) {
+                // Ignore...
+            }
+        }
+        return blockBuilder.build();
+    }
+
+    private static String generateRandomJsonValue()
+    {
+        int length = ThreadLocalRandom.current().nextInt(10) + 1;
+        StringBuilder builder = new StringBuilder(length + 2);
+        builder.append('"');
+        for (int i = 0; i < length; i++) {
+            char c = CHARACTERS.charAt(ThreadLocalRandom.current().nextInt(CHARACTERS.length()));
+            if (c == '"') {
+                builder.append('\\'); // escape double quote
+            }
+            builder.append(c);
+        }
+        builder.append('"');
+        return builder.toString();
+    }
+
+    private static String generateNestedJsonValue()
+    {
+        int size = ThreadLocalRandom.current().nextInt(5) + 1;
+        StringBuilder builder = new StringBuilder(size * 10);
+        builder.append('{');
+        for (int i = 0; i < size; i++) {
+            String key = generateRandomKey(ThreadLocalRandom.current().nextInt(5) + 2);
+            builder.append("\"").append(key).append("\":");
+            builder.append(generateRandomJsonValue());
+            if (i < size - 1) {
+                builder.append(",");
+            }
+        }
+        builder.append('}');
+        return builder.toString();
+    }
+
+    private static String generateRandomKey(int len)
+    {
+        StringBuilder builder = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            builder.append(CHARACTERS.charAt(ThreadLocalRandom.current().nextInt(CHARACTERS.length())));
+        }
+        return builder.toString();
+    }
+
+    @Test
+    public void verify()
+    {
+        BenchmarkJsonToArrayCast.BenchmarkData data = new BenchmarkJsonToArrayCast.BenchmarkData();
+        data.setup();
+        new BenchmarkJsonToArrayCast().benchmark(data);
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkJsonToArrayCast.BenchmarkData data = new BenchmarkJsonToArrayCast.BenchmarkData();
+        data.setup();
+        new BenchmarkJsonToArrayCast().benchmark(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkJsonExtract.class.getSimpleName() + ".*")
+                .warmupMode(WarmupMode.BULK_INDI)
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtractFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtractFunctions.java
@@ -13,11 +13,15 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.FunctionsConfig;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.JsonType.JSON;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static java.lang.String.format;
 
 public class TestJsonExtractFunctions
@@ -61,6 +65,21 @@ public class TestJsonExtractFunctions
             "    \"expensive\": 10\n" +
             "}";
 
+    private static FunctionAssertions canonicalizedJsonExtractDisabled;
+    private static FunctionAssertions canonicalizedJsonExtractEnabled;
+
+    @BeforeClass
+    public void setUp()
+    {
+        registerScalar(getClass());
+        FunctionsConfig featuresConfigWithCanonicalizedJsonExtractDisabled = new FunctionsConfig()
+                .setCanonicalizedJsonExtract(false);
+        canonicalizedJsonExtractDisabled = new FunctionAssertions(session, new FeaturesConfig(), featuresConfigWithCanonicalizedJsonExtractDisabled, true);
+        FunctionsConfig featuresConfigWithCanonicalizedJsonExtractEnabled = new FunctionsConfig()
+                .setCanonicalizedJsonExtract(true);
+        canonicalizedJsonExtractEnabled = new FunctionAssertions(session, new FeaturesConfig(), featuresConfigWithCanonicalizedJsonExtractEnabled, true);
+    }
+
     @Test
     public void testJsonExtract()
     {
@@ -75,6 +94,16 @@ public class TestJsonExtractFunctions
         assertFunction(format("JSON_EXTRACT('%s', '%s')", "INVALID_JSON", "$"), JSON, null);
         assertInvalidFunction(format("JSON_EXTRACT('%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
 
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), JSON, "{\"x\":{\"a\":1,\"b\":2}}");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), JSON, "{\"a\":1,\"b\":2}");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), JSON, "1");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.c"), JSON, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [2, 3]} }", "$.x.b[1]"), JSON, "3");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", "[1,2,3]", "$[1]"), JSON, "2");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", "[1,null,3]", "$[1]"), JSON, "null");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", "INVALID_JSON", "$"), JSON, null);
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_EXTRACT('%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
+
         // complex expressions (should run on Jayway)
         assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "$.store.book[*].isbn"), JSON, "[\"0-553-21311-3\",\"0-395-19395-8\"]");
         assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "$..price"), JSON, "[8.95,12.99,8.99,22.99,19.95]");
@@ -83,8 +112,47 @@ public class TestJsonExtractFunctions
         assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "concat($..category)"), JSON, "\"referencefictionfictionfiction\"");
         assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "$.store.keys()"), JSON, "[\"book\",\"bicycle\"]");
         assertFunction(format("JSON_EXTRACT('%s', '%s')", json, "$.store.book[1].author"), JSON, "\"Evelyn Waugh\"");
-
         assertInvalidFunction(format("JSON_EXTRACT('%s', '%s')", json, "$...invalid"), "Invalid JSON path: '$...invalid'");
+    }
+
+    @Test
+    public void testExtractJsonWithCanonicalOutput()
+    {
+        // Test with simple JSON object
+        String json = "{\"key_2\": 2, \"key_3\": 3, \"key_1\": 1}";
+        String path = "$";
+        String expected = "{\"key_1\":1,\"key_2\":2,\"key_3\":3}";
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", json, path), JSON, expected);
+
+        // Test with nested JSON object
+        json = "{\"key_1\": {\"nested_key_2\": \"value_2\", \"nested_key_1\": \"value_1\"}, \"key_2\": 2}";
+        path = "$.key_1";
+        expected = "{\"nested_key_1\":\"value_1\",\"nested_key_2\":\"value_2\"}";
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", json, path), JSON, expected);
+
+        // Test with Array of JSON objects
+        json = "[{\"key_b\":\"v_b\",\"key_a\":\"v_a\"}, {\"key_2\": \"value_2\"}]";
+        path = "$[0]";
+        expected = "{\"key_a\":\"v_a\",\"key_b\":\"v_b\"}";
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", json, path), JSON, expected);
+    }
+
+    @Test
+    public void testInvalidFunctionIfJsonInvalid()
+    {
+        // Unbalanced quotes
+        String json = "{ \"key_2\": 2, \"key_1\": \"z\"a1\" }";
+        String path = "$.key_1";
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", json, path), JSON, "\"z\"");
+        canonicalizedJsonExtractDisabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", json, path), JSON, "\"z\"");
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_EXTRACT('%s', '%s')", json, path), INVALID_FUNCTION_ARGUMENT);
+
+        // Extra comma
+        json = "{ \"key_2\": 2, \"key_1\": \"value_1\", }";
+        path = "$.key_1";
+        assertFunction(format("JSON_EXTRACT('%s', '%s')", json, path), JSON, "\"value_1\"");
+        canonicalizedJsonExtractDisabled.assertFunction(format("JSON_EXTRACT('%s', '%s')", json, path), JSON, "\"value_1\"");
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_EXTRACT('%s', '%s')", json, path), INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test
@@ -108,10 +176,32 @@ public class TestJsonExtractFunctions
         assertFunction(format("JSON_SIZE(null, '%s')", "$"), BIGINT, null);
         assertFunction(format("JSON_SIZE(JSON '%s', null)", "[1,2,3]"), BIGINT, null);
 
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), BIGINT, 1L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), BIGINT, 2L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [1,2,3], \"c\" : {\"w\":9}} }", "$.x"), BIGINT, 3L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), BIGINT, 0L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", "[1,2,3]", "$"), BIGINT, 3L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', CHAR '%s')", "[1,2,3]", "$"), BIGINT, 3L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE(null, '%s')", "$"), BIGINT, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", "INVALID_JSON", "$"), BIGINT, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', null)", "[1,2,3]"), BIGINT, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), BIGINT, 1L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), BIGINT, 2L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [1,2,3], \"c\" : {\"w\":9}} }", "$.x"), BIGINT, 3L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), BIGINT, 0L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE(JSON '%s', '%s')", "[1,2,3]", "$"), BIGINT, 3L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE(null, '%s')", "$"), BIGINT, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE(JSON '%s', null)", "[1,2,3]"), BIGINT, null);
+
         assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
         assertInvalidFunction(format("JSON_SIZE('%s', CHAR '%s')", "{\"\":\"\"}", " "), "Invalid JSON path: ' '");
         assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", "."), "Invalid JSON path: '.'");
         assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", "..."), "Invalid JSON path: '...'");
+
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_SIZE('%s', CHAR '%s')", "{\"\":\"\"}", " "), "Invalid JSON path: ' '");
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", "."), "Invalid JSON path: '.'");
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_SIZE('%s', '%s')", "{\"\":\"\"}", "..."), "Invalid JSON path: '...'");
 
         // complex expressions (should run on Jayway)
         assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.book[*].isbn"), BIGINT, 2L);
@@ -122,7 +212,16 @@ public class TestJsonExtractFunctions
         assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.keys()"), BIGINT, 2L);
         assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.book[1].author"), BIGINT, 0L);
 
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.book[*].isbn"), BIGINT, 2L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", json, "$..price"), BIGINT, 5L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.book[?(@.price < 10)].title"), BIGINT, 2L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", json, "max($..price)"), BIGINT, 0L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", json, "concat($..category)"), BIGINT, 0L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.keys()"), BIGINT, 2L);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_SIZE('%s', '%s')", json, "$.store.book[1].author"), BIGINT, 0L);
+
         assertInvalidFunction(format("JSON_SIZE('%s', '%s')", json, "$...invalid"), "Invalid JSON path: '$...invalid'");
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_SIZE('%s', '%s')", json, "$...invalid"), "Invalid JSON path: '$...invalid'");
     }
 
     @Test
@@ -136,6 +235,13 @@ public class TestJsonExtractFunctions
         assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "[1,2,3]", "$[1]"), VARCHAR, "2");
         assertInvalidFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
 
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$"), VARCHAR, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x"), VARCHAR, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : 2} }", "$.x.a"), VARCHAR, "1");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"x\": {\"a\" : 1, \"b\" : [2, 3]} }", "$.x.b[1]"), VARCHAR, "3");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "[1,2,3]", "$[1]"), VARCHAR, "2");
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", "{\"\":\"\"}", ""), "Invalid JSON path: ''");
+
         // complex expressions (should run on Jayway)
         assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.book[*].isbn"), VARCHAR, null);
         assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$..price"), VARCHAR, null);
@@ -145,6 +251,15 @@ public class TestJsonExtractFunctions
         assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.keys()"), VARCHAR, null);
         assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.book[1].author"), VARCHAR, "Evelyn Waugh");
 
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.book[*].isbn"), VARCHAR, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$..price"), VARCHAR, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.book[?(@.price < 10)].title"), VARCHAR, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "max($..price)"), VARCHAR, "22.99");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "concat($..category)"), VARCHAR, "referencefictionfictionfiction");
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.keys()"), VARCHAR, null);
+        canonicalizedJsonExtractEnabled.assertFunction(format("JSON_EXTRACT_SCALAR(JSON'%s', '%s')", json, "$.store.book[1].author"), VARCHAR, "Evelyn Waugh");
+
         assertInvalidFunction(format("JSON_EXTRACT_SCALAR('%s', '%s')", json, "$...invalid"), "Invalid JSON path: '$...invalid'");
+        canonicalizedJsonExtractEnabled.assertInvalidFunction(format("JSON_EXTRACT_SCALAR('%s', '%s')", json, "$...invalid"), "Invalid JSON path: '$...invalid'");
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFunctionsConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFunctionsConfig.java
@@ -54,6 +54,7 @@ public class TestFunctionsConfig
                 .setWarnOnCommonNanPatterns(false)
                 .setLegacyCharToVarcharCoercion(false)
                 .setLegacyJsonCast(true)
+                .setCanonicalizedJsonExtract(false)
                 .setDefaultNamespacePrefix(JAVA_BUILTIN_NAMESPACE.toString()));
     }
 
@@ -83,6 +84,7 @@ public class TestFunctionsConfig
                 .put("deprecated.legacy-char-to-varchar-coercion", "true")
                 .put("legacy-json-cast", "false")
                 .put("presto.default-namespace", "native.default")
+                .put("canonicalized-json-extract", "true")
                 .build();
 
         FunctionsConfig expected = new FunctionsConfig()
@@ -107,7 +109,8 @@ public class TestFunctionsConfig
                 .setWarnOnCommonNanPatterns(true)
                 .setLegacyCharToVarcharCoercion(true)
                 .setLegacyJsonCast(false)
-                .setDefaultNamespacePrefix("native.default");
+                .setDefaultNamespacePrefix("native.default")
+                .setCanonicalizedJsonExtract(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -1446,17 +1446,17 @@ public class TestExpressionCompiler
             for (String pattern : jsonPatterns) {
                 assertExecute(generateExpression("json_extract(%s, %s)", value, pattern),
                         JSON,
-                        value == null || pattern == null ? null : JsonFunctions.jsonExtract(utf8Slice(value), JsonPath.build(pattern)));
+                        value == null || pattern == null ? null : JsonFunctions.jsonExtract(session.getSqlFunctionProperties(), utf8Slice(value), JsonPath.build(pattern)));
                 assertExecute(generateExpression("json_extract_scalar(%s, %s)", value, pattern),
                         value == null ? createUnboundedVarcharType() : createVarcharType(value.length()),
-                        value == null || pattern == null ? null : JsonFunctions.jsonExtractScalar(utf8Slice(value), JsonPath.build(pattern)));
+                        value == null || pattern == null ? null : JsonFunctions.jsonExtractScalar(session.getSqlFunctionProperties(), utf8Slice(value), JsonPath.build(pattern)));
 
                 assertExecute(generateExpression("json_extract(%s, %s || '')", value, pattern),
                         JSON,
-                        value == null || pattern == null ? null : JsonFunctions.jsonExtract(utf8Slice(value), JsonPath.build(pattern)));
+                        value == null || pattern == null ? null : JsonFunctions.jsonExtract(session.getSqlFunctionProperties(), utf8Slice(value), JsonPath.build(pattern)));
                 assertExecute(generateExpression("json_extract_scalar(%s, %s || '')", value, pattern),
                         value == null ? createUnboundedVarcharType() : createVarcharType(value.length()),
-                        value == null || pattern == null ? null : JsonFunctions.jsonExtractScalar(utf8Slice(value), JsonPath.build(pattern)));
+                        value == null || pattern == null ? null : JsonFunctions.jsonExtractScalar(session.getSqlFunctionProperties(), utf8Slice(value), JsonPath.build(pattern)));
             }
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -78,6 +78,8 @@ public class TestRowOperators
     private static FunctionAssertions fieldNameInJsonCastEnabled;
     private static FunctionAssertions legacyJsonCastEnabled;
     private static FunctionAssertions legacyJsonCastDisabled;
+    private static FunctionAssertions canonicalizedJsonExtractDisabled;
+    private static FunctionAssertions canonicalizedJsonExtractEnabled;
 
     @BeforeClass
     public void setUp()
@@ -100,6 +102,13 @@ public class TestRowOperators
         FunctionsConfig featuresConfigWithLegacyJsonCastDisabled = new FunctionsConfig()
                 .setLegacyJsonCast(false);
         legacyJsonCastDisabled = new FunctionAssertions(session, new FeaturesConfig(), featuresConfigWithLegacyJsonCastDisabled, true);
+
+        FunctionsConfig featuresConfigWithCanonicalizedJsonExtractDisabled = new FunctionsConfig()
+                .setCanonicalizedJsonExtract(false);
+        canonicalizedJsonExtractDisabled = new FunctionAssertions(session, new FeaturesConfig(), featuresConfigWithCanonicalizedJsonExtractDisabled, true);
+        FunctionsConfig featuresConfigWithCanonicalizedJsonExtractEnabled = new FunctionsConfig()
+                .setCanonicalizedJsonExtract(true);
+        canonicalizedJsonExtractEnabled = new FunctionAssertions(session, new FeaturesConfig(), featuresConfigWithCanonicalizedJsonExtractEnabled, true);
     }
 
     @AfterClass(alwaysRun = true)
@@ -113,6 +122,10 @@ public class TestRowOperators
         legacyJsonCastEnabled = null;
         legacyJsonCastDisabled.close();
         legacyJsonCastDisabled = null;
+        canonicalizedJsonExtractDisabled.close();
+        canonicalizedJsonExtractDisabled = null;
+        canonicalizedJsonExtractEnabled.close();
+        canonicalizedJsonExtractEnabled = null;
     }
 
     @ScalarFunction
@@ -539,6 +552,13 @@ public class TestRowOperators
         assertInvalidCast("CAST(json_extract('{\"1\":[{\"key1\": \"John\", \"KEY1\":\"Johnny\"}]}', '$') AS MAP<bigint, ARRAY<ROW(key1 VARCHAR)>>)",
                 "Cannot cast to map(bigint,array(row(key1 varchar))). Duplicate field: KEY1\n" +
                         "{\"1\":[{\"key1\":\"John\",\"KEY1\":\"Johnny\"}]}");
+        canonicalizedJsonExtractDisabled.assertInvalidCast("CAST(json_extract('{\"1\":[{\"key1\": \"John\", \"KEY1\":\"Johnny\"}]}', '$') AS MAP<bigint, ARRAY<ROW(key1 VARCHAR)>>)",
+                "Cannot cast to map(bigint,array(row(key1 varchar))). Duplicate field: KEY1\n" +
+                        "{\"1\":[{\"key1\":\"John\",\"KEY1\":\"Johnny\"}]}");
+        canonicalizedJsonExtractEnabled.assertInvalidCast("CAST(json_extract('{\"1\":[{\"key1\": \"John\", \"KEY1\":\"Johnny\"}]}', '$') AS MAP<bigint, ARRAY<ROW(key1 VARCHAR)>>)",
+                "Cannot cast to map(bigint,array(row(key1 varchar))). Duplicate field: key1\n" +
+                        "{\"1\":[{\"KEY1\":\"Johnny\",\"key1\":\"John\"}]}");
+
         assertInvalidCast("CAST(unchecked_to_json('{\"a\":1,\"b\":2,\"a\":3}') AS ROW(a BIGINT, b BIGINT))", "Cannot cast to row(a bigint,b bigint). Duplicate field: a\n{\"a\":1,\"b\":2,\"a\":3}");
         assertInvalidCast("CAST(unchecked_to_json('[{\"a\":1,\"b\":2,\"a\":3}]') AS ARRAY<ROW(a BIGINT, b BIGINT)>)", "Cannot cast to array(row(a bigint,b bigint)). Duplicate field: a\n[{\"a\":1,\"b\":2,\"a\":3}]");
     }
@@ -779,5 +799,19 @@ public class TestRowOperators
             assertFunction(base + operator + greater, BOOLEAN, lessOrInequalityOperators.contains(operator));
             assertFunction(greater + operator + base, BOOLEAN, greaterOrInequalityOperators.contains(operator));
         }
+    }
+
+    @Test
+    public void testRowNestedJsonExtractNullVarchar()
+    {
+        assertInvalidCast("CAST(json_extract('{\"1\":[{\"key1\": \"John\", \"KEY1\":\"Johnny\"}]}', '$') AS MAP<bigint, ARRAY<ROW(key1 VARCHAR)>>)",
+                "Cannot cast to map(bigint,array(row(key1 varchar))). Duplicate field: KEY1\n" +
+                        "{\"1\":[{\"key1\":\"John\",\"KEY1\":\"Johnny\"}]}");
+        canonicalizedJsonExtractDisabled.assertInvalidCast("CAST(json_extract('{\"1\":[{\"key1\": \"John\", \"KEY1\":\"Johnny\"}]}', '$') AS MAP<bigint, ARRAY<ROW(key1 VARCHAR)>>)",
+                "Cannot cast to map(bigint,array(row(key1 varchar))). Duplicate field: KEY1\n" +
+                        "{\"1\":[{\"key1\":\"John\",\"KEY1\":\"Johnny\"}]}");
+        canonicalizedJsonExtractEnabled.assertInvalidCast("CAST(json_extract('{\"1\":[{\"key1\": \"John\", \"KEY1\":\"Johnny\"}]}', '$') AS MAP<bigint, ARRAY<ROW(key1 VARCHAR)>>)",
+                "Cannot cast to map(bigint,array(row(key1 varchar))). Duplicate field: key1\n" +
+                        "{\"1\":[{\"KEY1\":\"Johnny\",\"key1\":\"John\"}]}");
     }
 }


### PR DESCRIPTION
## Description
Canonicalize json_extract output by replacing the copy operation with writing the JSON to output stream with sorted keys

## Motivation and Context
This relates to issue [#24563](https://github.com/prestodb/presto/issues/24563).
Ensuring JSON output canonicalization guarantees the accuracy of JSON comparisons and aligns the behavior with json_parse


## Impact
low impact

## Test Plan
SET SESSION canonicalized_json_extract = true

1. json_extract result should be canonicalized
<img width="601" alt="image" src="https://github.com/user-attachments/assets/1674cf5c-0d5d-46d5-9dc3-9e9a85429a81" />

2. If the JSON result is invalid, a PrestoException will be thrown
<img width="961" alt="image" src="https://github.com/user-attachments/assets/8166cb06-3517-4d42-9b2a-29f2dfa2f283" />

3. Benchmark test result
Enabling canonicalized JSON extract (isCanonicalizedJsonExtract = true) causes a 11.7% performance drop compared to disabling it (isCanonicalizedJsonExtract = false), specifically in complex test cases involving nested JSON objects in the JSON path.
<img width="768" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/d95ec891-98dd-462f-9610-9a294fa283e9" />


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
== RELEASE NOTES ==

Presto Changes
- Add session property ``canonicalized_json_extract``. :pr:`24614`

