### PR TITLE
Add compression codec support for PageSerde

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -388,13 +388,14 @@ Limit for memory used for unspilling a single aggregation operator instance.
 
 The corresponding session property is :ref:`admin/properties-session:\`\`aggregation_operator_unspill_memory_limit\`\``. 
 
-``experimental.spill-compression-enabled``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``experimental.spill-compression-codec``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* **Type:** ``boolean``
-* **Default value:** ``false``
+* **Type:** ``string``
+* **Allowed value:** ``NONE``, ``LZ4``
+* **Default value:** ``NONE``
 
-Enables data compression for pages spilled to disk.
+The data compression codec to be used for pages spilled to disk.
 
 ``experimental.spill-encryption-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -392,7 +392,7 @@ The corresponding session property is :ref:`admin/properties-session:\`\`aggrega
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``string``
-* **Allowed value:** ``NONE``, ``LZ4``
+* **Allowed value:** ``SNAPPY``, ``NONE``, ``GZIP``, ``LZ4``, ``LZO``,, ``ZLIB`` ``ZSTD``
 * **Default value:** ``NONE``
 
 The data compression codec to be used for pages spilled to disk.

--- a/presto-docs/src/main/sphinx/admin/spill.rst
+++ b/presto-docs/src/main/sphinx/admin/spill.rst
@@ -93,10 +93,10 @@ there is no need to use RAID for spill.
 Spill Compression
 -----------------
 
-When spill compression is enabled (``spill-compression-enabled`` property in
-:ref:`tuning-spilling`), spilled pages will be compressed using the same
-implementation as exchange compression when they are sufficiently compressible.
-Enabling this feature can reduce the amount of disk IO at the cost
+When :ref:`admin/properties:\`\`experimental.spill-compression-codec\`\`` is 
+configured, spilled pages are compressed using 
+the configured codec implementation when they are sufficiently compressible.
+This feature can reduce the amount of disk IO at the cost
 of extra CPU load to compress and decompress spilled pages.
 
 Spill Encryption

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
@@ -302,7 +302,7 @@ public class TestJdbcConnection
         try (Connection connection = createConnection("sessionProperties=query_max_run_time:2d;max_failed_task_percentage:0.6")) {
             assertThat(listSession(connection))
                     .contains("join_distribution_type|AUTOMATIC|AUTOMATIC")
-                    .contains("exchange_compression|false|false")
+                    .contains("exchange_compression_codec|NONE|NONE")
                     .contains("query_max_run_time|2d|100.00d")
                     .contains("max_failed_task_percentage|0.6|0.3");
 
@@ -312,15 +312,15 @@ public class TestJdbcConnection
 
             assertThat(listSession(connection))
                     .contains("join_distribution_type|BROADCAST|AUTOMATIC")
-                    .contains("exchange_compression|false|false");
+                    .contains("exchange_compression_codec|NONE|NONE");
 
             try (Statement statement = connection.createStatement()) {
-                statement.execute("SET SESSION exchange_compression = true");
+                statement.execute("SET SESSION exchange_compression_codec = 'LZ4'");
             }
 
             assertThat(listSession(connection))
                     .contains("join_distribution_type|BROADCAST|AUTOMATIC")
-                    .contains("exchange_compression|true|false");
+                    .contains("exchange_compression_codec|LZ4|NONE");
         }
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/CompressionCodec.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/CompressionCodec.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+public enum CompressionCodec {
+    LZ4, NONE
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/CompressionCodec.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/CompressionCodec.java
@@ -14,5 +14,5 @@
 package com.facebook.presto;
 
 public enum CompressionCodec {
-    LZ4, NONE
+    GZIP, LZ4, LZO, SNAPPY, ZLIB, ZSTD, NONE
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -160,7 +160,7 @@ public final class SystemSessionProperties
     public static final String ITERATIVE_OPTIMIZER_TIMEOUT = "iterative_optimizer_timeout";
     public static final String QUERY_ANALYZER_TIMEOUT = "query_analyzer_timeout";
     public static final String RUNTIME_OPTIMIZER_ENABLED = "runtime_optimizer_enabled";
-    public static final String EXCHANGE_COMPRESSION = "exchange_compression";
+    public static final String EXCHANGE_COMPRESSION_CODEC = "exchange_compression_codec";
     public static final String EXCHANGE_CHECKSUM = "exchange_checksum";
     public static final String LEGACY_TIMESTAMP = "legacy_timestamp";
     public static final String ENABLE_INTERMEDIATE_AGGREGATIONS = "enable_intermediate_aggregations";
@@ -840,11 +840,15 @@ public final class SystemSessionProperties
                         "Experimental: enable runtime optimizer",
                         featuresConfig.isRuntimeOptimizerEnabled(),
                         false),
-                booleanProperty(
-                        EXCHANGE_COMPRESSION,
-                        "Enable compression in exchanges",
-                        featuresConfig.isExchangeCompressionEnabled(),
-                        false),
+                new PropertyMetadata<>(
+                        EXCHANGE_COMPRESSION_CODEC,
+                        "Exchange compression codec",
+                        VARCHAR,
+                        CompressionCodec.class,
+                        featuresConfig.getExchangeCompressionCodec(),
+                        false,
+                        value -> CompressionCodec.valueOf(((String) value).toUpperCase()),
+                        CompressionCodec::name),
                 booleanProperty(
                         EXCHANGE_CHECKSUM,
                         "Enable checksum in exchanges",
@@ -2291,9 +2295,9 @@ public final class SystemSessionProperties
         return session.getSystemProperty(QUERY_ANALYZER_TIMEOUT, Duration.class);
     }
 
-    public static boolean isExchangeCompressionEnabled(Session session)
+    public static CompressionCodec getExchangeCompressionCodec(Session session)
     {
-        return session.getSystemProperty(EXCHANGE_COMPRESSION, Boolean.class);
+        return session.getSystemProperty(EXCHANGE_COMPRESSION_CODEC, CompressionCodec.class);
     }
 
     public static boolean isExchangeChecksumEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/AirliftCompressorAdapter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/AirliftCompressorAdapter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import com.facebook.presto.spi.page.PageCompressor;
+import io.airlift.compress.Compressor;
+
+import java.nio.ByteBuffer;
+
+import static java.util.Objects.requireNonNull;
+
+public class AirliftCompressorAdapter
+        implements PageCompressor
+{
+    private final Compressor compressor;
+
+    public AirliftCompressorAdapter(Compressor compressor)
+    {
+        this.compressor = requireNonNull(compressor, "compressor is null");
+    }
+
+    @Override
+    public int maxCompressedLength(int uncompressedSize)
+    {
+        return compressor.maxCompressedLength(uncompressedSize);
+    }
+
+    @Override
+    public int compress(
+            byte[] input,
+            int inputOffset,
+            int inputLength,
+            byte[] output,
+            int outputOffset,
+            int maxOutputLength)
+    {
+        return compressor.compress(input, inputOffset, inputLength, output, outputOffset, maxOutputLength);
+    }
+
+    @Override
+    public void compress(ByteBuffer input, ByteBuffer output)
+    {
+        compressor.compress(input, output);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/AirliftDecompressorAdapter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/AirliftDecompressorAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import com.facebook.presto.spi.page.PageDecompressor;
+import io.airlift.compress.Decompressor;
+
+import java.nio.ByteBuffer;
+
+import static java.util.Objects.requireNonNull;
+
+public class AirliftDecompressorAdapter
+        implements PageDecompressor
+{
+    private final Decompressor decompressor;
+
+    public AirliftDecompressorAdapter(Decompressor decompressor)
+    {
+        this.decompressor = requireNonNull(decompressor, "decompressor is null");
+    }
+
+    @Override
+    public int decompress(
+            byte[] input,
+            int inputOffset,
+            int inputLength,
+            byte[] output,
+            int outputOffset,
+            int maxOutputLength)
+    {
+        return decompressor.decompress(input, inputOffset, inputLength, output, outputOffset, maxOutputLength);
+    }
+
+    @Override
+    public void decompress(ByteBuffer input, ByteBuffer output)
+    {
+        decompressor.decompress(input, output);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/GzipCompressor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/GzipCompressor.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import io.airlift.compress.Compressor;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.zip.GZIPOutputStream;
+
+public class GzipCompressor
+        implements Compressor
+{
+    private static final int EXTRA_COMPRESSION_SPACE = 16;
+
+    @Override
+    public int maxCompressedLength(int uncompressedSize)
+    {
+        // From Mark Adler's post http://stackoverflow.com/questions/1207877/java-size-of-compression-output-bytearray
+        return uncompressedSize + ((uncompressedSize + 7) >> 3) + ((uncompressedSize + 63) >> 6) + 5 + EXTRA_COMPRESSION_SPACE;
+    }
+
+    @Override
+    public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+    {
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream)) {
+            gzipOutputStream.write(input, inputOffset, inputLength);
+            gzipOutputStream.finish();
+            byte[] compressed = byteArrayOutputStream.toByteArray();
+            if (compressed.length > maxOutputLength) {
+                throw new IllegalArgumentException("maxCompressedLength formula is incorrect, because gzip produced more data");
+            }
+            System.arraycopy(compressed, 0, output, outputOffset, compressed.length);
+            return compressed.length;
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void compress(ByteBuffer input, ByteBuffer output)
+    {
+        if (input.isDirect() || output.isDirect() || !input.hasArray() || !output.hasArray()) {
+            throw new IllegalArgumentException("Non-direct byte buffer backed by byte array required");
+        }
+        int inputOffset = input.arrayOffset() + input.position();
+        int outputOffset = output.arrayOffset() + output.position();
+
+        int written = compress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
+        ((Buffer) output).position(output.position() + written);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/GzipDecompressor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/GzipDecompressor.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import io.airlift.compress.Decompressor;
+import io.airlift.compress.MalformedInputException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.zip.GZIPInputStream;
+
+public class GzipDecompressor
+        implements Decompressor
+{
+    @Override
+    public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength) throws MalformedInputException
+    {
+        try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(input, inputOffset, inputLength);
+                GZIPInputStream gzipInputStream = new GZIPInputStream(byteArrayInputStream)) {
+            int totalRead = 0;
+            int bytesRead;
+            while (totalRead < maxOutputLength) {
+                bytesRead = gzipInputStream.read(output, outputOffset + totalRead, maxOutputLength - totalRead);
+                if (bytesRead == -1) {
+                    break;
+                }
+                totalRead += bytesRead;
+            }
+            if (totalRead >= maxOutputLength && gzipInputStream.read() != -1) {
+                throw new IllegalArgumentException("maxOutputLength is incorrect, there is more data to be decompressed");
+            }
+            return totalRead;
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void decompress(ByteBuffer input, ByteBuffer output) throws MalformedInputException
+    {
+        int inputOffset = input.arrayOffset() + input.position();
+        int outputOffset = output.arrayOffset() + output.position();
+        int written = decompress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
+        ((Buffer) output).position(output.position() + written);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/PagesSerdeFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/PagesSerdeFactory.java
@@ -21,8 +21,15 @@ import com.facebook.presto.spi.page.PagesSerde;
 import com.facebook.presto.spi.spiller.SpillCipher;
 import io.airlift.compress.lz4.Lz4Compressor;
 import io.airlift.compress.lz4.Lz4Decompressor;
+import io.airlift.compress.lzo.LzoCompressor;
+import io.airlift.compress.lzo.LzoDecompressor;
+import io.airlift.compress.snappy.SnappyCompressor;
+import io.airlift.compress.snappy.SnappyDecompressor;
+import io.airlift.compress.zstd.ZstdCompressor;
+import io.airlift.compress.zstd.ZstdDecompressor;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static java.util.Objects.requireNonNull;
 
@@ -62,8 +69,18 @@ public class PagesSerdeFactory
     private Optional<PageCompressor> getPageCompressor()
     {
         switch (compressionCodec) {
+            case GZIP:
+                return Optional.of(new AirliftCompressorAdapter(new GzipCompressor()));
             case LZ4:
                 return Optional.of(new AirliftCompressorAdapter(new Lz4Compressor()));
+            case LZO:
+                return Optional.of(new AirliftCompressorAdapter(new LzoCompressor()));
+            case SNAPPY:
+                return Optional.of(new AirliftCompressorAdapter(new SnappyCompressor()));
+            case ZLIB:
+                return Optional.of(new AirliftCompressorAdapter(new ZlibCompressor(OptionalInt.empty())));
+            case ZSTD:
+                return Optional.of(new AirliftCompressorAdapter(new ZstdCompressor()));
             case NONE:
             default:
                 return Optional.empty();
@@ -73,8 +90,18 @@ public class PagesSerdeFactory
     private Optional<PageDecompressor> getPageDecompressor()
     {
         switch (compressionCodec) {
+            case GZIP:
+                return Optional.of(new AirliftDecompressorAdapter(new GzipDecompressor()));
             case LZ4:
                 return Optional.of(new AirliftDecompressorAdapter(new Lz4Decompressor()));
+            case LZO:
+                return Optional.of(new AirliftDecompressorAdapter(new LzoDecompressor()));
+            case SNAPPY:
+                return Optional.of(new AirliftDecompressorAdapter(new SnappyDecompressor()));
+            case ZLIB:
+                return Optional.of(new AirliftDecompressorAdapter(new ZlibDecompressor()));
+            case ZSTD:
+                return Optional.of(new AirliftDecompressorAdapter(new ZstdDecompressor()));
             case NONE:
             default:
                 return Optional.empty();

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/ZlibCompressor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/ZlibCompressor.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import io.airlift.compress.Compressor;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.OptionalInt;
+import java.util.zip.Deflater;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.zip.Deflater.FULL_FLUSH;
+
+public class ZlibCompressor
+        implements Compressor
+{
+    private static final int EXTRA_COMPRESSION_SPACE = 16;
+    private static final int DEFAULT_COMPRESSION_LEVEL = 4;
+
+    private final int compressionLevel;
+
+    public ZlibCompressor(OptionalInt compressionLevel)
+    {
+        requireNonNull(compressionLevel, "compressionLevel is null");
+        this.compressionLevel = compressionLevel.orElse(DEFAULT_COMPRESSION_LEVEL);
+    }
+
+    @Override
+    public int maxCompressedLength(int uncompressedSize)
+    {
+        // From Mark Adler's post http://stackoverflow.com/questions/1207877/java-size-of-compression-output-bytearray
+        return uncompressedSize + ((uncompressedSize + 7) >> 3) + ((uncompressedSize + 63) >> 6) + 5 + EXTRA_COMPRESSION_SPACE;
+    }
+
+    @Override
+    public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+    {
+        int maxCompressedLength = maxCompressedLength(inputLength);
+        if (maxOutputLength < maxCompressedLength) {
+            throw new IllegalArgumentException("Output buffer must be at least " + maxCompressedLength + " bytes");
+        }
+
+        Deflater deflater = new Deflater(compressionLevel, false);
+        try {
+            deflater.setInput(input, inputOffset, inputLength);
+            deflater.finish();
+
+            int compressedDataLength = deflater.deflate(output, outputOffset, maxOutputLength, FULL_FLUSH);
+            if (!deflater.finished()) {
+                throw new IllegalArgumentException("maxCompressedLength formula is incorrect, because deflate produced more data");
+            }
+            return compressedDataLength;
+        }
+        finally {
+            deflater.end();
+        }
+    }
+
+    @Override
+    public void compress(ByteBuffer input, ByteBuffer output)
+    {
+        if (input.isDirect() || output.isDirect() || !input.hasArray() || !output.hasArray()) {
+            throw new IllegalArgumentException("Non-direct byte buffer backed by byte array required");
+        }
+        int inputOffset = input.arrayOffset() + input.position();
+        int outputOffset = output.arrayOffset() + output.position();
+
+        int written = compress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
+        ((Buffer) output).position(output.position() + written);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/ZlibDecompressor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/buffer/ZlibDecompressor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import io.airlift.compress.Decompressor;
+import io.airlift.compress.MalformedInputException;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+
+public class ZlibDecompressor
+        implements Decompressor
+{
+    @Override
+    public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            throws MalformedInputException
+    {
+        Inflater inflater = new Inflater(false);
+        inflater.setInput(input, inputOffset, inputLength);
+        int uncompressedLength = 0;
+        try {
+            uncompressedLength = inflater.inflate(output, outputOffset, maxOutputLength);
+            if (!inflater.finished()) {
+                throw new IllegalArgumentException("maxOutputLength is incorrect, there is more data to be decompressed");
+            }
+        }
+        catch (DataFormatException e) {
+            throw new MalformedInputException(inputOffset, e.getMessage());
+        }
+        finally {
+            inflater.end();
+        }
+        return uncompressedLength;
+    }
+
+    @Override
+    public void decompress(ByteBuffer input, ByteBuffer output)
+            throws MalformedInputException
+    {
+        if (input.isDirect() || output.isDirect() || !input.hasArray() || !output.hasArray()) {
+            throw new IllegalArgumentException("Non-direct byte buffer backed by byte array required");
+        }
+        int inputOffset = input.arrayOffset() + input.position();
+        int outputOffset = output.arrayOffset() + output.position();
+
+        int written = decompress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
+        ((Buffer) output).position(output.position() + written);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.presto.CompressionCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDataSize;
@@ -32,7 +33,7 @@ public class FileFragmentResultCacheConfig
 {
     private boolean cachingEnabled;
     private URI baseDirectory;
-    private boolean blockEncodingCompressionEnabled;
+    private CompressionCodec blockEncodingCompressionCodec = CompressionCodec.NONE;
 
     private int maxCachedEntries = 10_000;
     private Duration cacheTtl = new Duration(2, DAYS);
@@ -68,16 +69,16 @@ public class FileFragmentResultCacheConfig
         return this;
     }
 
-    public boolean isBlockEncodingCompressionEnabled()
+    public CompressionCodec getBlockEncodingCompressionCodec()
     {
-        return blockEncodingCompressionEnabled;
+        return blockEncodingCompressionCodec;
     }
 
-    @Config("fragment-result-cache.block-encoding-compression-enabled")
-    @ConfigDescription("Enable compression for block encoding")
-    public FileFragmentResultCacheConfig setBlockEncodingCompressionEnabled(boolean blockEncodingCompressionEnabled)
+    @Config("fragment-result-cache.block-encoding-compression-codec")
+    @ConfigDescription("Compression codec for block encoding")
+    public FileFragmentResultCacheConfig setBlockEncodingCompressionCodec(CompressionCodec blockEncodingCompressionCodec)
     {
-        this.blockEncodingCompressionEnabled = blockEncodingCompressionEnabled;
+        this.blockEncodingCompressionCodec = blockEncodingCompressionCodec;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheManager.java
@@ -96,7 +96,7 @@ public class FileFragmentResultCacheManager
         this.maxSinglePagesBytes = cacheConfig.getMaxSinglePagesSize().toBytes();
         this.maxCacheBytes = cacheConfig.getMaxCacheSize().toBytes();
         // pagesSerde is not thread safe
-        this.pagesSerdeFactory = new PagesSerdeFactory(blockEncodingSerde, cacheConfig.isBlockEncodingCompressionEnabled());
+        this.pagesSerdeFactory = new PagesSerdeFactory(blockEncodingSerde, cacheConfig.getBlockEncodingCompressionCodec());
         this.fragmentCacheStats = requireNonNull(fragmentCacheStats, "fragmentCacheStats is null");
         this.flushExecutor = requireNonNull(flushExecutor, "flushExecutor is null");
         this.removalExecutor = requireNonNull(removalExecutor, "removalExecutor is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -75,11 +75,11 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.airlift.concurrent.MoreFutures.addTimeout;
+import static com.facebook.presto.SystemSessionProperties.getExchangeCompressionCodec;
 import static com.facebook.presto.SystemSessionProperties.getQueryRetryLimit;
 import static com.facebook.presto.SystemSessionProperties.getQueryRetryMaxExecutionTime;
 import static com.facebook.presto.SystemSessionProperties.getTargetResultSize;
 import static com.facebook.presto.SystemSessionProperties.isExchangeChecksumEnabled;
-import static com.facebook.presto.SystemSessionProperties.isExchangeCompressionEnabled;
 import static com.facebook.presto.SystemSessionProperties.retryQueryWithHistoryBasedOptimizationEnabled;
 import static com.facebook.presto.SystemSessionProperties.trackHistoryBasedPlanStatisticsEnabled;
 import static com.facebook.presto.SystemSessionProperties.useHistoryBasedPlanStatisticsEnabled;
@@ -231,7 +231,7 @@ class Query
         this.resultsProcessorExecutor = resultsProcessorExecutor;
         this.timeoutExecutor = timeoutExecutor;
 
-        this.serde = new PagesSerdeFactory(blockEncodingSerde, isExchangeCompressionEnabled(session), isExchangeChecksumEnabled(session)).createPagesSerde();
+        this.serde = new PagesSerdeFactory(blockEncodingSerde, getExchangeCompressionCodec(session), isExchangeChecksumEnabled(session)).createPagesSerde();
         this.retryCircuitBreaker = retryCircuitBreaker;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpillerFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpillerFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spiller;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.buffer.PagesSerdeFactory;
@@ -79,7 +80,7 @@ public class FileSingleStreamSpillerFactory
                 spillerStats,
                 requireNonNull(featuresConfig, "featuresConfig is null").getSpillerSpillPaths(),
                 requireNonNull(featuresConfig, "featuresConfig is null").getSpillMaxUsedSpaceThreshold(),
-                requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").isSpillCompressionEnabled(),
+                requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").getSpillCompressionCodec(),
                 requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").isSpillEncryptionEnabled());
     }
 
@@ -90,10 +91,10 @@ public class FileSingleStreamSpillerFactory
             SpillerStats spillerStats,
             List<Path> spillPaths,
             double maxUsedSpaceThreshold,
-            boolean spillCompressionEnabled,
+            CompressionCodec spillCompressionCodec,
             boolean spillEncryptionEnabled)
     {
-        this.serdeFactory = new PagesSerdeFactory(requireNonNull(blockEncodingSerde, "blockEncodingSerde is null"), spillCompressionEnabled);
+        this.serdeFactory = new PagesSerdeFactory(requireNonNull(blockEncodingSerde, "blockEncodingSerde is null"), spillCompressionCodec);
         this.executor = requireNonNull(executor, "executor is null");
         this.spillerStats = requireNonNull(spillerStats, "spillerStats can not be null");
         requireNonNull(spillPaths, "spillPaths is null");

--- a/presto-main-base/src/main/java/com/facebook/presto/spiller/NodeSpillConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/spiller/NodeSpillConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spiller;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.presto.CompressionCodec;
 import io.airlift.units.DataSize;
 
 import javax.validation.constraints.NotNull;
@@ -25,7 +26,7 @@ public class NodeSpillConfig
     private DataSize queryMaxSpillPerNode = new DataSize(100, DataSize.Unit.GIGABYTE);
     private DataSize tempStorageBufferSize = new DataSize(4, DataSize.Unit.KILOBYTE);
 
-    private boolean spillCompressionEnabled;
+    private CompressionCodec spillCompressionCodec = CompressionCodec.NONE;
     private boolean spillEncryptionEnabled;
 
     @NotNull
@@ -67,15 +68,15 @@ public class NodeSpillConfig
         return this;
     }
 
-    public boolean isSpillCompressionEnabled()
+    public CompressionCodec getSpillCompressionCodec()
     {
-        return spillCompressionEnabled;
+        return spillCompressionCodec;
     }
 
-    @Config("experimental.spill-compression-enabled")
-    public NodeSpillConfig setSpillCompressionEnabled(boolean spillCompressionEnabled)
+    @Config("experimental.spill-compression-codec")
+    public NodeSpillConfig setSpillCompressionCodec(CompressionCodec spillCompressionCodec)
     {
-        this.spillCompressionEnabled = spillCompressionEnabled;
+        this.spillCompressionCodec = spillCompressionCodec;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpillerFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpillerFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spiller;
 
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.buffer.PagesSerdeFactory;
@@ -61,7 +62,7 @@ public class TempStorageSingleStreamSpillerFactory
                         daemonThreadsNamed("binary-spiller-%s"))),
                 blockEncodingSerde,
                 spillerStats,
-                requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").isSpillCompressionEnabled(),
+                requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").getSpillCompressionCodec(),
                 requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").isSpillEncryptionEnabled(),
                 requireNonNull(featuresConfig, "featuresConfig is null").getSpillerTempStorage());
     }
@@ -72,7 +73,7 @@ public class TempStorageSingleStreamSpillerFactory
             ListeningExecutorService executor,
             BlockEncodingSerde blockEncodingSerde,
             SpillerStats spillerStats,
-            boolean spillCompressionEnabled,
+            CompressionCodec spillCompressionEnabled,
             boolean spillEncryptionEnabled,
             String tempStorageName)
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/spiller/TempStorageStandaloneSpillerFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/spiller/TempStorageStandaloneSpillerFactory.java
@@ -48,7 +48,7 @@ public class TempStorageStandaloneSpillerFactory
         this.tempStorageManager = requireNonNull(tempStorageManager, "tempStorageManager is null");
         requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         requireNonNull(nodeSpillConfig, "nodeSpillConfig is null");
-        this.serdeFactory = new PagesSerdeFactory(blockEncodingSerde, nodeSpillConfig.isSpillCompressionEnabled());
+        this.serdeFactory = new PagesSerdeFactory(blockEncodingSerde, nodeSpillConfig.getSpillCompressionCodec());
         this.tempStorageName = requireNonNull(featuresConfig, "featuresConfig is null").getSpillerTempStorage();
         this.spillerStats = requireNonNull(spillerStats, "spillerStats can not be null");
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.airlift.configuration.DefunctConfig;
 import com.facebook.airlift.configuration.LegacyConfig;
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.sql.tree.CreateView;
@@ -116,7 +117,7 @@ public class FeaturesConfig
     private boolean enableIntermediateAggregations;
     private boolean optimizeCaseExpressionPredicate;
     private boolean pushTableWriteThroughUnion = true;
-    private boolean exchangeCompressionEnabled;
+    private CompressionCodec exchangeCompressionCodec = CompressionCodec.NONE;
     private boolean exchangeChecksumEnabled;
     private boolean optimizeMixedDistinctAggregations;
     private boolean forceSingleNodeOutput = true;
@@ -1490,9 +1491,9 @@ public class FeaturesConfig
         return this;
     }
 
-    public boolean isExchangeCompressionEnabled()
+    public CompressionCodec getExchangeCompressionCodec()
     {
-        return exchangeCompressionEnabled;
+        return exchangeCompressionCodec;
     }
 
     public boolean isExchangeChecksumEnabled()
@@ -1500,10 +1501,10 @@ public class FeaturesConfig
         return exchangeChecksumEnabled;
     }
 
-    @Config("exchange.compression-enabled")
-    public FeaturesConfig setExchangeCompressionEnabled(boolean exchangeCompressionEnabled)
+    @Config("exchange.compression-codec")
+    public FeaturesConfig setExchangeCompressionCodec(CompressionCodec exchangeCompressionCodec)
     {
-        this.exchangeCompressionEnabled = exchangeCompressionEnabled;
+        this.exchangeCompressionCodec = exchangeCompressionCodec;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/HttpRemoteSourceFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/HttpRemoteSourceFactory.java
@@ -27,8 +27,8 @@ import com.facebook.presto.sql.gen.OrderingCompiler;
 
 import java.util.List;
 
+import static com.facebook.presto.SystemSessionProperties.getExchangeCompressionCodec;
 import static com.facebook.presto.SystemSessionProperties.isExchangeChecksumEnabled;
-import static com.facebook.presto.SystemSessionProperties.isExchangeCompressionEnabled;
 import static java.util.Objects.requireNonNull;
 
 public class HttpRemoteSourceFactory
@@ -52,7 +52,7 @@ public class HttpRemoteSourceFactory
                 operatorId,
                 planNodeId,
                 taskExchangeClientManager,
-                new PagesSerdeFactory(blockEncodingSerde, isExchangeCompressionEnabled(session), isExchangeChecksumEnabled(session)));
+                new PagesSerdeFactory(blockEncodingSerde, getExchangeCompressionCodec(session), isExchangeChecksumEnabled(session)));
     }
 
     @Override
@@ -69,7 +69,7 @@ public class HttpRemoteSourceFactory
                 operatorId,
                 planNodeId,
                 taskExchangeClientManager,
-                new PagesSerdeFactory(blockEncodingSerde, isExchangeCompressionEnabled(session), isExchangeChecksumEnabled(session)),
+                new PagesSerdeFactory(blockEncodingSerde, getExchangeCompressionCodec(session), isExchangeChecksumEnabled(session)),
                 orderingCompiler,
                 types,
                 outputChannels,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -260,6 +260,7 @@ import static com.facebook.presto.SystemSessionProperties.getAdaptivePartialAggr
 import static com.facebook.presto.SystemSessionProperties.getDynamicFilteringMaxPerDriverRowCount;
 import static com.facebook.presto.SystemSessionProperties.getDynamicFilteringMaxPerDriverSize;
 import static com.facebook.presto.SystemSessionProperties.getDynamicFilteringRangeRowLimitPerDriver;
+import static com.facebook.presto.SystemSessionProperties.getExchangeCompressionCodec;
 import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMinOutputPageRowCount;
 import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMinOutputPageSize;
 import static com.facebook.presto.SystemSessionProperties.getIndexLoaderTimeout;
@@ -269,7 +270,6 @@ import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
 import static com.facebook.presto.SystemSessionProperties.isAdaptivePartialAggregationEnabled;
 import static com.facebook.presto.SystemSessionProperties.isEnableDynamicFiltering;
 import static com.facebook.presto.SystemSessionProperties.isExchangeChecksumEnabled;
-import static com.facebook.presto.SystemSessionProperties.isExchangeCompressionEnabled;
 import static com.facebook.presto.SystemSessionProperties.isJoinSpillingEnabled;
 import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.SystemSessionProperties.isOptimizeCommonSubExpressions;
@@ -641,7 +641,7 @@ public class LocalExecutionPlanner
                                 outputTypes,
                                 pagePreprocessor,
                                 outputPartitioning,
-                                new PagesSerdeFactory(blockEncodingSerde, isExchangeCompressionEnabled(session), isExchangeChecksumEnabled(session))))
+                                new PagesSerdeFactory(blockEncodingSerde, getExchangeCompressionCodec(session), isExchangeChecksumEnabled(session))))
                         .build(),
                 context.getDriverInstanceCount(),
                 physicalOperation.getPipelineExecutionStrategy(),

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.airlift.stats.TestingGcMonitor;
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.type.Type;
@@ -165,7 +166,7 @@ public class TestSqlTaskExecution
                     TABLE_SCAN_NODE_ID,
                     outputBuffer,
                     Function.identity(),
-                    new PagesSerdeFactory(new BlockEncodingManager(), false));
+                    new PagesSerdeFactory(new BlockEncodingManager(), CompressionCodec.NONE));
             LocalExecutionPlan localExecutionPlan = new LocalExecutionPlan(
                     ImmutableList.of(new DriverFactory(
                             0,
@@ -395,7 +396,7 @@ public class TestSqlTaskExecution
                     joinCNodeId,
                     outputBuffer,
                     Function.identity(),
-                    new PagesSerdeFactory(new BlockEncodingManager(), false));
+                    new PagesSerdeFactory(new BlockEncodingManager(), CompressionCodec.NONE));
             TestingCrossJoinOperatorFactory joinOperatorFactoryA = new TestingCrossJoinOperatorFactory(2, joinANodeId, buildStatesA);
             TestingCrossJoinOperatorFactory joinOperatorFactoryB = new TestingCrossJoinOperatorFactory(102, joinBNodeId, buildStatesB);
             TestingCrossJoinOperatorFactory joinOperatorFactoryC = new TestingCrossJoinOperatorFactory(3, joinCNodeId, buildStatesC);

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution.buffer;
 
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
@@ -21,6 +22,7 @@ import com.facebook.presto.spi.page.PagesSerde;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Iterator;
@@ -39,10 +41,19 @@ import static org.testng.Assert.assertTrue;
 
 public class TestPagesSerde
 {
-    @Test
-    public void testRoundTrip()
+    @DataProvider(name = "testCompressionCodec")
+    public Object[][] createTestCompressionCodec()
     {
-        PagesSerde serde = new TestingPagesSerdeFactory().createPagesSerde();
+        return new Object[][] {
+                {CompressionCodec.LZ4},
+                {CompressionCodec.NONE}
+        };
+    }
+
+    @Test(dataProvider = "testCompressionCodec")
+    public void testRoundTrip(CompressionCodec codec)
+    {
+        PagesSerde serde = new TestingPagesSerdeFactory(codec).createPagesSerde();
         BlockBuilder expectedBlockBuilder = VARCHAR.createBlockBuilder(null, 5);
         VARCHAR.writeString(expectedBlockBuilder, "alice");
         VARCHAR.writeString(expectedBlockBuilder, "bob");
@@ -63,57 +74,57 @@ public class TestPagesSerde
         assertFalse(pageIterator.hasNext());
     }
 
-    @Test
-    public void testBigintSerializedSize()
+    @Test(dataProvider = "testCompressionCodec")
+    public void testBigintSerializedSize(CompressionCodec codec)
     {
         BlockBuilder builder = BIGINT.createBlockBuilder(null, 5);
 
         // empty page
         Page page = new Page(builder.build());
-        int pageSize = serializedSize(ImmutableList.of(BIGINT), page);
+        int pageSize = serializedSize(ImmutableList.of(BIGINT), page, codec);
         assertEquals(pageSize, 56); // page overhead ideally 35 but since a 0 sized block will be a RLEBlock we have an overhead of 13
 
         // page with one value
         BIGINT.writeLong(builder, 123);
         pageSize = 35; // Now we have moved to the normal block implementation so the page size overhead is 35
         page = new Page(builder.build());
-        int firstValueSize = serializedSize(ImmutableList.of(BIGINT), page) - pageSize;
+        int firstValueSize = serializedSize(ImmutableList.of(BIGINT), page, codec) - pageSize;
         assertEquals(firstValueSize, 17); // value size + value overhead
 
         // page with two values
         BIGINT.writeLong(builder, 456);
         page = new Page(builder.build());
-        int secondValueSize = serializedSize(ImmutableList.of(BIGINT), page) - (pageSize + firstValueSize);
+        int secondValueSize = serializedSize(ImmutableList.of(BIGINT), page, codec) - (pageSize + firstValueSize);
         assertEquals(secondValueSize, 8); // value size (value overhead is shared with previous value)
     }
 
-    @Test
-    public void testVarcharSerializedSize()
+    @Test(dataProvider = "testCompressionCodec")
+    public void testVarcharSerializedSize(CompressionCodec codec)
     {
         BlockBuilder builder = VARCHAR.createBlockBuilder(null, 5);
 
         // empty page
         Page page = new Page(builder.build());
-        int pageSize = serializedSize(ImmutableList.of(VARCHAR), page);
+        int pageSize = serializedSize(ImmutableList.of(VARCHAR), page, codec);
         assertEquals(pageSize, 52); // page overhead
 
         // page with one value
         VARCHAR.writeString(builder, "alice");
         page = new Page(builder.build());
-        int firstValueSize = serializedSize(ImmutableList.of(VARCHAR), page) - pageSize;
+        int firstValueSize = serializedSize(ImmutableList.of(VARCHAR), page, codec) - pageSize;
         assertEquals(firstValueSize, 4 + 5); // length + "alice"
 
         // page with two values
         VARCHAR.writeString(builder, "bob");
         page = new Page(builder.build());
-        int secondValueSize = serializedSize(ImmutableList.of(VARCHAR), page) - (pageSize + firstValueSize);
+        int secondValueSize = serializedSize(ImmutableList.of(VARCHAR), page, codec) - (pageSize + firstValueSize);
         assertEquals(secondValueSize, 4 + 3); // length + "bob" (null shared with first entry)
     }
 
-    @Test
-    public void testRoundTripSizeForCompactPageStaysWithinTwentyPercent()
+    @Test(dataProvider = "testCompressionCodec")
+    public void testRoundTripSizeForCompactPageStaysWithinTwentyPercent(CompressionCodec codec)
     {
-        PagesSerde serde = new TestingPagesSerdeFactory().createPagesSerde();
+        PagesSerde serde = new TestingPagesSerdeFactory(codec).createPagesSerde();
         BlockBuilder variableWidthBlockBuilder1 = VARCHAR.createBlockBuilder(null, 128);
         BlockBuilder variableWidthBlockBuilder2 = VARCHAR.createBlockBuilder(null, 256);
         BlockBuilder bigintBlockBuilder = BIGINT.createBlockBuilder(null, 128);
@@ -138,9 +149,9 @@ public class TestPagesSerde
         assertTrue(actualSize < expectedMaxSize, "Expected round trip size difference less than 20% of original page");
     }
 
-    private static int serializedSize(List<? extends Type> types, Page expectedPage)
+    private static int serializedSize(List<? extends Type> types, Page expectedPage, CompressionCodec codec)
     {
-        PagesSerde serde = new TestingPagesSerdeFactory().createPagesSerde();
+        PagesSerde serde = new TestingPagesSerdeFactory(codec).createPagesSerde();
         DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
         writePages(serde, sliceOutput, expectedPage);
         Slice slice = sliceOutput.slice();

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
@@ -45,7 +45,12 @@ public class TestPagesSerde
     public Object[][] createTestCompressionCodec()
     {
         return new Object[][] {
+                {CompressionCodec.GZIP},
                 {CompressionCodec.LZ4},
+                {CompressionCodec.LZO},
+                {CompressionCodec.SNAPPY},
+                {CompressionCodec.ZLIB},
+                {CompressionCodec.ZSTD},
                 {CompressionCodec.NONE}
         };
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/buffer/TestingPagesSerdeFactory.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/buffer/TestingPagesSerdeFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution.buffer;
 
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.block.BlockEncodingSerde;
@@ -32,10 +33,10 @@ import java.util.Optional;
 public class TestingPagesSerdeFactory
         extends PagesSerdeFactory
 {
-    public TestingPagesSerdeFactory()
+    public TestingPagesSerdeFactory(CompressionCodec compressionCodec)
     {
         // compression should be enabled in as many tests as possible
-        super(new BlockEncodingManager(), true);
+        super(new BlockEncodingManager(), compressionCodec);
     }
 
     public static PagesSerde testingPagesSerde()

--- a/presto-main-base/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.memory;
 
 import com.facebook.airlift.stats.TestingGcMonitor;
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.execution.buffer.TestingPagesSerdeFactory;
@@ -133,7 +134,7 @@ public class TestMemoryPools
                     TableScanOperator.class.getSimpleName());
 
             OutputFactory outputFactory = new PageConsumerOutputFactory(types -> (page -> {}));
-            Operator outputOperator = outputFactory.createOutputOperator(2, new PlanNodeId("output"), ImmutableList.of(), Function.identity(), Optional.empty(), new TestingPagesSerdeFactory())
+            Operator outputOperator = outputFactory.createOutputOperator(2, new PlanNodeId("output"), ImmutableList.of(), Function.identity(), Optional.empty(), new TestingPagesSerdeFactory(CompressionCodec.LZ4))
                     .createOperator(driverContext);
             RevocableMemoryOperator revocableMemoryOperator = new RevocableMemoryOperator(revokableOperatorContext, reservedPerPage, numberOfPages);
             createOperator.set(revocableMemoryOperator);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheConfig.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.CompressionCodec;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -36,7 +37,7 @@ public class TestFileFragmentResultCacheConfig
         assertRecordedDefaults(recordDefaults(FileFragmentResultCacheConfig.class)
                 .setCachingEnabled(false)
                 .setBaseDirectory(null)
-                .setBlockEncodingCompressionEnabled(false)
+                .setBlockEncodingCompressionCodec(CompressionCodec.NONE)
                 .setMaxCachedEntries(10_000)
                 .setCacheTtl(new Duration(2, DAYS))
                 .setMaxInFlightSize(new DataSize(1, GIGABYTE))
@@ -52,7 +53,7 @@ public class TestFileFragmentResultCacheConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("fragment-result-cache.enabled", "true")
                 .put("fragment-result-cache.base-directory", "tcp://abc")
-                .put("fragment-result-cache.block-encoding-compression-enabled", "true")
+                .put("fragment-result-cache.block-encoding-compression-codec", "LZ4")
                 .put("fragment-result-cache.max-cached-entries", "100000")
                 .put("fragment-result-cache.cache-ttl", "1d")
                 .put("fragment-result-cache.max-in-flight-size", "2GB")
@@ -64,7 +65,7 @@ public class TestFileFragmentResultCacheConfig
         FileFragmentResultCacheConfig expected = new FileFragmentResultCacheConfig()
                 .setCachingEnabled(true)
                 .setBaseDirectory(new URI("tcp://abc"))
-                .setBlockEncodingCompressionEnabled(true)
+                .setBlockEncodingCompressionCodec(CompressionCodec.LZ4)
                 .setMaxCachedEntries(100000)
                 .setCacheTtl(new Duration(1, DAYS))
                 .setMaxInFlightSize(new DataSize(2, GIGABYTE))

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestPartitionedOutputOperator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestPartitionedOutputOperator.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockEncodingManager;
@@ -182,7 +183,7 @@ public class TestPartitionedOutputOperator
                     false,
                     OptionalInt.empty());
         }
-        PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(), false);
+        PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(), CompressionCodec.NONE);
 
         DriverContext driverContext = TestingTaskContext.builder(EXECUTOR, SCHEDULER, TEST_SESSION)
                 .setMemoryPoolSize(MAX_MEMORY)

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
@@ -290,8 +290,16 @@ public class BenchmarkPartitionedOutputOperator
             switch (compressionCodec) {
                 case "NONE":
                     return CompressionCodec.NONE;
+                case "SNAPPY":
+                    return CompressionCodec.SNAPPY;
                 case "LZ4":
                     return CompressionCodec.LZ4;
+                case "ZLIB":
+                    return CompressionCodec.ZLIB;
+                case "GZIP":
+                    return CompressionCodec.GZIP;
+                case "ZSTD":
+                    return CompressionCodec.ZSTD;
                 default:
                     throw new UnsupportedOperationException("Unsupported compression codec: " + compressionCodec);
             }

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.BlockEncodingManager;
@@ -152,8 +153,8 @@ public class BenchmarkPartitionedOutputOperator
         private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
 
         @SuppressWarnings("unused")
-        @Param({"true", "false"})
-        private boolean enableCompression;
+        @Param({"NONE", "LZ4"})
+        private String codec = "NONE";
 
         @Param({"1", "2"})
         private int channelCount = 1;
@@ -284,6 +285,18 @@ public class BenchmarkPartitionedOutputOperator
             types = updateBlockTypesWithHashBlockAndNullBlock(types, true, false);
         }
 
+        private CompressionCodec getCompressionCodec(String compressionCodec)
+        {
+            switch (compressionCodec) {
+                case "NONE":
+                    return CompressionCodec.NONE;
+                case "LZ4":
+                    return CompressionCodec.LZ4;
+                default:
+                    throw new UnsupportedOperationException("Unsupported compression codec: " + compressionCodec);
+            }
+        }
+
         private PartitionedOutputBuffer createPartitionedOutputBuffer()
         {
             OutputBuffers buffers = createInitialEmptyOutputBuffers(PARTITIONED);
@@ -305,7 +318,7 @@ public class BenchmarkPartitionedOutputOperator
                     IntStream.range(0, PARTITION_COUNT).toArray());
             OutputPartitioning outputPartitioning = createOutputPartitioning(partitionFunction);
 
-            PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(), enableCompression);
+            PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(), getCompressionCodec(codec));
             PartitionedOutputBuffer buffer = createPartitionedOutputBuffer();
 
             OptimizedPartitionedOutputFactory operatorFactory = new OptimizedPartitionedOutputFactory(buffer, MAX_PARTITION_BUFFER_SIZE);
@@ -320,7 +333,7 @@ public class BenchmarkPartitionedOutputOperator
             PartitionFunction partitionFunction = new LocalPartitionGenerator(new PrecomputedHashGenerator(0), PARTITION_COUNT);
             OutputPartitioning outputPartitioning = createOutputPartitioning(partitionFunction);
 
-            PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(), enableCompression);
+            PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(), getCompressionCodec(codec));
             PartitionedOutputBuffer buffer = createPartitionedOutputBuffer();
 
             PartitionedOutputFactory operatorFactory = new PartitionedOutputFactory(buffer, MAX_PARTITION_BUFFER_SIZE);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
