### PR TITLE
Put event loop behind a toggle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${dep.netty.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-testing-docker</artifactId>
                 <version>${project.version}</version>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -512,6 +512,16 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+        
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>

--- a/presto-main/src/main/java/com/facebook/presto/execution/SafeEventLoopGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SafeEventLoopGroup.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.log.Logger;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/***
+ *  One observation about event loop is if submitted task fails, it could kill the thread but the event loop group will not create a new one.
+ *  Here, we wrap it as safe event loop so that if any submitted job fails, we chose to log the error and fail the entire task.
+ */
+
+public class SafeEventLoopGroup
+        extends DefaultEventLoopGroup
+{
+    private static final Logger log = Logger.get(SafeEventLoopGroup.class);
+
+    public SafeEventLoopGroup(int nThreads, ThreadFactory threadFactory)
+    {
+        super(nThreads, threadFactory);
+    }
+
+    @Override
+    protected EventLoop newChild(Executor executor, Object... args)
+    {
+        return new SafeEventLoop(this, executor);
+    }
+
+    public static class SafeEventLoop
+            extends DefaultEventLoop
+    {
+        public SafeEventLoop(EventLoopGroup parent, Executor executor)
+        {
+            super(parent, executor);
+        }
+
+        @Override
+        protected void run()
+        {
+            do {
+                Runnable task = takeTask();
+                if (task != null) {
+                    try {
+                        runTask(task);
+                    }
+                    catch (Throwable t) {
+                        log.error("Error running task on event loop", t);
+                    }
+                    updateLastExecutionTime();
+                }
+            }
+            while (!this.confirmShutdown());
+        }
+
+        public void execute(Runnable task, Consumer<Throwable> failureHandler)
+        {
+            requireNonNull(task, "task is null");
+            this.execute(() -> {
+                try {
+                    task.run();
+                }
+                catch (Throwable t) {
+                    log.error("Error executing task on event loop", t);
+                    if (failureHandler != null) {
+                        failureHandler.accept(t);
+                    }
+                }
+            });
+        }
+
+        public <T> void execute(Supplier<T> task, Consumer<T> successHandler, Consumer<Throwable> failureHandler)
+        {
+            requireNonNull(task, "task is null");
+            this.execute(() -> {
+                try {
+                    T result = task.get();
+                    if (successHandler != null) {
+                        successHandler.accept(result);
+                    }
+                }
+                catch (Throwable t) {
+                    log.error("Error executing task on event loop", t);
+                    if (failureHandler != null) {
+                        failureHandler.accept(t);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -100,6 +100,19 @@ public class TaskManagerConfig
     private double highMemoryTaskKillerGCReclaimMemoryThreshold = 0.01;
     private Duration highMemoryTaskKillerFrequentFullGCDurationThreshold = new Duration(1, SECONDS);
     private double highMemoryTaskKillerHeapMemoryThreshold = 0.9;
+    private boolean enableEventLoop;
+
+    @Config("task.enable-event-loop")
+    public TaskManagerConfig setEventLoopEnabled(boolean enableEventLoop)
+    {
+        this.enableEventLoop = enableEventLoop;
+        return this;
+    }
+
+    public boolean isEventLoopEnabled()
+    {
+        return enableEventLoop;
+    }
 
     @MinDuration("1ms")
     @MaxDuration("10s")

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcherWithEventLoop.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcherWithEventLoop.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.airlift.http.client.thrift.ThriftRequestUtils;
+import com.facebook.airlift.http.client.thrift.ThriftResponseHandler;
+import com.facebook.airlift.json.Codec;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.smile.SmileCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.drift.transport.netty.codec.Protocol;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.server.RequestErrorTracker;
+import com.facebook.presto.server.SimpleHttpResponseCallback;
+import com.facebook.presto.server.SimpleHttpResponseHandler;
+import com.facebook.presto.server.smile.BaseResponse;
+import com.facebook.presto.server.thrift.ThriftHttpResponseHandler;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
+import io.netty.channel.EventLoop;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_CURRENT_STATE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_MAX_WAIT;
+import static com.facebook.presto.server.RequestErrorTracker.taskRequestErrorTracker;
+import static com.facebook.presto.server.RequestHelpers.getBinaryTransportBuilder;
+import static com.facebook.presto.server.RequestHelpers.getJsonTransportBuilder;
+import static com.facebook.presto.server.smile.AdaptingJsonResponseHandler.createAdaptingJsonResponseHandler;
+import static com.facebook.presto.server.smile.FullSmileResponseHandler.createFullSmileResponseHandler;
+import static com.facebook.presto.server.thrift.ThriftCodecWrapper.unwrapThriftCodec;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_MISMATCH;
+import static com.facebook.presto.util.Failures.REMOTE_TASK_MISMATCH_ERROR;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.units.Duration.nanosSince;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+class ContinuousTaskStatusFetcherWithEventLoop
+        implements SimpleHttpResponseCallback<TaskStatus>
+{
+    private static final Logger log = Logger.get(ContinuousTaskStatusFetcherWithEventLoop.class);
+
+    private final TaskId taskId;
+    private final Consumer<Throwable> onFail;
+    private final StateMachine<TaskStatus> taskStatus;
+    private final Codec<TaskStatus> taskStatusCodec;
+
+    private final Duration refreshMaxWait;
+    private final EventLoop taskEventLoop;
+    private final HttpClient httpClient;
+    private final RequestErrorTracker errorTracker;
+    private final RemoteTaskStats stats;
+    private final boolean binaryTransportEnabled;
+    private final boolean thriftTransportEnabled;
+    private final Protocol thriftProtocol;
+    private long currentRequestStartNanos;
+    private boolean running;
+
+    private ListenableFuture<BaseResponse<TaskStatus>> future;
+
+    public ContinuousTaskStatusFetcherWithEventLoop(
+            Consumer<Throwable> onFail,
+            TaskId taskId,
+            TaskStatus initialTaskStatus,
+            Duration refreshMaxWait,
+            Codec<TaskStatus> taskStatusCodec,
+            EventLoop taskEventLoop,
+            HttpClient httpClient,
+            Duration maxErrorDuration,
+            RemoteTaskStats stats,
+            boolean binaryTransportEnabled,
+            boolean thriftTransportEnabled,
+            Protocol thriftProtocol)
+    {
+        requireNonNull(initialTaskStatus, "initialTaskStatus is null");
+
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.onFail = requireNonNull(onFail, "onFail is null");
+        this.taskStatus = new StateMachine<>("task-" + taskId, taskEventLoop, initialTaskStatus);
+
+        this.refreshMaxWait = requireNonNull(refreshMaxWait, "refreshMaxWait is null");
+        this.taskStatusCodec = requireNonNull(taskStatusCodec, "taskStatusCodec is null");
+
+        this.taskEventLoop = requireNonNull(taskEventLoop, "taskEventLoop is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+
+        this.errorTracker = taskRequestErrorTracker(taskId, initialTaskStatus.getSelf(), maxErrorDuration, taskEventLoop, "getting task status");
+        this.stats = requireNonNull(stats, "stats is null");
+        this.binaryTransportEnabled = binaryTransportEnabled;
+        this.thriftTransportEnabled = thriftTransportEnabled;
+        this.thriftProtocol = requireNonNull(thriftProtocol, "thriftProtocol is null");
+    }
+
+    public void start()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        if (running) {
+            // already running
+            return;
+        }
+        running = true;
+        scheduleNextRequest();
+    }
+
+    public void stop()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        running = false;
+        if (future != null) {
+            // do not terminate if the request is already running to avoid closing pooled connections
+            future.cancel(false);
+            future = null;
+        }
+    }
+
+    private void scheduleNextRequest()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        // stopped or done?
+        TaskStatus taskStatus = getTaskStatus();
+        if (!running || taskStatus.getState().isDone()) {
+            return;
+        }
+
+        // outstanding request?
+        if (future != null && !future.isDone()) {
+            // this should never happen
+            log.error("Can not reschedule update because an update is already running");
+            return;
+        }
+
+        // if throttled due to error, asynchronously wait for timeout and try again
+        ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+        if (!errorRateLimit.isDone()) {
+            errorRateLimit.addListener(this::scheduleNextRequest, taskEventLoop);
+            return;
+        }
+
+        Request.Builder requestBuilder;
+        ResponseHandler responseHandler;
+        if (thriftTransportEnabled) {
+            requestBuilder = ThriftRequestUtils.prepareThriftGet(thriftProtocol);
+            responseHandler = new ThriftResponseHandler(unwrapThriftCodec(taskStatusCodec));
+        }
+        else if (binaryTransportEnabled) {
+            requestBuilder = getBinaryTransportBuilder(prepareGet());
+            responseHandler = createFullSmileResponseHandler((SmileCodec<TaskStatus>) taskStatusCodec);
+        }
+        else {
+            requestBuilder = getJsonTransportBuilder(prepareGet());
+            responseHandler = createAdaptingJsonResponseHandler((JsonCodec<TaskStatus>) taskStatusCodec);
+        }
+
+        Request request = requestBuilder.setUri(uriBuilderFrom(taskStatus.getSelf()).appendPath("status").build())
+                .setHeader(PRESTO_CURRENT_STATE, taskStatus.getState().toString())
+                .setHeader(PRESTO_MAX_WAIT, refreshMaxWait.toString())
+                .build();
+
+        errorTracker.startRequest();
+        future = httpClient.executeAsync(request, responseHandler);
+        currentRequestStartNanos = System.nanoTime();
+        FutureCallback callback;
+        if (thriftTransportEnabled) {
+            callback = new ThriftHttpResponseHandler(this, request.getUri(), stats.getHttpResponseStats(), REMOTE_TASK_ERROR);
+        }
+        else {
+            callback = new SimpleHttpResponseHandler<>(this, request.getUri(), stats.getHttpResponseStats(), REMOTE_TASK_ERROR);
+        }
+
+        Futures.addCallback(
+                future,
+                callback,
+                taskEventLoop);
+    }
+
+    TaskStatus getTaskStatus()
+    {
+        return taskStatus.get();
+    }
+
+    @Override
+    public void success(TaskStatus value)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        updateStats(currentRequestStartNanos);
+        try {
+            updateTaskStatus(value);
+            errorTracker.requestSucceeded();
+        }
+        finally {
+            scheduleNextRequest();
+        }
+    }
+
+    @Override
+    public void failed(Throwable cause)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        updateStats(currentRequestStartNanos);
+        try {
+            // if task not already done, record error
+            TaskStatus taskStatus = getTaskStatus();
+            if (!taskStatus.getState().isDone()) {
+                errorTracker.requestFailed(cause);
+            }
+        }
+        catch (Error e) {
+            onFail.accept(e);
+            throw e;
+        }
+        catch (RuntimeException e) {
+            onFail.accept(e);
+        }
+        finally {
+            scheduleNextRequest();
+        }
+    }
+
+    @Override
+    public void fatal(Throwable cause)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        updateStats(currentRequestStartNanos);
+        onFail.accept(cause);
+    }
+
+    void updateTaskStatus(TaskStatus newValue)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        // change to new value if old value is not changed and new value has a newer version
+        AtomicBoolean taskMismatch = new AtomicBoolean();
+        taskStatus.setIf(newValue, oldValue -> {
+            // did the task instance id change
+            boolean isEmpty = (oldValue.getTaskInstanceIdLeastSignificantBits() == 0 && oldValue.getTaskInstanceIdMostSignificantBits() == 0)
+                    || (newValue.getTaskInstanceIdLeastSignificantBits() == 0 && newValue.getTaskInstanceIdMostSignificantBits() == 0);
+            if (!isEmpty &&
+                    !(oldValue.getTaskInstanceIdLeastSignificantBits() == newValue.getTaskInstanceIdLeastSignificantBits() &&
+                            oldValue.getTaskInstanceIdMostSignificantBits() == newValue.getTaskInstanceIdMostSignificantBits())) {
+                taskMismatch.set(true);
+                return false;
+            }
+
+            if (oldValue.getState().isDone()) {
+                // never update if the task has reached a terminal state
+                return false;
+            }
+            if (newValue.getVersion() < oldValue.getVersion()) {
+                // don't update to an older version (same version is ok)
+                return false;
+            }
+            return true;
+        });
+
+        if (taskMismatch.get()) {
+            // This will also set the task status to FAILED state directly.
+            // Additionally, this will issue a DELETE for the task to the worker.
+            // While sending the DELETE is not required, it is preferred because a task was created by the previous request.
+            onFail.accept(new PrestoException(REMOTE_TASK_MISMATCH, format("%s (%s)", REMOTE_TASK_MISMATCH_ERROR, HostAddress.fromUri(getTaskStatus().getSelf()))));
+        }
+    }
+
+    /**
+     * Listener is always notified asynchronously using a dedicated notification thread pool so, care should
+     * be taken to avoid leaking {@code this} when adding a listener in a constructor. Additionally, it is
+     * possible notifications are observed out of order due to the asynchronous execution.
+     */
+    public void addStateChangeListener(StateMachine.StateChangeListener<TaskStatus> stateChangeListener)
+    {
+        taskStatus.addStateChangeListener(stateChangeListener);
+    }
+
+    private void updateStats(long currentRequestStartNanos)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        stats.statusRoundTripMillis(nanosSince(currentRequestStartNanos).toMillis());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -31,6 +31,7 @@ import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.RemoteTaskFactory;
+import com.facebook.presto.execution.SafeEventLoopGroup;
 import com.facebook.presto.execution.SchedulerStatsTracker;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
@@ -49,19 +50,24 @@ import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.airlift.units.Duration;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.AbstractEventExecutorGroup;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.server.remotetask.HttpRemoteTaskWithEventLoop.createHttpRemoteTaskWithEventLoop;
 import static com.facebook.presto.server.thrift.ThriftCodecWrapper.wrapThriftCodec;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -102,6 +108,7 @@ public class HttpRemoteTaskFactory
     private final QueryManager queryManager;
     private final DecayCounter taskUpdateRequestSize;
     private final boolean taskUpdateSizeTrackingEnabled;
+    private final Optional<SafeEventLoopGroup> eventLoopGroup;
 
     @Inject
     public HttpRemoteTaskFactory(
@@ -186,6 +193,16 @@ public class HttpRemoteTaskFactory
         this.errorScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("remote-task-error-delay-%s"));
         this.taskUpdateRequestSize = new DecayCounter(ExponentialDecay.oneMinute());
         this.taskUpdateSizeTrackingEnabled = taskConfig.isTaskUpdateSizeTrackingEnabled();
+
+        this.eventLoopGroup = taskConfig.isEventLoopEnabled() ? Optional.of(new SafeEventLoopGroup(config.getRemoteTaskMaxCallbackThreads(),
+                new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build())
+        {
+            @Override
+            protected EventLoop newChild(Executor executor, Object... args)
+            {
+                return new SafeEventLoop(this, executor);
+            }
+        }) : Optional.empty();
     }
 
     @Managed
@@ -207,6 +224,8 @@ public class HttpRemoteTaskFactory
         coreExecutor.shutdownNow();
         updateScheduledExecutor.shutdownNow();
         errorScheduledExecutor.shutdownNow();
+
+        eventLoopGroup.map(AbstractEventExecutorGroup::shutdownGracefully);
     }
 
     @Override
@@ -222,6 +241,47 @@ public class HttpRemoteTaskFactory
             TableWriteInfo tableWriteInfo,
             SchedulerStatsTracker schedulerStatsTracker)
     {
+        if (eventLoopGroup.isPresent()) {
+            // Use event loop based HttpRemoteTask
+            return createHttpRemoteTaskWithEventLoop(
+                    session,
+                    taskId,
+                    node.getNodeIdentifier(),
+                    locationFactory.createLegacyTaskLocation(node, taskId),
+                    locationFactory.createTaskLocation(node, taskId),
+                    fragment,
+                    initialSplits,
+                    outputBuffers,
+                    httpClient,
+                    maxErrorDuration,
+                    taskStatusRefreshMaxWait,
+                    taskInfoRefreshMaxWait,
+                    taskInfoUpdateInterval,
+                    summarizeTaskInfo,
+                    taskStatusCodec,
+                    taskInfoCodec,
+                    taskInfoJsonCodec,
+                    taskUpdateRequestCodec,
+                    planFragmentCodec,
+                    metadataUpdatesCodec,
+                    nodeStatsTracker,
+                    stats,
+                    binaryTransportEnabled,
+                    thriftTransportEnabled,
+                    taskInfoThriftTransportEnabled,
+                    thriftProtocol,
+                    tableWriteInfo,
+                    maxTaskUpdateSizeInBytes,
+                    metadataManager,
+                    queryManager,
+                    taskUpdateRequestSize,
+                    taskUpdateSizeTrackingEnabled,
+                    handleResolver,
+                    connectorTypeSerdeManager,
+                    schedulerStatsTracker,
+                    (SafeEventLoopGroup.SafeEventLoop) eventLoopGroup.get().next());
+        }
+        // Use default executor based HttpRemoteTask
         return new HttpRemoteTask(
                 session,
                 taskId,

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskWithEventLoop.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskWithEventLoop.java
@@ -1,0 +1,1413 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpUriBuilder;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.airlift.http.client.StatusResponseHandler.StatusResponse;
+import com.facebook.airlift.http.client.thrift.ThriftRequestUtils;
+import com.facebook.airlift.http.client.thrift.ThriftResponse;
+import com.facebook.airlift.http.client.thrift.ThriftResponseHandler;
+import com.facebook.airlift.json.Codec;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.smile.SmileCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.stats.DecayCounter;
+import com.facebook.drift.transport.netty.codec.Protocol;
+import com.facebook.presto.Session;
+import com.facebook.presto.connector.ConnectorTypeSerdeManager;
+import com.facebook.presto.execution.FutureStateChange;
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
+import com.facebook.presto.execution.PartitionedSplitsInfo;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.RemoteTask;
+import com.facebook.presto.execution.SafeEventLoopGroup;
+import com.facebook.presto.execution.ScheduledSplit;
+import com.facebook.presto.execution.SchedulerStatsTracker;
+import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.execution.TaskSource;
+import com.facebook.presto.execution.TaskState;
+import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.execution.buffer.BufferInfo;
+import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.buffer.PageBufferInfo;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.MetadataUpdates;
+import com.facebook.presto.metadata.Split;
+import com.facebook.presto.operator.TaskStats;
+import com.facebook.presto.server.RequestErrorTracker;
+import com.facebook.presto.server.SimpleHttpResponseCallback;
+import com.facebook.presto.server.SimpleHttpResponseHandler;
+import com.facebook.presto.server.TaskUpdateRequest;
+import com.facebook.presto.server.smile.BaseResponse;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SplitWeight;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.google.common.base.Ticker;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.ObjectArrays;
+import com.google.common.collect.SetMultimap;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.sun.management.ThreadMXBean;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+
+import java.lang.management.ManagementFactory;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static com.facebook.airlift.http.client.HttpStatus.NO_CONTENT;
+import static com.facebook.airlift.http.client.HttpStatus.OK;
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.Request.Builder.prepareDelete;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static com.facebook.presto.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
+import static com.facebook.presto.execution.TaskInfo.createInitialTask;
+import static com.facebook.presto.execution.TaskState.ABORTED;
+import static com.facebook.presto.execution.TaskState.FAILED;
+import static com.facebook.presto.execution.TaskStatus.failWith;
+import static com.facebook.presto.server.RequestErrorTracker.isExpectedError;
+import static com.facebook.presto.server.RequestErrorTracker.taskRequestErrorTracker;
+import static com.facebook.presto.server.RequestHelpers.setContentTypeHeaders;
+import static com.facebook.presto.server.TaskResourceUtils.convertFromThriftTaskInfo;
+import static com.facebook.presto.server.smile.AdaptingJsonResponseHandler.createAdaptingJsonResponseHandler;
+import static com.facebook.presto.server.smile.FullSmileResponseHandler.createFullSmileResponseHandler;
+import static com.facebook.presto.server.thrift.ThriftCodecWrapper.unwrapThriftCodec;
+import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TASK_UPDATE_SIZE_LIMIT;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static com.facebook.presto.util.Failures.toFailure;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.util.concurrent.Futures.addCallback;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.lang.Math.addExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Represents a task running on a remote worker.
+ * <p>
+ * This class now uses an event loop concurrency model to eliminate the need for explicit synchronization:
+ * <ul>
+ * <li>All mutable state access and modifications are performed on a single dedicated event loop thread</li>
+ * <li>External threads submit operations to the event loop using {@code safeExecuteOnEventLoop()}</li>
+ * <li>The event loop serializes all operations, eliminating race conditions without using locks</li>
+ * </ul>
+ * <p>
+ * Key benefits of this approach:
+ * <ul>
+ * <li>Improved performance by creating fewer event processing threads to support running more tasks</li>
+ * <li>Simplified reasoning about concurrent operations since they are serialized</li>
+ * </ul>
+ */
+public final class HttpRemoteTaskWithEventLoop
+        implements RemoteTask
+{
+    private static final Logger log = Logger.get(HttpRemoteTaskWithEventLoop.class);
+    private static final double UPDATE_WITHOUT_PLAN_STATS_SAMPLE_RATE = 0.01;
+    private static final ThreadMXBean THREAD_MX_BEAN = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    private final TaskId taskId;
+    private final URI taskLocation;
+    private final URI remoteTaskLocation;
+
+    private final Session session;
+    private final String nodeId;
+    private final PlanFragment planFragment;
+
+    private final Set<PlanNodeId> tableScanPlanNodeIds;
+    private final Set<PlanNodeId> remoteSourcePlanNodeIds;
+
+    private long nextSplitId;
+
+    private final Duration maxErrorDuration;
+    private final RemoteTaskStats stats;
+    private final TaskInfoFetcherWithEventLoop taskInfoFetcher;
+    private final ContinuousTaskStatusFetcherWithEventLoop taskStatusFetcher;
+
+    private final LongArrayList taskUpdateTimeline = new LongArrayList();
+    private Future<?> currentRequest;
+    private long currentRequestStartNanos;
+    private long currentRequestLastTaskUpdate;
+
+    private final SetMultimap<PlanNodeId, ScheduledSplit> pendingSplits = HashMultimap.create();
+    private volatile int pendingSourceSplitCount;
+    private volatile long pendingSourceSplitsWeight;
+    private final SetMultimap<PlanNodeId, Lifespan> pendingNoMoreSplitsForLifespan = HashMultimap.create();
+    // The keys of this map represent all plan nodes that have "no more splits".
+    // The boolean value of each entry represents whether the "no more splits" notification is pending delivery to workers.
+    private final Map<PlanNodeId, Boolean> noMoreSplits = new HashMap<>();
+    private OutputBuffers outputBuffers;
+    private final FutureStateChange<?> whenSplitQueueHasSpace = new FutureStateChange<>();
+    private volatile boolean splitQueueHasSpace;
+    private OptionalLong whenSplitQueueHasSpaceThreshold = OptionalLong.empty();
+
+    private final boolean summarizeTaskInfo;
+
+    private final HttpClient httpClient;
+
+    private final Codec<TaskInfo> taskInfoCodec;
+    //Json codec required for TaskUpdateRequest endpoint which uses JSON and returns a TaskInfo
+    private final Codec<TaskInfo> taskInfoJsonCodec;
+    private final Codec<TaskUpdateRequest> taskUpdateRequestCodec;
+    private final Codec<PlanFragment> planFragmentCodec;
+
+    private final RequestErrorTracker updateErrorTracker;
+
+    private boolean needsUpdate = true;
+    private boolean sendPlan = true;
+
+    private final NodeStatsTracker nodeStatsTracker;
+
+    private boolean started;
+    private boolean aborting;
+
+    private final boolean binaryTransportEnabled;
+    private final boolean thriftTransportEnabled;
+    private final boolean taskInfoThriftTransportEnabled;
+    private final Protocol thriftProtocol;
+    private final ConnectorTypeSerdeManager connectorTypeSerdeManager;
+    private final HandleResolver handleResolver;
+    private final int maxTaskUpdateSizeInBytes;
+    private final int maxUnacknowledgedSplits;
+    private final DataSize maxTaskUpdateDataSize;
+
+    private final TableWriteInfo tableWriteInfo;
+
+    private final DecayCounter taskUpdateRequestSize;
+    private final boolean taskUpdateSizeTrackingEnabled;
+    private final SchedulerStatsTracker schedulerStatsTracker;
+
+    private final SafeEventLoopGroup.SafeEventLoop taskEventLoop;
+
+    public static HttpRemoteTaskWithEventLoop createHttpRemoteTaskWithEventLoop(
+            Session session,
+            TaskId taskId,
+            String nodeId,
+            URI location,
+            URI remoteLocation,
+            PlanFragment planFragment,
+            Multimap<PlanNodeId, Split> initialSplits,
+            OutputBuffers outputBuffers,
+            HttpClient httpClient,
+            Duration maxErrorDuration,
+            Duration taskStatusRefreshMaxWait,
+            Duration taskInfoRefreshMaxWait,
+            Duration taskInfoUpdateInterval,
+            boolean summarizeTaskInfo,
+            Codec<TaskStatus> taskStatusCodec,
+            Codec<TaskInfo> taskInfoCodec,
+            Codec<TaskInfo> taskInfoJsonCodec,
+            Codec<TaskUpdateRequest> taskUpdateRequestCodec,
+            Codec<PlanFragment> planFragmentCodec,
+            Codec<MetadataUpdates> metadataUpdatesCodec,
+            NodeStatsTracker nodeStatsTracker,
+            RemoteTaskStats stats,
+            boolean binaryTransportEnabled,
+            boolean thriftTransportEnabled,
+            boolean taskInfoThriftTransportEnabled,
+            Protocol thriftProtocol,
+            TableWriteInfo tableWriteInfo,
+            int maxTaskUpdateSizeInBytes,
+            MetadataManager metadataManager,
+            QueryManager queryManager,
+            DecayCounter taskUpdateRequestSize,
+            boolean taskUpdateSizeTrackingEnabled,
+            HandleResolver handleResolver,
+            ConnectorTypeSerdeManager connectorTypeSerdeManager,
+            SchedulerStatsTracker schedulerStatsTracker,
+            SafeEventLoopGroup.SafeEventLoop taskEventLoop)
+    {
+        HttpRemoteTaskWithEventLoop task = new HttpRemoteTaskWithEventLoop(session,
+                taskId,
+                nodeId,
+                location,
+                remoteLocation,
+                planFragment,
+                initialSplits,
+                outputBuffers,
+                httpClient,
+                maxErrorDuration,
+                taskStatusRefreshMaxWait,
+                taskInfoRefreshMaxWait,
+                taskInfoUpdateInterval,
+                summarizeTaskInfo,
+                taskStatusCodec,
+                taskInfoCodec,
+                taskInfoJsonCodec,
+                taskUpdateRequestCodec,
+                planFragmentCodec,
+                metadataUpdatesCodec,
+                nodeStatsTracker,
+                stats,
+                binaryTransportEnabled,
+                thriftTransportEnabled,
+                taskInfoThriftTransportEnabled,
+                thriftProtocol,
+                tableWriteInfo,
+                maxTaskUpdateSizeInBytes,
+                metadataManager,
+                queryManager,
+                taskUpdateRequestSize,
+                taskUpdateSizeTrackingEnabled,
+                handleResolver,
+                connectorTypeSerdeManager,
+                schedulerStatsTracker,
+                taskEventLoop);
+        task.initialize();
+        return task;
+    }
+
+    private HttpRemoteTaskWithEventLoop(Session session,
+            TaskId taskId,
+            String nodeId,
+            URI location,
+            URI remoteLocation,
+            PlanFragment planFragment,
+            Multimap<PlanNodeId, Split> initialSplits,
+            OutputBuffers outputBuffers,
+            HttpClient httpClient,
+            Duration maxErrorDuration,
+            Duration taskStatusRefreshMaxWait,
+            Duration taskInfoRefreshMaxWait,
+            Duration taskInfoUpdateInterval,
+            boolean summarizeTaskInfo,
+            Codec<TaskStatus> taskStatusCodec,
+            Codec<TaskInfo> taskInfoCodec,
+            Codec<TaskInfo> taskInfoJsonCodec,
+            Codec<TaskUpdateRequest> taskUpdateRequestCodec,
+            Codec<PlanFragment> planFragmentCodec,
+            Codec<MetadataUpdates> metadataUpdatesCodec,
+            NodeStatsTracker nodeStatsTracker,
+            RemoteTaskStats stats,
+            boolean binaryTransportEnabled,
+            boolean thriftTransportEnabled,
+            boolean taskInfoThriftTransportEnabled,
+            Protocol thriftProtocol,
+            TableWriteInfo tableWriteInfo,
+            int maxTaskUpdateSizeInBytes,
+            MetadataManager metadataManager,
+            QueryManager queryManager,
+            DecayCounter taskUpdateRequestSize,
+            boolean taskUpdateSizeTrackingEnabled,
+            HandleResolver handleResolver,
+            ConnectorTypeSerdeManager connectorTypeSerdeManager,
+            SchedulerStatsTracker schedulerStatsTracker,
+            SafeEventLoopGroup.SafeEventLoop taskEventLoop)
+    {
+        requireNonNull(session, "session is null");
+        requireNonNull(taskId, "taskId is null");
+        requireNonNull(nodeId, "nodeId is null");
+        requireNonNull(location, "location is null");
+        requireNonNull(remoteLocation, "remoteLocation is null");
+        requireNonNull(planFragment, "planFragment is null");
+        requireNonNull(outputBuffers, "outputBuffers is null");
+        requireNonNull(httpClient, "httpClient is null");
+        requireNonNull(taskStatusCodec, "taskStatusCodec is null");
+        requireNonNull(taskInfoCodec, "taskInfoCodec is null");
+        requireNonNull(taskUpdateRequestCodec, "taskUpdateRequestCodec is null");
+        requireNonNull(planFragmentCodec, "planFragmentCodec is null");
+        requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
+        requireNonNull(maxErrorDuration, "maxErrorDuration is null");
+        requireNonNull(stats, "stats is null");
+        requireNonNull(taskInfoRefreshMaxWait, "taskInfoRefreshMaxWait is null");
+        requireNonNull(tableWriteInfo, "tableWriteInfo is null");
+        requireNonNull(metadataManager, "metadataManager is null");
+        requireNonNull(queryManager, "queryManager is null");
+        requireNonNull(thriftProtocol, "thriftProtocol is null");
+        requireNonNull(handleResolver, "handleResolver is null");
+        requireNonNull(connectorTypeSerdeManager, "connectorTypeSerdeManager is null");
+        requireNonNull(taskUpdateRequestSize, "taskUpdateRequestSize cannot be null");
+        requireNonNull(schedulerStatsTracker, "schedulerStatsTracker is null");
+        requireNonNull(taskEventLoop, "taskEventLoop is null");
+
+        this.taskEventLoop = taskEventLoop;
+        this.taskId = taskId;
+        this.taskLocation = location;
+        this.remoteTaskLocation = remoteLocation;
+        this.session = session;
+        this.nodeId = nodeId;
+        this.planFragment = planFragment;
+        this.outputBuffers = outputBuffers;
+        this.httpClient = httpClient;
+        this.summarizeTaskInfo = summarizeTaskInfo;
+        this.taskInfoCodec = taskInfoCodec;
+        this.taskInfoJsonCodec = taskInfoJsonCodec;
+        this.taskUpdateRequestCodec = taskUpdateRequestCodec;
+        this.planFragmentCodec = planFragmentCodec;
+        this.updateErrorTracker = taskRequestErrorTracker(taskId, location, maxErrorDuration, taskEventLoop, "updating task");
+        this.nodeStatsTracker = requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
+        this.maxErrorDuration = maxErrorDuration;
+        this.stats = stats;
+        this.binaryTransportEnabled = binaryTransportEnabled;
+        this.thriftTransportEnabled = thriftTransportEnabled;
+        this.taskInfoThriftTransportEnabled = taskInfoThriftTransportEnabled;
+        this.thriftProtocol = thriftProtocol;
+        this.connectorTypeSerdeManager = connectorTypeSerdeManager;
+        this.handleResolver = handleResolver;
+        this.tableWriteInfo = tableWriteInfo;
+        this.maxTaskUpdateSizeInBytes = maxTaskUpdateSizeInBytes;
+        this.maxTaskUpdateDataSize = DataSize.succinctBytes(this.maxTaskUpdateSizeInBytes);
+        this.maxUnacknowledgedSplits = getMaxUnacknowledgedSplitsPerTask(session);
+        checkArgument(maxUnacknowledgedSplits > 0, "maxUnacknowledgedSplits must be > 0, found: %s", maxUnacknowledgedSplits);
+
+        this.tableScanPlanNodeIds = ImmutableSet.copyOf(planFragment.getTableScanSchedulingOrder());
+        this.remoteSourcePlanNodeIds = planFragment.getRemoteSourceNodes().stream()
+                .map(PlanNode::getId)
+                .collect(toImmutableSet());
+        this.taskUpdateRequestSize = taskUpdateRequestSize;
+        this.taskUpdateSizeTrackingEnabled = taskUpdateSizeTrackingEnabled;
+        this.schedulerStatsTracker = schedulerStatsTracker;
+
+        for (Entry<PlanNodeId, Split> entry : requireNonNull(initialSplits, "initialSplits is null").entries()) {
+            ScheduledSplit scheduledSplit = new ScheduledSplit(nextSplitId++, entry.getKey(), entry.getValue());
+            pendingSplits.put(entry.getKey(), scheduledSplit);
+        }
+        int pendingSourceSplitCount = 0;
+        long pendingSourceSplitsWeight = 0;
+        for (PlanNodeId planNodeId : planFragment.getTableScanSchedulingOrder()) {
+            Collection<Split> tableScanSplits = initialSplits.get(planNodeId);
+            if (tableScanSplits != null && !tableScanSplits.isEmpty()) {
+                pendingSourceSplitCount += tableScanSplits.size();
+                pendingSourceSplitsWeight = addExact(pendingSourceSplitsWeight, SplitWeight.rawValueSum(tableScanSplits, Split::getSplitWeight));
+            }
+        }
+        this.pendingSourceSplitCount = pendingSourceSplitCount;
+        this.pendingSourceSplitsWeight = pendingSourceSplitsWeight;
+
+        List<BufferInfo> bufferStates = outputBuffers.getBuffers()
+                .keySet().stream()
+                .map(outputId -> new BufferInfo(outputId, false, 0, 0, PageBufferInfo.empty()))
+                .collect(toImmutableList());
+
+        TaskInfo initialTask = createInitialTask(taskId, location, bufferStates, new TaskStats(DateTime.now(), null), nodeId);
+
+        this.taskStatusFetcher = new ContinuousTaskStatusFetcherWithEventLoop(
+                this::failTask,
+                taskId,
+                initialTask.getTaskStatus(),
+                taskStatusRefreshMaxWait,
+                taskStatusCodec,
+                taskEventLoop,
+                httpClient,
+                maxErrorDuration,
+                stats,
+                binaryTransportEnabled,
+                thriftTransportEnabled,
+                thriftProtocol);
+
+        this.taskInfoFetcher = new TaskInfoFetcherWithEventLoop(
+                this::failTask,
+                initialTask,
+                httpClient,
+                taskInfoUpdateInterval,
+                taskInfoRefreshMaxWait,
+                taskInfoCodec,
+                metadataUpdatesCodec,
+                maxErrorDuration,
+                summarizeTaskInfo,
+                taskEventLoop,
+                stats,
+                binaryTransportEnabled,
+                taskInfoThriftTransportEnabled,
+                session,
+                metadataManager,
+                queryManager,
+                handleResolver,
+                connectorTypeSerdeManager,
+                thriftProtocol);
+    }
+
+    // this is a separate method to ensure that the `this` reference is not leaked during construction
+    private void initialize()
+    {
+        taskStatusFetcher.addStateChangeListener(newStatus -> {
+            verify(taskEventLoop.inEventLoop());
+
+            TaskState state = newStatus.getState();
+            if (state.isDone()) {
+                cleanUpTask();
+            }
+            else {
+                updateTaskStats();
+                updateSplitQueueSpace();
+            }
+        });
+
+        updateTaskStats();
+        safeExecuteOnEventLoop(this::updateSplitQueueSpace);
+    }
+
+    public PlanFragment getPlanFragment()
+    {
+        return planFragment;
+    }
+
+    @Override
+    public TaskId getTaskId()
+    {
+        return taskId;
+    }
+
+    @Override
+    public String getNodeId()
+    {
+        return nodeId;
+    }
+
+    @Override
+    public TaskInfo getTaskInfo()
+    {
+        return taskInfoFetcher.getTaskInfo();
+    }
+
+    @Override
+    public TaskStatus getTaskStatus()
+    {
+        return taskStatusFetcher.getTaskStatus();
+    }
+
+    @Override
+    public URI getRemoteTaskLocation()
+    {
+        return remoteTaskLocation;
+    }
+
+    @Override
+    public void start()
+    {
+        safeExecuteOnEventLoop(() -> {
+            // to start we just need to trigger an update
+            started = true;
+            scheduleUpdate();
+
+            taskStatusFetcher.start();
+            taskInfoFetcher.start();
+        });
+    }
+
+    @Override
+    public void addSplits(Multimap<PlanNodeId, Split> splitsBySource)
+    {
+        requireNonNull(splitsBySource, "splitsBySource is null");
+
+        // only add pending split if not done
+        if (getTaskStatus().getState().isDone()) {
+            return;
+        }
+
+        safeExecuteOnEventLoop(() -> {
+            boolean updateNeeded = false;
+            for (Entry<PlanNodeId, Collection<Split>> entry : splitsBySource.asMap().entrySet()) {
+                PlanNodeId sourceId = entry.getKey();
+                Collection<Split> splits = entry.getValue();
+                boolean isTableScanSource = tableScanPlanNodeIds.contains(sourceId);
+
+                checkState(!noMoreSplits.containsKey(sourceId), "noMoreSplits has already been set for %s", sourceId);
+                int added = 0;
+                long addedWeight = 0;
+                for (Split split : splits) {
+                    if (pendingSplits.put(sourceId, new ScheduledSplit(nextSplitId++, sourceId, split))) {
+                        if (isTableScanSource) {
+                            added++;
+                            addedWeight = addExact(addedWeight, split.getSplitWeight().getRawValue());
+                        }
+                    }
+                }
+                if (isTableScanSource) {
+                    pendingSourceSplitCount += added;
+                    pendingSourceSplitsWeight = addExact(pendingSourceSplitsWeight, addedWeight);
+                    updateTaskStats();
+                }
+                updateNeeded = true;
+            }
+            updateSplitQueueSpace();
+
+            if (updateNeeded) {
+                needsUpdate = true;
+                scheduleUpdate();
+            }
+        });
+    }
+
+    @Override
+    public void noMoreSplits(PlanNodeId sourceId)
+    {
+        safeExecuteOnEventLoop(() -> {
+            if (noMoreSplits.containsKey(sourceId)) {
+                return;
+            }
+
+            noMoreSplits.put(sourceId, true);
+            needsUpdate = true;
+            scheduleUpdate();
+        });
+    }
+
+    @Override
+    public void noMoreSplits(PlanNodeId sourceId, Lifespan lifespan)
+    {
+        safeExecuteOnEventLoop(() -> {
+            if (pendingNoMoreSplitsForLifespan.put(sourceId, lifespan)) {
+                needsUpdate = true;
+                scheduleUpdate();
+            }
+        });
+    }
+
+    @Override
+    public void setOutputBuffers(OutputBuffers newOutputBuffers)
+    {
+        if (getTaskStatus().getState().isDone()) {
+            return;
+        }
+
+        safeExecuteOnEventLoop(() -> {
+            if (newOutputBuffers.getVersion() > outputBuffers.getVersion()) {
+                outputBuffers = newOutputBuffers;
+                needsUpdate = true;
+                scheduleUpdate();
+            }
+        });
+    }
+
+    @Override
+    public ListenableFuture<?> removeRemoteSource(TaskId remoteSourceTaskId)
+    {
+        URI remoteSourceUri = uriBuilderFrom(taskLocation)
+                .appendPath("remote-source")
+                .appendPath(remoteSourceTaskId.toString())
+                .build();
+
+        Request request = prepareDelete()
+                .setUri(remoteSourceUri)
+                .build();
+        RequestErrorTracker errorTracker = taskRequestErrorTracker(
+                taskId,
+                remoteSourceUri,
+                maxErrorDuration,
+                taskEventLoop,
+                "Remove exchange remote source");
+
+        SettableFuture<?> future = SettableFuture.create();
+        doRemoveRemoteSource(errorTracker, request, future);
+        return future;
+    }
+
+    /// This method may call itself recursively when retrying for failures
+    private void doRemoveRemoteSource(RequestErrorTracker errorTracker, Request request, SettableFuture<?> future)
+    {
+        errorTracker.startRequest();
+
+        FutureCallback<StatusResponse> callback = new FutureCallback<StatusResponse>()
+        {
+            @Override
+            public void onSuccess(@Nullable StatusResponse response)
+            {
+                verify(taskEventLoop.inEventLoop());
+
+                if (response == null) {
+                    throw new PrestoException(GENERIC_INTERNAL_ERROR, "Request failed with null response");
+                }
+                if (response.getStatusCode() != OK.code() && response.getStatusCode() != NO_CONTENT.code()) {
+                    throw new PrestoException(GENERIC_INTERNAL_ERROR, "Request failed with HTTP status " + response.getStatusCode());
+                }
+                future.set(null);
+            }
+
+            @Override
+            public void onFailure(Throwable failedReason)
+            {
+                verify(taskEventLoop.inEventLoop());
+
+                if (failedReason instanceof RejectedExecutionException && httpClient.isClosed()) {
+                    log.error("Unable to destroy exchange source at %s. HTTP client is closed", request.getUri());
+                    future.setException(failedReason);
+                    return;
+                }
+                // record failure
+                try {
+                    errorTracker.requestFailed(failedReason);
+                }
+                catch (PrestoException e) {
+                    future.setException(e);
+                    return;
+                }
+                // if throttled due to error, asynchronously wait for timeout and try again
+                ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+                if (errorRateLimit.isDone()) {
+                    doRemoveRemoteSource(errorTracker, request, future);
+                }
+                else {
+                    errorRateLimit.addListener(() -> doRemoveRemoteSource(errorTracker, request, future), taskEventLoop);
+                }
+            }
+        };
+
+        addCallback(httpClient.executeAsync(request, createStatusResponseHandler()), callback, taskEventLoop);
+    }
+
+    @Override
+    public PartitionedSplitsInfo getPartitionedSplitsInfo()
+    {
+        TaskStatus taskStatus = getTaskStatus();
+        if (taskStatus.getState().isDone()) {
+            return PartitionedSplitsInfo.forZeroSplits();
+        }
+        PartitionedSplitsInfo unacknowledgedSplitsInfo = getUnacknowledgedPartitionedSplitsInfo();
+        int count = unacknowledgedSplitsInfo.getCount() + taskStatus.getQueuedPartitionedDrivers() + taskStatus.getRunningPartitionedDrivers();
+        long weight = unacknowledgedSplitsInfo.getWeightSum() + taskStatus.getQueuedPartitionedSplitsWeight() + taskStatus.getRunningPartitionedSplitsWeight();
+        return PartitionedSplitsInfo.forSplitCountAndWeightSum(count, weight);
+    }
+
+    @SuppressWarnings("FieldAccessNotGuarded")
+    public PartitionedSplitsInfo getUnacknowledgedPartitionedSplitsInfo()
+    {
+        int count = pendingSourceSplitCount;
+        long weight = pendingSourceSplitsWeight;
+        return PartitionedSplitsInfo.forSplitCountAndWeightSum(count, weight);
+    }
+
+    @Override
+    public PartitionedSplitsInfo getQueuedPartitionedSplitsInfo()
+    {
+        TaskStatus taskStatus = getTaskStatus();
+        if (taskStatus.getState().isDone()) {
+            return PartitionedSplitsInfo.forZeroSplits();
+        }
+        PartitionedSplitsInfo unacknowledgedSplitsInfo = getUnacknowledgedPartitionedSplitsInfo();
+        int count = unacknowledgedSplitsInfo.getCount() + taskStatus.getQueuedPartitionedDrivers();
+        long weight = unacknowledgedSplitsInfo.getWeightSum() + taskStatus.getQueuedPartitionedSplitsWeight();
+        return PartitionedSplitsInfo.forSplitCountAndWeightSum(count, weight);
+    }
+
+    @Override
+    public int getUnacknowledgedPartitionedSplitCount()
+    {
+        return getPendingSourceSplitCount();
+    }
+
+    @SuppressWarnings("FieldAccessNotGuarded")
+    private int getPendingSourceSplitCount()
+    {
+        return pendingSourceSplitCount;
+    }
+
+    private long getQueuedPartitionedSplitsWeight()
+    {
+        TaskStatus taskStatus = getTaskStatus();
+        if (taskStatus.getState().isDone()) {
+            return 0;
+        }
+        return getPendingSourceSplitsWeight() + taskStatus.getQueuedPartitionedSplitsWeight();
+    }
+
+    @SuppressWarnings("FieldAccessNotGuarded")
+    private long getPendingSourceSplitsWeight()
+    {
+        return pendingSourceSplitsWeight;
+    }
+
+    @Override
+    public void addStateChangeListener(StateChangeListener<TaskStatus> stateChangeListener)
+    {
+        taskStatusFetcher.addStateChangeListener(stateChangeListener);
+    }
+
+    @Override
+    public void addFinalTaskInfoListener(StateChangeListener<TaskInfo> stateChangeListener)
+    {
+        taskInfoFetcher.addFinalTaskInfoListener(stateChangeListener);
+    }
+
+    @Override
+    public ListenableFuture<?> whenSplitQueueHasSpace(long weightThreshold)
+    {
+        if (splitQueueHasSpace) {
+            return immediateFuture(null);
+        }
+        SettableFuture<?> future = SettableFuture.create();
+        safeExecuteOnEventLoop(() -> {
+            if (whenSplitQueueHasSpaceThreshold.isPresent()) {
+                checkArgument(weightThreshold == whenSplitQueueHasSpaceThreshold.getAsLong(), "Multiple split queue space notification thresholds not supported");
+            }
+            else {
+                whenSplitQueueHasSpaceThreshold = OptionalLong.of(weightThreshold);
+                updateSplitQueueSpace();
+            }
+            if (splitQueueHasSpace) {
+                future.set(null);
+            }
+            whenSplitQueueHasSpace.createNewListener().addListener(() -> future.set(null), taskEventLoop);
+        });
+        return future;
+    }
+
+    private void updateSplitQueueSpace()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        // Must check whether the unacknowledged split count threshold is reached even without listeners registered yet
+        splitQueueHasSpace = getUnacknowledgedPartitionedSplitCount() < maxUnacknowledgedSplits &&
+                (!whenSplitQueueHasSpaceThreshold.isPresent() || getQueuedPartitionedSplitsWeight() < whenSplitQueueHasSpaceThreshold.getAsLong());
+        // Only trigger notifications if a listener might be registered
+        if (splitQueueHasSpace && whenSplitQueueHasSpaceThreshold.isPresent()) {
+            whenSplitQueueHasSpace.complete(null, taskEventLoop);
+        }
+    }
+
+    private void updateTaskStats()
+    {
+        TaskStatus taskStatus = getTaskStatus();
+        if (taskStatus.getState().isDone()) {
+            nodeStatsTracker.setPartitionedSplits(PartitionedSplitsInfo.forZeroSplits());
+            nodeStatsTracker.setMemoryUsage(0);
+            nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis(), 0);
+        }
+        else {
+            nodeStatsTracker.setPartitionedSplits(getPartitionedSplitsInfo());
+            nodeStatsTracker.setMemoryUsage(taskStatus.getMemoryReservationInBytes() + taskStatus.getSystemMemoryReservationInBytes());
+            nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis(), taskStatus.getTotalCpuTimeInNanos());
+        }
+    }
+
+    private void processTaskUpdate(TaskInfo newValue, List<TaskSource> sources)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        //Setting the flag as false since TaskUpdateRequest is not on thrift yet.
+        //Once it is converted to thrift we can use the isThrift enabled flag here.
+        updateTaskInfo(newValue, false);
+
+        // remove acknowledged splits, which frees memory
+        for (TaskSource source : sources) {
+            PlanNodeId planNodeId = source.getPlanNodeId();
+            boolean isTableScanSource = tableScanPlanNodeIds.contains(planNodeId);
+            int removed = 0;
+            long removedWeight = 0;
+            for (ScheduledSplit split : source.getSplits()) {
+                if (pendingSplits.remove(planNodeId, split)) {
+                    if (isTableScanSource) {
+                        removed++;
+                        removedWeight = addExact(removedWeight, split.getSplit().getSplitWeight().getRawValue());
+                    }
+                }
+            }
+            if (source.isNoMoreSplits()) {
+                noMoreSplits.put(planNodeId, false);
+            }
+            for (Lifespan lifespan : source.getNoMoreSplitsForLifespan()) {
+                pendingNoMoreSplitsForLifespan.remove(planNodeId, lifespan);
+            }
+            if (isTableScanSource) {
+                pendingSourceSplitCount -= removed;
+                pendingSourceSplitsWeight -= removedWeight;
+            }
+        }
+        // Update stats before split queue space to ensure node stats are up to date before waking up the scheduler
+        updateTaskStats();
+        updateSplitQueueSpace();
+    }
+
+    private void onSuccessTaskInfo(TaskInfo result)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        try {
+            updateTaskInfo(result, taskInfoThriftTransportEnabled);
+        }
+        finally {
+            if (!getTaskInfo().getTaskStatus().getState().isDone()) {
+                cleanUpLocally();
+            }
+        }
+    }
+
+    private void updateTaskInfo(TaskInfo taskInfo, boolean isTaskInfoThriftTransportEnabled)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        taskStatusFetcher.updateTaskStatus(taskInfo.getTaskStatus());
+        if (isTaskInfoThriftTransportEnabled) {
+            taskInfo = convertFromThriftTaskInfo(taskInfo, connectorTypeSerdeManager, handleResolver);
+        }
+        taskInfoFetcher.updateTaskInfo(taskInfo);
+    }
+
+    private void cleanUpLocally()
+    {
+        verify(taskEventLoop.inEventLoop());
+        // Update the taskInfo with the new taskStatus.
+
+        // Generally, we send a cleanup request to the worker, and update the TaskInfo on
+        // the coordinator based on what we fetched from the worker. If we somehow cannot
+        // get the cleanup request to the worker, the TaskInfo that we fetch for the worker
+        // likely will not say the task is done however many times we try. In this case,
+        // we have to set the local query info directly so that we stop trying to fetch
+        // updated TaskInfo from the worker. This way, the task on the worker eventually
+        // expires due to lack of activity.
+
+        // This is required because the query state machine depends on TaskInfo (instead of task status)
+        // to transition its own state.
+        // TODO: Update the query state machine and stage state machine to depend on TaskStatus instead
+
+        // Since this TaskInfo is updated in the client the "complete" flag will not be set,
+        // indicating that the stats may not reflect the final stats on the worker.
+        updateTaskInfo(getTaskInfo().withTaskStatus(getTaskStatus()), taskInfoThriftTransportEnabled);
+    }
+
+    private void onFailureTaskInfo(
+            Throwable t,
+            String action,
+            Request request,
+            Backoff cleanupBackoff)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        if (t instanceof RejectedExecutionException && httpClient.isClosed()) {
+            logError(t, "Unable to %s task at %s. HTTP client is closed.", action, request.getUri());
+            cleanUpLocally();
+            return;
+        }
+
+        // record failure
+        if (cleanupBackoff.failure()) {
+            logError(t, "Unable to %s task at %s. Back off depleted.", action, request.getUri());
+            cleanUpLocally();
+            return;
+        }
+
+        // reschedule
+        long delayNanos = cleanupBackoff.getBackoffDelayNanos();
+        if (delayNanos == 0) {
+            doScheduleAsyncCleanupRequest(cleanupBackoff, request, action);
+        }
+        else {
+            taskEventLoop.schedule(() -> doScheduleAsyncCleanupRequest(cleanupBackoff, request, action), delayNanos, NANOSECONDS);
+        }
+    }
+
+    private void scheduleUpdate()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        taskUpdateTimeline.add(System.nanoTime());
+        sendUpdate();
+    }
+
+    private void sendUpdate()
+    {
+        safeExecuteOnEventLoop(() -> {
+            TaskStatus taskStatus = getTaskStatus();
+            // don't update if the task hasn't been started yet or if it is already finished
+            if (!started || !needsUpdate || taskStatus.getState().isDone()) {
+                return;
+            }
+
+            // if there is a request already running, wait for it to complete
+            if (this.currentRequest != null && !this.currentRequest.isDone()) {
+                return;
+            }
+
+            // if throttled due to error, asynchronously wait for timeout and try again
+            ListenableFuture<?> errorRateLimit = updateErrorTracker.acquireRequestPermit();
+            if (!errorRateLimit.isDone()) {
+                errorRateLimit.addListener(this::sendUpdate, taskEventLoop);
+                return;
+            }
+
+            List<TaskSource> sources = getSources();
+
+            Optional<byte[]> fragment = Optional.empty();
+            if (sendPlan) {
+                long start = THREAD_MX_BEAN.getCurrentThreadCpuTime();
+                fragment = Optional.of(planFragment.bytesForTaskSerialization(planFragmentCodec));
+                schedulerStatsTracker.recordTaskPlanSerializedCpuTime(THREAD_MX_BEAN.getCurrentThreadCpuTime() - start);
+            }
+            Optional<TableWriteInfo> writeInfo = sendPlan ? Optional.of(tableWriteInfo) : Optional.empty();
+            TaskUpdateRequest updateRequest = new TaskUpdateRequest(
+                    session.toSessionRepresentation(),
+                    session.getIdentity().getExtraCredentials(),
+                    fragment,
+                    sources,
+                    outputBuffers,
+                    writeInfo);
+            long serializeStartCpuTimeNanos = THREAD_MX_BEAN.getCurrentThreadCpuTime();
+            byte[] taskUpdateRequestJson = taskUpdateRequestCodec.toBytes(updateRequest);
+            schedulerStatsTracker.recordTaskUpdateSerializedCpuTime(THREAD_MX_BEAN.getCurrentThreadCpuTime() - serializeStartCpuTimeNanos);
+
+            taskUpdateRequestSize.add(taskUpdateRequestJson.length);
+
+            if (taskUpdateRequestJson.length > maxTaskUpdateSizeInBytes) {
+                failTask(new PrestoException(EXCEEDED_TASK_UPDATE_SIZE_LIMIT, getExceededTaskUpdateSizeMessage(taskUpdateRequestJson)));
+                return;
+            }
+
+            if (taskUpdateSizeTrackingEnabled) {
+                taskUpdateRequestSize.add(taskUpdateRequestJson.length);
+
+                if (fragment.isPresent()) {
+                    stats.updateWithPlanSize(taskUpdateRequestJson.length);
+                }
+                else {
+                    if (ThreadLocalRandom.current().nextDouble() < UPDATE_WITHOUT_PLAN_STATS_SAMPLE_RATE) {
+                        // This is to keep track of the task update size even when the plan fragment is NOT present
+                        stats.updateWithoutPlanSize(taskUpdateRequestJson.length);
+                    }
+                }
+            }
+
+            HttpUriBuilder uriBuilder = getHttpUriBuilder(taskStatus);
+            Request request = setContentTypeHeaders(binaryTransportEnabled, preparePost())
+                    .setUri(uriBuilder.build())
+                    .setBodyGenerator(createStaticBodyGenerator(taskUpdateRequestJson))
+                    .build();
+
+            ResponseHandler responseHandler;
+            if (binaryTransportEnabled) {
+                responseHandler = createFullSmileResponseHandler((SmileCodec<TaskInfo>) taskInfoCodec);
+            }
+            else {
+                responseHandler = createAdaptingJsonResponseHandler((JsonCodec<TaskInfo>) taskInfoJsonCodec);
+            }
+
+            updateErrorTracker.startRequest();
+
+            ListenableFuture<BaseResponse<TaskInfo>> future = httpClient.executeAsync(request, responseHandler);
+            currentRequest = future;
+            currentRequestStartNanos = System.nanoTime();
+            if (!taskUpdateTimeline.isEmpty()) {
+                currentRequestLastTaskUpdate = taskUpdateTimeline.getLong(taskUpdateTimeline.size() - 1);
+            }
+
+            // The needsUpdate flag needs to be set to false BEFORE adding the Future callback since callback might change the flag value
+            // and does so without grabbing the instance lock.
+            needsUpdate = false;
+
+            Futures.addCallback(
+                    future,
+                    new SimpleHttpResponseHandler<>(new UpdateResponseHandler(sources), request.getUri(), stats.getHttpResponseStats(), REMOTE_TASK_ERROR),
+                    taskEventLoop);
+        });
+    }
+
+    private String getExceededTaskUpdateSizeMessage(byte[] taskUpdateRequestJson)
+    {
+        DataSize taskUpdateSize = DataSize.succinctBytes(taskUpdateRequestJson.length);
+        return format("TaskUpdate size of %s has exceeded the limit of %s", taskUpdateSize.toString(), this.maxTaskUpdateDataSize.toString());
+    }
+
+    private List<TaskSource> getSources()
+    {
+        return Stream.concat(tableScanPlanNodeIds.stream(), remoteSourcePlanNodeIds.stream())
+                .map(this::getSource)
+                .filter(Objects::nonNull)
+                .collect(toImmutableList());
+    }
+
+    private TaskSource getSource(PlanNodeId planNodeId)
+    {
+        Set<ScheduledSplit> splits = pendingSplits.get(planNodeId);
+        boolean pendingNoMoreSplits = Boolean.TRUE.equals(this.noMoreSplits.get(planNodeId));
+        boolean noMoreSplits = this.noMoreSplits.containsKey(planNodeId);
+        Set<Lifespan> noMoreSplitsForLifespan = pendingNoMoreSplitsForLifespan.get(planNodeId);
+
+        TaskSource element = null;
+        if (!splits.isEmpty() || !noMoreSplitsForLifespan.isEmpty() || pendingNoMoreSplits) {
+            element = new TaskSource(planNodeId, splits, noMoreSplitsForLifespan, noMoreSplits);
+        }
+        return element;
+    }
+
+    @Override
+    public void cancel()
+    {
+        safeExecuteOnEventLoop(() -> {
+            TaskStatus taskStatus = getTaskStatus();
+            if (taskStatus.getState().isDone()) {
+                return;
+            }
+
+            // send cancel to task and ignore response
+            HttpUriBuilder uriBuilder = getHttpUriBuilder(taskStatus).addParameter("abort", "false");
+            Request.Builder builder = setContentTypeHeaders(binaryTransportEnabled, prepareDelete());
+            if (taskInfoThriftTransportEnabled) {
+                builder = ThriftRequestUtils.prepareThriftDelete(thriftProtocol);
+            }
+            Request request = builder.setUri(uriBuilder.build())
+                    .build();
+            scheduleAsyncCleanupRequest(createCleanupBackoff(), request, "cancel");
+        });
+    }
+
+    private void cleanUpTask()
+    {
+        safeExecuteOnEventLoop(() -> {
+            checkState(getTaskStatus().getState().isDone(), "attempt to clean up a task that is not done yet");
+
+            // clear pending splits to free memory
+            pendingSplits.clear();
+            pendingSourceSplitCount = 0;
+            pendingSourceSplitsWeight = 0;
+            updateTaskStats();
+            splitQueueHasSpace = true;
+            whenSplitQueueHasSpace.complete(null, taskEventLoop);
+
+            // cancel pending request
+            if (currentRequest != null) {
+                // do not terminate if the request is already running to avoid closing pooled connections
+                currentRequest.cancel(false);
+                currentRequest = null;
+                currentRequestStartNanos = 0;
+            }
+
+            taskStatusFetcher.stop();
+
+            // The remote task is likely to get a delete from the PageBufferClient first.
+            // We send an additional delete anyway to get the final TaskInfo
+            HttpUriBuilder uriBuilder = getHttpUriBuilder(getTaskStatus());
+            Request.Builder requestBuilder = setContentTypeHeaders(binaryTransportEnabled, prepareDelete());
+            if (taskInfoThriftTransportEnabled) {
+                requestBuilder = ThriftRequestUtils.prepareThriftDelete(Protocol.BINARY);
+            }
+            Request request = requestBuilder
+                    .setUri(uriBuilder.build())
+                    .build();
+
+            scheduleAsyncCleanupRequest(createCleanupBackoff(), request, "cleanup");
+        });
+    }
+
+    @Override
+    public void abort()
+    {
+        if (getTaskStatus().getState().isDone()) {
+            return;
+        }
+
+        abort(failWith(getTaskStatus(), ABORTED, ImmutableList.of()));
+    }
+
+    private void abort(TaskStatus status)
+    {
+        safeExecuteOnEventLoop(() -> {
+            checkState(status.getState().isDone(), "cannot abort task with an incomplete status");
+
+            taskStatusFetcher.updateTaskStatus(status);
+
+            // send abort to task
+            HttpUriBuilder uriBuilder = getHttpUriBuilder(getTaskStatus());
+            Request.Builder builder = setContentTypeHeaders(binaryTransportEnabled, prepareDelete());
+            if (taskInfoThriftTransportEnabled) {
+                builder = ThriftRequestUtils.prepareThriftDelete(thriftProtocol);
+            }
+
+            Request request = builder.setUri(uriBuilder.build())
+                    .build();
+            scheduleAsyncCleanupRequest(createCleanupBackoff(), request, "abort");
+        });
+    }
+
+    private void scheduleAsyncCleanupRequest(Backoff cleanupBackoff, Request request, String action)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        if (aborting) {
+            // Do not initiate another round of cleanup requests if one had been initiated.
+            // Otherwise, we can get into an asynchronous recursion here. For example, when aborting a task after REMOTE_TASK_MISMATCH.
+            return;
+        }
+        aborting = true;
+        doScheduleAsyncCleanupRequest(cleanupBackoff, request, action);
+    }
+
+    private void doScheduleAsyncCleanupRequest(Backoff cleanupBackoff, Request request, String action)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        ResponseHandler responseHandler;
+        if (taskInfoThriftTransportEnabled) {
+            responseHandler = new ThriftResponseHandler(unwrapThriftCodec(taskInfoCodec));
+            Futures.addCallback(httpClient.executeAsync(request, responseHandler),
+                    new ThriftResponseFutureCallback(action, request, cleanupBackoff),
+                    taskEventLoop);
+        }
+        else if (binaryTransportEnabled) {
+            responseHandler = createFullSmileResponseHandler((SmileCodec<TaskInfo>) taskInfoCodec);
+            Futures.addCallback(httpClient.executeAsync(request, responseHandler),
+                    new BaseResponseFutureCallback(action, request, cleanupBackoff),
+                    taskEventLoop);
+        }
+        else {
+            responseHandler = createAdaptingJsonResponseHandler((JsonCodec<TaskInfo>) taskInfoCodec);
+            Futures.addCallback(httpClient.executeAsync(request, responseHandler),
+                    new BaseResponseFutureCallback(action, request, cleanupBackoff),
+                    taskEventLoop);
+        }
+    }
+
+    /**
+     * Move the task directly to the failed state if there was a failure in this task
+     */
+    private void failTask(Throwable cause)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        TaskStatus taskStatus = getTaskStatus();
+        if (!taskStatus.getState().isDone()) {
+            log.debug(cause, "Remote task %s failed with %s", taskStatus.getSelf(), cause);
+        }
+
+        TaskStatus failedTaskStatus = failWith(getTaskStatus(), FAILED, ImmutableList.of(toFailure(cause)));
+        // Transition task to failed state without waiting for the final task info returned by the abort request.
+        // The abort request is very likely not to succeed, leaving the task and the stage in the limbo state for
+        // the entire duration of abort retries. If the task is failed, it is not that important to actually
+        // record the final statistics and the final information about a failed task.
+        taskInfoFetcher.updateTaskInfo(getTaskInfo().withTaskStatus(failedTaskStatus));
+
+        // Initiate abort request
+        abort(failedTaskStatus);
+    }
+
+    private HttpUriBuilder getHttpUriBuilder(TaskStatus taskStatus)
+    {
+        HttpUriBuilder uriBuilder = uriBuilderFrom(taskStatus.getSelf());
+        if (summarizeTaskInfo) {
+            uriBuilder.addParameter("summarize");
+        }
+        return uriBuilder;
+    }
+
+    private static Backoff createCleanupBackoff()
+    {
+        return new Backoff(10, new Duration(10, TimeUnit.MINUTES), Ticker.systemTicker(), ImmutableList.<Duration>builder()
+                .add(new Duration(0, MILLISECONDS))
+                .add(new Duration(100, MILLISECONDS))
+                .add(new Duration(500, MILLISECONDS))
+                .add(new Duration(1, SECONDS))
+                .add(new Duration(10, SECONDS))
+                .build());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(getTaskInfo())
+                .toString();
+    }
+
+    private class UpdateResponseHandler
+            implements SimpleHttpResponseCallback<TaskInfo>
+    {
+        private final List<TaskSource> sources;
+
+        private UpdateResponseHandler(List<TaskSource> sources)
+        {
+            this.sources = ImmutableList.copyOf(requireNonNull(sources, "sources is null"));
+        }
+
+        @Override
+        public void success(TaskInfo value)
+        {
+            verify(taskEventLoop.inEventLoop());
+
+            try {
+                long oldestTaskUpdateTime = 0;
+                currentRequest = null;
+                sendPlan = value.isNeedsPlan();
+                if (!taskUpdateTimeline.isEmpty()) {
+                    oldestTaskUpdateTime = taskUpdateTimeline.getLong(0);
+                }
+                int deliveredUpdates = taskUpdateTimeline.size();
+                while (deliveredUpdates > 0 && taskUpdateTimeline.getLong(deliveredUpdates - 1) > currentRequestLastTaskUpdate) {
+                    deliveredUpdates--;
+                }
+                taskUpdateTimeline.removeElements(0, deliveredUpdates);
+
+                updateStats(currentRequestStartNanos);
+                processTaskUpdate(value, sources);
+                updateErrorTracker.requestSucceeded();
+                if (oldestTaskUpdateTime != 0) {
+                    schedulerStatsTracker.recordTaskUpdateDeliveredTime(System.nanoTime() - oldestTaskUpdateTime);
+                }
+            }
+            finally {
+                sendUpdate();
+            }
+        }
+
+        @Override
+        public void failed(Throwable cause)
+        {
+            verify(taskEventLoop.inEventLoop());
+
+            try {
+                long currentRequestStartNanos;
+                currentRequest = null;
+                currentRequestStartNanos = HttpRemoteTaskWithEventLoop.this.currentRequestStartNanos;
+                updateStats(currentRequestStartNanos);
+
+                // on failure assume we need to update again
+                needsUpdate = true;
+
+                // if task not already done, record error
+                TaskStatus taskStatus = getTaskStatus();
+                if (!taskStatus.getState().isDone()) {
+                    updateErrorTracker.requestFailed(cause);
+                }
+            }
+            catch (Error e) {
+                failTask(e);
+                throw e;
+            }
+            catch (RuntimeException e) {
+                failTask(e);
+            }
+            finally {
+                sendUpdate();
+            }
+        }
+
+        @Override
+        public void fatal(Throwable cause)
+        {
+            verify(taskEventLoop.inEventLoop());
+
+            failTask(cause);
+        }
+
+        private void updateStats(long currentRequestStartNanos)
+        {
+            verify(taskEventLoop.inEventLoop());
+            Duration requestRoundTrip = Duration.nanosSince(currentRequestStartNanos);
+            stats.updateRoundTripMillis(requestRoundTrip.toMillis());
+        }
+    }
+
+    private static void logError(Throwable t, String format, Object... args)
+    {
+        if (isExpectedError(t)) {
+            log.error(format + ": %s", ObjectArrays.concat(args, t));
+        }
+        else {
+            log.error(t, format, args);
+        }
+    }
+
+    private class ThriftResponseFutureCallback
+            implements FutureCallback<ThriftResponse<TaskInfo>>
+    {
+        private final String action;
+        private final Request request;
+        private final Backoff cleanupBackoff;
+
+        public ThriftResponseFutureCallback(String action, Request request, Backoff cleanupBackoff)
+        {
+            this.action = action;
+            this.request = request;
+            this.cleanupBackoff = cleanupBackoff;
+        }
+
+        @Override
+        public void onSuccess(ThriftResponse<TaskInfo> result)
+        {
+            verify(taskEventLoop.inEventLoop());
+            onSuccessTaskInfo(result.getValue());
+        }
+
+        @Override
+        public void onFailure(Throwable throwable)
+        {
+            verify(taskEventLoop.inEventLoop());
+            onFailureTaskInfo(throwable, this.action, this.request, this.cleanupBackoff);
+        }
+    }
+
+    private class BaseResponseFutureCallback
+            implements FutureCallback<BaseResponse<TaskInfo>>
+    {
+        private final String action;
+        private final Request request;
+        private final Backoff cleanupBackoff;
+
+        public BaseResponseFutureCallback(String action, Request request, Backoff cleanupBackoff)
+        {
+            this.action = action;
+            this.request = request;
+            this.cleanupBackoff = cleanupBackoff;
+        }
+
+        @Override
+        public void onSuccess(BaseResponse<TaskInfo> result)
+        {
+            verify(taskEventLoop.inEventLoop());
+            onSuccessTaskInfo(result.getValue());
+        }
+
+        @Override
+        public void onFailure(Throwable throwable)
+        {
+            verify(taskEventLoop.inEventLoop());
+            onFailureTaskInfo(throwable, this.action, this.request, this.cleanupBackoff);
+        }
+    }
+
+    private void safeExecuteOnEventLoop(Runnable r)
+    {
+        taskEventLoop.execute(r, this::failTask);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcherWithEventLoop.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcherWithEventLoop.java
@@ -1,0 +1,430 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpUriBuilder;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.Response;
+import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.airlift.http.client.thrift.ThriftRequestUtils;
+import com.facebook.airlift.http.client.thrift.ThriftResponseHandler;
+import com.facebook.airlift.json.Codec;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.smile.SmileCodec;
+import com.facebook.drift.transport.netty.codec.Protocol;
+import com.facebook.presto.Session;
+import com.facebook.presto.connector.ConnectorTypeSerdeManager;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.execution.StateMachine.StateChangeListener;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.MetadataUpdates;
+import com.facebook.presto.server.RequestErrorTracker;
+import com.facebook.presto.server.SimpleHttpResponseCallback;
+import com.facebook.presto.server.SimpleHttpResponseHandler;
+import com.facebook.presto.server.smile.BaseResponse;
+import com.facebook.presto.server.thrift.ThriftHttpResponseHandler;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
+import io.netty.channel.EventLoop;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.ResponseHandlerUtils.propagate;
+import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_CURRENT_STATE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_MAX_WAIT;
+import static com.facebook.presto.server.RequestErrorTracker.taskRequestErrorTracker;
+import static com.facebook.presto.server.RequestHelpers.setContentTypeHeaders;
+import static com.facebook.presto.server.TaskResourceUtils.convertFromThriftTaskInfo;
+import static com.facebook.presto.server.smile.AdaptingJsonResponseHandler.createAdaptingJsonResponseHandler;
+import static com.facebook.presto.server.smile.FullSmileResponseHandler.createFullSmileResponseHandler;
+import static com.facebook.presto.server.thrift.ThriftCodecWrapper.unwrapThriftCodec;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.units.Duration.nanosSince;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class TaskInfoFetcherWithEventLoop
+        implements SimpleHttpResponseCallback<TaskInfo>
+{
+    private final TaskId taskId;
+    private final Consumer<Throwable> onFail;
+    private final StateMachine<TaskInfo> taskInfo;
+    private final StateMachine<Optional<TaskInfo>> finalTaskInfo;
+    private final Codec<TaskInfo> taskInfoCodec;
+    private final Codec<MetadataUpdates> metadataUpdatesCodec;
+
+    private final long updateIntervalMillis;
+    private final Duration taskInfoRefreshMaxWait;
+    private long lastUpdateNanos;
+
+    private final EventLoop taskEventLoop;
+    private final HttpClient httpClient;
+    private final RequestErrorTracker errorTracker;
+
+    private final boolean summarizeTaskInfo;
+
+    private long currentRequestStartNanos;
+    private final RemoteTaskStats stats;
+    private boolean running;
+
+    private ScheduledFuture<?> scheduledFuture;
+    private ListenableFuture<BaseResponse<TaskInfo>> future;
+    private ListenableFuture<?> metadataUpdateFuture;
+
+    private final boolean isBinaryTransportEnabled;
+    private final boolean isThriftTransportEnabled;
+    private final Session session;
+    private final MetadataManager metadataManager;
+    private final QueryManager queryManager;
+    private final HandleResolver handleResolver;
+    private final ConnectorTypeSerdeManager connectorTypeSerdeManager;
+    private final Protocol thriftProtocol;
+
+    public TaskInfoFetcherWithEventLoop(
+            Consumer<Throwable> onFail,
+            TaskInfo initialTask,
+            HttpClient httpClient,
+            Duration updateInterval,
+            Duration taskInfoRefreshMaxWait,
+            Codec<TaskInfo> taskInfoCodec,
+            Codec<MetadataUpdates> metadataUpdatesCodec,
+            Duration maxErrorDuration,
+            boolean summarizeTaskInfo,
+            EventLoop taskEventLoop,
+            RemoteTaskStats stats,
+            boolean isBinaryTransportEnabled,
+            boolean isThriftTransportEnabled,
+            Session session,
+            MetadataManager metadataManager,
+            QueryManager queryManager,
+            HandleResolver handleResolver,
+            ConnectorTypeSerdeManager connectorTypeSerdeManager,
+            Protocol thriftProtocol)
+    {
+        requireNonNull(initialTask, "initialTask is null");
+
+        this.taskId = initialTask.getTaskId();
+        this.onFail = requireNonNull(onFail, "onFail is null");
+        this.taskInfo = new StateMachine<>("task " + taskId, taskEventLoop, initialTask);
+        this.finalTaskInfo = new StateMachine<>("task-" + taskId, taskEventLoop, Optional.empty());
+        this.taskInfoCodec = requireNonNull(taskInfoCodec, "taskInfoCodec is null");
+
+        this.metadataUpdatesCodec = requireNonNull(metadataUpdatesCodec, "metadataUpdatesCodec is null");
+
+        this.updateIntervalMillis = requireNonNull(updateInterval, "updateInterval is null").toMillis();
+        this.taskInfoRefreshMaxWait = requireNonNull(taskInfoRefreshMaxWait, "taskInfoRefreshMaxWait is null");
+        this.errorTracker = taskRequestErrorTracker(taskId, initialTask.getTaskStatus().getSelf(), maxErrorDuration, taskEventLoop, "getting info for task");
+
+        this.summarizeTaskInfo = summarizeTaskInfo;
+
+        this.taskEventLoop = requireNonNull(taskEventLoop, "taskEventLoop is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.stats = requireNonNull(stats, "stats is null");
+        this.isBinaryTransportEnabled = isBinaryTransportEnabled;
+        this.isThriftTransportEnabled = isThriftTransportEnabled;
+        this.session = requireNonNull(session, "session is null");
+        this.metadataManager = requireNonNull(metadataManager, "metadataManager is null");
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
+        this.handleResolver = requireNonNull(handleResolver, "handleResolver is null");
+        this.connectorTypeSerdeManager = requireNonNull(connectorTypeSerdeManager, "connectorTypeSerdeManager is null");
+        this.thriftProtocol = requireNonNull(thriftProtocol, "thriftProtocol is null");
+    }
+
+    public TaskInfo getTaskInfo()
+    {
+        return taskInfo.get();
+    }
+
+    public void start()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        if (running) {
+            // already running
+            return;
+        }
+        running = true;
+        scheduleUpdate();
+    }
+
+    private void stop()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        running = false;
+        if (future != null) {
+            // do not terminate if the request is already running to avoid closing pooled connections
+            future.cancel(false);
+            future = null;
+        }
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+        }
+    }
+
+    /**
+     * Add a listener for the final task info.  This notification is guaranteed to be fired only once.
+     * Listener is always notified asynchronously using a dedicated notification thread pool so, care should
+     * be taken to avoid leaking {@code this} when adding a listener in a constructor. Additionally, it is
+     * possible notifications are observed out of order due to the asynchronous execution.
+     */
+    public void addFinalTaskInfoListener(StateChangeListener<TaskInfo> stateChangeListener)
+    {
+        AtomicBoolean done = new AtomicBoolean();
+        StateChangeListener<Optional<TaskInfo>> fireOnceStateChangeListener = finalTaskInfo -> {
+            if (finalTaskInfo.isPresent() && done.compareAndSet(false, true)) {
+                stateChangeListener.stateChanged(finalTaskInfo.get());
+            }
+        };
+        finalTaskInfo.addStateChangeListener(fireOnceStateChangeListener);
+        fireOnceStateChangeListener.stateChanged(finalTaskInfo.get());
+    }
+
+    private void scheduleUpdate()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        scheduledFuture = taskEventLoop.scheduleWithFixedDelay(() -> {
+            try {
+                // if the previous request still running, don't schedule a new request
+                if (future != null && !future.isDone()) {
+                    return;
+                }
+
+                if (nanosSince(lastUpdateNanos).toMillis() >= updateIntervalMillis) {
+                    sendNextRequest();
+                }
+            }
+            catch (Throwable t) {
+                fatal(t);
+                throw t;
+            }
+        }, 0, 100, MILLISECONDS);
+    }
+
+    private void sendNextRequest()
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        TaskInfo taskInfo = getTaskInfo();
+        TaskStatus taskStatus = taskInfo.getTaskStatus();
+
+        if (!running) {
+            return;
+        }
+
+        // we already have the final task info
+        if (isDone(getTaskInfo())) {
+            stop();
+            return;
+        }
+
+        // if we have an outstanding request
+        if (future != null && !future.isDone()) {
+            return;
+        }
+
+        // if throttled due to error, asynchronously wait for timeout and try again
+        ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+        if (!errorRateLimit.isDone()) {
+            errorRateLimit.addListener(this::sendNextRequest, taskEventLoop);
+            return;
+        }
+
+        MetadataUpdates metadataUpdateRequests = taskInfo.getMetadataUpdates();
+        if (!metadataUpdateRequests.getMetadataUpdates().isEmpty()) {
+            scheduleMetadataUpdates(metadataUpdateRequests);
+        }
+
+        HttpUriBuilder httpUriBuilder = uriBuilderFrom(taskStatus.getSelf());
+        URI uri = summarizeTaskInfo ? httpUriBuilder.addParameter("summarize").build() : httpUriBuilder.build();
+        Request.Builder requestBuilder = setContentTypeHeaders(isBinaryTransportEnabled, prepareGet());
+
+        ResponseHandler responseHandler;
+        if (isThriftTransportEnabled) {
+            requestBuilder = ThriftRequestUtils.prepareThriftGet(thriftProtocol);
+            responseHandler = new ThriftResponseHandler(unwrapThriftCodec(taskInfoCodec));
+        }
+        else if (isBinaryTransportEnabled) {
+            responseHandler = createFullSmileResponseHandler((SmileCodec<TaskInfo>) taskInfoCodec);
+        }
+        else {
+            responseHandler = createAdaptingJsonResponseHandler((JsonCodec<TaskInfo>) taskInfoCodec);
+        }
+
+        if (taskInfoRefreshMaxWait.toMillis() != 0L) {
+            requestBuilder.setHeader(PRESTO_CURRENT_STATE, taskStatus.getState().toString())
+                    .setHeader(PRESTO_MAX_WAIT, taskInfoRefreshMaxWait.toString());
+        }
+
+        Request request = requestBuilder.setUri(uri).build();
+        errorTracker.startRequest();
+        future = httpClient.executeAsync(request, responseHandler);
+        currentRequestStartNanos = System.nanoTime();
+        FutureCallback callback;
+        if (isThriftTransportEnabled) {
+            callback = new ThriftHttpResponseHandler(this, request.getUri(), stats.getHttpResponseStats(), REMOTE_TASK_ERROR);
+        }
+        else {
+            callback = new SimpleHttpResponseHandler<>(this, request.getUri(), stats.getHttpResponseStats(), REMOTE_TASK_ERROR);
+        }
+
+        Futures.addCallback(
+                future,
+                callback,
+                taskEventLoop);
+    }
+
+    void updateTaskInfo(TaskInfo newValue)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        boolean updated = taskInfo.setIf(newValue, oldValue -> {
+            TaskStatus oldTaskStatus = oldValue.getTaskStatus();
+            TaskStatus newTaskStatus = newValue.getTaskStatus();
+            if (oldTaskStatus.getState().isDone()) {
+                // never update if the task has reached a terminal state
+                return false;
+            }
+            // don't update to an older version (same version is ok)
+            return newTaskStatus.getVersion() >= oldTaskStatus.getVersion();
+        });
+
+        if (updated && newValue.getTaskStatus().getState().isDone()) {
+            finalTaskInfo.compareAndSet(Optional.empty(), Optional.of(newValue));
+            stop();
+        }
+    }
+
+    @Override
+    public void success(TaskInfo newValue)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        lastUpdateNanos = System.nanoTime();
+
+        long startNanos;
+        startNanos = this.currentRequestStartNanos;
+        updateStats(startNanos);
+        errorTracker.requestSucceeded();
+        if (isThriftTransportEnabled) {
+            newValue = convertFromThriftTaskInfo(newValue, connectorTypeSerdeManager, handleResolver);
+        }
+        updateTaskInfo(newValue);
+    }
+
+    @Override
+    public void failed(Throwable cause)
+    {
+        verify(taskEventLoop.inEventLoop());
+
+        lastUpdateNanos = System.nanoTime();
+
+        try {
+            // if task not already done, record error
+            if (!isDone(getTaskInfo())) {
+                errorTracker.requestFailed(cause);
+            }
+        }
+        catch (Error e) {
+            onFail.accept(e);
+            throw e;
+        }
+        catch (RuntimeException e) {
+            onFail.accept(e);
+        }
+    }
+
+    @Override
+    public void fatal(Throwable cause)
+    {
+        verify(taskEventLoop.inEventLoop());
+        onFail.accept(cause);
+    }
+
+    private void updateStats(long currentRequestStartNanos)
+    {
+        verify(taskEventLoop.inEventLoop());
+        stats.infoRoundTripMillis(nanosSince(currentRequestStartNanos).toMillis());
+    }
+
+    private static boolean isDone(TaskInfo taskInfo)
+    {
+        return taskInfo.getTaskStatus().getState().isDone();
+    }
+
+    private void scheduleMetadataUpdates(MetadataUpdates metadataUpdateRequests)
+    {
+        MetadataUpdates results = metadataManager.getMetadataUpdateResults(session, queryManager, metadataUpdateRequests, taskId.getQueryId());
+        taskEventLoop.execute(() -> sendMetadataUpdates(results));
+    }
+
+    private void sendMetadataUpdates(MetadataUpdates results)
+    {
+        verify(taskEventLoop.inEventLoop());
+        TaskStatus taskStatus = getTaskInfo().getTaskStatus();
+
+        // we already have the final task info
+        if (isDone(getTaskInfo())) {
+            stop();
+            return;
+        }
+
+        // outstanding request?
+        if (metadataUpdateFuture != null && !metadataUpdateFuture.isDone()) {
+            // this should never happen
+            return;
+        }
+
+        byte[] metadataUpdatesJson = metadataUpdatesCodec.toBytes(results);
+        Request request = setContentTypeHeaders(isBinaryTransportEnabled, preparePost())
+                .setUri(uriBuilderFrom(taskStatus.getSelf()).appendPath("metadataresults").build())
+                .setBodyGenerator(createStaticBodyGenerator(metadataUpdatesJson))
+                .build();
+
+        errorTracker.startRequest();
+        metadataUpdateFuture = httpClient.executeAsync(request, new ResponseHandler<Response, RuntimeException>()
+        {
+            @Override
+            public Response handleException(Request request, Exception exception)
+            {
+                throw propagate(request, exception);
+            }
+
+            @Override
+            public Response handle(Request request, Response response)
+            {
+                return response;
+            }
+        });
+        currentRequestStartNanos = System.nanoTime();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -78,7 +78,8 @@ public class TestTaskManagerConfig
                 .setHighMemoryTaskKillerGCReclaimMemoryThreshold(0.01)
                 .setHighMemoryTaskKillerFrequentFullGCDurationThreshold(new Duration(1, SECONDS))
                 .setHighMemoryTaskKillerHeapMemoryThreshold(0.9)
-                .setTaskUpdateSizeTrackingEnabled(true));
+                .setTaskUpdateSizeTrackingEnabled(true)
+                .setEventLoopEnabled(false));
     }
 
     @Test
