### PR TITLE
[docs] Fix formatting in presto_cpp/properties.rst

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -2,7 +2,7 @@
 Presto C++ Configuration Properties
 ===================================
 
-This section describes Presto C++ configuration properties.
+This section describes Presto C++ configuration properties. 
 
 The following is not a complete list of all configuration properties,
 and does not include any connector-specific catalog configuration properties
@@ -310,12 +310,12 @@ The configuration properties of AsyncDataCache and SSD cache are described here.
   In-memory cache.
 
 ``async-cache-ssd-gb``
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``integer``
 * **Default value:** ``0``
 
-  The size of the SSD. Unit is in GiB (gibibytes).
+  The size of the SSD. Unit is in GiB (gibibytes). 
 
 ``async-cache-ssd-path``
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
Fix formatting of a heading in [presto_cpp/properties.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/presto_cpp/properties.rst).

## Motivation and Context
Incorrectly formatted headers generate warnings in doc builds. Fixing them reduces the warnings generated during doc builds.

## Impact
Fewer warnings during doc builds.

## Test Plan
Local doc builds. 

Before: 

```
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/properties.rst:313: WARNING: Title underline too short.

``async-cache-ssd-gb``
^^^^^^^^^^^^^^^^^^^^^ [docutils]
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/properties.rst:313: WARNING: Title underline too short.

``async-cache-ssd-gb``
^^^^^^^^^^^^^^^^^^^^^ [docutils]

build succeeded, 40 warnings.
```

After:

(errors shown above do not appear) 

```
build succeeded, 38 warnings.
```
## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```
