### PR TITLE
Upgrade sqlserver driver to version 12.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1445,7 +1445,7 @@
             <dependency>
                 <groupId>com.microsoft.sqlserver</groupId>
                 <artifactId>mssql-jdbc</artifactId>
-                <version>7.0.0.jre8</version>
+                <version>12.8.1.jre8</version>
             </dependency>
 
             <dependency>

--- a/presto-docs/src/main/sphinx/connector/sqlserver.rst
+++ b/presto-docs/src/main/sphinx/connector/sqlserver.rst
@@ -29,6 +29,10 @@ Connection security
 
 The JDBC driver and connector automatically use Transport Layer Security (TLS) encryption and certificate validation. This requires a suitable TLS certificate configured on your SQL Server database host.
 
+.. note::
+
+   Starting from release 0.292, the default value of ``encrypt`` has changed from ``false`` to ``true``.
+
 To disable encryption in the connection string, use the ``encrypt`` property:
 
 .. code-block:: none
@@ -61,6 +65,41 @@ A connection string using a truststore would be similar to the following example
 .. code-block:: none
 
     connection-url=jdbc:sqlserver://<host>:<port>;databaseName=<databaseName>;encrypt=true;trustServerCertificate=false;trustStoreType=PEM;hostNameInCertificate=hostname;trustStore=path/to/truststore.pem;trustStorePassword=password
+
+Authentication
+^^^^^^^^^^^^^^
++--------------------------+-----------------------------------------------------------------+------------------+
+| **Property**             | **Description**                                                 | **Default Value**|
++--------------------------+-----------------------------------------------------------------+------------------+
+| ``integratedSecurity``   | Enables Windows Authentication for SQL Server.                  | ``false``        |
+|                          |                                                                 |                  |
+|                          | - Set to ``true`` with ``authenticationScheme=JavaKerberos``    |                  |
+|                          |   to indicate that Kerberos credentials are used by SQL Server. |                  |
+|                          | - Set to ``true`` with ``authenticationScheme=NTLM`` to         |                  |
+|                          |   indicate that NTLM credentials are used by SQL Server.        |                  |
++--------------------------+-----------------------------------------------------------------+------------------+
+| ``authentication``       | Specifies the authentication method to use for connection.      | ``NotSpecified`` |
+|                          | Possible values:                                                |                  |
+|                          |                                                                 |                  |
+|                          | - ``NotSpecified``                                              |                  |
+|                          | - ``SqlPassword``                                               |                  |
+|                          | - ``ActiveDirectoryPassword``                                   |                  |
+|                          | - ``ActiveDirectoryIntegrated``                                 |                  |
+|                          | - ``ActiveDirectoryManagedIdentity``                            |                  |
+|                          | - ``ActiveDirectoryMSI``                                        |                  |
+|                          | - ``ActiveDirectoryInteractive``                                |                  |
+|                          | - ``ActiveDirectoryServicePrincipal``                           |                  |
++--------------------------+-----------------------------------------------------------------+------------------+
+
+Below is a sample connection URL with the NTLM authentication:
+
+.. code-block:: none
+
+    connection-url=jdbc:sqlserver://<host>:<port>;databaseName=<databaseName>;encrypt=true;trustServerCertificate=false;integratedSecurity=true;authenticationScheme=NTLM;
+
+
+Refer to `setting the connection properties <https://learn.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-ver16>`_ from the Microsoft official documentation.
+
 
 Multiple SQL Server Databases or Servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-main/etc/catalog/sqlserver.properties
+++ b/presto-main/etc/catalog/sqlserver.properties
@@ -1,4 +1,4 @@
 connector.name=sqlserver
-connection-url=jdbc:sqlserver://sqlserver
+connection-url=jdbc:sqlserver://sqlserver;encrypt=false;
 connection-user=sa
 connection-password=SQLServerPass1

--- a/presto-product-tests/conf/presto/etc/catalog/sqlserver.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/sqlserver.properties
@@ -1,5 +1,5 @@
 connector.name=sqlserver
-connection-url=jdbc:sqlserver://sqlserver
+connection-url=jdbc:sqlserver://sqlserver;encrypt=false;
 connection-user=sa
 connection-password=SQLServerPass1
 allow-drop-table=true

--- a/presto-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/presto-product-tests/src/main/resources/tempto-configuration.yaml
@@ -105,7 +105,7 @@ databases:
 
   sqlserver:
     jdbc_driver_class: com.microsoft.sqlserver.jdbc.SQLServerDriver
-    jdbc_url: jdbc:sqlserver://sqlserver
+    jdbc_url: jdbc:sqlserver://sqlserver;encrypt=false;
     jdbc_user: sa
     jdbc_password: SQLServerPass1
     jdbc_pooling: true


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

NTLM authentication is not supported in the current driver. We will get below error if we specify NTLM in the connection URL
`integratedSecurity=true;authenticationScheme=NTLM;`

![image](https://github.com/user-attachments/assets/e95a311b-c1d3-4d1a-983b-cf070624bfee)

We need to upgrade the driver to get this support

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

SQL Server Connector Changes
* Upgrade sqlserver driver to version 12.8.1, to include NTLM authentication support. See :ref:`connector/sqlserver:authentication`.
```

