### PR TITLE
[Iceberg] Rename "target_split_size" to "target_split_size_bytes"

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -468,7 +468,7 @@ Property Name                                         Description
 ``iceberg.rows_for_metadata_optimization_threshold``  Overrides the behavior of the connector property
                                                       ``iceberg.rows-for-metadata-optimization-threshold`` in the current
                                                       session.
-``iceberg.target_split_size``                         Overrides the target split size for all tables in a query in bytes.
+``iceberg.target_split_size_bytes``                   Overrides the target split size for all tables in a query in bytes.
                                                       Set to 0 to use the value in each Iceberg table's
                                                       ``read.split.target-size`` property.
 ``iceberg.affinity_scheduling_file_section_size``     When the ``node_selection_strategy`` or

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -66,7 +66,7 @@ public final class IcebergSessionProperties
     public static final String STATISTIC_SNAPSHOT_RECORD_DIFFERENCE_WEIGHT = "statistic_snapshot_record_difference_weight";
     public static final String ROWS_FOR_METADATA_OPTIMIZATION_THRESHOLD = "rows_for_metadata_optimization_threshold";
     public static final String STATISTICS_KLL_SKETCH_K_PARAMETER = "statistics_kll_sketch_k_parameter";
-    public static final String TARGET_SPLIT_SIZE = "target_split_size";
+    public static final String TARGET_SPLIT_SIZE_BYTES = "target_split_size_bytes";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -193,7 +193,7 @@ public final class IcebergSessionProperties
                         icebergConfig.getStatisticsKllSketchKParameter(),
                         false))
                 .add(longProperty(
-                        TARGET_SPLIT_SIZE,
+                        TARGET_SPLIT_SIZE_BYTES,
                         "The target split size. Set to 0 to use the iceberg table's read.split.target-size property",
                         0L,
                         false));
@@ -333,6 +333,6 @@ public final class IcebergSessionProperties
 
     public static Long getTargetSplitSize(ConnectorSession session)
     {
-        return session.getProperty(TARGET_SPLIT_SIZE, Long.class);
+        return session.getProperty(TARGET_SPLIT_SIZE_BYTES, Long.class);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
@@ -46,7 +46,7 @@ import static com.facebook.presto.hive.HiveCommonSessionProperties.AFFINITY_SCHE
 import static com.facebook.presto.hive.HiveCommonSessionProperties.NODE_SELECTION_STRATEGY;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILTER_ENABLED;
-import static com.facebook.presto.iceberg.IcebergSessionProperties.TARGET_SPLIT_SIZE;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.TARGET_SPLIT_SIZE_BYTES;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -178,7 +178,7 @@ public class TestIcebergSplitManager
     public void testSplitSchedulingWithTablePropertyAndSession()
     {
         Session session = Session.builder(getSession())
-                .setCatalogSessionProperty("iceberg", IcebergSessionProperties.TARGET_SPLIT_SIZE, "0")
+                .setCatalogSessionProperty("iceberg", IcebergSessionProperties.TARGET_SPLIT_SIZE_BYTES, "0")
                 .build();
         assertQuerySucceeds("CREATE TABLE test_split_size as SELECT * FROM UNNEST(sequence(1, 512)) as t(i)");
         // verify that the session property hasn't propagated into the table
@@ -198,7 +198,7 @@ public class TestIcebergSplitManager
         // Set it to 1 with the session property to override the table value and verify we get the
         // same number of splits as when the table value is set to 1.
         Session minSplitSession = Session.builder(session)
-                .setCatalogSessionProperty("iceberg", TARGET_SPLIT_SIZE, "1")
+                .setCatalogSessionProperty("iceberg", TARGET_SPLIT_SIZE_BYTES, "1")
                 .build();
         assertEquals(getSplitsForSql(minSplitSession, selectQuery).size(), maxSplits);
         assertQuerySucceeds("DROP TABLE test_split_size");
@@ -209,7 +209,7 @@ public class TestIcebergSplitManager
     {
         Session maxIdentifiers = Session.builder(getSession())
                 .setCatalogSessionProperty("iceberg", AFFINITY_SCHEDULING_FILE_SECTION_SIZE, "1B")
-                .setCatalogSessionProperty("iceberg", TARGET_SPLIT_SIZE, "1")
+                .setCatalogSessionProperty("iceberg", TARGET_SPLIT_SIZE_BYTES, "1")
                 .setCatalogSessionProperty("iceberg", NODE_SELECTION_STRATEGY, "SOFT_AFFINITY")
                 .build();
         assertQuerySucceeds("CREATE TABLE test_affinity_section_scheduling as SELECT * FROM UNNEST(sequence(1, 512)) as t(i)");


### PR DESCRIPTION
## Description

Renames the target split size property to make it clear that only a bytes value is accepted.

## Motivation and Context

Less confusion

## Impact

Renames a session property. This has not been in any release yet, so no serious impact. The original PR has had the release note updated with the correct name

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