@@ -107,7 +108,7 @@ public class TestOptimizedPartitionedOutputOperator
     private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%s"));
     private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
     private static final DataSize MAX_MEMORY = new DataSize(1, GIGABYTE);
-    private static final PagesSerde PAGES_SERDE = new PagesSerdeFactory(new BlockEncodingManager(), false).createPagesSerde(); //testingPagesSerde();
+    private static final PagesSerde PAGES_SERDE = new PagesSerdeFactory(new BlockEncodingManager(), CompressionCodec.NONE).createPagesSerde(); //testingPagesSerde();
 
     private static final int PARTITION_COUNT = 16;
     private static final int PAGE_COUNT = 50;
@@ -897,7 +898,7 @@ public class TestOptimizedPartitionedOutputOperator
             OptionalInt nullChannel,
             DataSize maxMemory)
     {
-        PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(), false);
+        PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(), CompressionCodec.NONE);
 
         OutputPartitioning outputPartitioning = new OutputPartitioning(
                 partitionFunction,

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/spiller/BenchmarkBinaryFileSpiller.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/spiller/BenchmarkBinaryFileSpiller.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.spiller;
 
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.BlockEncodingManager;
@@ -96,8 +97,8 @@ public class BenchmarkBinaryFileSpiller
         @Param("10")
         private int pagesCount = 10;
 
-        @Param("false")
-        private boolean compressionEnabled;
+        @Param("NONE")
+        private CompressionCodec compressionCodec;
 
         @Param("false")
         private boolean encryptionEnabled;
@@ -118,7 +119,7 @@ public class BenchmarkBinaryFileSpiller
                     spillerStats,
                     ImmutableList.of(SPILL_PATH),
                     1.0,
-                    compressionEnabled,
+                    compressionCodec,
                     encryptionEnabled);
             spillerFactory = new GenericSpillerFactory(singleStreamSpillerFactory);
             pages = createInputPages();

