### PR TITLE
[native] fix typo in exchange request counter

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -258,7 +258,7 @@ void PrestoExchangeSource::processDataResponse(
   RECORD_HISTOGRAM_METRIC_VALUE(
       kCounterExchangeRequestDuration, dataRequestRetryState_.durationMs());
   RECORD_HISTOGRAM_METRIC_VALUE(
-      kCounterExchangeRequestNumRetries, dataRequestRetryState_.numTries());
+      kCounterExchangeRequestNumTries, dataRequestRetryState_.numTries());
   if (closed_.load()) {
     // If PrestoExchangeSource is already closed, just free all buffers
     // allocated without doing any processing. This can happen when a super slow

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -123,7 +123,7 @@ void registerPrestoMetrics() {
   // Tracks exchange request num of retris in range of [0, 20] with
   // 20 buckets and reports P50, P90, P99, and P100.
   DEFINE_HISTOGRAM_METRIC(
-      kCounterExchangeRequestNumRetries,
+      kCounterExchangeRequestNumTries,
       1,
       0,
       20,

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -49,8 +49,8 @@ constexpr folly::StringPiece kCounterExchangeSourcePeakQueuedBytes{
 
 constexpr folly::StringPiece kCounterExchangeRequestDuration{
     "presto_cpp.exchange.request.duration"};
-constexpr folly::StringPiece kCounterExchangeRequestNumRetries{
-    "presto_cpp.exchange.request.num_retries"};
+constexpr folly::StringPiece kCounterExchangeRequestNumTries{
+    "presto_cpp.exchange.request.num_tries"};
 
 constexpr folly::StringPiece kCounterNumQueryContexts{
     "presto_cpp.num_query_contexts"};


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

