### PR TITLE
Upgrade sphinx to 8.2.1 and sphinx-immaterial to 0.13.0

### DIFF
--- a/presto-docs/requirements.txt
+++ b/presto-docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==7.2.6
-sphinx-immaterial==0.11.11
+sphinx==8.2.1
+sphinx-immaterial==0.13.0
 sphinx-copybutton==0.5.2

--- a/presto-docs/src/main/sphinx/_templates/partials/toc.html
+++ b/presto-docs/src/main/sphinx/_templates/partials/toc.html
@@ -1,9 +1,9 @@
 {#-
 This file was automatically generated - do not edit
 -#}
-{% set title = lang.t("toc.title") %}
+{% set title = lang.t("toc") %}
 {% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
-{% set title = config.mdx_configs.toc.title %}
+  {% set title = config.mdx_configs.toc.title %}
 {% endif %}
 <nav class="md-nav md-nav--secondary">
     <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>

--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -61,7 +61,7 @@ def get_version():
 # -- General configuration -----------------------------------------------------
 
 
-needs_sphinx = '7.2.6'
+needs_sphinx = '8.2.1'
 
 extensions = [
     'sphinx_immaterial', 'sphinx_copybutton', 'download', 'issue', 'pr', 'sphinx.ext.autosectionlabel'


### PR DESCRIPTION
## Description

Upgrade `sphinx` and `sphinx-immaterial` to the latest versions, which include bug fixes and new functionality.

Notes to consider:
- Python 3.11+ is required to build documentation
- The documentation pages look darker in dark mode

`Sphinx` change log:
- [Sphinx 8.2](https://www.sphinx-doc.org/en/master/changes/8.2.html)
- [Sphinx 8.1](https://www.sphinx-doc.org/en/master/changes/8.1.html)
- [Sphinx 8.0](https://www.sphinx-doc.org/en/master/changes/8.0.html)
- [Sphinx 7.4](https://www.sphinx-doc.org/en/master/changes/7.4.html)
- [Sphinx 7.3](https://www.sphinx-doc.org/en/master/changes/7.3.html)

## Motivation and Context

Keep dependencies up to date and allow to use new features, for instance [cve role](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-cve).

## Impact

None

## Test Plan

Build the documentation locally, ensure it looks the same, and verify that there are no issues.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

