### PR TITLE
Add tracking of analysis time

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
@@ -53,6 +53,7 @@ public class QueryManagerStats
     private final CounterStat consumedInputBytes = new CounterStat();
     private final CounterStat consumedCpuTimeSecs = new CounterStat();
     private final TimeStat executionTime = new TimeStat(MILLISECONDS);
+    private final TimeStat analysisTime = new TimeStat(MILLISECONDS);
     private final TimeStat queuedTime = new TimeStat(MILLISECONDS);
     private final DistributionStat wallInputBytesRate = new DistributionStat();
     private final DistributionStat cpuInputByteRate = new DistributionStat();
@@ -101,6 +102,7 @@ public class QueryManagerStats
         consumedInputBytes.update(info.getQueryStats().getRawInputDataSize().toBytes());
         consumedInputRows.update(info.getQueryStats().getRawInputPositions());
         executionTime.add(info.getQueryStats().getExecutionTime());
+        analysisTime.add(info.getQueryStats().getAnalysisTime());
         queuedTime.add(info.getQueryStats().getQueuedTime());
 
         long executionWallMillis = info.getQueryStats().getExecutionTime().toMillis();
@@ -271,6 +273,13 @@ public class QueryManagerStats
     public TimeStat getExecutionTime()
     {
         return executionTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getAnalysisTime()
+    {
+        return analysisTime;
     }
 
     @Managed

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -379,6 +379,7 @@ public class QueryStateMachine
                 queryStateTimer.getQueuedTime(),
                 queryStateTimer.getElapsedTime(),
                 queryStateTimer.getExecutionTime(),
+                queryStateTimer.getAnalysisTime(),
 
                 getCurrentRunningTaskCount(),
                 getPeakRunningTaskCount(),

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -50,6 +50,7 @@ public class BasicQueryStats
     private final Duration queuedTime;
     private final Duration elapsedTime;
     private final Duration executionTime;
+    private final Duration analysisTime;
 
     private final int runningTasks;
     private final int peakRunningTasks;
@@ -89,6 +90,7 @@ public class BasicQueryStats
             @JsonProperty("queuedTime") Duration queuedTime,
             @JsonProperty("elapsedTime") Duration elapsedTime,
             @JsonProperty("executionTime") Duration executionTime,
+            @JsonProperty("analysisTime") Duration analysisTime,
             @JsonProperty("runningTasks") int runningTasks,
             @JsonProperty("peakRunningTasks") int peakRunningTasks,
             @JsonProperty("totalDrivers") int totalDrivers,
@@ -119,7 +121,7 @@ public class BasicQueryStats
         this.queuedTime = requireNonNull(queuedTime, "queuedTime is null");
         this.elapsedTime = requireNonNull(elapsedTime, "elapsedTime is null");
         this.executionTime = requireNonNull(executionTime, "executionTime is null");
-
+        this.analysisTime = requireNonNull(analysisTime, "analysisTime is null");
         this.runningTasks = runningTasks;
         this.peakRunningTasks = peakRunningTasks;
 
@@ -162,6 +164,7 @@ public class BasicQueryStats
                 queryStats.getQueuedTime(),
                 queryStats.getElapsedTime(),
                 queryStats.getExecutionTime(),
+                queryStats.getAnalysisTime(),
                 queryStats.getRunningTasks(),
                 queryStats.getPeakRunningTasks(),
                 queryStats.getTotalDrivers(),
@@ -192,6 +195,7 @@ public class BasicQueryStats
         return new BasicQueryStats(
                 now,
                 now,
+                new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
@@ -413,5 +417,12 @@ public class BasicQueryStats
     public int getRunningTasks()
     {
         return runningTasks;
+    }
+
+    @ThriftField(29)
+    @JsonProperty
+    public Duration getAnalysisTime()
+    {
+        return analysisTime;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -131,6 +131,7 @@ public class MockManagedQueryExecution
                         new Duration(3, NANOSECONDS),
                         new Duration(4, NANOSECONDS),
                         new Duration(5, NANOSECONDS),
+                        new Duration(1, NANOSECONDS),
                         5,
                         5,
                         6,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -183,6 +183,7 @@ public class TestNodeScheduler
                     defaultDuration,
                     defaultDuration,
                     executionTime,
+                    defaultDuration,
                     0,
                     0,
                     0,

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -751,6 +751,7 @@ public class TestResourceManagerClusterStateProvider
                         Duration.valueOf("8m"),
                         Duration.valueOf("7m"),
                         Duration.valueOf("34m"),
+                        Duration.valueOf("10m"),
                         11,
                         12,
                         13,

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
@@ -88,6 +88,7 @@ public class TestClusterMemoryLeakDetector
                         Duration.valueOf("8m"),
                         Duration.valueOf("7m"),
                         Duration.valueOf("34m"),
+                        Duration.valueOf("10m"),
                         11,
                         12,
                         13,


### PR DESCRIPTION
Add tracking of analysis time as a Java bean. 
This is useful for tracking macro impact of planner features like Quick Stats

## Test Plan
Some tested that the beans show up in the JMX catalog -
```
presto> select "analysistime.alltime.max" from jmx.current."com.facebook.presto.execution:name=querymanager";
 analysistime.alltime.max 
--------------------------
               124.147567 
(1 row)

Query 20250226_150035_00008_nef5g, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 39ms, server-side: 35ms] [1 rows, 8B] [28 rows/s, 228B/s]

presto> select "analysistime.alltime.count" from jmx.current."com.facebook.presto.execution:name=querymanager";
 analysistime.alltime.count 
----------------------------
                        9.0 
(1 row)

```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

