### PR TITLE
Enable fail-fast for new JVM version matrix actions

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -17,7 +17,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         modules:
           - ":presto-base-arrow-flight"  # Only run tests for the `presto-base-arrow-flight` module

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         modules:
           - ":presto-docs"

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -32,7 +32,6 @@ jobs:
 
   hive-tests:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
@@ -80,7 +79,6 @@ jobs:
 
   hive-dockerized-tests:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -30,7 +30,6 @@ jobs:
             - '!presto-docs/**'
   kudu:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -13,7 +13,6 @@ env:
 jobs:
   maven-checks:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -30,7 +30,6 @@ jobs:
             - '!presto-docs/**'
   product-tests-basic-environment:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -30,7 +30,6 @@ jobs:
             - '!presto-docs/**'
   product-tests-specific-environment1:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
@@ -87,7 +86,6 @@ jobs:
 
   product-tests-specific-environment2:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -31,7 +31,6 @@ jobs:
               - '!presto-docs/**'
   singlestore-dockerized-tests:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -31,7 +31,6 @@ jobs:
             - '!presto-docs/**'
   spark-integration:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -31,7 +31,6 @@ jobs:
             - '!presto-docs/**'
   test-other-modules:
     strategy:
-      fail-fast: false
       matrix:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     strategy:
-      fail-fast: false
       matrix:
         java: [8, 17.0.13]
         modules:


### PR DESCRIPTION
## Description

Enables fail-fast on matrix builds

## Motivation and Context

Should save some CI resources on builds where items fail

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

