### PR TITLE
Dynamically compute node memory based on configured spark executor memory

### DIFF
--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -110,6 +110,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-server</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -72,6 +72,9 @@ public class PrestoSparkConfig
     private String nativeExecutionBroadcastBasePath;
     private boolean nativeTerminateWithCoreWhenUnresponsiveEnabled;
     private Duration nativeTerminateWithCoreTimeout = new Duration(5, MINUTES);
+    private boolean isDynamicPrestoMemoryPoolTuningEnabled;
+    private double dynamicPrestoMemoryPoolTuningFraction = 0.7;
+    private int attemptNumberToApplyDynamicMemoryPoolTuning = 1;
 
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
@@ -522,6 +525,45 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setNativeTerminateWithCoreTimeout(Duration nativeTerminateWithCoreTimeout)
     {
         this.nativeTerminateWithCoreTimeout = nativeTerminateWithCoreTimeout;
+        return this;
+    }
+
+    public boolean isDynamicPrestoMemoryPoolTuningEnabled()
+    {
+        return isDynamicPrestoMemoryPoolTuningEnabled;
+    }
+
+    @Config("spark.dynamic-presto-memory-pool-tuning-enabled")
+    @ConfigDescription("Dynamic tuning for Presto memory pool enabled")
+    public PrestoSparkConfig setDynamicPrestoMemoryPoolTuningEnabled(boolean isDynamicPrestoMemoryPoolTuningEnabled)
+    {
+        this.isDynamicPrestoMemoryPoolTuningEnabled = isDynamicPrestoMemoryPoolTuningEnabled;
+        return this;
+    }
+
+    public double getDynamicPrestoMemoryPoolTuningFraction()
+    {
+        return dynamicPrestoMemoryPoolTuningFraction;
+    }
+
+    @Config("spark.dynamic-presto-memory-pool-tuning-fraction")
+    @ConfigDescription("Percentage of JVM memory available to Presto")
+    public PrestoSparkConfig setDynamicPrestoMemoryPoolTuningFraction(double dynamicPrestoMemoryPoolTuningFraction)
+    {
+        this.dynamicPrestoMemoryPoolTuningFraction = dynamicPrestoMemoryPoolTuningFraction;
+        return this;
+    }
+
+    public int getAttemptNumberToApplyDynamicMemoryPoolTuning()
+    {
+        return attemptNumberToApplyDynamicMemoryPoolTuning;
+    }
+
+    @Config("spark.attempt-number-to-apply-dynamic-memory-pool-tuning")
+    @ConfigDescription("Attempt number after which dynamic memory pool tuning will be enabled")
+    public PrestoSparkConfig setAttemptNumberToApplyDynamicMemoryPoolTuning(int attemptNumberToApplyDynamicMemoryPoolTuning)
+    {
+        this.attemptNumberToApplyDynamicMemoryPoolTuning = attemptNumberToApplyDynamicMemoryPoolTuning;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -75,6 +75,9 @@ public class PrestoSparkSessionProperties
     public static final String NATIVE_EXECUTION_BROADCAST_BASE_PATH = "native_execution_broadcast_base_path";
     public static final String NATIVE_TERMINATE_WITH_CORE_WHEN_UNRESPONSIVE_ENABLED = "native_terminate_with_core_when_unresponsive_enabled";
     public static final String NATIVE_TERMINATE_WITH_CORE_TIMEOUT = "native_terminate_with_core_timeout";
+    public static final String DYNAMIC_PRESTO_MEMORY_POOL_TUNING_ENABLED = "dynamic_presto_memory_pool_tuning_enabled";
+    public static final String DYNAMIC_PRESTO_MEMORY_POOL_TUNING_FRACTION = "dynamic_presto_memory_pool_tuning_fraction";
+    public static final String ATTEMPT_NUMBER_TO_APPLY_DYNAMIC_MEMORY_POOL_TUNING = "attempt_number_to_apply_dynamic_memory_pool_tuning";
 
     private final List<PropertyMetadata<?>> sessionProperties;
     private final ExecutionStrategyValidator executionStrategyValidator;
@@ -278,6 +281,21 @@ public class PrestoSparkSessionProperties
                         NATIVE_TERMINATE_WITH_CORE_TIMEOUT,
                         "Timeout for native execution process termination with core. The process is forcefully killed on timeout",
                         prestoSparkConfig.getNativeTerminateWithCoreTimeout(),
+                        false),
+                booleanProperty(
+                        DYNAMIC_PRESTO_MEMORY_POOL_TUNING_ENABLED,
+                        "Dynamic tuning for Presto memory pool enabled",
+                        prestoSparkConfig.isDynamicPrestoMemoryPoolTuningEnabled(),
+                        false),
+                doubleProperty(
+                        DYNAMIC_PRESTO_MEMORY_POOL_TUNING_FRACTION,
+                        "Percentage of JVM memory available to Presto",
+                        prestoSparkConfig.getDynamicPrestoMemoryPoolTuningFraction(),
+                        false),
+                integerProperty(
+                        ATTEMPT_NUMBER_TO_APPLY_DYNAMIC_MEMORY_POOL_TUNING,
+                        "Attempt number after which dynamic memory pool tuning will be enabled",
+                        prestoSparkConfig.getAttemptNumberToApplyDynamicMemoryPoolTuning(),
                         false));
     }
 