--- a/presto-main-base/src/test/java/com/facebook/presto/spiller/TestBinaryFileSpiller.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/spiller/TestBinaryFileSpiller.java
@@ -70,7 +70,7 @@ public class TestBinaryFileSpiller
         NodeSpillConfig nodeSpillConfig = new NodeSpillConfig();
         singleStreamSpillerFactory = new FileSingleStreamSpillerFactory(blockEncodingSerde, spillerStats, featuresConfig, nodeSpillConfig);
         factory = new GenericSpillerFactory(singleStreamSpillerFactory);
-        PagesSerdeFactory pagesSerdeFactory = new PagesSerdeFactory(requireNonNull(blockEncodingSerde, "blockEncodingSerde is null"), nodeSpillConfig.isSpillCompressionEnabled());
+        PagesSerdeFactory pagesSerdeFactory = new PagesSerdeFactory(requireNonNull(blockEncodingSerde, "blockEncodingSerde is null"), nodeSpillConfig.getSpillCompressionCodec());
         pagesSerde = pagesSerdeFactory.createPagesSerde();
         memoryContext = newSimpleAggregatedMemoryContext();
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpiller.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpiller.java
@@ -29,6 +29,7 @@ import com.google.common.io.Files;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.slice.InputStreamSliceInput;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -66,33 +67,32 @@ public class TestFileSingleStreamSpiller
         deleteRecursively(tempDirectory.toPath(), ALLOW_INSECURE);
     }
 
