### PR TITLE
[Iceberg]Supplement tests and docs for supported types of each partition transform

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1213,6 +1213,30 @@ Create an Iceberg table partitioned by ``ts``::
         partitioning = ARRAY['hour(ts)']
     );
 
+Types for partition transforms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The list of supported types in Presto for each partition transform is as follows:
+
+===================== =======================================================================
+Transform Name        Source Types
+===================== =======================================================================
+``Identity``          ``boolean``, ``int``, ``bigint``, ``real``, ``double``, ``decimal``,
+                      ``varchar``, ``varbinary``, ``date``, ``time``, ``timestamp``
+
+``Bucket``            ``int``, ``bigint``, ``decimal``, ``varchar``, ``varbinary``, ``date``
+
+``Truncate``          ``int``, ``bigint``, ``decimal``, ``varchar``, ``varbinary``
+
+``Year``              ``date``, ``timestamp``
+
+``Month``             ``date``, ``timestamp``
+
+``Day``               ``date``, ``timestamp``
+
+``Hour``              ``timestamp``
+===================== =======================================================================
+
 CREATE VIEW
 ^^^^^^^^^^^
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1578,6 +1578,100 @@ public abstract class IcebergDistributedSmokeTestBase
     }
 
     @Test
+    public void testPartitionTransformOnTimestampWithTimeZone()
+    {
+        //TODO: Not yet support identity transform for timestamp with time zone, which was supported by Iceberg
+        assertUpdate("create table test_identity_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
+                "with (partitioning = ARRAY['col_timestamp_tz'])");
+        assertQueryFails("insert into test_identity_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
+                "Type not supported as partition column: timestamp with time zone");
+        assertUpdate("drop table if exists test_identity_transform_timestamp_tz");
+
+        //TODO: Not yet support bucket transform for timestamp with time zone, which was supported by Iceberg
+        assertUpdate("create table test_bucket_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
+                "with (partitioning = ARRAY['bucket(col_timestamp_tz, 2)'])");
+        assertQueryFails("insert into test_bucket_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
+                "Unsupported type for 'bucket': 1000: col_timestamp_tz_bucket: bucket\\[2\\]\\(1\\)");
+        assertUpdate("drop table if exists test_bucket_transform_timestamp_tz");
+
+        //TODO: Not yet support year transform for timestamp with time zone, which was supported by Iceberg
+        assertUpdate("create table test_year_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
+                "with (partitioning = ARRAY['year(col_timestamp_tz)'])");
+        assertQueryFails("insert into test_year_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
+                "Unsupported type for 'year': 1000: col_timestamp_tz_year: year\\(1\\)");
+        assertUpdate("drop table if exists test_year_transform_timestamp_tz");
+
+        //TODO: Not yet support month transform for timestamp with time zone, which was supported by Iceberg
+        assertUpdate("create table test_month_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
+                "with (partitioning = ARRAY['month(col_timestamp_tz)'])");
+        assertQueryFails("insert into test_month_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
+                "Unsupported type for 'month': 1000: col_timestamp_tz_month: month\\(1\\)");
+        assertUpdate("drop table if exists test_month_transform_timestamp_tz");
+
+        //TODO: Not yet support day transform for timestamp with time zone, which was supported by Iceberg
+        assertUpdate("create table test_day_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
+                "with (partitioning = ARRAY['day(col_timestamp_tz)'])");
+        assertQueryFails("insert into test_day_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
+                "Unsupported type for 'day': 1000: col_timestamp_tz_day: day\\(1\\)");
+        assertUpdate("drop table if exists test_day_transform_timestamp_tz");
+
+        //TODO: Not yet support hour transform for timestamp with time zone, which was supported by Iceberg
+        assertUpdate("create table test_hour_transform_timestamp_tz(col_timestamp_tz timestamp with time zone)" +
+                "with (partitioning = ARRAY['hour(col_timestamp_tz)'])");
+        assertQueryFails("insert into test_hour_transform_timestamp_tz " +
+                        "values(CAST('2023-01-01 00:00:00.000 UTC' AS TIMESTAMP WITH TIME ZONE))",
+                "Unsupported type for 'hour': 1000: col_timestamp_tz_hour: hour\\(1\\)");
+        assertUpdate("drop table if exists test_hour_transform_timestamp_tz");
+    }
+
+    @Test
+    public void testPartitionTransformOnUUID()
+    {
+        //TODO: Not yet support identity transform for uuid, which was supported by Iceberg
+        assertUpdate("create table test_identity_transform_uuid(col_uuid uuid)" +
+                "with (partitioning = ARRAY['col_uuid'])");
+        assertQueryFails("insert into test_identity_transform_uuid " +
+                        "values(cast ('d2177dd0-eaa2-11de-a572-001b779c76e1' as uuid))",
+                "Type not supported as partition column: uuid");
+        assertUpdate("drop table if exists test_identity_transform_uuid");
+
+        //TODO: Not yet support bucket transform for uuid, which was supported by Iceberg
+        assertUpdate("create table test_bucket_transform_uuid(col_uuid uuid)" +
+                "with (partitioning = ARRAY['bucket(col_uuid, 2)'])");
+        assertQueryFails("insert into test_bucket_transform_uuid " +
+                        "values(cast ('d2177dd0-eaa2-11de-a572-001b779c76e1' as uuid))",
+                "Unsupported type for 'bucket': 1000: col_uuid_bucket: bucket\\[2\\]\\(1\\)");
+        assertUpdate("drop table if exists test_bucket_transform_uuid");
+    }
+
+    @Test
+    public void testBucketTransformOnTime()
+    {
+        //TODO: Not yet support bucket transform for time, which was supported by Iceberg
+        assertUpdate("create table test_bucket_transform_time(col_time time)" +
+                "with (partitioning = ARRAY['bucket(col_time, 2)'])");
+        assertQueryFails("insert into test_bucket_transform_time values(time '01:02:03.123')",
+                "Unsupported type for 'bucket': 1000: col_time_bucket: bucket\\[2\\]\\(1\\)");
+        assertUpdate("drop table if exists test_bucket_transform_time");
+    }
+
+    @Test
+    public void testBucketTransformOnTimestamp()
+    {
+        //TODO: Not yet support bucket transform for timestamp, which was supported by Iceberg
+        assertUpdate("create table test_bucket_transform_timestamp(col_timestamp timestamp)" +
+                "with (partitioning = ARRAY['bucket(col_timestamp, 2)'])");
+        assertQueryFails("insert into test_bucket_transform_timestamp values(timestamp '1984-01-08 01:02:03.123')",
+                "Unsupported type for 'bucket': 1000: col_timestamp_bucket: bucket\\[2\\]\\(1\\)");
+        assertUpdate("drop table if exists test_bucket_transform_timestamp");
+    }
+
+    @Test
     public void testRegisterTable()
     {
         String schemaName = getSession().getSchema().get();


### PR DESCRIPTION
## Description

This PR did two things:
 - Add test cases for several presto data types who have not-yet-supported partition transforms which should be supported according to Iceberg's spec. And add TODO informations to them for future implementation.
 - Supplement the currently supported types list for each partition transform to Iceberg docs. Enable users to have a clearer understanding of Presto's current support for Iceberg partition transform. See issue #24731.

The effect is as follows:

<img width="722" alt="transform_types" src="https://github.com/user-attachments/assets/d132f957-4835-4ccd-a93d-70f1c5639962" />

## Motivation and Context

Make users and developers to have a better understanding of Presto's current support for Iceberg partition transform.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

