### PR TITLE
Support HDFS and S3 path as warehouse directory for Hive file catalog

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -421,7 +421,7 @@ Run the Presto server:
 File-Based Metastore
 --------------------
 
-For testing or development purposes, Presto can be configured to use a local 
+For testing or development purposes, Presto can be configured to use a HDFS, S3, or local
 filesystem directory as a Hive Metastore. 
 
 The file-based metastore works only with the following connectors: 
@@ -444,8 +444,9 @@ Configuring a File-Based Metastore
     hive.metastore=file
     hive.metastore.catalog.dir=file:///<catalog-dir>
 
-Replace ``<catalog-dir>`` in the example with the path to a directory on an 
-accessible filesystem.
+Replace ``file:///<catalog-dir>`` in the example with the path to a directory on an
+accessible filesystem. For example, use ``hdfs://<host:port>/<catalog-dir>`` on HDFS
+or ``s3://<bucket>/<catalog-dir>`` on an Object Storage System.
 
 Using a File-Based Warehouse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeOnS3Hadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeOnS3Hadoop.java
@@ -69,7 +69,7 @@ public class TestIcebergSmokeOnS3Hadoop
     {
         super(HADOOP);
         bucketName = "forhadoop-" + randomTableSuffix();
-        catalogWarehouseDir = createTempDirectory(bucketName).toUri().toString();
+        catalogWarehouseDir = new Path(createTempDirectory(bucketName).toUri()).toString();
     }
 
     protected QueryRunner createQueryRunner()
@@ -453,7 +453,7 @@ public class TestIcebergSmokeOnS3Hadoop
     protected String getLocation(String schema, String table)
     {
         Path tempLocation = getCatalogDirectory();
-        return format("%s/%s/%s", tempLocation.toUri(), schema, table);
+        return format("%s/%s/%s", tempLocation.toString(), schema, table);
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
@@ -13,13 +13,6 @@
  */
 package com.facebook.presto.iceberg.hive;
 
-import com.facebook.presto.hive.HdfsConfiguration;
-import com.facebook.presto.hive.HdfsConfigurationInitializer;
-import com.facebook.presto.hive.HdfsEnvironment;
-import com.facebook.presto.hive.HiveClientConfig;
-import com.facebook.presto.hive.HiveHdfsConfiguration;
-import com.facebook.presto.hive.MetastoreClientConfig;
-import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergDistributedSmokeTestBase;
@@ -28,7 +21,6 @@ import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.Table;
 
 import java.io.File;
@@ -53,16 +45,6 @@ public class TestIcebergSmokeHive
         Path dataDirectory = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getDataDirectory();
         File tempLocation = getIcebergDataDirectoryPath(dataDirectory, HIVE.name(), new IcebergConfig().getFileFormat(), false).toFile();
         return format("%s%s/%s", tempLocation.toURI(), schema, table);
-    }
-
-    protected static HdfsEnvironment getHdfsEnvironment()
-    {
-        HiveClientConfig hiveClientConfig = new HiveClientConfig();
-        MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig),
-                ImmutableSet.of(),
-                hiveClientConfig);
-        return new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
     }
 
     protected ExtendedHiveMetastore getFileHiveMetastore()


### PR DESCRIPTION
## Description

Hive file metastore is a file-based metastore used for testing or development purpose whose document is introduced in PR #24511. This PR enable File-based hive metastore to use HDFS/S3 locations as warehouse dir, as described in issue #19112. 

An example configuration to use HDFS path includes:

```
    connector.name=iceberg
    iceberg.catalog.type=HIVE
    hive.metastore=file
    hive.metastore.catalog.dir=hdfs://hostaddr:9000/warehouse

```

Besides, by configuring the s3 properties described in https://prestodb.io/docs/current/connector/hive.html#amazon-s3-configuration, we can specify a S3 location as the warehouse dir of Hive file catalog. This way, both metadata and data
of iceberg tables will be maintained on S3 storage.

An example configuration to use S3 path includes:

```
    connector.name=iceberg
    iceberg.catalog.type=HIVE
    hive.metastore=file
    hive.metastore.catalog.dir=s3://iceberg_bucket/warehouse

    hive.s3.use-instance-credentials=false
    hive.s3.aws-access-key=accesskey
    hive.s3.aws-secret-key=secretkey
    hive.s3.endpoint=http://192.168.0.103:9878
    hive.s3.path-style-access=true
```


## Motivation and Context

Support specifying a HDFS/S3 location directly as warehouse dir for file-based hive metastore

## Impact

Lake houses configured with hive file metastore can now specify a HDFS/S3 location directly as the warehouse dir

## Test Plan

 - Manually test `IcebergDistributedTestBase`, `IcebergDistributedSmokeTestBase` and `TestIcebergDistributedQueries` on Iceberg connector configured with Hive file catalog on local deployed MINIO object storage
 - Manually test `IcebergDistributedTestBase`, `IcebergDistributedSmokeTestBase` and `TestIcebergDistributedQueries` on Iceberg connector configured with Hive file catalog on local deployed HDFS

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Enable file-based hive metastore to use HDFS/S3 location as warehouse dir.
```