-    @Test
-    public void testSpill()
-            throws Exception
+    @DataProvider(name = "testCompressionCodec")
+    public Object[][] createTestCompressionCodec()
     {
-        assertSpill(CompressionCodec.NONE, false);
+        return new Object[][] {
+                {CompressionCodec.GZIP},
+                {CompressionCodec.LZ4},
+                {CompressionCodec.LZO},
+                {CompressionCodec.SNAPPY},
+                {CompressionCodec.ZLIB},
+                {CompressionCodec.ZSTD},
+                {CompressionCodec.NONE}
+        };
     }
 
-    @Test
-    public void testSpillCompression()
+    @Test(dataProvider = "testCompressionCodec")
+    public void testSpillCompression(CompressionCodec codec)
             throws Exception
     {
-        assertSpill(CompressionCodec.LZ4, false);
+        assertSpill(codec, false);
     }
 
-    @Test
-    public void testSpillEncryption()
+    @Test(dataProvider = "testCompressionCodec")
+    public void testSpillEncryptionWithCompression(CompressionCodec codec)
             throws Exception
     {
-        // Both with compression enabled and disabled
-        assertSpill(CompressionCodec.NONE, true);
-    }
-
-    @Test
-    public void testSpillEncryptionWithCompression()
-            throws Exception
-    {
-        assertSpill(CompressionCodec.LZ4, true);
+        assertSpill(codec, true);
     }
 
     private void assertSpill(CompressionCodec compressionCodec, boolean encryption)

