### PR TITLE
Fix path filtering for matrix jobs

### DIFF
--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -37,29 +37,34 @@ jobs:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-hive-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Install Hive Module
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl :presto-hive-hadoop2
       - name: Run Hive Tests
+        if: needs.changes.outputs.codechange == 'true'
         run: presto-hive-hadoop2/bin/run_hive_tests.sh
       - name: Run Hive S3 Tests
+        if: needs.changes.outputs.codechange == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.HIVE_AWS_ACCESSKEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.HIVE_AWS_SECRETKEY }}
@@ -70,6 +75,7 @@ jobs:
               presto-hive-hadoop2/bin/run_hive_s3_tests.sh
           fi
       - name: Run Hive Glue Tests
+        if: needs.changes.outputs.codechange == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.HIVE_AWS_ACCESSKEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.HIVE_AWS_SECRETKEY }}
@@ -85,25 +91,29 @@ jobs:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 20
     concurrency:
       group: ${{ github.workflow }}-hive-dockerized-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Install Hive Module
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl :presto-hive
       - name: Run Hive Dockerized Tests
+        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -pl :presto-hive -P test-hive-insert-overwrite

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -35,27 +35,31 @@ jobs:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-kudu-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven Install
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am --no-transfer-progress -pl presto-kudu
       - name: Kudu Tests
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           presto-kudu/bin/run_kudu_tests.sh 3 null
           presto-kudu/bin/run_kudu_tests.sh 1 ""

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -35,33 +35,38 @@ jobs:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-product-tests-basic-environment-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - name: Free Disk Space
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           df -h
           sudo apt-get clean
           rm -rf /opt/hostedtoolcache
           df -h
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven install
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-test-coverage'
       - name: Run Product Tests Basic Environment
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode -x quarantine,big_query,storage_formats,profile_specific_tests,tpcds,cassandra,mysql_connector,postgresql_connector,mysql,kafka,avro

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -35,37 +35,43 @@ jobs:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-product-tests-specific-environment1-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - name: Free Disk Space
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           df -h
           sudo apt-get clean
           rm -rf /opt/hostedtoolcache
           df -h
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven install
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-test-coverage'
       - name: Product Tests Specific 1.1
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode -g hdfs_no_impersonation,avro
       - name: Product Tests Specific 1.2
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-no-impersonation -g hdfs_no_impersonation
@@ -73,14 +79,17 @@ jobs:
       # - name: Product Tests Specific 1.3
       #  run: presto-product-tests/bin/run_on_docker.sh singlenode-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
       - name: Product Tests Specific 1.4
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header
       - name: Product Tests Specific 1.5
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-cross-realm -g storage_formats,cli,hdfs_impersonation
       - name: Product Tests Specific 1.6
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls-kerberos -g cli,group-by,join,tls
@@ -92,49 +101,58 @@ jobs:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-product-tests-specific-environment2-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - name: Free Disk Space
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           df -h
           sudo apt-get clean
           rm -rf /opt/hostedtoolcache
           df -h
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven install
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-test-coverage'
       - name: Product Tests Specific 2.1
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-ldap -g ldap -x simba_jdbc
       - name: Product Tests Specific 2.2
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls -g smoke,cli,group-by,join,tls
       - name: Product Tests Specific 2.3
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-mysql -g mysql_connector,mysql
       - name: Product Tests Specific 2.4
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-postgresql -g postgresql_connector
       - name: Product Tests Specific 2.5
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-cassandra -g cassandra
@@ -142,10 +160,12 @@ jobs:
       # - name: Product Tests Specific 2.6
       #  run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-with-wire-encryption -g storage_formats,cli,hdfs_impersonation,authorization
       - name: Product Tests Specific 2.7
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kafka -g kafka
       - name: Product Tests Specific 2.8
+        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-sqlserver -g sqlserver

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -36,17 +36,17 @@ jobs:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
-
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-singlestore-dockerized-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
       - name: Remove unnecessary pre-installed toolchains for free disk spaces
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           echo "=== BEFORE ==="
           df -h
@@ -58,17 +58,21 @@ jobs:
           echo "=== AFTER ==="
           df -h
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Install SingleStore Module
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am  --no-transfer-progress -pl :presto-singlestore
       - name: Run SingleStore Dockerized Tests
+        if: needs.changes.outputs.codechange == 'true'
         env:
           SINGLESTORE_LICENSE: ${{ secrets.SINGLESTORE_LICENSE }}
         run: ./mvnw test ${MAVEN_TEST} -pl :presto-singlestore

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -36,25 +36,29 @@ jobs:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-spark-integration-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven Install
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl presto-spark-launcher,presto-spark-package,presto-spark-testing
       - name: Maven Tests
+        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -pl :presto-spark-testing -P test-presto-spark-integration-smoke-test

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -36,30 +36,35 @@ jobs:
         java: [ 8, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-test-other-modules-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
       - uses: actions/setup-java@v4
+        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       # Workaround for Ubuntu 24 and mysql to find the dependent library (https://github.com/prestodb/presto/issues/24327)
       - name: Create symlink for libaio.so.1
+        if: needs.changes.outputs.codechange == 'true'
         run: sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Maven Install
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!:presto-docs,!:presto-server,!presto-test-coverage'
       - name: Maven Tests
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           ./mvnw test -T 1 ${MAVEN_TEST} -pl '
             !presto-tests, 


### PR DESCRIPTION
## Description

Due to new github branch protection rules, both Java 8 and 17 matrix jobs have to pass. Our old path filter rules prevent the matrix jobs from running if the path filter doesn't pass (e.g. doc-only PRs). In order to resolve this, we add a check at the beginning of each step for the path filter. It is not ideal, but github does not provide a better way at the moment


## Motivation and Context

Allow doc-only PRs to pass branch protection rules. Fixes #24698 


## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

