### PR TITLE
Clear warning for BaseSubfieldExtractionRewriter

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.predicate.NullableValue;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.expressions.DefaultRowExpressionTraversalVisitor;
 import com.facebook.presto.expressions.LogicalRowExpressions;
+import com.facebook.presto.hive.BaseHiveTableHandle;
 import com.facebook.presto.hive.BaseHiveTableLayoutHandle;
 import com.facebook.presto.hive.SubfieldExtractor;
 import com.facebook.presto.spi.ColumnHandle;
@@ -355,10 +356,8 @@ public abstract class BaseSubfieldExtractionRewriter
         session.getWarningCollector().add(new PrestoWarning(
                 HIVE_TABLESCAN_CONVERTED_TO_VALUESNODE,
                 format(
-                        "Table '%s' returns 0 rows, and is converted to an empty %s by %s",
-                        tableScan.getTable().getConnectorHandle(),
-                        ValuesNode.class.getSimpleName(),
-                        BaseSubfieldExtractionRewriter.class.getSimpleName())));
+                        "No rows from table '%s' matched the filter",
+                        ((BaseHiveTableHandle) (tableScan.getTable().getConnectorHandle())).getTableName())));
         return new ValuesNode(
                 tableScan.getSourceLocation(),
                 idAllocator.getNextId(),


### PR DESCRIPTION
## Description
Clear up the warning for BaseSubfieldExtractionRewriter

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
closes #23307 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
TestHivePushdownFilterQueries.java method testOptimizeWithWarningMessage tests this change out

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

