### PR TITLE
Fix silent overflow in DateTimeEncoding.pack

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/DateTimeEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DateTimeEncoding.java
@@ -15,6 +15,7 @@ package com.facebook.presto.common.type;
 
 import static com.facebook.presto.common.type.TimeZoneKey.getTimeZoneKey;
 import static com.facebook.presto.common.type.TimeZoneKey.getTimeZoneKeyForOffset;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class DateTimeEncoding
@@ -25,9 +26,14 @@ public final class DateTimeEncoding
 
     private static final int TIME_ZONE_MASK = 0xFFF;
     private static final int MILLIS_SHIFT = 12;
+    private static final long MAX_MILLIS = 0x7FFFFFFFFFFFFL;
+    private static final long MIN_MILLIS = (MAX_MILLIS + 1) * -1;
 
     private static long pack(long millisUtc, short timeZoneKey)
     {
+        if (millisUtc > MAX_MILLIS || millisUtc < MIN_MILLIS) {
+            throw new ArithmeticException(format("TimestampWithTimeZone overflow: %s ms", millisUtc));
+        }
         return (millisUtc << MILLIS_SHIFT) | (timeZoneKey & TIME_ZONE_MASK);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.common.type.TimeZoneKey.getTimeZoneKeyForOffse
 import static com.facebook.presto.operator.scalar.QuarterOfYearDateTimeField.QUARTER_OF_YEAR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static com.facebook.presto.spi.function.SqlFunctionVisibility.HIDDEN;
 import static com.facebook.presto.type.DateTimeOperators.modulo24Hour;
 import static com.facebook.presto.util.DateTimeZoneIndex.extractZoneOffsetMinutes;
@@ -128,6 +129,9 @@ public final class DateTimeFunctions
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
         }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
+        }
     }
 
     @Description("current time without time zone")
@@ -163,6 +167,9 @@ public final class DateTimeFunctions
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
         }
     }
 
@@ -215,6 +222,9 @@ public final class DateTimeFunctions
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
         }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
+        }
     }
 
     @ScalarFunction("from_unixtime")
@@ -230,6 +240,9 @@ public final class DateTimeFunctions
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
         }
     }
 
@@ -308,6 +321,9 @@ public final class DateTimeFunctions
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
         }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
+        }
     }
 
     @ScalarFunction("from_iso8601_date")
@@ -352,6 +368,9 @@ public final class DateTimeFunctions
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
         }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
+        }
     }
 
     @ScalarFunction(value = "at_timezone", visibility = HIDDEN)
@@ -368,6 +387,9 @@ public final class DateTimeFunctions
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
         }
     }
 
@@ -641,6 +663,9 @@ public final class DateTimeFunctions
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
         }
     }
 
@@ -1450,6 +1475,9 @@ public final class DateTimeFunctions
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
## Description
Throw an exception when DateTimeEncoding's pack method will see the millisUtc overflow/underflow when constructing a TimestampWithTimeZone long.

## Motivation and Context
Today operations that produce a TimestampWithTimeZone can sliently overflow/underflow when packing the millisUtc and time zone ID into a long.  The DateTimeEncoding.pack method accepts the millisUtc as a 64-bit long, and then uses 52 bits of the TimestampWithTimeZone long to hold that value.  If the value requires more than 52 bits, it will silently overflow/underflow producing incorrect results.

This change adds a check to see if the millisUtc can fit in 52 bits, and throws an ArithmeticException if it detects the value will overflow/underflow.

As an example
```
select from_iso8601_timestamp('73326-09-11T20:14:46.000Z');

             _col0
-------------------------------
 -69387-04-22 03:45:15.504 UTC
````

## Impact
Users will see exceptions now where they were previously seeing incorrect results.

## Test Plan
Added unit tests for a few UDFs I identified as producing TimestampWithTimeZone values to ensure their behavior with values that just fit in 52 bits, and values that require more than 52 bits.

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix silently returning incorrect results when trying to construct a TimestampWithTimeZone from a value that has a unix timestamp that is too large/small.
```

