### PR TITLE
Fix Sorted Tables header in iceberg document

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1955,7 +1955,7 @@ No other types are supported.
 
 
 Sorted Tables
-^^^^^^^^^^^^^
+-------------
 
 The Iceberg connector supports the creation of sorted tables.
 Data in the Iceberg table is sorted as each file is written.


### PR DESCRIPTION
## Description
Fix Sorted Tables header in iceberg document

## Motivation and Context
Fix Sorted Tables header in iceberg document. `Sorted Table` should not be a sub-heading of `Type mapping`

## Impact
Before -
![before](https://github.com/user-attachments/assets/f1374e69-5e12-4b7f-97ee-7d93dd37365a)

After -
![image](https://github.com/user-attachments/assets/9d4bca9c-186c-43d8-bcb7-5e49d1e4ee20)


## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

