### PR TITLE
[native] Advance Velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
@@ -15,13 +15,12 @@
 #include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/common/base/Exceptions.h"
-#include "velox/common/config/GlobalConfig.h"
 
 using namespace facebook::velox;
 using namespace facebook::presto;
 
 TEST(VeloxToPrestoExceptionTranslatorTest, exceptionTranslation) {
-  config::globalConfig().exceptionUserStacktraceEnabled = true;
+  FLAGS_velox_exception_user_stacktrace_enabled = true;
   for (const bool withContext : {false, true}) {
     for (const bool withAdditionalContext : {false, true}) {
       SCOPED_TRACE(fmt::format("withContext: {}", withContext));


### PR DESCRIPTION
## Description
This change moves presto-native-execution to use latest Velox and fixes a breaking test.

## Motivation and Context
Uses latest velox. 

## Test Plan
Tested locally.


```
== NO RELEASE NOTE ==
```

