### PR TITLE
[native] Default task.max-drivers-per-task to hardware concurrency

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -129,9 +129,10 @@ The configuration properties of Presto C++ workers are described here, in alphab
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``integer``
-* **Default value:** ``number of hardware CPUs``
+* **Default value:** ``number of concurrent threads supported by the host``
 
-  Number of drivers to use per task. Defaults to hardware CPUs.
+  Number of drivers to use per task. Defaults to the number of concurrent
+  threads supported by the host.
 
 ``query.max-memory-per-node``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -42,13 +42,6 @@ class ConfigBase {
     config_ = std::move(config);
   }
 
-  /// Registers an extra property in the config.
-  /// Returns true if succeeded, false if failed (due to the property already
-  /// registered).
-  bool registerProperty(
-      const std::string& propertyName,
-      const folly::Optional<std::string>& defaultValue = {});
-
   /// Adds or replaces value at the given key. Can be used by debugging or
   /// testing code.
   /// Returns previous value if there was any.

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -11,8 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <filesystem>
 #include <gtest/gtest.h>
+#include <filesystem>
 #include <unordered_set>
 #include "presto_cpp/main/common/ConfigReader.h"
 #include "presto_cpp/main/common/Configs.h"
@@ -217,7 +217,7 @@ TEST_F(ConfigTest, optionalNodeConfigs) {
 TEST_F(ConfigTest, optionalSystemConfigsWithDefault) {
   SystemConfig config;
   init(config, {});
-  ASSERT_EQ(config.maxDriversPerTask(), 16);
+  ASSERT_EQ(config.maxDriversPerTask(), std::thread::hardware_concurrency());
   init(config, {{std::string(SystemConfig::kMaxDriversPerTask), "1024"}});
   ASSERT_EQ(config.maxDriversPerTask(), 1024);
 }

--- a/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
@@ -240,7 +240,8 @@ TEST_F(ServerOperationTest, systemConfigEndpoint) {
       {.target = ServerOperation::Target::kSystemConfig,
        .action = ServerOperation::Action::kGetProperty},
       &httpMessage);
-  EXPECT_EQ(getPropertyResponse, "16\n");
+  EXPECT_EQ(
+      std::stoi(getPropertyResponse), std::thread::hardware_concurrency());
 }
 
 } // namespace facebook::presto


### PR DESCRIPTION
## Description
The doc says task.max-drivers-per-task defaults to CPU count.
https://prestodb.io/docs/current/presto_cpp/properties.html#task-max-drivers-per-task
But it defaults to 16 in the code.
This config must default to the thread concurrency count for better user experience.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution)
* Fix task.max-drivers-per-task to use thread concurrency of the host

```

