### PR TITLE
Add missing shared arbitrator configs

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -353,7 +353,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
 * **Type:** ``string``
 * **Default value:** ``false``
 
-  If true, global arbitration will not reclaim memory by spilling, but
+  If ``true``, global arbitration does not reclaim memory by spilling, but
   only by aborting. This flag is only effective if
   'shared-arbitrator.global-arbitration-enabled' is true
 

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -314,7 +314,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
   global arbitration also avoids reclaiming from a participant if its
   reclaimable used capacity is less than this threshold. This is to
   prevent inefficient memory reclaim operations on a participant with
-  small reclaimable used capacity which could causes a large number of
+  small reclaimable used capacity, which could cause a large number of
   small spilled file on disk.
 
 ``shared-arbitrator.memory-reclaim-threads-hw-multiplier``

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -355,7 +355,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
 
   If ``true``, global arbitration does not reclaim memory by spilling, but
   only by aborting. This flag is only effective if
-  'shared-arbitrator.global-arbitration-enabled' is true
+  ``shared-arbitrator.global-arbitration-enabled`` is ``true``.
 
 Cache Properties
 ----------------

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -297,7 +297,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
   Specifies the starting memory capacity limit for global arbitration to
   search for victim participant to reclaim used memory by abort. For
   participants with capacity larger than the limit, the global arbitration
-  choose to abort the youngest participant which has the largest
+  chooses to abort the youngest participant which has the largest
   participant id. This helps to let the old queries to run to completion.
   The abort capacity limit is reduced by half if could not find a victim
   participant until this reaches to zero.

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -345,7 +345,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
   The ratio used with ``shared-arbitrator.memory-reclaim-max-wait-time``,
   beyond which global arbitration will no longer reclaim memory by
   spilling, but instead directly abort. It is only in effect when
-  'global-arbitration-enabled' is true
+  ``global-arbitration-enabled`` is ``true``.
 
 ``shared-arbitrator.global-arbitration-without-spill``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -288,6 +288,75 @@ The configuration properties of Presto C++ workers are described here, in alphab
 
   See description for ``shared-arbitrator.memory-pool-min-free-capacity``
 
+``shared-arbitrator.memory-pool-abort-capacity-limit``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``1GB``
+
+  Specifies the starting memory capacity limit for global arbitration to
+  search for victim participant to reclaim used memory by abort. For
+  participants with capacity larger than the limit, the global arbitration
+  choose to abort the youngest participant which has the largest
+  participant id. This helps to let the old queries to run to completion.
+  The abort capacity limit is reduced by half if could not find a victim
+  participant until this reaches to zero.
+
+  NOTE: the limit must be zero or a power of 2.
+
+``shared-arbitrator.memory-pool-min-reclaim-bytes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``128MB``
+
+  Specifies the minimum bytes to reclaim from a participant at a time. The
+  global arbitration also avoids to reclaim from a participant if its
+  reclaimable used capacity is less than this threshold. This is to
+  prevent inefficient memory reclaim operations on a participant with
+  small reclaimable used capacity which could causes a large number of
+  small spilled file on disk.
+
+``shared-arbitrator.memory-reclaim-threads-hw-multiplier``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``0.5``
+
+  Floating point number used in calculating how many threads we would use
+  for memory reclaim execution: hw_concurrency x multiplier. 0.5 is
+  default.
+
+``shared-arbitrator.global-arbitration-memory-reclaim-pct``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``10``
+
+  If not zero, specifies the minimum amount of memory to reclaim by global
+  memory arbitration as percentage of total arbitrator memory capacity.
+
+``shared-arbitrator.global-arbitration-abort-time-ratio``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``0.5``
+
+  The ratio used with 'shared-arbitrator.memory-reclaim-max-wait-time',
+  beyond which, global arbitration will no longer reclaim memory by
+  spilling, but instead directly abort. It is only in effect when
+  'global-arbitration-enabled' is true
+
+``shared-arbitrator.global-arbitration-without-spill``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``false``
+
+  If true, global arbitration will not reclaim memory by spilling, but
+  only by aborting. This flag is only effective if
+  'shared-arbitrator.global-arbitration-enabled' is true
+
 Cache Properties
 ----------------
 

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -302,7 +302,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
   The abort capacity limit is reduced by half if could not find a victim
   participant until this reaches to zero.
 