--- a/presto-main-base/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpillerFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spiller;
 
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.BlockEncodingManager;
@@ -83,7 +84,7 @@ public class TestFileSingleStreamSpillerFactory
                 new SpillerStats(),
                 spillPaths,
                 1.0,
-                false,
+                CompressionCodec.NONE,
                 false);
 
         assertEquals(listFiles(spillPath1.toPath()).size(), 0);
@@ -123,7 +124,7 @@ public class TestFileSingleStreamSpillerFactory
                 new SpillerStats(),
                 spillPaths,
                 0.0,
-                false,
+                CompressionCodec.NONE,
                 false);
 
         spillerFactory.create(types, new TestingSpillContext(), newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
@@ -140,7 +141,7 @@ public class TestFileSingleStreamSpillerFactory
                 new SpillerStats(),
                 spillPaths,
                 1.0,
-                false,
+                CompressionCodec.NONE,
                 false);
         spillerFactory.create(types, new TestingSpillContext(), newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
     }
@@ -170,7 +171,7 @@ public class TestFileSingleStreamSpillerFactory
                 new SpillerStats(),
                 spillPaths,
                 1.0,
-                false,
+                CompressionCodec.NONE,
                 false);
         spillerFactory.cleanupOldSpillFiles();
 

--- a/presto-main-base/src/test/java/com/facebook/presto/spiller/TestNodeSpillConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/spiller/TestNodeSpillConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spiller;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.presto.CompressionCodec;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
@@ -35,7 +36,7 @@ public class TestNodeSpillConfig
                 .setMaxSpillPerNode(new DataSize(100, GIGABYTE))
                 .setMaxRevocableMemoryPerNode(new DataSize(16, GIGABYTE))
                 .setQueryMaxSpillPerNode(new DataSize(100, GIGABYTE))
