### PR TITLE
Upgrade json-smart version to 2.5.2 in response to CVE-2024-57699

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -922,6 +922,12 @@
             </dependency>
 
             <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.5.2</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.facebook.presto.hadoop</groupId>
                 <artifactId>hadoop-apache2</artifactId>
                 <version>2.7.4-12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dep.logback.version>1.2.13</dep.logback.version>
         <dep.parquet.version>1.13.1</dep.parquet.version>
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
-        <dep.asm.version>9.2</dep.asm.version>
+        <dep.asm.version>9.7.1</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
         <dep.alluxio.version>313</dep.alluxio.version>
         <dep.slf4j.version>1.7.32</dep.slf4j.version>


### PR DESCRIPTION
## Description
Upgrade the json-smart dependency to version 2.5.2 to address CVE-2024-57699. The json-smart dependency is a transitive dependency of com.jayway.jsonpath:json-path:2.9.0, which uses an older version that contains this vulnerability. Therefore, upgrading the json-smart dependency to 2.5.2 resolves the issue. 'json-smart' 2.5.2 uses the latest version of org.ow2.asm:asm 9.7.1, therefore avoiding future conflicts by upgrading the asm version to 9.7.1.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes

* Upgrade json-smart version to 2.5.2 in response to `CVE-2024-57699 <https://nvd.nist.gov/vuln/detail/CVE-2024-57699>`_. 
```


