### PR TITLE
Add ConnectorDeleteTableHandle to ConnectorProtocol

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import static com.facebook.presto.execution.TaskStatus.initialTaskStatus;
 import static com.facebook.presto.execution.buffer.BufferState.OPEN;
 import static com.facebook.presto.metadata.MetadataUpdates.DEFAULT_METADATA_UPDATES;
-import static com.facebook.presto.util.DateTimeUtils.toTimeStampInMillis;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.System.currentTimeMillis;
@@ -56,15 +55,18 @@ public class TaskInfo
     private final MetadataUpdates metadataUpdates;
     private final String nodeId;
 
-    public TaskInfo(TaskId taskId,
-            TaskStatus taskStatus,
-            long lastHeartbeatInMillis,
-            OutputBufferInfo outputBuffers,
-            Set<PlanNodeId> noMoreSplits,
-            TaskStats stats,
-            boolean needsPlan,
-            MetadataUpdates metadataUpdates,
-            String nodeId)
+    @JsonCreator
+    @ThriftConstructor
+    public TaskInfo(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("taskStatus") TaskStatus taskStatus,
+            @JsonProperty("lastHeartbeatInMillis") long lastHeartbeatInMillis,
+            @JsonProperty("outputBuffers") OutputBufferInfo outputBuffers,
+            @JsonProperty("noMoreSplits") Set<PlanNodeId> noMoreSplits,
+            @JsonProperty("stats") TaskStats stats,
+            @JsonProperty("needsPlan") boolean needsPlan,
+            @JsonProperty("metadataUpdates") MetadataUpdates metadataUpdates,
+            @JsonProperty("nodeId") String nodeId)
     {
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.taskStatus = requireNonNull(taskStatus, "taskStatus is null");
@@ -77,30 +79,6 @@ public class TaskInfo
         this.needsPlan = needsPlan;
         this.metadataUpdates = metadataUpdates;
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
-    }
-
-    @JsonCreator
-    @ThriftConstructor
-    public TaskInfo(
-            @JsonProperty("taskId") TaskId taskId,
-            @JsonProperty("taskStatus") TaskStatus taskStatus,
-            @JsonProperty("lastHeartbeat") DateTime lastHeartbeat,
-            @JsonProperty("outputBuffers") OutputBufferInfo outputBuffers,
-            @JsonProperty("noMoreSplits") Set<PlanNodeId> noMoreSplits,
-            @JsonProperty("stats") TaskStats stats,
-            @JsonProperty("needsPlan") boolean needsPlan,
-            @JsonProperty("metadataUpdates") MetadataUpdates metadataUpdates,
-            @JsonProperty("nodeId") String nodeId)
-    {
-        this(taskId,
-                taskStatus,
-                toTimeStampInMillis(lastHeartbeat),
-                outputBuffers,
-                noMoreSplits,
-                stats,
-                needsPlan,
-                metadataUpdates,
-                nodeId);
     }
 
     @JsonProperty
@@ -117,13 +95,13 @@ public class TaskInfo
         return taskStatus;
     }
 
