### PR TITLE
Move Java page to Clients menu and fix references

### DIFF
--- a/presto-docs/src/main/sphinx/clients.rst
+++ b/presto-docs/src/main/sphinx/clients.rst
@@ -9,6 +9,7 @@ Clients
     clients/presto-console
     clients/dbeaver
     clients/superset
+    clients/java
     clients/python
     clients/go
     clients/js

--- a/presto-docs/src/main/sphinx/clients/java.rst
+++ b/presto-docs/src/main/sphinx/clients/java.rst
@@ -1,5 +1,5 @@
 ===========
-JDBC Driver
+Java Client
 ===========
 
 Presto can be accessed from Java using the JDBC driver.

--- a/presto-docs/src/main/sphinx/connector/hana.rst
+++ b/presto-docs/src/main/sphinx/connector/hana.rst
@@ -78,14 +78,12 @@ General Configuration Properties
 Property Name                                      Description                                                          Default
 ================================================== ==================================================================== ===========
 ``user-credential-name``                           Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user name. See ``extraCredentials`` in `Parameter Reference
-                                                   <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user name. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``password-credential-name``                       Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user password. See ``extraCredentials`` in `Parameter
-                                                   Reference <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user password. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``case-insensitive-name-matching``                 Match dataset and table names case-insensitively.                    ``false``
 

--- a/presto-docs/src/main/sphinx/connector/mysql.rst
+++ b/presto-docs/src/main/sphinx/connector/mysql.rst
@@ -55,14 +55,12 @@ General Configuration Properties
 Property Name                                      Description                                                          Default
 ================================================== ==================================================================== ===========
 ``user-credential-name``                           Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user name. See ``extraCredentials`` in `Parameter Reference
-                                                   <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user name. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``password-credential-name``                       Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user password. See ``extraCredentials`` in `Parameter
-                                                   Reference <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user password. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``case-insensitive-name-matching``                 Match dataset and table names case-insensitively.                    ``false``
 

--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -57,14 +57,12 @@ General Configuration Properties
 Property Name                                      Description                                                          Default
 ================================================== ==================================================================== ===========
 ``user-credential-name``                           Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user name. See ``extraCredentials`` in `Parameter Reference
-                                                   <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user name. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``password-credential-name``                       Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user password. See ``extraCredentials`` in `Parameter
-                                                   Reference <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user password. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``case-insensitive-name-matching``                 Match dataset and table names case-insensitively.                    ``false``
 

--- a/presto-docs/src/main/sphinx/connector/postgresql.rst
+++ b/presto-docs/src/main/sphinx/connector/postgresql.rst
@@ -43,14 +43,12 @@ General Configuration Properties
 Property Name                                      Description                                                          Default
 ================================================== ==================================================================== ===========
 ``user-credential-name``                           Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user name. See ``extraCredentials`` in `Parameter Reference
-                                                   <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user name. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``password-credential-name``                       Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user password. See ``extraCredentials`` in `Parameter
-                                                   Reference <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user password. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``case-insensitive-name-matching``                 Match dataset and table names case-insensitively.                    ``false``
 

--- a/presto-docs/src/main/sphinx/connector/redshift.rst
+++ b/presto-docs/src/main/sphinx/connector/redshift.rst
@@ -43,14 +43,12 @@ General Configuration Properties
 Property Name                                      Description                                                          Default
 ================================================== ==================================================================== ===========
 ``user-credential-name``                           Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user name. See ``extraCredentials`` in `Parameter Reference
-                                                   <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user name. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``password-credential-name``                       Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user password. See ``extraCredentials`` in `Parameter
-                                                   Reference <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user password. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``case-insensitive-name-matching``                 Match dataset and table names case-insensitively.                    ``false``
 

--- a/presto-docs/src/main/sphinx/connector/sqlserver.rst
+++ b/presto-docs/src/main/sphinx/connector/sqlserver.rst
@@ -82,14 +82,12 @@ General Configuration Properties
 Property Name                                      Description                                                          Default
 ================================================== ==================================================================== ===========
 ``user-credential-name``                           Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user name. See ``extraCredentials`` in `Parameter Reference
-                                                   <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user name. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``password-credential-name``                       Name of the ``extraCredentials`` property whose value is the JDBC
-                                                   driver's user password. See ``extraCredentials`` in `Parameter
-                                                   Reference <https://prestodb.io/docs/current/installation/jdbc.html
-                                                   #parameter-reference>`_.
+                                                   driver's user password. See ``extraCredentials`` in
+                                                   :ref:`Parameter Reference <jdbc-parameter-reference>`.
 
 ``case-insensitive-name-matching``                 Match dataset and table names case-insensitively.                    ``false``
 

--- a/presto-docs/src/main/sphinx/installation.rst
+++ b/presto-docs/src/main/sphinx/installation.rst
@@ -6,7 +6,6 @@ Installation
     :maxdepth: 1
 
     installation/deployment
-    installation/jdbc
     installation/benchmark-driver
     installation/tableau
     installation/spark

--- a/presto-docs/src/main/sphinx/release/release-0.272.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.272.rst
@@ -30,7 +30,7 @@ ______________________
 
 JDBC Changes
 ____________
-* Add a new parameter ``timeZoneID`` which will set the time zone used for the timestamp columns. (See :doc:`/installation/jdbc` :issue:`16680`).
+* Add a new parameter ``timeZoneID`` which will set the time zone used for the timestamp columns. (See :doc:`/clients/java` and issue :issue:`16680`).
 
 MongoDB Connector Changes
 _________________________

--- a/presto-docs/src/main/sphinx/release/release-0.57.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.57.rst
@@ -42,7 +42,7 @@ to specify your AWS Access Key ID and Secret Access Key:
 Miscellaneous
 -------------
 
-* Allow specifying catalog and schema in the :doc:`/installation/jdbc` URL.
+* Allow specifying catalog and schema in the :doc:`JDBC </clients/java>` URL.
 
 * Implement more functionality in the JDBC driver.
 

--- a/presto-docs/src/main/sphinx/release/release-0.90.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.90.rst
@@ -24,7 +24,7 @@ General Changes
   to bytecode. To enable this option, add ``compiler.interpreter-enabled=true``
   to the coordinator and worker config properties. Enabling this option will
   allow certain queries to run slowly rather than failing.
-* Improve :doc:`/installation/jdbc` conformance. In particular, all unimplemented
+* Improve :doc:`/clients/java` conformance. In particular, all unimplemented
   methods now throw ``SQLException`` rather than ``UnsupportedOperationException``.
 
 Functions and Language Features


### PR DESCRIPTION
## Description

Rename `JDBC Driver` page to `Java Client` and move it to `Clients` menu similar to `Python/Go/JavaScript`.
Fix references to point current docs instead of latest hosted documentation.

## Motivation and Context

The change makes documentation cleaner and consistent.

## Impact

None

## Test Plan

Built documentation locally and checked updated pages.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