-  NOTE: the limit must be zero or a power of 2.
+  NOTE: the limit value must be either zero, or a power of 2.
 
 ``shared-arbitrator.memory-pool-min-reclaim-bytes``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -343,7 +343,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
 * **Default value:** ``0.5``
 
   The ratio used with ``shared-arbitrator.memory-reclaim-max-wait-time``,
-  beyond which, global arbitration will no longer reclaim memory by
+  beyond which global arbitration will no longer reclaim memory by
   spilling, but instead directly abort. It is only in effect when
   'global-arbitration-enabled' is true
 

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -311,7 +311,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
 * **Default value:** ``128MB``
 
   Specifies the minimum bytes to reclaim from a participant at a time. The
-  global arbitration also avoids to reclaim from a participant if its
+  global arbitration also avoids reclaiming from a participant if its
   reclaimable used capacity is less than this threshold. This is to
   prevent inefficient memory reclaim operations on a participant with
   small reclaimable used capacity which could causes a large number of

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -323,7 +323,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
 * **Type:** ``string``
 * **Default value:** ``0.5``
 
-  Floating point number used in calculating how many threads we would use
+  Floating point number used in calculating how many threads to use
   for memory reclaim execution: hw_concurrency x multiplier. 0.5 is
   default.
 

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -315,7 +315,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
   reclaimable used capacity is less than this threshold. This is to
   prevent inefficient memory reclaim operations on a participant with
   small reclaimable used capacity, which could cause a large number of
-  small spilled file on disk.
+  small spilled files on disk.
 
 ``shared-arbitrator.memory-reclaim-threads-hw-multiplier``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -342,7 +342,7 @@ The configuration properties of Presto C++ workers are described here, in alphab
 * **Type:** ``string``
 * **Default value:** ``0.5``
 
-  The ratio used with 'shared-arbitrator.memory-reclaim-max-wait-time',
+  The ratio used with ``shared-arbitrator.memory-reclaim-max-wait-time``,
   beyond which, global arbitration will no longer reclaim memory by
   spilling, but instead directly abort. It is only in effect when
   'global-arbitration-enabled' is true

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -917,7 +917,20 @@ void PrestoServer::initializeVeloxMemory() {
         {std::string(SharedArbitratorConfig::kSlowCapacityGrowPct),
          systemConfig->sharedArbitratorSlowCapacityGrowPct()},
         {std::string(SharedArbitratorConfig::kCheckUsageLeak),
-         folly::to<std::string>(systemConfig->enableMemoryLeakCheck())}};
+         folly::to<std::string>(systemConfig->enableMemoryLeakCheck())},
+        {std::string(SharedArbitratorConfig::kMemoryPoolAbortCapacityLimit),
+         systemConfig->sharedArbitratorMemoryPoolAbortCapacityLimit()},
+        {std::string(SharedArbitratorConfig::kMemoryPoolMinReclaimBytes),
+         systemConfig->sharedArbitratorMemoryPoolMinReclaimBytes()},
+        {std::string(SharedArbitratorConfig::kMemoryReclaimThreadsHwMultiplier),
+         systemConfig->sharedArbitratorMemoryReclaimThreadsHwMultiplier()},
+        {std::string(
+             SharedArbitratorConfig::kGlobalArbitrationMemoryReclaimPct),
+         systemConfig->sharedArbitratorGlobalArbitrationMemoryReclaimPct()},
+        {std::string(SharedArbitratorConfig::kGlobalArbitrationAbortTimeRatio),
+         systemConfig->sharedArbitratorGlobalArbitrationAbortTimeRatio()},
+        {std::string(SharedArbitratorConfig::kGlobalArbitrationWithoutSpill),
+         systemConfig->sharedArbitratorGlobalArbitrationWithoutSpill()}};
   }
   velox::memory::initializeMemoryManager(options);
   PRESTO_STARTUP_LOG(INFO) << "Memory manager has been setup: "

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -638,6 +638,63 @@ std::string SystemConfig::sharedArbitratorMemoryPoolMinFreeCapacityPct() const {
           std::string(kSharedArbitratorMemoryPoolMinFreeCapacityPctDefault));
 }
 
