### PR TITLE
[native] Update prometheus metrics asynchronously

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -892,6 +892,7 @@ NodeConfig::NodeConfig() {
           NONE_PROP(kNodeIp),
           NONE_PROP(kNodeInternalAddress),
           NONE_PROP(kNodeLocation),
+          NONE_PROP(kNodePrometheusExecutorThreads),
       };
 }
 
@@ -902,6 +903,16 @@ NodeConfig* NodeConfig::instance() {
 
 std::string NodeConfig::nodeEnvironment() const {
   return requiredProperty(kNodeEnvironment);
+}
+
+int NodeConfig::prometheusExecutorThreads() const {
+  static constexpr int
+      kNodePrometheusExecutorThreadsDefault = 2;
+  auto resultOpt = optionalProperty<int>(kNodePrometheusExecutorThreads);
+  if (resultOpt.hasValue()) {
+    return resultOpt.value();
+  }
+  return kNodePrometheusExecutorThreadsDefault;
 }
 
 std::string NodeConfig::nodeId() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -1025,6 +1025,7 @@ class NodeConfig : public ConfigBase {
   static constexpr std::string_view kNodeInternalAddress{
       "node.internal-address"};
   static constexpr std::string_view kNodeLocation{"node.location"};
+  static constexpr std::string_view kNodePrometheusExecutorThreads{"node.prometheus.executor-threads"};
 
   NodeConfig();
 
@@ -1033,6 +1034,8 @@ class NodeConfig : public ConfigBase {
   static NodeConfig* instance();
 
   std::string nodeEnvironment() const;
+
+  int prometheusExecutorThreads() const;
 
   std::string nodeId() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -1025,7 +1025,7 @@ class NodeConfig : public ConfigBase {
   static constexpr std::string_view kNodeInternalAddress{
       "node.internal-address"};
   static constexpr std::string_view kNodeLocation{"node.location"};
-  static constexpr std::string_view kNodePrometheusExecutorThreads{"node.prometheus.executor-threads"};
+  static constexpr std::string_view kNodePrometheusExecutorThreads{"node.prometheus.num-executor-threads"};
 
   NodeConfig();
 

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -212,6 +212,11 @@ TEST_F(ConfigTest, optionalNodeConfigs) {
   init(config, {{std::string(NodeConfig::kNodeIp), "127.0.0.1"}});
   ASSERT_EQ(
       config.nodeInternalAddress([]() { return "0.0.0.0"; }), "127.0.0.1");
+
+  // make sure "node.kNodePrometheusExecutorThreads" works too
+  init(config, {{std::string(NodeConfig::kNodePrometheusExecutorThreads), "4"}});
+  ASSERT_EQ(
+      config.prometheusExecutorThreads(), 4);
 }
 
 TEST_F(ConfigTest, optionalSystemConfigsWithDefault) {

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -213,7 +213,6 @@ TEST_F(ConfigTest, optionalNodeConfigs) {
   ASSERT_EQ(
       config.nodeInternalAddress([]() { return "0.0.0.0"; }), "127.0.0.1");
 
-  // make sure "node.kNodePrometheusExecutorThreads" works too
   init(config, {{std::string(NodeConfig::kNodePrometheusExecutorThreads), "4"}});
   ASSERT_EQ(
       config.prometheusExecutorThreads(), 4);

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.h
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.h
@@ -12,11 +12,13 @@
  * limitations under the License.
  */
 
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/concurrency/ConcurrentHashMap.h>
 #include "presto_cpp/main/common/Configs.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/StatsReporter.h"
-#include <folly/executors/CPUThreadPoolExecutor.h>
+
 
 namespace facebook::presto::prometheus {
 
@@ -39,11 +41,7 @@ class PrometheusStatsReporter : public facebook::velox::BaseStatsReporter {
   class PrometheusImpl;
 
  public:
-  /**
-   * @brief Constructor with optional thread count
-   * @param labels Labels for metrics.
-   * @param numThreads Number of threads in the executor
-   */
+
   explicit PrometheusStatsReporter(
       const std::map<std::string, std::string>& labels, int numThreads);
 
@@ -99,14 +97,12 @@ class PrometheusStatsReporter : public facebook::velox::BaseStatsReporter {
     return std::make_unique<PrometheusStatsReporter>(labels, nodeConfig->prometheusExecutorThreads());
   }
 
-  // Visible for testing
-  mutable std::unordered_map<std::string, StatsInfo> registeredMetricsMap_;
-
  private:
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
   std::shared_ptr<PrometheusImpl> impl_;
   // A map of labels assigned to each metric which helps in filtering at client
   // end.
+  mutable folly::ConcurrentHashMap<std::string, StatsInfo> registeredMetricsMap_;
   VELOX_FRIEND_TEST(PrometheusReporterTest, testCountAndGauge);
   VELOX_FRIEND_TEST(PrometheusReporterTest, testHistogramSummary);
   VELOX_FRIEND_TEST(PrometheusReporterTest, testConcurrentReporting);

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.h
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.h
@@ -16,6 +16,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/StatsReporter.h"
+#include <folly/executors/CPUThreadPoolExecutor.h>
 
 namespace facebook::presto::prometheus {
 
@@ -38,8 +39,13 @@ class PrometheusStatsReporter : public facebook::velox::BaseStatsReporter {
   class PrometheusImpl;
 
  public:
+  /**
+   * @brief Constructor with optional thread count
+   * @param labels Labels for metrics.
+   * @param numThreads Number of threads in the executor
+   */
   explicit PrometheusStatsReporter(
-      const std::map<std::string, std::string>& labels);
+      const std::map<std::string, std::string>& labels, int numThreads);
 
   void registerMetricExportType(const char* key, velox::StatType)
       const override;
@@ -77,6 +83,12 @@ class PrometheusStatsReporter : public facebook::velox::BaseStatsReporter {
 
   std::string fetchMetrics() override;
 
+  /**
+   * Waits for all pending metric updates to complete.
+   * This is only used in tests to ensure correct timing.
+   */
+  void waitForCompletion() const;
+
   static std::unique_ptr<velox::BaseStatsReporter> createPrometheusReporter() {
     auto nodeConfig = NodeConfig::instance();
     const std::string cluster = nodeConfig->nodeEnvironment();
@@ -84,14 +96,17 @@ class PrometheusStatsReporter : public facebook::velox::BaseStatsReporter {
     const std::string worker = !hostName ? "" : hostName;
     std::map<std::string, std::string> labels{
         {"cluster", cluster}, {"worker", worker}};
-    return std::make_unique<PrometheusStatsReporter>(labels);
+    return std::make_unique<PrometheusStatsReporter>(labels, nodeConfig->prometheusExecutorThreads());
   }
 
+  // Visible for testing
+  mutable std::unordered_map<std::string, StatsInfo> registeredMetricsMap_;
+
  private:
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
   std::shared_ptr<PrometheusImpl> impl_;
   // A map of labels assigned to each metric which helps in filtering at client
   // end.
-  mutable std::unordered_map<std::string, StatsInfo> registeredMetricsMap_;
   VELOX_FRIEND_TEST(PrometheusReporterTest, testCountAndGauge);
   VELOX_FRIEND_TEST(PrometheusReporterTest, testHistogramSummary);
 };

--- a/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.h
+++ b/presto-native-execution/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.h
@@ -109,5 +109,6 @@ class PrometheusStatsReporter : public facebook::velox::BaseStatsReporter {
   // end.
   VELOX_FRIEND_TEST(PrometheusReporterTest, testCountAndGauge);
   VELOX_FRIEND_TEST(PrometheusReporterTest, testHistogramSummary);
+  VELOX_FRIEND_TEST(PrometheusReporterTest, testConcurrentReporting);
 };
 } // namespace facebook::presto::prometheus

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeApiEndpointUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeApiEndpointUtils.java
@@ -40,7 +40,6 @@ public final class NativeApiEndpointUtils
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                System.out.println(line);
                 Matcher matcher = metricPattern.matcher(line);
                 if (matcher.matches()) {
                     String metricName = matcher.group(1);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeApiEndpointUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeApiEndpointUtils.java
@@ -40,6 +40,7 @@ public final class NativeApiEndpointUtils
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
             String line;
             while ((line = reader.readLine()) != null) {
+                System.out.println(line);
                 Matcher matcher = metricPattern.matcher(line);
                 if (matcher.matches()) {
                     String metricName = matcher.group(1);


### PR DESCRIPTION
## Description

Make metric updation async to rule out any slowness in the main thread. This is to rule out any slowness due to extensive metric  use as we had seen such issue for histograms before.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