@@ -454,5 +472,20 @@ public class PrestoSparkSessionProperties
     public static Duration getNativeTerminateWithCoreTimeout(Session session)
     {
         return session.getSystemProperty(NATIVE_TERMINATE_WITH_CORE_TIMEOUT, Duration.class);
+    }
+
+    public static boolean isDynamicPrestoMemoryPoolTuningEnabled(Session session)
+    {
+        return session.getSystemProperty(DYNAMIC_PRESTO_MEMORY_POOL_TUNING_ENABLED, Boolean.class);
+    }
+
+    public static double getDynamicPrestoMemoryPoolTuningFraction(Session session)
+    {
+        return session.getSystemProperty(DYNAMIC_PRESTO_MEMORY_POOL_TUNING_FRACTION, Double.class);
+    }
+
+    public static int getAttemptNumberToApplyDynamicMemoryPoolTuning(Session session)
+    {
+        return session.getSystemProperty(ATTEMPT_NUMBER_TO_APPLY_DYNAMIC_MEMORY_POOL_TUNING, Integer.class);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkTaskExecutorFactory.java
@@ -13,11 +13,14 @@
  */
 package com.facebook.presto.spark.execution.task;
 
+import com.facebook.airlift.http.server.BasicPrincipal;
 import com.facebook.airlift.json.Codec;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.TestingGcMonitor;
 import com.facebook.presto.Session;
+import com.facebook.presto.SessionRepresentation;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.io.DataOutput;
 import com.facebook.presto.event.SplitMonitor;
@@ -79,10 +82,13 @@ import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleReadInfo;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleWriteInfo;
 import com.facebook.presto.spark.util.PrestoSparkStatsCollectionUtils;
 import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.page.PageDataOutput;
 import com.facebook.presto.spi.plan.PlanFragmentId;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.TokenAuthenticator;
 import com.facebook.presto.spi.storage.TempDataOperationContext;
 import com.facebook.presto.spi.storage.TempDataSink;
@@ -116,7 +122,9 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -132,6 +140,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.CRC32;
 
 import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalTotalMemoryLimit;
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY_PER_NODE;
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_REVOCABLE_MEMORY_PER_NODE;
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_TOTAL_MEMORY_PER_NODE;
 import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
 import static com.facebook.presto.SystemSessionProperties.getHeapDumpFileDirectory;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxBroadcastMemory;
@@ -145,11 +156,14 @@ import static com.facebook.presto.execution.TaskState.FAILED;
 import static com.facebook.presto.execution.TaskStatus.STARTING_VERSION;
 import static com.facebook.presto.execution.buffer.BufferState.FINISHED;
 import static com.facebook.presto.metadata.MetadataUpdates.DEFAULT_METADATA_UPDATES;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.getAttemptNumberToApplyDynamicMemoryPoolTuning;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.getDynamicPrestoMemoryPoolTuningFraction;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMemoryRevokingTarget;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMemoryRevokingThreshold;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getShuffleOutputTargetAverageRowSize;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getSparkBroadcastJoinMaxMemoryOverride;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getStorageBasedBroadcastJoinWriteBufferSize;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.isDynamicPrestoMemoryPoolTuningEnabled;
 import static com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats.Operation.WRITE;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.deserializeZstdCompressed;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.getNullifyingIterator;
@@ -373,10 +387,26 @@ public class PrestoSparkTaskExecutorFactory
         ImmutableMap.Builder<String, TokenAuthenticator> extraAuthenticators = ImmutableMap.builder();
         authenticatorProviders.forEach(provider -> extraAuthenticators.putAll(provider.getTokenAuthenticators()));
 
-        Session session = taskDescriptor.getSession().toSession(
+        SessionRepresentation sessionRepresentation = taskDescriptor.getSession();
+        Session session = sessionRepresentation.toSession(
                 sessionPropertyManager,
                 taskDescriptor.getExtraCredentials(),
                 extraAuthenticators.build());
+        DataSize maxUserMemory = getDynamicallyComputedMemory(session, getQueryMaxMemoryPerNode(session), attemptNumber);
+        DataSize maxTotalMemory = getDynamicallyComputedMemory(session, getQueryMaxTotalMemoryPerNode(session), attemptNumber);
+        DataSize maxRevocableMemory = getDynamicallyComputedMemory(session, getQueryMaxRevocableMemoryPerNode(session), attemptNumber);
+
+        ImmutableMap.Builder<String, String> extraSessionProperties = ImmutableMap.<String, String>builder()
+                .put(QUERY_MAX_MEMORY_PER_NODE, maxUserMemory.toString())
+                .put(QUERY_MAX_TOTAL_MEMORY_PER_NODE, maxTotalMemory.toString())
+                .put(QUERY_MAX_REVOCABLE_MEMORY_PER_NODE, maxRevocableMemory.toString());
+
+        session = createSessionWithExtraSessionProperties(
+                 sessionRepresentation,
+                 taskDescriptor.getExtraCredentials(),
+                 extraAuthenticators.build(),
+                 extraSessionProperties.build());
+
         PlanFragment fragment = taskDescriptor.getFragment();
         StageId stageId = new StageId(session.getQueryId(), fragment.getId().getId());
 
@@ -388,9 +418,6 @@ public class PrestoSparkTaskExecutorFactory
 
         log.info(PlanPrinter.textPlanFragment(fragment, functionAndTypeManager, session, true));
 
-        DataSize maxUserMemory = getQueryMaxMemoryPerNode(session);
-        DataSize maxTotalMemory = getQueryMaxTotalMemoryPerNode(session);
-        DataSize maxRevocableMemory = getQueryMaxRevocableMemoryPerNode(session);
         DataSize maxBroadcastMemory = getSparkBroadcastJoinMaxMemoryOverride(session);
         if (maxBroadcastMemory == null) {
             maxBroadcastMemory = new DataSize(min(nodeMemoryConfig.getMaxQueryBroadcastMemory().toBytes(), getQueryMaxBroadcastMemory(session).toBytes()), BYTE);
@@ -438,6 +465,7 @@ public class PrestoSparkTaskExecutorFactory
                 memoryRevokingTarget <= memoryRevokingThreshold,
                 "memoryRevokingTarget should be less than or equal memoryRevokingThreshold, but got %s and %s respectively",
                 memoryRevokingTarget, memoryRevokingThreshold);
+        boolean heapDumpOnExceededMemoryLimitEnabled = isHeapDumpOnExceededMemoryLimitEnabled(session);
         if (isSpillEnabled(session)) {
             memoryPool.addListener((pool, queryId, totalMemoryReservationBytes) -> {
                 if (totalMemoryReservationBytes > queryContext.getPeakNodeTotalMemory()) {
@@ -483,7 +511,7 @@ public class PrestoSparkTaskExecutorFactory
                                     format("Total reserved memory: %s, Total revocable memory: %s",
                                             succinctBytes(pool.getQueryMemoryReservation(queryId)),
                                             succinctBytes(pool.getQueryRevocableMemoryReservation(queryId))),
-                            isHeapDumpOnExceededMemoryLimitEnabled(session),
+                            heapDumpOnExceededMemoryLimitEnabled,
                             Optional.ofNullable(heapDumpFilePath),
                             UNKNOWN);
                 }
@@ -599,6 +627,67 @@ public class PrestoSparkTaskExecutorFactory
                 outputBuffer,
                 tempStorage,
                 tempDataOperationContext);
+    }
+
+    private DataSize getDynamicallyComputedMemory(Session session, DataSize memory, int attemptNumber)
+    {
+        // For the first attempt, use the static memory values present in SessionProperties.
+        // Second attempt onwards use configured JVM memory for computing presto memory limits.
+        if (isDynamicPrestoMemoryPoolTuningEnabled(session) && attemptNumber >= getAttemptNumberToApplyDynamicMemoryPoolTuning(session)) {
+            double jvmMaxMemoryInBytes = Runtime.getRuntime().maxMemory();
+            double prestoMemoryPoolTuningFraction = getDynamicPrestoMemoryPoolTuningFraction(session);
+            log.info("Dynamically Tuning Presto Memory Configs. Configured JVM Memory: %f; Dynamic Memory Tuning fraction: %f", jvmMaxMemoryInBytes, prestoMemoryPoolTuningFraction);
+            double finalMemoryValue = Math.max(prestoMemoryPoolTuningFraction * jvmMaxMemoryInBytes, memory.toBytes());
+            return DataSize.succinctDataSize(finalMemoryValue, DataSize.Unit.BYTE);
+        }
+
+        return memory;
+    }
+
+    private Session createSessionWithExtraSessionProperties(
+            SessionRepresentation sessionRepresentation,
+            Map<String, String> extraCredentials,
+            Map<String, TokenAuthenticator> extraAuthenticators,
+            Map<String, String> extraSystemProperties)
+    {
+        Map<String, String> updatedSessionProperties = new HashMap<>(sessionRepresentation.getSystemProperties());
+        updatedSessionProperties.putAll(extraSystemProperties);
+
+        return new Session(
+                new QueryId(sessionRepresentation.getQueryId()),
+                sessionRepresentation.getTransactionId(),
+                sessionRepresentation.isClientTransactionSupport(),
+                new Identity(
+                        sessionRepresentation.getUser(),
+                        sessionRepresentation.getPrincipal().map(BasicPrincipal::new),
+                        sessionRepresentation.getRoles(),
+                        extraCredentials,
+                        extraAuthenticators,
+                        Optional.empty(),
+                        Optional.empty()),
+                sessionRepresentation.getSource(),
+                sessionRepresentation.getCatalog(),
+                sessionRepresentation.getSchema(),
+                sessionRepresentation.getTraceToken(),
+                sessionRepresentation.getTimeZoneKey(),
+                sessionRepresentation.getLocale(),
+                sessionRepresentation.getRemoteUserAddress(),
+                sessionRepresentation.getUserAgent(),
+                sessionRepresentation.getClientInfo(),
+                sessionRepresentation.getClientTags(),
+                sessionRepresentation.getResourceEstimates(),
+                sessionRepresentation.getStartTime(),
+                ImmutableMap.copyOf(updatedSessionProperties),
+                sessionRepresentation.getCatalogProperties(),
+                sessionRepresentation.getUnprocessedCatalogProperties(),
+                sessionPropertyManager,
+                sessionRepresentation.getPreparedStatements(),
+                sessionRepresentation.getSessionFunctions(),
+                Optional.empty(),
+                // we use NOOP to create a session from the representation as worker does not require warning collectors
+                WarningCollector.NOOP,
+                new RuntimeStats(),
+                Optional.empty());
     }
 
     public boolean isMemoryRevokePending(TaskContext taskContext)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -67,7 +67,10 @@ public class TestPrestoSparkConfig
                 .setHashPartitionCountAllocationStrategyEnabled(false)
                 .setNativeExecutionBroadcastBasePath(null)
                 .setNativeTerminateWithCoreWhenUnresponsiveEnabled(false)
-                .setNativeTerminateWithCoreTimeout(new Duration(5, MINUTES)));
+                .setNativeTerminateWithCoreTimeout(new Duration(5, MINUTES))
+                .setDynamicPrestoMemoryPoolTuningEnabled(false)
+                .setDynamicPrestoMemoryPoolTuningFraction(0.7)
+                .setAttemptNumberToApplyDynamicMemoryPoolTuning(1));
     }
 
     @Test
