### PR TITLE
[docs] Add links from lakehouse connector docs to file-based metastore

### DIFF
--- a/presto-docs/src/main/sphinx/connector/deltalake.rst
+++ b/presto-docs/src/main/sphinx/connector/deltalake.rst
@@ -22,6 +22,12 @@ replacing the properties as appropriate:
     connector.name=delta
     hive.metastore.uri=hostname:port
 
+File-Based Metastore
+^^^^^^^^^^^^^^^^^^^^
+
+For testing or development purposes, this connector can be configured to use a local 
+filesystem directory as a Hive Metastore. See :ref:`installation/deployment:File-Based Metastore`.  
+
 Configuration Properties
 ------------------------
 

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -108,6 +108,12 @@ The properties that apply to Hive connector security are listed in the
 :doc:`/connector/hive-security` section for a more detailed discussion of the
 security options in the Hive connector.
 
+File-Based Metastore
+^^^^^^^^^^^^^^^^^^^^
+
+For testing or development purposes, this connector can be configured to use a local 
+filesystem directory as a Hive Metastore. See :ref:`installation/deployment:File-Based Metastore`.  
+
 Hive Configuration Properties
 -----------------------------
 

--- a/presto-docs/src/main/sphinx/connector/hudi.rst
+++ b/presto-docs/src/main/sphinx/connector/hudi.rst
@@ -40,6 +40,12 @@ Property Name                           Description                             
                                         Hudi's metadata table rather than storage.
 ======================================= ============================================= ===========
 
+File-Based Metastore
+^^^^^^^^^^^^^^^^^^^^
+
+For testing or development purposes, this connector can be configured to use a local 
+filesystem directory as a Hive Metastore. See :ref:`installation/deployment:File-Based Metastore`.  
+
 SQL Support
 -----------
 

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -32,6 +32,12 @@ as a Hive connector.
     hive.metastore.uri=hostname:port
     iceberg.catalog.type=hive
 
+File-Based Metastore
+^^^^^^^^^^^^^^^^^^^^
+
+For testing or development purposes, this connector can be configured to use a local 
+filesystem directory as a Hive Metastore. See :ref:`installation/deployment:File-Based Metastore`.  
+
 Glue catalog
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description
Add text linking to File-Based Metastore documentation into the doc of the supported lakehouse connectors. 

## Motivation and Context
Fixes #24643. 

## Impact
Documentation. 

## Test Plan
Local doc builds. 

See screenshot of the added "File-Based Metastore" heading and text in the Delta Lake Connector page as an example. 
<img width="1164" alt="Screenshot 2025-02-28 at 11 41 23 AM" src="https://github.com/user-attachments/assets/712ea9a8-ac1c-40b6-ad5c-2a339b3391b4" />

The same heading and text was added to the Hive, Hudi, and Iceberg Connector documentation as well. Verified that all of the new links work as intended. 

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

