### PR TITLE
Make OutputBuffers Thrift-compatible

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffers.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution.buffer;
 
 import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftEnum;
 import com.facebook.drift.annotations.ThriftField;
 import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.plan.PartitioningHandle;
@@ -40,6 +41,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public final class OutputBuffers
 {
     public static final int BROADCAST_PARTITION_ID = 0;
@@ -76,6 +78,7 @@ public final class OutputBuffers
         return SPOOLING_OUTPUT_BUFFERS;
     }
 
+    @ThriftEnum
     public enum BufferType
     {
         PARTITIONED,
@@ -91,6 +94,7 @@ public final class OutputBuffers
     private final Map<OutputBufferId, Integer> buffers;
 
     // Visible only for Jackson... Use the "with" methods instead
+    @ThriftConstructor
     @JsonCreator
     public OutputBuffers(
             @JsonProperty("type") BufferType type,
@@ -104,24 +108,28 @@ public final class OutputBuffers
         this.noMoreBufferIds = noMoreBufferIds;
     }
 
+    @ThriftField(1)
     @JsonProperty
     public BufferType getType()
     {
         return type;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public long getVersion()
     {
         return version;
     }
 
+    @ThriftField(3)
     @JsonProperty
     public boolean isNoMoreBufferIds()
     {
         return noMoreBufferIds;
     }
 
+    @ThriftField(4)
     @JsonProperty
     public Map<OutputBufferId, Integer> getBuffers()
     {


### PR DESCRIPTION
## Description
1. We are doing thrift migration for TaskUpdateRequest
2. OutputBuffers is one of the fields in TaskUpdateRequest

## Motivation and Context
1. Use thrift for TaskUpdateRequest to make the communication between coordinator and worker fast

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. running verifier test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Make OutputBuffers class Thrift ready.
```


