### PR TITLE
Correct catalog name for iceberg tests

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestExpireSnapshotProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestExpireSnapshotProcedure.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.SystemSessionProperties.LEGACY_TIMESTAMP;
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
@@ -50,7 +51,6 @@ import static org.testng.Assert.assertTrue;
 public class TestExpireSnapshotProcedure
         extends AbstractTestQueryFramework
 {
-    public static final String ICEBERG_CATALOG = "test_hive";
     public static final String TEST_SCHEMA = "tpch";
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestFastForwardBranchProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestFastForwardBranchProcedure.java
@@ -31,13 +31,13 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static java.lang.String.format;
 
 public class TestFastForwardBranchProcedure
         extends AbstractTestQueryFramework
 {
-    public static final String ICEBERG_CATALOG = "test_hadoop";
     public static final String TEST_SCHEMA = "tpch";
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestSetTablePropertyProcedure.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/procedure/TestSetTablePropertyProcedure.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
 import static java.lang.String.format;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE_DEFAULT;
@@ -39,7 +40,6 @@ import static org.testng.Assert.assertEquals;
 public class TestSetTablePropertyProcedure
         extends AbstractTestQueryFramework
 {
-    public static final String ICEBERG_CATALOG = "test_hadoop";
     public static final String TEST_SCHEMA = "tpch";
 
     @Override


### PR DESCRIPTION
## Description
Correct catalog name for iceberg tests

## Motivation and Context
IcebergQueryRunner registers catalog name with `iceberg` so use the same.
https://github.com/prestodb/presto/blob/master/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergQueryRunner.java#L242

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