-                .setSpillCompressionEnabled(false)
+                .setSpillCompressionCodec(CompressionCodec.NONE)
                 .setSpillEncryptionEnabled(false)
                 .setTempStorageBufferSize(new DataSize(4, KILOBYTE)));
     }
@@ -47,7 +48,7 @@ public class TestNodeSpillConfig
                 .put("experimental.max-spill-per-node", "10MB")
                 .put("experimental.max-revocable-memory-per-node", "24MB")
                 .put("experimental.query-max-spill-per-node", "15 MB")
-                .put("experimental.spill-compression-enabled", "true")
+                .put("experimental.spill-compression-codec", "LZ4")
                 .put("experimental.spill-encryption-enabled", "true")
                 .put("experimental.temp-storage-buffer-size", "24MB")
                 .build();
@@ -56,7 +57,7 @@ public class TestNodeSpillConfig
                 .setMaxSpillPerNode(new DataSize(10, MEGABYTE))
                 .setMaxRevocableMemoryPerNode(new DataSize(24, MEGABYTE))
                 .setQueryMaxSpillPerNode(new DataSize(15, MEGABYTE))
-                .setSpillCompressionEnabled(true)
+                .setSpillCompressionCodec(CompressionCodec.LZ4)
                 .setSpillEncryptionEnabled(true)
                 .setTempStorageBufferSize(new DataSize(24, MEGABYTE));
 

