### PR TITLE
Upgrade org.apache.calcite dependency to address CVE-2023-2976

### DIFF
--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <dep.calcite.version>1.38.0</dep.calcite.version>
     </properties>
 
     <dependencies>
@@ -275,7 +276,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.32.0</version>
+            <version>${dep.calcite.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -381,7 +382,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-babel</artifactId>
-            <version>1.29.0</version>
+            <version>${dep.calcite.version}</version>
         </dependency>
         <dependency>
             <groupId>io.perfmark</groupId>


### PR DESCRIPTION
## Description
Upgrade the  org.apache.calcite dependency from version 1.32.0 to 1.38.0 to avoiding CVE issues.

## Motivation and Context

Upgrading the  org.apache.calcite dependency from version 1.32.0 to 1.38.0 to reduce the risk of introducing new security flaws

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```

== RELEASE NOTES ==

Security Changes
* Upgrade org.apache.calcite to 1.38.0 in response to `CVE-2023-2976<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976>`_. 




