### PR TITLE
Move Tableau page to Clients menu and fix link to Web Data Connector

### DIFF
--- a/presto-docs/src/main/sphinx/clients.rst
+++ b/presto-docs/src/main/sphinx/clients.rst
@@ -9,6 +9,7 @@ Clients
     clients/presto-console
     clients/dbeaver
     clients/superset
+    clients/tableau
     clients/java
     clients/python
     clients/go

--- a/presto-docs/src/main/sphinx/clients/tableau.rst
+++ b/presto-docs/src/main/sphinx/clients/tableau.rst
@@ -1,11 +1,10 @@
-*************************
-Web Connector for Tableau
-*************************
+*******
+Tableau
+*******
 
-The Presto web connector for Tableau lets users run queries from
-Tableau against Presto. It implements the functions in the
-`Tableau web connector API
-<https://community.tableau.com/community/developers/web-data-connectors>`_.
+The Presto web connector for Tableau lets users run queries from Tableau against Presto.
+It implements the functions in the
+`Tableau web connector API <https://www.tableau.com/developer/tools/web-data-connector>`_.
 
 When creating a new web data source, Tableau will ask for the URL of the web
 connector. Use the following URL, replacing ``example.net:8080`` with the

--- a/presto-docs/src/main/sphinx/installation.rst
+++ b/presto-docs/src/main/sphinx/installation.rst
@@ -7,7 +7,6 @@ Installation
 
     installation/deployment
     installation/benchmark-driver
-    installation/tableau
     installation/spark
     installation/deploy-docker
     installation/deploy-brew

--- a/presto-docs/src/main/sphinx/release/release-0.126.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.126.rst
@@ -23,7 +23,7 @@ General Changes
   within a task. This allows us to optimize for index cache hits or for more
   CPU parallelism. This option is toggled by the ``task.share-index-loading``
   config property or the ``task_share_index_loading`` session property.
-* Add :doc:`Tableau web connector </installation/tableau>`.
+* Add :doc:`Tableau web connector </clients/tableau>`.
 * Improve performance of queries that use an ``IN`` expression with a large
   list of constant values.
 * Enable connector predicate push down for all comparable and equatable types.

--- a/presto-docs/src/main/sphinx/release/release-0.151.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.151.rst
@@ -14,7 +14,7 @@ General Changes
   behavior (ignore ``NULL`` input). This flag will be removed in a future release.
 * Add support for uncorrelated ``EXISTS`` clause.
 * Add :func:`!cosine_similarity` function.
-* Allow :doc:`/installation/tableau` to use catalogs other than ``hive``.
+* Allow :doc:`/clients/tableau` to use catalogs other than ``hive``.
 
 Verifier Changes
 ----------------


### PR DESCRIPTION
## Description

Move Tableau page to Clients similar to Apache Superset.
Fix link to Tableau Web Data Connector.

## Motivation and Context

The change makes documentation cleaner and consistent.

## Impact

None

## Test Plan

Built documentation locally and checked updated pages.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

