### PR TITLE
Change array_top_n to return null on bad n

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -163,7 +163,7 @@ public class ArraySqlFunctions
     @SqlParameters({@SqlParameter(name = "input", type = "array(T)"), @SqlParameter(name = "n", type = "int")})
     @SqlType("array<T>")
     public static String arrayTopN()
-    { return "RETURN IF(n < 0, fail('Parameter n: ' || cast(n as varchar) || ' to ARRAY_TOP_N is negative'), SLICE(ARRAY_SORT_DESC(input), 1, n))"; }
+    { return "RETURN IF(n < 0, NULL, SLICE(ARRAY_SORT_DESC(input), 1, n))"; }
 
     @SqlInvokedScalarFunction(value = "array_top_n", deterministic = true, calledOnNullInput = true)
     @Description("Returns the top N values of the given map sorted using the provided lambda comparator.")
@@ -172,6 +172,6 @@ public class ArraySqlFunctions
     @SqlType("array<T>")
     public static String arrayTopNComparator()
     {
-        return "RETURN IF(n < 0, fail('Parameter n: ' || cast(n as varchar) || ' to ARRAY_TOP_N is negative'), SLICE(REVERSE(ARRAY_SORT(input, f)), 1, n))";
+        return "RETURN IF(n < 0, NULL, SLICE(REVERSE(ARRAY_SORT(input, f)), 1, n))";
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
@@ -393,12 +393,23 @@ public class TestArraySqlFunctions
         // Test exceptions
         assertInvalidFunction("ARRAY_TOP_N(ARRAY [ROW('a', 1), ROW('a', null), null, ROW('a', 0)], 2)", StandardErrorCode.INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("ARRAY_TOP_N(ARRAY [MAP(ARRAY['foo', 'bar'], ARRAY[1, 2]), MAP(ARRAY['foo', 'bar'], ARRAY[0, 3])], 2)", SemanticErrorCode.FUNCTION_NOT_FOUND);
-        assertInvalidFunction("ARRAY_TOP_N(ARRAY ['a', 'a', 'd', 'a', 'a', 'a'], -1)", StandardErrorCode.GENERIC_USER_ERROR, "Parameter n: -1 to ARRAY_TOP_N is negative");
 
         // Test edge cases
         assertFunction("ARRAY_TOP_N(ARRAY [null, null], 3)", new ArrayType(UNKNOWN), asList(null, null));
         assertFunction("ARRAY_TOP_N(ARRAY [3, 5, 1, 2], 0)", new ArrayType(INTEGER), emptyList());
         assertFunction("ARRAY_TOP_N(ARRAY [], 3)", new ArrayType(UNKNOWN), emptyList());
         assertFunction("ARRAY_TOP_N(ARRAY [1, 4], 3)", new ArrayType(INTEGER), ImmutableList.of(4, 1));
+    }
+
+    @Test
+    public void testArrayTopNNegativeParameter()
+    {
+        assertFunction("ARRAY_TOP_N(ARRAY ['a', 'a', 'd', 'a', 'a', 'a'], -1)", new ArrayType(createVarcharType(1)), null);
+        assertFunction("ARRAY_TOP_N(ARRAY [1,2,3,4,5,6], -5)", new ArrayType(INTEGER), null);
+        assertFunction("ARRAY_TOP_N(ARRAY [DOUBLE '1.0', 100, 2, DOUBLE '5.0', DOUBLE '3.0'], -3)", new ArrayType(DOUBLE), null);
+        assertFunction("ARRAY_TOP_N(ARRAY [true, true, false, true, false], -4)", new ArrayType(BOOLEAN), null);
+        assertFunction("ARRAY_TOP_N(ARRAY [null, null], -3)", new ArrayType(UNKNOWN), null);
+        assertFunction("ARRAY_TOP_N(ARRAY [], -3)", new ArrayType(UNKNOWN), null);
+        assertFunction("ARRAY_TOP_N(null, -3)", new ArrayType(UNKNOWN), null);
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Function array_top_n throws for invalid n value and this exception is now properly caught returning NULL similar to Velox 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
closes #24700 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
```
presto:tpch> SELECT try(array_top_n(c0, (- INTEGER '153792828'))) from (values array[1,23]) t(c0);
 _col0                
-------
 NULL  
(1 row)
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Update :func:`array_top_n` to return ``NULL`` for invalid values of ``n`` to match the behavior of Prestissimo
```