--- a/presto-main-base/src/test/java/com/facebook/presto/spiller/TestSpillCipherPagesSerde.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/spiller/TestSpillCipherPagesSerde.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spiller;
 
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
@@ -42,7 +43,7 @@ public class TestSpillCipherPagesSerde
     public void test()
     {
         SpillCipher cipher = new AesSpillCipher();
-        PagesSerde serde = new TestingPagesSerdeFactory().createPagesSerdeForSpill(Optional.of(cipher));
+        PagesSerde serde = new TestingPagesSerdeFactory(CompressionCodec.LZ4).createPagesSerdeForSpill(Optional.of(cipher));
         List<Type> types = ImmutableList.of(VARCHAR);
         Page emptyPage = new Page(VARCHAR.createBlockBuilder(null, 0).build());
         assertPageEquals(types, serde.deserialize(serde.serialize(emptyPage)), emptyPage);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.analyzer;
 
 import com.facebook.airlift.configuration.ConfigurationFactory;
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationIfToFilterRewriteStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
@@ -126,7 +127,7 @@ public class TestFeaturesConfig
                 .setIgnoreStatsCalculatorFailures(true)
                 .setPrintStatsForNonJoinQuery(false)
                 .setDefaultFilterFactorEnabled(false)
-                .setExchangeCompressionEnabled(false)
+                .setExchangeCompressionCodec(CompressionCodec.NONE)
                 .setExchangeChecksumEnabled(false)
                 .setEnableIntermediateAggregations(false)
                 .setPushAggregationThroughJoin(true)
@@ -330,7 +331,7 @@ public class TestFeaturesConfig
                 .put("experimental.spiller.single-stream-spiller-choice", "TEMP_STORAGE")
                 .put("experimental.spiller.spiller-temp-storage", "crail")
                 .put("experimental.spiller.max-revocable-task-memory", "1GB")
-                .put("exchange.compression-enabled", "true")
+                .put("exchange.compression-codec", "LZ4")
                 .put("exchange.checksum-enabled", "true")
                 .put("optimizer.enable-intermediate-aggregations", "true")
                 .put("optimizer.force-single-node-output", "false")
@@ -529,7 +530,7 @@ public class TestFeaturesConfig
                 .setSingleStreamSpillerChoice(SingleStreamSpillerChoice.TEMP_STORAGE)
                 .setSpillerTempStorage("crail")
                 .setMaxRevocableMemoryPerTask(new DataSize(1, GIGABYTE))
-                .setExchangeCompressionEnabled(true)
+                .setExchangeCompressionCodec(CompressionCodec.LZ4)
                 .setExchangeChecksumEnabled(true)
                 .setEnableIntermediateAggregations(true)
                 .setForceSingleNodeOutput(false)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.testing.TestingHttpClient;
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.Location;
@@ -63,7 +64,7 @@ import static org.testng.Assert.assertTrue;
 public class TestExchangeOperator
 {
     private static final List<Type> TYPES = ImmutableList.of(VARCHAR);
-    private static final PagesSerdeFactory SERDE_FACTORY = new TestingPagesSerdeFactory();
+    private static final PagesSerdeFactory SERDE_FACTORY = new TestingPagesSerdeFactory(CompressionCodec.LZ4);
 
     private static final String TASK_1_ID = "task1.0.0.0.0";
     private static final String TASK_2_ID = "task2.0.0.0.0";

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.testing.TestingHttpClient;
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.type.Type;
@@ -80,7 +81,7 @@ public class TestMergeOperator
     public void setUp()
     {
         executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("test-merge-operator-%s"));
-        serdeFactory = new TestingPagesSerdeFactory();
+        serdeFactory = new TestingPagesSerdeFactory(CompressionCodec.LZ4);
 
         taskBuffers = CacheBuilder.newBuilder().build(CacheLoader.from(TestingTaskBuffer::new));
         httpClient = new TestingHttpClient(new TestingExchangeHttpClientHandler(taskBuffers), executor);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
@@ -22,6 +22,7 @@ import com.facebook.airlift.http.client.UnexpectedResponseException;
 import com.facebook.airlift.http.client.jetty.JettyHttpClient;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.testing.Closeables;
+import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.common.Page;
@@ -193,7 +194,7 @@ public class TestServer
         byte[] decodedPage = Base64.getDecoder().decode((String) encodedPages.get(0));
 
         BlockEncodingManager blockEncodingSerde = new BlockEncodingManager();
-        PagesSerde pagesSerde = new PagesSerdeFactory(blockEncodingSerde, false, false).createPagesSerde();
+        PagesSerde pagesSerde = new PagesSerdeFactory(blockEncodingSerde, CompressionCodec.NONE, false).createPagesSerde();
         BasicSliceInput pageInput = new BasicSliceInput(Slices.wrappedBuffer(decodedPage, 0, decodedPage.length));
         SerializedPage serializedPage = readSerializedPage(pageInput);
 

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -212,19 +212,17 @@ QueryContextManager::toVeloxConfigs(
       traceFragmentId = it.second;
     } else if (it.first == SessionProperties::kQueryTraceShardId) {
       traceShardId = it.second;
-    } else if (it.first == SessionProperties::kShuffleCompressionEnabled) {
-      if (it.second == "true") {
-        // NOTE: Presto java only support lz4 compression so configure the same
-        // compression kind on velox.
-        configs[core::QueryConfig::kShuffleCompressionKind] =
-            velox::common::compressionKindToString(
-                velox::common::CompressionKind_LZ4);
-      } else {
-        VELOX_USER_CHECK_EQ(it.second, "false");
-        configs[core::QueryConfig::kShuffleCompressionKind] =
-            velox::common::compressionKindToString(
-                velox::common::CompressionKind_NONE);
-      }
+    } else if (it.first == SessionProperties::kShuffleCompressionCodec) {
+      auto compression = it.second;
+      std::transform(
+          compression.begin(),
+          compression.end(),
+          compression.begin(),
+          ::tolower);
+      velox::common::CompressionKind compressionKind =
+          common::stringToCompressionKind(compression);
+      configs[core::QueryConfig::kShuffleCompressionKind] =
+          velox::common::compressionKindToString(compressionKind);
     } else {
       configs[sessionProperties_.toVeloxConfig(it.first)] = it.second;
       sessionProperties_.updateVeloxConfig(it.first, it.second);

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -283,9 +283,9 @@ class SessionProperties {
   static constexpr const char* kPrefixSortMinRows =
       "native_prefixsort_min_rows";
 
-  /// If true, enable the shuffle compression.
-  static constexpr const char* kShuffleCompressionEnabled =
-      "exchange_compression";
+  /// The compression algorithm type to compress the shuffle.
+  static constexpr const char* kShuffleCompressionCodec =
+      "exchange_compression_codec";
 
   /// If set to true, enables scaled processing for table scans.
   static constexpr const char* kTableScanScaledProcessingEnabled =

--- a/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerde.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerde.java
@@ -41,7 +41,7 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 @NotThreadSafe
 public class PagesSerde
 {
-    private static final double MINIMUM_COMPRESSION_RATIO = 0.8;
+    private static final double MINIMUM_COMPRESSION_RATIO = 0.9;
 
     private final BlockEncodingSerde blockEncodingSerde;
     private final Optional<PageCompressor> compressor;


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

The compression codec for PageSerde is currently hardcoded as LZ4. This PR adds supports for additional codecs, including ZSTD, SNAPPY, LZO, GZIP and ZLIB. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
#24597 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Replace `exchange.compression-enabled`,  `fragment-result-cache.block-encoding-compression-enabled`, `experimental.spill-compression-enabled` with `exchange.compression-codec`, `fragment-result-cache.block-encoding-compression-codec` to enable compression codec configurations. Supported codecs include GZIP, LZ4, LZO, SNAPPY, ZLIB and ZSTD.
```

