### PR TITLE
[codemod] Remove unused private from github/presto-trunk/presto-native-execution/presto_cpp/main/http/filters/InternalAuthenticationFilter.h +1

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/filters/InternalAuthenticationFilter.h
+++ b/presto-native-execution/presto_cpp/main/http/filters/InternalAuthenticationFilter.h
@@ -22,7 +22,7 @@ namespace facebook::presto::http::filters {
 class InternalAuthenticationFilter : public proxygen::Filter {
  public:
   explicit InternalAuthenticationFilter(proxygen::RequestHandler* upstream)
-      : Filter(upstream), requestRejected_(false) {}
+      : Filter(upstream) {}
 
   /// For details on the filter request handling see Filters.h and
   /// RequestHandler.h.
@@ -54,8 +54,6 @@ class InternalAuthenticationFilter : public proxygen::Filter {
   void processAndVerifyJwt(
       const std::string& token,
       std::unique_ptr<proxygen::HTTPMessage> msg);
-
-  bool requestRejected_;
 };
 
 class InternalAuthenticationFilterFactory


### PR DESCRIPTION
Summary:
`-Wunused-private-field` has identified an unused private field. This diff removes it.

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D71063945


