### PR TITLE
[native] Fix custom type headers in unit tests

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxQueryPlanTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxQueryPlanTest.cpp
@@ -15,11 +15,17 @@
 
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/HyperLogLogRegistration.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/IPAddressRegistration.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
+#include "velox/functions/prestosql/types/IPPrefixRegistration.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/functions/prestosql/types/JsonRegistration.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/UuidRegistration.h"
 #include "velox/functions/prestosql/types/UuidType.h"
 
 using namespace facebook::presto;

--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -18,7 +18,7 @@
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
 #include "velox/core/Expressions.h"
 #include "velox/type/Type.h"
-#include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/JsonRegistration.h"
 
 using namespace facebook::presto;
 using namespace facebook::velox;


### PR DESCRIPTION
## Description
Update the unit tests that register custom Presto types from Velox to include the appropriate headers.

## Motivation and Context
Velox refactored the header files for Presto's custom types, separating the type definition from the type registration. Type
registration is used in a couple of unit tests in Presto, so these need to explicitly include the appropriate header files. This will unblock Velox from completing the refactor.

## Impact

## Test Plan
Built and ran the unit tests.

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

