### PR TITLE
Move benchmark driver page to Administration and refine installation steps

### DIFF
--- a/presto-docs/src/main/sphinx/admin.rst
+++ b/presto-docs/src/main/sphinx/admin.rst
@@ -7,6 +7,7 @@ Administration
 
     admin/web-interface
     admin/tuning
+    admin/benchmark-driver
     admin/properties
     admin/properties-session
     admin/spill

--- a/presto-docs/src/main/sphinx/admin/benchmark-driver.rst
+++ b/presto-docs/src/main/sphinx/admin/benchmark-driver.rst
@@ -2,11 +2,26 @@
 Benchmark Driver
 ================
 
-The benchmark driver can be used to measure the performance of queries in a
-Presto cluster. We use it to continuously measure the performance of trunk.
+The benchmark driver measures the performance of queries in a Presto cluster.
+It is used to continuously evaluate the performance of trunk.
 
-Download :maven_download:`benchmark-driver`, rename it to ``presto-benchmark-driver``,
-then make it executable with ``chmod +x``.
+Installation
+------------
+
+Download :maven_download:`benchmark-driver`.
+
+Rename the JAR file to ``presto-benchmark-driver`` with the following command
+(replace ``*`` with the version number of the downloaded jar file):
+
+.. code-block:: none
+
+    mv presto-benchmark-driver-*-executable.jar presto-benchmark-driver
+
+Use ``chmod +x`` to make the renamed file executable:
+
+.. code-block:: none
+
+    chmod +x presto-benchmark-driver
 
 Suites
 ------

--- a/presto-docs/src/main/sphinx/installation.rst
+++ b/presto-docs/src/main/sphinx/installation.rst
@@ -6,7 +6,6 @@ Installation
     :maxdepth: 1
 
     installation/deployment
-    installation/benchmark-driver
     installation/spark
     installation/deploy-docker
     installation/deploy-brew


### PR DESCRIPTION
## Description

Move `Benchmark Driver` page to `Administration` menu after `Tuning Presto` page.
Refine installation steps similar to `Presto CLI`.

## Motivation and Context

The change makes documentation cleaner and consistent.

## Impact

None

## Test Plan

Check that changed `Benchmark Driver` page in the `Administration` menu.
Before:
<img width="1071" alt="image" src="https://github.com/user-attachments/assets/0c9f902f-9572-49ea-a0ca-46c69529de90" />

After:
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/3966d899-5ce2-4b4d-8c88-9f0c3c31f74a" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