@@ -108,6 +111,9 @@ public class TestPrestoSparkConfig
                 .put("native-execution-broadcast-base-path", "/tmp/broadcast_path")
                 .put("native-terminate-with-core-when-unresponsive-enabled", "true")
                 .put("native-terminate-with-core-timeout", "1m")
+                .put("spark.dynamic-presto-memory-pool-tuning-enabled", "true")
+                .put("spark.dynamic-presto-memory-pool-tuning-fraction", "0.8")
+                .put("spark.attempt-number-to-apply-dynamic-memory-pool-tuning", "0")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -143,7 +149,10 @@ public class TestPrestoSparkConfig
                 .setExecutorAllocationStrategyEnabled(true)
                 .setNativeExecutionBroadcastBasePath("/tmp/broadcast_path")
                 .setNativeTerminateWithCoreWhenUnresponsiveEnabled(true)
-                .setNativeTerminateWithCoreTimeout(new Duration(1, MINUTES));
+                .setNativeTerminateWithCoreTimeout(new Duration(1, MINUTES))
+                .setDynamicPrestoMemoryPoolTuningEnabled(true)
+                .setDynamicPrestoMemoryPoolTuningFraction(0.8)
+                .setAttemptNumberToApplyDynamicMemoryPoolTuning(0);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkDynamicMemoryPoolTuning.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkDynamicMemoryPoolTuning.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY_PER_NODE;
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_TOTAL_MEMORY_PER_NODE;
+import static com.facebook.presto.spark.PrestoSparkQueryRunner.createHivePrestoSparkQueryRunner;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.ATTEMPT_NUMBER_TO_APPLY_DYNAMIC_MEMORY_POOL_TUNING;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.DYNAMIC_PRESTO_MEMORY_POOL_TUNING_ENABLED;
+import static io.airlift.tpch.TpchTable.getTables;
+
+public class TestPrestoSparkDynamicMemoryPoolTuning
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return createHivePrestoSparkQueryRunner(getTables());
+    }
+
+    @Test
+    public void testDynamicMemoryPoolTuning()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "100B")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "100B")
+                .setSystemProperty(DYNAMIC_PRESTO_MEMORY_POOL_TUNING_ENABLED, "false")
+                .build();
+
+        // Query should fail with OOM
+        assertQueryFails(
+                session,
+                "select * from lineitem l join orders o on l.orderkey = o.orderkey",
+                ".*Query exceeded per-node total memory limit.*");
+
+        session = Session.builder(getSession())
+                .setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "100B")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "100B")
+                .setSystemProperty(DYNAMIC_PRESTO_MEMORY_POOL_TUNING_ENABLED, "true")
+                .setSystemProperty(ATTEMPT_NUMBER_TO_APPLY_DYNAMIC_MEMORY_POOL_TUNING, "0")
+                .build();
+
+        // Query should succeed since dynamic memory tuning will override the static presto memory config values
+        assertQuery(
+                session,
+                "select * from lineitem l join orders o on l.orderkey = o.orderkey");
+    }
+}


### PR DESCRIPTION
Summary:
PoS Memory configs are currently statically defined in session properties 
or config properties. These are not dynamically computed based on the 
configured spark's container memory. Adding the logic to dynamically 
compute different memory configs based on configured spark executor 
memory.

Differential Revision: D70345244