+std::string SystemConfig::sharedArbitratorMemoryPoolAbortCapacityLimit() const {
+  static constexpr std::string_view
+      kSharedArbitratorMemoryPoolAbortCapacityLimitDefault = "1GB";
+  return optionalProperty<std::string>(
+             kSharedArbitratorMemoryPoolAbortCapacityLimit)
+      .value_or(
+          std::string(kSharedArbitratorMemoryPoolAbortCapacityLimitDefault));
+}
+
+std::string SystemConfig::sharedArbitratorMemoryPoolMinReclaimBytes() const {
+  static constexpr std::string_view
+      kSharedArbitratorMemoryPoolMinReclaimBytesDefault = "128MB";
+  return optionalProperty<std::string>(
+             kSharedArbitratorMemoryPoolMinReclaimBytes)
+      .value_or(std::string(kSharedArbitratorMemoryPoolMinReclaimBytesDefault));
+}
+
+std::string SystemConfig::sharedArbitratorMemoryReclaimThreadsHwMultiplier()
+    const {
+  static constexpr std::string_view
+      kSharedArbitratorMemoryReclaimThreadsHwMultiplierDefault = "0.5";
+  return optionalProperty<std::string>(
+             kSharedArbitratorMemoryReclaimThreadsHwMultiplier)
+      .value_or(std::string(
+          kSharedArbitratorMemoryReclaimThreadsHwMultiplierDefault));
+}
+
+std::string SystemConfig::sharedArbitratorGlobalArbitrationMemoryReclaimPct()
+    const {
+  static constexpr std::string_view
+      kSharedArbitratorGlobalArbitrationMemoryReclaimPctDefault = "10";
+  return optionalProperty<std::string>(
+             kSharedArbitratorGlobalArbitrationMemoryReclaimPct)
+      .value_or(std::string(
+          kSharedArbitratorGlobalArbitrationMemoryReclaimPctDefault));
+}
+
+std::string SystemConfig::sharedArbitratorGlobalArbitrationAbortTimeRatio()
+    const {
+  static constexpr std::string_view
+      kSharedArbitratorGlobalArbitrationAbortTimeRatioDefault = "0.5";
+  return optionalProperty<std::string>(
+             kSharedArbitratorGlobalArbitrationAbortTimeRatio)
+      .value_or(
+          std::string(kSharedArbitratorGlobalArbitrationAbortTimeRatioDefault));
+}
+
+std::string SystemConfig::sharedArbitratorGlobalArbitrationWithoutSpill()
+    const {
+  static constexpr std::string_view
+      kSharedArbitratorGlobalArbitrationWithoutSpillDefault = "false";
+  return optionalProperty<std::string>(
+             kSharedArbitratorGlobalArbitrationWithoutSpill)
+      .value_or(
+          std::string(kSharedArbitratorGlobalArbitrationWithoutSpillDefault));
+}
+
 bool SystemConfig::enableSystemMemoryPoolUsageTracking() const {
   return optionalProperty<bool>(kEnableSystemMemoryPoolUsageTracking)
       .value_or(true);

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -491,6 +491,56 @@ class SystemConfig : public ConfigBase {
       kSharedArbitratorMemoryPoolMinFreeCapacityPct{
           "shared-arbitrator.memory-pool-min-free-capacity-pct"};
 
+  /// Specifies the starting memory capacity limit for global arbitration to
+  /// search for victim participant to reclaim used memory by abort. For
+  /// participants with capacity larger than the limit, the global arbitration
+  /// choose to abort the youngest participant which has the largest
+  /// participant id. This helps to let the old queries to run to completion.
+  /// The abort capacity limit is reduced by half if could not find a victim
+  /// participant until this reaches to zero.
+  ///
+  /// NOTE: the limit must be zero or a power of 2.
+  static constexpr std::string_view
+      kSharedArbitratorMemoryPoolAbortCapacityLimit{
+          "shared-arbitrator.memory-pool-abort-capacity-limit"};
+
+  /// Specifies the minimum bytes to reclaim from a participant at a time. The
+  /// global arbitration also avoids to reclaim from a participant if its
+  /// reclaimable used capacity is less than this threshold. This is to
+  /// prevent inefficient memory reclaim operations on a participant with
+  /// small reclaimable used capacity which could causes a large number of
+  /// small spilled file on disk.
+  static constexpr std::string_view kSharedArbitratorMemoryPoolMinReclaimBytes{
+      "shared-arbitrator.memory-pool-min-reclaim-bytes"};
+
+  /// Floating point number used in calculating how many threads we would use
+  /// for memory reclaim execution: hw_concurrency x multiplier. 0.5 is
+  /// default.
+  static constexpr std::string_view
+      kSharedArbitratorMemoryReclaimThreadsHwMultiplier{
+          "shared-arbitrator.memory-reclaim-threads-hw-multiplier"};
+
+  /// If not zero, specifies the minimum amount of memory to reclaim by global
+  /// memory arbitration as percentage of total arbitrator memory capacity.
+  static constexpr std::string_view
+      kSharedArbitratorGlobalArbitrationMemoryReclaimPct{
+          "shared-arbitrator.global-arbitration-memory-reclaim-pct"};
+
+  /// The ratio used with 'shared-arbitrator.memory-reclaim-max-wait-time',
+  /// beyond which, global arbitration will no longer reclaim memory by
+  /// spilling, but instead directly abort. It is only in effect when
+  /// 'global-arbitration-enabled' is true
+  static constexpr std::string_view
+      kSharedArbitratorGlobalArbitrationAbortTimeRatio{
+          "shared-arbitrator.global-arbitration-abort-time-ratio"};
+
+  /// If true, global arbitration will not reclaim memory by spilling, but
+  /// only by aborting. This flag is only effective if
+  /// 'shared-arbitrator.global-arbitration-enabled' is true
+  static constexpr std::string_view
+      kSharedArbitratorGlobalArbitrationWithoutSpill{
+          "shared-arbitrator.global-arbitration-without-spill"};
+
   /// Enables the memory usage tracking for the system memory pool used for
   /// cases such as disk spilling.
   static constexpr std::string_view kEnableSystemMemoryPoolUsageTracking{
@@ -831,6 +881,18 @@ class SystemConfig : public ConfigBase {
   std::string sharedArbitratorMemoryPoolMinFreeCapacity() const;
 
   std::string sharedArbitratorMemoryPoolMinFreeCapacityPct() const;
+
+  std::string sharedArbitratorMemoryPoolAbortCapacityLimit() const;
+
+  std::string sharedArbitratorMemoryPoolMinReclaimBytes() const;
+
+  std::string sharedArbitratorMemoryReclaimThreadsHwMultiplier() const;
+
+  std::string sharedArbitratorGlobalArbitrationMemoryReclaimPct() const;
+
+  std::string sharedArbitratorGlobalArbitrationAbortTimeRatio() const;
+
+  std::string sharedArbitratorGlobalArbitrationWithoutSpill() const;
 
   int32_t queryMemoryGb() const;
 


### PR DESCRIPTION
```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add Presto native shared arbitrator configuration properties:
   * ``shared-arbitrator.memory-pool-abort-capacity-limit``
   * ``shared-arbitrator.memory-pool-min-reclaim-bytes``
   * ``shared-arbitrator.memory-reclaim-threads-hw-multiplier``
   * ``shared-arbitrator.global-arbitration-memory-reclaim-pct``
   * ``shared-arbitrator.global-arbitration-abort-time-ratio``
   * ``shared-arbitrator.global-arbitration-without-spill``