@@ -127,6 +128,7 @@ public class TestTaskManagerConfig
                 .put("experimental.task.high-memory-task-killer-frequent-full-gc-duration-threshold", "2s")
                 .put("experimental.task.high-memory-task-killer-heap-memory-threshold", "0.8")
                 .put("task.update-size-tracking-enabled", "false")
+                .put("task.enable-event-loop", "true")
                 .build();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -171,7 +173,8 @@ public class TestTaskManagerConfig
                 .setHighMemoryTaskKillerGCReclaimMemoryThreshold(0.8)
                 .setHighMemoryTaskKillerFrequentFullGCDurationThreshold(new Duration(2, SECONDS))
                 .setHighMemoryTaskKillerHeapMemoryThreshold(0.8)
-                .setTaskUpdateSizeTrackingEnabled(false);
+                .setTaskUpdateSizeTrackingEnabled(false)
+                .setEventLoopEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskWithEventLoop.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskWithEventLoop.java
@@ -1,0 +1,665 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.http.client.testing.TestingHttpClient;
+import com.facebook.airlift.jaxrs.JsonMapper;
+import com.facebook.airlift.jaxrs.testing.JaxrsTestingHttpProcessor;
+import com.facebook.airlift.jaxrs.thrift.ThriftMapper;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.json.smile.SmileCodec;
+import com.facebook.airlift.json.smile.SmileModule;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.guice.ThriftCodecModule;
+import com.facebook.drift.codec.utils.DataSizeToBytesThriftCodec;
+import com.facebook.drift.codec.utils.DurationToMillisThriftCodec;
+import com.facebook.drift.codec.utils.JodaDateTimeToEpochMillisThriftCodec;
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.common.ErrorCode;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.connector.ConnectorTypeSerdeManager;
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.NodeTaskMap;
+import com.facebook.presto.execution.QueryManagerConfig;
+import com.facebook.presto.execution.RemoteTask;
+import com.facebook.presto.execution.SchedulerStatsTracker;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.execution.TaskManagerConfig;
+import com.facebook.presto.execution.TaskSource;
+import com.facebook.presto.execution.TaskState;
+import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.execution.TestQueryManager;
+import com.facebook.presto.execution.TestSqlTaskManager;
+import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.HandleJsonModule;
+import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.MetadataUpdates;
+import com.facebook.presto.metadata.Split;
+import com.facebook.presto.server.ConnectorMetadataUpdateHandleJsonSerde;
+import com.facebook.presto.server.InternalCommunicationConfig;
+import com.facebook.presto.server.TaskUpdateRequest;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.Serialization;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.testing.TestingHandleResolver;
+import com.facebook.presto.testing.TestingSplit;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.type.TypeDeserializer;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_BINARY;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_COMPACT;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_FB_COMPACT;
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.airlift.json.smile.SmileCodecBinder.smileCodecBinder;
+import static com.facebook.drift.codec.guice.ThriftCodecBinder.thriftCodecBinder;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_CURRENT_STATE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_MAX_WAIT;
+import static com.facebook.presto.execution.TaskTestUtils.TABLE_SCAN_NODE_ID;
+import static com.facebook.presto.execution.TaskTestUtils.createPlanFragment;
+import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.SplitContext.NON_CACHEABLE;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_MISMATCH;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
+
+public class TestHttpRemoteTaskWithEventLoop
+{
+    // This 30 sec per-test timeout should never be reached because the test should fail and do proper cleanup after 20 sec.
+    private static final Duration POLL_TIMEOUT = new Duration(100, MILLISECONDS);
+    private static final Duration IDLE_TIMEOUT = new Duration(3, SECONDS);
+    private static final Duration FAIL_TIMEOUT = new Duration(40, SECONDS);
+    private static final TaskManagerConfig TASK_MANAGER_CONFIG = new TaskManagerConfig()
+            // Shorten status refresh wait and info update interval so that we can have a shorter test timeout
+            .setStatusRefreshMaxWait(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 100, MILLISECONDS))
+            .setInfoUpdateInterval(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 10, MILLISECONDS))
+            .setEventLoopEnabled(true);
+
+    private static final boolean TRACE_HTTP = false;
+
+    @DataProvider
+    public Object[][] thriftEncodingToggle()
+    {
+        return new Object[][] {{true}, {false}};
+    }
+
+    @Test(timeOut = 50000, dataProvider = "thriftEncodingToggle")
+    public void testRemoteTaskMismatch(boolean useThriftEncoding)
+            throws Exception
+    {
+        runTest(FailureScenario.TASK_MISMATCH, useThriftEncoding);
+    }
+
+    @Test(timeOut = 50000, dataProvider = "thriftEncodingToggle")
+    public void testRejectedExecutionWhenVersionIsHigh(boolean useThriftEncoding)
+            throws Exception
+    {
+        runTest(FailureScenario.TASK_MISMATCH_WHEN_VERSION_IS_HIGH, useThriftEncoding);
+    }
+
+    @Test(timeOut = 40000, dataProvider = "thriftEncodingToggle")
+    public void testRejectedExecution(boolean useThriftEncoding)
+            throws Exception
+    {
+        runTest(FailureScenario.REJECTED_EXECUTION, useThriftEncoding);
+    }
+
+    @Test(timeOut = 60000, dataProvider = "thriftEncodingToggle")
+    public void testRegular(boolean useThriftEncoding)
+            throws Exception
+    {
+        AtomicLong lastActivityNanos = new AtomicLong(System.nanoTime());
+        TestingTaskResource testingTaskResource = new TestingTaskResource(lastActivityNanos, FailureScenario.NO_FAILURE);
+
+        HttpRemoteTaskFactory httpRemoteTaskFactory = createHttpRemoteTaskFactory(testingTaskResource, useThriftEncoding);
+
+        RemoteTask remoteTask = createRemoteTask(httpRemoteTaskFactory);
+
+        testingTaskResource.setInitialTaskInfo(remoteTask.getTaskInfo());
+        remoteTask.start();
+
+        Lifespan lifespan = Lifespan.driverGroup(3);
+        remoteTask.addSplits(ImmutableMultimap.of(TABLE_SCAN_NODE_ID, new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit(), lifespan, NON_CACHEABLE)));
+        poll(() -> testingTaskResource.getTaskSource(TABLE_SCAN_NODE_ID) != null);
+        poll(() -> testingTaskResource.getTaskSource(TABLE_SCAN_NODE_ID).getSplits().size() == 1);
+
+        remoteTask.noMoreSplits(TABLE_SCAN_NODE_ID, lifespan);
+        poll(() -> testingTaskResource.getTaskSource(TABLE_SCAN_NODE_ID).getNoMoreSplitsForLifespan().size() == 1);
+
+        remoteTask.noMoreSplits(TABLE_SCAN_NODE_ID);
+        poll(() -> testingTaskResource.getTaskSource(TABLE_SCAN_NODE_ID).isNoMoreSplits());
+
+        remoteTask.cancel();
+        poll(() -> remoteTask.getTaskStatus().getState().isDone());
+        poll(() -> remoteTask.getTaskInfo().getTaskStatus().getState().isDone());
+
+        httpRemoteTaskFactory.stop();
+    }
+
+    @Test(timeOut = 50000)
+    public void testHTTPRemoteTaskSize()
+            throws Exception
+    {
+        AtomicLong lastActivityNanos = new AtomicLong(System.nanoTime());
+        TestingTaskResource testingTaskResource = new TestingTaskResource(lastActivityNanos, FailureScenario.NO_FAILURE);
+
+        HttpRemoteTaskFactory httpRemoteTaskFactory = createHttpRemoteTaskFactory(testingTaskResource, false);
+
+        RemoteTask remoteTask = createRemoteTask(httpRemoteTaskFactory);
+
+        testingTaskResource.setInitialTaskInfo(remoteTask.getTaskInfo());
+        remoteTask.start();
+        // just need to run a TaskUpdateRequest to increment the decay counter
+        remoteTask.cancel();
+
+        waitUntilTaskFinish(remoteTask);
+
+        httpRemoteTaskFactory.stop();
+
+        assertTrue(httpRemoteTaskFactory.getTaskUpdateRequestSize() > 0);
+    }
+
+    @Test(timeOut = 50000)
+    public void testHTTPRemoteBadTaskSize()
+            throws Exception
+    {
+        AtomicLong lastActivityNanos = new AtomicLong(System.nanoTime());
+        TestingTaskResource testingTaskResource = new TestingTaskResource(lastActivityNanos, FailureScenario.NO_FAILURE);
+        boolean useThriftEncoding = false;
+        DataSize maxDataSize = DataSize.succinctBytes(1024);
+        InternalCommunicationConfig internalCommunicationConfig = new InternalCommunicationConfig()
+                .setThriftTransportEnabled(useThriftEncoding)
+                .setMaxTaskUpdateSize(maxDataSize);
+
+        HttpRemoteTaskFactory httpRemoteTaskFactory = createHttpRemoteTaskFactory(testingTaskResource, useThriftEncoding, internalCommunicationConfig);
+
+        RemoteTask remoteTask = createRemoteTask(httpRemoteTaskFactory);
+        testingTaskResource.setInitialTaskInfo(remoteTask.getTaskInfo());
+        remoteTask.start();
+
+        waitUntilTaskFinish(remoteTask);
+
+        httpRemoteTaskFactory.stop();
+
+        assertTrue(remoteTask.getTaskStatus().getState().isDone(), format("TaskStatus is not in a done state: %s", remoteTask.getTaskStatus()));
+        assertThat(getOnlyElement(remoteTask.getTaskStatus().getFailures()).getMessage())
+                .matches("TaskUpdate size of .+? has exceeded the limit of 1kB");
+    }
+
+    @Test(dataProvider = "getUpdateSize")
+    public void testGetExceededTaskUpdateSizeListMessage(int updateSizeInBytes, int maxDataSizeInBytes,
+            String expectedMessage)
+            throws Exception
+    {
+        AtomicLong lastActivityNanos = new AtomicLong(System.nanoTime());
+        TestingTaskResource testingTaskResource = new TestingTaskResource(lastActivityNanos, FailureScenario.NO_FAILURE);
+        boolean useThriftEncoding = false;
+        DataSize maxDataSize = DataSize.succinctBytes(maxDataSizeInBytes);
+        InternalCommunicationConfig internalCommunicationConfig = new InternalCommunicationConfig()
+                .setThriftTransportEnabled(useThriftEncoding)
+                .setMaxTaskUpdateSize(maxDataSize);
+        HttpRemoteTaskFactory httpRemoteTaskFactory = createHttpRemoteTaskFactory(testingTaskResource, useThriftEncoding, internalCommunicationConfig);
+        RemoteTask remoteTask = createRemoteTask(httpRemoteTaskFactory);
+
+        Method targetMethod = HttpRemoteTaskWithEventLoop.class.getDeclaredMethod("getExceededTaskUpdateSizeMessage", new Class[] {byte[].class});
+        targetMethod.setAccessible(true);
+        byte[] taskUpdateRequestJson = new byte[updateSizeInBytes];
+        String message = (String) targetMethod.invoke(remoteTask, new Object[] {taskUpdateRequestJson});
+        assertEquals(message, expectedMessage);
+    }
+
+    @DataProvider(name = "getUpdateSize")
+    protected Object[][] getUpdateSize()
+    {
+        return new Object[][] {
+                {2000, 1000, "TaskUpdate size of 1.95kB has exceeded the limit of 1000B"},
+                {2000, 1024, "TaskUpdate size of 1.95kB has exceeded the limit of 1kB"},
+                {5000, 4 * 1024, "TaskUpdate size of 4.88kB has exceeded the limit of 4kB"},
+                {2 * 1024, 1024, "TaskUpdate size of 2kB has exceeded the limit of 1kB"},
+                {1024 * 1024, 512 * 1024, "TaskUpdate size of 1MB has exceeded the limit of 512kB"},
+                {16 * 1024 * 1024, 8 * 1024 * 1024, "TaskUpdate size of 16MB has exceeded the limit of 8MB"},
+                {485 * 1000 * 1000, 1024 * 1024 * 512, "TaskUpdate size of 462.53MB has exceeded the limit of 512MB"},
+                {1024 * 1024 * 1024, 1024 * 1024 * 512, "TaskUpdate size of 1GB has exceeded the limit of 512MB"},
+                {860492511, 524288000, "TaskUpdate size of 820.63MB has exceeded the limit of 500MB"}};
+    }
+
+    private void runTest(FailureScenario failureScenario, boolean useThriftEncoding)
+            throws Exception
+    {
+        AtomicLong lastActivityNanos = new AtomicLong(System.nanoTime());
+        TestingTaskResource testingTaskResource = new TestingTaskResource(lastActivityNanos, failureScenario);
+
+        HttpRemoteTaskFactory httpRemoteTaskFactory = createHttpRemoteTaskFactory(testingTaskResource, useThriftEncoding);
+        RemoteTask remoteTask = createRemoteTask(httpRemoteTaskFactory);
+
+        testingTaskResource.setInitialTaskInfo(remoteTask.getTaskInfo());
+        remoteTask.start();
+
+        waitUntilTaskFinish(remoteTask);
+
+        httpRemoteTaskFactory.stop();
+        assertTrue(remoteTask.getTaskStatus().getState().isDone(), format("TaskStatus is not in a done state: %s", remoteTask.getTaskStatus()));
+
+        ErrorCode actualErrorCode = getOnlyElement(remoteTask.getTaskStatus().getFailures()).getErrorCode();
+        switch (failureScenario) {
+            case TASK_MISMATCH:
+            case TASK_MISMATCH_WHEN_VERSION_IS_HIGH:
+                assertTrue(remoteTask.getTaskInfo().getTaskStatus().getState().isDone(), format("TaskInfo is not in a done state: %s", remoteTask.getTaskInfo()));
+                assertEquals(actualErrorCode, REMOTE_TASK_MISMATCH.toErrorCode());
+                break;
+            case REJECTED_EXECUTION:
+                // for a rejection to occur, the http client must be shutdown, which means we will not be able to ge the final task info
+                assertEquals(actualErrorCode, REMOTE_TASK_ERROR.toErrorCode());
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    private RemoteTask createRemoteTask(HttpRemoteTaskFactory httpRemoteTaskFactory)
+    {
+        return httpRemoteTaskFactory.createRemoteTask(
+                TEST_SESSION,
+                new TaskId("test", 1, 0, 2, 0),
+                new InternalNode("node-id", URI.create("http://fake.invalid/"), new NodeVersion("version"), false),
+                createPlanFragment(),
+                ImmutableMultimap.of(),
+                createInitialEmptyOutputBuffers(OutputBuffers.BufferType.BROADCAST),
+                new NodeTaskMap.NodeStatsTracker(i -> {}, i -> {}, (age, i) -> {}),
+                true,
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                SchedulerStatsTracker.NOOP);
+    }
+
+    private static HttpRemoteTaskFactory createHttpRemoteTaskFactory(TestingTaskResource testingTaskResource, boolean useThriftEncoding)
+            throws Exception
+    {
+        InternalCommunicationConfig internalCommunicationConfig = new InternalCommunicationConfig().setThriftTransportEnabled(useThriftEncoding);
+        return createHttpRemoteTaskFactory(testingTaskResource, useThriftEncoding, internalCommunicationConfig);
+    }
+
+    private static HttpRemoteTaskFactory createHttpRemoteTaskFactory(TestingTaskResource testingTaskResource, boolean useThriftEncoding, InternalCommunicationConfig internalCommunicationConfig)
+            throws Exception
+    {
+        Bootstrap app = new Bootstrap(
+                new JsonModule(),
+                new SmileModule(),
+                new ThriftCodecModule(),
+                new HandleJsonModule(),
+                new Module()
+                {
+                    @Override
+                    public void configure(Binder binder)
+                    {
+                        binder.bind(JsonMapper.class);
+                        binder.bind(ThriftMapper.class);
+                        configBinder(binder).bindConfig(FeaturesConfig.class);
+                        FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+                        binder.bind(TypeManager.class).toInstance(functionAndTypeManager);
+                        jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+                        newSetBinder(binder, Type.class);
+                        smileCodecBinder(binder).bindSmileCodec(TaskStatus.class);
+                        smileCodecBinder(binder).bindSmileCodec(TaskInfo.class);
+                        smileCodecBinder(binder).bindSmileCodec(TaskUpdateRequest.class);
+                        smileCodecBinder(binder).bindSmileCodec(PlanFragment.class);
+                        smileCodecBinder(binder).bindSmileCodec(MetadataUpdates.class);
+                        jsonCodecBinder(binder).bindJsonCodec(TaskStatus.class);
+                        jsonCodecBinder(binder).bindJsonCodec(TaskInfo.class);
+                        jsonCodecBinder(binder).bindJsonCodec(TaskUpdateRequest.class);
+                        jsonCodecBinder(binder).bindJsonCodec(PlanFragment.class);
+                        jsonCodecBinder(binder).bindJsonCodec(MetadataUpdates.class);
+                        jsonBinder(binder).addKeySerializerBinding(VariableReferenceExpression.class).to(Serialization.VariableReferenceExpressionSerializer.class);
+                        jsonBinder(binder).addKeyDeserializerBinding(VariableReferenceExpression.class).to(Serialization.VariableReferenceExpressionDeserializer.class);
+                        thriftCodecBinder(binder).bindThriftCodec(TaskStatus.class);
+                        thriftCodecBinder(binder).bindThriftCodec(TaskInfo.class);
+                        thriftCodecBinder(binder).bindCustomThriftCodec(JodaDateTimeToEpochMillisThriftCodec.class);
+                        thriftCodecBinder(binder).bindCustomThriftCodec(DurationToMillisThriftCodec.class);
+                        thriftCodecBinder(binder).bindCustomThriftCodec(DataSizeToBytesThriftCodec.class);
+                    }
+
+                    @Provides
+                    private HttpRemoteTaskFactory createHttpRemoteTaskFactory(
+                            JsonMapper jsonMapper,
+                            ThriftMapper thriftMapper,
+                            JsonCodec<TaskStatus> taskStatusJsonCodec,
+                            SmileCodec<TaskStatus> taskStatusSmileCodec,
+                            ThriftCodec<TaskStatus> taskStatusThriftCodec,
+                            JsonCodec<TaskInfo> taskInfoJsonCodec,
+                            ThriftCodec<TaskInfo> taskInfoThriftCodec,
+                            SmileCodec<TaskInfo> taskInfoSmileCodec,
+                            JsonCodec<TaskUpdateRequest> taskUpdateRequestJsonCodec,
+                            SmileCodec<TaskUpdateRequest> taskUpdateRequestSmileCodec,
+                            JsonCodec<PlanFragment> planFragmentJsonCodec,
+                            SmileCodec<PlanFragment> planFragmentSmileCodec,
+                            JsonCodec<MetadataUpdates> metadataUpdatesJsonCodec,
+                            SmileCodec<MetadataUpdates> metadataUpdatesSmileCodec)
+                    {
+                        JaxrsTestingHttpProcessor jaxrsTestingHttpProcessor = new JaxrsTestingHttpProcessor(URI.create("http://fake.invalid/"), testingTaskResource, jsonMapper, thriftMapper);
+                        TestingHttpClient testingHttpClient = new TestingHttpClient(jaxrsTestingHttpProcessor.setTrace(TRACE_HTTP));
+                        testingTaskResource.setHttpClient(testingHttpClient);
+                        return new HttpRemoteTaskFactory(
+                                new QueryManagerConfig(),
+                                TASK_MANAGER_CONFIG,
+                                testingHttpClient,
+                                new TestSqlTaskManager.MockLocationFactory(),
+                                taskStatusJsonCodec,
+                                taskStatusSmileCodec,
+                                taskStatusThriftCodec,
+                                taskInfoJsonCodec,
+                                taskInfoSmileCodec,
+                                taskInfoThriftCodec,
+                                taskUpdateRequestJsonCodec,
+                                taskUpdateRequestSmileCodec,
+                                planFragmentJsonCodec,
+                                planFragmentSmileCodec,
+                                metadataUpdatesJsonCodec,
+                                metadataUpdatesSmileCodec,
+                                new RemoteTaskStats(),
+                                internalCommunicationConfig,
+                                createTestMetadataManager(),
+                                new TestQueryManager(),
+                                new HandleResolver(),
+                                new ConnectorTypeSerdeManager(new ConnectorMetadataUpdateHandleJsonSerde()));
+                    }
+                });
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+        HandleResolver handleResolver = injector.getInstance(HandleResolver.class);
+        handleResolver.addConnectorName("test", new TestingHandleResolver());
+        return injector.getInstance(HttpRemoteTaskFactory.class);
+    }
+
+    private static void poll(BooleanSupplier success)
+            throws InterruptedException
+    {
+        long failAt = System.nanoTime() + FAIL_TIMEOUT.roundTo(NANOSECONDS);
+
+        while (!success.getAsBoolean()) {
+            long millisUntilFail = (failAt - System.nanoTime()) / 1_000_000;
+            if (millisUntilFail <= 0) {
+                throw new AssertionError(format("Timeout of %s reached", FAIL_TIMEOUT));
+            }
+            Thread.sleep(min(POLL_TIMEOUT.toMillis(), millisUntilFail));
+        }
+    }
+
+    private static void waitUntilTaskFinish(RemoteTask task)
+            throws Exception
+    {
+        SettableFuture<?> taskFinished = SettableFuture.create();
+
+        task.addStateChangeListener(status -> {
+            if (status.getState().isDone()) {
+                taskFinished.set(null);
+            }
+        });
+        taskFinished.get();
+    }
+
+    private enum FailureScenario
+    {
+        NO_FAILURE,
+        TASK_MISMATCH,
+        TASK_MISMATCH_WHEN_VERSION_IS_HIGH,
+        REJECTED_EXECUTION,
+    }
+
+    @Path("/task/{nodeId}")
+    public static class TestingTaskResource
+    {
+        private static final UUID INITIAL_TASK_INSTANCE_ID = UUID.randomUUID();
+        private static final UUID NEW_TASK_INSTANCE_ID = UUID.randomUUID();
+
+        private final AtomicLong lastActivityNanos;
+        private final FailureScenario failureScenario;
+
+        private AtomicReference<TestingHttpClient> httpClient = new AtomicReference<>();
+
+        private TaskInfo initialTaskInfo;
+        private TaskStatus initialTaskStatus;
+        private long version;
+        private TaskState taskState;
+        private long taskInstanceIdLeastSignificantBits = INITIAL_TASK_INSTANCE_ID.getLeastSignificantBits();
+        private long taskInstanceIdMostSignificantBits = INITIAL_TASK_INSTANCE_ID.getMostSignificantBits();
+
+        private long statusFetchCounter;
+
+        public TestingTaskResource(AtomicLong lastActivityNanos, FailureScenario failureScenario)
+        {
+            this.lastActivityNanos = requireNonNull(lastActivityNanos, "lastActivityNanos is null");
+            this.failureScenario = requireNonNull(failureScenario, "failureScenario is null");
+        }
+
+        public void setHttpClient(TestingHttpClient newValue)
+        {
+            httpClient.set(newValue);
+        }
+
+        @GET
+        @Path("{taskId}")
+        @Produces(MediaType.APPLICATION_JSON)
+        public synchronized TaskInfo getTaskInfo(
+                @PathParam("taskId") final TaskId taskId,
+                @HeaderParam(PRESTO_CURRENT_STATE) TaskState currentState,
+                @HeaderParam(PRESTO_MAX_WAIT) Duration maxWait,
+                @Context UriInfo uriInfo)
+        {
+            lastActivityNanos.set(System.nanoTime());
+            return buildTaskInfo();
+        }
+
+        Map<PlanNodeId, TaskSource> taskSourceMap = new HashMap<>();
+
+        @POST
+        @Path("{taskId}")
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public synchronized TaskInfo createOrUpdateTask(
+                @PathParam("taskId") TaskId taskId,
+                TaskUpdateRequest taskUpdateRequest,
+                @Context UriInfo uriInfo)
+        {
+            for (TaskSource source : taskUpdateRequest.getSources()) {
+                taskSourceMap.compute(source.getPlanNodeId(), (planNodeId, taskSource) -> taskSource == null ? source : taskSource.update(source));
+            }
+            lastActivityNanos.set(System.nanoTime());
+            return buildTaskInfo();
+        }
+
+        public synchronized TaskSource getTaskSource(PlanNodeId planNodeId)
+        {
+            TaskSource source = taskSourceMap.get(planNodeId);
+            if (source == null) {
+                return null;
+            }
+            return new TaskSource(source.getPlanNodeId(), source.getSplits(), source.getNoMoreSplitsForLifespan(), source.isNoMoreSplits());
+        }
+
+        @GET
+        @Path("{taskId}/status")
+        @Produces({MediaType.APPLICATION_JSON, APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT})
+        public synchronized TaskStatus getTaskStatus(
+                @PathParam("taskId") TaskId taskId,
+                @HeaderParam(PRESTO_CURRENT_STATE) TaskState currentState,
+                @HeaderParam(PRESTO_MAX_WAIT) Duration maxWait,
+                @Context UriInfo uriInfo)
+                throws InterruptedException
+        {
+            lastActivityNanos.set(System.nanoTime());
+
+            wait(maxWait.roundTo(MILLISECONDS));
+            return buildTaskStatus();
+        }
+
+        @DELETE
+        @Path("{taskId}")
+        @Produces(MediaType.APPLICATION_JSON)
+        public synchronized TaskInfo deleteTask(
+                @PathParam("taskId") TaskId taskId,
+                @QueryParam("abort") @DefaultValue("true") boolean abort,
+                @Context UriInfo uriInfo)
+        {
+            lastActivityNanos.set(System.nanoTime());
+
+            taskState = abort ? TaskState.ABORTED : TaskState.CANCELED;
+            return buildTaskInfo();
+        }
+
+        public void setInitialTaskInfo(TaskInfo initialTaskInfo)
+        {
+            this.initialTaskInfo = initialTaskInfo;
+            this.initialTaskStatus = initialTaskInfo.getTaskStatus();
+            this.taskState = initialTaskStatus.getState();
+            this.version = initialTaskStatus.getVersion();
+            switch (failureScenario) {
+                case TASK_MISMATCH_WHEN_VERSION_IS_HIGH:
+                    // Make the initial version large enough.
+                    // This way, the version number can't be reached if it is reset to 0.
+                    version = 1_000_000;
+                    break;
+                case TASK_MISMATCH:
+                case REJECTED_EXECUTION:
+                case NO_FAILURE:
+                    break; // do nothing
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        private TaskInfo buildTaskInfo()
+        {
+            return new TaskInfo(
+                    initialTaskInfo.getTaskId(),
+                    buildTaskStatus(),
+                    initialTaskInfo.getLastHeartbeat(),
+                    initialTaskInfo.getOutputBuffers(),
+                    initialTaskInfo.getNoMoreSplits(),
+                    initialTaskInfo.getStats(),
+                    initialTaskInfo.isNeedsPlan(),
+                    initialTaskInfo.getMetadataUpdates(),
+                    initialTaskInfo.getNodeId());
+        }
+
+        private TaskStatus buildTaskStatus()
+        {
+            statusFetchCounter++;
+            // Change the task instance id after 10th fetch to simulate worker restart
+            switch (failureScenario) {
+                case TASK_MISMATCH:
+                case TASK_MISMATCH_WHEN_VERSION_IS_HIGH:
+                    if (statusFetchCounter == 10) {
+                        taskInstanceIdLeastSignificantBits = NEW_TASK_INSTANCE_ID.getLeastSignificantBits();
+                        taskInstanceIdMostSignificantBits = NEW_TASK_INSTANCE_ID.getMostSignificantBits();
+                        version = 0;
+                    }
+                    break;
+                case REJECTED_EXECUTION:
+                    if (statusFetchCounter >= 10) {
+                        httpClient.get().close();
+                        throw new RejectedExecutionException();
+                    }
+                    break;
+                case NO_FAILURE:
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+
+            return new TaskStatus(
+                    taskInstanceIdLeastSignificantBits,
+                    taskInstanceIdMostSignificantBits,
+                    ++version,
+                    taskState,
+                    initialTaskStatus.getSelf(),
+                    ImmutableSet.of(),
+                    initialTaskStatus.getFailures(),
+                    initialTaskStatus.getQueuedPartitionedDrivers(),
+                    initialTaskStatus.getRunningPartitionedDrivers(),
+                    initialTaskStatus.getOutputBufferUtilization(),
+                    initialTaskStatus.isOutputBufferOverutilized(),
+                    initialTaskStatus.getPhysicalWrittenDataSizeInBytes(),
+                    initialTaskStatus.getMemoryReservationInBytes(),
+                    initialTaskStatus.getSystemMemoryReservationInBytes(),
+                    initialTaskStatus.getPeakNodeTotalMemoryReservationInBytes(),
+                    initialTaskStatus.getFullGcCount(),
+                    initialTaskStatus.getFullGcTimeInMillis(),
+                    initialTaskStatus.getTotalCpuTimeInNanos(),
+                    initialTaskStatus.getTaskAgeInMillis(),
+                    initialTaskStatus.getQueuedPartitionedSplitsWeight(),
+                    initialTaskStatus.getRunningPartitionedSplitsWeight());
+        }
+    }
+}


### PR DESCRIPTION
## Description
1. This pr proposed to bring back event loop implementation for HttpRemoteTask.java but have it behind a feature toggle. Huge thanks to @arhimondr on his comments here https://github.com/prestodb/presto/pull/24548#issuecomment-2671515802
 
2. This pr basically bring back the following two prs: #24288 and #24412 

## Motivation and Context
1. we saw a big number of tasks were created for certain queries which causes contention on the underlying synchronous queue
2. this pr proposed to use a event loop to run task's method so that multiple tasks can be assigned to the same event loop and a task's method will be executed on the same thread
4. some methods within http remote task does not need the "synchronized" keywords if we are certain they will be executed in the same thread.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. Running the verifier tests on two cluster with different config
2. Confirmed that the config can be used to enable/disable the event loop for clusters
 
Two different clusters have different config
<img width="1107" alt="Screenshot 2025-03-03 at 17 56 38" src="https://github.com/user-attachments/assets/ed352187-302b-478f-bc82-87d5a8c92703" />

For the one with event loop enabled
<img width="1465" alt="Screenshot 2025-03-03 at 18 05 53" src="https://github.com/user-attachments/assets/4bb241ed-21bf-436f-a9f5-aef9c8bf4a56" />

for the one without event loop
<img width="1465" alt="Screenshot 2025-03-03 at 18 07 16" src="https://github.com/user-attachments/assets/7329a82c-dc6d-4925-a16c-466cb8823b36" />
And both pass the verifier runs:
https://www.internalfb.com/intern/presto/verifier/results/?test_id=212715
https://www.internalfb.com/intern/presto/verifier/results/?test_id=212714


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
General Changes
* Improve efficiency of coordinator when running a large number of tasks by adding a toggle-controlled event loop implementation for HttpRemoteTask.java.
```

