### PR TITLE
[native] Include storageParameters in HiveConnectorSplit

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxConnector.cpp
@@ -1128,6 +1128,11 @@ HivePrestoToVeloxConnector::toVeloxSplit(
   for (const auto& [key, value] : hiveSplit->storage.serdeParameters) {
     serdeParameters[key] = value;
   }
+  std::unordered_map<std::string, std::string> storageParameters;
+  storageParameters.reserve(hiveSplit->storage.parameters.size());
+  for (const auto& [key, value] : hiveSplit->storage.parameters) {
+    storageParameters[key] = value;
+  }
   std::unordered_map<std::string, std::string> infoColumns = {
       {"$path", hiveSplit->fileSplit.path},
       {"$file_size", std::to_string(hiveSplit->fileSplit.fileSize)},
@@ -1151,6 +1156,7 @@ HivePrestoToVeloxConnector::toVeloxSplit(
           customSplitInfo,
           extraFileInfo,
           serdeParameters,
+          storageParameters,
           hiveSplit->splitWeight,
           splitContext->cacheable,
           infoColumns);


### PR DESCRIPTION
Advance Velox version and include storageParameters in HiveConnectorSplit.

```
== NO RELEASE NOTE ==
```

