### PR TITLE
[Iceberg]Standardized type name for timestamp with and without tz

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1892,8 +1892,8 @@ Map of Iceberg types to the relevant PrestoDB types:
     - ``TIME``
   * - ``TIMESTAMP``
     - ``TIMESTAMP``
-  * - ``TIMESTAMP``
-    - ``TIMESTAMP_WITH_TIMEZONE``
+  * - ``TIMESTAMP TZ``
+    - ``TIMESTAMP WITH TIME ZONE``
   * - ``UUID``
     - ``UUID``
   * - ``LIST``
@@ -1938,9 +1938,9 @@ Map of PrestoDB types to the relevant Iceberg types:
   * - ``TIME``
     - ``TIME``
   * - ``TIMESTAMP``
-    - ``TIMESTAMP WITHOUT ZONE``
-  * - ``TIMESTAMP WITH TIMEZONE``
-    - ``TIMESTAMP WITH ZONE``
+    - ``TIMESTAMP``
+  * - ``TIMESTAMP WITH TIME ZONE``
+    - ``TIMESTAMP TZ``
   * - ``UUID``
     - ``UUID``
   * - ``ARRAY``


### PR DESCRIPTION
## Description

In Presto, the standardized type names for timestamp with and without tz are `TIMESTAMP WITH TIME ZONE` and `TIMESTAMP`, see [date-and-time](https://prestodb.io/docs/current/language/types.html#date-and-time). While, in Iceberg, the standardized type names for timestamp with and without tz are `TIMESTAMP TZ` and `TIMESTAMP`, see [primitive-types](https://iceberg.apache.org/spec/#primitive-types).

This PR standardized the timestamp type names for `Type mapping` section in presto iceberg document.

## Motivation and Context

Standardized the type names for timestamp with and without tz in iceberg document.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

