### PR TITLE
Specify code block syntax

### DIFF
--- a/presto-docs/README.md
+++ b/presto-docs/README.md
@@ -5,24 +5,24 @@ Presto documentation is authored in `rst` format and published using [Sphinx](ht
 ## Prerequisites
 
 Building the presto-docs module requires Python3 with virtual environment. You can check if you have it installed by running:
-```
+```shell
 python3 -m venv --help
 ```
 
 To install venv:
-```
+```shell
 python3 -m pip install --user virtualenv
 ```
 
 Optionally, the PDF version of `presto-docs` requires LaTeX tooling.
 
 For MacOS,
-```
+```shell
 brew install --cask mactex
 ```
 
 For Ubuntu,
-```
+```shell
 sudo apt-get update
 sudo apt-get install -y texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra latexmk tex-gyre texlive-xetex fonts-freefont-otf xindy
 ```
@@ -30,17 +30,17 @@ sudo apt-get install -y texlive-fonts-recommended texlive-latex-recommended texl
 
 ## Building manually
 The default build uses Apache Maven to download dependencies and generate the HTML. You can run it as follows:
-```
+```shell
 cd presto-docs
 mvn install
 ```
 Or, to build the documentation more quickly:
-```
+```shell
 cd presto-docs
 ./build
 ```
 To build PDF version of the documentation
-```
+```shell
 cd presto-docs
 ./build --with-pdf
 ```
@@ -49,11 +49,11 @@ cd presto-docs
 When the build is complete, you'll find the output HTML files in the `target/html/` folder.
 
 To view the docs, you can open the file `target/html/index.html` in a web browser on macOS with
-```
+```shell
 open target/html/index.html
 ```
 Or, you can start a web server e.g., using Python:
-```
+```shell
 cd target/html/
 python3 -m http.server
 ```


### PR DESCRIPTION
## Description

The PR specifies `shell` script syntax in the code blocks.

## Motivation and Context

Better syntax highlighting and the ability to execute code from the IDE.

## Impact

No

## Test Plan

Compare how `presto-docs/README.md` rendered before and after changes.

Before - there are no launch buttons:
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/5705442c-af26-4ffc-bb13-9fbda216c04c" />

After - there are launch buttons:
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/56c7c770-fbc5-43a0-b42f-362ffdc4e997" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