-    @JsonProperty
-    @ThriftField(3)
     public DateTime getLastHeartbeat()
     {
         return new DateTime(lastHeartbeatInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(3)
     public long getLastHeartbeatInMillis()
     {
         return lastHeartbeatInMillis;

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -23,8 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 
-import javax.annotation.Nullable;
-
 import java.util.List;
 import java.util.Set;
 
@@ -138,11 +136,11 @@ public class TaskStats
 
     public TaskStats(DateTime createTime, DateTime endTime)
     {
-        this(createTime,
-                null,
-                null,
-                null,
-                endTime,
+        this(toTimeStampInMillis(createTime),
+                0L,
+                0L,
+                0L,
+                toTimeStampInMillis(endTime),
                 0L,
                 0L,
                 0,
@@ -181,59 +179,61 @@ public class TaskStats
                 new RuntimeStats());
     }
 
+    @JsonCreator
+    @ThriftConstructor
     public TaskStats(
-            long createTimeInMillis,
-            long firstStartTimeInMillis,
-            long lastStartTimeInMillis,
-            long lastEndTimeInMillis,
-            long endTimeInMillis,
-            long elapsedTimeInNanos,
-            long queuedTimeInNanos,
+            @JsonProperty("createTimeInMillis") long createTimeInMillis,
+            @JsonProperty("firstStartTimeInMillis") long firstStartTimeInMillis,
+            @JsonProperty("lastStartTimeInMillis") long lastStartTimeInMillis,
+            @JsonProperty("lastEndTimeInMillis") long lastEndTimeInMillis,
+            @JsonProperty("endTimeInMillis") long endTimeInMillis,
+            @JsonProperty("elapsedTimeInNanos") long elapsedTimeInNanos,
+            @JsonProperty("queuedTimeInNanos") long queuedTimeInNanos,
 
-            int totalDrivers,
-            int queuedDrivers,
-            int queuedPartitionedDrivers,
-            long queuedPartitionedSplitsWeight,
-            int runningDrivers,
-            int runningPartitionedDrivers,
-            long runningPartitionedSplitsWeight,
-            int blockedDrivers,
-            int completedDrivers,
+            @JsonProperty("totalDrivers") int totalDrivers,
+            @JsonProperty("queuedDrivers") int queuedDrivers,
+            @JsonProperty("queuedPartitionedDrivers") int queuedPartitionedDrivers,
+            @JsonProperty("queuedPartitionedSplitsWeight") long queuedPartitionedSplitsWeight,
+            @JsonProperty("runningDrivers") int runningDrivers,
+            @JsonProperty("runningPartitionedDrivers") int runningPartitionedDrivers,
+            @JsonProperty("runningPartitionedSplitsWeight") long runningPartitionedSplitsWeight,
+            @JsonProperty("blockedDrivers") int blockedDrivers,
+            @JsonProperty("completedDrivers") int completedDrivers,
 
-            double cumulativeUserMemory,
-            double cumulativeTotalMemory,
-            long userMemoryReservationInBytes,
-            long revocableMemoryReservationInBytes,
-            long systemMemoryReservationInBytes,
+            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
+            @JsonProperty("userMemoryReservationInBytes") long userMemoryReservationInBytes,
+            @JsonProperty("revocableMemoryReservationInBytes") long revocableMemoryReservationInBytes,
+            @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
 
-            long peakTotalMemoryInBytes,
-            long peakUserMemoryInBytes,
-            long peakNodeTotalMemoryInBytes,
+            @JsonProperty("peakTotalMemoryInBytes") long peakTotalMemoryInBytes,
+            @JsonProperty("peakUserMemoryInBytes") long peakUserMemoryInBytes,
+            @JsonProperty("peakNodeTotalMemoryInBytes") long peakNodeTotalMemoryInBytes,
 
-            long totalScheduledTimeInNanos,
-            long totalCpuTimeInNanos,
-            long totalBlockedTimeInNanos,
-            boolean fullyBlocked,
-            Set<BlockedReason> blockedReasons,
+            @JsonProperty("totalScheduledTimeInNanos") long totalScheduledTimeInNanos,
+            @JsonProperty("totalCpuTimeInNanos") long totalCpuTimeInNanos,
+            @JsonProperty("totalBlockedTimeInNanos") long totalBlockedTimeInNanos,
+            @JsonProperty("fullyBlocked") boolean fullyBlocked,
+            @JsonProperty("blockedReasons") Set<BlockedReason> blockedReasons,
 
-            long totalAllocationInBytes,
+            @JsonProperty("totalAllocationInBytes") long totalAllocationInBytes,
 
-            long rawInputDataSizeInBytes,
-            long rawInputPositions,
+            @JsonProperty("rawInputDataSizeInBytes") long rawInputDataSizeInBytes,
+            @JsonProperty("rawInputPositions") long rawInputPositions,
 
-            long processedInputDataSizeInBytes,
-            long processedInputPositions,
+            @JsonProperty("processedInputDataSizeInBytes") long processedInputDataSizeInBytes,
+            @JsonProperty("processedInputPositions") long processedInputPositions,
 
-            long outputDataSizeInBytes,
-            long outputPositions,
+            @JsonProperty("outputDataSizeInBytes") long outputDataSizeInBytes,
+            @JsonProperty("outputPositions") long outputPositions,
 
-            long physicalWrittenDataSizeInBytes,
+            @JsonProperty("physicalWrittenDataSizeInBytes") long physicalWrittenDataSizeInBytes,
 
-            int fullGcCount,
-            long fullGcTimeInMillis,
+            @JsonProperty("fullGcCount") int fullGcCount,
+            @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis,
 
-            List<PipelineStats> pipelines,
-            RuntimeStats runtimeStats)
+            @JsonProperty("pipelines") List<PipelineStats> pipelines,
+            @JsonProperty("runtimeStats") RuntimeStats runtimeStats)
     {
         checkArgument(createTimeInMillis >= 0, "createTimeInMillis is negative");
         this.createTimeInMillis = createTimeInMillis;
@@ -307,176 +307,61 @@ public class TaskStats
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
     }
 
-    @JsonCreator
-    @ThriftConstructor
-    public TaskStats(
-            @JsonProperty("createTime") DateTime createTime,
-            @JsonProperty("firstStartTime") DateTime firstStartTime,
-            @JsonProperty("lastStartTime") DateTime lastStartTime,
-            @JsonProperty("lastEndTime") DateTime lastEndTime,
-            @JsonProperty("endTime") DateTime endTime,
-            @JsonProperty("elapsedTimeInNanos") long elapsedTimeInNanos,
-            @JsonProperty("queuedTimeInNanos") long queuedTimeInNanos,
-
-            @JsonProperty("totalDrivers") int totalDrivers,
-            @JsonProperty("queuedDrivers") int queuedDrivers,
-            @JsonProperty("queuedPartitionedDrivers") int queuedPartitionedDrivers,
-            @JsonProperty("queuedPartitionedSplitsWeight") long queuedPartitionedSplitsWeight,
-            @JsonProperty("runningDrivers") int runningDrivers,
-            @JsonProperty("runningPartitionedDrivers") int runningPartitionedDrivers,
-            @JsonProperty("runningPartitionedSplitsWeight") long runningPartitionedSplitsWeight,
-            @JsonProperty("blockedDrivers") int blockedDrivers,
-            @JsonProperty("completedDrivers") int completedDrivers,
-
-            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
-            @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
-            @JsonProperty("userMemoryReservationInBytes") long userMemoryReservationInBytes,
-            @JsonProperty("revocableMemoryReservationInBytes") long revocableMemoryReservationInBytes,
-            @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
-
-            @JsonProperty("peakTotalMemoryInBytes") long peakTotalMemoryInBytes,
-            @JsonProperty("peakUserMemoryInBytes") long peakUserMemoryInBytes,
-            @JsonProperty("peakNodeTotalMemoryInBytes") long peakNodeTotalMemoryInBytes,
-
-            @JsonProperty("totalScheduledTimeInNanos") long totalScheduledTimeInNanos,
-            @JsonProperty("totalCpuTimeInNanos") long totalCpuTimeInNanos,
-            @JsonProperty("totalBlockedTimeInNanos") long totalBlockedTimeInNanos,
-            @JsonProperty("fullyBlocked") boolean fullyBlocked,
-            @JsonProperty("blockedReasons") Set<BlockedReason> blockedReasons,
-
-            @JsonProperty("totalAllocationInBytes") long totalAllocationInBytes,
-
-            @JsonProperty("rawInputDataSizeInBytes") long rawInputDataSizeInBytes,
-            @JsonProperty("rawInputPositions") long rawInputPositions,
-
-            @JsonProperty("processedInputDataSizeInBytes") long processedInputDataSizeInBytes,
-            @JsonProperty("processedInputPositions") long processedInputPositions,
-
-            @JsonProperty("outputDataSizeInBytes") long outputDataSizeInBytes,
-            @JsonProperty("outputPositions") long outputPositions,
-
-            @JsonProperty("physicalWrittenDataSizeInBytes") long physicalWrittenDataSizeInBytes,
-
-            @JsonProperty("fullGcCount") int fullGcCount,
-            @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis,
-
-            @JsonProperty("pipelines") List<PipelineStats> pipelines,
-            @JsonProperty("runtimeStats") RuntimeStats runtimeStats)
-    {
-        this(toTimeStampInMillis(createTime),
-                toTimeStampInMillis(firstStartTime),
-                toTimeStampInMillis(lastStartTime),
-                toTimeStampInMillis(lastEndTime),
-                toTimeStampInMillis(endTime),
-
-                elapsedTimeInNanos,
-                queuedTimeInNanos,
-
-                totalDrivers,
-                queuedDrivers,
-                queuedPartitionedDrivers,
-                queuedPartitionedSplitsWeight,
-                runningDrivers,
-                runningPartitionedDrivers,
-                runningPartitionedSplitsWeight,
-                blockedDrivers,
-                completedDrivers,
-
-                cumulativeUserMemory,
-                cumulativeTotalMemory,
-                userMemoryReservationInBytes,
-                revocableMemoryReservationInBytes,
-                systemMemoryReservationInBytes,
-
-                peakTotalMemoryInBytes,
-                peakUserMemoryInBytes,
-                peakNodeTotalMemoryInBytes,
-
-                totalScheduledTimeInNanos,
-                totalCpuTimeInNanos,
-                totalBlockedTimeInNanos,
-                fullyBlocked,
-                blockedReasons,
-
-                totalAllocationInBytes,
-
-                rawInputDataSizeInBytes,
-                rawInputPositions,
-
-                processedInputDataSizeInBytes,
-                processedInputPositions,
-
-                outputDataSizeInBytes,
-                outputPositions,
-
-                physicalWrittenDataSizeInBytes,
-
-                fullGcCount,
-                fullGcTimeInMillis,
-
-                pipelines,
-                runtimeStats);
-    }
-
-    @JsonProperty
-    @ThriftField(1)
     public DateTime getCreateTime()
     {
         return new DateTime(createTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(1)
     public long getCreateTimeInMillis()
     {
         return createTimeInMillis;
     }
 
-    @Nullable
-    @JsonProperty
-    @ThriftField(2)
     public DateTime getFirstStartTime()
     {
         return new DateTime(firstStartTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(2)
     public long getFirstStartTimeInMillis()
     {
         return firstStartTimeInMillis;
     }
 
-    @Nullable
-    @JsonProperty
-    @ThriftField(3)
     public DateTime getLastStartTime()
     {
         return new DateTime(lastStartTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(3)
     public long getLastStartTimeInMillis()
     {
         return lastStartTimeInMillis;
     }
 
-    @Nullable
-    @JsonProperty
-    @ThriftField(4)
     public DateTime getLastEndTime()
     {
         return new DateTime(lastEndTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(4)
     public long getLastEndTimeInMillis()
     {
         return lastEndTimeInMillis;
     }
 
-    @Nullable
-    @JsonProperty
-    @ThriftField(5)
     public DateTime getEndTime()
     {
         return new DateTime(endTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(5)
     public long getEndTimeInMillis()
     {
         return endTimeInMillis;
@@ -737,11 +622,11 @@ public class TaskStats
     public TaskStats summarize()
     {
         return new TaskStats(
-                new DateTime(createTimeInMillis),
-                new DateTime(firstStartTimeInMillis),
-                new DateTime(lastStartTimeInMillis),
-                new DateTime(lastEndTimeInMillis),
-                new DateTime(endTimeInMillis),
+                createTimeInMillis,
+                firstStartTimeInMillis,
+                lastStartTimeInMillis,
+                lastEndTimeInMillis,
+                endTimeInMillis,
                 elapsedTimeInNanos,
                 queuedTimeInNanos,
                 totalDrivers,
@@ -783,11 +668,11 @@ public class TaskStats
     public TaskStats summarizeFinal()
     {
         return new TaskStats(
-                new DateTime(createTimeInMillis),
-                new DateTime(firstStartTimeInMillis),
-                new DateTime(lastStartTimeInMillis),
-                new DateTime(lastEndTimeInMillis),
-                new DateTime(endTimeInMillis),
+                createTimeInMillis,
+                firstStartTimeInMillis,
+                lastStartTimeInMillis,
+                lastEndTimeInMillis,
+                endTimeInMillis,
                 elapsedTimeInNanos,
                 queuedTimeInNanos,
                 totalDrivers,

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/hive/HiveConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/hive/HiveConnectorProtocol.h
@@ -25,5 +25,6 @@ using HiveConnectorProtocol = ConnectorProtocolTemplate<
     HiveSplit,
     HivePartitioningHandle,
     HiveTransactionHandle,
-    HiveMetadataUpdateHandle>;
+    HiveMetadataUpdateHandle,
+    NotImplemented>;
 } // namespace facebook::presto::protocol::hive

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
@@ -27,6 +27,7 @@ using IcebergConnectorProtocol = ConnectorProtocolTemplate<
     IcebergSplit,
     NotImplemented,
     hive::HiveTransactionHandle,
+    NotImplemented,
     NotImplemented>;
 
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1068,6 +1068,13 @@ void to_json(json& j, const IcebergSplit& p) {
       "IcebergSplit",
       "int64_t",
       "dataSequenceNumber");
+  to_json_key(
+      j,
+      "affinitySchedulingSectionSize",
+      p.affinitySchedulingSectionSize,
+      "IcebergSplit",
+      "int64_t",
+      "affinitySchedulingSectionSize");
 }
 
 void from_json(const json& j, IcebergSplit& p) {
@@ -1140,6 +1147,13 @@ void from_json(const json& j, IcebergSplit& p) {
       "IcebergSplit",
       "int64_t",
       "dataSequenceNumber");
+  from_json_key(
+      j,
+      "affinitySchedulingSectionSize",
+      p.affinitySchedulingSectionSize,
+      "IcebergSplit",
+      "int64_t",
+      "affinitySchedulingSectionSize");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -658,6 +658,33 @@ void from_json(const json& j, PrestoIcebergPartitionSpec& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
+
+void to_json(json& j, const SortField& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "sourceColumnId",
+      p.sourceColumnId,
+      "SortField",
+      "int",
+      "sourceColumnId");
+  to_json_key(
+      j, "sortOrder", p.sortOrder, "SortField", "SortOrder", "sortOrder");
+}
+
+void from_json(const json& j, SortField& p) {
+  from_json_key(
+      j,
+      "sourceColumnId",
+      p.sourceColumnId,
+      "SortField",
+      "int",
+      "sourceColumnId");
+  from_json_key(
+      j, "sortOrder", p.sortOrder, "SortField", "SortOrder", "sortOrder");
+}
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
 IcebergInsertTableHandle::IcebergInsertTableHandle() noexcept {
   _type = "hive-iceberg";
 }
@@ -728,6 +755,13 @@ void to_json(json& j, const IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "Map<String, String>",
       "storageProperties");
+  to_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergInsertTableHandle",
+      "List<SortField>",
+      "sortOrder");
 }
 
 void from_json(const json& j, IcebergInsertTableHandle& p) {
@@ -795,6 +829,13 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "Map<String, String>",
       "storageProperties");
+  from_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergInsertTableHandle",
+      "List<SortField>",
+      "sortOrder");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -868,6 +909,13 @@ void to_json(json& j, const IcebergOutputTableHandle& p) {
       "IcebergOutputTableHandle",
       "Map<String, String>",
       "storageProperties");
+  to_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergOutputTableHandle",
+      "List<SortField>",
+      "sortOrder");
 }
 
 void from_json(const json& j, IcebergOutputTableHandle& p) {
@@ -935,6 +983,13 @@ void from_json(const json& j, IcebergOutputTableHandle& p) {
       "IcebergOutputTableHandle",
       "Map<String, String>",
       "storageProperties");
+  from_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergOutputTableHandle",
+      "List<SortField>",
+      "sortOrder");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -1151,6 +1206,20 @@ void to_json(json& j, const IcebergTableHandle& p) {
       "IcebergTableHandle",
       "List<Integer>",
       "equalityFieldIds");
+  to_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergTableHandle",
+      "List<SortField>",
+      "sortOrder");
+  to_json_key(
+      j,
+      "updatedColumns",
+      p.updatedColumns,
+      "IcebergTableHandle",
+      "List<IcebergColumnHandle>",
+      "updatedColumns");
 }
 
 void from_json(const json& j, IcebergTableHandle& p) {
@@ -1211,6 +1280,20 @@ void from_json(const json& j, IcebergTableHandle& p) {
       "IcebergTableHandle",
       "List<Integer>",
       "equalityFieldIds");
+  from_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergTableHandle",
+      "List<SortField>",
+      "sortOrder");
+  from_json_key(
+      j,
+      "updatedColumns",
+      p.updatedColumns,
+      "IcebergTableHandle",
+      "List<IcebergColumnHandle>",
+      "updatedColumns");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -173,6 +173,14 @@ struct PrestoIcebergPartitionSpec {
 void to_json(json& j, const PrestoIcebergPartitionSpec& p);
 void from_json(const json& j, PrestoIcebergPartitionSpec& p);
 } // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
+struct SortField {
+  int sourceColumnId = {};
+  SortOrder sortOrder = {};
+};
+void to_json(json& j, const SortField& p);
+void from_json(const json& j, SortField& p);
+} // namespace facebook::presto::protocol::iceberg
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,6 +209,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   FileFormat fileFormat = {};
   hive::HiveCompressionCodec compressionCodec = {};
   Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
 
   IcebergInsertTableHandle() noexcept;
 };
@@ -235,6 +244,7 @@ struct IcebergOutputTableHandle : public ConnectorOutputTableHandle {
   FileFormat fileFormat = {};
   hive::HiveCompressionCodec compressionCodec = {};
   Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
 
   IcebergOutputTableHandle() noexcept;
 };
@@ -289,6 +299,8 @@ struct IcebergTableHandle : public ConnectorTableHandle {
   std::shared_ptr<String> tableSchemaJson = {};
   std::shared_ptr<List<Integer>> partitionFieldIds = {};
   std::shared_ptr<List<Integer>> equalityFieldIds = {};
+  List<SortField> sortOrder = {};
+  List<IcebergColumnHandle> updatedColumns = {};
 
   IcebergTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -283,6 +283,7 @@ struct IcebergSplit : public ConnectorSplit {
   List<DeleteFile> deletes = {};
   std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo = {};
   int64_t dataSequenceNumber = {};
+  int64_t affinitySchedulingSectionSize = {};
 
   IcebergSplit() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -74,3 +74,5 @@ JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogOperation.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitInfo.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/SortField.java
+  

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
@@ -26,6 +26,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   FileFormat fileFormat = {};
   hive::HiveCompressionCodec compressionCodec = {};
   Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
 
   IcebergInsertTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergOutputTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergOutputTableHandle.hpp.inc
@@ -26,6 +26,7 @@ struct IcebergOutputTableHandle : public ConnectorOutputTableHandle {
   FileFormat fileFormat = {};
   hive::HiveCompressionCodec compressionCodec = {};
   Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
 
   IcebergOutputTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergSplit.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergSplit.hpp.inc
@@ -30,6 +30,7 @@ struct IcebergSplit : public ConnectorSplit {
   List<DeleteFile> deletes = {};
   std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo = {};
   int64_t dataSequenceNumber = {};
+  int64_t affinitySchedulingSectionSize = {};
 
   IcebergSplit() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/core/ConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/ConnectorProtocol.h
@@ -89,6 +89,13 @@ class ConnectorProtocol {
   virtual void from_json(
       const json& j,
       std::shared_ptr<ConnectorMetadataUpdateHandle>& p) const = 0;
+
+  virtual void to_json(
+      json& j,
+      const std::shared_ptr<ConnectorDeleteTableHandle>& p) const = 0;
+  virtual void from_json(
+      const json& j,
+      std::shared_ptr<ConnectorDeleteTableHandle>& p) const = 0;
 };
 
 namespace {
@@ -104,7 +111,8 @@ template <
     typename ConnectorSplitType = NotImplemented,
     typename ConnectorPartitioningHandleType = NotImplemented,
     typename ConnectorTransactionHandleType = NotImplemented,
-    typename ConnectorMetadataUpdateHandleType = NotImplemented>
+    typename ConnectorMetadataUpdateHandleType = NotImplemented,
+    typename ConnectorDeleteTableHandleType = NotImplemented>
 class ConnectorProtocolTemplate final : public ConnectorProtocol {
  public:
   void to_json(json& j, const std::shared_ptr<ConnectorTableHandle>& p)
@@ -184,6 +192,16 @@ class ConnectorProtocolTemplate final : public ConnectorProtocol {
       const json& j,
       std::shared_ptr<ConnectorMetadataUpdateHandle>& p) const final {
     from_json_template<ConnectorMetadataUpdateHandleType>(j, p);
+  }
+
+  void to_json(json& j, const std::shared_ptr<ConnectorDeleteTableHandle>& p)
+      const final {
+    to_json_template<ConnectorDeleteTableHandleType>(j, p);
+  }
+  void from_json(
+      const json& j,
+      std::shared_ptr<ConnectorDeleteTableHandle>& p) const final {
+    from_json_template<ConnectorDeleteTableHandleType>(j, p);
   }
 
  private:

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -4338,10 +4338,26 @@ void to_json(json& j, const DriverStats& p) {
   j = json::object();
   to_json_key(j, "lifespan", p.lifespan, "DriverStats", "Lifespan", "lifespan");
   to_json_key(
-      j, "createTimeInMillis", p.createTimeInMillis, "DriverStats", "int64_t", "createTimeInMillis");
+      j,
+      "createTimeInMillis",
+      p.createTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "createTimeInMillis");
   to_json_key(
-      j, "startTimeInMillis", p.startTimeInMillis, "DriverStats", "int64_t", "startTimeInMillis");
-  to_json_key(j, "endTimeInMillis", p.endTimeInMillis, "DriverStats", "int64_t", "endTimeInMillis");
+      j,
+      "startTimeInMillis",
+      p.startTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "startTimeInMillis");
+  to_json_key(
+      j,
+      "endTimeInMillis",
+      p.endTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "endTimeInMillis");
   to_json_key(
       j, "queuedTime", p.queuedTime, "DriverStats", "Duration", "queuedTime");
   to_json_key(
@@ -4478,10 +4494,26 @@ void from_json(const json& j, DriverStats& p) {
   from_json_key(
       j, "lifespan", p.lifespan, "DriverStats", "Lifespan", "lifespan");
   from_json_key(
-      j, "createTimeInMillis", p.createTimeInMillis, "DriverStats", "int64_t", "createTimeInMillis");
+      j,
+      "createTimeInMillis",
+      p.createTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "createTimeInMillis");
   from_json_key(
-      j, "startTimeInMillis", p.startTimeInMillis, "DriverStats", "int64_t", "startTimeInMillis");
-  from_json_key(j, "endTimeInMillis", p.endTimeInMillis, "DriverStats", "int64_t", "endTimeInMillis");
+      j,
+      "startTimeInMillis",
+      p.startTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "startTimeInMillis");
+  from_json_key(
+      j,
+      "endTimeInMillis",
+      p.endTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "endTimeInMillis");
   from_json_key(
       j, "queuedTime", p.queuedTime, "DriverStats", "Duration", "queuedTime");
   from_json_key(
@@ -10014,7 +10046,12 @@ namespace facebook::presto::protocol {
 void to_json(json& j, const TaskStats& p) {
   j = json::object();
   to_json_key(
-      j, "createTimeInMillis", p.createTimeInMillis, "TaskStats", "int64_t", "createTimeInMillis");
+      j,
+      "createTimeInMillis",
+      p.createTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "createTimeInMillis");
   to_json_key(
       j,
       "firstStartTimeInMillis",
@@ -10030,8 +10067,19 @@ void to_json(json& j, const TaskStats& p) {
       "int64_t",
       "lastStartTimeInMillis");
   to_json_key(
-      j, "lastEndTimeInMillis", p.lastEndTimeInMillis, "TaskStats", "int64_t", "lastEndTimeInMillis");
-  to_json_key(j, "endTimeInMillis", p.endTimeInMillis, "TaskStats", "int64_t", "endTimeInMillis");
+      j,
+      "lastEndTimeInMillis",
+      p.lastEndTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "lastEndTimeInMillis");
+  to_json_key(
+      j,
+      "endTimeInMillis",
+      p.endTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "endTimeInMillis");
   to_json_key(
       j,
       "elapsedTimeInNanos",
@@ -10268,7 +10316,12 @@ void to_json(json& j, const TaskStats& p) {
 
 void from_json(const json& j, TaskStats& p) {
   from_json_key(
-      j, "createTimeInMillis", p.createTimeInMillis, "TaskStats", "int64_t", "createTimeInMillis");
+      j,
+      "createTimeInMillis",
+      p.createTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "createTimeInMillis");
   from_json_key(
       j,
       "firstStartTimeInMillis",
@@ -10284,8 +10337,19 @@ void from_json(const json& j, TaskStats& p) {
       "int64_t",
       "lastStartTimeInMillis");
   from_json_key(
-      j, "lastEndTimeInMillis", p.lastEndTimeInMillis, "TaskStats", "int64_t", "lastEndTimeInMillis");
-  from_json_key(j, "endTimeInMillis", p.endTimeInMillis, "TaskStats", "int64_t", "endTimeInMillis");
+      j,
+      "lastEndTimeInMillis",
+      p.lastEndTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "lastEndTimeInMillis");
+  from_json_key(
+      j,
+      "endTimeInMillis",
+      p.endTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "endTimeInMillis");
   from_json_key(
       j,
       "elapsedTimeInNanos",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -3251,6 +3251,91 @@ void from_json(const json& j, CreateHandle& p) {
       "schemaTableName");
 }
 } // namespace facebook::presto::protocol
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorDeleteTableHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+  getConnectorProtocol(type).to_json(j, p);
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorDeleteTableHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ConnectorDeleteTableHandle  ConnectorDeleteTableHandle");
+  }
+  getConnectorProtocol(type).from_json(j, p);
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const DeleteTableHandle& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "DeleteTableHandle",
+      "ConnectorId",
+      "connectorId");
+  to_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "DeleteTableHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  to_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "DeleteTableHandle",
+      "ConnectorDeleteTableHandle",
+      "connectorHandle");
+}
+
+void from_json(const json& j, DeleteTableHandle& p) {
+  from_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "DeleteTableHandle",
+      "ConnectorId",
+      "connectorId");
+  from_json_key(
+      j,
+      "transactionHandle",
+      p.transactionHandle,
+      "DeleteTableHandle",
+      "ConnectorTransactionHandle",
+      "transactionHandle");
+  from_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "DeleteTableHandle",
+      "ConnectorDeleteTableHandle",
+      "connectorHandle");
+}
+} // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 DeleteHandle::DeleteHandle() noexcept {
   _type = "DeleteHandle";
@@ -3259,7 +3344,8 @@ DeleteHandle::DeleteHandle() noexcept {
 void to_json(json& j, const DeleteHandle& p) {
   j = json::object();
   j["@type"] = "DeleteHandle";
-  to_json_key(j, "handle", p.handle, "DeleteHandle", "TableHandle", "handle");
+  to_json_key(
+      j, "handle", p.handle, "DeleteHandle", "DeleteTableHandle", "handle");
   to_json_key(
       j,
       "schemaTableName",
@@ -3271,7 +3357,8 @@ void to_json(json& j, const DeleteHandle& p) {
 
 void from_json(const json& j, DeleteHandle& p) {
   p._type = j["@type"];
-  from_json_key(j, "handle", p.handle, "DeleteHandle", "TableHandle", "handle");
+  from_json_key(
+      j, "handle", p.handle, "DeleteHandle", "DeleteTableHandle", "handle");
   from_json_key(
       j,
       "schemaTableName",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -312,6 +312,11 @@ void to_json(json& j, const std::shared_ptr<ConnectorOutputTableHandle>& p);
 void from_json(const json& j, std::shared_ptr<ConnectorOutputTableHandle>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+struct ConnectorDeleteTableHandle : public JsonEncodedSubclass {};
+void to_json(json& j, const std::shared_ptr<ConnectorDeleteTableHandle>& p);
+void from_json(const json& j, std::shared_ptr<ConnectorDeleteTableHandle>& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 struct InputDistribution : public JsonEncodedSubclass {};
 void to_json(json& j, const std::shared_ptr<InputDistribution>& p);
 void from_json(const json& j, std::shared_ptr<InputDistribution>& p);
@@ -1026,8 +1031,17 @@ void to_json(json& j, const CreateHandle& p);
 void from_json(const json& j, CreateHandle& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+struct DeleteTableHandle {
+  ConnectorId connectorId = {};
+  std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
+  std::shared_ptr<ConnectorDeleteTableHandle> connectorHandle = {};
+};
+void to_json(json& j, const DeleteTableHandle& p);
+void from_json(const json& j, DeleteTableHandle& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 struct DeleteHandle : public ExecutionWriterTarget {
-  TableHandle handle = {};
+  DeleteTableHandle handle = {};
   SchemaTableName schemaTableName = {};
 
   DeleteHandle() noexcept;

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -104,6 +104,7 @@ using Subfield = std::string;
 using HiveType = std::string;
 using Type = std::string;
 
+using DateTime = std::string;
 using Locale = std::string;
 using TimeZoneKey = long;
 using URI = std::string;
@@ -1191,9 +1192,9 @@ void from_json(const json& j, OperatorStats& p);
 namespace facebook::presto::protocol {
 struct DriverStats {
   Lifespan lifespan = {};
-  long createTimeInMillis = {};
-  long startTimeInMillis = {};
-  long endTimeInMillis = {};
+  int64_t createTimeInMillis = {};
+  int64_t startTimeInMillis = {};
+  int64_t endTimeInMillis = {};
   Duration queuedTime = {};
   Duration elapsedTime = {};
   int64_t userMemoryReservationInBytes = {};

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -82,6 +82,10 @@ AbstractClasses:
       - { name: HiveInsertTableHandle,          key: hive }
       - { name: IcebergInsertTableHandle,       key: hive-iceberg }
 
+  ConnectorDeleteTableHandle:
+    super: JsonEncodedSubclass
+    subclasses:
+
   ConnectorTransactionHandle:
     super: JsonEncodedSubclass
     subclasses:
@@ -288,6 +292,7 @@ JavaClasses:
   - presto-main/src/main/java/com/facebook/presto/execution/scheduler/ExecutionWriterTarget.java
   - presto-main/src/main/java/com/facebook/presto/metadata/OutputTableHandle.java
   - presto-main/src/main/java/com/facebook/presto/metadata/InsertTableHandle.java
+  - presto-main/src/main/java/com/facebook/presto/metadata/DeleteTableHandle.java
   - presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
   - presto-main/src/main/java/com/facebook/presto/execution/TaskSource.java
   - presto-main/src/main/java/com/facebook/presto/execution/TaskState.java

--- a/presto-native-execution/presto_cpp/presto_protocol/core/special/ConnectorDeleteTableHandle.cpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/special/ConnectorDeleteTableHandle.cpp.inc
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorDeleteTableHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+  getConnectorProtocol(type).to_json(j, p);
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorDeleteTableHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) + " ConnectorDeleteTableHandle  ConnectorDeleteTableHandle");
+  }
+  getConnectorProtocol(type).from_json(j, p);
+}
+} // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/java-to-struct-json.py
+++ b/presto-native-execution/presto_cpp/presto_protocol/java-to-struct-json.py
@@ -41,7 +41,7 @@ IGNORED_TYPES = {
 language = {
     "cpp": {
         "TypeMap": {
-            r"([ ,<])(ColumnHandle|PlanNode|RowExpression|ConnectorMetadataUpdateHandle)([ ,>])": r"\1std::shared_ptr<\2>\3",
+            r"([ ,<])(ColumnHandle|PlanNode|RowExpression|ConnectorMetadataUpdateHandle|ConnectorDeleteTableHandle)([ ,>])": r"\1std::shared_ptr<\2>\3",
             r"Optional<int\[\]>": "Optional<List<int>>",
             r"Optional<byte\[\]>": "Optional<List<byte>>",
             r"int\[\]": "List<int>",
@@ -351,23 +351,25 @@ def main():
             classes[abstract_name].comparable = True
         classes[abstract_name].subclasses = []
 
-        for subclass in abstract_value.subclasses:
-            subclasses[subclass.name] = util.attrdict(
-                super=abstract_name, key=subclass.key
-            )
-
-            classes[abstract_name].subclasses.append(
-                util.attrdict(
-                    type=subclass.name,
-                    name=member_name(subclass.name),
-                    key=subclass.key,
+        if abstract_value.subclasses:
+            for subclass in abstract_value.subclasses:
+                subclasses[subclass.name] = util.attrdict(
+                    super=abstract_name, key=subclass.key
                 )
-            )
-            classes[abstract_name].subclasses[-1]._N = len(
-                classes[abstract_name].subclasses
-            )
 
-        classes[abstract_name].subclasses[-1]._last = True
+                classes[abstract_name].subclasses.append(
+                    util.attrdict(
+                        type=subclass.name,
+                        name=member_name(subclass.name),
+                        key=subclass.key,
+                    )
+                )
+                classes[abstract_name].subclasses[-1]._N = len(
+                    classes[abstract_name].subclasses
+                )
+
+        if classes[abstract_name].subclasses:
+            classes[abstract_name].subclasses[-1]._last = True
 
         if "source" in abstract_value:
             file = abstract_value.source

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -81,6 +81,10 @@ AbstractClasses:
         - { name: HiveInsertTableHandle,          key: hive }
         - { name: IcebergInsertTableHandle,       key: hive-iceberg }
 
+    ConnectorDeleteTableHandle:
+      super: JsonEncodedSubclass
+      subclasses:
+
     ConnectorTransactionHandle:
       super: JsonEncodedSubclass
       subclasses:
@@ -335,6 +339,7 @@ JavaClasses:
   - presto-main/src/main/java/com/facebook/presto/execution/scheduler/ExecutionWriterTarget.java
   - presto-main/src/main/java/com/facebook/presto/metadata/OutputTableHandle.java
   - presto-main/src/main/java/com/facebook/presto/metadata/InsertTableHandle.java
+  - presto-main/src/main/java/com/facebook/presto/metadata/DeleteTableHandle.java
   - presto-hive/src/main/java/com/facebook/presto/hive/TableToPartitionMapping.java
   - presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
   - presto-main/src/main/java/com/facebook/presto/execution/TaskSource.java


### PR DESCRIPTION
## Description
In PR #24528 we added a new `ConnectorDeleteTableHandle` interface for use in `ConnectorMetadata::beginDelete` and `finishDelete`.  This changes adds a type parameter for ConnectorDeleteTableHandle implementations to the `ConnectorProtocolTemplate` declaration, with corresponding hooks in `ConnectorProtocol` for presto_protocol (de)serialization.

## Motivation and Context
Adding the implementing type as a parameter to `ConnectorProtocolTemplate` is required to correctly serialize `ConnectorDeleteTableHandle`  implementations to native workers.

## Impact
Any current connectors defining `ConnectorProtocolTemplate` specializations will need to add a type parameter for the `ConnectorDeleteTableHandle` implementing type.  If the connector does not currently handle `ConnectorDeleteTableHandle`, it can use the `NotImplemented` type.

## Test Plan
No new tests added, as testing the `ConnectorDeleteTableHandle` serialization would require a corresponding implementation to test.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo Changes
* Added a type parameter for `ConnectorDeleteTableHandle` implementations to `ConnectorProtocolTemplate`, along with support for (de)serialization of connector-specific types.  Existing native connector implementations defining `ConnectorProtocolTemplate` specializations will need to update their definitions to supply their specific type or use `NotImplemented`.


Hive Connector Changes
* Updated native `HiveConnectorProtocol` to supply `NotImplemented` for `ConnectorDeleteTableHandle` type.


Iceberg Connector Changes
* Updated native `IcebergConnectorProtocol` to supply `NotImplemented` for `ConnectorDeleteTableHandle` type.
```


Differential Revision: D70209547


