### PR TITLE
Add registerProperty back for fbcode usage

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -85,6 +85,21 @@ std::string ConfigBase::capacityPropertyAsBytesString(
       velox::config::CapacityUnit::BYTE));
 }
 
+bool ConfigBase::registerProperty(
+    const std::string& propertyName,
+    const folly::Optional<std::string>& defaultValue) {
+  if (registeredProps_.count(propertyName) != 0) {
+    PRESTO_STARTUP_LOG(WARNING)
+        << "Property '" << propertyName
+        << "' is already registered with default value '"
+        << registeredProps_[propertyName].value_or("<none>") << "'.";
+    return false;
+  }
+
+  registeredProps_[propertyName] = defaultValue;
+  return true;
+}
+
 folly::Optional<std::string> ConfigBase::setValue(
     const std::string& propertyName,
     const std::string& value) {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -42,6 +42,14 @@ class ConfigBase {
     config_ = std::move(config);
   }
 
+  /// DO NOT DELETE THIS METHOD!
+  /// The method is used to register new properties after the config class is created.
+  /// Returns true if succeeded, false if failed (due to the property already
+  /// registered).
+  bool registerProperty(
+    const std::string& propertyName,
+    const folly::Optional<std::string>& defaultValue = {});
+
   /// Adds or replaces value at the given key. Can be used by debugging or
   /// testing code.
   /// Returns previous value if there was any.


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
registerProperty is used in fbcode, deleting it broke internal tests, thus adding it back.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

