### PR TITLE
[native] Use Velox GlobalConfig instead of GFlags

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(
   velox_dwio_parquet_writer
   velox_encode
   velox_exec
+  velox_flag_definitions
   velox_file
   velox_functions_lib
   velox_functions_prestosql

--- a/presto-native-execution/presto_cpp/main/PrestoMain.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoMain.cpp
@@ -18,6 +18,7 @@
 #include "presto_cpp/main/PrestoServer.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/common/base/StatsReporter.h"
+#include "velox/flag_definitions/flags.h"
 
 DEFINE_string(etc_dir, ".", "etc directory for presto configuration");
 
@@ -26,6 +27,7 @@ int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
 
   PRESTO_STARTUP_LOG(INFO) << "Entering main()";
+  facebook::velox::translateFlagsToGlobalConfig();
   facebook::presto::PrestoServer presto(FLAGS_etc_dir);
   presto.run();
   PRESTO_SHUTDOWN_LOG(INFO) << "Exiting main()";

--- a/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/AnnouncerTest.cpp
@@ -17,8 +17,7 @@
 #include <gtest/gtest.h>
 #include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
-
-DECLARE_bool(velox_memory_leak_check_enabled);
+#include "velox/common/config/GlobalConfig.h"
 
 namespace fs = boost::filesystem;
 using namespace facebook::presto;
@@ -100,7 +99,7 @@ std::unique_ptr<facebook::presto::test::HttpServerWrapper> makeDiscoveryServer(
 
 class AnnouncerTestSuite : public ::testing::TestWithParam<bool> {
   void SetUp() override {
-    FLAGS_velox_memory_leak_check_enabled = true;
+    facebook::velox::config::globalConfig().memoryLeakCheckEnabled = true;
 
     std::string keyPath = getCertsPath("client_ca.pem");
     std::string ciphers = "ECDHE-ECDSA-AES256-GCM-SHA384,AES256-GCM-SHA384";

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -23,13 +23,12 @@
 #include "presto_cpp/main/tests/HttpServerWrapper.h"
 #include "presto_cpp/main/tests/MultableConfigs.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/config/GlobalConfig.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/ExchangeQueue.h"
-
-DECLARE_bool(velox_memory_leak_check_enabled);
 
 namespace fs = boost::filesystem;
 using namespace facebook::presto;
@@ -1290,6 +1289,6 @@ INSTANTIATE_TEST_CASE_P(
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::Init init{&argc, &argv};
-  FLAGS_velox_memory_leak_check_enabled = true;
+  facebook::velox::config::globalConfig().memoryLeakCheckEnabled = true;
   return RUN_ALL_TESTS();
 }

--- a/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
@@ -14,9 +14,8 @@
 #include "presto_cpp/main/PrestoTask.h"
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/config/GlobalConfig.h"
 #include "velox/common/time/Timer.h"
-
-DECLARE_bool(velox_memory_leak_check_enabled);
 
 using namespace facebook::velox;
 using namespace facebook::presto;
@@ -25,7 +24,7 @@ using facebook::presto::PrestoTaskId;
 
 class PrestoTaskTest : public testing::Test {
   void SetUp() override {
-    FLAGS_velox_memory_leak_check_enabled = true;
+    facebook::velox::config::globalConfig().memoryLeakCheckEnabled = true;
   }
 };
 

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
@@ -11,10 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <gtest/gtest.h>
 #include "presto_cpp/main/QueryContextManager.h"
-
-DECLARE_bool(velox_memory_leak_check_enabled);
+#include "velox/common/config/GlobalConfig.h"
 
 namespace facebook::presto {
 
@@ -41,7 +41,7 @@ class QueryContextCacheTest : public testing::Test {
   }
 
   void SetUp() override {
-    FLAGS_velox_memory_leak_check_enabled = true;
+    facebook::velox::config::globalConfig().memoryLeakCheckEnabled = true;
   }
 };
 

--- a/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
@@ -15,12 +15,11 @@
 #include <gtest/gtest.h>
 #include "presto_cpp/main/PrestoServerOperations.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/config/GlobalConfig.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-
-DECLARE_bool(velox_memory_leak_check_enabled);
 
 using namespace facebook::velox;
 
@@ -28,7 +27,7 @@ namespace facebook::presto {
 
 class ServerOperationTest : public exec::test::OperatorTestBase {
   void SetUp() override {
-    FLAGS_velox_memory_leak_check_enabled = true;
+    facebook::velox::config::globalConfig().memoryLeakCheckEnabled = true;
     exec::test::OperatorTestBase::SetUp();
   }
 

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -45,9 +45,6 @@
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/Type.h"
 
-DECLARE_int32(old_task_ms);
-DECLARE_bool(velox_memory_leak_check_enabled);
-
 static const std::string kHiveConnectorId = "test-hive";
 
 using namespace facebook::velox;


### PR DESCRIPTION
## Description
Velox deprecated GFlags in favor of GlobalConfig. Forward fit this change.
Existing users can continue to use GFlags. They will be translated to GlobalConfig.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.


```
== NO RELEASE NOTE ==
```

